### PR TITLE
Update error class for latest version of kazoo

### DIFF
--- a/lib/zookeeper.py
+++ b/lib/zookeeper.py
@@ -22,7 +22,7 @@ import threading
 import time
 
 from kazoo.client import (KazooClient, KazooState, KazooRetry)
-from kazoo.handlers.threading import TimeoutError
+from kazoo.handlers.threading import KazooTimeoutError
 from kazoo.exceptions import (LockTimeout, SessionExpiredError,
                               NoNodeError, ConnectionLoss)
 from lib.util import timed
@@ -127,7 +127,7 @@ class Zookeeper(object):
         logging.info("Connecting to Zookeeper")
         try:
             self._zk.start()
-        except TimeoutError:
+        except KazooTimeoutError:
             logging.critical(
                 "Timed out connecting to Zookeeper on startup, exiting")
             kill_self()


### PR DESCRIPTION
If you already have kazoo installed, you'll need to do:

```
pip3 install --upgrade --user kazoo
```

To get the latest version.
