### PR TITLE
host_addr type fixed in scion_addr.py

### DIFF
--- a/lib/packet/scion_addr.py
+++ b/lib/packet/scion_addr.py
@@ -72,7 +72,7 @@ class SCIONAddr(object):
     :ivar ad_id: AD identifier.
     :type ad_id: int
     :ivar host_addr: host address.
-    :type host_addr: string
+    :type host_addr: IPv4Address or IPv6Address
     :ivar addr_len: address length.
     :type addr_len: int
     """
@@ -101,7 +101,7 @@ class SCIONAddr(object):
         :param ad_id: AD identifier.
         :type ad_id: int
         :param host_addr: host IP addresses.
-        :type host_addr: string
+        :type host_addr: IPv4Address or IPv6Address
 
         :returns: SCION address.
         :rtype: :class:`SCIONAddr`


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/222?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/222'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
