### PR TITLE
Added Tests for class PathStore in lib/path_store.py 

### DIFF
--- a/test/lib_path_store_test.py
+++ b/test/lib_path_store_test.py
@@ -605,18 +605,18 @@ class TestPathStoreGetLatestHistorySnapshot(object):
 
     def test_basic(self):
         pth_str = PathStore(self._setup())
-        pth_str.best_paths_history = [1]
-        pth_str.best_paths_history[0] = [MagicMock(spec_set=['pcb'])
-                                         for i in range(5)]
+        pth_str.best_paths_history = []
+        pth_str.best_paths_history.append([MagicMock(spec_set=['pcb'])
+                                           for i in range(5)])
         for i in range(5):
             pth_str.best_paths_history[0][i].pcb = i
         ntools.eq_(pth_str.get_latest_history_snapshot(3), [0, 1, 2])
 
     def test_less_arg(self):
         pth_str = PathStore(self._setup({'best_set_size': 4}))
-        pth_str.best_paths_history = [1]
-        pth_str.best_paths_history[0] = [MagicMock(spec_set=['pcb'])
-                                         for i in range(5)]
+        pth_str.best_paths_history = []
+        pth_str.best_paths_history.append([MagicMock(spec_set=['pcb'])
+                                           for i in range(5)])
         for i in range(5):
             pth_str.best_paths_history[0][i].pcb = i
         ntools.eq_(pth_str.get_latest_history_snapshot(), [0, 1, 2, 3])


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/214%23issuecomment-116665177%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33471521%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33473367%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33473512%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33473537%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33473701%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33475370%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33476152%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33476897%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33478042%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33478080%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33478117%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33565135%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33565165%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33565183%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33565194%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33565212%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33567485%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33567502%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33567908%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33567945%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33568080%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23issuecomment-117165185%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23issuecomment-117168938%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23issuecomment-117170641%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23issuecomment-117172797%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23issuecomment-117173246%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23issuecomment-117174479%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23issuecomment-117182870%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23issuecomment-117183174%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23issuecomment-116665177%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20Ready%20for%20review%22%2C%20%22created_at%22%3A%20%222015-06-29T13%3A47%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40prateshg%20-%20there%27s%20%7E5%20lines%20missing%20from%20test%20coverage%20in%20this%20file.%20If%20this%20loads%20for%20you%2C%20you%20should%20be%20able%20to%20see%20them%3A%20https%3A//circle-artifacts.com/gh/netsec-ethz/scion/613/artifacts/0/tmp/circle-artifacts.ylUPwNl/coverage/lib_path_store.html%20%28it%27s%20taking%20ages%20for%20me%29.%20Otherwise%20run%20%27./scion.sh%20coverage%20lib_path_store_test%27%20and%20then%20look%20at%20the%20html%20report%20that%27s%20linked%20at%20the%20bottom%20of%20the%20output.%5Cr%5Cn%5Cr%5CnThe%20affected%20code%20is%20not%20part%20of%20what%20you%27re%20testing%20here%2C%20so%20i%27m%20happy%20for%20you%20to%20make%20a%20new%20PR%20to%20fix%20that%2C%20and%20i%27ll%20merge%20this%20one.%22%2C%20%22created_at%22%3A%20%222015-06-30T12%3A51%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20just%20looked%20at%20those%205%20lines.%20The%20first%202%20are%20because%20of%20the%20test%20generator%20that%20is%20used.%20The%20next%203%20are%20for%20except%20in%20%28try/except%29%20so%20I%20am%20not%20sure%20do%20I%20raise%20an%20exception%20for%20testing%20this%3F%22%2C%20%22created_at%22%3A%20%222015-06-30T13%3A00%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20you%20can%20merge%20this%22%2C%20%22created_at%22%3A%20%222015-06-30T13%3A04%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40prateshg%20-%20The%20test%20generator%20has%20a%20bug%20in%20it%2C%20and%20i%27m%20surprised%20it%20didn%27t%20fail%20%3A%28%5Cr%5Cn%60pth_pol.property_ranges%5B%27GuaranteedBandwidth%27%5D.extend%28range_%29%60%5Cr%5Cnshould%20be%3A%5Cr%5Cn%60pth_pol.property_ranges%5Bkey%5D.extend%28range_%29%60%22%2C%20%22created_at%22%3A%20%222015-06-30T13%3A07%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22And%20yes%2C%20for%20%60from_file%60%2C%20you%20should%20use%20a%20test%20generator%20to%20raise%20all%203%20exceptions.%22%2C%20%22created_at%22%3A%20%222015-06-30T13%3A08%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Well%20it%20didn%27t%20fail%20because%20of%20the%20almost%20equal%22%2C%20%22created_at%22%3A%20%222015-06-30T13%3A11%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22Maybe%20we%27re%20looking%20at%20somewhere%20different%2C%20but%20https%3A//github.com/netsec-ethz/scion/blob/master/test/lib_path_store_test.py%23L200%20just%20uses%20%60eq_%60%22%2C%20%22created_at%22%3A%20%222015-06-30T13%3A24%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ahh.%20The%20return%20of%20%60check_property_ranges%60%20defaults%20to%20%60True%60%22%2C%20%22created_at%22%3A%20%222015-06-30T13%3A25%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206b6d9fe9e9e685f3470805c10d87573dc11c797a%20test/lib_path_store_test.py%20172%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33476897%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Check%20that%20%60get_timestamp%60%20is%20called%22%2C%20%22created_at%22%3A%20%222015-06-29T15%3A37%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%22%2C%20%22created_at%22%3A%20%222015-06-29T15%3A47%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T12%3A06%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL361-706%22%7D%2C%20%22Pull%206b6d9fe9e9e685f3470805c10d87573dc11c797a%20test/lib_path_store_test.py%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33471521%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20name%20is%20a%20duplicate%22%2C%20%22created_at%22%3A%20%222015-06-29T14%3A52%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T12%3A06%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL361-706%22%7D%2C%20%22Pull%206b6d9fe9e9e685f3470805c10d87573dc11c797a%20test/lib_path_store_test.py%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33473367%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Need%20a%20test%20for%20when%20%60check_filters%60%20returns%20%60False%60%22%2C%20%22created_at%22%3A%20%222015-06-29T15%3A07%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oops%2C%20i%20missed%20%60test_filters%60%22%2C%20%22created_at%22%3A%20%222015-06-29T15%3A09%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-29T15%3A09%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22There%20is%20one%20for%20when%20check_filters%20return%20false%20%5C%22test_filters%5C%22%22%2C%20%22created_at%22%3A%20%222015-06-29T15%3A10%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T12%3A05%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL361-706%22%7D%2C%20%22Pull%206b6d9fe9e9e685f3470805c10d87573dc11c797a%20test/lib_path_store_test.py%20125%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33476152%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Check%20that%20%60get_n_hops%60%20is%20called%22%2C%20%22created_at%22%3A%20%222015-06-29T15%3A30%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T12%3A06%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL361-706%22%7D%2C%20%22Pull%206bdf83a8ec814ff92071216271c834405b91b4d4%20test/lib_path_store_test.py%20249%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33567502%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20a%20bit%20weird.%20It%20would%20be%20simpler%20to%20just%20do%3A%5Cr%5Cn%60%60%60%5Cr%5Cnpth_str.best_paths_history%20%3D%20%5B%5D%5Cr%5Cnpth_str.best_paths_history.append%28%5BMagicMock%28spec_set%3D%5B%27pcb%27%5D%20for%20i%20in%20range%285%29%5D%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-30T12%3A40%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%22%2C%20%22created_at%22%3A%20%222015-06-30T12%3A45%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T12%3A47%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL361-710%22%7D%2C%20%22Pull%206b6d9fe9e9e685f3470805c10d87573dc11c797a%20test/lib_path_store_test.py%20106%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33475370%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Need%20a%20check%20that%20%60get_n_peer_links%28%29%60%20was%20called%20on%20each%20candidate.%22%2C%20%22created_at%22%3A%20%222015-06-29T15%3A24%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T12%3A06%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL361-706%22%7D%2C%20%22Pull%206b6d9fe9e9e685f3470805c10d87573dc11c797a%20test/lib_path_store_test.py%20232%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/214%23discussion_r33478080%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Having%20%60setUp%60/%60tearDown%60%20methods%20that%20aren%27t%20used%20by%20all%20test%20cases%20%28and%20in%20fact%20whose%20work%20is%20partially%20duplicated%20by%20a%20test%20case%29%20isn%27t%20a%20good%20approach.%20I%20would%20instead%20make%20a%20%60_setup%60%20method%20like%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20%20def%20_setup%28self%2C%20attrs%3DNone%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20def_attrs%20%3D%20%7B%27history_limit%27%3A%203%7D%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20%20%20%20%20%20if%20attrs%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20def_attrs.update%28attrs%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20path_policy%20%3D%20MagicMock%28spec_set%3Ddef_attrs.keys%28%29%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20for%20k%2C%20v%20in%20def_attrs.items%28%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20setattr%28path_policy%2C%20k%2C%20v%29%5Cr%5Cn%20%20%20%20%20%20%20%20%20return%20path_policy%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-29T15%3A47%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22And%20then%20call%20that%20from%20each%20test%20method%2C%20passing%20in%20a%20different%20attribute%20dictionary%20as%20necessary.%22%2C%20%22created_at%22%3A%20%222015-06-29T15%3A48%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%5Cr%5Cn%28ping%29%22%2C%20%22created_at%22%3A%20%222015-06-30T12%3A39%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12234672%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/prateshg%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-30T12%3A45%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_path_store_test.py%3AL361-706%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/214#issuecomment-116665177'>General Comment</a></b>
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat Ready for review
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @prateshg - there's ~5 lines missing from test coverage in this file. If this loads for you, you should be able to see them: https://circle-artifacts.com/gh/netsec-ethz/scion/613/artifacts/0/tmp/circle-artifacts.ylUPwNl/coverage/lib_path_store.html (it's taking ages for me). Otherwise run './scion.sh coverage lib_path_store_test' and then look at the html report that's linked at the bottom of the output.
  The affected code is not part of what you're testing here, so i'm happy for you to make a new PR to fix that, and i'll merge this one.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> I just looked at those 5 lines. The first 2 are because of the test generator that is used. The next 3 are for except in (try/except) so I am not sure do I raise an exception for testing this?
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> @kormat you can merge this
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @prateshg - The test generator has a bug in it, and i'm surprised it didn't fail :(
  `pth_pol.property_ranges['GuaranteedBandwidth'].extend(range_)`
  should be:
  `pth_pol.property_ranges[key].extend(range_)`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> And yes, for `from_file`, you should use a test generator to raise all 3 exceptions.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Well it didn't fail because of the almost equal
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Maybe we're looking at somewhere different, but https://github.com/netsec-ethz/scion/blob/master/test/lib_path_store_test.py#L200 just uses `eq_`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ahh. The return of `check_property_ranges` defaults to `True`
- [x] <a href='#crh-comment-Pull 6b6d9fe9e9e685f3470805c10d87573dc11c797a test/lib_path_store_test.py 21'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/214#discussion_r33471521'>File: test/lib_path_store_test.py:L361-706</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This name is a duplicate
- [x] <a href='#crh-comment-Pull 6b6d9fe9e9e685f3470805c10d87573dc11c797a test/lib_path_store_test.py 24'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/214#discussion_r33473367'>File: test/lib_path_store_test.py:L361-706</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Need a test for when `check_filters` returns `False`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Oops, i missed `test_filters`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> There is one for when check_filters return false "test_filters"
- [x] <a href='#crh-comment-Pull 6b6d9fe9e9e685f3470805c10d87573dc11c797a test/lib_path_store_test.py 106'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/214#discussion_r33475370'>File: test/lib_path_store_test.py:L361-706</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Need a check that `get_n_peer_links()` was called on each candidate.
- [x] <a href='#crh-comment-Pull 6b6d9fe9e9e685f3470805c10d87573dc11c797a test/lib_path_store_test.py 125'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/214#discussion_r33476152'>File: test/lib_path_store_test.py:L361-706</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Check that `get_n_hops` is called
- [x] <a href='#crh-comment-Pull 6b6d9fe9e9e685f3470805c10d87573dc11c797a test/lib_path_store_test.py 172'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/214#discussion_r33476897'>File: test/lib_path_store_test.py:L361-706</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Check that `get_timestamp` is called
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Fixed
- [x] <a href='#crh-comment-Pull 6b6d9fe9e9e685f3470805c10d87573dc11c797a test/lib_path_store_test.py 232'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/214#discussion_r33478080'>File: test/lib_path_store_test.py:L361-706</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Having `setUp`/`tearDown` methods that aren't used by all test cases (and in fact whose work is partially duplicated by a test case) isn't a good approach. I would instead make a `_setup` method like:

```
def _setup(self, attrs=None):
def_attrs = {'history_limit': 3}
if attrs:
def_attrs.update(attrs)
path_policy = MagicMock(spec_set=def_attrs.keys())
for k, v in def_attrs.items():
setattr(path_policy, k, v)
return path_policy
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> And then call that from each test method, passing in a different attribute dictionary as necessary.
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Fixed
  (ping)
- [x] <a href='#crh-comment-Pull 6bdf83a8ec814ff92071216271c834405b91b4d4 test/lib_path_store_test.py 249'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/214#discussion_r33567502'>File: test/lib_path_store_test.py:L361-710</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is a bit weird. It would be simpler to just do:

```
pth_str.best_paths_history = []
pth_str.best_paths_history.append([MagicMock(spec_set=['pcb'] for i in range(5)])
```
- <a href='https://github.com/prateshg'><img border=0 src='https://avatars.githubusercontent.com/u/12234672?v=3' height=16 width=16'></a> Fixed

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/214?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/214?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/214'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
