### PR TITLE
Add initial support for Supervisord

### DIFF
--- a/supervisor/README.md
+++ b/supervisor/README.md
@@ -1,0 +1,35 @@
+'Supervisor' allows to manage processes easily, both individually and in groups.
+
+0. Install dependencies (Python 2.7 is required for now)
+
+  sudo apt-get install python-pip
+  sudo pip2 install supervisor==3.1.3 && sudo pip2 install supervisor-quick
+
+1. Create 'supervisor' configuration files (among others)
+
+  ./scion.sh topology
+
+2. Check status
+
+  ./supervisor/supervisor.sh status
+
+3. Manage processes
+
+  \# start all processes
+  ./supervisor/supervisor.sh start all
+
+  \# stop all processes
+  ./supervisor/supervisor.sh stop all
+
+  \# restart all processes in AD1-11
+  ./supervisor/supervisor.sh restart ad1-11:*
+
+### Caveat 1
+
+The current version of 'supervisor' (3.1.3) supports only Python 2.7, the planned 4.0 version will support both Python branches (2.x and 3.x).
+
+### Caveat 2
+
+Start/stop/restart operations might be a bit slow if the number of processes is large. This will be fixed in the version 4.0, but for now you may want to try the same commands with the 'quick-' prefix ('quickstart', 'quickstop', 'quickrestart'). These are not included in the core 'supervisor' package, but they make it fast ignoring the callback stack.
+
+

--- a/supervisor/supervisor.sh
+++ b/supervisor/supervisor.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Get the full path to the script directory
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+INFR_PATH="${SCRIPT_DIR}/../infrastructure"
+cd $INFR_PATH
+
+# Wrap the 'supervisorctl' command
+OPTIONS="$@"
+CONF_FILE="${SCRIPT_DIR}/supervisord.conf"
+supervisord -c $CONF_FILE &> /dev/null
+supervisorctl -c $CONF_FILE $OPTIONS
+

--- a/supervisor/supervisord.conf
+++ b/supervisor/supervisord.conf
@@ -1,0 +1,58 @@
+; Sample supervisor config file.
+;
+; For more information on the config file, please see:
+; http://supervisord.org/configuration.html
+;
+; Note: shell expansion ("~" or "$HOME") is not supported.  Environment
+; variables can be expanded using this syntax: "%(ENV_HOME)s".
+
+[unix_http_server]
+file=/tmp/supervisor.sock   ; (the path to the socket file)
+;chmod=0700                 ; socket file mode (default 0700)
+;chown=nobody:nogroup       ; socket file uid:gid owner
+;username=user              ; (default is no username (open server))
+;password=123               ; (default is no password (open server))
+
+[inet_http_server]         ; inet (TCP) server disabled by default
+port=127.0.0.1:9001        ; (ip_address:port specifier, *:port for all iface)
+;username=user              ; (default is no username (open server))
+;password=123               ; (default is no password (open server))
+
+[supervisord]
+logfile=/tmp/supervisord.log ; (main log file;default $CWD/supervisord.log)
+logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
+logfile_backups=10           ; (num of main logfile rotation backups;default 10)
+loglevel=info                ; (log level;default info; others: debug,warn,trace)
+pidfile=/tmp/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+nodaemon=false               ; (start in foreground if true;default false)
+minfds=1024                  ; (min. avail startup file descriptors;default 1024)
+minprocs=200                 ; (min. avail process descriptors;default 200)
+;umask=022                   ; (process file creation umask;default 022)
+;user=chrism                 ; (default is current user, required if root)
+;identifier=supervisor       ; (supervisord identifier, default is 'supervisor')
+;directory=/tmp              ; (default is not to cd during start)
+;nocleanup=true              ; (don't clean up tempfiles at start;default false)
+;childlogdir=/tmp            ; ('AUTO' child log dir, default $TEMP)
+;environment=KEY=value       ; (key value pairs to add to environment)
+;strip_ansi=false            ; (strip ansi escape codes in logs; def. false)
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+;serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
+;username=chris              ; should be same as http_username if set
+;password=123                ; should be same as http_password if set
+;prompt=mysupervisor         ; cmd line prompt (default "supervisor")
+;history_file=~/.sc_history  ; use readline history if available
+
+[ctlplugin:quick]
+supervisor.ctl_factory = supervisor_quick:make_quick_controllerplugin
+
+[include]
+files = ../topology/ISD*/supervisor/*.conf
+

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -29,6 +29,7 @@ import json
 import logging
 import shutil
 import os
+import sys
 import struct
 import socket
 import base64
@@ -47,6 +48,7 @@ ENC_KEYS_DIR = '/encryption_keys/'
 SETUP_DIR = '/setup/'
 RUN_DIR = '/run/'
 PATH_POL_DIR = '/path_policies/'
+SUPERVISOR_DIR = '/supervisor/'
 
 CORE_AD = 'CORE'
 INTERMEDIATE_AD = 'INTERMEDIATE'
@@ -150,6 +152,7 @@ def create_directories(AD_configs):
         setup_path = 'ISD' + isd_id + SETUP_DIR
         run_path = 'ISD' + isd_id + RUN_DIR
         path_pol_path = 'ISD' + isd_id + PATH_POL_DIR
+        supervisor_path = 'ISD' + isd_id + SUPERVISOR_DIR
         if not os.path.exists(cert_path):
             os.makedirs(cert_path)
         if not os.path.exists(conf_path):
@@ -166,6 +169,8 @@ def create_directories(AD_configs):
             os.makedirs(run_path)
         if not os.path.exists(path_pol_path):
             os.makedirs(path_pol_path)
+        if not os.path.exists(supervisor_path):
+            os.makedirs(supervisor_path)
 
 
 def write_keys_certs(AD_configs):
@@ -256,6 +261,7 @@ def write_topo_files(AD_configs, er_ip_addresses):
         topo_file = 'ISD' + isd_id + TOPO_DIR + file_name + '-V:0.json'
         trc_file = get_trc_file_path(isd_id, ad_id, isd_id, 0)
         path_pol_file = 'ISD' + isd_id + PATH_POL_DIR + file_name + '-V:0.json'
+        supervisor_file = 'ISD' + isd_id + SUPERVISOR_DIR + file_name + '.conf'
         is_core = (AD_configs[isd_ad_id]['level'] == CORE_AD)
         if "subnet" in AD_configs[isd_ad_id]:
             first_byte = AD_configs[isd_ad_id]["subnet"].split('.')[0]
@@ -283,22 +289,37 @@ def write_topo_files(AD_configs, er_ip_addresses):
                      'CertificateServers': {},
                      'PathServers': {},
                      'EdgeRouters': {}}
-        with open(setup_file, 'a') as setup_fh, open(run_file, 'a') as run_fh:
+        group_programs = []
+        with open(setup_file, 'a') as setup_fh,\
+             open(run_file, 'a') as run_fh,\
+             open(supervisor_file, 'a') as supervisor_fh:
             # Write Beacon Servers
             ip_address = '.'.join([first_byte, isd_id, ad_id, BS_RANGE])
+            supervisor_common = ['autostart=false\n', 'redirect_stderr=True\n',
+                                 'environment=PYTHONPATH=..\n',
+                                 'stdout_logfile_maxbytes=0\n']
             for b_server in range(1, number_bs + 1):
                 topo_dict['BeaconServers'][b_server] = {'AddrType': 'IPv4',
                                                         'Addr': ip_address}
                 setup_fh.write('ip addr add ' + ip_address + '/' + mask +
                     ' dev lo\n')
-                log = ' >> ../logs/bs-%s-%s-%s.log 2>&1' % (isd_id, ad_id,
-                                                            str(b_server))
-                run_fh.write(''.join(['screen -d -m -S bs', isd_id, '-', ad_id,
-                    '-', str(b_server), ' sh -c \"',
-                    'PYTHONPATH=../ python3 beacon_server.py ',
+                log_file = '../logs/bs-%s-%s-%s.log' % (isd_id, ad_id,
+                                                        str(b_server))
+                log = ' >> %s 2>&1' % (log_file,)
+                bs_name = ''.join(['bs', isd_id, '-', ad_id, '-',
+                                   str(b_server)])
+                run_fh.write(''.join(['screen -d -m -S ', bs_name,
+                    ' sh -c \"', 'PYTHONPATH=../ python3 beacon_server.py ',
                     ('core ' if is_core else 'local '), ip_address, ' ..',
                      SCRIPTS_DIR, topo_file, ' ..', SCRIPTS_DIR, conf_file,
                      ' ..', SCRIPTS_DIR, path_pol_file, log, '\"\n']))
+                supervisor_fh.write(''.join(['[program:', bs_name, ']\n',
+                    'command=/usr/bin/python3 beacon_server.py ',
+                    ('core ' if is_core else 'local '), ip_address, ' ..',
+                    SCRIPTS_DIR, topo_file, ' ..', SCRIPTS_DIR, conf_file, '\n',
+                    'stdout_logfile=', log_file, '\n']
+                    + supervisor_common + ['\n\n']))
+                group_programs.append(bs_name)
                 ip_address = increment_address(ip_address, mask)
             # Write Certificate Servers
             ip_address = '.'.join([first_byte, isd_id, ad_id, CS_RANGE])
@@ -307,13 +328,22 @@ def write_topo_files(AD_configs, er_ip_addresses):
                                                              'Addr': ip_address}
                 setup_fh.write('ip addr add ' + ip_address + '/' + mask +
                     ' dev lo\n')
-                log = ' >> ../logs/cs-%s-%s-%s.log 2>&1' % (isd_id, ad_id,
-                                                            str(b_server))
-                run_fh.write(''.join(['screen -d -m -S cs', isd_id, '-', ad_id,
-                    '-', str(c_server), ' sh -c \"',
+                log_file = '../logs/cs-%s-%s-%s.log' % (isd_id, ad_id,
+                                                        str(c_server))
+                log = ' >> %s 2>&1' % (log_file,)
+                cs_name = ''.join(['cs', isd_id, '-', ad_id, '-',
+                                   str(c_server)])
+                run_fh.write(''.join(['screen -d -m -S ', cs_name, ' sh -c \"',
                     "PYTHONPATH=../ python3 cert_server.py ", ip_address, ' ..',
-                    SCRIPTS_DIR, topo_file, ' ..', SCRIPTS_DIR, conf_file, ' ',
-                    trc_file, log, '\"\n']))
+                    SCRIPTS_DIR, topo_file, ' ..', SCRIPTS_DIR, conf_file,
+                    ' ..', SCRIPTS_DIR, trc_file, log, '\"\n']))
+                supervisor_fh.write(''.join(['[program:', cs_name, ']\n',
+                    'command=/usr/bin/python3 cert_server.py ', ip_address,
+                    ' ..', SCRIPTS_DIR, topo_file, ' ..', SCRIPTS_DIR,
+                    conf_file, ' ..', SCRIPTS_DIR, trc_file, '\n',
+                    'stdout_logfile=', log_file, '\n']
+                    + supervisor_common + ['\n\n']))
+                group_programs.append(cs_name)
                 ip_address = increment_address(ip_address, mask)
             # Write Path Servers
             if (AD_configs[isd_ad_id]['level'] != INTERMEDIATE_AD or
@@ -324,14 +354,23 @@ def write_topo_files(AD_configs, er_ip_addresses):
                                                           'Addr': ip_address}
                     setup_fh.write('ip addr add ' + ip_address + '/' + mask +
                         ' dev lo\n')
-                    log = ' >> ../logs/ps-%s-%s-%s.log 2>&1' % (isd_id, ad_id,
-                                                                str(b_server))
-                    run_fh.write(''.join(['screen -d -m -S ps', isd_id, '-',
-                        ad_id, '-', str(p_server), ' sh -c \"',
-                        'PYTHONPATH=../ python3 path_server.py ',
+                    log_file = '../logs/ps-%s-%s-%s.log' % (isd_id, ad_id,
+                                                            str(p_server))
+                    log = ' >> %s 2>&1' % (log_file,)
+                    ps_name = ''.join(['ps', isd_id, '-', ad_id, '-',
+                                       str(p_server)])
+                    run_fh.write(''.join(['screen -d -m -S ', ps_name,
+                        ' sh -c \"', 'PYTHONPATH=../ python3 path_server.py ',
                         ('core ' if is_core else 'local '), ip_address, ' ..',
                          SCRIPTS_DIR, topo_file, ' ..', SCRIPTS_DIR, conf_file,
                          log, '\"\n']))
+                    supervisor_fh.write(''.join(['[program:', ps_name, ']\n',
+                        'command=/usr/bin/python3 path_server.py ',
+                        ('core ' if is_core else 'local '), ip_address,
+                        ' ..', SCRIPTS_DIR, topo_file, ' ..', SCRIPTS_DIR,
+                        conf_file, '\n', 'stdout_logfile=', log_file, '\n']
+                        + supervisor_common +['\n\n']))
+                    group_programs.append(ps_name)
                     ip_address = increment_address(ip_address, mask)
             # Write Edge Routers
             edge_router = 1
@@ -357,14 +396,26 @@ def write_topo_files(AD_configs, er_ip_addresses):
                                    'ToUdpPort': int(PORT)}}
                 setup_fh.write('ip addr add ' + ip_address_loc + '/' + mask +
                     ' dev lo\n')
-                log = ' >> ../logs/er-%s-%s-%s-%s.log 2>&1' % (isd_id, ad_id,
-                    nbr_isd_id, nbr_ad_id)
-                run_fh.write(''.join(['screen -d -m -S er', isd_id, '-', ad_id,
-                    'er', nbr_isd_id, '-', nbr_ad_id, ' sh -c \"',
-                    'PYTHONPATH=../ python3 router.py ', ip_address_loc, ' ..',
-                    SCRIPTS_DIR, topo_file, ' ..', SCRIPTS_DIR, conf_file,
-                    log, '\"\n']))
+                log_file = '../logs/er-%s-%s-%s-%s.log' % (isd_id, ad_id,
+                                                           nbr_isd_id,
+                                                           nbr_ad_id)
+                log = ' >> %s 2>&1' % (log_file,)
+                router_name = ''.join(['er', isd_id, '-', ad_id, 'er',
+                                       nbr_isd_id, '-', nbr_ad_id])
+                run_fh.write(''.join(['screen -d -m -S ', router_name,
+                    ' sh -c \"', 'PYTHONPATH=../ python3 router.py ',
+                    ip_address_loc, ' ..', SCRIPTS_DIR, topo_file, ' ..',
+                    SCRIPTS_DIR, conf_file, log, '\"\n']))
+                supervisor_fh.write(''.join(['[program:', router_name, ']\n',
+                    'command=/usr/bin/python3 router.py ', ip_address_loc,
+                    ' ..', SCRIPTS_DIR, topo_file, ' ..', SCRIPTS_DIR,
+                    conf_file, '\n', 'stdout_logfile=', log_file, '\n']
+                    + supervisor_common + ['\n\n']))
+                group_programs.append(router_name)
                 edge_router += 1
+
+            supervisor_fh.write(''.join(['[group:ad', isd_id, '-', ad_id, ']\n',
+                'programs=', ','.join(group_programs), '\n\n']))
         with open(topo_file, 'w') as topo_fh:
             json.dump(topo_dict, topo_fh, sort_keys=True, indent=4)
         # Test if parser works


### PR DESCRIPTION
As a follow-up to #37, here's the experimental integration with 'supervisord' as a process manager. This PR does NOT replace the original `scion.sh`, it only adds a `supervisor/`directory with the `supervisor.sh` script, which is basically a wrapper around `supervisord` and `supervisorctl`. This allows to try the new approach to the process management, having the old and the new scripts side by side. It is not recommended to mix two approaches, though, since it will lead to duplicated instances of the processes.

Advantages of 'supervisord' were listed in #37, so straight to the new workflow (there's also README.md in the `supervisor/` dir):

  0) Install dependencies (Python 2.7 is required for the current version of 'supervisor', but they are planning to release a new version soon with the Python 3.x support):

```
  $ sudo apt-get install python-pip
  $ sudo pip2 install supervisor==3.1.3 supervisor-quick
```

  1) Create 'supervisor' configuration files ('generator.py' is updated to generate 'supervisor' config files)

  ./scion.sh topology

  2) Check status

  ./supervisor/supervisor.sh status

Output example:

```
ad1-10:bs1-10-1                  STOPPED   Not started
ad1-10:cs1-10-1                  STOPPED   Not started
ad1-10:er1-10er1-19              STOPPED   Not started
ad1-10:ps1-10-1                  STOPPED   Not started
ad1-11:bs1-11-1                  STOPPED   Not started
ad1-11:cs1-11-1                  STOPPED   Not started
...
ad2-25:cs2-25-1                  STOPPED   Not started
ad2-25:er2-25er2-23              STOPPED   Not started
ad2-25:ps2-25-1                  STOPPED   Not started
ad2-26:bs2-26-1                  STOPPED   Not started
ad2-26:cs2-26-1                  STOPPED   Not started
ad2-26:er2-26er2-23              STOPPED   Not started
ad2-26:er2-26er2-24              STOPPED   Not started
ad2-26:ps2-26-1                  STOPPED   Not started
```

  4) Manage processes

  # start all processes
  ./supervisor/supervisor.sh start all

  # stop all processes
  ./supervisor/supervisor.sh stop all

  # restart all processes in AD1-11
  ./supervisor/supervisor.sh restart ad1-11:*

  # restart only the certificate server in AD2-26
  ./supervisor/supervisor.sh restart ad2-26:cs2-26-1

---

'Supervisor' also starts a local XML-RPC server on the port 9001, which allows to connect and control processes over API (more info: http://supervisord.org/api.html).

On a later stage, `supervisor.sh` can be called right from 'scion.sh', proxying control actions (such as run/stop).

Please tell me what you think of it. 
