### PR TITLE
Fix bug where circleci would wipe coverage results

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ test:
     override:
         - ./docker.sh run bash -lc "./scion.sh coverage -v"
         - ./docker.sh run bash -lc "./scion.sh lint"
-        - ./docker.sh run bash -lc "make -C sphinx-doc html"
+        - ./docker.sh run bash -lc "make -C sphinx-doc clean html"
     post:
         - cp -a htmlcov "$CIRCLE_ARTIFACTS"/coverage
         - cp -a sphinx-doc/_build/html "$CIRCLE_ARTIFACTS"/docs


### PR DESCRIPTION
docker run would wipe htmlcov/ on every run, so when circleci ran the sphinx-doc generation, the coverage report would be deleted.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/shitz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/255%23issuecomment-121178901%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22after%20a%20detailed%20explanation%20by%20%40kormat%2C%20I%20can%20only%20approve%20of%20this%20%3A%29%20%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-07-14T09%3A27%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/255%23issuecomment-121178901%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/shitz'><img src='https://avatars.githubusercontent.com/u/3840858?v=3' width=34 height=34></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/255#issuecomment-121178901'>General Comment</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> after a detailed explanation by @kormat, I can only approve of this :) :shipit:

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/255?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/255?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/255?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/255'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
