### PR TITLE
Don't silently ignore errors when installing dependancies.

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -6,6 +6,9 @@ PKG_DEPS="python python3 python-dev python-pip python3-dev python3-pip screen zo
 PIP3_DEPS="python-pytun pydblite pygments pycrypto kazoo Sphinx sphinxcontrib-napoleon nose nose-descriptionfixer nose-cov coverage parse dnslib"
 
 cmd_deps() {
+    # Treat all non-zero returns as fatal errors. Prevents issues like pip
+    # package failing to install, causing the rest to be ignored.
+    set -e
     if [ -e /etc/debian_version ]; then
         deps_debian || exit 1
     else


### PR DESCRIPTION
This would have made #162 much simpler to debug.
