### PR TITLE
Unit tests for lib/log.py

### DIFF
--- a/test/lib_log_test.py
+++ b/test/lib_log_test.py
@@ -48,9 +48,7 @@ class TestStreamErrorHandlerHandleError(object):
             raise SCIONTestException
         except:
             ntools.assert_raises(SCIONTestException, handler.handleError, "hi")
-        calls = [call("Exception in logging module:\n"), call('line0\n'),
-                 call('line1\n')]
-        handler.stream.write.assert_has_calls(calls)
+        ntools.eq_(handler.stream.write.call_count, 3)
         handler.flush.assert_called_once_with()
 
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/221%23issuecomment-117564663%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23issuecomment-117564735%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23issuecomment-117999438%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23issuecomment-118005639%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23discussion_r33577791%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23discussion_r33579926%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23discussion_r33583777%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23discussion_r33585927%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23discussion_r33586256%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23discussion_r33587205%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23discussion_r33662646%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23discussion_r33663130%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23discussion_r33769158%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23issuecomment-117564663%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20rest%20looks%20good%20to%20me.%22%2C%20%22created_at%22%3A%20%222015-07-01T09%3A42%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28For%20%23129%29%22%2C%20%22created_at%22%3A%20%222015-07-01T09%3A42%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%2C%20can%20merge%20this%20I%20think.%22%2C%20%22created_at%22%3A%20%222015-07-02T11%3A05%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-07-02T11%3A36%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%203d5368aed79afe5ead6f67701df8ed48c7053b45%20test/lib_log_test.py%2053%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23discussion_r33662646%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20prefer%20to%20check%20just%20that%20it%20is%20called%203%20times.%20Relying%20on%20certain%20string%20constants%20makes%20the%20tests%20more%20brittle%20than%20necessary.%20Even%20for%20line0/line1%2C%20formatting%20may%20change.%22%2C%20%22created_at%22%3A%20%222015-07-01T09%3A35%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-07-02T11%3A36%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_log_test.py%3AL1-107%22%7D%2C%20%22Pull%20d72ef2665b49e3d6f83ff542f065dece98236187%20test/lib_log_test.py%2036%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/221%23discussion_r33577791%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20I%27m%20getting%20%60AttributeError%3A%20%3Cclass%20%27lib.log._StreamErrorHandler%27%3E%20does%20not%20have%20the%20attribute%20%27stream%27%60%20if%20I%20do%20this%20patch.%20Could%20it%20be%20because%20%60_StreamErrorHandler%60%20is%20protected%3F%20Any%20workaround%3F%22%2C%20%22created_at%22%3A%20%222015-06-30T14%3A25%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hum.%20I%27m%20looking%20at%20it%2C%20i%20don%27t%20have%20a%20solution%20yet%22%2C%20%22created_at%22%3A%20%222015-06-30T14%3A42%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Here%27s%20a%20rough%20solution%2C%20still%20needs%20work%20to%20mock%20out%20traceback%20etc%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20%40patch%28%5C%22lib.log.logging.StreamHandler%5C%22%2C%20autospec%3DTrue%29%5Cr%5Cn%20%20%20%20def%20test%28self%2C%20log_sh%29%3A%5Cr%5Cn%20%20%20%20%20%20%20%20handler%20%3D%20_StreamErrorHandler%28%29%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20%20%20%20%20handler.stream%20%3D%20MagicMock%28spec_set%3D%5B%27write%27%5D%29%5Cr%5Cn%20%20%20%20%20%20%20%20handler.stream.write%20%3D%20MagicMock%28spec_set%3D%5B%5D%29%5Cr%5Cn%20%20%20%20%20%20%20%20handler.flush%20%3D%20MagicMock%28spec_set%3D%5B%5D%29%5Cr%5Cn%20%20%20%20%20%20%20%20try%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20raise%20SCIONTestException%5Cr%5Cn%20%20%20%20%20%20%20%20except%3A%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20ntools.assert_raises%28SCIONTestException%2C%20handler.handleError%2C%20%5C%22hi%5C%22%29%5Cr%5Cn%20%20%20%20%20%20%20%20ntools.assert_greater_equal%28handler.stream.write.call_count%2C%201%29%5Cr%5Cn%20%20%20%20%20%20%20%20handler.flush.assert_called_once_with%28%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-30T15%3A12%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks.%5Cr%5CnAlso%2C%20should%20I%20test%20the%20other%20methods%20in%20this%20manner%3F%20%28ie.%20by%20raising%20%60SCIONTestException%60%29%22%2C%20%22created_at%22%3A%20%222015-06-30T15%3A29%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20only%20reason%20this%20needed%20special%20handling%20is%20because%20it%20was%20calling%20%60raise%60%20on%20its%20own%2C%20which%20relies%20on%20there%20already%20being%20an%20exception%20to%20handle.%20The%20rest%20can%20be%20handled%20by%20mocking.%22%2C%20%22created_at%22%3A%20%222015-06-30T15%3A32%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fine%2C%20you%20can%20review%20other%20tests%20as%20well.%20I%27m%20done.%20%22%2C%20%22created_at%22%3A%20%222015-06-30T15%3A40%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-07-01T09%3A42%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_log_test.py%3AL1-91%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull d72ef2665b49e3d6f83ff542f065dece98236187 test/lib_log_test.py 36'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/221#discussion_r33577791'>File: test/lib_log_test.py:L1-91</a></b>
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> @kormat I'm getting `AttributeError: <class 'lib.log._StreamErrorHandler'> does not have the attribute 'stream'` if I do this patch. Could it be because `_StreamErrorHandler` is protected? Any workaround?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Hum. I'm looking at it, i don't have a solution yet
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Here's a rough solution, still needs work to mock out traceback etc:

```
@patch("lib.log.logging.StreamHandler", autospec=True)
def test(self, log_sh):
handler = _StreamErrorHandler()
handler.stream = MagicMock(spec_set=['write'])
handler.stream.write = MagicMock(spec_set=[])
handler.flush = MagicMock(spec_set=[])
try:
raise SCIONTestException
except:
ntools.assert_raises(SCIONTestException, handler.handleError, "hi")
ntools.assert_greater_equal(handler.stream.write.call_count, 1)
handler.flush.assert_called_once_with()
```
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> Thanks.
  Also, should I test the other methods in this manner? (ie. by raising `SCIONTestException`)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The only reason this needed special handling is because it was calling `raise` on its own, which relies on there already being an exception to handle. The rest can be handled by mocking.
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> Fine, you can review other tests as well. I'm done.
- [x] <a href='#crh-comment-Pull 3d5368aed79afe5ead6f67701df8ed48c7053b45 test/lib_log_test.py 53'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/221#discussion_r33662646'>File: test/lib_log_test.py:L1-107</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I would prefer to check just that it is called 3 times. Relying on certain string constants makes the tests more brittle than necessary. Even for line0/line1, formatting may change.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/221#issuecomment-117564663'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The rest looks good to me.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (For #129)
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> @kormat, can merge this I think.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/221?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/221?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/221'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
