### PR TITLE
UnitTest for lib/util.py

### DIFF
--- a/test/lib_util_test.py
+++ b/test/lib_util_test.py
@@ -69,7 +69,7 @@ class TestGetCertChainFilePath(object):
         ntools.eq_(get_cert_chain_file_path(1, 2, 3, 4, 5, 6), "data2")
         isd_prefix.assert_called_once_with(6)
         join.assert_any_call("isd_prefix1", CERT_DIR, 'AD2',
-                                     'ISD:3-AD:4-V:5.crt')
+                             'ISD:3-AD:4-V:5.crt')
 
     def test_len(self, isd_prefix, join):
         get_cert_chain_file_path(1, 2, 3, 4, 5)
@@ -87,8 +87,7 @@ class TestGetTRCFilePath(object):
         join.return_value = "data2"
         ntools.eq_(get_trc_file_path(1, 2, 3, 4, 5), "data2")
         isd_prefix.assert_called_once_with(5)
-        join.assert_any_call("isd_prefix1", CERT_DIR, 'AD2',
-                                     'ISD:3-V:4.crt')
+        join.assert_any_call("isd_prefix1", CERT_DIR, 'AD2', 'ISD:3-V:4.crt')
 
     def test_len(self, isd_prefix, join):
         get_trc_file_path(1, 2, 3, 4)
@@ -106,8 +105,7 @@ class TestGetSigKeyFilePath(object):
         join.return_value = "data2"
         ntools.eq_(get_sig_key_file_path(1, 2, 3), "data2")
         isd_prefix.assert_called_once_with(3)
-        join.assert_any_call("isd_prefix1", SIG_KEYS_DIR,
-                                     'ISD:1-AD:2.key')
+        join.assert_any_call("isd_prefix1", SIG_KEYS_DIR, 'ISD:1-AD:2.key')
 
     def test_len(self, isd_prefix, join):
         get_sig_key_file_path(1, 2)
@@ -125,8 +123,7 @@ class TestGetEncKeyFilePath(object):
         join.return_value = "data2"
         ntools.eq_(get_enc_key_file_path(1, 2, 3), "data2")
         isd_prefix.assert_called_once_with(3)
-        join.assert_any_call("isd_prefix1", ENC_KEYS_DIR,
-                                     'ISD:1-AD:2.key')
+        join.assert_any_call("isd_prefix1", ENC_KEYS_DIR, 'ISD:1-AD:2.key')
 
     def test_len(self, isd_prefix, join):
         get_enc_key_file_path(1, 2)


### PR DESCRIPTION
Tests remaining for lib.util.timed
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/201%23issuecomment-114808061%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23issuecomment-114837126%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23issuecomment-114841942%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23issuecomment-114842282%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23issuecomment-114842365%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23issuecomment-114890689%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23issuecomment-114902087%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33132160%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33133850%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33133923%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33134051%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33134118%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33134293%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33136250%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33136254%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33136264%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33136355%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33136367%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33136390%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33136472%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33136539%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33136840%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33137002%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33137032%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33137075%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33137582%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33137629%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33137695%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33137760%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33137782%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33137994%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33138464%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33138727%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33139556%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33139641%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33139855%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33140076%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33140362%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33140737%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33153990%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33154095%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33154258%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33154300%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33154574%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33154703%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33154760%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33154862%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33155322%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33155405%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33155421%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33155542%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33156124%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33252668%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33252670%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33252671%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33252673%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33254253%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33254360%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33254998%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33257087%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33257632%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33258090%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33259353%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23issuecomment-115274534%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23issuecomment-115277460%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23issuecomment-114808061%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20ready%20for%20review%22%2C%20%22created_at%22%3A%20%222015-06-24T09%3A43%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Should%20I%20write%20test%20for%20timed%20as%20well%3F%20If%20yes%2C%20where%20do%20I%20start%3F%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A32%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Haha%2C%20good%20question%20%3A%29%20Yes%2C%20please%20write%20tests%20for%20timed.%20I%20think%20the%20way%20to%20test%20this%20is%20to%20define%20a%20method%20in%20a%20test%20class%20that%20is%20wrapped%20by%20timed.%20E.g.%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20%40timed%280.1%29%5Cr%5Cn%20%20%20%20def%20wrapped%28self%2C%20sleep%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20time.sleep%28sleep%29%5Cr%5Cn%20%20%20%20%20%20%20%20return%20sleep%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A48%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Then%20patch%20%60logging.warning%60%2C%20and%20call%20%60self.wrapped%60%20with%2C%20say%2C%200.0%20and%200.5%2C%20and%20check%20that%20the%20warning%20is%20logged%20%28or%20not%2C%20as%20appropriate%29%2C%20and%20that%20the%20return%20value%20is%20correct.%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A49%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20haven%27t%20tried%20this%2C%20so%20you%27re%20breaking%20new%20territory%20here%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A50%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28For%20%23129%29%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A36%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20I%20have%20addressed%20your%20comments%22%2C%20%22created_at%22%3A%20%222015-06-24T15%3A11%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-06-25T14%3A22%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20reviewing%22%2C%20%22created_at%22%3A%20%222015-06-25T14%3A33%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%205b2a5d8b7b82efeb32f6dcb781efc9f9570bf442%20test/lib_util_test.py%20135%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33153990%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%222%20blank%20lines%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A40%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-25T13%3A14%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-284%22%7D%2C%20%22Pull%201b4a404c0277860be36eebe97a82434295f3f9ff%20test/lib_util_test.py%20236%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33136840%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20change%20the%20last%20param%20to%20something%20like%20%60%5C%22desc%5C%22%60%2C%20just%20to%20make%20it%20easier%20to%20follow.%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A56%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A41%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-270%22%7D%2C%20%22Pull%2063f0032790b9e7307a64abed7b03b4d379fa7b27%20test/lib_util_test.py%2078%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33134118%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20don%27t%20need%20to%20check%20the%20return%20value%20here%2C%20%60test_basic%60%20handles%20that.%20Just%20call%20the%20function%20directly.%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A10%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Same%20applies%20below%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A46%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%20Already%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A48%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A09%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-287%22%7D%2C%20%22Pull%201b4a404c0277860be36eebe97a82434295f3f9ff%20test/lib_util_test.py%20235%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33137002%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22While%20this%20does%20technically%20work%2C%20it%27s%20not%20something%20that%20should%20ever%20happen%20in%20the%20real%20code.%20I%20would%20suggest%20swapping%20this%20and%20the%20%60start%60%20value.%20That%20way%20%60start%60%20is%20before%20%60now%60%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A58%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20is%2C%20%60time.return_value%60%20should%20be%2C%20say%2C%203%2C%20and%20%60start%60%20should%20be%200.%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A59%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20did%20that%20and%20I%20get%20this%5Cr%5CnTypeError%3A%20test_basic%28%29%20missing%201%20required%20positional%20argument%3A%20%27open_f%27%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A25%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Was%20this%20comment%20meant%20for%20here%3F%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A41%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah.%20Here%27s%20what%20i%20get%3A%5Cr%5Cn%60nose.proxy.AssertionError%3A%20Expected%20%27time%27%20to%20be%20called%20once.%20Called%202%20times.%60%5Cr%5CnThe%20reason%20is%20that%20%60logging.warning%60%20calls%20%60time%60%20internally.%20You%20need%20to%20patch%20%60logging.warning%60%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A43%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sorry%20the%20comment%20was%20meant%20for%20read_file%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A47%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Playing%20with%20this%20a%20bit%2C%20here%27s%20what%20i%20have%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%40patch%28%5C%22lib.util.time.sleep%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cn%20%20%40patch%28%5C%22lib.util.time.time%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cn%20%20class%20TestSleepInterval%28object%29%3A%5Cr%5Cn%20%20%20%20%20%20%5C%22%5C%22%5C%22%5Cr%5Cn%20%20%20%20%20%20Unit%20tests%20for%20lib.util.sleep_interval%5Cr%5Cn%20%20%20%20%20%20%5C%22%5C%22%5C%22%5Cr%5Cn%20%20%20%20%20%20%40patch%28%5C%22lib.util.logging.warning%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cn%20%20%20%20%20%20def%20test_basic%28self%2C%20warning%2C%20time%2C%20sleep%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20time.return_value%20%3D%203%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20sleep_interval%280%2C%202%2C%20%5C%22desc%5C%22%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20time.assert_called_once_with%28%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20ntools.eq_%28warning.call_count%2C%201%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20sleep.assert_called_once_with%280%29%5Cr%5Cn%60%60%60%5Cr%5CnIt%20still%20needs%20another%20test%20for%20when%20operation%20didn%27t%20take%20too%20long%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A57%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A42%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-270%22%7D%2C%20%22Pull%2063f0032790b9e7307a64abed7b03b4d379fa7b27%20test/lib_util_test.py%2041%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33132160%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Tests%20Remaining%20for%20timed%22%2C%20%22created_at%22%3A%20%222015-06-24T09%3A42%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A53%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-287%22%7D%2C%20%22Pull%2063f0032790b9e7307a64abed7b03b4d379fa7b27%20test/lib_util_test.py%2065%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33133850%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Reverse%20the%20order%20of%20these%20patches%2C%20as%20%60_get_isd_prefix%60%20is%20called%20first.%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A06%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A06%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-287%22%7D%2C%20%22Pull%2063f0032790b9e7307a64abed7b03b4d379fa7b27%20test/lib_util_test.py%2060%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33134293%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20every%20function%20in%20a%20class%20uses%20the%20same%20patches%2C%20you%20can%20put%20them%20as%20class%20decorators%20instead.%5Cr%5Cn%60%60%60%5Cr%5Cn%40patch%28%5C%22lib.util.os.path.join%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cn%40patch%28%5C%22lib.util._get_isd_prefix%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cnclass%20TestGetCertChainFilePath%28object%29%3A%5Cr%5Cn...%5Cr%5Cn%20%20%20%20def%20test_basic%28self%2C%20gip%2C%20join%29%3A%5Cr%5Cn...%5Cr%5Cn%20%20%20%20def%20test_len%28self%2C%20gip%2C%20join%29%3A%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A13%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A10%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-287%22%7D%2C%20%22Pull%2063f0032790b9e7307a64abed7b03b4d379fa7b27%20test/lib_util_test.py%2072%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33134051%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20this%20is%20same%20code%20as%20the%20target%20function%2C%20i%20would%20hard-code%20the%20expected%20result%3A%5Cr%5Cn%5Cr%5Cn%60join.assert_called_once_with%28%5C%22data11%5C%22%2C%20CERT_DIR%2C%20%27AD2%27%2C%20%27ISD%3A3-AD%3A4-V%3A5.crt%27%29%60%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A09%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Same%20applies%20below%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A45%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A47%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A08%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-287%22%7D%2C%20%22Pull%201b4a404c0277860be36eebe97a82434295f3f9ff%20test/lib_util_test.py%20254%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33137075%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20mis-indented%2C%20it%20should%20line%20up%20with%20%60call%60%20in%20the%20previous%20line%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A00%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A42%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-270%22%7D%2C%20%22Pull%20980244ca16bda1b3bb8e629283ce5db96404e968%20test/lib_util_test.py%2072%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33254253%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Turns%20out%20to%20be%20a%20weird%20bug%20here.%20Try%20this%3A%5Cr%5Cn%60%60%60%5Cr%5Cn./scion.sh%20coverage%20lib_util_test%5Cr%5Cn%60%60%60%5Cr%5Cnyou%27ll%20see%20this%20in%20the%20output%3A%5Cr%5Cn%60%60%60%5Cr%5Cnnose.proxy.AssertionError%3A%20Expected%20%27join%27%20to%20be%20called%20once.%20Called%2012%20times.%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-25T13%3A30%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20i%20print%20out%20%60join.mock_calls%60%2C%20i%20get%20this%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%5Bcall%28%27isd_prefix1%27%2C%20%27certificates%27%2C%20%27AD2%27%2C%20%27ISD%3A3-AD%3A4-V%3A5.crt%27%29%2C%5Cr%5Cn%20call%28%27/%27%2C%20%27home%27%29%2C%5Cr%5Cn%20call%28%27data2%27%2C%20%27kormat%27%29%2C%5Cr%5Cn%20call%28%27data2%27%2C%20%27.local%27%29%2C%5Cr%5Cn%20call%28%27data2%27%2C%20%27lib%27%29%2C%5Cr%5Cn%20call%28%27data2%27%2C%20%27python3.4%27%29%2C%5Cr%5Cn%20call%28%27data2%27%2C%20%27site-packages%27%29%2C%5Cr%5Cn%20call%28%27data2%27%2C%20%27nose%27%29%2C%5Cr%5Cn%20call%28%27data2%27%2C%20%27tools%27%29%2C%5Cr%5Cn%20call%28%27data2%27%2C%20%27trivial.py%27%29%2C%5Cr%5Cn%20call%28%27/home/kormat/github/scion/test%27%2C%20%27data2%27%29%2C%5Cr%5Cn%20call%28%27/home/kormat/github/scion/test%27%2C%20%27data2%27%29%5D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-25T13%3A31%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%2C%20there%27s%20something%20subtly%20different%20in%20the%20environment%20that%20coverage%20runs%20in.%20As%20a%20workaround%2C%20i%20propose%20changing%20this%20check%20to%3A%20%60join.assert_any_call%28...%29%60%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-25T13%3A37%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20weird.%20I%20changed%20it%20anyway%22%2C%20%22created_at%22%3A%20%222015-06-25T13%3A58%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20need%20to%20fix%20the%20indentation%20of%20the%20new%20join%20assertion%20lines%22%2C%20%22created_at%22%3A%20%222015-06-25T14%3A04%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oops.%20Fixed%20it.%22%2C%20%22created_at%22%3A%20%222015-06-25T14%3A08%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-06-25T14%3A20%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-287%22%7D%2C%20%22Pull%207d76c2d66da55a63f8a738e1771e90ee0e6cea32%20test/lib_util_test.py%20224%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33154574%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Having%20the%20time%20too%20short%20can%20lead%20to%20flaky%20tests%20when%20the%20system%20is%20heavily%20loaded.%20I%20would%20prefer%20this%20was%20%600.5%60%2C%20and%20the%20exceeded%20time%20was%20%601.0%60%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A45%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20since%20the%20system%20actually%20sleeps%20this%20test%20might%20take%20a%20lot%20of%20time.%20IMHO%20.1%20and%20.2%20is%20ok%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A47%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ahh%2C%20actually%2C%20we%20can%20do%20this%20properly%2C%20by%20patching%20%60time.time%60.%20%5Cr%5Cn%5Cr%5Cn%20%20%20%20%20%20%40timed%281.0%29%5Cr%5Cn%20%20%20%20%20%20def%20wrapped%28self%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20pass%5Cr%5Cn%20%20%5Cr%5Cn%20%20%20%20%20%20%40patch%28%5C%22lib.util.logging.warning%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cn%20%20%20%20%20%20%40patch%28%5C%22lib.util.time.time%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cn%20%20%20%20%20%20def%20test_basic%28self%2C%20time_%2C%20warning%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20time_.side_effect%20%3D%20%5B0%2C%200.1%5D%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20self.wrapped%28%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20ntools.eq_%28warning.call_count%2C%200%29%5Cr%5Cn%20%20%5Cr%5Cn%20%20%20%20%20%20%40patch%28%5C%22lib.util.logging.warning%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cn%20%20%20%20%20%20%40patch%28%5C%22lib.util.time.time%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cn%20%20%20%20%20%20def%20test_limit_exceeded%28self%2C%20time_%2C%20warning%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20time_.side_effect%20%3D%20%5B0%2C%202.0%5D%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20self.wrapped%28%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20ntools.eq_%28warning.call_count%2C%201%29%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A52%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20nice%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A58%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-25T13%3A14%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-285%22%7D%2C%20%22Pull%2063f0032790b9e7307a64abed7b03b4d379fa7b27%20test/lib_util_test.py%2067%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33133923%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Making%20this%20%60%5C%22isd_prefix%5C%22%60%20would%20be%20clearer%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A07%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Same%20applies%20below%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A45%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A48%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oops%2C%20what%20i%20meant%20was%20the%20string%20value.%20Renaming%20%60gip%60%20to%20%60isd_prefix%60%20is%20good%20too%20though%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A07%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A46%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-287%22%7D%2C%20%22Pull%20719af36539ebec2f8029dbd3f4622878d96c631c%20test/lib_util_test.py%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33155405%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Unused%20import%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A53%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-25T13%3A14%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-285%22%7D%2C%20%22Pull%2063f0032790b9e7307a64abed7b03b4d379fa7b27%20test/lib_util_test.py%20153%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33136472%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20better%20to%20use%20%60mock_open%60%20for%20this%3A%20http%3A//www.voidspace.org.uk/python/mock/helpers.html%23mock-open%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A49%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Same%20for%20%60write_file%60%22%2C%20%22created_at%22%3A%20%222015-06-24T10%3A51%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20not%20able%20to%20use%20it%20and%20I%20am%20getting%20error.%20What%20should%20I%20write%20in%20%40patch%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A14%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Try%20this%3A%5Cr%5Cn%60%40patch%28%27lib.util.open%27%2C%20mock_open%28read_data%3D%5C%22file%20contents%5C%22%29%2C%20create%3DTrue%29%60%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A22%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20giving%20you%20errors%2C%20you%20mentioned.%20I%27ll%20have%20a%20look.%22%2C%20%22created_at%22%3A%20%222015-06-24T11%3A52%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah.%20I%20see%20the%20problem%20now.%20Ok%2C%20it%27s%20best%20to%20patch%20this%20inside%20the%20method%20then%2C%20and%20not%20use%20a%20decorator%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20%20%20%40patch%28%5C%22lib.util.os.path.exists%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cn%20%20%20%20%20%20def%20test_basic%28self%2C%20exists%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20exists.return_value%20%3D%20True%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20with%20patch%28%27lib.util.open%27%2C%20mock_open%28read_data%3D%5C%22file%20contents%5C%22%29%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20create%3DTrue%29%20as%20open_f%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20ntools.eq_%28read_file%28%5C%22File_Path%5C%22%29%2C%20%5C%22file%20contents%5C%22%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20exists.assert_called_once_with%28%5C%22File_Path%5C%22%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20open_f.assert_called_once_with%28%5C%22File_Path%5C%22%2C%20%27r%27%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20open_f.return_value.read.assert_called_once_with%28%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-24T12%3A03%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A46%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-287%22%7D%2C%20%22Pull%20719af36539ebec2f8029dbd3f4622878d96c631c%20test/lib_util_test.py%20247%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/201%23discussion_r33155542%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Try%20not%20to%20use%20variable%20names%20that%20clash%20with%20stdlib%20module%20names%20%28or%20function%20names%2C%20really%29.%20I%20would%20rename%20those%20to%20%60time_%60%20and%20%60sleep_%60.%20Same%20applies%20in%20other%20places.%22%2C%20%22created_at%22%3A%20%222015-06-24T14%3A54%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-25T13%3A14%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL1-285%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#issuecomment-114808061'>General Comment</a></b>
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat ready for review
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Should I write test for timed as well? If yes, where do I start?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Haha, good question :) Yes, please write tests for timed. I think the way to test this is to define a method in a test class that is wrapped by timed. E.g.:

```
@timed(0.1)
def wrapped(self, sleep):
time.sleep(sleep)
return sleep
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Then patch `logging.warning`, and call `self.wrapped` with, say, 0.0 and 0.5, and check that the warning is logged (or not, as appropriate), and that the return value is correct.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I haven't tried this, so you're breaking new territory here :)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (For #129)
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat I have addressed your comments
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM :)
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Thanks for reviewing
- [x] <a href='#crh-comment-Pull 63f0032790b9e7307a64abed7b03b4d379fa7b27 test/lib_util_test.py 41'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33132160'>File: test/lib_util_test.py:L1-287</a></b>
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Tests Remaining for timed
- [x] <a href='#crh-comment-Pull 63f0032790b9e7307a64abed7b03b4d379fa7b27 test/lib_util_test.py 65'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33133850'>File: test/lib_util_test.py:L1-287</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Reverse the order of these patches, as `_get_isd_prefix` is called first.
- [x] <a href='#crh-comment-Pull 63f0032790b9e7307a64abed7b03b4d379fa7b27 test/lib_util_test.py 67'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33133923'>File: test/lib_util_test.py:L1-287</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Making this `"isd_prefix"` would be clearer
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same applies below
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Fixed
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Oops, what i meant was the string value. Renaming `gip` to `isd_prefix` is good too though :)
- [x] <a href='#crh-comment-Pull 63f0032790b9e7307a64abed7b03b4d379fa7b27 test/lib_util_test.py 72'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33134051'>File: test/lib_util_test.py:L1-287</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> As this is same code as the target function, i would hard-code the expected result:
  `join.assert_called_once_with("data11", CERT_DIR, 'AD2', 'ISD:3-AD:4-V:5.crt')`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same applies below
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Fixed
- [x] <a href='#crh-comment-Pull 63f0032790b9e7307a64abed7b03b4d379fa7b27 test/lib_util_test.py 78'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33134118'>File: test/lib_util_test.py:L1-287</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You don't need to check the return value here, `test_basic` handles that. Just call the function directly.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same applies below
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Fixed Already
- [x] <a href='#crh-comment-Pull 63f0032790b9e7307a64abed7b03b4d379fa7b27 test/lib_util_test.py 60'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33134293'>File: test/lib_util_test.py:L1-287</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> If every function in a class uses the same patches, you can put them as class decorators instead.

```
@patch("lib.util.os.path.join", autospec=True)
@patch("lib.util._get_isd_prefix", autospec=True)
class TestGetCertChainFilePath(object):
...
def test_basic(self, gip, join):
...
def test_len(self, gip, join):
```
- [x] <a href='#crh-comment-Pull 63f0032790b9e7307a64abed7b03b4d379fa7b27 test/lib_util_test.py 153'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33136472'>File: test/lib_util_test.py:L1-287</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It's better to use `mock_open` for this: http://www.voidspace.org.uk/python/mock/helpers.html#mock-open
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same for `write_file`
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> I am not able to use it and I am getting error. What should I write in @patch
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Try this:
  `@patch('lib.util.open', mock_open(read_data="file contents"), create=True)`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is giving you errors, you mentioned. I'll have a look.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ah. I see the problem now. Ok, it's best to patch this inside the method then, and not use a decorator:

```
@patch("lib.util.os.path.exists", autospec=True)
def test_basic(self, exists):
exists.return_value = True
with patch('lib.util.open', mock_open(read_data="file contents"),
create=True) as open_f:
ntools.eq_(read_file("File_Path"), "file contents")
exists.assert_called_once_with("File_Path")
open_f.assert_called_once_with("File_Path", 'r')
open_f.return_value.read.assert_called_once_with()
```
- [x] <a href='#crh-comment-Pull 1b4a404c0277860be36eebe97a82434295f3f9ff test/lib_util_test.py 236'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33136840'>File: test/lib_util_test.py:L1-270</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I would change the last param to something like `"desc"`, just to make it easier to follow.
- [x] <a href='#crh-comment-Pull 1b4a404c0277860be36eebe97a82434295f3f9ff test/lib_util_test.py 235'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33137002'>File: test/lib_util_test.py:L1-270</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> While this does technically work, it's not something that should ever happen in the real code. I would suggest swapping this and the `start` value. That way `start` is before `now`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> That is, `time.return_value` should be, say, 3, and `start` should be 0.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> I did that and I get this
  TypeError: test_basic() missing 1 required positional argument: 'open_f'
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Was this comment meant for here?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ah. Here's what i get:
  `nose.proxy.AssertionError: Expected 'time' to be called once. Called 2 times.`
  The reason is that `logging.warning` calls `time` internally. You need to patch `logging.warning`
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Sorry the comment was meant for read_file
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Playing with this a bit, here's what i have:

```
@patch("lib.util.time.sleep", autospec=True)
@patch("lib.util.time.time", autospec=True)
class TestSleepInterval(object):
"""
Unit tests for lib.util.sleep_interval
"""
@patch("lib.util.logging.warning", autospec=True)
def test_basic(self, warning, time, sleep):
time.return_value = 3
sleep_interval(0, 2, "desc")
time.assert_called_once_with()
ntools.eq_(warning.call_count, 1)
sleep.assert_called_once_with(0)
```

It still needs another test for when operation didn't take too long
- [x] <a href='#crh-comment-Pull 1b4a404c0277860be36eebe97a82434295f3f9ff test/lib_util_test.py 254'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33137075'>File: test/lib_util_test.py:L1-270</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is mis-indented, it should line up with `call` in the previous line
- [x] <a href='#crh-comment-Pull 5b2a5d8b7b82efeb32f6dcb781efc9f9570bf442 test/lib_util_test.py 135'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33153990'>File: test/lib_util_test.py:L1-284</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> 2 blank lines
- [x] <a href='#crh-comment-Pull 7d76c2d66da55a63f8a738e1771e90ee0e6cea32 test/lib_util_test.py 224'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33154574'>File: test/lib_util_test.py:L1-285</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Having the time too short can lead to flaky tests when the system is heavily loaded. I would prefer this was `0.5`, and the exceeded time was `1.0`
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Well since the system actually sleeps this test might take a lot of time. IMHO .1 and .2 is ok
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ahh, actually, we can do this properly, by patching `time.time`.
  @timed(1.0)
  def wrapped(self):
  pass
  @patch("lib.util.logging.warning", autospec=True)
  @patch("lib.util.time.time", autospec=True)
  def test_basic(self, time_, warning):
  time_.side_effect = [0, 0.1]
  self.wrapped()
  ntools.eq_(warning.call_count, 0)
  @patch("lib.util.logging.warning", autospec=True)
  @patch("lib.util.time.time", autospec=True)
  def test_limit_exceeded(self, time_, warning):
  time_.side_effect = [0, 2.0]
  self.wrapped()
  ntools.eq_(warning.call_count, 1)
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> This is nice
- [x] <a href='#crh-comment-Pull 719af36539ebec2f8029dbd3f4622878d96c631c test/lib_util_test.py 19'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33155405'>File: test/lib_util_test.py:L1-285</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Unused import
- [x] <a href='#crh-comment-Pull 719af36539ebec2f8029dbd3f4622878d96c631c test/lib_util_test.py 247'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33155542'>File: test/lib_util_test.py:L1-285</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Try not to use variable names that clash with stdlib module names (or function names, really). I would rename those to `time_` and `sleep_`. Same applies in other places.
- [x] <a href='#crh-comment-Pull 980244ca16bda1b3bb8e629283ce5db96404e968 test/lib_util_test.py 72'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/201#discussion_r33254253'>File: test/lib_util_test.py:L1-287</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Turns out to be a weird bug here. Try this:

```
./scion.sh coverage lib_util_test
```

you'll see this in the output:

```
nose.proxy.AssertionError: Expected 'join' to be called once. Called 12 times.
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> If i print out `join.mock_calls`, i get this:

```
[call('isd_prefix1', 'certificates', 'AD2', 'ISD:3-AD:4-V:5.crt'),
call('/', 'home'),
call('data2', 'kormat'),
call('data2', '.local'),
call('data2', 'lib'),
call('data2', 'python3.4'),
call('data2', 'site-packages'),
call('data2', 'nose'),
call('data2', 'tools'),
call('data2', 'trivial.py'),
call('/home/kormat/github/scion/test', 'data2'),
call('/home/kormat/github/scion/test', 'data2')]
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> So, there's something subtly different in the environment that coverage runs in. As a workaround, i propose changing this check to: `join.assert_any_call(...)`
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> This is weird. I changed it anyway
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You need to fix the indentation of the new join assertion lines
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Oops. Fixed it.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/201?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/201?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/201'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
