### PR TITLE
Move logging functions from util.py to a new lib/log.py

### DIFF
--- a/endhost/gateway.py
+++ b/endhost/gateway.py
@@ -25,7 +25,7 @@ from pytun import TunTapDevice, IFF_TUN, IFF_NO_PI
 from endhost.sciond import SCIONDaemon
 from lib.packet.scion import SCIONPacket
 from lib.packet.scion_addr import SCIONAddr
-from lib.util import init_logging
+from lib.log import init_logging
 from infrastructure.scion_elem import SCION_UDP_EH_DATA_PORT, BUFLEN
 from ipaddress import IPv4Address
 

--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -36,9 +36,10 @@ from lib.packet.scion import (SCIONPacket, get_type, PacketType as PT,
 from lib.packet.scion_addr import SCIONAddr, ISD_AD
 from lib.path_store import PathPolicy, PathStoreRecord, PathStore
 from lib.util import (read_file, write_file, get_cert_chain_file_path,
-    get_sig_key_file_path, get_trc_file_path, init_logging, log_exception,
+    get_sig_key_file_path, get_trc_file_path,
     trace, timed, sleep_interval)
 from lib.thread import thread_safety_net
+from lib.log import (init_logging, log_exception)
 from lib.zookeeper import (Zookeeper, ZkConnectionLoss, ZkNoNodeError)
 from Crypto import Random
 from Crypto.Hash import SHA256

--- a/infrastructure/cert_server.py
+++ b/infrastructure/cert_server.py
@@ -22,7 +22,8 @@ from lib.crypto.certificate import TRC
 from lib.packet.scion import (SCIONPacket, get_type, PacketType as PT,
     CertChainRequest, CertChainReply, TRCRequest, TRCReply)
 from lib.util import (read_file, write_file, get_cert_chain_file_path,
-    get_trc_file_path, init_logging, log_exception)
+    get_trc_file_path)
+from lib.log import (init_logging, log_exception)
 import collections
 import datetime
 import logging

--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -29,7 +29,8 @@ from lib.packet.path_mgmt import (PathSegmentRecords, PathSegmentInfo,
 from lib.packet.pcb import PathSegment
 from lib.path_db import PathSegmentDB, DBResult
 from lib.packet.scion_addr import ISD_AD
-from lib.util import (update_dict, init_logging, log_exception)
+from lib.util import update_dict
+from lib.log import (init_logging, log_exception)
 import copy
 import datetime
 import logging

--- a/infrastructure/router.py
+++ b/infrastructure/router.py
@@ -24,7 +24,7 @@ from lib.packet.pcb import PathConstructionBeacon
 from lib.packet.scion import (PacketType as PT, SCIONPacket, IFIDRequest,
     IFIDReply, get_type)
 from lib.packet.scion_addr import SCIONAddr, ISD_AD
-from lib.util import (init_logging, log_exception)
+from lib.log import (init_logging, log_exception)
 from lib.thread import thread_safety_net
 import datetime
 import logging

--- a/lib/log.py
+++ b/lib/log.py
@@ -1,0 +1,57 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`log` --- Logging utilites
+===============================
+"""
+
+import logging
+import traceback
+
+# This file should not include other SCION libraries, to prevent cirular import
+# errors.
+
+class _StreamErrorHandler(logging.StreamHandler):
+    """
+    A logging StreamHandler that will exit the application if there's a logging
+    exception.
+
+    We don't try to use the normal logging system at this point because we
+    don't know if that's working at all. If it is (e.g. when the exception is a
+    formatting error), when we re-raise the exception, it'll get handled by the
+    normal process.
+    """
+    def handleError(self, record):
+        self.stream.write("Exception in logging module:\n")
+        for line in traceback.format_exc().split("\n"):
+            self.stream.write(line+"\n")
+        self.flush()
+        raise
+
+
+def init_logging(level=logging.DEBUG):
+    """
+    Configure logging for components (servers, routers, gateways).
+    """
+    logging.basicConfig(level=level,
+                        handlers=[_StreamErrorHandler()],
+                        format='%(asctime)s [%(levelname)s]\t%(message)s')
+
+def log_exception(msg, *args, level=logging.CRITICAL, **kwargs):
+    """
+    Properly format an exception before logging
+    """
+    logging.log(level, msg, *args, **kwargs)
+    for line in traceback.format_exc().split("\n"):
+        logging.log(level, line)

--- a/lib/thread.py
+++ b/lib/thread.py
@@ -21,11 +21,7 @@ Threading utilities for SCION.
 import os
 import signal
 
-# For log_exception()
-import lib.util
-
-# This is seperated out from lib.util as otherwise there's a circular
-# dependancy between util.py and stacktracer.py, causing import to fail.
+from lib.log import log_exception
 
 def kill_self():
     """
@@ -43,7 +39,7 @@ def thread_safety_net(name):
             try:
                 return f(*args, **kwargs)
             except:
-                lib.util.log_exception("Exception in %s thread:", name)
+                log_exception("Exception in %s thread:", name)
                 kill_self()
         return wrapper
     return wrap

--- a/lib/util.py
+++ b/lib/util.py
@@ -18,36 +18,18 @@
 Various utilities for SCION functionality.
 """
 
-import logging
 import os
 import signal
 import time
 import traceback
+
 from lib.defines import TOPOLOGY_PATH
 from external.stacktracer import trace_start
 
 CERT_DIR = 'certificates'
 SIG_KEYS_DIR = 'signature_keys'
 ENC_KEYS_DIR = 'encryption_keys'
-TRACE_DIR = "../traces"
-
-
-class _StreamErrorHandler(logging.StreamHandler):
-    """
-    A logging StreamHandler that will exit the application if there's a logging
-    exception.
-
-    We don't try to use the normal logging system at this point because we
-    don't know if that's working at all. If it is (e.g. when the exception is a
-    formatting error), when we re-raise the exception, it'll get handled by the
-    normal process.
-    """
-    def handleError(self, record):
-        self.stream.write("Exception in logging module:\n")
-        for line in traceback.format_exc().split("\n"):
-            self.stream.write(line+"\n")
-        self.flush()
-        raise
+TRACE_DIR = '../traces'
 
 
 def _get_isd_prefix(isd_dir):
@@ -175,25 +157,10 @@ def update_dict(dictionary, key, values, elem_num=0):
     dictionary[key] = dictionary[key][-elem_num:]
 
 
-def init_logging(level=logging.DEBUG):
-    """
-    Configure logging for components (servers, routers, gateways).
-    """
-    logging.basicConfig(level=level,
-                        handlers=[_StreamErrorHandler()],
-                        format='%(asctime)s [%(levelname)s]\t%(message)s')
-
-def log_exception(msg, *args, level=logging.CRITICAL, **kwargs):
-    """
-    Properly format an exception before logging
-    """
-    logging.log(level, msg, *args, **kwargs)
-    for line in traceback.format_exc().split("\n"):
-        logging.log(level, line)
-
 def trace():
     path = os.path.join(TRACE_DIR,
-                        "%s.trace.html" % os.environ['SUPERVISOR_PROCESS_NAME'])
+                        "%s.trace.html" %
+                        os.environ['SUPERVISOR_PROCESS_NAME'])
     trace_start(path)
 
 def timed(limit):

--- a/sphinx-doc/lib/log.rst
+++ b/sphinx-doc/lib/log.rst
@@ -1,0 +1,3 @@
+
+.. automodule:: lib.log
+   :members:


### PR DESCRIPTION
This (finally) fully solves the circular import problem:

$ for i in lib.util lib.thread lib.log lib.zookeeper external.stacktracer; do python3 -c "import $i"; done
$

Compare this with what happens now unless you're very careful about which order you import libraries:
$ for i in lib.util lib.thread lib.zookeeper external.stacktracer; do python3 -c "import $i"; done
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/kormat/github/scion/lib/thread.py", line 25, in <module>
    import lib.util
  File "/home/kormat/github/scion/lib/util.py", line 27, in <module>
    from external.stacktracer import trace_start
  File "/home/kormat/github/scion/external/stacktracer.py", line 21, in <module>
    from lib.thread import thread_safety_net
ImportError: cannot import name 'thread_safety_net'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/kormat/github/scion/lib/zookeeper.py", line 28, in <module>
    from lib.thread import (kill_self, thread_safety_net)
  File "/home/kormat/github/scion/lib/thread.py", line 25, in <module>
    import lib.util
  File "/home/kormat/github/scion/lib/util.py", line 27, in <module>
    from external.stacktracer import trace_start
  File "/home/kormat/github/scion/external/stacktracer.py", line 21, in <module>
    from lib.thread import thread_safety_net
ImportError: cannot import name 'thread_safety_net'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/kormat/github/scion/external/stacktracer.py", line 21, in <module>
    from lib.thread import thread_safety_net
  File "/home/kormat/github/scion/lib/thread.py", line 25, in <module>
    import lib.util
  File "/home/kormat/github/scion/lib/util.py", line 27, in <module>
    from external.stacktracer import trace_start
ImportError: cannot import name 'trace_start'
$
