### PR TITLE
Changed way of assigning if_id and ip addresses

### DIFF
--- a/topology/generator.py
+++ b/topology/generator.py
@@ -82,7 +82,8 @@ class ConfigGenerator():
     """
     Configuration and/or topology generator.
     """
-    def __init__(self, out_dir=TOPOLOGY_PATH, subnet=DEFAULT_SUBNET):
+    def __init__(self, out_dir=TOPOLOGY_PATH, subnet=DEFAULT_SUBNET,
+                 next_ip_address=IP_ADDRESS_BASE):
         """
         Initialize an instance of the class ConfigGenerator.
 
@@ -96,6 +97,7 @@ class ConfigGenerator():
             sys.exit()
         self.out_dir = out_dir
         self.subnet = subnet
+        self.next_ip_address = next_ip_address
 
     def _get_subnet_params(self, ad_config=None):
         """
@@ -721,7 +723,6 @@ def main():
         sys.exit()
 
     generator = ConfigGenerator(out_dir)
-    generator.next_ip_address = IP_ADDRESS_BASE
     generator.generate_all(adconfigurations_file, path_policy_file)
 
 


### PR DESCRIPTION
- Till now, the way in which IFID's are generated assumes that no two AD's have same AD number even across different ISD's.
- if_id's are supposed to be unique for an AD among all its outgoing links. Hence, a counter is maintained to assign if_id's.
- Way in which IP addresses are assigned is also changed
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-112441960%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-112442426%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-112443208%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-112450577%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-112450667%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-112450987%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-112453052%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-112453635%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-112826660%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-112853663%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-113073760%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-114078518%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-114078778%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-114081079%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-114084369%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-114084401%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32641375%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825371%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825418%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825473%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825597%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825902%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825915%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825931%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825979%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32912878%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32912879%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32912880%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32912881%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32912884%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32912885%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32926731%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32926820%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32928498%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23issuecomment-112441960%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-06-16T13%3A57%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20assume%20you%20ran%20the%20tests%20%28especially%20end2end%20test%29%20to%20ensure%20this%20doesn%27t%20break%20anything%3F%22%2C%20%22created_at%22%3A%20%222015-06-16T13%3A58%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mskd96%20you%20could%20do%20similar%20change%20with%20IP%20addresses%20assigned%2C%20as%20AFAIR%20this%20was%20an%20issue%20too.%5Cr%5CnJust%20start%20with%20IPv4Address%28%5C%22127.0.0.1%5C%22%29%20and%20increment%20by%201%20for%20every%20new%20element.%22%2C%20%22created_at%22%3A%20%222015-06-16T14%3A01%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20we%20don%27t%20want%20IP%20addresses%20to%20be%20related%20to%20the%20corresponding%20ISD%20or%20AD%20in%20any%20way%2C%20is%20that%20right%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-16T14%3A30%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40shitz%20Thanks%20for%20reminding%20me%20that.%20It%20works%20well%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-16T14%3A31%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%2C%20%7B%22body%22%3A%20%22Exactly.%20I%20mean%20in%20a%20real%20deployment%20each%20AD%20would%20have%20its%20own%20prefix%20but%20for%20the%20local%20testbed%20just%20increasing%20127.0.0.1%20is%20fine.%22%2C%20%22created_at%22%3A%20%222015-06-16T14%3A32%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20what%27s%20wrong%20with%20the%20current%20approach%20%28127.ISD.AD.X%29%20for%20the%20local%20testbed%3F%20It%27s%20much%20simpler%20to%20know%20who%20this%20IP%20belongs%20to%20%28location%2C%20type%20of%20server%29.%22%2C%20%22created_at%22%3A%20%222015-06-16T14%3A40%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1120468%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rev112%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20problem%20is%20that%20we%20run%20into%20problems%20if%20an%20ISD%20contains%20more%20than%20255%20ADs%2C%20since%20the%20current%20scheme%20is%20127.ISD_ID.AD_ID.X.%22%2C%20%22created_at%22%3A%20%222015-06-16T14%3A42%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20have%20also%20changed%20the%20way%20IP%20addresses%20are%20assigned.%20%22%2C%20%22created_at%22%3A%20%222015-06-17T14%3A38%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%2C%20%7B%22body%22%3A%20%22As%20we%20can%20use%20ipaddress%20package%2C%20this%20_increment_addr%28%29%20looks%20weird%2C%20but%20I%20know%20that%20it%20was%20before%2C%20so%20lgtm.%22%2C%20%22created_at%22%3A%20%222015-06-17T15%3A39%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20could%20remove%20the%20_increment_address%20function%20altogether.%20Then%20we%20will%20be%20removing%20the%20check%20that%20ip%20addresses%20have%20reached%20the%20broadcast%20address%20which%20will%20not%20happen%20most%20likely.%5Cr%5Cn%40pszalach%20Should%20I%20do%20this%3F%22%2C%20%22created_at%22%3A%20%222015-06-18T08%3A24%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%2C%20%7B%22body%22%3A%20%22One%20minor%20comment%20from%20me%2C%20and%20then%20LGTM%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A00%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28Oh%2C%20and%20please%20don%27t%20mark%20tasks%20resolved%20yourself.%20That%27s%20for%20reviewers%20to%20do.%20Much%20easier%20to%20keep%20track%20of%20this%20way%29%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A00%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oops..%20Sorry%20for%20that%20trouble%2C%20I%20thought%20it%20was%20a%20way%20for%20me%20to%20keep%20track%20of%20stuff.%5Cr%5CnAnyway%2C%20fixed%20it.%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A10%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A26%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A27%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ccaa046d77af49c132c4f513f521782f75447c00%20topology/generator.py%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825418%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Having%20a%20class%20attribute%20that%20mutates%20is%20a%20recipe%20for%20weird%20bugs.%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A50%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20naming%20is%20also%20somewhat%20unclear%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A51%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22My%20bad%2C%20I%20actually%20meant%20%5C%22instance%20attribute%5C%22%20when%20I%20recommended%20to%20remove%20it%20from%20globals.%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A53%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1120468%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rev112%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T08%3A17%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL72-85%22%7D%2C%20%22Pull%20677422e9f12a66a961fd033ff6c4129ffcb29cfd%20topology/generator.py%20111%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32926731%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20would%20make%20more%20sense%20just%20to%20make%20this%20a%20parameter%20to%20%60ConfigGenerator.__init__%60%22%2C%20%22created_at%22%3A%20%222015-06-22T11%3A58%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28I%20had%20to%20spend%20a%20minute%20finding%20where%20it%20was%20initialised%29%22%2C%20%22created_at%22%3A%20%222015-06-22T11%3A59%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A26%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL721-728%22%7D%2C%20%22Pull%20ccaa046d77af49c132c4f513f521782f75447c00%20topology/generator.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825371%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Need%202%20blank%20lines%20before%20a%20class%20definition%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A49%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T08%3A17%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL72-85%22%7D%2C%20%22Pull%20ccaa046d77af49c132c4f513f521782f75447c00%20topology/generator.py%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825902%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Trailing%20whitespace%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A58%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T08%3A17%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL196-214%22%7D%2C%20%22Pull%20ccaa046d77af49c132c4f513f521782f75447c00%20topology/generator.py%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825915%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Line%20too%20long%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A58%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28And%20trailing%20whitespace%29%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A58%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T08%3A18%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL196-214%22%7D%2C%20%22Pull%20ccaa046d77af49c132c4f513f521782f75447c00%20topology/generator.py%2057%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32825979%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Line%20too%20long%20%28same%20for%20repetitions%20below%29%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A59%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T08%3A18%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL357-392%22%7D%2C%20%22Pull%20fa1f02bde9999b21079eb7fdc0db0d20e4b787b1%20topology/generator.py%2065%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/163%23discussion_r32641375%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22CURR_IP_ADDRESS%20is%20global%20and%20uppercase%2C%20but%20not%20a%20constant.%20It%27s%20better%20to%20make%20it%20a%20class%20attribute.%22%2C%20%22created_at%22%3A%20%222015-06-17T15%3A47%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1120468%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rev112%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T08%3A18%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL356-391%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/kormat%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/kormat'><img src='https://avatars.githubusercontent.com/u/6919822?v=3' width=34 height=34></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/163#issuecomment-112441960'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> I assume you ran the tests (especially end2end test) to ensure this doesn't break anything?
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> @mskd96 you could do similar change with IP addresses assigned, as AFAIR this was an issue too.
  Just start with IPv4Address("127.0.0.1") and increment by 1 for every new element.
- <a href='https://github.com/mskd96'><img border=0 src='https://avatars.githubusercontent.com/u/6560106?v=3' height=16 width=16'></a> So we don't want IP addresses to be related to the corresponding ISD or AD in any way, is that right?
- <a href='https://github.com/mskd96'><img border=0 src='https://avatars.githubusercontent.com/u/6560106?v=3' height=16 width=16'></a> @shitz Thanks for reminding me that. It works well :+1:
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Exactly. I mean in a real deployment each AD would have its own prefix but for the local testbed just increasing 127.0.0.1 is fine.
- <a href='https://github.com/rev112'><img border=0 src='https://avatars.githubusercontent.com/u/1120468?v=3' height=16 width=16'></a> But what's wrong with the current approach (127.ISD.AD.X) for the local testbed? It's much simpler to know who this IP belongs to (location, type of server).
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> The problem is that we run into problems if an ISD contains more than 255 ADs, since the current scheme is 127.ISD_ID.AD_ID.X.
- <a href='https://github.com/mskd96'><img border=0 src='https://avatars.githubusercontent.com/u/6560106?v=3' height=16 width=16'></a> I have also changed the way IP addresses are assigned.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> As we can use ipaddress package, this _increment_addr() looks weird, but I know that it was before, so lgtm.
- <a href='https://github.com/mskd96'><img border=0 src='https://avatars.githubusercontent.com/u/6560106?v=3' height=16 width=16'></a> I could remove the _increment_address function altogether. Then we will be removing the check that ip addresses have reached the broadcast address which will not happen most likely.
  @pszalach Should I do this?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> One minor comment from me, and then LGTM
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (Oh, and please don't mark tasks resolved yourself. That's for reviewers to do. Much easier to keep track of this way)
- <a href='https://github.com/mskd96'><img border=0 src='https://avatars.githubusercontent.com/u/6560106?v=3' height=16 width=16'></a> Oops.. Sorry for that trouble, I thought it was a way for me to keep track of stuff.
  Anyway, fixed it.
- [x] <a href='#crh-comment-Pull fa1f02bde9999b21079eb7fdc0db0d20e4b787b1 topology/generator.py 65'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/163#discussion_r32641375'>File: topology/generator.py:L356-391</a></b>
- <a href='https://github.com/rev112'><img border=0 src='https://avatars.githubusercontent.com/u/1120468?v=3' height=16 width=16'></a> CURR_IP_ADDRESS is global and uppercase, but not a constant. It's better to make it a class attribute.
- [x] <a href='#crh-comment-Pull ccaa046d77af49c132c4f513f521782f75447c00 topology/generator.py 13'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/163#discussion_r32825371'>File: topology/generator.py:L72-85</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Need 2 blank lines before a class definition
- [x] <a href='#crh-comment-Pull ccaa046d77af49c132c4f513f521782f75447c00 topology/generator.py 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/163#discussion_r32825418'>File: topology/generator.py:L72-85</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Having a class attribute that mutates is a recipe for weird bugs.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The naming is also somewhat unclear
- <a href='https://github.com/rev112'><img border=0 src='https://avatars.githubusercontent.com/u/1120468?v=3' height=16 width=16'></a> My bad, I actually meant "instance attribute" when I recommended to remove it from globals.
- [x] <a href='#crh-comment-Pull ccaa046d77af49c132c4f513f521782f75447c00 topology/generator.py 28'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/163#discussion_r32825902'>File: topology/generator.py:L196-214</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Trailing whitespace
- [x] <a href='#crh-comment-Pull ccaa046d77af49c132c4f513f521782f75447c00 topology/generator.py 39'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/163#discussion_r32825915'>File: topology/generator.py:L196-214</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Line too long
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (And trailing whitespace)
- [x] <a href='#crh-comment-Pull ccaa046d77af49c132c4f513f521782f75447c00 topology/generator.py 57'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/163#discussion_r32825979'>File: topology/generator.py:L357-392</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Line too long (same for repetitions below)
- [x] <a href='#crh-comment-Pull 677422e9f12a66a961fd033ff6c4129ffcb29cfd topology/generator.py 111'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/163#discussion_r32926731'>File: topology/generator.py:L721-728</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It would make more sense just to make this a parameter to `ConfigGenerator.__init__`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (I had to spend a minute finding where it was initialised)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/163?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/163?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/163?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/163'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
