### PR TITLE
Add timestamps to logs

### DIFF
--- a/endhost/gateway.py
+++ b/endhost/gateway.py
@@ -25,6 +25,7 @@ from pytun import TunTapDevice, IFF_TUN, IFF_NO_PI
 from endhost.sciond import SCIONDaemon
 from lib.packet.host_addr import IPv4HostAddr
 from lib.packet.scion import SCIONPacket
+from lib.util import init_logging
 from infrastructure.scion_elem import SCION_UDP_EH_DATA_PORT, BUFLEN
 
 
@@ -140,7 +141,7 @@ def main():
     """
     Main function.
     """
-    logging.basicConfig(level=logging.DEBUG)
+    init_logging()
     if len(sys.argv) != 3:
         logging.error("run: %s addr topology_file", sys.argv[0])
         sys.exit()

--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -28,6 +28,7 @@ from lib.packet.pcb import (PathSegment, ADMarking, PCBMarking, PeerMarking,
     PathConstructionBeacon, PathSegmentInfo, PathSegmentRecords,
     PathSegmentType as PST)
 from lib.packet.scion import SCIONPacket, get_type, PacketType as PT
+from lib.util import init_logging
 import logging
 import sys
 import threading
@@ -380,7 +381,7 @@ def main():
     """
     Main function.
     """
-    logging.basicConfig(level=logging.DEBUG)
+    init_logging()
     if len(sys.argv) != 5:
         logging.error("run: %s <core|local> IP topo_file conf_file",
             sys.argv[0])

--- a/infrastructure/cert_server.py
+++ b/infrastructure/cert_server.py
@@ -19,6 +19,7 @@ limitations under the License.
 from lib.packet.host_addr import IPv4HostAddr
 from lib.packet.scion import (SCIONPacket, get_type, PacketType as PT,
     CertRequest, CertReply, RotRequest, RotReply, get_addr_from_type)
+from lib.util import init_logging
 from infrastructure.scion_elem import SCIONElement
 from lib.packet.path import EmptyPath
 import sys
@@ -203,7 +204,7 @@ def main():
     """
     Main function.
     """
-    logging.basicConfig(level=logging.DEBUG)
+    init_logging()
     if len(sys.argv) != 5:
         logging.error("run: %s IP topo_file conf_file rot_file", sys.argv[0])
         sys.exit()

--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -25,7 +25,7 @@ from lib.packet.pcb import (PathSegmentRequest, PathSegmentRecords,
 from lib.packet.scion import PacketType as PT
 from lib.packet.scion import SCIONPacket, get_type
 from lib.path_db import PathSegmentDB
-from lib.util import update_dict
+from lib.util import update_dict, init_logging
 import logging
 import sys
 
@@ -497,7 +497,7 @@ def main():
     """
     Main function.
     """
-    logging.basicConfig(level=logging.DEBUG)
+    init_logging()
     if len(sys.argv) != 5:
         logging.error("run: %s <core|local>  IP topo_file conf_file",
                       sys.argv[0])

--- a/infrastructure/router.py
+++ b/infrastructure/router.py
@@ -28,6 +28,7 @@ from lib.packet.opaque_field import OpaqueFieldType as OFT
 from lib.packet.pcb import PathConstructionBeacon
 from lib.packet.scion import PacketType as PT
 from lib.packet.scion import SCIONPacket, IFIDRequest, IFIDReply, get_type
+from lib.util import init_logging
 import logging
 import socket
 import sys
@@ -35,7 +36,6 @@ import threading
 import time
 import datetime
 import os
-
 
 class NextHop(object):
     """
@@ -515,7 +515,7 @@ def main():
     """
     Initializes and starts router.
     """
-    logging.basicConfig(level=logging.DEBUG)
+    init_logging()
     if len(sys.argv) != 4:
         logging.error("run: %s IP topo_file conf_file", sys.argv[0])
         sys.exit()

--- a/lib/util.py
+++ b/lib/util.py
@@ -101,6 +101,7 @@ def get_paths(dst_isd, src_ad, dst_ad):
 
     return paths
 
+
 def update_dict(dictionary, key, values, elem_num=0):
     """
     Updates dictionary. Used for managing a temporary paths' cache.
@@ -111,3 +112,10 @@ def update_dict(dictionary, key, values, elem_num=0):
         dictionary[key] = values
     dictionary[key] = dictionary[key][-elem_num:]
 
+
+def init_logging(level=logging.DEBUG):
+    """
+    Configure logging for components (servers, routers, gateways).
+    """
+    logging.basicConfig(level=level,
+                        format='%(asctime)s [%(levelname)s]\t%(message)s')


### PR DESCRIPTION
Log files now look like this:

```
2015-03-05 14:01:15,989 [DEBUG] Core Segment PCB already seen. Dropping...
2015-03-05 14:01:15,992 [INFO]  PCB received
```

It's useful to know timestamps to perform any kind of offline analysis.
