### PR TITLE
UnitTest for lib/path_db.py

### DIFF
--- a/test/lib_path_db_test.py
+++ b/test/lib_path_db_test.py
@@ -112,10 +112,10 @@ class TestPathSegmentDBGetItem(object):
     """
     def test_basic(self):
         cur_rec = MagicMock(spec_set=['pcb'])
+        cur_rec.pcb = "data1"
         pth_seg_db = PathSegmentDB()
         pth_seg_db._db = MagicMock(spec_set=[])
         pth_seg_db._db.return_value = {0: {'record': cur_rec}}
-        pth_seg_db._db.return_value[0]['record'].pcb = "data1"
         ntools.eq_(pth_seg_db["data2"], "data1")
         pth_seg_db._db.assert_called_once_with(id="data2")
 
@@ -242,9 +242,10 @@ class TestPathSegmentDBCall(object):
     def test_basic(self, time):
         recs = []
         for i in range(5):
-            recs.append({'record': MagicMock(spec_set=['pcb', 'fidelity'])})
-            recs[i]['record'].pcb.get_expiration_time.return_value = 1
-            recs[i]['record'].fidelity = i
+            cur_rec = MagicMock(spec_set=['pcb', 'fidelity'])
+            cur_rec.pcb.get_expiration_time.return_value = 1
+            cur_rec.fidelity = i
+            recs.append({'record': cur_rec})
         time.return_value = 0
         pth_seg_db = PathSegmentDB()
         pth_seg_db._db = MagicMock(spec_set=['delete'])
@@ -260,9 +261,10 @@ class TestPathSegmentDBCall(object):
     def test_expiration(self, time):
         recs = []
         for i in range(5):
-            recs.append({'record': MagicMock(spec_set=['pcb']), 'src_isd': 0,
+            cur_rec = MagicMock(spec_set=['pcb'])
+            cur_rec.pcb.get_expiration_time.return_value = -1
+            recs.append({'record': cur_rec, 'src_isd': 0,
                          'src_ad': 1, 'dst_isd': 2, 'dst_ad': 3})
-            recs[i]['record'].pcb.get_expiration_time.return_value = -1
         time.return_value = 0
         pth_seg_db = PathSegmentDB()
         pth_seg_db._db = MagicMock(spec_set=['delete'])


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/196%23issuecomment-114463753%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23issuecomment-114500835%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33033442%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33033463%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33034475%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33034667%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33034797%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33036193%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33036317%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33036424%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33036456%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33036472%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33036760%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33037016%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33037144%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33037181%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33037799%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33038145%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33038147%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33038881%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33038882%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33038884%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33038885%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33038886%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33038887%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33038888%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33038889%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33038890%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33039059%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33039474%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33039682%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33039696%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23issuecomment-114501037%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23issuecomment-114501913%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23issuecomment-114502307%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23issuecomment-114463753%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20Ready%20for%20review%22%2C%20%22created_at%22%3A%20%222015-06-23T11%3A46%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A25%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20LGTM%20to%20me%2C%20merging%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A26%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%21%20for%20reviewing%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A27%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28For%20%23129%29%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A28%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2090812c7f1f2e66ae87fdb21e48addd8eaaf1ff28%20test/lib_path_db_test.py%20258%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33037181%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Need%20to%20check%20that%20%60get_expiration_time%60%20has%20been%20called%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A56%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A17%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_db_test.py%3AL1-292%22%7D%2C%20%22Pull%2090812c7f1f2e66ae87fdb21e48addd8eaaf1ff28%20test/lib_path_db_test.py%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33033442%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22import%20not%20used%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A02%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A17%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_db_test.py%3AL1-292%22%7D%2C%20%22Pull%2090812c7f1f2e66ae87fdb21e48addd8eaaf1ff28%20test/lib_path_db_test.py%20186%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33036424%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Needs%202%20asserts%20to%20check%20that%20%60pcb.get_expiration_time%60%20and%20%60cur_rec.pcb.get_expiration_time%60%20are%20called.%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A47%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Same%20applies%20to%20%60test_entry_update%60%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A48%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A17%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_db_test.py%3AL1-292%22%7D%2C%20%22Pull%2090812c7f1f2e66ae87fdb21e48addd8eaaf1ff28%20test/lib_path_db_test.py%20182%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33036193%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20would%20be%20slightly%20easier%20to%20follow%20if%20the%20order%20is%20changed%3A%5Cr%5Cn%60%60%60%5Cr%5Cncur_rec%20%3D%20MagicMock%28spec_set%3D%5B%27pcb%27%5D%29%5Cr%5Cncur_rec.pcb.get_expiration_time.return_value%20%3D%200%5Cr%5Cndb_rec.return_value%20%3D%20%7B0%3A%20%7B%27record%27%3A%20cur_rec%7D%7D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A44%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Same%20applies%20in%20similar%20places%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A51%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%2A%20%60TestPathSegmentDBGetItem.test_basic%60%5Cr%5Cn%2A%20%60TestPathSegmentDBCall.test_basic%60%20and%20%60test_expiration%60%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A09%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Isn%27t%20this%20OK%20for%20TestPathSegmentDBCall.test_basic%20and%20test_expiration%20%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A19%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Changed%20this%20anyway%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A23%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looks%20good%20now%2C%20thanks.%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A25%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A25%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_db_test.py%3AL1-292%22%7D%2C%20%22Pull%20e81cd49d21207915719cc719469c1bda403d4b16%20test/lib_path_db_test.py%20188%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33037799%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%221%20blank%20line%20between%20methods%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A05%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20already%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A09%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A17%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_db_test.py%3AL1-287%22%7D%2C%20%22Pull%2090812c7f1f2e66ae87fdb21e48addd8eaaf1ff28%20test/lib_path_db_test.py%20188%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33036317%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%202%20assertions%20are%20already%20covered%20by%20%60test_basic%60%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A45%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Same%20applies%20to%20%60test_entry_update%60%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A47%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A17%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_db_test.py%3AL1-292%22%7D%2C%20%22Pull%2090812c7f1f2e66ae87fdb21e48addd8eaaf1ff28%20test/lib_path_db_test.py%20128%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33034797%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20assertion%20is%20covered%20by%20%60test_basic%60%20already%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A23%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A17%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_db_test.py%3AL1-292%22%7D%2C%20%22Pull%2090812c7f1f2e66ae87fdb21e48addd8eaaf1ff28%20test/lib_path_db_test.py%2059%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33034475%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60id%60%20is%20a%20built-in%20function%20name%2C%20change%20the%20var%20to%20%60id_%60%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A18%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A17%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_db_test.py%3AL1-292%22%7D%2C%20%22Pull%2090812c7f1f2e66ae87fdb21e48addd8eaaf1ff28%20test/lib_path_db_test.py%2032%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33033463%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%22lib.packet%5C%22%20sorts%20before%20%5C%22lib.path%5C%22%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A02%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A17%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_db_test.py%3AL1-292%22%7D%2C%20%22Pull%2090812c7f1f2e66ae87fdb21e48addd8eaaf1ff28%20test/lib_path_db_test.py%20240%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33037016%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Already%20covered%20by%20%60test_basic%60%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A55%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20have%20fixed%20these%20already%5Cn%5CnOn%20Tue%2C%20Jun%2023%2C%202015%20at%202%3A55%20PM%2C%20Stephen%20Shirley%20%3Cnotifications%40github.com%3E%5Cnwrote%3A%5Cn%5Cn%3E%20In%20test/lib_path_db_test.py%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33037016%3E%3A%5Cn%3E%5Cn%3E%20%3E%20%2B%20%20%20%20Unit%20tests%20for%20lib.path_db.PathSegmentDB.delete%5Cn%3E%20%3E%20%2B%20%20%20%20%5C%22%5C%22%5C%22%5Cn%3E%20%3E%20%2B%20%20%20%20def%20test_basic%28self%29%3A%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20pth_seg_db%20%3D%20PathSegmentDB%28%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20pth_seg_db._db%20%3D%20MagicMock%28spec_set%3D%5B%27delete%27%5D%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20pth_seg_db._db.return_value%20%3D%20%5C%22data1%5C%22%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20ntools.eq_%28pth_seg_db.delete%28%5C%22data2%5C%22%29%2C%20DBResult.ENTRY_DELETED%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20pth_seg_db._db.assert_called_once_with%28id%3D%5C%22data2%5C%22%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20pth_seg_db._db.delete.assert_called_once_with%28%5C%22data1%5C%22%29%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2B%20%20%20%20def%20test_not_present%28self%29%3A%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20pth_seg_db%20%3D%20PathSegmentDB%28%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20pth_seg_db._db%20%3D%20MagicMock%28spec_set%3D%5B%5D%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20pth_seg_db._db.return_value%20%3D%20False%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20ntools.eq_%28pth_seg_db.delete%28%5C%22data%5C%22%29%2C%20DBResult.NONE%29%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20pth_seg_db._db.assert_called_once_with%28id%3D%5C%22data%5C%22%29%5Cn%3E%5Cn%3E%20Already%20covered%20by%20test_basic%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/196/files%23r33037016%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A56%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-23T13%3A17%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_db_test.py%3AL1-292%22%7D%2C%20%22Pull%2090812c7f1f2e66ae87fdb21e48addd8eaaf1ff28%20test/lib_path_db_test.py%20107%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/196%23discussion_r33034667%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-23T12%3A21%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_db_test.py%3AL1-292%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/kormat%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/kormat'><img src='https://avatars.githubusercontent.com/u/6919822?v=3' width=34 height=34></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/196#issuecomment-114463753'>General Comment</a></b>
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat Ready for review
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok, LGTM to me, merging
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Thanks! for reviewing
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (For #129)
- [x] <a href='#crh-comment-Pull 90812c7f1f2e66ae87fdb21e48addd8eaaf1ff28 test/lib_path_db_test.py 19'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/196#discussion_r33033442'>File: test/lib_path_db_test.py:L1-292</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> import not used
- [x] <a href='#crh-comment-Pull 90812c7f1f2e66ae87fdb21e48addd8eaaf1ff28 test/lib_path_db_test.py 32'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/196#discussion_r33033463'>File: test/lib_path_db_test.py:L1-292</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> "lib.packet" sorts before "lib.path"
- [x] <a href='#crh-comment-Pull 90812c7f1f2e66ae87fdb21e48addd8eaaf1ff28 test/lib_path_db_test.py 59'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/196#discussion_r33034475'>File: test/lib_path_db_test.py:L1-292</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `id` is a built-in function name, change the var to `id_`
- [x] <a href='#crh-comment-Pull 90812c7f1f2e66ae87fdb21e48addd8eaaf1ff28 test/lib_path_db_test.py 128'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/196#discussion_r33034797'>File: test/lib_path_db_test.py:L1-292</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This assertion is covered by `test_basic` already
- [x] <a href='#crh-comment-Pull 90812c7f1f2e66ae87fdb21e48addd8eaaf1ff28 test/lib_path_db_test.py 182'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/196#discussion_r33036193'>File: test/lib_path_db_test.py:L1-292</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This would be slightly easier to follow if the order is changed:

```
cur_rec = MagicMock(spec_set=['pcb'])
cur_rec.pcb.get_expiration_time.return_value = 0
db_rec.return_value = {0: {'record': cur_rec}}
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same applies in similar places
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> \* `TestPathSegmentDBGetItem.test_basic`
- `TestPathSegmentDBCall.test_basic` and `test_expiration`
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Isn't this OK for TestPathSegmentDBCall.test_basic and test_expiration
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Changed this anyway
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Looks good now, thanks.
- [x] <a href='#crh-comment-Pull 90812c7f1f2e66ae87fdb21e48addd8eaaf1ff28 test/lib_path_db_test.py 188'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/196#discussion_r33036317'>File: test/lib_path_db_test.py:L1-292</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> These 2 assertions are already covered by `test_basic`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same applies to `test_entry_update`
- [x] <a href='#crh-comment-Pull 90812c7f1f2e66ae87fdb21e48addd8eaaf1ff28 test/lib_path_db_test.py 186'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/196#discussion_r33036424'>File: test/lib_path_db_test.py:L1-292</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Needs 2 asserts to check that `pcb.get_expiration_time` and `cur_rec.pcb.get_expiration_time` are called.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same applies to `test_entry_update`
- [x] <a href='#crh-comment-Pull 90812c7f1f2e66ae87fdb21e48addd8eaaf1ff28 test/lib_path_db_test.py 240'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/196#discussion_r33037016'>File: test/lib_path_db_test.py:L1-292</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Already covered by `test_basic`
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> I have fixed these already
  On Tue, Jun 23, 2015 at 2:55 PM, Stephen Shirley notifications@github.com
  wrote:
  > In test/lib_path_db_test.py
  > https://github.com/netsec-ethz/scion/pull/196#discussion_r33037016:
  >
  > > +    Unit tests for lib.path_db.PathSegmentDB.delete
  > > +    """
  > > +    def test_basic(self):
  > > +        pth_seg_db = PathSegmentDB()
  > > +        pth_seg_db._db = MagicMock(spec_set=['delete'])
  > > +        pth_seg_db._db.return_value = "data1"
  > > +        ntools.eq_(pth_seg_db.delete("data2"), DBResult.ENTRY_DELETED)
  > > +        pth_seg_db._db.assert_called_once_with(id="data2")
  > > +        pth_seg_db._db.delete.assert_called_once_with("data1")
  > > +
  > > +    def test_not_present(self):
  > > +        pth_seg_db = PathSegmentDB()
  > > +        pth_seg_db._db = MagicMock(spec_set=[])
  > > +        pth_seg_db._db.return_value = False
  > > +        ntools.eq_(pth_seg_db.delete("data"), DBResult.NONE)
  > > +        pth_seg_db._db.assert_called_once_with(id="data")
  >
  > Already covered by test_basic
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/196/files#r33037016.
  >
- [x] <a href='#crh-comment-Pull 90812c7f1f2e66ae87fdb21e48addd8eaaf1ff28 test/lib_path_db_test.py 258'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/196#discussion_r33037181'>File: test/lib_path_db_test.py:L1-292</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Need to check that `get_expiration_time` has been called
- [x] <a href='#crh-comment-Pull e81cd49d21207915719cc719469c1bda403d4b16 test/lib_path_db_test.py 188'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/196#discussion_r33037799'>File: test/lib_path_db_test.py:L1-287</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> 1 blank line between methods
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Fixed already

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/196?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/196?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/196?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/196'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
