### PR TITLE
Add thread error handling to stacktracer

### DIFF
--- a/external/stacktracer.py
+++ b/external/stacktracer.py
@@ -17,6 +17,8 @@ import traceback
 from pygments import highlight
 from pygments.lexers import PythonLexer
 from pygments.formatters import HtmlFormatter
+
+from lib.thread import thread_safety_net
  
  # Taken from http://bzimmer.ziclix.com/2008/12/17/python-thread-dumps/
  
@@ -58,6 +60,7 @@ class TraceDumper(threading.Thread):
         self.stop_requested = threading.Event()
         threading.Thread.__init__(self)
     
+    @thread_safety_net("stacktracer")
     def run(self):
         while not self.stop_requested.isSet():
             time.sleep(self.interval)

--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -34,11 +34,11 @@ from lib.packet.scion_addr import SCIONAddr, ISD_AD
 from lib.path_store import PathPolicy, PathStoreRecord, PathStore
 from lib.util import (read_file, write_file, get_cert_chain_file_path,
     get_sig_key_file_path, get_trc_file_path, init_logging, log_exception,
-    thread_safety_net)
+    trace)
+from lib.thread import thread_safety_net
 from lib.zookeeper import (Zookeeper, ZkConnectionLoss, ZkNoNodeError)
 from Crypto import Random
 from Crypto.Hash import SHA256
-from external.stacktracer import trace_start
 import base64
 import copy
 import datetime
@@ -942,10 +942,7 @@ def main():
             sys.argv[0])
         sys.exit()
 
-    # TODO(kormat): un-hardcode this path
-    trace_start(os.path.join(
-                    "../trace",
-                    os.environ['SUPERVISOR_PROCESS_NAME']+".trace.html"))
+    trace()
 
     if sys.argv[1] == "core":
         beacon_server = CoreBeaconServer(IPv4Address(sys.argv[2]), sys.argv[3],

--- a/infrastructure/router.py
+++ b/infrastructure/router.py
@@ -24,7 +24,8 @@ from lib.packet.pcb import PathConstructionBeacon
 from lib.packet.scion import (PacketType as PT, SCIONPacket, IFIDRequest,
     IFIDReply, get_type)
 from lib.packet.scion_addr import SCIONAddr, ISD_AD
-from lib.util import (init_logging, thread_safety_net, log_exception)
+from lib.util import (init_logging, log_exception)
+from lib.thread import thread_safety_net
 import datetime
 import logging
 import os

--- a/lib/thread.py
+++ b/lib/thread.py
@@ -1,0 +1,49 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`thread` --- Thread handling
+=================================
+
+Threading utilities for SCION.
+"""
+
+import os
+import signal
+
+# For log_exception()
+import lib.util
+
+# This is seperated out from lib.util as otherwise there's a circular
+# dependancy between util.py and stacktracer.py, causing import to fail.
+
+def kill_self():
+    """
+    Sends SIGTERM to self, to allow quitting the process from threads.
+    """
+    os.kill(os.getpid(), signal.SIGTERM)
+
+def thread_safety_net(name):
+    """
+    Decorator to handle uncaught thread exceptions, log them, then kill the
+    process.
+    """
+    def wrap(f):
+        def wrapper(*args, **kwargs):
+            try:
+                return f(*args, **kwargs)
+            except:
+                lib.util.log_exception("Exception in %s thread:", name)
+                kill_self()
+        return wrapper
+    return wrap

--- a/lib/util.py
+++ b/lib/util.py
@@ -26,10 +26,12 @@ import logging
 import signal
 import traceback
 from lib.defines import TOPOLOGY_PATH
+from external.stacktracer import trace_start
 
 CERT_DIR = 'certificates'
 SIG_KEYS_DIR = 'signature_keys'
 ENC_KEYS_DIR = 'encryption_keys'
+TRACE_DIR = "../traces"
 
 
 def _get_isd_prefix(isd_dir):
@@ -172,23 +174,7 @@ def log_exception(msg, *args, level=logging.CRITICAL, **kwargs):
     for line in traceback.format_exc().split("\n"):
         logging.log(level, line)
 
-def kill_self():
-    """
-    Sends SIGTERM to self, to allow quitting the process from threads.
-    """
-    os.kill(os.getpid(), signal.SIGTERM)
-
-def thread_safety_net(name):
-    """
-    Decorator to handle uncaught thread exceptions, log them, then kill the
-    process.
-    """
-    def wrap(f):
-        def wrapper(*args, **kwargs):
-            try:
-                return f(*args, **kwargs)
-            except:
-                log_exception("Exception in %s thread:", name)
-                kill_self()
-        return wrapper
-    return wrap
+def trace():
+    path = os.path.join(TRACE_DIR,
+                        "%s.trace.html" % os.environ['SUPERVISOR_PROCESS_NAME'])
+    trace_start(path)

--- a/lib/zookeeper.py
+++ b/lib/zookeeper.py
@@ -25,7 +25,7 @@ from kazoo.client import (KazooClient, KazooState, KazooRetry)
 from kazoo.handlers.threading import TimeoutError
 from kazoo.exceptions import (LockTimeout, SessionExpiredError,
                               NoNodeError, ConnectionLoss)
-from lib.util import (kill_self, thread_safety_net)
+from lib.thread import (kill_self, thread_safety_net)
 from lib.packet.pcb import PathSegment
 
 class ZkConnectionLoss(Exception):


### PR DESCRIPTION
stacktracer would fail if the output directory didn't exist, and without
error handling this would be lost in the logs.

Also:
- Move thread_safety_net to a new library (thread.py), as otherwise
  there was a circular import failure.
- Add a trace() function to lib.util

@pszalach @shitz 
