### PR TITLE
Tests for lib/packet/path_mgmt.py

### DIFF
--- a/test/lib_packet_path_mgmt_test.py
+++ b/test/lib_packet_path_mgmt_test.py
@@ -354,9 +354,9 @@ class TestRevocationInfoParse(object):
             b"superlengthybigstringoflength321" \
             b"superlengthybigstringoflength322"
         rev_inf.parse(data)
-        ntools.eq_(rev_inf.rev_type, 0b00000101 & 0x7)
-        ntools.eq_(rev_inf.incl_seg_id, (0b00000101 >> 3) & 0x1)
-        ntools.eq_(rev_inf.incl_hop, (0b00000101 >> 4) & 0x1)
+        ntools.eq_(rev_inf.rev_type, 0b101)
+        ntools.eq_(rev_inf.incl_seg_id, 0b0)
+        ntools.eq_(rev_inf.incl_hop, 0b0)
         ntools.eq_(rev_inf.seg_id, b"")
         ntools.eq_(rev_inf.rev_token1, b"superlengthybigstringoflength321")
         ntools.eq_(rev_inf.proof1, b"superlengthybigstringoflength322")


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-112781992%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113117525%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113130146%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113497600%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113503720%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113531907%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113536426%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113546753%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113548076%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113548602%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113549173%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113549640%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113567133%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-114095777%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32725087%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32725099%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729172%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729238%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729341%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729486%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729529%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729628%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729789%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32730032%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32730067%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32730307%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32730376%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32730836%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32730895%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32732150%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32732268%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32744694%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820143%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820613%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820640%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820835%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820962%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820980%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820994%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821017%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821025%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821038%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821070%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821084%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821092%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821547%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821618%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821650%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821695%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821784%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821934%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822032%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822100%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822141%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822162%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822290%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822391%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822478%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822575%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822620%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822782%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822923%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822948%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32823006%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32823375%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32823392%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32823484%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830039%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830082%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830094%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830157%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830208%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830244%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830271%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830297%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830338%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830349%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830370%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830417%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830437%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830460%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830473%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830495%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830512%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830571%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830627%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830641%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830685%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830708%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830767%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830777%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830798%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830843%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830901%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830921%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831154%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831188%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831215%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831227%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831272%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831286%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831435%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831464%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831519%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831568%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831672%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831696%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32831718%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32832240%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32832400%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32832432%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834354%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834446%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834622%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834720%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834742%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834803%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834851%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834858%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834886%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834937%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32836005%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32836253%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32836268%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32836469%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32836551%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32836605%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32836989%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32837116%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32837167%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32837189%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32840744%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32840940%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32841296%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32842093%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32842383%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32842596%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32843366%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32843579%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32844735%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929276%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929278%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929283%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929287%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929291%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929294%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929297%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929301%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929303%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929306%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929309%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929314%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929327%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929330%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929339%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929346%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929349%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929350%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929353%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929354%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929362%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929363%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929373%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929374%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929378%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929384%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929386%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929594%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929597%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929602%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929606%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929609%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929611%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929612%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929619%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929635%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929642%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929645%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929646%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929651%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929652%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929656%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929662%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929665%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929670%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929672%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929680%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929681%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929684%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929685%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929689%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929692%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929696%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929710%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929713%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929714%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929716%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929725%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929732%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929736%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929741%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929746%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929749%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929755%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929757%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929761%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929765%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929768%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929772%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929774%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929779%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929783%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929788%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929790%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929794%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929798%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32929802%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933045%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933047%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933051%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933057%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933059%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933065%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933070%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933072%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933075%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933079%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933082%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933112%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933115%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933116%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933122%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933124%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933130%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933134%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933136%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933140%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933143%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933151%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933154%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933162%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933167%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933202%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933203%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933205%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933206%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933207%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933208%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933209%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933210%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933212%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933213%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933214%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933217%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933221%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933223%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933224%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933225%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933227%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933230%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933231%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933232%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933233%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933235%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933238%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933239%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933240%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933244%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933246%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933247%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933248%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933250%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933251%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933253%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933260%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933264%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933266%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933267%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933272%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933275%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933276%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933277%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933280%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933286%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933289%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933290%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933294%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933296%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32933299%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32934052%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32934607%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32934702%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32934720%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32934992%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32935130%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32935939%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32936094%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32936552%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32936627%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32936904%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32937339%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32937425%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32937897%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32938227%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32938248%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-114126862%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32940102%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32941787%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32942131%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32942172%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32942192%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32942236%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32942302%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32942330%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32943004%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-114142289%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-114142874%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-114145466%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-114502800%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20370%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821784%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22In%20this%20case%20it%20would%20just%20be%20clearer%20to%20format%20this%20by%20using%20a%20set%20of%20%60%28%29%60%27s%20around%20the%20whole%20right%20side%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20%20%20%20%20data%20%3D%20%28struct.pack%28%5C%22%21B%5C%22%2C%200b00011011%29%20%2B%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20b%5C%22superlengthybigstringoflength321%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20b%5C%22superlengthybigstringoflength322%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20b%5C%22superlengthybigstringoflength323%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20b%5C%22superlengthybigstringoflength324%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20b%5C%22superlengthybigstringoflength325%5C%22%29%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cn%28You%20don%27t%20need%20%2B%27s%20between%20the%20literal%20bytes%20strings.%20Python%20does%20implicit%20string%20joining%29%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A44%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A59%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%2041%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820962%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20don%27t%20%28currently%29%20use%20%60PayloadBase%60%2C%20%60PathSegment%60%2C%20%60SCIONPacket%60%20or%20%60SCIONHeader%60.%20You%20don%27t%20need%20to%20import%20them%20to%20patch%20them%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A27%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A56%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A42%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%201d959d9a1a0b902b2db071b84b5ba3888e2bf406%20test/lib_packet_path_mgmt_test.py%20289%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834622%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20be%20more%20specific%2C%20%60parse.assert_called_once_with%28pth_seg_les%2C%20data%29%60%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A35%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A19%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-738%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%2077%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729341%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27d%20move%20this%20assertion%20above%20the%20other%20checks%2C%20as%20PayloadBase.parse%20gets%20called%20before%20struct%20unpack%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A31%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A52%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%20104%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729628%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22For%20full%20marks%2C%20you%20could%20also%20check%20that%20the%20returned%20type%20is%20a%20PathSegmentInfo%20object%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A34%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A53%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%20281%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32732150%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20you%20want%20to%20check%20here%20is%20that%20%60LeaseInfo%60%20is%20called%204%20times%20with%20the%20correct%20data%2C%20and%20that%20%60leases%60%20contains%20the%204%20return%20values%20afterwards.%20The%20first%20bit%20is%20done%20by%20using%20%60assert_has_calls%60.%20The%20return%20values%20can%20be%20specified%20by%20using%20a%20mock%20with%20the%20%60side_effect%60%20attribute%20set%20to%20a%20list.%5Cr%5Cn%5Cr%5Cn%5BHere%5D%28https%3A//github.com/netsec-ethz/scion/blob/master/test/lib_zookeeper_test.py%23L877%29%20is%20an%20example%20test%20that%20does%20both%20of%20these%20things.%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A59%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Should%20a%20similar%20thing%20be%20done%20for%20TestPathSegmentLeasesPack%20as%20well%3F%20IMHO%20current%20code%20is%20more%20understandable.%22%2C%20%22created_at%22%3A%20%222015-06-18T15%3A45%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes.%20One%20of%20the%20principles%20of%20unit%20testing%20is%20that%20you%20limit%20the%20scope%20to%20precisely%20what%20you%20mean%20to%20test.%20Otherwise%20errors%20in%20other%20parts%20of%20the%20code%20will%20cause%20lots%20of%20seemingly%20unrelated%20unit%20tests%20to%20fail%2C%20making%20diagnosing%20and%20fixing%20much%20harder.%20It%20also%20means%20the%20test%20is%20very%20clear%20in%20what%20exactly%20it%20is%20%28and%20is%20not%29%20testing.%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A12%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A36%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A42%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%20284178dd199ded80570d85d813fa524488819b50%20test/lib_packet_path_mgmt_test.py%20645%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32823484%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Perhaps%20rename%20these%202%20tests%20to%20something%20like%20%60test_to_scionaddr%60%20and%20%60test_from_scionaddr%60%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A17%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A07%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A42%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-692%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20289%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821084%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Line%20too%20long%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A30%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A57%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A42%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20453%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822141%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Keep%20the%20tests%20in%20the%20same%20order%20as%20the%20args%20%28%60seg_id%60%20is%20before%20%60incl_hop%60%29%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A51%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A02%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A42%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20287%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821070%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22No%20need%20for%20%60%5C%5C%60%2C%20the%20line%20already%20has%20an%20open%20set%20of%20parentheses.%20%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A30%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A37%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20401%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822032%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20method%20names%20in%20this%20class%20have%20reversed%20meaning%20to%20the%20previous%20class.%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A49%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20should%20probably%20clarify%3A%5Cr%5Cn%2A%20In%20%60TestRevocationInfoParse%60%2C%20%60test_var_size%60%20is%20with%20%60incl_seg_id%60%20and%20%60incl_hop%60%20set%20to%201.%20%5Cr%5Cn%2A%20In%20%60TestRevocationInfoPack%60%2C%20%60test_var_size%60%20is%20with%20%60incl_seg_id%60%20and%20%60incl_hop%60%20set%20to%200.%5Cr%5Cn%5Cr%5CnI%20think%20you%20need%20to%20swap%20the%20contents%20of%20the%20two%20methods%20in%20%60TestRevocationInfoPack%60%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A01%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A38%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A40%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20608%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822948%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Just%20one%20test%20missing%20-%20for%20when%20an%20unsupported%20type%20is%20parsed%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A08%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A05%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20282%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821038%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Over-indented%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A29%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A37%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-112781992%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20have%20written%20test%20for%20class%20PathSegmentInfo.%20After%20reviewing%20is%20done%20I%20will%20write%20tests%20for%20rest%20of%20the%20classes%20since%20the%20other%20classes%20are%20very%20similar%20to%20this%20one%20it%20will%20save%20some%20effort.%22%2C%20%22created_at%22%3A%20%222015-06-17T12%3A35%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20Can%20you%20review%20this%3F%22%2C%20%22created_at%22%3A%20%222015-06-18T11%3A21%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%2C%20will%20get%20to%20it%20shortly%22%2C%20%22created_at%22%3A%20%222015-06-18T12%3A01%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20just%20finished%20a%20major%20review%20of%20the%20code.%20Let%20me%20know%20when%20i%20should%20do%20another.%20Thanks%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A20%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20%20Thanks%20for%20reviewing.%20I%20have%20addressed%20all%20of%20your%20comments%20except%20some%20on%20TestRevocationPayloadParse%20and%20TestPathSegmentLeasesParse.%20So%20if%20you%20want%20to%20review%20again%20now%20would%20be%20the%20time%20as%20you%20have%20just%20finished%20reviewing.%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A40%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20i%27ll%20take%20another%20look%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A31%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20made%20changes%20as%20suggested%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A50%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20I%20am%20sorry%20but%20I%20don%27t%20understand%20you%20completely.%20I%20have%20changed%20the%20code%20so%20that%20there%20are%20no%20more%20assert_called%28%29%20calls.%20Is%20this%20okay%3F%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A20%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40prateshg%20-%20the%20problem%20is%20that%20Mock%20objects%2C%20by%20default%2C%20allow%20you%20to%20any%20operation%20on%20them%20without%20throwing%20an%20error.%20This%20means%20that%20any%20typo%20in%20the%20test%2C%20or%20in%20the%20target%20code%2C%20can%20be%20hidden%20with%20no%20notice.%20That%27s%20why%20the%20incorrect%20method%20call%20didn%27t%20raise%20an%20error%2C%20and%20it%20means%20that%20other%20errors%20may%20also%20be%20invisible.%5Cr%5Cn%5Cr%5CnThe%20way%20to%20fix%20this%20is%20to%20configure%20the%20Mock%20objects%20to%20only%20allow%20specific%20attributes/methods%20on%20them%20to%20be%20accessed.%20This%20is%20what%20a%20%27spec%27%20is.%5Cr%5Cn%5Cr%5CnI%27ll%20post%20a%20quick%20example%20in%20a%20minute%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A26%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22https%3A//gist.github.com/kormat/bcb0192e00c3adf374c8%20is%20a%20simple%20example%20of%20how%20to%20detect%20errors.%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A29%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20in%20short%20I%20should%20just%20add%20autospec%3DTrue%20to%20every%20patch%20decorator%5Cn%5CnOn%20Fri%2C%20Jun%2019%2C%202015%20at%205%3A29%20PM%2C%20Stephen%20Shirley%20%3Cnotifications%40github.com%3E%5Cnwrote%3A%5Cn%5Cn%3E%20https%3A//gist.github.com/kormat/bcb0192e00c3adf374c8%20is%20a%20simple%20example%5Cn%3E%20of%20how%20to%20detect%20errors.%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-113548602%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A31%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20100%25%20sure%20if%20that%20will%20fix%20everything%2C%20but%20that%27s%20definitely%20a%20good%20start.%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A33%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20I%20think%20this%20can%20be%20merged%20now%22%2C%20%22created_at%22%3A%20%222015-06-19T16%3A31%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Are%20there%20any%20more%20comments%20or%20is%20everything%20OK%3F%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A07%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Damn.%20Looks%20like%20codereviewhub%20isn%27t%20coping%20with%20the%20/305/%20%20comments%20on%20this%20PR.%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A22%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20i%20think%20that%27s%20everything%20%3A%29%20I%27ll%20merge%20this%20as%20soon%20as%20%23189%20is%20resolved.%20Thanks%21%22%2C%20%22created_at%22%3A%20%222015-06-22T15%3A02%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20a%20lot%21%21%20This%20review%20must%20have%20been%20a%20pain%20in%20the%20ass%20thanks%20for%5Cnbearing%20it%20with%20me.%20%3A%29%5Cn%5CnOn%20Mon%2C%20Jun%2022%2C%202015%20at%205%3A02%20PM%2C%20Stephen%20Shirley%20%3Cnotifications%40github.com%3E%5Cnwrote%3A%5Cn%5Cn%3E%20Ok%2C%20i%20think%20that%27s%20everything%20%3A%29%20I%27ll%20merge%20this%20as%20soon%20as%20%23189%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/issues/189%3E%20is%20resolved.%20Thanks%21%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/169%23issuecomment-114142289%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-22T15%3A04%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20having%20the%20patience%20to%20stick%20with%20it%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-06-22T15%3A08%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28For%20%23129%29%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A29%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%20158%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32730307%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20don%27t%20need%20a%20patch%20for%20this.%20You%20can%20simply%3A%5Cr%5Cn%60%60%60%5Cr%5Cnpth_seg_rec.info%20%3D%20MagicMock%28spec_set%3D%5B%27pack%27%5D%29%5Cr%5Cnpth_seg_rec.info.pack.return_value%20%3D%20%5C%22data1%5C%22%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A42%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A54%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%2093%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729486%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20don%27t%20need%20%60%5C%5C%60%20to%20do%20line%20continuations%20here.%20I%20would%20probably%20just%20move%20bytes%20down%20to%20the%20next%20line%20anyway%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cnntools.eq_%28pth_seg_info.pack%28%29%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20bytes.fromhex%28%270e%202a0a%200b0c%200102030405060708%209192939495969798%27%29%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A33%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A33%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%20010d9d538532dac2ea7f3d8f09e2c16a118fc643%20test/lib_packet_path_mgmt_test.py%2048%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32934052%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Remove%20%60new_callable%3DMagicMock%60.%20The%20only%20place%20it%20was%20needed%20was%20for%20patching%20%60PathSegment.deserialize%60%2C%20as%20that%20is%20a%20static%20method.%20unittest.mock.patch%20has%20a%20bug%20when%20patching%20static%20or%20class%20methods%20%28https%3A//bugs.python.org/issue23078%29.%5Cr%5Cn%5Cr%5CnThinking%20about%20it%20some%20more%2C%20here%20are%20some%20guidelines%3A%5Cr%5Cn%20%2A%20When%20patching%20a%20method%2C%20use%20%60spec_set%3D%5B%5D%60.%5Cr%5Cn%20%2A%20When%20patching%20an%20object%2C%20use%20%60autospec%3DTrue%60.%5Cr%5Cn%20%2A%20When%20patching%20a%20staticmethod/classmethod%2C%20use%20%60new_callable%3DMagicMock%60.%5Cr%5Cn%5Cr%5CnPlease%20update%20the%20various%20patch%20calls%20to%20match%20the%20above%2C%20and%20let%20me%20know%20if%20you%20run%20into%20further%20issues.%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A36%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5C%22lib.packet.packet_base.PayloadBase.parse%5C%22%20is%20a%20method%20and%20using%20spec_set%5Cnonly%20gives%20error%5Cn%5CnOn%20Mon%2C%20Jun%2022%2C%202015%20at%203%3A36%20PM%2C%20Stephen%20Shirley%20%3Cnotifications%40github.com%3E%5Cnwrote%3A%5Cn%5Cn%3E%20In%20test/lib_packet_path_mgmt_test.py%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32934052%3E%3A%5Cn%3E%5Cn%3E%20%3E%20%2B%20%20%20%20PathSegmentRecords%2C%5Cn%3E%20%3E%20%2B%20%20%20%20PathSegmentType%2C%5Cn%3E%20%3E%20%2B%20%20%20%20RevocationInfo%2C%5Cn%3E%20%3E%20%2B%20%20%20%20RevocationPayload%2C%5Cn%3E%20%3E%20%2B%20%20%20%20RevocationType%5Cn%3E%20%3E%20%2B%29%5Cn%3E%20%3E%20%2Bfrom%20lib.packet.scion%20import%20PacketType%5Cn%3E%20%3E%20%2Bfrom%20lib.packet.scion_addr%20import%20ISD_AD%2C%20SCIONAddr%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2Bclass%20TestPathSegmentInfoInit%28object%29%3A%5Cn%3E%20%3E%20%2B%20%20%20%20%5C%22%5C%22%5C%22%5Cn%3E%20%3E%20%2B%20%20%20%20Unit%20tests%20for%20lib.packet.path_mgmt.PathSegmentInfo.__init__%5Cn%3E%20%3E%20%2B%20%20%20%20%5C%22%5C%22%5C%22%5Cn%3E%20%3E%20%2B%20%20%20%20%40patch%28%5C%22lib.packet.packet_base.PayloadBase.__init__%5C%22%2C%20spec_set%3D%5B%5D%2C%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20new_callable%3DMagicMock%29%5Cn%3E%5Cn%3E%20Remove%20new_callable%3DMagicMock.%20The%20only%20place%20it%20was%20needed%20was%20for%5Cn%3E%20patching%20PathSegment.deserialize%2C%20as%20that%20is%20a%20static%20method.%5Cn%3E%20unittest.mock.patch%20has%20a%20bug%20when%20patching%20static%20or%20class%20methods%20%28%5Cn%3E%20https%3A//bugs.python.org/issue23078%29.%5Cn%3E%5Cn%3E%20Thinking%20about%20it%20some%20more%2C%20here%20are%20some%20guidelines%3A%5Cn%3E%5Cn%3E%20%20%20%20-%20When%20patching%20a%20method%2C%20use%20spec_set%3D%5B%5D.%5Cn%3E%20%20%20%20-%20When%20patching%20an%20object%2C%20use%20autospec%3DTrue.%5Cn%3E%20%20%20%20-%20When%20patching%20a%20staticmethod/classmethod%2C%20use%20new_callable%3DMagicMock.%5Cn%3E%5Cn%3E%20Please%20update%20the%20various%20patch%20calls%20to%20match%20the%20above%2C%20and%20let%20me%20know%5Cn%3E%20if%20you%20run%20into%20further%20issues.%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/169/files%23r32934052%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A43%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%27s%20the%20exact%20error%3F%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A46%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Traceback%20%28most%20recent%20call%20last%29%3A%5Cn%20%20File%20%5C%22/home/prateesh/.local/lib/python3.4/site-packages/nose/case.py%5C%22%2C%5Cnline%20198%2C%20in%20runTest%5Cn%20%20%20%20self.test%28%2Aself.arg%29%5Cn%20%20File%20%5C%22/usr/lib/python3.4/unittest/mock.py%5C%22%2C%20line%201125%2C%20in%20patched%5Cn%20%20%20%20return%20func%28%2Aargs%2C%20%2A%2Akeywargs%29%5Cn%20%20File%5Cn%5C%22/home/prateesh/Downloads/Work/UnitTests/scion/test/lib_packet_path_mgmt_test.py%5C%22%2C%5Cnline%2073%2C%20in%20test_basic%5Cn%20%20%20%20pth_seg_info.parse%28data%29%5Cn%20%20File%5Cn%5C%22/home/prateesh/Downloads/Work/UnitTests/scion/lib/packet/path_mgmt.py%5C%22%2C%5Cnline%2088%2C%20in%20parse%5Cn%20%20%20%20PayloadBase.parse%28self%2C%20raw%29%5CnTypeError%3A%20%27NonCallableMagicMock%27%20object%20is%20not%20callable%5Cn%5Cn%5CnOn%20Mon%2C%20Jun%2022%2C%202015%20at%203%3A46%20PM%2C%20Stephen%20Shirley%20%3Cnotifications%40github.com%3E%5Cnwrote%3A%5Cn%5Cn%3E%20In%20test/lib_packet_path_mgmt_test.py%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32934992%3E%3A%5Cn%3E%5Cn%3E%20%3E%20%2B%20%20%20%20PathSegmentRecords%2C%5Cn%3E%20%3E%20%2B%20%20%20%20PathSegmentType%2C%5Cn%3E%20%3E%20%2B%20%20%20%20RevocationInfo%2C%5Cn%3E%20%3E%20%2B%20%20%20%20RevocationPayload%2C%5Cn%3E%20%3E%20%2B%20%20%20%20RevocationType%5Cn%3E%20%3E%20%2B%29%5Cn%3E%20%3E%20%2Bfrom%20lib.packet.scion%20import%20PacketType%5Cn%3E%20%3E%20%2Bfrom%20lib.packet.scion_addr%20import%20ISD_AD%2C%20SCIONAddr%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2Bclass%20TestPathSegmentInfoInit%28object%29%3A%5Cn%3E%20%3E%20%2B%20%20%20%20%5C%22%5C%22%5C%22%5Cn%3E%20%3E%20%2B%20%20%20%20Unit%20tests%20for%20lib.packet.path_mgmt.PathSegmentInfo.__init__%5Cn%3E%20%3E%20%2B%20%20%20%20%5C%22%5C%22%5C%22%5Cn%3E%20%3E%20%2B%20%20%20%20%40patch%28%5C%22lib.packet.packet_base.PayloadBase.__init__%5C%22%2C%20spec_set%3D%5B%5D%2C%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20new_callable%3DMagicMock%29%5Cn%3E%5Cn%3E%20What%27s%20the%20exact%20error%3F%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/169/files%23r32934992%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A47%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%20ok.%20This%20works%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%40patch%28%5C%22lib.packet.path_mgmt.PathSegmentInfo.parse%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cndef%20test_raw%28self%2C%20parse%29%3A%5Cr%5Cn%20%20%20%20pth_seg_info%20%3D%20PathSegmentInfo%28%5C%22data%5C%22%29%5Cr%5Cn%20%20%20%20parse.assert_called_once_with%28psi%2C%20%5C%22data%5C%22%29%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A55%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Then%20should%20the%20guidelines%20be%5Cr%5CnWhen%20patching%20an%20object/method%2C%20use%20autospec%3DTrue.%5Cr%5CnWhen%20patching%20a%20staticmethod/classmethod%2C%20use%20new_callable%3DMagicMock.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A57%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Agreed.%20Guidelines%20updated.%20It%20is%20a%20bit%20hit-and-miss%2C%20as%20it%27s%20tricky%20stuff.%20The%20good%20thing%20is%20that%20you%20can%20test%20if%20the%20object%20is%20patched%20correctly%20by%20calling%20a%20non-existent%20method%20on%20it%2C%20and%20see%20if%20you%20get%20an%20error%20or%20not.%5Cr%5Cn%5Cr%5Cn%60self.parse%28raw%29%60%20actually%20translates%20to%20%60%3Cobj%3E.parse%28self%2C%20raw%29%60%20in%20python%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A16%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A52%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-768%22%7D%2C%20%22Pull%205ed27af9291987086d9d731b58bab0a0ec3d6e90%20test/lib_packet_path_mgmt_test.py%20539%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32936627%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20need%20to%20mock%20out%20the%20%60PayloadBase.parse%60%20call%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A03%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-768%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20163%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820835%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20should%20still%20do%20%60pth_seg_rec.info.pack.assert_called_once_with%28%29%60%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A24%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A55%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20536%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822620%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Missing%20a%20test%20for%20%60add_rev_info%60%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A01%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A04%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A42%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20fe16ada219c8dad59e29647aceb61228ac8b99b6%20test/lib_packet_path_mgmt_test.py%20504%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830767%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Issue%20over%20here%20is%20that%20now%20RevocationInfo%20returns%20a%20string%20but%20we%20need%20to%20access%20the%20parsed%20and%20len%20field%20of%20the%20returned%20value%20on%20line%20417%20of%20%5C%22/lib/packet/path_mgmt.py%5C%22.%20Can%20you%20suggest%20something%20for%20this%3F%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A57%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Good%20point.%20It%20turns%20out%20that%20side_effect%20can%20be%20a%20function.%20So%2C%20you%20could%20add%20a%20small%20function%20that%20returns%20a%20Mock%20that%27s%20configured%20with%20%60parsed%60%20and%20%60__len__%60%20configured.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A13%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ahh%2C%20no%2C%20a%20better%20way%20is%20to%20pass%20%60spec_set%3DTrue%60%20to%20the%20%60patch%60%20decorator.%20That%20will%20mean%20the%20mock%20object%20will%20have%20the%20same%20attributes%20as%20the%20RevocationInfo%20object.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A15%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28If%20that%27s%20too%20strict%2C%20%60spec%3DTrue%60%20is%20probably%20good%20enough%29%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A15%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A56%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-734%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20642%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32823392%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Line%20too%20long%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A16%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A07%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A40%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20010d9d538532dac2ea7f3d8f09e2c16a118fc643%20test/lib_packet_path_mgmt_test.py%20299%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32934702%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Need%201%20space%20after%20%60%2B%60%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A43%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A52%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-768%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20216%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821025%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Over-indented%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A29%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A57%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20553%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822923%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20a%20really%20nice%20set%20of%20tests%20%3A%29%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A07%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20512%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822575%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Same%20issue%20here%20as%20with%20TestPathSegmentLeasesParse%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A00%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A02%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20d8e84253d90a5ab25676839d202ace24c397be36%20test/lib_packet_path_mgmt_test.py%20134%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32842093%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20am%20getting%20an%20error%20saying%20TypeError%3A%20%27NonCallableMagicMock%27%20object%20is%20not%20callable%5Cr%5CnThe%20fix%20for%20this%20is%20writing%20new_callable%3DNonCallableMock%20in%20the%20patch%20decorator.%5Cr%5CnShould%20I%20do%20this%3F%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A54%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20that%27s%20a%20bug%3A%20https%3A//bugs.python.org/issue23078%5Cr%5CnI%20think%20the%20fix%20is%20actually%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%40patch%28%5C%22lib.packet.pcb.PathSegment.deserialize%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20spec_set%3D%5B%5D%2C%20new_callable%3DMagicMock%29%5Cr%5Cn%60%60%60%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-19T16%3A08%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A51%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-715%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20492%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822290%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20be%20more%20specific.%20%60assert_called_once_with%28rev_pld%2C%20data%29%60%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A55%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A03%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20491%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822478%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20calls%20RevocationInfo%2C%20that%20needs%20to%20be%20patched%2C%20too.%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A58%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A55%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A40%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%201d959d9a1a0b902b2db071b84b5ba3888e2bf406%20test/lib_packet_path_mgmt_test.py%20298%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834720%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20great%2C%20much%20much%20better%21%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A36%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A19%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-738%22%7D%2C%20%22Pull%201d959d9a1a0b902b2db071b84b5ba3888e2bf406%20test/lib_packet_path_mgmt_test.py%20117%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834354%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20rename%20to%20%60init%60%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A32%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A52%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A40%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-738%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%20208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32730895%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20like%20it%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A47%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20647%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32823375%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Really%20good%20test%2C%20just%20one%20minor%20request%20-%20can%20you%20please%20change%20the%20string%20values%20to%20be%20more%20descriptive%20of%20what%20they%20represent%3F%20It%20would%20make%20it%20easier%20to%20follow.%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A16%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A07%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A42%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%2048%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729172%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27d%20call%20the%20mock%20%60init%60%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A30%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20%3A%2B1%3A%20for%20testing%20this%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A30%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Still%20needs%20changing.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A51%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28and%20in%20a%20few%20other%20places%2C%20too%29%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A53%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A52%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A40%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%206c45bc093751ca7b6998969e480c063873fa2aaf%20test/path_mgmt_test.py%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32725099%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20also%20changes%20with%20the%20rename%22%2C%20%22created_at%22%3A%20%222015-06-18T12%3A45%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A51%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/path_mgmt_test.py%3AL1-448%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%20118%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729789%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%27s%20actually%20an%20%60assert_is_none%60%2C%20which%20would%20be%20better%20here.%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A36%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A53%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A40%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20381%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821934%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60parsed%60%20is%20set%20after%20%60raw%60%20is%20assigned.%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A47%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A59%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A40%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20435%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822100%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22No%20need%20for%20%60%5C%5C%60%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A50%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A02%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%205ed27af9291987086d9d731b58bab0a0ec3d6e90%20test/lib_packet_path_mgmt_test.py%20543%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32936904%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Do%20these%202%20lines%20do%20anything%3F%20If%20i%27m%20reading%20this%20right%2C%20the%20next%20line%20overrites%20the%20rinfo%20entry%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A05%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A10%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A52%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-768%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20457%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822162%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20isinstance%20check%20in%20test_basic%20is%20sufficient%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A52%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A02%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%20299%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32732268%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60data%20%2B%3D%20temp%60%20is%20a%20more%20concise%20way%20of%20writing%20this%22%2C%20%22created_at%22%3A%20%222015-06-18T14%3A00%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A55%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20175%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820994%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Need%20second%20blank%20line.%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A28%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A56%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%20103%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32729529%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22No%20need%20for%20%60%5C%5C%60%27s%20here%20either.%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A34%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A53%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%20dccd4cb452d8245b7a3ca6835cf2bc00dfc5484c%20test/lib_packet_path_mgmt_test.py%20289%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32836989%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ah.%20This%20is%20a%20problem.%20Mock%20objects%20%5Bdon%27t%20actually%20have%5D%28http%3A//www.voidspace.org.uk/python/mock/mock.html%23mock.Mock%29%20an%20%60assert_called%60%20method.%20The%20reason%20this%20check%20is%20passing%20is%20that%20the%20Mock%20is%20inventing%20an%20%60assert_called%60%20method%20for%20you.%20Add%20%60spec_set%3D%5B%5D%60%20to%20the%20%60%40patch%60%20decorator.%5Cr%5Cn%5Cr%5CnIn%20general%20all%20mocks/patches%20should%20be%20using%20a%20spec%20of%20some%20kind%2C%20whether%20%60spec%60%2C%20%60spec_set%60%2C%20or%20%60autospec%60.%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A00%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Once%20you%20fix%20this%20instance%2C%20please%20go%20back%20over%20your%20existing%20patch/mocks%2C%20and%20configure%20them%20appropriately.%20If%20you%20need%20advice%2C%20let%20me%20know.%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A02%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28I%20should%20have%20noticed%20this%20earlier%2C%20apologies%29%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A02%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A51%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-738%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20625%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32823006%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Needs%20a%20test%20for%20when%20self.payload%20is%20bytes%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A09%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A06%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A34%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%20162%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32730376%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Pack%20is%20called%20before%20serialize%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A43%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A54%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%206c45bc093751ca7b6998969e480c063873fa2aaf%20test/path_mgmt_test.py%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32725087%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20rename%20to%20%60test/lib_packet_path_mgmt_test.py%60%22%2C%20%22created_at%22%3A%20%222015-06-18T12%3A44%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A51%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/path_mgmt_test.py%3AL1-448%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20562%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822782%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Line%20too%20long%20%28same%20for%20other%20methods%20in%20this%20class%29%22%2C%20%22created_at%22%3A%20%222015-06-19T12%3A04%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A05%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%20203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32730836%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20need%20to%20check%20that%20%60PayloadBase.parse%60%20is%20called%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A47%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A54%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%207d1bfb467e5e20cfb7959e751ef52ad046500209%20test/lib_packet_path_mgmt_test.py%20145%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32730032%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%202%20assignments%20don%27t%20do%20anything%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A39%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20you%20want%20to%20change%20them%20into%20assertions%22%2C%20%22created_at%22%3A%20%222015-06-18T13%3A39%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A53%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-525%22%7D%2C%20%22Pull%2061da0ba90f2f149ddc546e54e0397d59a29039e2%20test/lib_packet_path_mgmt_test.py%2060%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32840744%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20Assertion%20Fails%20over%20here%20but%20this%20is%20fine%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A39%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ahh.%20Ok%2C%20the%20fix%20at%20least%20is%20straight%20forward%3A%5Cr%5Cn%60%60%60%5Cr%5Cnpth_seg_info%20%3D%20PathSegmentInfo%28%5C%22data%5C%22%29%5Cr%5Cnparse.assert_called_once_with%28pth_seg_info%2C%20%5C%22data%5C%22%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A42%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20parse%20as%20actually%20caled%20with%20%5C%22data%5C%22%20and%20pth_seg_info%20is%20the%20caller%5Cn%5CnOn%20Fri%2C%20Jun%2019%2C%202015%20at%205%3A42%20PM%2C%20Stephen%20Shirley%20%3Cnotifications%40github.com%3E%5Cnwrote%3A%5Cn%5Cn%3E%20In%20test/lib_packet_path_mgmt_test.py%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32840940%3E%3A%5Cn%3E%5Cn%3E%20%3E%20%2B%20%20%20%20Unit%20tests%20for%20lib.packet.path_mgmt.PathSegmentInfo.__init__%5Cn%3E%20%3E%20%2B%20%20%20%20%5C%22%5C%22%5C%22%5Cn%3E%20%3E%20%2B%20%20%20%20%40patch%28%5C%22lib.packet.packet_base.PayloadBase.__init__%5C%22%2C%20autospec%3DTrue%29%5Cn%3E%20%3E%20%2B%20%20%20%20def%20test_basic%28self%2C%20init%29%3A%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20pth_seg_info%20%3D%20PathSegmentInfo%28%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20ntools.eq_%28pth_seg_info.type%2C%200%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20ntools.eq_%28pth_seg_info.src_isd%2C%200%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20ntools.eq_%28pth_seg_info.dst_isd%2C%200%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20ntools.eq_%28pth_seg_info.src_ad%2C%200%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20ntools.eq_%28pth_seg_info.dst_ad%2C%200%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20init.assert_called_once_with%28pth_seg_info%29%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2B%20%20%20%20%40patch%28%5C%22lib.packet.path_mgmt.PathSegmentInfo.parse%5C%22%2C%20autospec%3DTrue%29%5Cn%3E%20%3E%20%2B%20%20%20%20def%20test_raw%28self%2C%20parse%29%3A%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20PathSegmentInfo%28%5C%22data%5C%22%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20parse.assert_called_once_with%28%5C%22data%5C%22%29%5Cn%3E%5Cn%3E%20Ahh.%20Ok%2C%20the%20fix%20at%20least%20is%20straight%20forward%3A%5Cn%3E%5Cn%3E%20pth_seg_info%20%3D%20PathSegmentInfo%28%5C%22data%5C%22%29%5Cn%3E%20parse.assert_called_once_with%28pth_seg_info%2C%20%5C%22data%5C%22%29%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/169/files%23r32840940%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A46%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20actual%20call%20is%20%60PayloadBase.parse%28self%2C%20raw%29%60%2C%20which%20means%20the%20PathSegmentInfo%20object%20is%20passed%20in%20as%20the%20first%20argument%2C%20%60self%60.%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A57%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20But%20the%20patch%20is%20for%20%5C%22lib.packet.path_mgmt.PathSegmentInfo.parse%5C%22%20and%20the%5Cr%5Cncall%20is%20self.parse%5Cr%5Cn%5Cr%5CnOn%20Fri%2C%20Jun%2019%2C%202015%20at%205%3A57%20PM%2C%20Stephen%20Shirley%20%3Cnotifications%40github.com%3E%5Cr%5Cnwrote%3A%5Cr%5Cn%5Cr%5Cn%3E%20In%20test/lib_packet_path_mgmt_test.py%5Cr%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32842383%3E%3A%5Cr%5Cn%3E%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20Unit%20tests%20for%20lib.packet.path_mgmt.PathSegmentInfo.__init__%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20%5C%22%5C%22%5C%22%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20%40patch%28%5C%22lib.packet.packet_base.PayloadBase.__init__%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20def%20test_basic%28self%2C%20init%29%3A%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20pth_seg_info%20%3D%20PathSegmentInfo%28%29%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20ntools.eq_%28pth_seg_info.type%2C%200%29%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20ntools.eq_%28pth_seg_info.src_isd%2C%200%29%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20ntools.eq_%28pth_seg_info.dst_isd%2C%200%29%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20ntools.eq_%28pth_seg_info.src_ad%2C%200%29%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20ntools.eq_%28pth_seg_info.dst_ad%2C%200%29%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20init.assert_called_once_with%28pth_seg_info%29%5Cr%5Cn%3E%20%3E%20%2B%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20%40patch%28%5C%22lib.packet.path_mgmt.PathSegmentInfo.parse%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20def%20test_raw%28self%2C%20parse%29%3A%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20PathSegmentInfo%28%5C%22data%5C%22%29%5Cr%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20parse.assert_called_once_with%28%5C%22data%5C%22%29%5Cr%5Cn%3E%5Cr%5Cn%3E%20The%20actual%20call%20is%20PayloadBase.parse%28self%2C%20raw%29%2C%20which%20means%20the%5Cr%5Cn%3E%20PathSegmentInfo%20object%20is%20passed%20in%20as%20the%20first%20argument%2C%20self.%5Cr%5Cn%3E%5Cr%5Cn%3E%20%5Cu2014%5Cr%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cr%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/169/files%23r32842383%3E.%5Cr%5Cn%3E%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A59%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ahh%2C%20crap.%20I%20was%20confusing%20it%20with%20a%20test%20for%20%60parse%60%20itself%20%3A%29%20How%20is%20the%20assertion%20failing%2C%20then%3F%22%2C%20%22created_at%22%3A%20%222015-06-19T16%3A10%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22idk.%20I%20am%20using%20%5Cr%5Cn%40patch%28%5C%22lib.packet.pcb.PathSegment.deserialize%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20spec_set%3D%5B%5D%2C%20new_callable%3DMagicMock%29%5Cr%5Cneverywhere%20and%20this%20works%20fine%22%2C%20%22created_at%22%3A%20%222015-06-19T16%3A23%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A51%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-715%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20111%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820980%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Need%202%20blank%20lines%20between%20classes%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A28%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A56%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20110%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820640%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60ntools.assert_is_instance%60%20would%20be%20better%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A21%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A55%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A27%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%201d959d9a1a0b902b2db071b84b5ba3888e2bf406%20test/lib_packet_path_mgmt_test.py%20508%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32834803%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Trailing%20whitespace%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A37%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T15%3A02%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A27%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-738%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20363%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821695%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22One%20blank%20line%20too%20many%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A42%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A58%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A42%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821017%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Continuation%20line%20is%20over-indented%2C%20should%20just%20be%204%20spaces.%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A28%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A56%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A27%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%201d959d9a1a0b902b2db071b84b5ba3888e2bf406%20test/lib_packet_path_mgmt_test.py%20522%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32836005%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ok%2C%20this%20is%20definitely%20heading%20in%20the%20right%20direction%2C%20but%20it%20can%20be%20made%20a%20lot%20simpler.%20The%20thing%20to%20remember%20is%20that%20nothing%20directly%20in%20%60RevocationPayload.parse%60%20cares%20about%20the%20data%20it%27s%20processing.%20This%20means%20you%20can%20make%20raw%20be%20just%20a%20short%20bytestring%20like%20%60b%5C%221234%5C%22%60%2C%20and%20have%20the%20mock%27d%20%60__len__%60%20return%20%601%60%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20%20%20%20%20data%20%3D%20%5C%22abcde%5C%22%5Cr%5Cn%20%20%20%20%20%20%20%20side_effect%20%3D%20%5B%5D%5Cr%5Cn%20%20%20%20%20%20%20%20for%20i%20in%20range%28len%28data%29%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20side_effect.append%28MagicMock%28spec_set%3D%5B%27__len__%27%2C%20%27parsed%27%5D%29%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20side_effect%5Bi%5D.__len__.return_value%20%3D%201%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20side_effect%5Bi%5D.parsed%20%3D%20True%5Cr%5Cn%20%20%20%20%20%20%20%20rev_inf.MAX_LEN%20%3D%201%5Cr%5Cn%20%20%20%20%20%20%20%20rev_inf.side_effect%20%3D%20side_effect%5Cr%5Cn%20%20%20%20%20%20%20%20rev_pld.parse%28data%29%5Cr%5Cn%20%20%20%20%20%20%20%20parse.assert_called_once_with%28rev_pld%2C%20data%29%5Cr%5Cn%20%20%20%20%20%20%20%20rev_inf.assert_has_calls%28%5Bcall%28i%29%20for%20i%20in%20data%5D%29%5Cr%5Cn%20%20%20%20%20%20%20%20ntools.eq_%28rev_pld.rev_infos%5Bi%5D%2C%20side_effect%5Bi%5D%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A50%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A11%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-738%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20354%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821547%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22So%2C%20i%20can%20understand%20where%20these%20tests%20come%20from%2C%20but%20if%20we%20just%20run%20identical%20code%20in%20the%20test%20as%20in%20the%20target%20method%2C%20rather%20than%20testing%20specifically%20against%20the%20correct%20result%2C%20we%20end%20up%20the%20risk%20of%20having%20the%20test%20and%20code%20both%20match%2C%20but%20be%20wrong.%20I%20would%20suggest%3A%5Cr%5Cn%5Cr%5Cn%2A%20%7E%7EChange%20the%20bit%20string%20so%20that%20at%20least%20one%20of%20incl_seg_id%20or%20incl_hop%20isn%27t%200.%7E%7E%5Cr%5Cn%2A%20Test%20exactly%20for%20the%20expected%20results%3A%5Cr%5Cn%60%60%60%5Cr%5Cnntools.eq_%28rev_inf.rev_type%2C%200b101%29%5Cr%5Cnntools.eq_%28rev_inf.incl_seg_id%2C%200b0%29%5Cr%5Cnntools.eq_%28rev_inf.incl_hop%2C%200b0%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A39%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh.%20I%20should%20have%20read%20the%20next%20two%20tests.%20Ignore%20the%20struck-out%20bits%20above%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A41%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20still%20out-standing.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A38%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28ping%29%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A42%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed.%20Sorry%20I%20forgot%20about%20this.%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A48%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-22T14%3A57%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%2094%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32820613%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Heh%2C%20this%20line%20is%20now%20too%20long.%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A20%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A55%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A39%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A43%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T12%3A44%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A25%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A26%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20fa627700bb5f8d866a7df7013eb6130660fb4ff4%20test/lib_packet_path_mgmt_test.py%2092%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32830208%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Don%27t%20need%20the%20%60%5C%5C%60%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A52%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A56%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A27%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-721%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20302%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32821092%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Over-indented%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A30%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22A%20number%20of%20other%20places%2C%20too.%20I%27ll%20stop%20commenting%20on%20them%20now.%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A41%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A58%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A27%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%2C%20%22Pull%20ff80a93e54acde8f8f1a675398fe21eb8d12a210%20test/lib_packet_path_mgmt_test.py%20502%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/169%23discussion_r32822391%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20should%20still%20patch%20PayloadBase.parse%20so%20that%20any%20bugs%20in%20that%20don%27t%20cause%20this%20test%20to%20fail.%20You%20don%27t%20need%20to%20repeat%20the%20assert_called_once_with%20check%20though.%22%2C%20%22created_at%22%3A%20%222015-06-19T11%3A57%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Resolved.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A03%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-22T13%3A27%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL1-682%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#issuecomment-112781992'>General Comment</a></b>
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> I have written test for class PathSegmentInfo. After reviewing is done I will write tests for rest of the classes since the other classes are very similar to this one it will save some effort.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat Can you review this?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Yep, will get to it shortly
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok, just finished a major review of the code. Let me know when i should do another. Thanks :)
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat  Thanks for reviewing. I have addressed all of your comments except some on TestRevocationPayloadParse and TestPathSegmentLeasesParse. So if you want to review again now would be the time as you have just finished reviewing.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok, i'll take another look
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat made changes as suggested
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat I am sorry but I don't understand you completely. I have changed the code so that there are no more assert_called() calls. Is this okay?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @prateshg - the problem is that Mock objects, by default, allow you to any operation on them without throwing an error. This means that any typo in the test, or in the target code, can be hidden with no notice. That's why the incorrect method call didn't raise an error, and it means that other errors may also be invisible.
  The way to fix this is to configure the Mock objects to only allow specific attributes/methods on them to be accessed. This is what a 'spec' is.
  I'll post a quick example in a minute
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> https://gist.github.com/kormat/bcb0192e00c3adf374c8 is a simple example of how to detect errors.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> So in short I should just add autospec=True to every patch decorator
  On Fri, Jun 19, 2015 at 5:29 PM, Stephen Shirley notifications@github.com
  wrote:
  > https://gist.github.com/kormat/bcb0192e00c3adf374c8 is a simple example
  > of how to detect errors.
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/169#issuecomment-113548602.
  >
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I'm not 100% sure if that will fix everything, but that's definitely a good start.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat I think this can be merged now
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Are there any more comments or is everything OK?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Damn. Looks like codereviewhub isn't coping with the /305/  comments on this PR.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok, i think that's everything :) I'll merge this as soon as #189 is resolved. Thanks!
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Thanks a lot!! This review must have been a pain in the ass thanks for
  bearing it with me. :)
  On Mon, Jun 22, 2015 at 5:02 PM, Stephen Shirley notifications@github.com
  wrote:
  > Ok, i think that's everything :) I'll merge this as soon as #189
  > https://github.com/netsec-ethz/scion/issues/189 is resolved. Thanks!
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/169#issuecomment-114142289.
  >
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Thanks for having the patience to stick with it :)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (For #129)
- [x] <a href='#crh-comment-Pull 5ed27af9291987086d9d731b58bab0a0ec3d6e90 test/lib_packet_path_mgmt_test.py 539'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32936627'>File: test/lib_packet_path_mgmt_test.py:L1-768</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You need to mock out the `PayloadBase.parse` call
- [x] <a href='#crh-comment-Pull 6c45bc093751ca7b6998969e480c063873fa2aaf test/path_mgmt_test.py 1'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32725087'>File: test/path_mgmt_test.py:L1-448</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Please rename to `test/lib_packet_path_mgmt_test.py`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 6c45bc093751ca7b6998969e480c063873fa2aaf test/path_mgmt_test.py 15'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32725099'>File: test/path_mgmt_test.py:L1-448</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This also changes with the rename
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 48'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32729172'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I'd call the mock `init`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> But :+1: for testing this
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Still needs changing.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (and in a few other places, too)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 77'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32729341'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I'd move this assertion above the other checks, as PayloadBase.parse gets called before struct unpack
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 93'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32729486'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You don't need `\` to do line continuations here. I would probably just move bytes down to the next line anyway:

```
ntools.eq_(pth_seg_info.pack(),
bytes.fromhex('0e 2a0a 0b0c 0102030405060708 9192939495969798'))
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 103'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32729529'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> No need for `\`'s here either.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 104'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32729628'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> For full marks, you could also check that the returned type is a PathSegmentInfo object
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 118'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32729789'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> There's actually an `assert_is_none`, which would be better here.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 145'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32730032'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> These 2 assignments don't do anything
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ah, you want to change them into assertions
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 158'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32730307'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You don't need a patch for this. You can simply:

```
pth_seg_rec.info = MagicMock(spec_set=['pack'])
pth_seg_rec.info.pack.return_value = "data1"
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 162'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32730376'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Pack is called before serialize
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 203'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32730836'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You need to check that `PayloadBase.parse` is called
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 208'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32730895'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I like it :+1:
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 281'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32732150'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> What you want to check here is that `LeaseInfo` is called 4 times with the correct data, and that `leases` contains the 4 return values afterwards. The first bit is done by using `assert_has_calls`. The return values can be specified by using a mock with the `side_effect` attribute set to a list.
  [Here](https://github.com/netsec-ethz/scion/blob/master/test/lib_zookeeper_test.py#L877) is an example test that does both of these things.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Should a similar thing be done for TestPathSegmentLeasesPack as well? IMHO current code is more understandable.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Yes. One of the principles of unit testing is that you limit the scope to precisely what you mean to test. Otherwise errors in other parts of the code will cause lots of seemingly unrelated unit tests to fail, making diagnosing and fixing much harder. It also means the test is very clear in what exactly it is (and is not) testing.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 7d1bfb467e5e20cfb7959e751ef52ad046500209 test/lib_packet_path_mgmt_test.py 299'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32732268'>File: test/lib_packet_path_mgmt_test.py:L1-525</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `data += temp` is a more concise way of writing this
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 94'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32820613'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Heh, this line is now too long.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 110'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32820640'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `ntools.assert_is_instance` would be better
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 163'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32820835'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You should still do `pth_seg_rec.info.pack.assert_called_once_with()`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 41'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32820962'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You don't (currently) use `PayloadBase`, `PathSegment`, `SCIONPacket` or `SCIONHeader`. You don't need to import them to patch them
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 111'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32820980'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Need 2 blank lines between classes
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 175'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32820994'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Need second blank line.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 203'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32821017'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Continuation line is over-indented, should just be 4 spaces.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 216'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32821025'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Over-indented
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 282'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32821038'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Over-indented
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 287'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32821070'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> No need for `\`, the line already has an open set of parentheses.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 289'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32821084'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Line too long
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 302'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32821092'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Over-indented
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> A number of other places, too. I'll stop commenting on them now. :)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 354'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32821547'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> So, i can understand where these tests come from, but if we just run identical code in the test as in the target method, rather than testing specifically against the correct result, we end up the risk of having the test and code both match, but be wrong. I would suggest:
- ~~Change the bit string so that at least one of incl_seg_id or incl_hop isn't 0.~~
- Test exactly for the expected results:

```
ntools.eq_(rev_inf.rev_type, 0b101)
ntools.eq_(rev_inf.incl_seg_id, 0b0)
ntools.eq_(rev_inf.incl_hop, 0b0)
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Oh. I should have read the next two tests. Ignore the struck-out bits above :)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is still out-standing.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (ping)
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Fixed. Sorry I forgot about this.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 363'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32821695'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> One blank line too many
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 370'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32821784'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> In this case it would just be clearer to format this by using a set of `()`'s around the whole right side:

```
data = (struct.pack("!B", 0b00011011) +
b"superlengthybigstringoflength321"
b"superlengthybigstringoflength322"
b"superlengthybigstringoflength323"
b"superlengthybigstringoflength324"
b"superlengthybigstringoflength325")
```

(You don't need +'s between the literal bytes strings. Python does implicit string joining)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 381'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32821934'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `parsed` is set after `raw` is assigned.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 401'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32822032'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The method names in this class have reversed meaning to the previous class.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I should probably clarify:
- In `TestRevocationInfoParse`, `test_var_size` is with `incl_seg_id` and `incl_hop` set to 1.
- In `TestRevocationInfoPack`, `test_var_size` is with `incl_seg_id` and `incl_hop` set to 0.
  I think you need to swap the contents of the two methods in `TestRevocationInfoPack`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 435'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32822100'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> No need for `\`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 453'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32822141'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Keep the tests in the same order as the args (`seg_id` is before `incl_hop`)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 457'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32822162'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The isinstance check in test_basic is sufficient
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 492'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32822290'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This should be more specific. `assert_called_once_with(rev_pld, data)`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 502'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32822391'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You should still patch PayloadBase.parse so that any bugs in that don't cause this test to fail. You don't need to repeat the assert_called_once_with check though.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 491'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32822478'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This calls RevocationInfo, that needs to be patched, too.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 512'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32822575'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same issue here as with TestPathSegmentLeasesParse
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 536'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32822620'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Missing a test for `add_rev_info`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 562'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32822782'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Line too long (same for other methods in this class)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 553'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32822923'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is a really nice set of tests :) :+1:
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 608'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32822948'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Just one test missing - for when an unsupported type is parsed
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 625'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32823006'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Needs a test for when self.payload is bytes
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 647'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32823375'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Really good test, just one minor request - can you please change the string values to be more descriptive of what they represent? It would make it easier to follow.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull ff80a93e54acde8f8f1a675398fe21eb8d12a210 test/lib_packet_path_mgmt_test.py 642'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32823392'>File: test/lib_packet_path_mgmt_test.py:L1-682</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Line too long
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 284178dd199ded80570d85d813fa524488819b50 test/lib_packet_path_mgmt_test.py 645'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32823484'>File: test/lib_packet_path_mgmt_test.py:L1-692</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Perhaps rename these 2 tests to something like `test_to_scionaddr` and `test_from_scionaddr`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull fa627700bb5f8d866a7df7013eb6130660fb4ff4 test/lib_packet_path_mgmt_test.py 92'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32830208'>File: test/lib_packet_path_mgmt_test.py:L1-721</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Don't need the `\`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull fe16ada219c8dad59e29647aceb61228ac8b99b6 test/lib_packet_path_mgmt_test.py 504'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32830767'>File: test/lib_packet_path_mgmt_test.py:L1-734</a></b>
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Issue over here is that now RevocationInfo returns a string but we need to access the parsed and len field of the returned value on line 417 of "/lib/packet/path_mgmt.py". Can you suggest something for this?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Good point. It turns out that side_effect can be a function. So, you could add a small function that returns a Mock that's configured with `parsed` and `__len__` configured.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ahh, no, a better way is to pass `spec_set=True` to the `patch` decorator. That will mean the mock object will have the same attributes as the RevocationInfo object.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (If that's too strict, `spec=True` is probably good enough)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 1d959d9a1a0b902b2db071b84b5ba3888e2bf406 test/lib_packet_path_mgmt_test.py 117'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32834354'>File: test/lib_packet_path_mgmt_test.py:L1-738</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Please rename to `init`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 1d959d9a1a0b902b2db071b84b5ba3888e2bf406 test/lib_packet_path_mgmt_test.py 289'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32834622'>File: test/lib_packet_path_mgmt_test.py:L1-738</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This should be more specific, `parse.assert_called_once_with(pth_seg_les, data)`
- [x] <a href='#crh-comment-Pull 1d959d9a1a0b902b2db071b84b5ba3888e2bf406 test/lib_packet_path_mgmt_test.py 298'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32834720'>File: test/lib_packet_path_mgmt_test.py:L1-738</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is great, much much better!
- [x] <a href='#crh-comment-Pull 1d959d9a1a0b902b2db071b84b5ba3888e2bf406 test/lib_packet_path_mgmt_test.py 508'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32834803'>File: test/lib_packet_path_mgmt_test.py:L1-738</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Trailing whitespace
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Resolved.
- [x] <a href='#crh-comment-Pull 1d959d9a1a0b902b2db071b84b5ba3888e2bf406 test/lib_packet_path_mgmt_test.py 522'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32836005'>File: test/lib_packet_path_mgmt_test.py:L1-738</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok, this is definitely heading in the right direction, but it can be made a lot simpler. The thing to remember is that nothing directly in `RevocationPayload.parse` cares about the data it's processing. This means you can make raw be just a short bytestring like `b"1234"`, and have the mock'd `__len__` return `1`:

```
data = "abcde"
side_effect = []
for i in range(len(data)):
side_effect.append(MagicMock(spec_set=['__len__', 'parsed']))
side_effect[i].__len__.return_value = 1
side_effect[i].parsed = True
rev_inf.MAX_LEN = 1
rev_inf.side_effect = side_effect
rev_pld.parse(data)
parse.assert_called_once_with(rev_pld, data)
rev_inf.assert_has_calls([call(i) for i in data])
ntools.eq_(rev_pld.rev_infos[i], side_effect[i])
```
- [x] <a href='#crh-comment-Pull dccd4cb452d8245b7a3ca6835cf2bc00dfc5484c test/lib_packet_path_mgmt_test.py 289'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32836989'>File: test/lib_packet_path_mgmt_test.py:L1-738</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ah. This is a problem. Mock objects [don't actually have](http://www.voidspace.org.uk/python/mock/mock.html#mock.Mock) an `assert_called` method. The reason this check is passing is that the Mock is inventing an `assert_called` method for you. Add `spec_set=[]` to the `@patch` decorator.
  In general all mocks/patches should be using a spec of some kind, whether `spec`, `spec_set`, or `autospec`.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Once you fix this instance, please go back over your existing patch/mocks, and configure them appropriately. If you need advice, let me know.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (I should have noticed this earlier, apologies)
- [x] <a href='#crh-comment-Pull 61da0ba90f2f149ddc546e54e0397d59a29039e2 test/lib_packet_path_mgmt_test.py 60'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32840744'>File: test/lib_packet_path_mgmt_test.py:L1-715</a></b>
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat Assertion Fails over here but this is fine
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ahh. Ok, the fix at least is straight forward:

```
pth_seg_info = PathSegmentInfo("data")
parse.assert_called_once_with(pth_seg_info, "data")
```
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> But parse as actually caled with "data" and pth_seg_info is the caller
  On Fri, Jun 19, 2015 at 5:42 PM, Stephen Shirley notifications@github.com
  wrote:
  > In test/lib_packet_path_mgmt_test.py
  > https://github.com/netsec-ethz/scion/pull/169#discussion_r32840940:
  >
  > > +    Unit tests for lib.packet.path_mgmt.PathSegmentInfo.**init**
  > > +    """
  > > +    @patch("lib.packet.packet_base.PayloadBase.**init**", autospec=True)
  > > +    def test_basic(self, init):
  > > +        pth_seg_info = PathSegmentInfo()
  > > +        ntools.eq_(pth_seg_info.type, 0)
  > > +        ntools.eq_(pth_seg_info.src_isd, 0)
  > > +        ntools.eq_(pth_seg_info.dst_isd, 0)
  > > +        ntools.eq_(pth_seg_info.src_ad, 0)
  > > +        ntools.eq_(pth_seg_info.dst_ad, 0)
  > > +        init.assert_called_once_with(pth_seg_info)
  > > +
  > > +    @patch("lib.packet.path_mgmt.PathSegmentInfo.parse", autospec=True)
  > > +    def test_raw(self, parse):
  > > +        PathSegmentInfo("data")
  > > +        parse.assert_called_once_with("data")
  >
  > Ahh. Ok, the fix at least is straight forward:
  >
  > pth_seg_info = PathSegmentInfo("data")
  > parse.assert_called_once_with(pth_seg_info, "data")
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/169/files#r32840940.
  >
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The actual call is `PayloadBase.parse(self, raw)`, which means the PathSegmentInfo object is passed in as the first argument, `self`.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat But the patch is for "lib.packet.path_mgmt.PathSegmentInfo.parse" and the
  call is self.parse
  On Fri, Jun 19, 2015 at 5:57 PM, Stephen Shirley notifications@github.com
  wrote:
  > In test/lib_packet_path_mgmt_test.py
  > https://github.com/netsec-ethz/scion/pull/169#discussion_r32842383:
  >
  > > +    Unit tests for lib.packet.path_mgmt.PathSegmentInfo.**init**
  > > +    """
  > > +    @patch("lib.packet.packet_base.PayloadBase.**init**", autospec=True)
  > > +    def test_basic(self, init):
  > > +        pth_seg_info = PathSegmentInfo()
  > > +        ntools.eq_(pth_seg_info.type, 0)
  > > +        ntools.eq_(pth_seg_info.src_isd, 0)
  > > +        ntools.eq_(pth_seg_info.dst_isd, 0)
  > > +        ntools.eq_(pth_seg_info.src_ad, 0)
  > > +        ntools.eq_(pth_seg_info.dst_ad, 0)
  > > +        init.assert_called_once_with(pth_seg_info)
  > > +
  > > +    @patch("lib.packet.path_mgmt.PathSegmentInfo.parse", autospec=True)
  > > +    def test_raw(self, parse):
  > > +        PathSegmentInfo("data")
  > > +        parse.assert_called_once_with("data")
  >
  > The actual call is PayloadBase.parse(self, raw), which means the
  > PathSegmentInfo object is passed in as the first argument, self.
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/169/files#r32842383.
  >
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ahh, crap. I was confusing it with a test for `parse` itself :) How is the assertion failing, then?
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> idk. I am using
  @patch("lib.packet.pcb.PathSegment.deserialize",
  spec_set=[], new_callable=MagicMock)
  everywhere and this works fine
- [x] <a href='#crh-comment-Pull d8e84253d90a5ab25676839d202ace24c397be36 test/lib_packet_path_mgmt_test.py 134'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32842093'>File: test/lib_packet_path_mgmt_test.py:L1-715</a></b>
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> I am getting an error saying TypeError: 'NonCallableMagicMock' object is not callable
  The fix for this is writing new_callable=NonCallableMock in the patch decorator.
  Should I do this?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ah, that's a bug: https://bugs.python.org/issue23078
  I think the fix is actually:

```
@patch("lib.packet.pcb.PathSegment.deserialize",
spec_set=[], new_callable=MagicMock)
```
- [x] <a href='#crh-comment-Pull 010d9d538532dac2ea7f3d8f09e2c16a118fc643 test/lib_packet_path_mgmt_test.py 48'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32934052'>File: test/lib_packet_path_mgmt_test.py:L1-768</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Remove `new_callable=MagicMock`. The only place it was needed was for patching `PathSegment.deserialize`, as that is a static method. unittest.mock.patch has a bug when patching static or class methods (https://bugs.python.org/issue23078).
  Thinking about it some more, here are some guidelines:
- When patching a method, use `spec_set=[]`.
- When patching an object, use `autospec=True`.
- When patching a staticmethod/classmethod, use `new_callable=MagicMock`.
  Please update the various patch calls to match the above, and let me know if you run into further issues.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> "lib.packet.packet_base.PayloadBase.parse" is a method and using spec_set
  only gives error
  On Mon, Jun 22, 2015 at 3:36 PM, Stephen Shirley notifications@github.com
  wrote:
  > In test/lib_packet_path_mgmt_test.py
  > https://github.com/netsec-ethz/scion/pull/169#discussion_r32934052:
  >
  > > +    PathSegmentRecords,
  > > +    PathSegmentType,
  > > +    RevocationInfo,
  > > +    RevocationPayload,
  > > +    RevocationType
  > > +)
  > > +from lib.packet.scion import PacketType
  > > +from lib.packet.scion_addr import ISD_AD, SCIONAddr
  > > +
  > > +
  > > +class TestPathSegmentInfoInit(object):
  > > +    """
  > > +    Unit tests for lib.packet.path_mgmt.PathSegmentInfo.**init**
  > > +    """
  > > +    @patch("lib.packet.packet_base.PayloadBase.**init**", spec_set=[],
  > > +           new_callable=MagicMock)
  >
  > Remove new_callable=MagicMock. The only place it was needed was for
  > patching PathSegment.deserialize, as that is a static method.
  > unittest.mock.patch has a bug when patching static or class methods (
  > https://bugs.python.org/issue23078).
  >
  > Thinking about it some more, here are some guidelines:
  >
  >    - When patching a method, use spec_set=[].
  >    - When patching an object, use autospec=True.
  >    - When patching a staticmethod/classmethod, use new_callable=MagicMock.
  >
  > Please update the various patch calls to match the above, and let me know
  > if you run into further issues.
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/169/files#r32934052.
  >
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> What's the exact error?
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Traceback (most recent call last):
  File "/home/prateesh/.local/lib/python3.4/site-packages/nose/case.py",
  line 198, in runTest
  self.test(_self.arg)
  File "/usr/lib/python3.4/unittest/mock.py", line 1125, in patched
  return func(_args, **keywargs)
  File
  "/home/prateesh/Downloads/Work/UnitTests/scion/test/lib_packet_path_mgmt_test.py",
  line 73, in test_basic
  pth_seg_info.parse(data)
  File
  "/home/prateesh/Downloads/Work/UnitTests/scion/lib/packet/path_mgmt.py",
  line 88, in parse
  PayloadBase.parse(self, raw)
  TypeError: 'NonCallableMagicMock' object is not callable
  On Mon, Jun 22, 2015 at 3:46 PM, Stephen Shirley notifications@github.com
  wrote:
  > In test/lib_packet_path_mgmt_test.py
  > https://github.com/netsec-ethz/scion/pull/169#discussion_r32934992:
  >
  > > +    PathSegmentRecords,
  > > +    PathSegmentType,
  > > +    RevocationInfo,
  > > +    RevocationPayload,
  > > +    RevocationType
  > > +)
  > > +from lib.packet.scion import PacketType
  > > +from lib.packet.scion_addr import ISD_AD, SCIONAddr
  > > +
  > > +
  > > +class TestPathSegmentInfoInit(object):
  > > +    """
  > > +    Unit tests for lib.packet.path_mgmt.PathSegmentInfo.**init**
  > > +    """
  > > +    @patch("lib.packet.packet_base.PayloadBase.**init**", spec_set=[],
  > > +           new_callable=MagicMock)
  >
  > What's the exact error?
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/169/files#r32934992.
  >
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Hmm, ok. This works:

```
@patch("lib.packet.path_mgmt.PathSegmentInfo.parse", autospec=True)
def test_raw(self, parse):
pth_seg_info = PathSegmentInfo("data")
parse.assert_called_once_with(psi, "data")
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Then should the guidelines be
When patching an object/method, use autospec=True.
When patching a staticmethod/classmethod, use new_callable=MagicMock.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Agreed. Guidelines updated. It is a bit hit-and-miss, as it's tricky stuff. The good thing is that you can test if the object is patched correctly by calling a non-existent method on it, and see if you get an error or not.
`self.parse(raw)` actually translates to `<obj>.parse(self, raw)` in python
- [x] <a href='#crh-comment-Pull 010d9d538532dac2ea7f3d8f09e2c16a118fc643 test/lib_packet_path_mgmt_test.py 299'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32934702'>File: test/lib_packet_path_mgmt_test.py:L1-768</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Need 1 space after `+`
- [x] <a href='#crh-comment-Pull 5ed27af9291987086d9d731b58bab0a0ec3d6e90 test/lib_packet_path_mgmt_test.py 543'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/169#discussion_r32936904'>File: test/lib_packet_path_mgmt_test.py:L1-768</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Do these 2 lines do anything? If i'm reading this right, the next line overrites the rinfo entry
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> fixed


<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/169?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/169?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/169'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
```
