### PR TITLE
Fix bug where ./scion.sh lint would always return 0

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -69,6 +69,7 @@ cmd_coverage(){
 }
 
 cmd_lint() {
+    set -o pipefail
     flake8 --config flake8.ini "${@:-.}" | sort -t: -k1,1 -k2n,2 -k3n,3
 }
 


### PR DESCRIPTION
The sort pipe meant the return value from flake8 was lost. Using `set -o
pipefail` fixes that.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/shitz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/245%23issuecomment-119546368%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-07-08T11%3A32%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/245%23issuecomment-119546368%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/shitz'><img src='https://avatars.githubusercontent.com/u/3840858?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/245?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/245?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/245'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
