### PR TITLE
Update MockCollection

### DIFF
--- a/test/lib_zookeeper_test.py
+++ b/test/lib_zookeeper_test.py
@@ -37,7 +37,8 @@ def mock_wrapper(f):
     """
     @wraps(f)
     def wrap(self, *args, **kwargs):
-        self.mocks = MockCollection()
+        if not hasattr(self, "mocks"):
+            self.mocks = MockCollection()
         self.mocks.add('lib.zookeeper.KazooClient', 'kclient')
         self.mocks.add('lib.zookeeper.KazooRetry', 'kretry')
         self.mocks.add('kazoo.recipe.party.Party', 'kparty')
@@ -53,8 +54,9 @@ def mock_wrapper(f):
         try:
             return f(self, *args, **kwargs)
         finally:
-            self.mocks.stop()
-            del self.mocks
+            if hasattr(self, "mocks"):
+                self.mocks.stop()
+                del self.mocks
     return wrap
 
 


### PR DESCRIPTION
MockCollection will now work properly even if it's used by multiple
decorators on the same method.

It also can use a specified replacement object, instead of the default
MagicMock.

Both of these features are used by the pending dns_server unit tests.
