### PR TITLE
Make supervisord the default for process management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Necessary steps in order to run SCION:
 
 0. Install required packages with dependencies:
 
-    sudo apt-get install python3 python-dev python3-dev python3-pip screen
+    sudo apt-get install python python3 python-dev python3-dev python3-pip screen
     sudo pip3 install bitstring python-pytun pydblite
+    sudo pip2 install supervisor==3.1.3
+    sudo pip2 install supervisor-quick
 
 1. Compile the crypto library:
 

--- a/scion.sh
+++ b/scion.sh
@@ -32,17 +32,13 @@ cmd_setup() {
 
 cmd_run() {
     echo "Running the network..."
-    cd infrastructure/
-    for d in ../topology/ISD*; do
-        for f in $d/run/*; do
-            bash $f
-        done
-    done
+    supervisor/supervisor.sh reload
+    supervisor/supervisor.sh quickstart all
 }
 
 cmd_stop() {
     echo "Terminating this run of the SCION infrastructure"
-    sudo killall screen
+    supervisor/supervisor.sh quickstop all
 }
 
 cmd_clean() {


### PR DESCRIPTION
Using the supervisor-quick variant as the default is very very slow.

This should fix #57.
