### PR TITLE
Start zookeeper and do scion.sh setup in full image

### DIFF
--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -2,5 +2,6 @@ FROM scionbasic
 
 RUN ./scion.sh init
 RUN ./scion.sh topology
-RUN ./scion.sh setup
-RUN bash -l -c "make -C sphinx-doc/ html"
+RUN . ~/.profile && make -C sphinx-doc/ html
+
+CMD sudo service zookeeper start; ./scion.sh setup; exec bash -l


### PR DESCRIPTION
Can't do `scion.sh setup` during build, as the IP changes only affect a running image. Ditto for starting zookeeper. Instead do them when the container is run.
