### PR TITLE
Add Stacktracer to help with debugging threading problems

### DIFF
--- a/external/stacktracer.py
+++ b/external/stacktracer.py
@@ -11,7 +11,7 @@ stacktracer.stop_trace()
 # Source: http://code.activestate.com/recipes/577334-how-to-debug-deadlocked-multi-threaded-programs/
 
 
-
+from datetime import datetime
 import sys
 import traceback
 from pygments import highlight
@@ -76,6 +76,7 @@ class TraceDumper(threading.Thread):
     def stacktraces(self):
         fout = open(self.fpath,"wb+")
         try:
+            fout.write(bytes("Generated at %s" % datetime.now(), "UTF-8"))
             fout.write(bytes(stacktraces(), "UTF-8"))
         finally:
             fout.close()


### PR DESCRIPTION
[Stacktracer](http://code.activestate.com/recipes/577334-how-to-debug-deadlocked-multi-threaded-programs/) is a fairly simple module that writes a stack trace of all threads every 5s (configurable) to a html file. This should make debugging deadlocks etc much simpler.
