### PR TITLE
Unit tests for lib.packet.path.PathCombinator

### DIFF
--- a/test/lib_packet_path_test.py
+++ b/test/lib_packet_path_test.py
@@ -955,7 +955,7 @@ class TestPathCombinatorBuildShortcutPath(object):
 
     def test_none(self):
         up_segs = [[], [1], MagicMock(spec_set=['ads']),
-                       MagicMock(spec_set=['ads'])]
+                   MagicMock(spec_set=['ads'])]
         up_segs[2].ads = []
         up_segs[3].ads = [456]
         down_segs = [123, [], [2], MagicMock(spec_set=['ads'])]
@@ -1017,7 +1017,7 @@ class TestPathCombinatorBuildCorePath(object):
 
     def test_none(self):
         up_segs = [[], [1], MagicMock(spec_set=['ads']),
-                       MagicMock(spec_set=['ads'])]
+                   MagicMock(spec_set=['ads'])]
         up_segs[2].ads = []
         up_segs[3].ads = [456]
         down_segs = [123, [], [2], MagicMock(spec_set=['ads'])]
@@ -1196,14 +1196,14 @@ class TestPathCombinatorCheckConnected(object):
         del self.up_seg
         del self.down_seg
 
-    def test1(self):
+    def test_up_seg_disconnected(self):
         self.core_seg.get_last_pcbm.return_value.ad_id = 123
         self.up_seg.get_first_pcbm.return_value.ad_id = 456
         ntools.assert_false(PathCombinator._check_connected(self.up_seg,
                                                             self.core_seg,
                                                             'down_seg'))
 
-    def test2(self):
+    def test_down_seg_disconnected(self):
         self.core_seg.get_last_pcbm.return_value.ad_id = 123
         self.up_seg.get_first_pcbm.return_value.ad_id = 123
         self.core_seg.get_first_pcbm.return_value.ad_id = 456
@@ -1212,7 +1212,7 @@ class TestPathCombinatorCheckConnected(object):
                                                             self.core_seg,
                                                             self.down_seg))
 
-    def test3(self):
+    def test_connected_with_core(self):
         self.core_seg.get_last_pcbm.return_value.ad_id = 123
         self.up_seg.get_first_pcbm.return_value.ad_id = 123
         self.core_seg.get_first_pcbm.return_value.ad_id = 456
@@ -1221,14 +1221,14 @@ class TestPathCombinatorCheckConnected(object):
                                                            self.core_seg,
                                                            self.down_seg))
 
-    def test4(self):
+    def test_disconnected_without_core(self):
         self.up_seg.get_first_pcbm.return_value.ad_id = 123
         self.down_seg.get_first_pcbm.return_value.ad_id = 456
         ntools.assert_false(PathCombinator._check_connected(self.up_seg,
                                                             None,
                                                             self.down_seg))
 
-    def test5(self):
+    def test_connected_without_core(self):
         self.up_seg.get_first_pcbm.return_value.ad_id = 123
         self.down_seg.get_first_pcbm.return_value.ad_id = 123
         ntools.assert_true(PathCombinator._check_connected(self.up_seg,


### PR DESCRIPTION
~~(work in progress)~~
~~depends on #227~~
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/229%23issuecomment-119204039%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23discussion_r34054550%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23discussion_r34056011%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23discussion_r34123379%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23discussion_r34123505%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23discussion_r34123608%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23issuecomment-119495402%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23issuecomment-119544289%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23discussion_r34141517%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23discussion_r34141529%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23discussion_r34141554%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23issuecomment-119558821%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23issuecomment-119559763%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23issuecomment-119204039%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%2C%20can%20review%20this.%22%2C%20%22created_at%22%3A%20%222015-07-07T13%3A36%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20just%20some%20minor%20comments.%20When%20you%27ve%20fixed%20those%2C%20please%20rebase%20it%20on%20master%2C%20and%20then%20ping%20me%20here%20for%20merging.%22%2C%20%22created_at%22%3A%20%222015-07-08T08%3A35%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%2C%20can%20merge%20this%20now.%22%2C%20%22created_at%22%3A%20%222015-07-08T11%3A16%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-07-08T12%3A30%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28For%20%23217%29%22%2C%20%22created_at%22%3A%20%222015-07-08T12%3A35%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a6466dd8edb4a1373c9619ca1e7ca58e2000b936%20test/lib_packet_path_test.py%20223%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23discussion_r34123379%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20a%20really%20strong%20set%20of%20tests.%20Nice%20work%20%3A%29%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-07-08T07%3A54%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_test.py%3AL889-1404%22%7D%2C%20%22Pull%20a6466dd8edb4a1373c9619ca1e7ca58e2000b936%20test/lib_packet_path_test.py%20150%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23discussion_r34056011%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Over-indented%22%2C%20%22created_at%22%3A%20%222015-07-07T15%3A53%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-07-08T12%3A28%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_test.py%3AL889-1404%22%7D%2C%20%22Pull%20a6466dd8edb4a1373c9619ca1e7ca58e2000b936%20test/lib_packet_path_test.py%20329%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23discussion_r34123505%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%20aren%27t%20good%20test%20names.%20It%20should%20be%20possible%20to%20at%20least%20guess%20what%20the%20test%20is%20doing%20from%20the%20name%2C%20because%20when%20it%20fails%2C%20it%27s%20the%20test%20name%20that%20will%20be%20printed%20in%20the%20error%22%2C%20%22created_at%22%3A%20%222015-07-08T07%3A56%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20tests%20themselves%20look%20good%20though%22%2C%20%22created_at%22%3A%20%222015-07-08T07%3A57%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-07-08T12%3A28%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_test.py%3AL889-1404%22%7D%2C%20%22Pull%20b065d88dc4b60581b2bb6ebd56023ebb6f0aac39%20test/lib_packet_path_test.py%2088%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/229%23discussion_r34054550%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22over-indented%22%2C%20%22created_at%22%3A%20%222015-07-07T15%3A40%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-07-08T12%3A27%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_test.py%3AL889-1404%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/229#issuecomment-119204039'>General Comment</a></b>
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> @kormat, can review this.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok, just some minor comments. When you've fixed those, please rebase it on master, and then ping me here for merging.
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> @kormat, can merge this now.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM :)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (For #217)
- [x] <a href='#crh-comment-Pull b065d88dc4b60581b2bb6ebd56023ebb6f0aac39 test/lib_packet_path_test.py 88'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/229#discussion_r34054550'>File: test/lib_packet_path_test.py:L889-1404</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> over-indented
- [x] <a href='#crh-comment-Pull a6466dd8edb4a1373c9619ca1e7ca58e2000b936 test/lib_packet_path_test.py 150'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/229#discussion_r34056011'>File: test/lib_packet_path_test.py:L889-1404</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Over-indented
- [x] <a href='#crh-comment-Pull a6466dd8edb4a1373c9619ca1e7ca58e2000b936 test/lib_packet_path_test.py 223'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/229#discussion_r34123379'>File: test/lib_packet_path_test.py:L889-1404</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is a really strong set of tests. Nice work :)
  :+1:
- [x] <a href='#crh-comment-Pull a6466dd8edb4a1373c9619ca1e7ca58e2000b936 test/lib_packet_path_test.py 329'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/229#discussion_r34123505'>File: test/lib_packet_path_test.py:L889-1404</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> These aren't good test names. It should be possible to at least guess what the test is doing from the name, because when it fails, it's the test name that will be printed in the error
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The tests themselves look good though

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/229?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/229?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/229'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
