### PR TITLE
Added segment_id comparison in PathSegment.__eq__

### DIFF
--- a/lib/packet/pcb.py
+++ b/lib/packet/pcb.py
@@ -576,6 +576,7 @@ class PathSegment(Marking):
         if type(other) is type(self):
             return (self.iof == other.iof and
                     self.trc_ver == other.trc_ver and
+                    self.segment_id == other.segment_id and
                     self.ads == other.ads)
         else:
             return False


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/215%23issuecomment-117184890%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/215%23discussion_r33575020%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/215%23issuecomment-117184890%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Seems%20this%20was%20missed%20in%20%60__eq__%60%2C%20%40pszalach%20%40shitz%20%3F%22%2C%20%22created_at%22%3A%20%222015-06-30T13%3A28%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20584c92820e6dd7fb8a315547d2e01ec620d96238%20lib/packet/pcb.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/215%23discussion_r33575020%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Drop%20this%20line.%20This%20is%20auxiliary%20field%20changed%20by%20every%20ingress%20edge%20router.%22%2C%20%22created_at%22%3A%20%222015-06-30T14%3A00%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/pcb.py%3AL576-584%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/215#issuecomment-117184890'>General Comment</a></b>
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> Seems this was missed in `__eq__`, @pszalach @shitz ?
- [ ] <a href='#crh-comment-Pull 584c92820e6dd7fb8a315547d2e01ec620d96238 lib/packet/pcb.py 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/215#discussion_r33575020'>File: lib/packet/pcb.py:L576-584</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> Drop this line. This is auxiliary field changed by every ingress edge router.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/215?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/215?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/215'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
