### PR TITLE
Add initial circle.yml for circleci.com

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  python:
+    version: 3.4.2
+
+dependencies:
+  cache_directories:
+    - "/var/cache/apt"
+  post:
+    - "./scion.sh init"
+    - "./scion.sh topology"
+
+test:
+  override:
+    - ./scion.sh test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+Sphinx
+alabaster==0.7.4
+coverage
+dnslib
+kazoo
+nose
+nose-cov
+nose-descriptionfixer
+parse
+pycrypto
+pydblite
+pygments
+python-pytun
+sphinxcontrib-napoleon

--- a/scion.sh
+++ b/scion.sh
@@ -3,7 +3,6 @@
 # BEGIN subcommand functions
 
 PKG_DEPS="python python3 python-dev python-pip python3-dev python3-pip screen zookeeperd build-essential docker.io dnsutils"
-PIP3_DEPS="python-pytun pydblite pygments pycrypto kazoo alabaster==0.7.4 Sphinx sphinxcontrib-napoleon nose nose-descriptionfixer nose-cov coverage parse dnslib"
 
 cmd_deps() {
     # Treat all non-zero returns as fatal errors. Prevents issues like pip
@@ -16,7 +15,7 @@ cmd_deps() {
         echo "    $PKG_DEPS"
     fi
     echo "Installing necessary packages from pip3"
-    pip3 install --user $PIP3_DEPS
+    pip3 install --user -r requirements.txt
     echo "Installing supervisor packages from pip2"
     pip2 install --user supervisor==3.1.3
     pip2 install --user supervisor-quick


### PR DESCRIPTION
Also moving the pip3 requiremnts into requirements.txt, which is better
supported by pip, and supported automatically by circle ci.

(This is still in testing, so please don't merge yet)
