### PR TITLE
Added proper expiration of beacons from the path store

### DIFF
--- a/lib/path_store.py
+++ b/lib/path_store.py
@@ -240,7 +240,7 @@ class PathStoreRecord(object):
         self.hops_length = 0
         self.disjointness = 0
         self.last_sent_time = 1420070400  # year 2015
-        self.last_seen_time = int(time.time())
+        self.last_seen_time = time.time()
         self.delay_time = 0
         self.expiration_time = pcb.get_expiration_time()
         self.guaranteed_bandwidth = 0
@@ -305,14 +305,17 @@ class PathStore(object):
     Path Store class.
     """
 
-    def __init__(self, path_policy):
+    def __init__(self, path_policy, beacon_ttl):
         """
         Initialize an instance of the class PathStore.
 
         :param path_policy: path policy.
         :type path_policy: dict
+        :param beacon_ttl: Time (in seconds) until a PCB gets evicted from the
+                           path store
         """
         self.path_policy = path_policy
+        self.beacon_ttl = beacon_ttl
         self.candidates = []
         self.best_paths_history = deque(maxlen=self.path_policy.history_limit)
 
@@ -441,7 +444,7 @@ class PathStore(object):
         rec_ids = []
         now = time.time()
         for candidate in self.candidates:
-            if candidate.expiration_time <= now:
+            if candidate.last_seen_time + self.beacon_ttl <= now:
                 rec_ids.append(candidate.id)
         self.remove_segments(rec_ids)
 


### PR DESCRIPTION
Added proper expiration of beacons from the path store
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/228%23issuecomment-117652778%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/228%23issuecomment-117956278%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/228%23issuecomment-117991736%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/228%23issuecomment-118100121%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/228%23issuecomment-118767851%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/228%23issuecomment-119557344%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/228%23issuecomment-119616008%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/228%23issuecomment-117652778%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%2C%20%40kormat%20%22%2C%20%22created_at%22%3A%20%222015-07-01T12%3A58%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Code%20is%20fine%20to%20me%2C%20but%20why%20we%20want%20to%20remove%20these%20beacons%20from%20pathstore%3F%20I%20thought%20that%20we%20discussed%20to%20removing%20old%20beacons%20from%20ZK%2C%20while%20pathstore%20should%20be%20adjusted%20with%20a%20policy%20file%20%28that%20defines%20how%20beacons%20should%20be%20selected%20and%20dropped%29.%22%2C%20%22created_at%22%3A%20%222015-07-02T08%3A30%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Then%20you%27ll%20run%20into%20inconsistencies%20between%20the%20path%20store%20and%20the%20shared%20path%2C%20which%20I%20don%27t%20think%20is%20a%20good%20idea.%20What%20we%20could%20do%20is%20adding%20the%20%27path%20freshness%27%20to%20the%20policy%20file.%22%2C%20%22created_at%22%3A%20%222015-07-02T10%3A20%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22IMO%20PathStore%20should%20be%20driven%20only%20by%20a%20policy%2C%20and%20I%27m%20against%20hardcoding%5Cnsuch%20things.%20The%20policy%20should%20define%20how%20paths%20are%20preferred%20%28and%20which%5Cnpaths%20are%20dropped%20as%20a%20consequence%29.%20And%20AFAIR%20you%20don%27t%20need%20to%20add%20a%20new%5Cnpolicy%20parameter%2C%20it%20should%20be%20doable%20with%20Freshness%20parameter%20that%20exists%5Cnalready%20%28%40syclops%20maybe%20can%20clarify%20a%20little%20bit%29.%20Also%20propagation%20times%5Cnare%20local%20so%20this%20hardcoded%20parameter%20may%20be%20dangerous%2C%20e.g.%2C%20parent%20AD%5Cnpropagates%20every%20minute%2C%20and%20its%20child%20AD%20propagates%20every%205s%2C%20then%20the%5Cnchild%20%28and%20its%20children%29%20is%20disconnected.%5Cn%5CnI%20see%20old%20paths%20in%20ZK%20more%20as%20a%20backup%20cache%20and%20an%20initial%20feed%20for%5Cnnewcomer%20BSes%20%28just%20in%20case%20that%20a%20newcomer%20BS%20becomes%20master%20and%20has%20to%5Cnpropagate%29.%5CnAnd%20I%27m%20not%20convinced%20about%20full%20consistency%20between%20local%20pathstores%20and%5CnZK%20%28especially%20that%20such%20consistency%20is%20impossible%2C%20as%20BSes%20%20may%20update%5Cnpathstores%20at%20the%20different%20time%20--%20depending%20on%20their%20start%20time%29.%20I%20would%5Cnrather%20put%20a%20new%20parameter%20to%20BS%20config%20to%20indicate%20when%20old%20paths%20should%5Cnbe%20deleted%20by%20a%20master%20from%20ZK.%5CnI%27m%20happy%20to%20discuss%20if%20you%20disagree.%5Cn%5CnOn%202%20July%202015%20at%2012%3A20%2C%20shitz%20%3Cnotifications%40github.com%3E%20wrote%3A%5Cn%5Cn%3E%20Then%20you%27ll%20run%20into%20inconsistencies%20between%20the%20path%20store%20and%20the%20shared%5Cn%3E%20path%2C%20which%20I%20don%27t%20think%20is%20a%20good%20idea.%20What%20we%20could%20do%20is%20adding%20the%5Cn%3E%20%27path%20freshness%27%20to%20the%20policy%20file.%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/228%23issuecomment-117991736%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-07-02T17%3A29%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20I%27m%20fine%20with%20that.%20Although%20there%20is%20no%20%27freshness%27%20parameter%20in%20the%20policy.%20I%20think%20path%20freshness%20gets%20achieved%20with%20the%20%60last_seen_time%60%20parameter%2C%20but%20we%20can%20easily%20add%20such%20a%20parameter%20to%20the%20policy.%22%2C%20%22created_at%22%3A%20%222015-07-06T08%3A09%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Is%20this%20PR%20going%20to%20be%20further%20developed%2C%20or%20should%20we%20just%20close%20it%3F%22%2C%20%22created_at%22%3A%20%222015-07-08T12%3A26%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20should%20answer%20your%20question%20%3B%29%22%2C%20%22created_at%22%3A%20%222015-07-08T15%3A04%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/228#issuecomment-117652778'>General Comment</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> @pszalach, @kormat
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> Code is fine to me, but why we want to remove these beacons from pathstore? I thought that we discussed to removing old beacons from ZK, while pathstore should be adjusted with a policy file (that defines how beacons should be selected and dropped).
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Then you'll run into inconsistencies between the path store and the shared path, which I don't think is a good idea. What we could do is adding the 'path freshness' to the policy file.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> IMO PathStore should be driven only by a policy, and I'm against hardcoding
  such things. The policy should define how paths are preferred (and which
  paths are dropped as a consequence). And AFAIR you don't need to add a new
  policy parameter, it should be doable with Freshness parameter that exists
  already (@syclops maybe can clarify a little bit). Also propagation times
  are local so this hardcoded parameter may be dangerous, e.g., parent AD
  propagates every minute, and its child AD propagates every 5s, then the
  child (and its children) is disconnected.
  I see old paths in ZK more as a backup cache and an initial feed for
  newcomer BSes (just in case that a newcomer BS becomes master and has to
  propagate).
  And I'm not convinced about full consistency between local pathstores and
  ZK (especially that such consistency is impossible, as BSes  may update
  pathstores at the different time -- depending on their start time). I would
  rather put a new parameter to BS config to indicate when old paths should
  be deleted by a master from ZK.
  I'm happy to discuss if you disagree.
  On 2 July 2015 at 12:20, shitz notifications@github.com wrote:
  > Then you'll run into inconsistencies between the path store and the shared
  > path, which I don't think is a good idea. What we could do is adding the
  > 'path freshness' to the policy file.
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/228#issuecomment-117991736.
  >
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Ok, I'm fine with that. Although there is no 'freshness' parameter in the policy. I think path freshness gets achieved with the `last_seen_time` parameter, but we can easily add such a parameter to the policy.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Is this PR going to be further developed, or should we just close it?
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> That should answer your question ;)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/228?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/228?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/228'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
