### PR TITLE
Build docker image in CI environment.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN DEBIAN_FRONTEND=noninteractive APTARGS=-y ./scion.sh deps pkgs
 # Copy over requirements.txt. If it has changed, then re-run the remaining steps.
 COPY requirements.txt $BASE/
 RUN sudo chown -R scion: $HOME
-RUN ./scion.sh deps pip3
+RUN ./scion.sh deps pip
 
 RUN ./scion.sh deps
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,18 +1,22 @@
 machine:
-  python:
-    version: 3.4.2
+    python:
+        version: 3.4.2
+    services:
+        - docker
 
 dependencies:
-  cache_directories:
-    - "/var/cache/apt"
-  post:
-    - "./scion.sh init"
-    - "./scion.sh topology"
+    cache_directories:
+        - "~/cache"
+    override:
+        - docker/cache.sh restore
+        - mv ~/cache ~/cache.old; mkdir ~/cache
+        - ./docker.sh build
+        - docker/cache.sh save
 
 test:
-  override:
-    - ./scion.sh coverage
-    - make -C sphinx-doc html
-  post:
-    - cp -a htmlcov "$CIRCLE_ARTIFACTS"/coverage
-    - cp -a sphinx-doc/_build/html "$CIRCLE_ARTIFACTS"/docs
+    override:
+        - ./docker.sh run bash -lc "./scion.sh coverage -v"
+        - ./docker.sh run bash -lc "make -C sphinx-doc html"
+    post:
+        - cp -a htmlcov "$CIRCLE_ARTIFACTS"/coverage
+        - cp -a sphinx-doc/_build/html "$CIRCLE_ARTIFACTS"/docs

--- a/docker/cache.sh
+++ b/docker/cache.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# For caching docker builds in circleci
+# Expects to be run in the root directory of a scion repo checkout
+
+CACHEDIR=~/cache
+DOCKERCACHE=$CACHEDIR/scion-docker.tar.gz
+BUILDDIR=docker/_build
+
+cmd_save() {
+    echo "====> Docker image: saving"
+    time docker save scion:latest | gzip -1 > "$DOCKERCACHE"
+    echo "====> Docker image: saved ($(get_size "$DOCKERCACHE"))"
+}
+
+cmd_restore() {
+    if [ ! -e "$DOCKERCACHE" ]; then
+        echo "====> Docker image: nothing to restore"
+        return 0
+    fi
+    echo "====> Docker image: restoring ($(get_size "$DOCKERCACHE"))"
+    time gunzip -c "$DOCKERCACHE" | docker load
+    echo "====> Docker image: restored"
+}
+
+get_size() {
+    du -hs "${1:?}" | awk '{print $1}'
+}
+
+cmd_clean() {
+    rm -r "${CACHEDIR:?}"
+}
+
+CMD="$1"
+shift
+
+case "$CMD" in
+    save)
+        cmd_save "$@"
+        ;;
+    restore)
+        cmd_restore "$@"
+        ;;
+    clean)
+        cmd_clean "$@"
+        ;;
+    *)
+        echo "Error: unknown command \"$1\""
+        exit 1
+        ;;
+esac

--- a/scion.sh
+++ b/scion.sh
@@ -120,6 +120,7 @@ cmd_test(){
 }
 
 cmd_coverage(){
+    set -e
     PYTHONPATH=. nosetests --with-cov -w test "$@"
     coverage html --omit 'external/*'
     echo "Coverage report here: file://$PWD/htmlcov/index.html"


### PR DESCRIPTION
Also:
- Fix pip deps docker command
- Run tests inside docker
- Export html coverage report, and sphinx docs
- Fix a bug where 'scion.sh coverage' would exit success even if  
  coverage itself errored out
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/195%23issuecomment-115655524%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/195%23issuecomment-118873729%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/195%23discussion_r33940072%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/195%23issuecomment-118876198%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/195%23discussion_r33940931%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/195%23issuecomment-115655524%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Depends%20on%20%23208%20%22%2C%20%22created_at%22%3A%20%222015-06-26T11%3A57%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20now%20ready%20for%20review%22%2C%20%22created_at%22%3A%20%222015-07-06T14%3A33%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-07-06T14%3A42%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201318b42c38e4e22cfe641d6a9bc4df63f57a5b7b%20Dockerfile%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/195%23discussion_r33940072%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22does%20it%20run%20pip3%20as%20a%20default%3F%20What%20is%20the%20case%20here%3F%22%2C%20%22created_at%22%3A%20%222015-07-06T14%3A36%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60pip3%60%20was%20a%20typo%2C%20scion.sh%27s%20%60cmd_deps%60%20understands%20%60pkgs%60%20and%20%60pip%60%22%2C%20%22created_at%22%3A%20%222015-07-06T14%3A44%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Dockerfile%3AL37-44%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/195#issuecomment-115655524'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Depends on #208
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is now ready for review
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- [ ] <a href='#crh-comment-Pull 1318b42c38e4e22cfe641d6a9bc4df63f57a5b7b Dockerfile 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/195#discussion_r33940072'>File: Dockerfile:L37-44</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> does it run pip3 as a default? What is the case here?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `pip3` was a typo, scion.sh's `cmd_deps` understands `pkgs` and `pip`

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/195?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/195?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/195'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
