### PR TITLE
adding test for lib/thread.py

### DIFF
--- a/test/lib_thread_test.py
+++ b/test/lib_thread_test.py
@@ -48,11 +48,9 @@ class TestThreadSafetyNet(object):
     """
     Unit tests for lib.thread.thread_safety_net
     """
-    @thread_safety_net("no_exp")
     def no_exception_f(self):
         return "test_data"
 
-    @thread_safety_net("exp")
     def exception_f(self):
         raise Exception('')
         return "test_data"
@@ -60,12 +58,12 @@ class TestThreadSafetyNet(object):
     @patch("lib.thread.kill_self", autospec=True)
     @patch("lib.thread.log_exception", autospec=True)
     def test_exception(self, log_test, kill_test):
-        ntools.assert_is_none(self.exception_f())
+        ntools.assert_is_none(thread_safety_net("exp", self.exception_f))
         log_test.assert_called_once_with("Exception in %s thread:", "exp")
         kill_test.assert_called_once_with()
 
     def test_no_exception(self):
-        ntools.eq_(self.no_exception_f(), "test_data")
+        ntools.eq_(thread_safety_net("n_exp", self.no_exception_f), "test_data")
 
 if __name__ == "__main__":
     nose.run(defaultTest=__name__)


### PR DESCRIPTION
Ready for review
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/233%23issuecomment-118048102%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/233%23issuecomment-118053041%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/233%23issuecomment-118076134%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/233%23issuecomment-118782647%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/233%23issuecomment-119531202%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/233%23issuecomment-119541726%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/233%23issuecomment-118048102%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%28For%20%23129%29%22%2C%20%22created_at%22%3A%20%222015-07-02T14%3A19%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22There%20is%20a%20subtle%20timing%20bug%20going%20on%20here%2C%20unfortunately%20%3A%28%5Cr%5Cn%60%60%60%5Cr%5CnERROR%3A%20test.lib_thread_test.TestThreadSafetyNet.test_exception%5Cr%5Cn----------------------------------------------------------------------%5Cr%5CnTraceback%20%28most%20recent%20call%20last%29%3A%5Cr%5Cn%20%20File%20%5C%22/home/kormat/.local/lib/python3.4/site-packages/nose/case.py%5C%22%2C%20line%20198%2C%20in%20runTest%5Cr%5Cn%20%20%20%20self.test%28%2Aself.arg%29%5Cr%5Cn%20%20File%20%5C%22/usr/lib/python3.4/unittest/mock.py%5C%22%2C%20line%201125%2C%20in%20patched%5Cr%5Cn%20%20%20%20return%20func%28%2Aargs%2C%20%2A%2Akeywargs%29%5Cr%5Cn%20%20File%20%5C%22/home/kormat/github/scion/test/lib_thread_test.py%5C%22%2C%20line%2063%2C%20in%20test_exception%5Cr%5Cn%20%20%20%20ntools.assert_is_none%28self.exception_f%28%29%29%5Cr%5Cn%20%20File%20%5C%22/home/kormat/github/scion/test/testcommon.py%5C%22%2C%20line%2034%2C%20in%20wrapper%5Cr%5Cn%20%20%20%20return%20f%28%2Aargs%2C%20%2A%2Akwargs%29%5Cr%5Cn%20%20File%20%5C%22/home/kormat/github/scion/test/lib_thread_test.py%5C%22%2C%20line%2057%2C%20in%20exception_f%5Cr%5Cn%20%20%20%20raise%20Exception%28%27%27%29%5Cr%5CnException%5Cr%5Cn%60%60%60%5Cr%5CnThis%20only%20happens%20when%20you%20run%20the%20test%20along%20with%20the%20rest.%20%60./scion.sh%20test%20lib_thread_test%60%20will%20always%20work%2C%20%60./scion.sh%20test%60%20will%20work%20or%20not%20depending%20on%20what%20order%20tests%20get%20run%20in.%5Cr%5Cn%5Cr%5CnThe%20problem%20is%20that%20%60test/testcommon.py%60%20unconditionally%20patches%20%60thread_safety_net%60%2C%20so%20if%20any%20test%20module%20imports%20%60testcommon%60%20before%20%60lib_thread_test.py%60%20is%20run%2C%20then%20the%20wrapper%20is%20what%20gets%20run.%20I%27ll%20see%20if%20i%20can%20figure%20out%20a%20fix.%22%2C%20%22created_at%22%3A%20%222015-07-02T14%3A38%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20created%20%23235%20to%20fix%20the%20underlying%20issue%20properly%22%2C%20%22created_at%22%3A%20%222015-07-02T15%3A54%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20%23235%20is%20merged%2C%20can%20you%20please%20update/rewrite%20the%20tests%20for%20%60thread_safety_net%60%3F%20Thanks%22%2C%20%22created_at%22%3A%20%222015-07-06T09%3A19%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22ping%22%2C%20%22created_at%22%3A%20%222015-07-08T10%3A12%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6755507%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/MDHD%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%2C%20thanks%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-07-08T11%3A00%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/233#issuecomment-118048102'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (For #129)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> There is a subtle timing bug going on here, unfortunately :(

```
ERROR: test.lib_thread_test.TestThreadSafetyNet.test_exception
----------------------------------------------------------------------
Traceback (most recent call last):
File "/home/kormat/.local/lib/python3.4/site-packages/nose/case.py", line 198, in runTest
self.test(*self.arg)
File "/usr/lib/python3.4/unittest/mock.py", line 1125, in patched
return func(*args, **keywargs)
File "/home/kormat/github/scion/test/lib_thread_test.py", line 63, in test_exception
ntools.assert_is_none(self.exception_f())
File "/home/kormat/github/scion/test/testcommon.py", line 34, in wrapper
return f(*args, **kwargs)
File "/home/kormat/github/scion/test/lib_thread_test.py", line 57, in exception_f
raise Exception('')
Exception
```

This only happens when you run the test along with the rest. `./scion.sh test lib_thread_test` will always work, `./scion.sh test` will work or not depending on what order tests get run in.
The problem is that `test/testcommon.py` unconditionally patches `thread_safety_net`, so if any test module imports `testcommon` before `lib_thread_test.py` is run, then the wrapper is what gets run. I'll see if i can figure out a fix.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I've created #235 to fix the underlying issue properly
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok, #235 is merged, can you please update/rewrite the tests for `thread_safety_net`? Thanks
- <a href='https://github.com/MDHD'><img border=0 src='https://avatars.githubusercontent.com/u/6755507?v=3' height=16 width=16'></a> ping
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM, thanks :)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/233?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/233?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/233'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
