### PR TITLE
Move dependancy management into deps.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Python implementation of [SCION](http://www.netsec.ethz.ch/research/SCION), a fu
 
 Necessary steps in order to run SCION:
 
-1. Make sure that `~/.local/bin` can be found in your $PATH variable. 
+1. Make sure that `~/.local/bin` can be found in your $PATH variable.
 
 	For example, do the following to update $PATH in your `~/.profile` and apply the changes to your session:
 
 	`echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.profile && source ~/.profile`
-	
+
 2. Install required packages with dependencies:
 
-	`./scion.sh deps`
+	`./deps.sh all`
 
 3. Compile the crypto library:
 

--- a/deps.sh
+++ b/deps.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -e
+
+cmd_all() {
+    cmd_pkgs
+    cmd_pip
+    cmd_misc
+}
+
+cmd_pkgs() {
+    if [ -e /etc/debian_version ]; then
+        pkgs_debian
+    else
+        echo "As this is not a debian-based OS, please install the equivalents of these packages:"
+        cat pkgs_debian.txt
+    fi
+}
+
+pkgs_debian() {
+    local pkgs=""
+    echo "Checking for necessary debian packages"
+    for pkg in $(< pkgs_debian.txt); do
+        if ! dpkg-query -W --showformat='${Status}\n' $pkg 2> /dev/null | \
+            grep -q "install ok installed"; then
+            pkgs+="$pkg "
+        fi
+    done
+    if [ -n "$pkgs" ]; then
+        echo "Installing missing necessary packages: $pkgs"
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install $APTARGS --no-install-recommends $pkgs
+    fi
+}
+
+cmd_pip() {
+    echo "Installing necessary packages from pip3"
+    pip3 install --user -r requirements.txt
+}
+
+
+cmd_misc() {
+    echo "Installing supervisor packages from pip2"
+    pip2 install --user supervisor==3.1.3
+    pip2 install --user supervisor-quick
+}
+
+cmd_help() {
+	cat <<-_EOF
+	$PROGRAM [all|pkgs|pip|misc|help]
+	
+	Usage:
+	    $PROGRAM all
+	        Install all dependancies.
+	    $PROGRAM pkgs
+	        Install all system package dependancies (e.g. via apt-get).
+	        Uses sudo.
+	    $PROGRAM pip
+	        Install all pip package dependancies (using --user, so no root
+	        access required)
+	    $PROGRAM misc
+	        Install any additional packages not from the first 2 sources.
+	    $PROGRAM help
+	        Show this text.
+	_EOF
+}
+# END subcommand functions
+
+PROGRAM="${0##*/}"
+COMMAND="$1"
+shift
+
+case "$COMMAND" in
+    all|pkgs|pip|misc)
+            "cmd_$COMMAND" "$@" ;;
+    help|*)  cmd_help ;;
+esac

--- a/scion.sh
+++ b/scion.sh
@@ -2,64 +2,6 @@
 
 # BEGIN subcommand functions
 
-cmd_deps() {
-    dep_type=${1:-ALL}
-    # Treat all non-zero returns as fatal errors. Prevents issues like pip
-    # package failing to install, causing the rest to be ignored.
-    set -e
-    case "$dep_type" in
-      ALL)
-        deps_pkgs ;;
-      pkgs)
-        deps_pkgs
-        return ;;
-    esac
-    case "$dep_type" in
-      ALL)
-        deps_pip3 ;;
-      pip)
-        deps_pip3
-        return ;;
-    esac
-    deps_misc
-}
-
-deps_pkgs() {
-    if [ -e /etc/debian_version ]; then
-        deps_debian
-    else
-        echo "As this is not a debian-based OS, please install the equivalents of these packages:"
-        cat pkgs_debian.txt
-    fi
-}
-
-deps_debian() {
-    local pkgs=""
-    echo "Checking for necessary debian packages"
-    for pkg in $(< pkgs_debian.txt); do
-        if ! dpkg-query -W --showformat='${Status}\n' $pkg 2> /dev/null | \
-            grep -q "install ok installed"; then
-            pkgs+="$pkg "
-        fi
-    done
-    if [ -n "$pkgs" ]; then
-        echo "Installing missing necessary packages: $pkgs"
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install $APTARGS --no-install-recommends $pkgs
-    fi
-}
-
-deps_pip3() {
-    echo "Installing necessary packages from pip3"
-    pip3 install --user -r requirements.txt
-}
-
-
-deps_misc() {
-    echo "Installing supervisor packages from pip2"
-    pip2 install --user supervisor==3.1.3
-    pip2 install --user supervisor-quick
-}
-
 cmd_init() {
     echo "Checking if tweetnacl has been built..."
     if [ -f lib/crypto/python-tweetnacl-20140309/build/python3.4/tweetnacl.so ]
@@ -142,8 +84,6 @@ cmd_help() {
 	Usage:
 	    $PROGRAM start
 	        (not implemented) Performs all tasks (compile crypto lib, creates a topology, adds IP aliases, runs the network)
-	    $PROGRAM deps
-	        Install the necessary dependancies.
 	    $PROGRAM init
 	        Compile the SCION crypto library.
 	    $PROGRAM topology
@@ -173,7 +113,7 @@ COMMAND="$1"
 shift
 
 case "$COMMAND" in
-    clean|coverage|deps|help|init|run|setup|start|stop|test|topology|version)
+    clean|coverage|help|init|run|setup|start|stop|test|topology|version)
         "cmd_$COMMAND" "$@" ;;
     *)  cmd_help ;;
 esac


### PR DESCRIPTION
This means that making changes to scion.sh will no longer cause a ~full
docker rebuild, and separates out non-scion logic.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/240?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/240'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
