### PR TITLE
Fix zookeeper not running in docker

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -2,10 +2,8 @@
 
 # Small script to fully setup environment
 
-if [ $(hostname) == "scionfull" ]; then
-    sudo service zookeeper start
-    ./scion.sh setup
-fi
+sudo service zookeeper start
+./scion.sh setup
 
 # Can't be fixed during build due to
 # https://github.com/docker/docker/issues/6828


### PR DESCRIPTION
Now that there's only 1 scion image built, the hostname check no longer works, and is obsolete.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/234?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/234'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
