### PR TITLE
Fix so that screen can be run in docker image

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -40,11 +40,11 @@ cmd_clean_full() {
 }
 
 cmd_run_basic() {
-    docker run -i -t --rm --privileged -h scionbasic scionbasic
+    docker run -i -t --rm --privileged -h scionbasic scionbasic "$@"
 }
 
 cmd_run_full() {
-    docker run -i -t --rm --privileged -h scionfull scionfull
+    docker run -i -t --rm --privileged -h scionfull scionfull "$@"
 }
 
 stop_cntrs() {
@@ -133,8 +133,8 @@ case $COMMAND in
     build_basic)        cmd_build_basic ;;
     clean)              cmd_clean ;;
     clean_full)         cmd_clean_full ;;
-    run|run_full)       cmd_run_full ;;
-    run_basic)          cmd_run_basic ;;
+    run|run_full)       shift; cmd_run_full "$@" ;;
+    run_basic)          shift; cmd_run_basic "$@" ;;
     help)               cmd_help ;;
     *)                  cmd_help ;;
 esac

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y bu
 # Pre-download some of the known major dependancies, to speed up rebuilds.
 RUN DEBIAN_FRONTEND=noninteractive apt-get install --download-only --no-install-recommends -y python python3 python-dev python3-dev screen zookeeperd
 
-
 # Just copy over scion.sh for now, to install dependancies. Don't want docker
 # to re-run this step everytime anything in the repo changes.
 COPY _build/scion.git/scion.sh /home/scion/scion.git/
@@ -29,7 +28,15 @@ RUN apt-get clean
 
 # Now copy over the current branch
 COPY _build/scion.git /home/scion/scion.git
+# Copy over init.sh:
+COPY init.sh /home/scion/bin/
+# Install basic screen config
+COPY screenrc /home/scion/.screenrc
+
+# Fix ownership:
 RUN chown -R scion: /home/scion
+# Fix some image problems:
+RUN chmod g+s /usr/bin/screen
 
 USER scion
-CMD ["bash", "-l"]
+CMD /home/scion/bin/init.sh

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Small script to fully setup environment
+
+if [ $(hostname) == "scionfull" ]; then
+    sudo service zookeeper start
+    ./scion.sh setup
+fi
+
+# Can't be fixed during build due to
+# https://github.com/docker/docker/issues/6828
+sudo chmod g+s /usr/bin/screen
+
+# Properly setup terminal to allow use of screen, etc:
+exec bash -l >/dev/tty 2>/dev/tty </dev/tty

--- a/docker/screenrc
+++ b/docker/screenrc
@@ -1,0 +1,4 @@
+shell -bash
+startup_message off
+hardstatus alwayslastline
+hardstatus string "%-w%{= BW}%50>%n %t%{-}%+w%< %=%{= ck}A%{-}"


### PR DESCRIPTION
Also:
- Allow commands to be run in docker image from command line, for
  simpler debugging of image problems. E.g.:
    ./docker.sh run hostname
- Add basic screenrc
