### PR TITLE
Multi ISD topology generator

### DIFF
--- a/topology/brite/topology_generator.py
+++ b/topology/brite/topology_generator.py
@@ -117,8 +117,8 @@ def add_random_edges(isd_graph, core_ad_dict, max_degree):
         [isd, neighbor_isd] = random.sample(denser_isds, 2)
         isd_graph.add_edge(isd, neighbor_isd)
         # Break if one of the nodes has reached max_degree 
-        if isd_graph.degree(isd) >= max_degree or \
-           isd_graph.degree(neighbor_isd) >= max_degree:
+        if (isd_graph.degree(isd) >= max_degree or
+            isd_graph.degree(neighbor_isd) >= max_degree):
            break
     return isd_graph
 


### PR DESCRIPTION
- An extension to #151, to generate SCION topology with many ISD's
- Argparse module is used. Input can be in the form of multiple files specified at the command line (or) to convert all files in a specified directory.
- Connecting the core AD's in these ISD's is done based on connections in a model graph. Currently, they are completely connected to each other(model graph being the complete graph). So, each core AD in an ISD is connected to every other core AD in every other ISD. Maybe this is too much? Suggestions are welcome regarding this part.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/183%23issuecomment-113519259%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23issuecomment-113529444%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23issuecomment-113533480%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23issuecomment-114448486%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23issuecomment-115180061%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23issuecomment-115221961%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23issuecomment-115234813%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23issuecomment-115274385%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23issuecomment-116680473%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r32834247%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r32834439%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33233467%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33233709%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33234268%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33234269%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33234568%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33243250%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33360888%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33361210%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33361309%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33361413%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33464199%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33464653%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33464654%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33464655%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33464656%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33464658%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33464659%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23issuecomment-113519259%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Tests%20failed%20because%20your%20branch%20is%20out-of-date%20and%20has%20no%20%60circle.yml%60%20file.%5Cr%5CnPlease%20rebase%20your%20changes%20against%20%60master%60%20and%20then%20do%20%60git%20push%20-f%60%20to%20update%20the%20PR.%22%2C%20%22created_at%22%3A%20%222015-06-19T13%3A46%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1120468%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rev112%22%7D%7D%2C%20%7B%22body%22%3A%20%22Rebased.%20%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A20%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%2C%20%7B%22body%22%3A%20%22As%20an%20alternative%20to%20using%20a%20complete%20graph%20to%20interconnect%20core%20ADs%2C%20you%20could%20let%20the%20user%20specify%20some%20constraints%20like%20total%20number%20of%20inter-ISD%20connections%20per%20ISD%20and%20minimum/maximum%20number%20of%20connections%20to%20different%20ISDs%20%28per%20ISD%29%20and%20then%20generate%20the%20inter-ISD%20peering%20links%20based%20on%20these%20constraints.%20%5Cr%5Cn%5Cr%5CnFor%20example%2C%20lets%20assume%20we%20have%206%20ISDs%20and%20each%20ISD%20should%20have%20connections%20to%20at%20least%203%20different%20other%20ISDS%20and%20in%20total%206%20inter-ISD%20peering%20links.%20You%20can%20easily%20generate%20links%20between%20core%20ADs%2C%20such%20that%20these%20constraints%20are%20satisfied.%20%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A39%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20way%20in%20which%20inter-ISD%20connections%20are%20made%20is%20changed.%20A%20command%20line%20parameter%20%27degree%27%20is%20introduced%20which%20is%20used%20to%20determine%20the%20number%20of%20inter-ISD%20connections.%22%2C%20%22created_at%22%3A%20%222015-06-23T11%3A22%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%20this%20looks%20pretty%20good%20now.%20The%20only%20thing%20that%20would%20be%20nice%20is%20if%20we%20could%20have%20some%20variance%20among%20the%20degrees%20of%20ISDs.%20E.g.%2C%20the%20US%20ISD%20would%20be%20much%20better%20interconnected%20than%20an%20ISD%20from%20a%20smaller%20country.%20Basically%2C%20instead%20of%20just%20a%20single%20average%20degree%20parameter%2C%20a%20user%20could%20specify%20a%20degree%20range%20%5Bmin_degree%2C%20max_degree%5D%20and%20the%20generator%20would%20make%20sure%20that%20every%20ISD%20has%20at%20least%20min_degree%20connections%2C%20but%20some%20of%20them%20have%20a%20higher%20degree%20but%20only%20up%20to%20max_degree.%22%2C%20%22created_at%22%3A%20%222015-06-25T09%3A17%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok.%20So%2C%20we%20want%20core%20AD%27s%20in%20some%20particular%20ISD%20to%20have%20a%20higher%20degree%20of%20inter-ISD%20connections%20than%20those%20in%20some%20other%20ISD.%5Cr%5CnThis%20can%20be%20done%20in%20the%20following%20way%3A%5Cr%5CnFirstly%2C%20connect%20all%20core%20AD%27s%20assuming%20the%20degree%20to%20be%20min_degree.%20Then%20choose%20some%20ISD%27s%20to%20be%20connected%20even%20more.%20We%20can%20probably%20choose%20this%20based%20on%20the%20number%20of%20AD%27s%20in%20that%20ISD.%20Interconnect%20the%20core%20AD%27s%20in%20only%20these%20ISD%27s%20so%20that%20degree%20becomes%20max_degree.%5Cr%5CnIs%20that%20fine%3F%22%2C%20%22created_at%22%3A%20%222015-06-25T11%3A57%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20a%20good%20indication%20which%20ISDs%20to%20choose%20for%20having%20more%20inter-ISD%20connections%20is%20probably%20the%20number%20of%20core%20ADs.%20It%20also%20not%20necessary%20to%20guarantee%20that%20some%20ISDs%20have%20this%20max_degree.%20It%20can%20be%20pretty%20random.%20This%20is%20only%20to%20bring%20more%20variance%20into%20the%20ISD%20interconnections.%20If%20a%20user%20doesn%27t%20want%20this%2C%20he%20can%20always%20specify%20min_degree%20%3D%20max_degree.%22%2C%20%22created_at%22%3A%20%222015-06-25T12%3A31%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Min%2C%20max%20degrees%20introduced.%20Half%20of%20the%20ISD%27s%20with%20higher%20number%20of%20core%20AD%27s%20are%20selected%20to%20be%20interconnected%20further%2C%20the%20degree%20being%20chosen%20as%20a%20random%20number%20between%20min_degree%20and%20max_degree.%20Remaining%20ISD%27s%20are%20interconnected%20with%20degree%20of%20min_degree%22%2C%20%22created_at%22%3A%20%222015-06-25T14%3A21%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-06-29T14%3A06%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ea011f4c8dc8ac0320e34af88a9574c371cda4cc%20topology/brite/topology_generator.py%20125%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33361210%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22By%20always%20choosing%20the%20lowest%20degree%20ones%2C%20you%20won%27t%20have%20much%20variance%20in%20the%20degree%20of%20ISDs.%20I%20suggest%20you%20really%20choose%20two%20ISD%20from%20the%20%60denser_isd%60%20list%20at%20random%20and%20connect%20them.%20Obviously%2C%20you%20have%20to%20make%20sure%20that%20they%20won%27t%20surpass%20%60max_degree%60%20by%20doing%20that.%20Once%20an%20ISD%20has%20reached%20%60max_degree%60%20you%20can%20remove%20it%20from%20the%20list%2C%20so%20it%20won%27t%20be%20considered%20for%20further%20connections%20anymore.%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A37%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-29T13%3A46%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/brite/topology_generator.py%3AL15-183%22%7D%2C%20%22Pull%20ea011f4c8dc8ac0320e34af88a9574c371cda4cc%20topology/brite/topology_generator.py%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33361413%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22A%20general%20remark%3A%20It%20would%20be%20nice%20if%20you%20could%20split%20this%20huge%20function%20into%20smaller%20ones%20with%20clear%20names.%20It%20would%20make%20it%20much%20easier%20to%20follow%20the%20flow%20of%20the%20code.%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A40%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-29T13%3A46%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/brite/topology_generator.py%3AL15-183%22%7D%2C%20%22Pull%2029694a13cc418f3cbb8626e866e8cd02f5c9f4c4%20topology/brite/topology_generator.py%2078%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r32834247%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20Python%20way%20to%20do%20this%20is%20%60for%20%28src_isd%2C%20src_cads%29%20in%20core_ad_dict.items%28%29%60.%20%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A31%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-25T08%3A54%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/brite/topology_generator.py%3AL15-116%22%7D%2C%20%22Pull%20ea011f4c8dc8ac0320e34af88a9574c371cda4cc%20topology/brite/topology_generator.py%20115%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33361309%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20instead%20of%20defining%20%60max_num_edges%60%20like%20this%2C%20you%20could%20just%20start%20adding%20edges%20between%20the%20higher%20density%20ISDs%20until%20one%20ISD%20has%20reached%20%60max_degree%60.%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A38%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-29T13%3A46%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/brite/topology_generator.py%3AL15-183%22%7D%2C%20%22Pull%2029694a13cc418f3cbb8626e866e8cd02f5c9f4c4%20topology/brite/topology_generator.py%20137%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r32834439%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20could%20add%20another%20command%20line%20parameter%20to%20generate%20a%20%60.dot%60%20file%20of%20the%20generated%20topology.%22%2C%20%22created_at%22%3A%20%222015-06-19T14%3A33%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-25T08%3A54%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/brite/topology_generator.py%3AL218-235%22%7D%2C%20%22Pull%2039b7348182f60f57e989f1b989b38e74e440502d%20topology/brite/topology_generator.py%20112%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33464199%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20parenthesis%20instead%20of%20%27%5C%5C%27%22%2C%20%22created_at%22%3A%20%222015-06-29T13%3A41%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/brite/topology_generator.py%3AL15-221%22%7D%2C%20%22Pull%20ea011f4c8dc8ac0320e34af88a9574c371cda4cc%20topology/brite/topology_generator.py%20119%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33360888%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Since%20this%20is%20the%20same%20process%20as%20above%2C%20you%20can%20put%20it%20into%20a%20function%20that%20takes%20the%20list%20it%20works%20on%20as%20a%20parameter.%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A34%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-29T13%3A46%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/brite/topology_generator.py%3AL15-183%22%7D%2C%20%22Pull%2047b3f88c0cbd12f1db9de90b88124adebddad7e0%20topology/brite/topology_generator.py%2073%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33233467%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22you%20can%20shorten%20this%3A%20%60ISD_dict%5Bnum_isd%5D%2C%20core_ad_dict%5Bnum_isd%5D%29%20%3D%20_parse%28brite_file%2C%20num_isd%29%60%22%2C%20%22created_at%22%3A%20%222015-06-25T08%3A43%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-29T13%3A46%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/brite/topology_generator.py%3AL15-158%22%7D%2C%20%22Pull%2047b3f88c0cbd12f1db9de90b88124adebddad7e0%20topology/brite/topology_generator.py%2098%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/183%23discussion_r33233709%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Does%20Python%20use%20a%20stable%20sort%3F%20I.e.%2C%20if%20item%20x1%20and%20x2%20have%20the%20same%20degree%20and%20x1%20comes%20before%20x2%20in%20the%20shuffled%20list%2C%20will%20x1%20still%20be%20sorted%20before%20x2%20in%20the%20sorted%20list%3F%20This%20should%20hold%2C%20otherwise%20this%20approach%20doesn%27t%20work%20well.%22%2C%20%22created_at%22%3A%20%222015-06-25T08%3A47%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60sorted%60%20is%20guaranteed%20to%20be%20stable%2C%20AFAIK.%22%2C%20%22created_at%22%3A%20%222015-06-25T08%3A58%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20assumed%20it%20to%20be%20stable.%20But%20it%20indeed%20seems%20to%20be%20stable%20sort.%5Cr%5Cnhttps%3A//wiki.python.org/moin/HowTo/Sorting/%5Cr%5CnA%20statement%20from%20the%20above%20link%3A%20Starting%20with%20Python%202.2%2C%20sorts%20are%20guaranteed%20to%20be%20stable.%22%2C%20%22created_at%22%3A%20%222015-06-25T11%3A01%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-29T13%3A46%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/brite/topology_generator.py%3AL15-158%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/shitz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/shitz'><img src='https://avatars.githubusercontent.com/u/3840858?v=3' width=34 height=34></a>
- [ ] <a href='#crh-comment-Pull 39b7348182f60f57e989f1b989b38e74e440502d topology/brite/topology_generator.py 112'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/183#discussion_r33464199'>File: topology/brite/topology_generator.py:L15-221</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Use parenthesis instead of '\'
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/183#issuecomment-113519259'>General Comment</a></b>
- <a href='https://github.com/rev112'><img border=0 src='https://avatars.githubusercontent.com/u/1120468?v=3' height=16 width=16'></a> Tests failed because your branch is out-of-date and has no `circle.yml` file.
  Please rebase your changes against `master` and then do `git push -f` to update the PR.
- <a href='https://github.com/mskd96'><img border=0 src='https://avatars.githubusercontent.com/u/6560106?v=3' height=16 width=16'></a> Rebased.
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> As an alternative to using a complete graph to interconnect core ADs, you could let the user specify some constraints like total number of inter-ISD connections per ISD and minimum/maximum number of connections to different ISDs (per ISD) and then generate the inter-ISD peering links based on these constraints.
  For example, lets assume we have 6 ISDs and each ISD should have connections to at least 3 different other ISDS and in total 6 inter-ISD peering links. You can easily generate links between core ADs, such that these constraints are satisfied.
- <a href='https://github.com/mskd96'><img border=0 src='https://avatars.githubusercontent.com/u/6560106?v=3' height=16 width=16'></a> The way in which inter-ISD connections are made is changed. A command line parameter 'degree' is introduced which is used to determine the number of inter-ISD connections.
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Ok this looks pretty good now. The only thing that would be nice is if we could have some variance among the degrees of ISDs. E.g., the US ISD would be much better interconnected than an ISD from a smaller country. Basically, instead of just a single average degree parameter, a user could specify a degree range [min_degree, max_degree] and the generator would make sure that every ISD has at least min_degree connections, but some of them have a higher degree but only up to max_degree.
- <a href='https://github.com/mskd96'><img border=0 src='https://avatars.githubusercontent.com/u/6560106?v=3' height=16 width=16'></a> Ok. So, we want core AD's in some particular ISD to have a higher degree of inter-ISD connections than those in some other ISD.
  This can be done in the following way:
  Firstly, connect all core AD's assuming the degree to be min_degree. Then choose some ISD's to be connected even more. We can probably choose this based on the number of AD's in that ISD. Interconnect the core AD's in only these ISD's so that degree becomes max_degree.
  Is that fine?
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Yes a good indication which ISDs to choose for having more inter-ISD connections is probably the number of core ADs. It also not necessary to guarantee that some ISDs have this max_degree. It can be pretty random. This is only to bring more variance into the ISD interconnections. If a user doesn't want this, he can always specify min_degree = max_degree.
- <a href='https://github.com/mskd96'><img border=0 src='https://avatars.githubusercontent.com/u/6560106?v=3' height=16 width=16'></a> Min, max degrees introduced. Half of the ISD's with higher number of core AD's are selected to be interconnected further, the degree being chosen as a random number between min_degree and max_degree. Remaining ISD's are interconnected with degree of min_degree
- [x] <a href='#crh-comment-Pull 29694a13cc418f3cbb8626e866e8cd02f5c9f4c4 topology/brite/topology_generator.py 78'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/183#discussion_r32834247'>File: topology/brite/topology_generator.py:L15-116</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> The Python way to do this is `for (src_isd, src_cads) in core_ad_dict.items()`.
- [x] <a href='#crh-comment-Pull 29694a13cc418f3cbb8626e866e8cd02f5c9f4c4 topology/brite/topology_generator.py 137'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/183#discussion_r32834439'>File: topology/brite/topology_generator.py:L218-235</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> You could add another command line parameter to generate a `.dot` file of the generated topology.
- [x] <a href='#crh-comment-Pull 47b3f88c0cbd12f1db9de90b88124adebddad7e0 topology/brite/topology_generator.py 73'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/183#discussion_r33233467'>File: topology/brite/topology_generator.py:L15-158</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> you can shorten this: `ISD_dict[num_isd], core_ad_dict[num_isd]) = _parse(brite_file, num_isd)`
- [x] <a href='#crh-comment-Pull 47b3f88c0cbd12f1db9de90b88124adebddad7e0 topology/brite/topology_generator.py 98'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/183#discussion_r33233709'>File: topology/brite/topology_generator.py:L15-158</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Does Python use a stable sort? I.e., if item x1 and x2 have the same degree and x1 comes before x2 in the shuffled list, will x1 still be sorted before x2 in the sorted list? This should hold, otherwise this approach doesn't work well.
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> `sorted` is guaranteed to be stable, AFAIK.
- <a href='https://github.com/mskd96'><img border=0 src='https://avatars.githubusercontent.com/u/6560106?v=3' height=16 width=16'></a> I assumed it to be stable. But it indeed seems to be stable sort.
  https://wiki.python.org/moin/HowTo/Sorting/
  A statement from the above link: Starting with Python 2.2, sorts are guaranteed to be stable.
- [x] <a href='#crh-comment-Pull ea011f4c8dc8ac0320e34af88a9574c371cda4cc topology/brite/topology_generator.py 119'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/183#discussion_r33360888'>File: topology/brite/topology_generator.py:L15-183</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Since this is the same process as above, you can put it into a function that takes the list it works on as a parameter.
- [x] <a href='#crh-comment-Pull ea011f4c8dc8ac0320e34af88a9574c371cda4cc topology/brite/topology_generator.py 125'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/183#discussion_r33361210'>File: topology/brite/topology_generator.py:L15-183</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> By always choosing the lowest degree ones, you won't have much variance in the degree of ISDs. I suggest you really choose two ISD from the `denser_isd` list at random and connect them. Obviously, you have to make sure that they won't surpass `max_degree` by doing that. Once an ISD has reached `max_degree` you can remove it from the list, so it won't be considered for further connections anymore.
- [x] <a href='#crh-comment-Pull ea011f4c8dc8ac0320e34af88a9574c371cda4cc topology/brite/topology_generator.py 115'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/183#discussion_r33361309'>File: topology/brite/topology_generator.py:L15-183</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Maybe instead of defining `max_num_edges` like this, you could just start adding edges between the higher density ISDs until one ISD has reached `max_degree`.
- [x] <a href='#crh-comment-Pull ea011f4c8dc8ac0320e34af88a9574c371cda4cc topology/brite/topology_generator.py 50'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/183#discussion_r33361413'>File: topology/brite/topology_generator.py:L15-183</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> A general remark: It would be nice if you could split this huge function into smaller ones with clear names. It would make it much easier to follow the flow of the code.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/183?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/183?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/183?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/183'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
