### PR TITLE
Don't cleanup on build, use per-branch caches

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -1,37 +1,68 @@
 #!/bin/bash
 
+branch=
+build_dir=
+image_tag=
+
+get_params() {
+  # If we're on a local branch, use that. If we're on a detached HEAD from a
+  # remote branch, or from a bare rev id, use that instead.
+  branch=$(git status | head -n1 |
+           awk '/^On branch|HEAD detached at/ {print $NF}')
+  build_dir="docker/_build/$branch"
+  image_tag=$(echo "$branch" | tr '/' '.')
+}
+
 cmd_build_basic() {
-    stop_cntrs
-    del_cntrs
+    set -e
+    set -o pipefail
+    get_params
     echo
     echo "Copying current working tree for Docker image"
     echo "============================================="
-    mkdir -p docker/_build/
+    mkdir -p "${build_dir:?}"
     # Just in case it's sitting there from a previous failed run
-    rm -rf docker/_build/scion.tmp
-    # Ignore timestamps; only update files if their checksums have changed. This
-    # prevents Docker from doing unnecessary cache invalidations.
-    # As rsync --from-files cannot delete unknown files in the destionation,
-    # first rsync to a clean dir using --from-files, then rsync again from that
-    # dir to the actual Docker context dir using --delete
-    git ls-files -z | rsync -a0 --files-from=- . docker/_build/scion.tmp/
-    rsync -rlpc --delete --info=FLIST2,STATS docker/_build/scion.tmp/ docker/_build/scion.git/
+    rm -rf docker/_build/.scion.tmp
+    # Ignore timestamps; only update files if their checksums have changed.
+    # This prevents Docker from doing unnecessary cache invalidations. As
+    # rsync --from-files cannot delete unknown files in the destionation, first
+    # rsync to a clean dir using --from-files, then rsync again from that dir
+    # to the actual Docker context dir using --delete
+    git ls-files -z | rsync -a0 --files-from=- . docker/_build/.scion.tmp/
+    rsync -rlpc --delete --info=FLIST2,STATS \
+      docker/_build/.scion.tmp/ "${build_dir}/scion.git/"
     # Cleanup the temp directory
-    rm -rf docker/_build/scion.tmp
+    rm -rf docker/_build/.scion.tmp
     echo
-    echo "Setting up Docker basic image"
-    echo "============================="
-    docker build -t scionbasic docker || exit 1
-    del_imgs
+    echo "Building Docker basic image"
+    echo "==========================="
+    cp -a docker/Dockerfile "$build_dir"
+    docker_build "scion/basic" "build-basic.log"
 }
 
 cmd_build_full() {
+    set -e
+    set -o pipefail
     cmd_build_basic
     echo
-    echo "Setting up Docker full image"
+    echo "Building Docker full image"
     echo "============================"
-    docker build -t scionfull - < docker/Dockerfile.full || exit 1
-    del_imgs
+    cp -a docker/Dockerfile.full "$build_dir/Dockerfile"
+    docker_build "scion/full" "build-full.log"
+}
+
+docker_build() {
+    set -e
+    set -o pipefail
+    local image_name="$1"; shift
+    local log_file="$1"; shift
+    echo "Image: $image_name:$image_tag"
+    echo "Log: $build_dir/$log_file"
+    echo "============================"
+    echo
+    docker build -t "${image_name:?}:${image_tag:?}" "${build_dir:?}" |
+      tee "$build_dir/${log_file:?}"
+    docker tag "$image_name:$image_tag" "$image_name:latest"
 }
 
 cmd_clean() {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,15 +21,15 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install --download-only --no-install-
 USER scion
 ENV HOME /home/scion
 WORKDIR /home/scion/scion.git
-COPY _build/scion.git/scion.sh /home/scion/scion.git/
+COPY scion.git/scion.sh /home/scion/scion.git/
 
 # Copy over pkgs_debian.txt. If it has changed, then re-run the remaining steps.
-COPY _build/scion.git/pkgs_debian.txt /home/scion/scion.git/
+COPY scion.git/pkgs_debian.txt /home/scion/scion.git/
 RUN sudo chown -R scion: /home/scion
 RUN DEBIAN_FRONTEND=noninteractive APTARGS=-y ./scion.sh deps pkgs
 
 # Copy over requirements.txt. If it has changed, then re-run the remaining steps.
-COPY _build/scion.git/requirements.txt /home/scion/scion.git/
+COPY scion.git/requirements.txt /home/scion/scion.git/
 RUN sudo chown -R scion: /home/scion
 RUN ./scion.sh deps pip3
 
@@ -44,11 +44,11 @@ RUN sudo apt-get clean
 
 RUN echo "PATH=$HOME/.local/bin:/usr/share/zookeeper/bin:$PATH" >> ~/.profile
 # Now copy over the current branch
-COPY _build/scion.git /home/scion/scion.git
+COPY scion.git /home/scion/scion.git
 # Copy over init.sh:
-COPY init.sh /home/scion/bin/
+COPY scion.git/docker/init.sh /home/scion/bin/
 # Install basic screen config
-COPY screenrc /home/scion/.screenrc
+COPY scion.git/docker/screenrc /home/scion/.screenrc
 
 # Fix ownership one last time:
 RUN sudo chown -R scion: /home/scion

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -1,4 +1,4 @@
-FROM scionbasic
+FROM scion/basic
 
 RUN ./scion.sh init
 RUN ./scion.sh topology


### PR DESCRIPTION
It makes switching between branches too expensive, as docker loses all
state, and has to do an almost complete new build if anything in
requirements changes.

This required making a per-branch copy of the source, as otherwise
switching branch makes Docker think all the source updated. This now
works:

```
git co branch1; ./docker.sh build # Does full build
git co branch2; ./docker.sh build # Does full build
git co branch1; ./docker.sh build # Re-uses build from step 1
```

This also works for detached HEADs.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/205%23issuecomment-115160614%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/205%23issuecomment-115161805%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/205%23issuecomment-115249879%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/205%23issuecomment-115254091%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/205%23issuecomment-115254138%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/205%23issuecomment-115160614%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40shitz%20%3A%29%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-25T08%3A23%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm.%20This%20isn%27t%20working%20as%20expected.%20Please%20don%27t%20merge%20yet.%22%2C%20%22created_at%22%3A%20%222015-06-25T08%3A31%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20problem%20was%20that%20all%20builds%20were%20using%20the%20same%20cache%20dir.%20Checking%20out%20a%20new%20branch%20would%20invalide%20the%20cache%2C%20and%20make%20docker%20build%20everything%20from%20%7Escratch.%20I%27ve%20updated%20it%20to%20provide%20a%20per-branch%20cache%2C%20which%20fixes%20this%20issue.%22%2C%20%22created_at%22%3A%20%222015-06-25T13%3A09%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nice%20optimization%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-25T13%3A17%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-06-25T13%3A17%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/shitz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/shitz'><img src='https://avatars.githubusercontent.com/u/3840858?v=3' width=34 height=34></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/205#issuecomment-115160614'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @shitz :)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Hmm. This isn't working as expected. Please don't merge yet.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The problem was that all builds were using the same cache dir. Checking out a new branch would invalide the cache, and make docker build everything from ~scratch. I've updated it to provide a per-branch cache, which fixes this issue.
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Nice optimization :+1:

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/205?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/205?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/205?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/205'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
