### PR TITLE
Fix an issue where thread_safety_net would kill a test.

### DIFF
--- a/test/common_header_test.py
+++ b/test/common_header_test.py
@@ -18,9 +18,12 @@
 # Stdlib
 import unittest
 
+# Has to be imported before anything else so that any relevant decorators are
+# patched.
+from test.testcommon import SCIONCommonTest
+
 # SCION
 from lib.packet.scion import SCIONCommonHdr
-from test.testcommon import SCIONCommonTest
 
 
 class TestCommonHeader(SCIONCommonTest):

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -24,10 +24,13 @@ import nose
 import nose.tools as ntools
 from unittest.mock import patch, mock_open
 
+# Has to be imported before anything else so that any relevant decorators are
+# patched.
+from test.testcommon import SCIONTestException
+
 # SCION
 from lib.config import Config
 from lib.defines import TOPOLOGY_PATH
-from test.testcommon import SCIONTestException
 
 
 class BaseLibConfig(object):

--- a/test/dns_server_test.py
+++ b/test/dns_server_test.py
@@ -26,11 +26,14 @@ import nose.tools as ntools
 from dnslib import DNSLabel, DNSRecord, QTYPE, RCODE
 from dnslib import A, AAAA, PTR, RR, SRV
 
+# Has to be imported before anything else so that any relevant decorators are
+# patched.
+from test.testcommon import MockCollection, SCIONTestException
+
 # SCION
 from infrastructure.dns_server import SCIONDnsServer, SrvInst, ZoneResolver
 from lib.defines import SCION_DNS_PORT
 from lib.zookeeper import ZkConnectionLoss, ConnectionLoss, SessionExpiredError
-from test.testcommon import MockCollection, SCIONTestException
 
 
 class BaseDNSServer(object):

--- a/test/hash_chain_test.py
+++ b/test/hash_chain_test.py
@@ -22,9 +22,12 @@ import unittest
 # External packages
 from Crypto import Random
 
+# Has to be imported before anything else so that any relevant decorators are
+# patched.
+from test.testcommon import SCIONCommonTest
+
 # SCION
 from lib.crypto.hash_chain import HashChain
-from test.testcommon import SCIONCommonTest
 
 
 class TestHashChain(SCIONCommonTest):

--- a/test/lib_zookeeper_test.py
+++ b/test/lib_zookeeper_test.py
@@ -25,9 +25,12 @@ import nose
 import nose.tools as ntools
 from kazoo.protocol.states import ZnodeStat
 
+# Has to be imported before anything else so that any relevant decorators are
+# patched.
+from test.testcommon import MockCollection, SCIONTestException
+
 # SCION
 import lib.zookeeper as libzk
-from test.testcommon import MockCollection, SCIONTestException
 
 
 def mock_wrapper(f):

--- a/test/symcrypto_test.py
+++ b/test/symcrypto_test.py
@@ -19,6 +19,10 @@
 import logging
 import unittest
 
+# Has to be imported before anything else so that any relevant decorators are
+# patched.
+from test.testcommon import SCIONCommonTest
+
 # SCION
 from lib.crypto.symcrypto import (
     authenticated_decrypt,
@@ -31,7 +35,6 @@ from lib.crypto.symcrypto import (
     sha3hash,
     verify_cbcmac,
 )
-from test.testcommon import SCIONCommonTest
 
 
 class TestSymcrypto(SCIONCommonTest):


### PR DESCRIPTION
As thread_safety_net wasn't patched in time,
when TestLibZookeeperStateHandler._check would (intentionally) trigger a
StopIteration exception in _state_handler, thread_safety_net would then
kill the process.

This also was a problem if another unit test file imported lib.thread
first, so i've moved all imports of testcommon to before any other SCION
imports in unit test files.

E.g. dns_server_test.py was importing lib.zookeeper, which then imported
thread_safety_net; this sometimes happened before lib_zookeeper_test was
run, so changing the import order only in lib_zookeeper_test was
unreliable.
