### PR TITLE
Unit tests for lib/packet/scion.py

### DIFF
--- a/test/lib_packet_scion_test.py
+++ b/test/lib_packet_scion_test.py
@@ -419,10 +419,10 @@ class TestSCIONHeaderParseCommonHdr(object):
         scion_common_hdr.return_value = common_hdr
         scion_common_hdr.LEN = 2
         scion_addr.side_effect = ['src_addr', 'dst_addr']
-        ntools.eq_(hdr._parse_common_hdr(data, 2), 2 + 2 + 3 + 5)
-        scion_common_hdr.assert_called_once_with(data[2:4])
+        ntools.eq_(hdr._parse_common_hdr(data, 1), 1 + 2 + 3 + 5)
+        scion_common_hdr.assert_called_once_with(data[1:3])
         ntools.eq_(hdr.common_hdr, common_hdr)
-        scion_addr.assert_has_calls([call(data[4:7]), call(data[7:12])])
+        scion_addr.assert_has_calls([call(data[3:6]), call(data[6:11])])
         ntools.eq_(hdr.src_addr, 'src_addr')
         ntools.eq_(hdr.dst_addr, 'dst_addr')
 


### PR DESCRIPTION
~~(work in progress)~~ 
@kormat, this is ready for a review.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/204%23issuecomment-116555179%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23issuecomment-116707254%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33348887%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33350874%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33363302%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33363370%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33364923%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33365261%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33365334%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33367230%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33367308%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368052%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368259%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368285%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368574%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368726%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368850%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368864%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33369463%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33370018%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33443956%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33444362%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33444749%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33444873%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33444914%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33457275%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33459311%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33461494%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33554897%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33555079%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33555191%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33555210%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33555255%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33555433%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33555961%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33556258%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33556304%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33556514%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33556622%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33556649%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33556716%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33556828%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33558076%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33558192%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564525%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564526%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564529%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564733%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564734%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564735%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564736%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564737%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564738%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564740%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564741%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564743%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564745%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33564748%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23issuecomment-117150406%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20236%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33367230%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22don%27t%20need%20to%20repeat%20the%20assertion%22%2C%20%22created_at%22%3A%20%222015-06-26T15%3A39%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A31%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20154%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33365334%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60src_addr_len%60%20comes%20before%20%60dst_addr_len%60%22%2C%20%22created_at%22%3A%20%222015-06-26T15%3A18%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A29%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20375%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368726%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22TODO%22%2C%20%22created_at%22%3A%20%222015-06-26T15%3A56%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T10%3A09%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23issuecomment-116555179%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ok%2C%20finished%20this%20review%20pass%2C%20with%20mostly%20minor%20comments.%22%2C%20%22created_at%22%3A%20%222015-06-29T09%3A13%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20%2C%20I%20think%20this%20is%20complete%2C%20you%20can%20have%20a%20look.%22%2C%20%22created_at%22%3A%20%222015-06-29T14%3A36%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%2C%20nice%20work%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-06-30T12%3A00%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20853%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33444362%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Same%20applies%20here%20with%20leading%200%27s%22%2C%20%22created_at%22%3A%20%222015-06-29T08%3A48%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A59%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%20c47a636bd2d7d32fe701641f9510a3e9fae517de%20test/lib_packet_scion_test.py%20286%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33556304%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Need%20an%20assertion%20that%20%60pack.pack%60%20was%20called%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A42%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A59%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1188%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20955%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33444749%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Indent%204%20spaces%20only%22%2C%20%22created_at%22%3A%20%222015-06-29T08%3A54%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A59%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20386%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368850%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22space%20before%20%60%3D%60%22%2C%20%22created_at%22%3A%20%222015-06-26T15%3A57%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A59%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20240%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33367308%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%204%20assertions%20aren%27t%20needed%20either%22%2C%20%22created_at%22%3A%20%222015-06-26T15%3A40%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Apologies%2C%20the%20%60scion_common_hdr.assert_called_once_with%60%20is%20still%20needed%2C%20to%20check%20that%20%60next_hdr%60%20does%20default%20to%200.%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A38%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A55%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20502%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33369463%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Same%20here%20about%20not%20using%200%20as%20an%20initial%20value%20for%20a%20calculation%22%2C%20%22created_at%22%3A%20%222015-06-26T16%3A04%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A59%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33363302%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20know%20the%20exact%20legal%20rules%20here%2C%20but%20i%20would%20leave%20the%20year%20untouched.%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A58%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A25%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL1-5%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20777%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33443956%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27d%20put%20a%20leading%200%20on%20the%20constants%2C%20just%20so%20it%27s%20more%20obvious.%20%600x0102%60%20and%20%600x0304%60%22%2C%20%22created_at%22%3A%20%222015-06-29T08%3A42%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A59%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20992%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33444914%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20add%20leading%200%27s%20to%20constants%22%2C%20%22created_at%22%3A%20%222015-06-29T08%3A56%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A59%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20676%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33370018%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Unused%20variable%22%2C%20%22created_at%22%3A%20%222015-06-26T16%3A10%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A59%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20142%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33364923%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20prefer%20to%20see%20this%20done%20more%20explicitly%3A%5Cr%5Cn%60%60%60%5Cr%5Cndata%20%3D%20bytes%28%5B0b11110000%2C%200b00111111%5D%29%20%2B%20bytes.fromhex%28%270304%2005%2006%2007%2008%27%29%5Cr%5Cn...%5Cr%5Cnntools.eq_%28hdr.version%2C%200b1111%29%5Cr%5Cnntools.eq_%28hdr.src_addr_len%2C%200x000000%29%5Cr%5Cnntools.eq_%28hdr.dst_addr_len%2C%200x111111%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-26T15%3A14%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Same%20applies%20to%20%60pack%28%29%60%22%2C%20%22created_at%22%3A%20%222015-06-26T15%3A18%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A28%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20327%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368259%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Doesn%27t%20cover%20%60self._extension_hdrs%60%20containing%20items.%22%2C%20%22created_at%22%3A%20%222015-06-26T15%3A51%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20just%20noticed%20the%20FIXME%22%2C%20%22created_at%22%3A%20%222015-06-26T15%3A51%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%2C%20if%20I%20patch%20out%20%60self.pop_ext_hdr%28%29%60%20call%2C%20how%20can%20I%20ensure%20that%20the%20while%20loop%20is%20terminated%3F%22%2C%20%22created_at%22%3A%20%222015-06-29T12%3A13%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22something%20like%20this%20should%20work%3A%5Cr%5Cn%60%60%60%5Cr%5Cnhdr._extension_hdrs%20%3D%20MagicMock%28spect_set%3D%5B%27__bool__%27%5D%29%5Cr%5Cnhdr._extension_hdrs.__bool__.side_effects%20%3D%20%5BTrue%2C%20True%2C%20False%5D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-29T12%3A44%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Aha%2C%20cool%21%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-29T13%3A11%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20made%20a%20typo%20in%20my%20example%2C%20%60spect_set%60%20should%20be%20%60spec_set%60%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A45%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Weird%20that%20it%20didn%27t%20throw%20any%20error%20%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A47%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22MagicMock%20has%20a%20%60%2A%2Akwargs%60%20argument%2C%20that%20will%20silently%20accept%20any%20unknown%20keyword%20args%2C%20which%20is%20why%20it%20was%20hidden%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A48%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Av%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A50%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A55%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20988%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33444873%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Need%20assertion%20that%20parse%20was%20called%20with%20%60%27data%27%60%22%2C%20%22created_at%22%3A%20%222015-06-29T08%3A56%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A59%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20342%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368574%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Minor%20comment%20-%20i%20would%20change%20this%20to%20a%20non-zero%20value.%20That%20way%20we%20can%20tell%20that%20%60append_ext_hdr%60%20is%20using%20addition%2C%20and%20not%20just%20setting%20%60total_len%60%20equal%20to%20%60len%28ext_hdr%29%60%22%2C%20%22created_at%22%3A%20%222015-06-26T15%3A54%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A47%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%20c47a636bd2d7d32fe701641f9510a3e9fae517de%20test/lib_packet_scion_test.py%20423%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33558076%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20suggest%20changing%20the%20initial%20offset%20to%201%2C%20so%20it%27s%20easier%20to%20see%20where%20the%20result%20numbers%20come%20from.%22%2C%20%22created_at%22%3A%20%222015-06-30T10%3A08%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A59%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1188%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33363370%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Put%20each%20import%20on%20a%20separate%20line%2C%20and%20sort%20them%2C%20please.%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A59%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Much%20better%2C%20just%20one%20more%20minor%20change%20-%20%60lib.packet.opaque_field%60%20should%20come%20before%20%60lib.packet.path%60%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A27%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A55%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20lib/packet/scion.py%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33348887%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22After%20seeing%20the%20sorts%20of%20changes%20needed%20for%20this%2C%20i%20would%20prefer%20it%20was%20in%20a%20separate%20PR%22%2C%20%22created_at%22%3A%20%222015-06-26T11%3A49%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Here%20you%20go%3A%20%23209%20%22%2C%20%22created_at%22%3A%20%222015-06-26T12%3A25%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A28%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/scion.py%3AL563-574%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20277%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368052%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20first%20test%20covers%20%60path%3DNone%2C%20_path%3Dsomething%60%2C%20this%20test%20currently%20covers%20%60path%3Dsomething%2C%20_path%3Dsomething%60%2C%20but%20currently%20nothing%20covers%20the%20%60_path%3DNone%60%20case.%20I%20would%20change%20this%20test%20to%20cover%20that.%22%2C%20%22created_at%22%3A%20%222015-06-26T15%3A48%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T09%3A42%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%2C%20%22Pull%205b257f0d0688c6b00f67624d4b6ab0f61edf21fe%20test/lib_packet_scion_test.py%20394%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/204%23discussion_r33368864%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22space%20before%20%60%2B%60%22%2C%20%22created_at%22%3A%20%222015-06-26T15%3A57%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-30T11%3A59%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_scion_test.py%3AL16-1065%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#issuecomment-116555179'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok, finished this review pass, with mostly minor comments.
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> @kormat , I think this is complete, you can have a look.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM, nice work :)
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe lib/packet/scion.py 39'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33348887'>File: lib/packet/scion.py:L563-574</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> After seeing the sorts of changes needed for this, i would prefer it was in a separate PR
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> Here you go: #209
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 2'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33363302'>File: test/lib_packet_scion_test.py:L1-5</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I don't know the exact legal rules here, but i would leave the year untouched.
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 27'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33363370'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Put each import on a separate line, and sort them, please.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Much better, just one more minor change - `lib.packet.opaque_field` should come before `lib.packet.path`
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 142'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33364923'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I would prefer to see this done more explicitly:

```
data = bytes([0b11110000, 0b00111111]) + bytes.fromhex('0304 05 06 07 08')
...
ntools.eq_(hdr.version, 0b1111)
ntools.eq_(hdr.src_addr_len, 0x000000)
ntools.eq_(hdr.dst_addr_len, 0x111111)
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same applies to `pack()`
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 154'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33365334'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `src_addr_len` comes before `dst_addr_len`
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 236'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33367230'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> don't need to repeat the assertion
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 240'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33367308'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> These 4 assertions aren't needed either
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Apologies, the `scion_common_hdr.assert_called_once_with` is still needed, to check that `next_hdr` does default to 0.
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 277'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33368052'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The first test covers `path=None, _path=something`, this test currently covers `path=something, _path=something`, but currently nothing covers the `_path=None` case. I would change this test to cover that.
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 327'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33368259'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Doesn't cover `self._extension_hdrs` containing items.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ah, just noticed the FIXME
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> @kormat, if I patch out `self.pop_ext_hdr()` call, how can I ensure that the while loop is terminated?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> something like this should work:

```
hdr._extension_hdrs = MagicMock(spect_set=['__bool__'])
hdr._extension_hdrs.__bool__.side_effects = [True, True, False]
```
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> Aha, cool!
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I made a typo in my example, `spect_set` should be `spec_set`
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> Weird that it didn't throw any error
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> MagicMock has a `**kwargs` argument, that will silently accept any unknown keyword args, which is why it was hidden
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> :v:
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 342'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33368574'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Minor comment - i would change this to a non-zero value. That way we can tell that `append_ext_hdr` is using addition, and not just setting `total_len` equal to `len(ext_hdr)`
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 375'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33368726'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> TODO
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 386'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33368850'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> space before `=`
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 394'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33368864'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> space before `+`
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 502'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33369463'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same here about not using 0 as an initial value for a calculation
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 676'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33370018'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Unused variable
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 777'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33443956'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I'd put a leading 0 on the constants, just so it's more obvious. `0x0102` and `0x0304`
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 853'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33444362'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same applies here with leading 0's
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 955'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33444749'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Indent 4 spaces only
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 988'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33444873'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Need assertion that parse was called with `'data'`
- [x] <a href='#crh-comment-Pull 5b257f0d0688c6b00f67624d4b6ab0f61edf21fe test/lib_packet_scion_test.py 992'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33444914'>File: test/lib_packet_scion_test.py:L16-1065</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Please add leading 0's to constants
- [x] <a href='#crh-comment-Pull c47a636bd2d7d32fe701641f9510a3e9fae517de test/lib_packet_scion_test.py 286'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33556304'>File: test/lib_packet_scion_test.py:L16-1188</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Need an assertion that `pack.pack` was called
- [x] <a href='#crh-comment-Pull c47a636bd2d7d32fe701641f9510a3e9fae517de test/lib_packet_scion_test.py 423'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/204#discussion_r33558076'>File: test/lib_packet_scion_test.py:L16-1188</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I would suggest changing the initial offset to 1, so it's easier to see where the result numbers come from.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/204?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/204?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/204'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
