### PR TITLE
Remove lib_config_test's FS dependancy

### DIFF
--- a/test/lib_config_test.py
+++ b/test/lib_config_test.py
@@ -17,8 +17,6 @@
 """
 # Stdlib
 import base64
-import json
-import os
 
 # External packages
 import nose
@@ -27,7 +25,6 @@ from unittest.mock import patch, mock_open
 
 # SCION
 from lib.config import Config
-from lib.defines import TOPOLOGY_PATH
 from test.testcommon import SCIONTestException
 
 
@@ -35,10 +32,6 @@ class BaseLibConfig(object):
     """
     Base class for lib.config unit tests
     """
-    config_path = os.path.join(TOPOLOGY_PATH,
-                               'ISD1', 'configurations', 'ISD:1-AD:10.conf')
-    config_json = json.load(open(config_path))
-
     ATTRS_TO_KEYS = {
         'master_of_gen_key': 'MasterOFGKey',
         'master_ad_key': 'MasterADKey',
@@ -73,8 +66,8 @@ class TestConfigFromFile(BaseLibConfig):
     @patch("builtins.open", new_callable=mock_open)
     def test_success(self, io_open, load, from_dict):
         from_dict.return_value = "All ok"
-        ntools.eq_(Config.from_file(self.config_path), "All ok")
-        io_open.assert_called_once_with(self.config_path)
+        ntools.eq_(Config.from_file("path"), "All ok")
+        io_open.assert_called_once_with("path")
         load.assert_called_once_with(io_open.return_value)
 
     @patch("lib.config.Config.from_dict")
@@ -86,7 +79,7 @@ class TestConfigFromFile(BaseLibConfig):
         from_dict.side_effect = SCIONTestException("from_dict should not "
                                                    "have been called")
         # Call
-        ntools.eq_(Config.from_file(self.config_path), None)
+        ntools.eq_(Config.from_file("path"), None)
 
     def test_error(self):
         for excp in (ValueError, KeyError, TypeError):
@@ -99,14 +92,28 @@ class TestConfigFromDict(BaseLibConfig):
     """
     @patch("lib.config.Config.parse_dict")
     def test_basic(self, parse_dict):
-        ntools.assert_is_instance(Config.from_dict(self.config_json), Config)
-        parse_dict.assert_called_once_with(self.config_json)
+        ntools.assert_is_instance(Config.from_dict("dict"), Config)
+        parse_dict.assert_called_once_with("dict")
 
 
 class TestConfigParseDict(BaseLibConfig):
     """
     Unit tests for lib.config.Config.parse_dict
     """
+    config_json = {
+        "CertChainVersion": 0,
+        "MasterADKey": "Xf93o3Wz/4Gb0m6CXEaxag==",
+        "MasterOFGKey": "8clgjqBlI6f3FwAZ419i4A==",
+        "NumRegisteredPaths": 10,
+        "NumShortestUPs": 3,
+        "PCBQueueSize": 10,
+        "PSQueueSize": 10,
+        "PropagateTime": 5,
+        "RegisterPath": 1,
+        "RegisterTime": 5,
+        "ResetTime": 600
+    }
+
     def test_basic(self):
         cfg = Config()
         cfg.parse_dict(self.config_json)


### PR DESCRIPTION
Noticed today that a lot of these unit tests fail if a specific topology config hasn't been generated. Unit tests shouldn't depend on external state like that, so i've removed that dependency.

@rev112
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/rev112%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1120468%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/254%23issuecomment-120911275%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-07-13T12%3A32%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1120468%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rev112%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/254%23issuecomment-120911275%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/rev112'><img src='https://avatars.githubusercontent.com/u/1120468?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/254?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/254?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/254'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
