### PR TITLE
Fixed minor bug in scion.sh's topology command

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -51,7 +51,7 @@ cmd_topology() {
     echo "Create topology, configuration, and execution files."
     mkdir -p logs traces
     cd topology/
-    PYTHONPATH=../ python3 generator.py $@
+    PYTHONPATH=../ python3 generator.py "$@"
 }
 
 cmd_setup() {


### PR DESCRIPTION
There was a very small bug in the topology command of scion.sh that prevented generating with any topology, path policy, or output directory other than the default. I've fixed this by simply passing the parameters to topology/generator.py which can handle the arguments on its own.
