### PR TITLE
UnitTest for lib/path_store.py

### DIFF
--- a/test/lib_path_store_test.py
+++ b/test/lib_path_store_test.py
@@ -260,7 +260,6 @@ class TestPathPolicyParseDict(object):
         ntools.eq_(pth_pol2.update_after_number, "update_after_number")
         ntools.eq_(pth_pol2.update_after_time, "update_after_time")
         ntools.eq_(pth_pol2.property_ranges, {'key1': (1, 11), 'key2': (2, 12)})
-        ntools.eq_(len(pth_pol2.property_ranges), 2)
         ntools.eq_(pth_pol2.property_weights, "property_weights")
 
 


### PR DESCRIPTION
Tests remaining for class PathStore. Rest is ready for review.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/206%23issuecomment-115638255%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23issuecomment-115697929%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354171%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354297%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354318%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354351%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354360%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354493%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354618%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354910%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354989%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33355100%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33355151%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33355268%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33355318%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33355621%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33355742%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33355981%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33356140%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33356489%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33357716%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33357815%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33358023%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33358350%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33359462%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33359710%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33359828%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33359871%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33359924%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33359968%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33360129%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33360150%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33360151%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33360153%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33360189%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33360232%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33360320%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33361065%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33361284%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33362195%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33362227%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33362240%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33362249%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23issuecomment-115713175%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23issuecomment-115713581%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23issuecomment-115715323%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23issuecomment-115638255%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20Can%20you%20review%20this%3F%20I%20will%20create%20a%20separate%20PR%20for%20PathStore%20tests.%22%2C%20%22created_at%22%3A%20%222015-06-26T10%3A39%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20Unused%20imports%20will%20be%20used%20for%20testing%20class%20PathStore%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A53%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Great%2C%20LGTM%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A48%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20the%20review%5Cn%5CnOn%20Fri%2C%20Jun%2026%2C%202015%20at%204%3A48%20PM%2C%20Stephen%20Shirley%20%3Cnotifications%40github.com%3E%5Cnwrote%3A%5Cn%5Cn%3E%20Merged%20%23206%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/206%3E.%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/206%23event-341236114%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A49%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28For%20%23129%29%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A54%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%2075%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354297%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Always%20set%20a%20spec%20for%20patches/mocks.%20For%20patches%2C%20%60autospec%3DTrue%60%20is%20the%20default.%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A16%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Same%20applies%20to%20the%20rest%20of%20the%20patches%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A17%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A26%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%20145%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33355100%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20%60setUp%60/%60tearDown%60%20for%20this%20%28and%20don%27t%20remember%20to%20delete%20%60self.d%60%20in%20tearDown%29%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A27%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20means%20you%20also%20don%27t%20need%20to%20do%20copies%20in%20the%20test%2C%20as%20these%20special%20functions%20are%20run%20before%20and%20after%20each%20test.%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A27%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A27%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%20258%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33356140%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Perfect%20%3A%29%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A40%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%2072%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354171%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20isn%27t%20bad%2C%20but%20i%20think%20this%20could%20be%20done%20cleaner%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20def%20test_basic%28self%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20keys%20%3D%20%5B%5C%22best_set_size%5C%22%2C%20%5C%22candidates_set_size%5C%22%2C%20%5C%22history_limit%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22update_after_number%5C%22%2C%20%5C%22update_after_time%5C%22%2C%20%5C%22unwanted_ads%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5C%22property_ranges%5C%22%2C%20%5C%22property_weights%5C%22%5D%5Cr%5Cn%20%20%20%20%20%20%20%20pth_pol%20%3D%20PathPolicy%28%29%5Cr%5Cn%20%20%20%20%20%20%20%20target%20%3D%20%7B%7D%5Cr%5Cn%20%20%20%20%20%20%20%20for%20key%20in%20keys%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20setattr%28pth_pol%2C%20key%2C%20key%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20target%5Bkey%5D%20%3D%20key%5Cr%5Cn%20%20%20%20%20%20%20%20dict_%20%3D%20pth_pol.get_path_policy_dict%28%29%5Cr%5Cn%20%20%20%20%20%20%20%20ntools.eq_%28dict_%2C%20target%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A15%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A23%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%2098%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354618%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Don%27t%20check%20the%20exact%20logging%20string%2C%20just%20make%20sure%20that%20a%20warning%20was%20logged%3A%5Cr%5Cn%60ntools.eq_%28wrng.call_count%2C%201%29%60%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A20%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Normally%20this%20would%20be%20Okay%20but%20there%20are%20two%20cases%20for%20warning%20call%20and%20I%20guess%20it%20is%20ok%20to%20check%20that%20the%20current%20warning%20is%20being%20called%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A24%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20i%20see%20your%20point.%20I%20think%20checking%20that%20the%20count%20is%201%20is%20still%20fine%20in%20this%20case.%20The%20other%20checks%20can%20tell%20which%20case%20%60check_filters%60%20is%20failing%20on.%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A26%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%20168%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33355318%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Need%20an%20assertion%20that%20%60pcb.get_n_peer_links%60%20is%20called%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A29%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A47%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%20363%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33357716%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm.%20The%20problem%20is%20that%20it%27s%20too%20hard%20to%20see%20that%20this%20test%20is%20obviously%20correct.%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A58%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20thats%20why%20I%20have%20written%20it%20in%20a%20way%20that%20makes%20more%20sense.%20If%20you%20look%20at%20the%20supposed%20output%20you%20will%20understand%20the%20logic%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A01%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%2210%20%2A%2010%20%5E%205%5Cr%5Cn1%20%2A%2010%20%5E%204%5Cr%5Cn2%20%2A%2010%20%5E%203%5Cr%5Cn3%20%2A%2010%20%5E%202%5Cr%5Cn4%20%2A%2010%20%5E%201%5Cr%5Cn5%20%2A%2010%20%5E%200%5Cr%5Cn6%20%2A%2010%20%5E%20-1%5Cr%5Cn7%20%2A%2010%20%5E%20-2%5Cr%5Cn8%20%2A%2010%20%5E%20-3%5Cr%5Cn9%20%2A%2010%20%5E%20-4%5Cr%5Cn%5Cr%5CnThese%20values%20are%20incremented%20for%20self.fidelity%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A05%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Here%27s%20my%20attempt%20at%20making%20it%20clearer%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20%20%20%20%20pcb%20%3D%20MagicMock%28spec_set%3D%5B%27__class__%27%2C%20%27segment_id%27%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%27get_expiration_time%27%5D%29%5Cr%5Cn%20%20%20%20%20%20%20%20pcb.__class__%20%3D%20PathSegment%5Cr%5Cn%20%20%20%20%20%20%20%20pth_str_rec%20%3D%20PathStoreRecord%28pcb%29%5Cr%5Cn%20%20%20%20%20%20%20%20path_policy%20%3D%20PathPolicy%28%29%5Cr%5Cn%20%20%20%20%20%20%20%20path_policy.property_weights%5B%27PeerLinks%27%5D%20%3D%2010%5Cr%5Cn%20%20%20%20%20%20%20%20pth_str_rec.peer_links%20%3D%201%5Cr%5Cn%20%20%20%20%20%20%20%20path_policy.property_weights%5B%27HopsLength%27%5D%20%3D%2010%5Cr%5Cn%20%20%20%20%20%20%20%20pth_str_rec.hops_length%20%3D%201%5Cr%5Cn%20%20%20%20%20%20%20%20path_policy.property_weights%5B%27Disjointness%27%5D%20%3D%2010%5Cr%5Cn%20%20%20%20%20%20%20%20pth_str_rec.disjointness%20%3D%201%5Cr%5Cn%20%20%20%20%20%20%20%20path_policy.property_weights%5B%27LastSentTime%27%5D%20%3D%2010%5Cr%5Cn%20%20%20%20%20%20%20%20pth_str_rec.last_sent_time%20%3D%200%5Cr%5Cn%20%20%20%20%20%20%20%20path_policy.property_weights%5B%27LastSeenTime%27%5D%20%3D%2010%5Cr%5Cn%20%20%20%20%20%20%20%20pth_str_rec.last_seen_time%20%3D%201%5Cr%5Cn%20%20%20%20%20%20%20%20path_policy.property_weights%5B%27DelayTime%27%5D%20%3D%2010%5Cr%5Cn%20%20%20%20%20%20%20%20pth_str_rec.delay_time%20%3D%201%5Cr%5Cn%20%20%20%20%20%20%20%20path_policy.property_weights%5B%27ExpirationTime%27%5D%20%3D%2020%5Cr%5Cn%20%20%20%20%20%20%20%20pth_str_rec.expiration_time%20%3D%202%5Cr%5Cn%20%20%20%20%20%20%20%20path_policy.property_weights%5B%27GuaranteedBandwidth%27%5D%20%3D%2010%5Cr%5Cn%20%20%20%20%20%20%20%20pth_str_rec.guaranteed_bandwidth%20%3D%201%5Cr%5Cn%20%20%20%20%20%20%20%20path_policy.property_weights%5B%27AvailableBandwidth%27%5D%20%3D%2010%5Cr%5Cn%20%20%20%20%20%20%20%20pth_str_rec.available_bandwidth%20%3D%201%5Cr%5Cn%20%20%20%20%20%20%20%20path_policy.property_weights%5B%27TotalBandwidth%27%5D%20%3D%2010%5Cr%5Cn%20%20%20%20%20%20%20%20pth_str_rec.total_bandwidth%20%3D%201%5Cr%5Cn%20%20%20%20%20%20%20%20time_.return_value%20%3D%201%5Cr%5Cn%20%20%20%20%20%20%20%20pth_str_rec.update_fidelity%28path_policy%29%5Cr%5Cn%20%20%20%20%20%20%20%20ntools.assert_almost_equal%28pth_str_rec.fidelity%2C%20100%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A18%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20what%20is%20written%20already%20is%20OK.%20The%20reason%20being%20if%20you%20change%20two%20different%20values%20of%20path_policy.property_weights%20the%20effect%20can%20be%20seen%20easily.%20While%20what%20is%20written%20already%20might%20be%20hard%20to%20understand%20but%20serves%20as%20a%20better%20check%5Cr%5CnFor%20example%20if%20you%20change%20%20path_policy.property_weights%5B%27Disjointness%27%5D%20%20to%205%20then%20the%20answer%20would%20be%201015345.6789%20instead%20of%2010123456.789%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A21%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ahh%2C%20now%20i%20get%20it%20%3A%29%20Ok%2C%20your%20approach%20looks%20good.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A38%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%20193%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33355621%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Move%20this%20above%20%60pcb%20%3D%60%2C%20as%20%60time.time%28%29%60%20is%20called%20first%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A33%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A47%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%20165%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33355268%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22While%20this%20does%20match%20the%20code%20logic%2C%20i%20think%20it%20doesn%27t%20match%20the%20code%27s%20intention.%20Instead%20test%20with%20%60%5B0%2C%202%5D%60%20and%20%603%60%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A29%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A28%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%2084%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354318%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60spec_set%3D%5B%5D%60%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A16%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Same%20applies%20to%20the%20rest%20of%20the%20mocks%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A17%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A26%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%20296%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33356489%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20can%20be%20simplified%20to%3A%20%60ntools.eq_%28pth_pol2.property_ranges%2C%20%7B%27key1%27%3A%20%281%2C%2011%29%2C%20%27key2%27%3A%20%282%2C%2012%29%7D%29%60%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A44%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A48%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%2093%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354493%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20the%20test%20is%20%60isinstance%60%2C%20and%20not%20%60type%60%2C%20you%20can%20do%20this%20directly%3A%5Cr%5Cn%60pcb%20%3D%20MagicMock%28spec_set%3DPathSegment%29%60%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A19%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A26%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20d7bdf3965b81e69d81419b37a411527117d2f342%20test/lib_path_store_test.py%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33359871%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Unused%20import%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A23%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh%2C%20heh%2C%20you%27re%20testing%20that%20in%20a%20later%20PR.%20Not%20important%20then.%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A24%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20Unused%20imports%20will%20be%20used%20for%20testing%20class%20PathStore%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A24%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A36%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-366%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%20123%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33354989%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20these%205%20lines%20are%20identical%20in%20both%20tests%2C%20i%27d%20suggest%20pulling%20them%20out%20into%20a%20separate%20method.%20You%20could%20use%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20def%20setUp%28self%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20self.pcb%20%3D%20MagicMock%28spec_set%3D%5B%27ads%27%5D%29%5Cr%5Cn%20%20%20%20%20%20%20%20self.pcb.ads%20%3D%20%5BMagicMock%28spec_set%3D%5B%27pcbm%27%5D%29%20for%20i%20in%20range%285%29%5D%5Cr%5Cn%20%20%20%20%20%20%20%20for%20i%20in%20range%285%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20self.pcb.ads%5Bi%5D.pcbm%20%3D%20MagicMock%28spec_set%3D%5B%27isd_id%27%2C%20%27ad_id%27%5D%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20self.pcb.ads%5Bi%5D.pcbm.isd_id%20%3D%20%5C%22isd_id%5C%22%20%2B%20str%28i%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20self.pcb.ads%5Bi%5D.pcbm.ad_id%20%3D%20%5C%22ad_id%5C%22%20%2B%20str%28i%29%5Cr%5Cn%20%20%20%20%20%20%20%20self.pth_pol%20%3D%20PathPolicy%28%29%5Cr%5Cn%5Cr%5Cn%20%20%20%20def%20tearDown%28self%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20del%20self.pcb%5Cr%5Cn%20%20%20%20%20%20%20%20del%20self.pth_pol%5Cr%5Cn%5Cr%5Cn%20%20%20%20def%20test_basic%28self%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20self.pth_pol.unwanted_ads%20%3D%20%5B%28%5C%22isd_id1%5C%22%2C%20%5C%22ad_id1%5C%22%29%5D%5Cr%5Cn%20%20%20%20%20%20%20%20ntools.assert_false%28self.pth_pol._check_unwanted_ads%28self.pcb%29%29%5Cr%5Cn%5Cr%5Cn%20%20%20%20def%20test_not_present%28self%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20self.pth_pol.unwanted_ads%20%3D%20%5B%5D%5Cr%5Cn%20%20%20%20%20%20%20%20ntools.assert_true%28self.pth_pol._check_unwanted_ads%28self.pcb%29%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A25%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A26%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%2C%20%22Pull%20ff27ee40447d48a173cbfd9f7082881341b82042%20test/lib_path_store_test.py%20207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/206%23discussion_r33355742%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%20next%206%20tests%20are%20almost%20identical%2C%20so%20you%20could%20replace%20them%20with%20a%20generator%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A35%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60%60%60%5Cr%5Cn%20%20%20%20def%20_check_bandwidth%28self%2C%20key%2C%20range_%2C%20result%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20pth_pol%20%3D%20PathPolicy%28%29%5Cr%5Cn%20%20%20%20%20%20%20%20pth_pol.property_ranges%20%3D%20self.d%5Cr%5Cn%20%20%20%20%20%20%20%20pth_pol.property_ranges%5B%27GuaranteedBandwidth%27%5D.extend%28range_%29%5Cr%5Cn%20%20%20%20%20%20%20%20ntools.eq_%28pth_pol._check_property_ranges%28%5C%22pcb%5C%22%29%2C%20result%29%5Cr%5Cn%5Cr%5Cn%20%20%20%20def%20test_bandwidth%28self%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20for%20key%20in%20%28%27GuaranteedBandwidth%27%2C%20%27AvailableBandwidth%27%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%27TotalBandwidth%27%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20yield%20self._check_bandwidth%2C%20key%2C%20%5B0%2C%2020%5D%2C%20True%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20yield%20self._check_bandwidth%2C%20key%2C%20%5B0%2C%209%5D%2C%20False%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A38%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nice%22%2C%20%22created_at%22%3A%20%222015-06-26T13%3A59%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-26T14%3A48%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL1-397%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#issuecomment-115638255'>General Comment</a></b>
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat Can you review this? I will create a separate PR for PathStore tests.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> The Unused imports will be used for testing class PathStore
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Great, LGTM :)
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Thanks for the review
  On Fri, Jun 26, 2015 at 4:48 PM, Stephen Shirley notifications@github.com
  wrote:
  > Merged #206 https://github.com/netsec-ethz/scion/pull/206.
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/206#event-341236114.
  >
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (For #129)
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 72'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33354171'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This isn't bad, but i think this could be done cleaner:

```
def test_basic(self):
keys = ["best_set_size", "candidates_set_size", "history_limit",
"update_after_number", "update_after_time", "unwanted_ads",
"property_ranges", "property_weights"]
pth_pol = PathPolicy()
target = {}
for key in keys:
setattr(pth_pol, key, key)
target[key] = key
dict_ = pth_pol.get_path_policy_dict()
ntools.eq_(dict_, target)
```
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 75'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33354297'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Always set a spec for patches/mocks. For patches, `autospec=True` is the default.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same applies to the rest of the patches
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 84'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33354318'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `spec_set=[]`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same applies to the rest of the mocks
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 93'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33354493'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> As the test is `isinstance`, and not `type`, you can do this directly:
  `pcb = MagicMock(spec_set=PathSegment)`
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 98'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33354618'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Don't check the exact logging string, just make sure that a warning was logged:
  `ntools.eq_(wrng.call_count, 1)`
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Normally this would be Okay but there are two cases for warning call and I guess it is ok to check that the current warning is being called
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ah, i see your point. I think checking that the count is 1 is still fine in this case. The other checks can tell which case `check_filters` is failing on.
  :+1:
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 123'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33354989'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> As these 5 lines are identical in both tests, i'd suggest pulling them out into a separate method. You could use:

```
def setUp(self):
self.pcb = MagicMock(spec_set=['ads'])
self.pcb.ads = [MagicMock(spec_set=['pcbm']) for i in range(5)]
for i in range(5):
self.pcb.ads[i].pcbm = MagicMock(spec_set=['isd_id', 'ad_id'])
self.pcb.ads[i].pcbm.isd_id = "isd_id" + str(i)
self.pcb.ads[i].pcbm.ad_id = "ad_id" + str(i)
self.pth_pol = PathPolicy()
def tearDown(self):
del self.pcb
del self.pth_pol
def test_basic(self):
self.pth_pol.unwanted_ads = [("isd_id1", "ad_id1")]
ntools.assert_false(self.pth_pol._check_unwanted_ads(self.pcb))
def test_not_present(self):
self.pth_pol.unwanted_ads = []
ntools.assert_true(self.pth_pol._check_unwanted_ads(self.pcb))
```
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 145'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33355100'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Use `setUp`/`tearDown` for this (and don't remember to delete `self.d` in tearDown)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It means you also don't need to do copies in the test, as these special functions are run before and after each test.
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 165'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33355268'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> While this does match the code logic, i think it doesn't match the code's intention. Instead test with `[0, 2]` and `3`
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 168'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33355318'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Need an assertion that `pcb.get_n_peer_links` is called
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 193'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33355621'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Move this above `pcb =`, as `time.time()` is called first
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 207'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33355742'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> These next 6 tests are almost identical, so you could replace them with a generator
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> 

```
def _check_bandwidth(self, key, range_, result):
pth_pol = PathPolicy()
pth_pol.property_ranges = self.d
pth_pol.property_ranges['GuaranteedBandwidth'].extend(range_)
ntools.eq_(pth_pol._check_property_ranges("pcb"), result)
def test_bandwidth(self):
for key in ('GuaranteedBandwidth', 'AvailableBandwidth',
'TotalBandwidth'):
yield self._check_bandwidth, key, [0, 20], True
yield self._check_bandwidth, key, [0, 9], False
```
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Nice
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 258'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33356140'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Perfect :)
  :+1:
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 296'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33356489'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This can be simplified to: `ntools.eq_(pth_pol2.property_ranges, {'key1': (1, 11), 'key2': (2, 12)})`
- [x] <a href='#crh-comment-Pull ff27ee40447d48a173cbfd9f7082881341b82042 test/lib_path_store_test.py 363'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33357716'>File: test/lib_path_store_test.py:L1-397</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Hmm. The problem is that it's too hard to see that this test is obviously correct.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Yeah thats why I have written it in a way that makes more sense. If you look at the supposed output you will understand the logic
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> 10 \* 10 ^ 5
  1 \* 10 ^ 4
  2 \* 10 ^ 3
  3 \* 10 ^ 2
  4 \* 10 ^ 1
  5 \* 10 ^ 0
  6 \* 10 ^ -1
  7 \* 10 ^ -2
  8 \* 10 ^ -3
  9 \* 10 ^ -4
  These values are incremented for self.fidelity
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Here's my attempt at making it clearer:

```
pcb = MagicMock(spec_set=['__class__', 'segment_id',
'get_expiration_time'])
pcb.__class__ = PathSegment
pth_str_rec = PathStoreRecord(pcb)
path_policy = PathPolicy()
path_policy.property_weights['PeerLinks'] = 10
pth_str_rec.peer_links = 1
path_policy.property_weights['HopsLength'] = 10
pth_str_rec.hops_length = 1
path_policy.property_weights['Disjointness'] = 10
pth_str_rec.disjointness = 1
path_policy.property_weights['LastSentTime'] = 10
pth_str_rec.last_sent_time = 0
path_policy.property_weights['LastSeenTime'] = 10
pth_str_rec.last_seen_time = 1
path_policy.property_weights['DelayTime'] = 10
pth_str_rec.delay_time = 1
path_policy.property_weights['ExpirationTime'] = 20
pth_str_rec.expiration_time = 2
path_policy.property_weights['GuaranteedBandwidth'] = 10
pth_str_rec.guaranteed_bandwidth = 1
path_policy.property_weights['AvailableBandwidth'] = 10
pth_str_rec.available_bandwidth = 1
path_policy.property_weights['TotalBandwidth'] = 10
pth_str_rec.total_bandwidth = 1
time_.return_value = 1
pth_str_rec.update_fidelity(path_policy)
ntools.assert_almost_equal(pth_str_rec.fidelity, 100)
```
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> I think what is written already is OK. The reason being if you change two different values of path_policy.property_weights the effect can be seen easily. While what is written already might be hard to understand but serves as a better check
  For example if you change  path_policy.property_weights['Disjointness']  to 5 then the answer would be 1015345.6789 instead of 10123456.789
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ahh, now i get it :) Ok, your approach looks good. :+1:
- [x] <a href='#crh-comment-Pull d7bdf3965b81e69d81419b37a411527117d2f342 test/lib_path_store_test.py 29'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/206#discussion_r33359871'>File: test/lib_path_store_test.py:L1-366</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Unused import
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Oh, heh, you're testing that in a later PR. Not important then.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> The Unused imports will be used for testing class PathStore

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/206?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/206?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/206'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
