### PR TITLE
Treat sphinx warnings as errors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,3 +12,4 @@ dependencies:
 test:
   override:
     - ./scion.sh test
+    - make -C sphinx-doc html

--- a/infrastructure/dns_server.py
+++ b/infrastructure/dns_server.py
@@ -123,7 +123,7 @@ class SrvInst(object):
         :param qtype: Query type (e.g. ``"AAAA"``).
         :type qtype:
         :param reply: DNSRecord object to add the replies to.
-        :type reply.
+        :type reply:
         """
         # 'answer' section
         if qtype in ["A", "ANY"]:

--- a/sphinx-doc/Makefile
+++ b/sphinx-doc/Makefile
@@ -15,7 +15,7 @@ endif
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -W -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 


### PR DESCRIPTION
Build sphinx docs as part of CI so that errors are caught.

Also fixed a docs typo.
