### PR TITLE
Remove IP addresses from commandlines

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -44,7 +44,7 @@ class SCIONDaemon(SCIONElement):
     TIMEOUT = 5
 
     def __init__(self, addr, topo_file, run_local_api=False):
-        SCIONElement.__init__(self, addr, topo_file)
+        SCIONElement.__init__(self, "sciond", topo_file, host_addr=addr)
         # TODO replace by pathstore instance
         self.up_segments = PathSegmentDB()
         self.down_segments = PathSegmentDB()

--- a/infrastructure/cert_server.py
+++ b/infrastructure/cert_server.py
@@ -35,8 +35,9 @@ class CertServer(SCIONElement):
     """
     The SCION Certificate Server.
     """
-    def __init__(self, addr, topo_file, config_file, trc_file):
-        SCIONElement.__init__(self, addr, topo_file, config_file=config_file)
+    def __init__(self, server_id, topo_file, config_file, trc_file):
+        SCIONElement.__init__(self, "cs", topo_file, server_id=server_id,
+                              config_file=config_file)
         self.trc = TRC(trc_file)
         self.cert_chain_requests = collections.defaultdict(list)
         self.trc_requests = collections.defaultdict(list)
@@ -191,6 +192,7 @@ class CertServer(SCIONElement):
         else:
             logging.info("Type not supported")
 
+
 def main():
     """
     Main function.
@@ -198,11 +200,11 @@ def main():
     init_logging()
     handle_signals()
     if len(sys.argv) != 5:
-        logging.error("run: %s IP topo_file conf_file trc_file", sys.argv[0])
+        logging.error("run: %s server_id topo_file conf_file trc_file",
+                      sys.argv[0])
         sys.exit()
 
-    cert_server = CertServer(IPv4Address(sys.argv[1]), sys.argv[2],
-                             sys.argv[3], sys.argv[4])
+    cert_server = CertServer(*sys.argv[1:])
 
     logging.info("Started: %s", datetime.datetime.now())
     cert_server.run()

--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -44,8 +44,9 @@ class PathServer(SCIONElement):
     """
     MAX_SEG_NO = 5  # TODO: replace by config variable.
 
-    def __init__(self, addr, topo_file, config_file):
-        SCIONElement.__init__(self, addr, topo_file, config_file=config_file)
+    def __init__(self, server_id, topo_file, config_file):
+        SCIONElement.__init__(self, "ps", topo_file, server_id=server_id,
+                              config_file=config_file)
         # TODO replace by pathstore instance
         self.down_segments = PathSegmentDB()
         self.core_segments = PathSegmentDB()  # Direction of the propagation.
@@ -255,8 +256,8 @@ class CorePathServer(PathServer):
                 entries[:] = [e for e in entries if e.exp_time > now]
                 self._nentries += len(entries)
 
-    def __init__(self, addr, topo_file, config_file):
-        PathServer.__init__(self, addr, topo_file, config_file)
+    def __init__(self, server_id, topo_file, config_file):
+        PathServer.__init__(self, server_id, topo_file, config_file)
         # Sanity check that we should indeed be a core path server.
         assert self.topology.is_core_ad, "This shouldn't be a core PS!"
 
@@ -597,8 +598,8 @@ class LocalPathServer(PathServer):
     SCION Path Server in a non-core AD. Stores up-paths to the core and
     registers down-paths with the CPS. Can cache paths learned from a CPS.
     """
-    def __init__(self, addr, topo_file, config_file):
-        PathServer.__init__(self, addr, topo_file, config_file)
+    def __init__(self, server_id, topo_file, config_file):
+        PathServer.__init__(self, server_id, topo_file, config_file)
         # Sanity check that we should indeed be a local path server.
         assert not self.topology.is_core_ad, "This shouldn't be a local PS!"
         # Database of up-segments to the core.
@@ -869,16 +870,14 @@ def main():
     init_logging()
     handle_signals()
     if len(sys.argv) != 5:
-        logging.error("run: %s <core|local>  IP topo_file conf_file",
+        logging.error("run: %s <core|local> server_id topo_file conf_file",
                       sys.argv[0])
         sys.exit()
 
     if sys.argv[1] == "core":
-        path_server = CorePathServer(IPv4Address(sys.argv[2]), sys.argv[3],
-                                     sys.argv[4])
+        path_server = CorePathServer(*sys.argv[2:])
     elif sys.argv[1] == "local":
-        path_server = LocalPathServer(IPv4Address(sys.argv[2]), sys.argv[3],
-                                      sys.argv[4])
+        path_server = LocalPathServer(*sys.argv[2:])
     else:
         logging.error("First parameter can only be 'local' or 'core'!")
         sys.exit()

--- a/infrastructure/router.py
+++ b/infrastructure/router.py
@@ -80,7 +80,7 @@ class Router(SCIONElement):
     :vartype post_ext_handlers: dict
     """
 
-    def __init__(self, addr, topo_file, config_file, pre_ext_handlers=None,
+    def __init__(self, router_id, topo_file, config_file, pre_ext_handlers=None,
                  post_ext_handlers=None):
         """
         Constructor.
@@ -99,7 +99,8 @@ class Router(SCIONElement):
         :type post_ext_handlers: dict
 
         """
-        SCIONElement.__init__(self, addr, topo_file, config_file=config_file)
+        SCIONElement.__init__(self, "er", topo_file, server_id=router_id,
+                              config_file=config_file)
         self.interface = None
         for edge_router in self.topology.get_all_edge_routers():
             if edge_router.addr == self.addr.host_addr:
@@ -521,10 +522,10 @@ def main():
     init_logging()
     handle_signals()
     if len(sys.argv) != 4:
-        logging.error("run: %s IP topo_file conf_file", sys.argv[0])
+        logging.error("run: %s router_id topo_file conf_file", sys.argv[0])
         sys.exit()
 
-    router = Router(IPv4Address(sys.argv[1]), sys.argv[2], sys.argv[3])
+    router = Router(*sys.argv[1:])
 
     logging.info("Started: %s", datetime.datetime.now())
     router.run()

--- a/lib/topology.py
+++ b/lib/topology.py
@@ -271,3 +271,23 @@ class Topology(object):
         all_edge_routers.extend(self.peer_edge_routers)
         all_edge_routers.extend(self.routing_edge_routers)
         return all_edge_routers
+
+    def get_own_config(self, server_type, server_id):
+        target = None
+        if server_type == "bs":
+            target = self.beacon_servers
+        elif server_type == "cs":
+            target = self.certificate_servers
+        elif server_type == "ps":
+            target = self.path_servers
+        elif server_type == "er":
+            target = self.get_all_edge_routers()
+        else:
+            logging.error("Unknown server type: \"%s\"", server_type)
+
+        for i in target:
+            if i.name == server_id:
+                return i
+        else:
+            logging.error("Could not find server %s%s-%s-%s", server_type,
+                          self.isd_id, self.ad_id, server_id)

--- a/lib/util.py
+++ b/lib/util.py
@@ -42,6 +42,7 @@ _SIG_MAP = {
     SIGUSR2: "SIGUSR2"
 }
 
+
 def _get_isd_prefix(isd_dir):
     return os.path.join(isd_dir, 'ISD')
 
@@ -167,10 +168,8 @@ def update_dict(dictionary, key, values, elem_num=0):
     dictionary[key] = dictionary[key][-elem_num:]
 
 
-def trace():
-    path = os.path.join(TRACE_DIR,
-                        "%s.trace.html" %
-                        os.environ['SUPERVISOR_PROCESS_NAME'])
+def trace(id_):
+    path = os.path.join(TRACE_DIR, "%s.trace.html" % id_)
     trace_start(path)
 
 
@@ -218,6 +217,7 @@ def sleep_interval(start, interval, desc):
         delay = 0
     time.sleep(delay)
 
+
 def handle_signals():
     """
     Setup basic signal handler for the most common signals
@@ -225,6 +225,7 @@ def handle_signals():
     for sig in _SIG_MAP.keys():
         signal(sig, _signal_handler)
     pass
+
 
 def _signal_handler(signum, _):
     """

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -444,13 +444,12 @@ class ConfigGenerator():
 
         for (num, element_dict, element_type) \
                 in self._get_typed_elements(topo_dict):
-            ip_addr = element_dict['Addr']
             element_location = 'core' if topo_dict['Core'] else 'local'
             if element_type == 'BeaconServers':
                 element_name = 'bs{}-{}-{}'.format(isd_id, ad_id, num)
                 cmd_args = ['beacon_server.py',
                             element_location,
-                            ip_addr,
+                            num,
                             p['topo_file_rel'],
                             p['conf_file_rel'],
                             p['path_pol_file_rel']]
@@ -458,7 +457,7 @@ class ConfigGenerator():
             elif element_type == 'CertificateServers':
                 element_name = 'cs{}-{}-{}'.format(isd_id, ad_id, num)
                 cmd_args = ['cert_server.py',
-                            ip_addr,
+                            num,
                             p['topo_file_rel'],
                             p['conf_file_rel'],
                             p['trc_file_rel']]
@@ -466,7 +465,7 @@ class ConfigGenerator():
                 element_name = 'ps{}-{}-{}'.format(isd_id, ad_id, num)
                 cmd_args = ['path_server.py',
                             element_location,
-                            ip_addr,
+                            num,
                             p['topo_file_rel'],
                             p['conf_file_rel']]
 
@@ -477,7 +476,7 @@ class ConfigGenerator():
                 element_name = 'er{}-{}er{}-{}'.format(isd_id, ad_id,
                                                        nbr_isd_id, nbr_ad_id)
                 cmd_args = ['router.py',
-                            ip_addr,
+                            num,
                             p['topo_file_rel'],
                             p['conf_file_rel']]
             else:


### PR DESCRIPTION
Building on @rev112's work, the infrastructure servers now get an ID on
the commandline, and then look up their specific config in the topology
file. It gets rid of redundant information (IP on commandline and in
topology file), allows each server to know their own identity, and means
i can remove the depdancy on the special supervisor env var.

@pszalach :)
