### PR TITLE
Added tests for __hash__ methods

### DIFF
--- a/test/lib_packet_packet_base_test.py
+++ b/test/lib_packet_packet_base_test.py
@@ -157,7 +157,7 @@ class TestPacketBaseHash(object):
     @patch("lib.packet.packet_base.PacketBase.pack", autospec=True)
     def test(self, pack):
         packet_base = PacketBase()
-        pack.return_value = MagicMock()
+        pack.return_value = MagicMock(spec_set=['__hash__'])
         pack.return_value.__hash__.return_value = 123
         ntools.eq_(hash(packet_base), 123)
         pack.return_value.__hash__.assert_called_once_with()
@@ -258,7 +258,7 @@ class TestPayloadBaseHash(object):
     """
     def test(self):
         payload = PayloadBase()
-        payload.raw = MagicMock()
+        payload.raw = MagicMock(spec_set=['__hash__'])
         payload.raw.__hash__.return_value = 123
         ntools.eq_(hash(payload), 123)
         payload.raw.__hash__.assert_called_once_with()


### PR DESCRIPTION
For the sake of completeness.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/199%23issuecomment-114810222%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/199%23issuecomment-114828959%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/199%23discussion_r33132782%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/199%23discussion_r33132833%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/199%23discussion_r33132954%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/199%23discussion_r33137206%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/199%23discussion_r33137207%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/199%23discussion_r33137208%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/199%23issuecomment-114810222%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Otherwise%20looks%20good%22%2C%20%22created_at%22%3A%20%222015-06-24T09%3A54%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A02%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2058ad0c35f6296bd8be60bd029686eb5e3f58d2ae%20test/lib_packet_base_test.py%2051%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/199%23discussion_r33132782%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Needs%20%60spec_set%60%22%2C%20%22created_at%22%3A%20%222015-06-24T09%3A51%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A02%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_base_test.py%3AL150-169%22%7D%2C%20%22Pull%2058ad0c35f6296bd8be60bd029686eb5e3f58d2ae%20test/lib_packet_base_test.py%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/199%23discussion_r33132954%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ah.%20Didn%27t%20catch%20this%20before%2C%20but%20please%20rename%20this%20to%20%60lib_packet_packet_base_test.py%60%20%28yeah%2C%20it%27s%20ugly%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-06-24T09%3A53%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A02%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_base_test.py%3AL16-23%22%7D%2C%20%22Pull%2058ad0c35f6296bd8be60bd029686eb5e3f58d2ae%20test/lib_packet_base_test.py%2070%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/199%23discussion_r33132833%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Needs%20%60spec_set%60%22%2C%20%22created_at%22%3A%20%222015-06-24T09%3A51%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A02%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_base_test.py%3AL252-270%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 58ad0c35f6296bd8be60bd029686eb5e3f58d2ae test/lib_packet_base_test.py 51'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/199#discussion_r33132782'>File: test/lib_packet_base_test.py:L150-169</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Needs `spec_set`
- [x] <a href='#crh-comment-Pull 58ad0c35f6296bd8be60bd029686eb5e3f58d2ae test/lib_packet_base_test.py 70'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/199#discussion_r33132833'>File: test/lib_packet_base_test.py:L252-270</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Needs `spec_set`
- [x] <a href='#crh-comment-Pull 58ad0c35f6296bd8be60bd029686eb5e3f58d2ae test/lib_packet_base_test.py 1'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/199#discussion_r33132954'>File: test/lib_packet_base_test.py:L16-23</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ah. Didn't catch this before, but please rename this to `lib_packet_packet_base_test.py` (yeah, it's ugly :)
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/199#issuecomment-114810222'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Otherwise looks good

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/199?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/199?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/199'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
