### PR TITLE
Import and formatting cleanup

### DIFF
--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -15,34 +15,7 @@
 :mod:`beacon_server` --- SCION beacon server
 ============================================
 """
-
-from _collections import deque, defaultdict
-from asyncio.tasks import sleep
-from infrastructure.router import IFID_PKT_TOUT
-from infrastructure.scion_elem import SCIONElement
-from ipaddress import IPv4Address
-from lib.crypto.asymcrypto import sign
-from lib.crypto.certificate import verify_sig_chain_trc, CertificateChain, TRC
-from lib.crypto.hash_chain import HashChain
-from lib.packet.opaque_field import (OpaqueFieldType as OFT, InfoOpaqueField,
-    SupportSignatureField, HopOpaqueField, SupportPCBField, SupportPeerField,
-    TRCField)
-from lib.packet.path_mgmt import (PathSegmentInfo, PathSegmentRecords,
-    PathSegmentType as PST, PathMgmtPacket, PathMgmtType as PMT, RevocationInfo,
-    RevocationPayload, RevocationType as RT)
-from lib.packet.pcb import (PathSegment, ADMarking, PCBMarking, PeerMarking,
-    PathConstructionBeacon)
-from lib.packet.scion import (SCIONPacket, get_type, PacketType as PT,
-    CertChainRequest, CertChainReply, TRCRequest, TRCReply, IFIDPacket)
-from lib.packet.scion_addr import SCIONAddr, ISD_AD
-from lib.path_store import PathPolicy, PathStoreRecord, PathStore
-from lib.util import (read_file, write_file, get_cert_chain_file_path,
-    get_sig_key_file_path, get_trc_file_path,
-    trace, timed, sleep_interval, handle_signals)
-from lib.thread import thread_safety_net
-from lib.log import (init_logging, log_exception)
-from lib.zookeeper import (Zookeeper, ZkConnectionLoss, ZkNoNodeError)
-from Crypto.Hash import SHA256
+# Stdlib
 import base64
 import copy
 import datetime
@@ -51,6 +24,69 @@ import os
 import sys
 import threading
 import time
+from _collections import defaultdict, deque
+
+# External packages
+from Crypto.Hash import SHA256
+
+# SCION
+from infrastructure.router import IFID_PKT_TOUT
+from infrastructure.scion_elem import SCIONElement
+from lib.crypto.asymcrypto import sign
+from lib.crypto.certificate import CertificateChain, TRC, verify_sig_chain_trc
+from lib.crypto.hash_chain import HashChain
+from lib.log import init_logging, log_exception
+from lib.packet.opaque_field import (
+    HopOpaqueField,
+    InfoOpaqueField,
+    OpaqueFieldType as OFT,
+    SupportPCBField,
+    SupportPeerField,
+    SupportSignatureField,
+    TRCField,
+)
+from lib.packet.path_mgmt import (
+    PathMgmtPacket,
+    PathMgmtType as PMT,
+    PathSegmentInfo,
+    PathSegmentRecords,
+    PathSegmentType as PST,
+    RevocationInfo,
+    RevocationPayload,
+    RevocationType as RT,
+)
+from lib.packet.pcb import (
+    ADMarking,
+    PCBMarking,
+    PathConstructionBeacon,
+    PathSegment,
+    PeerMarking,
+)
+from lib.packet.scion import (
+    CertChainReply,
+    CertChainRequest,
+    IFIDPacket,
+    PacketType as PT,
+    SCIONPacket,
+    TRCReply,
+    TRCRequest,
+    get_type,
+)
+from lib.packet.scion_addr import SCIONAddr, ISD_AD
+from lib.path_store import PathPolicy, PathStore
+from lib.util import (
+    get_cert_chain_file_path,
+    get_sig_key_file_path,
+    get_trc_file_path,
+    handle_signals,
+    read_file,
+    sleep_interval,
+    timed,
+    trace,
+    write_file,
+)
+from lib.thread import thread_safety_net
+from lib.zookeeper import ZkConnectionLoss, ZkNoNodeError, Zookeeper
 
 
 class InterfaceState(object):
@@ -289,8 +325,8 @@ class BeaconServer(SCIONElement):
         assert isinstance(pcb, PathSegment)
         last_pcbm = pcb.get_last_pcbm()
         if self._check_certs_trc(last_pcbm.spcbf.isd_id, last_pcbm.ad_id,
-            last_pcbm.ssf.cert_chain_version, pcb.trcf.trc_version,
-            pcb.trcf.if_id):
+                                 last_pcbm.ssf.cert_chain_version,
+                                 pcb.trcf.trc_version, pcb.trcf.if_id):
             if self._verify_beacon(pcb):
                 self._handle_verified_beacon(pcb)
             else:
@@ -315,7 +351,8 @@ class BeaconServer(SCIONElement):
         if not trc:
             # Try loading file from disk
             trc_file = get_trc_file_path(self.topology.isd_id,
-                self.topology.ad_id, isd_id, trc_version)
+                                         self.topology.ad_id,
+                                         isd_id, trc_version)
             if os.path.exists(trc_file):
                 trc = TRC(trc_file)
                 self.trcs[(isd_id, trc_version)] = trc
@@ -325,9 +362,10 @@ class BeaconServer(SCIONElement):
             now = int(time.time())
             if (trc_tuple not in self.trc_requests or
                 (now - self.trc_requests[trc_tuple] >
-                BeaconServer.REQUESTS_TIMEOUT)):
-                new_trc_req = TRCRequest.from_values(PT.TRC_REQ_LOCAL,
-                    self.addr, if_id, self.topology.isd_id, self.topology.ad_id,
+                    BeaconServer.REQUESTS_TIMEOUT)):
+                new_trc_req = TRCRequest.from_values(
+                    PT.TRC_REQ_LOCAL, self.addr, if_id,
+                    self.topology.isd_id, self.topology.ad_id,
                     isd_id, trc_version)
                 dst_addr = self.topology.certificate_servers[0].addr
                 self.send(new_trc_req, dst_addr)
@@ -347,14 +385,15 @@ class BeaconServer(SCIONElement):
         cert_chain_version = last_pcbm.ssf.cert_chain_version
         trc_version = pcb.trcf.trc_version
         subject = 'ISD:' + str(cert_chain_isd) + '-AD:' + str(cert_chain_ad)
-        cert_chain_file = get_cert_chain_file_path(self.topology.isd_id,
-            self.topology.ad_id, cert_chain_isd, cert_chain_ad,
-            cert_chain_version)
+        cert_chain_file = get_cert_chain_file_path(
+            self.topology.isd_id, self.topology.ad_id,
+            cert_chain_isd, cert_chain_ad, cert_chain_version)
         if os.path.exists(cert_chain_file):
             chain = CertificateChain(cert_chain_file)
         else:
             chain = CertificateChain.from_values([])
-        trc_file = get_trc_file_path(self.topology.isd_id, self.topology.ad_id,
+        trc_file = get_trc_file_path(
+            self.topology.isd_id, self.topology.ad_id,
             cert_chain_isd, trc_version)
         trc = TRC(trc_file)
         data_to_verify = (str(cert_chain_ad).encode('utf-8') +
@@ -376,7 +415,8 @@ class BeaconServer(SCIONElement):
         """
         assert isinstance(trc_rep, TRCReply)
         logging.info("TRC reply received.")
-        trc_file = get_trc_file_path(self.topology.isd_id, self.topology.ad_id,
+        trc_file = get_trc_file_path(
+            self.topology.isd_id, self.topology.ad_id,
             trc_rep.isd_id, trc_rep.version)
         write_file(trc_file, trc_rep.trc.decode('utf-8'))
         self.trcs[(trc_rep.isd_id, trc_rep.version)] = TRC(trc_file)
@@ -681,9 +721,9 @@ class LocalBeaconServer(BeaconServer):
         self.down_segments = PathStore(self.path_policy)
         self.cert_chain_requests = {}
         self.cert_chains = {}
-        cert_chain_file = get_cert_chain_file_path(self.topology.isd_id,
-            self.topology.ad_id, self.topology.isd_id, self.topology.ad_id,
-            self.config.cert_chain_version)
+        cert_chain_file = get_cert_chain_file_path(
+            self.topology.isd_id, self.topology.ad_id, self.topology.isd_id,
+            self.topology.ad_id, self.config.cert_chain_version)
         self.cert_chain = CertificateChain(cert_chain_file)
 
     def _check_certs_trc(self, isd_id, ad_id, cert_chain_version, trc_version,
@@ -698,8 +738,9 @@ class LocalBeaconServer(BeaconServer):
                                                cert_chain_version))
             if not cert_chain:
                 # Try loading file from disk
-                cert_chain_file = get_cert_chain_file_path(self.topology.isd_id,
-                    self.topology.ad_id, isd_id, ad_id, cert_chain_version)
+                cert_chain_file = get_cert_chain_file_path(
+                    self.topology.isd_id, self.topology.ad_id,
+                    isd_id, ad_id, cert_chain_version)
                 if os.path.exists(cert_chain_file):
                     cert_chain = CertificateChain(cert_chain_file)
                     self.cert_chains[(isd_id, ad_id,
@@ -712,9 +753,10 @@ class LocalBeaconServer(BeaconServer):
                 now = int(time.time())
                 if (cert_chain_tuple not in self.cert_chain_requests or
                     (now - self.cert_chain_requests[cert_chain_tuple] >
-                    BeaconServer.REQUESTS_TIMEOUT)):
+                        BeaconServer.REQUESTS_TIMEOUT)):
                     new_cert_chain_req = \
-                        CertChainRequest.from_values(PT.CERT_CHAIN_REQ_LOCAL,
+                        CertChainRequest.from_values(
+                            PT.CERT_CHAIN_REQ_LOCAL,
                             self.addr, if_id, self.topology.isd_id,
                             self.topology.ad_id, isd_id, ad_id,
                             cert_chain_version)
@@ -729,9 +771,9 @@ class LocalBeaconServer(BeaconServer):
         """
         Send up-segment to Local Path Servers
         """
-        info = PathSegmentInfo.from_values(PST.UP, self.topology.isd_id,
-            self.topology.isd_id, pcb.get_first_pcbm().ad_id,
-            self.topology.ad_id)
+        info = PathSegmentInfo.from_values(
+            PST.UP, self.topology.isd_id, self.topology.isd_id,
+            pcb.get_first_pcbm().ad_id, self.topology.ad_id)
         # TODO: pick other than the first path server
         dst = SCIONAddr.from_values(self.topology.isd_id,
                                     self.topology.ad_id,
@@ -745,9 +787,9 @@ class LocalBeaconServer(BeaconServer):
         """
         Send down-segment to Core Path Server
         """
-        info = PathSegmentInfo.from_values(PST.DOWN, self.topology.isd_id,
-            self.topology.isd_id, pcb.get_first_pcbm().ad_id,
-            self.topology.ad_id)
+        info = PathSegmentInfo.from_values(
+            PST.DOWN, self.topology.isd_id, self.topology.isd_id,
+            pcb.get_first_pcbm().ad_id, self.topology.ad_id)
         core_path = pcb.get_path(reverse_direction=True)
         records = PathSegmentRecords.from_values(info, [pcb])
         dst_isd_ad = ISD_AD(pcb.get_isd(), pcb.get_first_pcbm().ad_id)
@@ -794,16 +836,20 @@ class LocalBeaconServer(BeaconServer):
         """
         assert isinstance(cert_chain_rep, CertChainReply)
         logging.info("Certificate chain reply received.")
-        cert_chain_file = get_cert_chain_file_path(self.topology.isd_id,
-            self.topology.ad_id, cert_chain_rep.isd_id, cert_chain_rep.ad_id,
+        cert_chain_file = get_cert_chain_file_path(
+            self.topology.isd_id, self.topology.ad_id,
+            cert_chain_rep.isd_id, cert_chain_rep.ad_id,
             cert_chain_rep.version)
         write_file(cert_chain_file, cert_chain_rep.cert_chain.decode('utf-8'))
-        self.cert_chains[(cert_chain_rep.isd_id, cert_chain_rep.ad_id,
-            cert_chain_rep.version)] = CertificateChain(cert_chain_file)
+        self.cert_chains[
+            (cert_chain_rep.isd_id,
+             cert_chain_rep.ad_id,
+             cert_chain_rep.version)] = CertificateChain(cert_chain_file)
         if (cert_chain_rep.isd_id, cert_chain_rep.ad_id,
-            cert_chain_rep.version) in self.cert_chain_requests:
+                cert_chain_rep.version) in self.cert_chain_requests:
             del self.cert_chain_requests[(cert_chain_rep.isd_id,
-                cert_chain_rep.ad_id, cert_chain_rep.version)]
+                                          cert_chain_rep.ad_id,
+                                          cert_chain_rep.version)]
         self.handle_unverified_beacons()
 
     def _process_revocation(self, rev_info):
@@ -829,22 +875,22 @@ class LocalBeaconServer(BeaconServer):
                 if rev_info.rev_token1 in cand.pcb.get_all_iftokens():
                     to_remove.append(cand.pcb.segment_id)
                     if cand in self.up_segments.candidates:
-                        info = RevocationInfo.from_values(RT.UP_SEGMENT,
-                            rev_info.rev_token1, rev_info.proof1,
-                            True, cand.pcb.segment_id)
+                        info = RevocationInfo.from_values(
+                            RT.UP_SEGMENT, rev_info.rev_token1,
+                            rev_info.proof1, True, cand.pcb.segment_id)
                         rev_infos.append(info)
         elif rev_info.rev_type == RT.HOP:
             # Go through all candidates that contain both interface tokens.
             for cand in (self.down_segments.candidates +
                          self.up_segments.candidates):
                 if (rev_info.rev_token1 in cand.pcb.get_all_iftokens() and
-                    rev_info.rev_token2 in cand.pcb.get_all_iftokens()):
+                        rev_info.rev_token2 in cand.pcb.get_all_iftokens()):
                     to_remove.append(cand.pcb.segment_id)
                     if cand in self.up_segments:
-                        info = RevocationInfo.from_values(RT.UP_SEGMENT,
-                            rev_info.rev_token1, rev_info.proof1,
-                            True, cand.pcb.segment_id,
-                            True, rev_info.rev_token2, rev_info.rev_token2)
+                        info = RevocationInfo.from_values(
+                            RT.UP_SEGMENT, rev_info.rev_token1, rev_info.proof1,
+                            True, cand.pcb.segment_id, True,
+                            rev_info.rev_token2, rev_info.rev_token2)
                         rev_infos.append(info)
 
         # Remove the affected segments from the path stores.

--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -15,27 +15,36 @@
 :mod:`path_server` --- SCION path server
 ========================================
 """
-
-from _collections import defaultdict
-from external.expiring_dict import ExpiringDict
-from infrastructure.scion_elem import SCIONElement
-from ipaddress import IPv4Address
-from lib.crypto.hash_chain import HashChain
-from lib.packet.path import EmptyPath
-from lib.packet.path_mgmt import (PathSegmentRecords, PathSegmentInfo,
-    PathSegmentType as PST, PathMgmtPacket, PathMgmtType as PMT,
-    PathSegmentLeases, RevocationPayload, RevocationType as RT, RevocationInfo,
-    LeaseInfo)
-from lib.packet.pcb import PathSegment
-from lib.path_db import PathSegmentDB, DBResult
-from lib.packet.scion_addr import ISD_AD
-from lib.util import (update_dict, handle_signals)
-from lib.log import (init_logging, log_exception)
+# Stdlib
 import copy
 import datetime
 import logging
 import sys
 import time
+from _collections import defaultdict
+
+# External packages
+from external.expiring_dict import ExpiringDict
+
+# SCION
+from infrastructure.scion_elem import SCIONElement
+from lib.crypto.hash_chain import HashChain
+from lib.log import init_logging, log_exception
+from lib.packet.path_mgmt import (
+    LeaseInfo,
+    PathMgmtPacket,
+    PathMgmtType as PMT,
+    PathSegmentInfo,
+    PathSegmentLeases,
+    PathSegmentRecords,
+    PathSegmentType as PST,
+    RevocationInfo,
+    RevocationPayload,
+    RevocationType as RT,
+)
+from lib.packet.scion_addr import ISD_AD
+from lib.path_db import DBResult, PathSegmentDB
+from lib.util import handle_signals, update_dict
 
 
 class PathServer(SCIONElement):
@@ -81,8 +90,8 @@ class PathServer(SCIONElement):
         # Verify revocation token.
         if not HashChain.verify(rev_info.proof1, rev_info.rev_token1):
             return False
-        if (rev_info.incl_hop and
-            not HashChain.verify(rev_info.proof2, rev_info.rev_token2)):
+        if (rev_info.incl_hop and not HashChain.verify(rev_info.proof2,
+                                                       rev_info.rev_token2)):
             return False
 
         return True
@@ -99,7 +108,8 @@ class PathServer(SCIONElement):
         tokens = segment.get_all_iftokens()
         if ((rev_info.rev_token1 == segment.segment_id) or
             (not rev_info.incl_hop and rev_info.rev_token1 in tokens) or
-            (rev_info.rev_token1 in tokens and rev_info.rev_token2 in tokens)):
+                (rev_info.rev_token1 in tokens and
+                 rev_info.rev_token2 in tokens)):
             return True
 
         return False
@@ -446,7 +456,7 @@ class CorePathServer(PathServer):
                 if cpaths:
                     path = cpaths[0].get_path(reverse_direction=True)
                     dst_isd_ad = ISD_AD(cpaths[0].get_first_pcbm().spcbf.isd_id,
-                                  cpaths[0].get_first_pcbm().ad_id)
+                                        cpaths[0].get_first_pcbm().ad_id)
                     if_id = path.get_first_hop_of().ingress_if
                     next_hop = self.ifid2addr[if_id]
                     request = PathMgmtPacket.from_values(PMT.REQUEST,

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -22,17 +22,16 @@ Module docstring here.
 
 """
 
-from lib.config import Config
-from lib.packet.scion_addr import SCIONAddr
-from lib.topology import Topology
+# Stdlib
 import logging
 import select
 import socket
 
-
-SCION_UDP_PORT = 30040
-SCION_UDP_EH_DATA_PORT = 30041
-BUFLEN = 8092
+# SCION
+from lib.config import Config
+from lib.defines import SCION_BUFLEN, SCION_UDP_PORT
+from lib.packet.scion_addr import SCIONAddr
+from lib.topology import Topology
 
 
 class SCIONElement(object):
@@ -200,7 +199,7 @@ class SCIONElement(object):
         while True:
             recvlist, _, _ = select.select(self._sockets, [], [])
             for sock in recvlist:
-                packet, addr = sock.recvfrom(BUFLEN)
+                packet, addr = sock.recvfrom(SCION_BUFLEN)
                 self.handle_request(packet, addr, sock == self._local_socket)
 
     def clean(self):

--- a/lib/config.py
+++ b/lib/config.py
@@ -15,7 +15,7 @@
 :mod:`config` --- SCION configuration parser
 ============================================
 """
-
+# Stdlib
 import json
 import logging
 

--- a/lib/defines.py
+++ b/lib/defines.py
@@ -14,11 +14,9 @@
 """
 :mod:`defines` --- Constants
 ============================
-
 Contains constant definitions used throughout the codebase.
-
 """
-
+# Stdlib
 import os
 
 #: Max TTL of a PathSegment in realtime seconds.
@@ -30,3 +28,10 @@ EXP_TIME_UNIT = MAX_SEGMENT_TTL / 2 ** 8
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 #: Topology subdir path
 TOPOLOGY_PATH = os.path.join(PROJECT_ROOT, 'topology')
+
+#: Buffer size for receiving packets
+SCION_BUFLEN = 8092
+#: Default SCION server data port
+SCION_UDP_PORT = 30040
+#: Default SCION endhost data port
+SCION_UDP_EH_DATA_PORT = 30041

--- a/lib/log.py
+++ b/lib/log.py
@@ -15,7 +15,7 @@
 :mod:`log` --- Logging utilites
 ===============================
 """
-
+# Stdlib
 import logging
 import traceback
 

--- a/lib/packet/ext_hdr.py
+++ b/lib/packet/ext_hdr.py
@@ -15,11 +15,14 @@
 :mod:`ext_hdr` --- Extension header classes
 ===========================================
 """
+# Stdlib
 import logging
 
-from bitstring import BitArray
+# External packages
 import bitstring
+from bitstring import BitArray
 
+# SCION
 from lib.packet.packet_base import HeaderBase
 
 
@@ -45,7 +48,7 @@ class ExtensionHeader(HeaderBase):
         dlen = len(raw)
         if dlen < ExtensionHeader.MIN_LEN:
             logging.warning("Data too short to parse extension hdr: "
-                "data len %u", dlen)
+                            "data len %u", dlen)
             return
         bits = BitArray(bytes=raw)
         self.next_ext, self.hdr_len = bits.unpack("uintbe:8, uintbe:8")
@@ -75,8 +78,9 @@ class ICNExtHdr(ExtensionHeader):
 
     def __init__(self, raw=None):
         ExtensionHeader.__init__(self)
-        self.fwd_flag = 0  # Tells the edge router whether to forward this pkt
-                           # to the local Content Cache or to the next AD.
+        # Tells the edge router whether to forward this pkt
+        # to the local Content Cache or to the next AD.
+        self.fwd_flag = 0
 #         self.src_addr_len = 0  # src addr len (6 bits)
 #         self.dst_addr_len = 0  # dst addr len (6 bits)
 #         self.cid = 0  # Content ID (20 bytes)
@@ -91,7 +95,7 @@ class ICNExtHdr(ExtensionHeader):
         dlen = len(raw)
         if dlen < ExtensionHeader.MIN_LEN:
             logging.warning("Data too short to parse ICN extension hdr: "
-                "data len %u", dlen)
+                            "data len %u", dlen)
             return
         bits = BitArray(bytes=raw)
         (self.next_ext, self.hdr_len, self.fwd_flag, _rsvd) = \
@@ -101,7 +105,8 @@ class ICNExtHdr(ExtensionHeader):
 
     def pack(self):
         return bitstring.pack("uintbe:8, uintbe:8, uintbe:8, uintbe:40",
-            self.next_ext, self.hdr_len, self.fwd_flag, 0).bytes
+                              self.next_ext, self.hdr_len,
+                              self.fwd_flag, 0).bytes
 
     def __len__(self):
         return ICNExtHdr.MIN_LEN

--- a/lib/packet/opaque_field.py
+++ b/lib/packet/opaque_field.py
@@ -15,10 +15,12 @@
 :mod:`opaque_field` --- SCION Opaque fields
 ===========================================
 """
-
-from bitstring import BitArray
+# Stdlib
 import logging
+
+# External packages
 import bitstring
+from bitstring import BitArray
 
 
 class OpaqueFieldType(object):
@@ -127,8 +129,8 @@ class HopOpaqueField(OpaqueField):
             logging.warning("HOF: Data too short for parsing, len: %u", dlen)
             return
         bits = BitArray(bytes=raw)
-        (self.info, self.exp_time, ifs, self.mac) = bits.unpack("uintbe:8, " +
-            "uintbe:8, uintbe:24, uintbe:24")
+        (self.info, self.exp_time, ifs, self.mac) = bits.unpack(
+            "uintbe:8, uintbe:8, uintbe:24, uintbe:24")
         self.ingress_if = (ifs & 0xFFF000) >> 12
         self.egress_if = ifs & 0x000FFF
         self.parsed = True
@@ -167,9 +169,10 @@ class HopOpaqueField(OpaqueField):
             return False
 
     def __str__(self):
-        hof_str = (("[Hop OF info: %u, exp_time: %d, ingress if: %u, " +
-                    "egress if: %u, mac: %x]") % (self.info, self.exp_time,
-                      self.ingress_if, self.egress_if, self.mac))
+        hof_str = ("[Hop OF info: %u, exp_time: %d, ingress if: %u, "
+                   "egress if: %u, mac: %x]" % (
+                       self.info, self.exp_time, self.ingress_if,
+                       self.egress_if, self.mac))
         return hof_str
 
 
@@ -233,12 +236,14 @@ class InfoOpaqueField(OpaqueField):
         Returns InfoOpaqueFIeld as 8 byte binary string.
         """
         info = (self.info << 1) + self.up_flag
-        return bitstring.pack("uintbe:8, uintbe:32, uintbe:16, uintbe:8",
+        return bitstring.pack(
+            "uintbe:8, uintbe:32, uintbe:16, uintbe:8",
             info, self.timestamp, self.isd_id, self.hops).bytes
 
     def __str__(self):
         iof_str = ("[Info OF info: %x, up: %r, TS: %u, ISD ID: %u, hops: %u]" %
-            (self.info, self.up_flag, self.timestamp, self.isd_id, self.hops))
+                   (self.info, self.up_flag, self.timestamp, self.isd_id,
+                    self.hops))
         return iof_str
 
     def __eq__(self, other):
@@ -303,12 +308,13 @@ class TRCField(OpaqueField):
         """
         Returns TRCField as 8 byte binary string.
         """
-        return bitstring.pack("uintbe:8, uintbe:32, uintbe:16, uintbe:8",
+        return bitstring.pack(
+            "uintbe:8, uintbe:32, uintbe:16, uintbe:8",
             self.info, self.trc_version, self.if_id, self.reserved).bytes
 
     def __str__(self):
         trcf_str = ("[TRC OF info: %x, TRCv: %u, IF ID: %u]\n" %
-            (self.info, self.trc_version, self.if_id))
+                    (self.info, self.trc_version, self.if_id))
         return trcf_str
 
     def __eq__(self, other):
@@ -376,9 +382,9 @@ class SupportSignatureField(OpaqueField):
                               self.block_size).bytes
 
     def __str__(self):
-        ssf_str = ("[Support Signature OF cert_chain_version: %x, " +
-            "sig_len: %u, block_size: %u]\n") % (self.cert_chain_version,
-            self.sig_len, self.block_size)
+        ssf_str = ("[Support Signature OF cert_chain_version: %x, "
+                   "sig_len: %u, block_size: %u]\n" % (
+                       self.cert_chain_version, self.sig_len, self.block_size))
         return ssf_str
 
     def __eq__(self, other):
@@ -449,14 +455,16 @@ class SupportPeerField(OpaqueField):
         """
         Returns SupportPeerField as 8 byte binary string.
         """
-        return bitstring.pack("uintbe:16, uintbe:8, uintbe:8, uint:1, uint:31",
+        return bitstring.pack(
+            "uintbe:16, uintbe:8, uintbe:8, uint:1, uint:31",
             self.isd_id, self.bwalloc_f, self.bwalloc_r, self.bw_class,
             self.reserved).bytes
 
     def __str__(self):
-        spf_str = ("[Support Peer OF TD ID: %x, bwalloc_f: %u, " +
-            "bwalloc_r: %u, bw_class: %u]\n") % (self.isd_id, self.bwalloc_f,
-            self.bwalloc_r, self.bw_class)
+        spf_str = ("[Support Peer OF TD ID: %x, bwalloc_f: %u, "
+                   "bwalloc_r: %u, bw_class: %u]\n" % (
+                       self.isd_id, self.bwalloc_f, self.bwalloc_r,
+                       self.bw_class))
         return spf_str
 
     def __eq__(self, other):
@@ -536,14 +544,15 @@ class SupportPCBField(OpaqueField):
         """
         Returns SupportPCBField as 8 byte binary string.
         """
-        return bitstring.pack("uintbe:16, uintbe:8, uintbe:8, uintbe:8, "
+        return bitstring.pack(
+            "uintbe:16, uintbe:8, uintbe:8, uintbe:8, "
             "uintbe:8, uintbe:8, uintbe:8", self.isd_id, self.bwalloc_f,
             self.bwalloc_r, self.dyn_bwalloc_f, self.dyn_bwalloc_r, self.bebw_f,
             self.bebw_r).bytes
 
     def __str__(self):
         spcbf_str = ("[Info OF TD ID: %x, bwalloc_f: %u, bwalloc_r: %u]\n" %
-            (self.isd_id, self.bwalloc_f, self.bwalloc_r))
+                     (self.isd_id, self.bwalloc_f, self.bwalloc_r))
         return spcbf_str
 
     def __eq__(self, other):

--- a/lib/packet/packet_base.py
+++ b/lib/packet/packet_base.py
@@ -82,8 +82,8 @@ class PacketBase(object):
         Set the packet payload.  Expects bytes or a Packet subclass.
         """
         if (not isinstance(new_payload, PacketBase) and
-            not isinstance(new_payload, PayloadBase) and
-            not isinstance(new_payload, bytes)):
+                not isinstance(new_payload, PayloadBase) and
+                not isinstance(new_payload, bytes)):
             raise TypeError("payload must be bytes or packet/payload subclass.")
         else:
             self._payload = new_payload

--- a/lib/packet/path.py
+++ b/lib/packet/path.py
@@ -16,9 +16,15 @@
 ==================================
 """
 
+# Stdlib
 import copy
-from lib.packet.opaque_field import (InfoOpaqueField, HopOpaqueField,
-    OpaqueFieldType)
+
+# SCION
+from lib.packet.opaque_field import (
+    HopOpaqueField,
+    InfoOpaqueField,
+    OpaqueFieldType,
+)
 
 
 class PathBase(object):
@@ -399,7 +405,6 @@ class PeerPath(PathBase):
             HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN])
         offset += HopOpaqueField.LEN
 
-
         # Parse down-segment
         self.down_segment_info = \
             InfoOpaqueField(raw[offset:offset + InfoOpaqueField.LEN])
@@ -529,20 +534,20 @@ class PathCombinator(object):
         down-segment orientation.
         """
         if (not up_segment or not down_segment or
-            not up_segment.ads or not down_segment.ads):
+                not up_segment.ads or not down_segment.ads):
             return None
 
         # If we have a core segment, check that the core_segment connects the
         # up_ and down_segment. Otherwise, check that up- and down-segment meet
         # at a single core AD.
         if ((core_segment and
-             (core_segment.get_last_pcbm().ad_id !=
-              up_segment.get_first_pcbm().ad_id) or
-             (core_segment.get_first_pcbm().ad_id !=
-              down_segment.get_first_pcbm().ad_id)) or
-             (not core_segment and
-              (up_segment.get_first_pcbm().ad_id !=
-               down_segment.get_first_pcbm().ad_id))):
+                (core_segment.get_last_pcbm().ad_id !=
+                 up_segment.get_first_pcbm().ad_id) or
+                (core_segment.get_first_pcbm().ad_id !=
+                 down_segment.get_first_pcbm().ad_id)) or
+                (not core_segment and
+                 (up_segment.get_first_pcbm().ad_id !=
+                  down_segment.get_first_pcbm().ad_id))):
             return None
 
         full_path = CorePath()
@@ -630,7 +635,7 @@ class PathCombinator(object):
         """
         # TODO check if stub ADs are the same...
         if (not up_segment or not down_segment or
-            not up_segment.ads or not down_segment.ads):
+                not up_segment.ads or not down_segment.ads):
             return None
         # looking for xovr and peer points
         xovrs = []
@@ -702,4 +707,3 @@ class PathCombinator(object):
                 if path and path not in paths:
                     paths.append(path)
         return paths
-

--- a/lib/packet/path_mgmt.py
+++ b/lib/packet/path_mgmt.py
@@ -17,16 +17,19 @@
 
 Contains all the packet formats used for path management.
 """
-
-from lib.packet.packet_base import PayloadBase
-from lib.packet.pcb import PathSegment
-from lib.packet.scion import SCIONPacket, PacketType, SCIONHeader
-from lib.packet.scion_addr import SCIONAddr, ISD_AD
+# Stdlib
 import logging
 import struct
 
-from bitstring import BitArray
+# Stdlib
 import bitstring
+from bitstring import BitArray
+
+# SCION
+from lib.packet.packet_base import PayloadBase
+from lib.packet.pcb import PathSegment
+from lib.packet.scion import PacketType, SCIONPacket, SCIONHeader
+from lib.packet.scion_addr import ISD_AD, SCIONAddr
 
 
 class PathMgmtType:
@@ -156,6 +159,7 @@ class LeaseInfo(PayloadBase):
     Class containing necessary information for a path-segment lease.
     """
     LEN = 1 + 2 + 2 + 4 + 32
+
     def __init__(self, raw=None):
         PayloadBase.__init__(self)
         self.seg_type = PathSegmentType.DOWN

--- a/lib/packet/pcb.py
+++ b/lib/packet/pcb.py
@@ -15,20 +15,29 @@
 :mod:`pcb` --- SCION Beacon
 ===========================
 """
-
-from lib.defines import EXP_TIME_UNIT
-from lib.packet.opaque_field import (SupportSignatureField, HopOpaqueField,
-    SupportPCBField, SupportPeerField, TRCField, InfoOpaqueField)
-from lib.packet.path import CorePath
-from lib.packet.scion import SCIONPacket, PacketType, SCIONHeader
-from lib.packet.scion_addr import SCIONAddr
+# Stdlib
 import base64
 import copy
 import logging
 
+# External packages
+import bitstring
 from Crypto.Hash import SHA256
 from bitstring import BitArray
-import bitstring
+
+# SCION
+from lib.defines import EXP_TIME_UNIT
+from lib.packet.opaque_field import (
+    HopOpaqueField,
+    InfoOpaqueField,
+    SupportPCBField,
+    SupportPeerField,
+    SupportSignatureField,
+    TRCField,
+)
+from lib.packet.path import CorePath
+from lib.packet.scion import PacketType, SCIONHeader, SCIONPacket
+from lib.packet.scion_addr import SCIONAddr
 
 
 class Marking(object):
@@ -312,8 +321,8 @@ class ADMarking(Marking):
         ad_str += str(self.pcbm)
         for peer_marking in self.pms:
             ad_str += str(peer_marking)
-        ad_str += ("[Signature: " + base64.b64encode(self.sig).decode('utf-8') +
-            "]\n")
+        ad_str += ("[Signature: %s]\n" %
+                   base64.b64encode(self.sig).decode('utf-8'))
         return ad_str
 
     def __eq__(self, other):
@@ -593,4 +602,3 @@ class PathConstructionBeacon(SCIONPacket):
     def pack(self):
         self.payload = self.pcb.pack()
         return SCIONPacket.pack(self)
-

--- a/lib/packet/scion.py
+++ b/lib/packet/scion.py
@@ -15,19 +15,31 @@
 :mod:`scion` --- SCION packets
 ===========================================
 """
-
-from lib.packet.ext_hdr import ExtensionHeader, ICNExtHdr
-from lib.packet.opaque_field import (InfoOpaqueField, OpaqueField,
-                                     OpaqueFieldType as OFT)
-from lib.packet.packet_base import HeaderBase, PacketBase
-from lib.packet.path import (CorePath, PeerPath, CrossOverPath,
-                             EmptyPath, PathBase)
-from lib.packet.scion_addr import SCIONAddr, ISD_AD
-from bitstring import BitArray
-import bitstring
-from ipaddress import IPv4Address
+# Stdlib
 import logging
 import struct
+from ipaddress import IPv4Address
+
+# External packages
+import bitstring
+from bitstring import BitArray
+
+# SCION
+from lib.packet.ext_hdr import ExtensionHeader, ICNExtHdr
+from lib.packet.opaque_field import (
+    InfoOpaqueField,
+    OpaqueField,
+    OpaqueFieldType as OFT,
+)
+from lib.packet.packet_base import HeaderBase, PacketBase
+from lib.packet.path import (
+    CorePath,
+    CrossOverPath,
+    EmptyPath,
+    PathBase,
+    PeerPath,
+)
+from lib.packet.scion_addr import SCIONAddr
 
 
 class PacketType(object):
@@ -42,7 +54,7 @@ class PacketType(object):
     TRC_REP = IPv4Address("10.224.0.5")  # TRC file reply from parent AD
     CERT_CHAIN_REQ = IPv4Address("10.224.0.6")  # cert chain request to parent AD
     CERT_CHAIN_REQ_LOCAL = IPv4Address("10.224.0.7")  # local cert chain request
-    CERT_CHAIN_REP = IPv4Address("10.224.0.8")  # cert chain reply from lCS 
+    CERT_CHAIN_REP = IPv4Address("10.224.0.8")  # cert chain reply from lCS
     IFID_PKT = IPv4Address("10.224.0.9")  # IF ID packet to the peer router
     SRC = [BEACON, PATH_MGMT, CERT_CHAIN_REP, TRC_REP]
     DST = [PATH_MGMT, TRC_REQ, TRC_REQ_LOCAL, CERT_CHAIN_REQ,
@@ -138,9 +150,9 @@ class SCIONCommonHdr(HeaderBase):
     def __str__(self):
         res = ("[CH ver: %u, src len: %u, dst len: %u, total len: %u bytes, "
                "TS: %u, current OF: %u, next hdr: %u, hdr len: %u]") % (
-               self.version, self.src_addr_len, self.dst_addr_len,
-               self.total_len, self.curr_iof_p, self.curr_of_p, self.next_hdr,
-               self.hdr_len)
+                   self.version, self.src_addr_len, self.dst_addr_len,
+                   self.total_len, self.curr_iof_p, self.curr_of_p,
+                   self.next_hdr, self.hdr_len)
         return res
 
 
@@ -583,12 +595,13 @@ class CertChainRequest(SCIONPacket):
         SCIONPacket.parse(self, raw)
         bits = BitArray(bytes=self.payload)
         (self.ingress_if, self.src_isd, self.src_ad, self.isd_id,
-            self.ad_id, self.version) = bits.unpack("uintbe:16, " +
-            "uintbe:16, uintbe:64, uintbe:16, uintbe:64, uintbe:32")
+            self.ad_id, self.version) = bits.unpack(
+                "uintbe:16, uintbe:16, uintbe:64, "
+                "uintbe:16, uintbe:64, uintbe:32")
 
     @classmethod
     def from_values(cls, req_type, src, ingress_if, src_isd, src_ad, isd_id,
-        ad_id, version):
+                    ad_id, version):
         """
         Return a Certificate Chain Request with the values specified.
 
@@ -621,9 +634,9 @@ class CertChainRequest(SCIONPacket):
         req.isd_id = isd_id
         req.ad_id = ad_id
         req.version = version
-        req.payload = bitstring.pack("uintbe:16, uintbe:16, uintbe:64, " +
-            "uintbe:16, uintbe:64, uintbe:32", ingress_if, src_isd, src_ad,
-            isd_id, ad_id, version).bytes
+        req.payload = bitstring.pack(
+            "uintbe:16, uintbe:16, uintbe:64, uintbe:16, uintbe:64, uintbe:32",
+            ingress_if, src_isd, src_ad, isd_id, ad_id, version).bytes
         return req
 
 
@@ -700,7 +713,7 @@ class CertChainReply(SCIONPacket):
         rep.version = version
         rep.cert_chain = cert_chain
         rep.payload = bitstring.pack("uintbe:16, uintbe:64, uintbe:32",
-            isd_id, ad_id, version).bytes + cert_chain
+                                     isd_id, ad_id, version).bytes + cert_chain
         return rep
 
 
@@ -748,12 +761,12 @@ class TRCRequest(SCIONPacket):
         SCIONPacket.parse(self, raw)
         bits = BitArray(bytes=self.payload)
         (self.ingress_if, self.src_isd, self.src_ad, self.isd_id,
-            self.version) = bits.unpack("uintbe:16, uintbe:16, " +
-            "uintbe:64, uintbe:16, uintbe:32")
+            self.version) = bits.unpack(
+                "uintbe:16, uintbe:16, uintbe:64, uintbe:16, uintbe:32")
 
     @classmethod
     def from_values(cls, req_type, src, ingress_if, src_isd, src_ad, isd_id,
-        version):
+                    version):
         """
         Return a TRC Request with the values specified.
 
@@ -783,9 +796,9 @@ class TRCRequest(SCIONPacket):
         req.src_ad = src_ad
         req.isd_id = isd_id
         req.version = version
-        req.payload = bitstring.pack("uintbe:16, uintbe:16, uintbe:64, " +
-            "uintbe:16, uintbe:32", ingress_if, src_isd, src_ad, isd_id,
-            version).bytes
+        req.payload = bitstring.pack(
+            "uintbe:16, uintbe:16, uintbe:64, uintbe:16, uintbe:32",
+            ingress_if, src_isd, src_ad, isd_id, version).bytes
         return req
 
 
@@ -849,12 +862,12 @@ class TRCReply(SCIONPacket):
         :rtype: :class:`TRCReply`
         """
         rep = TRCReply()
-        # TODO: revise TRC/Cert request/replies 
+        # TODO: revise TRC/Cert request/replies
         src = SCIONAddr.from_values(dst.isd_id, dst.ad_id, PacketType.TRC_REP)
         rep.hdr = SCIONHeader.from_values(src, dst)
         rep.isd_id = isd_id
         rep.version = version
         rep.trc = trc
         rep.payload = bitstring.pack("uintbe:16, uintbe:32", isd_id,
-            version).bytes + trc
+                                     version).bytes + trc
         return rep

--- a/lib/packet/scion_addr.py
+++ b/lib/packet/scion_addr.py
@@ -14,20 +14,15 @@
 """
 :mod:`scion_addr` --- SCION host address specifications
 =======================================================
-
-Module docstring here.
-
-.. note::
-    Fill in the docstring.
 """
-
-from bitstring import BitArray
-import bitstring
-from collections import namedtuple
-from ipaddress import IPv4Address, IPv6Address, IPV4LENGTH, IPV6LENGTH
+# Stdlib
 import logging
-import socket
-import struct
+from collections import namedtuple
+from ipaddress import IPV4LENGTH, IPV6LENGTH, IPv4Address, IPv6Address
+
+# External packages
+import bitstring
+from bitstring import BitArray
 
 
 ISD_AD = namedtuple('ISD_AD', ['isd', 'ad'])
@@ -65,14 +60,14 @@ class SCIONAddr(object):
         addr_len = len(raw)
         if addr_len < SCIONAddr.ISD_AD_LEN:
             logging.warning("SCIONAddr: Data too short for parsing, len: %u",
-                             addr_len)
+                            addr_len)
             return
         bits = BitArray(bytes=raw[:SCIONAddr.ISD_AD_LEN])
         (self.isd_id, self.ad_id) = bits.unpack("uintbe:16, uintbe:64")
         host_addr_len = addr_len - SCIONAddr.ISD_AD_LEN
-        if host_addr_len == IPV4LENGTH // 8: 
+        if host_addr_len == IPV4LENGTH // 8:
             self.host_addr = IPv4Address(raw[SCIONAddr.ISD_AD_LEN:])
-        elif host_addr_len == IPV6LENGTH // 8: 
+        elif host_addr_len == IPV6LENGTH // 8:
             self.host_addr = IPv6Address(raw[SCIONAddr.ISD_AD_LEN:])
         else:
             logging.warning("SCIONAddr: host address unsupported, len: %u",
@@ -89,4 +84,3 @@ class SCIONAddr(object):
 
     def get_isd_ad(self):
         return ISD_AD(self.isd_id, self.ad_id)
-

--- a/lib/path_db.py
+++ b/lib/path_db.py
@@ -15,11 +15,15 @@
 :mod:`path_db` --- Path Database
 ========================================
 """
-from lib.packet.pcb import PathSegment
+# Stdlib
 import logging
 import time
 
+# External packages
 from pydblite.pydblite import Base
+
+# SCION
+from lib.packet.pcb import PathSegment
 
 
 class DBResult(object):
@@ -60,7 +64,8 @@ class PathSegmentDB(object):
     """
     def __init__(self):
         db = Base("", save_to_file=False)
-        db.create('record', 'id', 'src_isd', 'src_ad', 'dst_isd', 'dst_ad',mode='override')
+        db.create('record', 'id', 'src_isd', 'src_ad', 'dst_isd',
+                  'dst_ad', mode='override')
         db.create_index('id')
         db.create_index('dst_isd')
         db.create_index('dst_ad')

--- a/lib/path_store.py
+++ b/lib/path_store.py
@@ -15,12 +15,14 @@
 :mod:`path_store` --- Path record storage and selection for path servers
 ========================================================================
 """
-
-from collections import defaultdict, deque
-from lib.packet.pcb import PathSegment
+# Stdlib
 import json
 import logging
 import time
+from collections import defaultdict, deque
+
+# SCION
+from lib.packet.pcb import PathSegment
 
 
 class PathPolicy(object):
@@ -394,7 +396,7 @@ class PathStore(object):
             self._update_all_fidelity()
             self.candidates = sorted(self.candidates, key=lambda x: x.fidelity,
                                      reverse=True)
-        
+
     def get_segment(self, seg_id):
         """
         Returns the segment for the corresponding ID or None.

--- a/lib/thread.py
+++ b/lib/thread.py
@@ -17,18 +17,21 @@
 
 Threading utilities for SCION.
 """
-
+# Stdlib
 import os
 import signal
 from functools import wraps
 
+# SCION
 from lib.log import log_exception
+
 
 def kill_self():
     """
     Sends SIGTERM to self, to allow quitting the process from threads.
     """
     os.kill(os.getpid(), signal.SIGTERM)
+
 
 def thread_safety_net(name):
     """

--- a/lib/topology.py
+++ b/lib/topology.py
@@ -15,7 +15,7 @@
 :mod:`topology` --- SCION topology parser
 ===========================================
 """
-
+# Stdlib
 from ipaddress import IPv4Address, IPv6Address
 import json
 import logging

--- a/lib/util.py
+++ b/lib/util.py
@@ -17,16 +17,19 @@
 
 Various utilities for SCION functionality.
 """
-
-import os
+# Stdlib
 import logging
-from signal import (SIGHUP, SIGINT, SIGQUIT, SIGTERM, SIGUSR1, SIGUSR2, signal)
+import os
 import sys
+import signal
 import time
 from functools import wraps
 
-from lib.defines import TOPOLOGY_PATH
+# External packages
 from external.stacktracer import trace_start
+
+# SCION
+from lib.defines import TOPOLOGY_PATH
 
 CERT_DIR = 'certificates'
 SIG_KEYS_DIR = 'signature_keys'
@@ -34,12 +37,12 @@ ENC_KEYS_DIR = 'encryption_keys'
 TRACE_DIR = '../traces'
 
 _SIG_MAP = {
-    SIGHUP: "SIGHUP",
-    SIGINT: "SIGINT",
-    SIGQUIT: "SIGQUIT",
-    SIGTERM: "SIGTERM",
-    SIGUSR1: "SIGUSR1",
-    SIGUSR2: "SIGUSR2"
+    signal.SIGHUP: "SIGHUP",
+    signal.SIGINT: "SIGINT",
+    signal.SIGQUIT: "SIGQUIT",
+    signal.SIGTERM: "SIGTERM",
+    signal.SIGUSR1: "SIGUSR1",
+    signal.SIGUSR2: "SIGUSR2"
 }
 
 
@@ -223,7 +226,7 @@ def handle_signals():
     Setup basic signal handler for the most common signals
     """
     for sig in _SIG_MAP.keys():
-        signal(sig, _signal_handler)
+        signal.signal(sig, _signal_handler)
     pass
 
 

--- a/scion.sh
+++ b/scion.sh
@@ -2,7 +2,7 @@
 
 # BEGIN subcommand functions
 
-PKG_DEPS="python python3 python-dev python-pip python3-dev python3-pip screen zookeeperd build-essential"
+PKG_DEPS="python python3 python-dev python-pip python3-dev python3-pip screen zookeeperd build-essential docker.io"
 PIP3_DEPS="bitstring python-pytun pydblite pygments pycrypto kazoo Sphinx sphinxcontrib-napoleon nose nose-descriptionfixer nose-cov coverage parse"
 
 cmd_deps() {

--- a/test/common_header_test.py
+++ b/test/common_header_test.py
@@ -15,8 +15,10 @@
 :mod:`common_header_test` --- SCION common header tests
 =======================================================
 """
+# Stdlib
 import unittest
 
+# SCION
 from lib.packet.scion import SCIONCommonHdr
 from test.testcommon import SCIONCommonTest
 
@@ -25,7 +27,6 @@ class TestCommonHeader(SCIONCommonTest):
     """
     Unit tests for scion.py.
     """
-
     def test_opaque_field(self):
         sch = SCIONCommonHdr()
         self.assertTrue(sch.version == 0)

--- a/test/hash_chain_test.py
+++ b/test/hash_chain_test.py
@@ -15,11 +15,14 @@
 :mod:`hash_chain_test` --- SCION hash chain tests
 =================================================
 """
+# Stdlib
 import logging
 import unittest
 
+# External packages
 from Crypto import Random
 
+# SCION
 from lib.crypto.hash_chain import HashChain
 from test.testcommon import SCIONCommonTest
 

--- a/test/integration/bandwidth_test.py
+++ b/test/integration/bandwidth_test.py
@@ -15,20 +15,25 @@
 :mod:`bandwidth_test` --- Bandwidth tests
 =========================================
 """
-from endhost.sciond import SCIONDaemon
-from lib.packet.scion import SCIONPacket
-from lib.packet.scion_addr import SCIONAddr
-from infrastructure.scion_elem import SCION_UDP_EH_DATA_PORT, BUFLEN
-from ipaddress import IPv4Address
+# Stdlib
+import logging
 import socket
 import threading
 import time
 import unittest
-import logging
+from ipaddress import IPv4Address
+
+# SCION
+from endhost.sciond import SCIONDaemon
+from lib.defines import SCION_BUFLEN, SCION_UDP_EH_DATA_PORT
+from lib.packet.scion import SCIONPacket
+from lib.packet.scion_addr import SCIONAddr
 
 PACKETS_NO = 1000
 PAYLOAD_SIZE = 1300
-SLEEP = 0.000005 # Time interval between transmission of two consecutive packets
+# Time interval between transmission of two consecutive packets
+SLEEP = 0.000005
+
 
 class TestBandwidth(unittest.TestCase):
     """
@@ -43,21 +48,22 @@ class TestBandwidth(unittest.TestCase):
         rcv_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         rcv_sock.bind((str("127.2.26.254"), SCION_UDP_EH_DATA_PORT))
         rcv_sock.settimeout(1)
-        
+
         i = 0
         try:
-            packet, _ = rcv_sock.recvfrom(BUFLEN)
+            packet, _ = rcv_sock.recvfrom(SCION_BUFLEN)
             i += 1
             start = time.time()
             while i < PACKETS_NO:
-                packet, _ = rcv_sock.recvfrom(BUFLEN)
+                packet, _ = rcv_sock.recvfrom(SCION_BUFLEN)
                 i += 1
             duration = time.time() - start
         except socket.timeout:
-            duration = time.time() - start - 1 # minus timeout
+            duration = time.time() - start - 1  # minus timeout
             print("Timeouted - there are lost packets")
 
-        print("Goodput %.2fKBps, loss %.2f\n" % ((i*PAYLOAD_SIZE)/duration/1000,
+        print("Goodput %.2fKBps, loss %.2f\n" %
+              ((i*PAYLOAD_SIZE)/duration/1000,
                100*float(PACKETS_NO-i)/PACKETS_NO))
 
     def test(self):

--- a/test/lib_zookeeper_test.py
+++ b/test/lib_zookeeper_test.py
@@ -16,16 +16,19 @@
 :mod:`lib_zookeeper_test` --- lib.zookeeper unit tests
 ======================================================
 """
+# Stdlib
 import logging
 from functools import wraps
-from unittest.mock import (MagicMock, PropertyMock, call)
+from unittest.mock import MagicMock, PropertyMock, call
 
+# External packages
 import nose
 import nose.tools as ntools
-
-from test.testcommon import SCIONTestException, MockCollection
-import lib.zookeeper as libzk
 from kazoo.protocol.states import ZnodeStat
+
+# SCION
+import lib.zookeeper as libzk
+from test.testcommon import MockCollection, SCIONTestException
 
 
 def mock_wrapper(f):

--- a/test/opaque_field_test.py
+++ b/test/opaque_field_test.py
@@ -15,10 +15,16 @@
 :mod:`opaque_field_test` --- SCION opaque field tests
 =====================================================
 """
+# Stdlib
 import unittest
 
-from lib.packet.opaque_field import (OpaqueField, OpaqueFieldType,
-                                     HopOpaqueField, InfoOpaqueField)
+# SCION
+from lib.packet.opaque_field import (
+    HopOpaqueField,
+    InfoOpaqueField,
+    OpaqueField,
+    OpaqueFieldType,
+)
 from test.testcommon import SCIONCommonTest
 
 
@@ -26,7 +32,6 @@ class TestOpaqueFields(SCIONCommonTest):
     """
     Unit tests for opaque_field.py.
     """
-
     def test_opaque_field(self):
         of = OpaqueField()
         self.assertEqual(of.type, OpaqueFieldType.NORMAL_OF)

--- a/test/path_store_test.py
+++ b/test/path_store_test.py
@@ -15,19 +15,29 @@
 :mod:`path_store_test` --- SCION path store unit test
 =========================================================
 """
-
-from Crypto import Random
-from lib.crypto.asymcrypto import sign
-from lib.crypto.hash_chain import HashChain
-from lib.packet.opaque_field import (OpaqueFieldType as OFT, InfoOpaqueField,
-    SupportSignatureField, HopOpaqueField, SupportPCBField, TRCField)
-from lib.packet.pcb import (PathSegment, ADMarking, PCBMarking)
-from lib.path_store import PathPolicy, PathStore
-from lib.util import read_file, get_sig_key_file_path, sleep_interval
+# Stdlib
 import base64
 import logging
 import time
 import unittest
+
+# External packages
+from Crypto import Random
+
+# SCION
+from lib.crypto.asymcrypto import sign
+from lib.crypto.hash_chain import HashChain
+from lib.packet.opaque_field import (
+    HopOpaqueField,
+    InfoOpaqueField,
+    OpaqueFieldType as OFT,
+    SupportPCBField,
+    SupportSignatureField,
+    TRCField,
+)
+from lib.packet.pcb import ADMarking, PCBMarking, PathSegment
+from lib.path_store import PathPolicy, PathStore
+from lib.util import get_sig_key_file_path, read_file
 
 
 class TestPathStore(unittest.TestCase):
@@ -52,9 +62,6 @@ class TestPathStore(unittest.TestCase):
         return ADMarking.from_values(pcbm, peer_markings, signature)
 
     def test(self):
-        """
-        
-        """
         path_policy_file = "../topology/ISD1/path_policies/ISD:1-AD:10.json"
         path_policy = PathPolicy.from_file(path_policy_file)
         test_segments = PathStore(path_policy)
@@ -83,7 +90,7 @@ class TestPathStore(unittest.TestCase):
                   str(len(test_segments.get_latest_history_snapshot())))
             print("Time: " + str(int(time.time())) + "\n")
             time.sleep(5)
-        
+
         print("Waiting for some paths to expire...")
         time.sleep(25)
         print("Best paths: " + str(len(test_segments.get_best_segments())))

--- a/test/symcrypto_test.py
+++ b/test/symcrypto_test.py
@@ -15,10 +15,22 @@
 :mod:`symcrypto` --- SCION symmetric encryption tests
 =====================================================
 """
+# Stdlib
 import logging
 import unittest
 
-from lib.crypto.symcrypto import *
+# SCION
+from lib.crypto.symcrypto import (
+    authenticated_decrypt,
+    authenticated_encrypt,
+    cbc_decrypt,
+    cbc_encrypt,
+    get_cbcmac,
+    get_random_bytes,
+    get_roundkey_cache,
+    sha3hash,
+    verify_cbcmac,
+)
 from test.testcommon import SCIONCommonTest
 
 
@@ -36,40 +48,43 @@ class TestSymcrypto(SCIONCommonTest):
         3. Block cipher (AES-CBC) testing with random keys and messages.
         4. Authenticated encryption (AES-GCM) testing with.
         """
-        print ('1. Hash Test:')
+        print('1. Hash Test:')
         msg = 'VRJ8JiM0J4M4ioyLJM6qR1CznEMYnymr1jJxgcLATjlEOFMc6x02wpRCUjo'
-        print ('msg = %s' % msg)
-        print ('sha3-224(msg) = %s' % sha3hash(msg, 'SHA3-224'))
-        print ('sha3-256(msg) = %s' % sha3hash(msg, 'SHA3-256'))
-        print ('sha3-384(msg) = %s' % sha3hash(msg, 'SHA3-384'))
-        print ('sha3-512(msg) = %s' % sha3hash(msg))# default is SHA-512
+        print('msg = %s' % msg)
+        print('sha3-224(msg) = %s' % sha3hash(msg, 'SHA3-224'))
+        print('sha3-256(msg) = %s' % sha3hash(msg, 'SHA3-256'))
+        print('sha3-384(msg) = %s' % sha3hash(msg, 'SHA3-384'))
+        print('sha3-512(msg) = %s' % sha3hash(msg))  # default is SHA-512
 
         key = get_random_bytes(16)
         key_cache = get_roundkey_cache(key)
-        print ('key = %s' % key)
+        print('key = %s' % key)
 
-        print ('2. MAC Test:')
+        print('2. MAC Test:')
         mac = get_cbcmac(key_cache, msg.encode('utf-8'))
-        print ("get_cbcmac(key_cache, msg) = %s" % mac)
-        print ("CBC-MAC-Verify(key_cache, msg, mac) = ",
-               verify_cbcmac(key_cache, msg.encode('utf-8'), mac))
+        print("get_cbcmac(key_cache, msg) = %s" % mac)
+        print("CBC-MAC-Verify(key_cache, msg, mac) = ",
+              verify_cbcmac(key_cache, msg.encode('utf-8'), mac))
 
-        print ('3. Block Cipher Test:')
-        msg = 'Message to be encrypted by AES-CBC block cipher. This is end of message.'
-        cipher = cbc_encrypt(key_cache, msg.encode('utf-8')) # iv = 0
-        print ('msg = %s' % msg)
-        print ('cipher = %s' % cipher)
+        print('3. Block Cipher Test:')
+        msg = ('Message to be encrypted by AES-CBC block cipher. '
+               'This is end of message.')
+        cipher = cbc_encrypt(key_cache, msg.encode('utf-8'))  # iv = 0
+        print('msg = %s' % msg)
+        print('cipher = %s' % cipher)
         decipher = cbc_decrypt(key_cache, cipher)
-        print ('decipher = %s' % decipher.decode('utf-8'))
+        print('decipher = %s' % decipher.decode('utf-8'))
 
-        print ('4. Authenticated Encryption Test:')
+        print('4. Authenticated Encryption Test:')
         msg = 'This is a message to be protected'
-        auth = 'D609B1F056637A0D46DF998D88E5222AB2C2846512153524C0895E8108000F10'
-        authcipher = authenticated_encrypt(key_cache, msg.encode('utf-8'), 
-                                           auth.encode('utf-8')) # iv = None
-        print ('authcipher = %s' % authcipher)
-        decipher = authenticated_decrypt(key_cache, authcipher, auth.encode('utf-8'))
-        print ('decipher = %s' % decipher.decode('utf-8'))
+        auth = ('D609B1F056637A0D46DF998D88E5222A'
+                'B2C2846512153524C0895E8108000F10')
+        authcipher = authenticated_encrypt(key_cache, msg.encode('utf-8'),
+                                           auth.encode('utf-8'))  # iv = None
+        print('authcipher = %s' % authcipher)
+        decipher = authenticated_decrypt(key_cache, authcipher,
+                                         auth.encode('utf-8'))
+        print('decipher = %s' % decipher.decode('utf-8'))
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/test/testcommon.py
+++ b/test/testcommon.py
@@ -15,6 +15,7 @@
 :mod:`testcommon` --- Common test classes/utilities
 ===================================================
 """
+# Stdlib
 import unittest
 from unittest.mock import patch
 


### PR DESCRIPTION
- All imports categorised into stdlib/external package/scion, and sorted
  alphabetically.
- Sort "import x" before "from x import y"
- All multi-line imports are now 1-per-line, to make diffs trivial to
  read, and to make it easier to see what's being used.
- Only use () on multi-line imports.
- Code should now comply with https://www.python.org/dev/peps/pep-0008/
- Also added missing dependancy for docker.io
- Moved port and buffer-size constants into lib/defines.py

I have ignored lib/crypto, as its future is uncertain.

All unit tests and integration tests still pass.
