### PR TITLE
Pin alabaster to 0.7.4...

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -3,7 +3,7 @@
 # BEGIN subcommand functions
 
 PKG_DEPS="python python3 python-dev python-pip python3-dev python3-pip screen zookeeperd build-essential docker.io dnsutils"
-PIP3_DEPS="python-pytun pydblite pygments pycrypto kazoo Sphinx sphinxcontrib-napoleon nose nose-descriptionfixer nose-cov coverage parse dnslib"
+PIP3_DEPS="python-pytun pydblite pygments pycrypto kazoo alabaster==0.7.4 Sphinx sphinxcontrib-napoleon nose nose-descriptionfixer nose-cov coverage parse dnslib"
 
 cmd_deps() {
     if [ -e /etc/debian_version ]; then


### PR DESCRIPTION
until https://github.com/bitprophet/alabaster/issues/40 is fixed. Alabaster is a dependency of Sphinx, so if we install an older, working version before Sphinx gets pulled in (and so long as Sphinx doesn't demand the broken version of alabaster (0.7.5)), things work again.

This works around the issue in #162.
