### PR TITLE
Fix docker dependancy installation after circleci integration.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,20 +12,37 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y bu
 # Pre-download some of the known major dependancies, to speed up rebuilds.
 RUN DEBIAN_FRONTEND=noninteractive apt-get install --download-only --no-install-recommends -y python python3 python-dev python3-dev screen zookeeperd
 
-# Just copy over scion.sh for now, to install dependancies. Don't want docker
-# to re-run this step everytime anything in the repo changes.
-COPY _build/scion.git/scion.sh /home/scion/scion.git/
-RUN chown -R scion: /home/scion
+################################################################################
+# Handle installing all dependancies up-front. That way code changes don't cause
+# the expensive part of the image build to be re-run.
+################################################################################
+
+# Copy over scion.sh. If it has changed, everything gets rebuilt.
 USER scion
 ENV HOME /home/scion
 WORKDIR /home/scion/scion.git
-RUN DEBIAN_FRONTEND=noninteractive APTARGS=-y ./scion.sh deps
-RUN echo "PATH=$HOME/.local/bin:/usr/share/zookeeper/bin:$PATH" >> ~/.profile
+COPY _build/scion.git/scion.sh /home/scion/scion.git/
 
-USER root
+# Copy over pkgs_debian.txt. If it has changed, then re-run the remaining steps.
+COPY _build/scion.git/pkgs_debian.txt /home/scion/scion.git/
+RUN sudo chown -R scion: /home/scion
+RUN DEBIAN_FRONTEND=noninteractive APTARGS=-y ./scion.sh deps pkgs
+
+# Copy over requirements.txt. If it has changed, then re-run the remaining steps.
+COPY _build/scion.git/requirements.txt /home/scion/scion.git/
+RUN sudo chown -R scion: /home/scion
+RUN ./scion.sh deps pip3
+
+RUN ./scion.sh deps
+
 # Clean out the cached packages now they're no longer necessary
-RUN apt-get clean
+RUN sudo apt-get clean
 
+################################################################################
+# All dependancies are now installed, carry on with the rest.
+################################################################################
+
+RUN echo "PATH=$HOME/.local/bin:/usr/share/zookeeper/bin:$PATH" >> ~/.profile
 # Now copy over the current branch
 COPY _build/scion.git /home/scion/scion.git
 # Copy over init.sh:
@@ -33,10 +50,9 @@ COPY init.sh /home/scion/bin/
 # Install basic screen config
 COPY screenrc /home/scion/.screenrc
 
-# Fix ownership:
-RUN chown -R scion: /home/scion
+# Fix ownership one last time:
+RUN sudo chown -R scion: /home/scion
 # Fix some image problems:
-RUN chmod g+s /usr/bin/screen
+RUN sudo chmod g+s /usr/bin/screen
 
-USER scion
 CMD ["/home/scion/bin/init.sh"]

--- a/pkgs_debian.txt
+++ b/pkgs_debian.txt
@@ -1,0 +1,11 @@
+build-essential
+dnsutils
+docker.io
+python
+python-dev
+python-pip
+python3
+python3-dev
+python3-pip
+screen
+zookeeperd


### PR DESCRIPTION
All dependancies are now listed in 2 files, pkgs_debian.txt for things
installed via apt-get, and requirements.txt for things installed via
pip3. This means that if a pip3 dependancy changes, docker doesn't have
to redo the (slow) apt-get steps.

I broke docker building in #168, this fixes it.

(Ref: #167)
