### PR TITLE
Tests for lib.util.SCIONTime

### DIFF
--- a/test/lib_util_test.py
+++ b/test/lib_util_test.py
@@ -303,11 +303,18 @@ class TestSCIONTimeSetTimeMethod(object):
     """
     Unit tests for lib.util.SCIONTime.set_time_method
     """
-    @patch("lib.util.SCIONTime._custom_time", spec_set=[],
-           new_callable=MagicMock)
-    def test(self, custom_time):
-        SCIONTime.set_time_method('time_method')
-        ntools.eq_(SCIONTime._custom_time, 'time_method')
+    class MockSCIONTime(SCIONTime):
+        pass
+
+    def setUp(self):
+        self.MockSCIONTime._custom_time = 'before'
+
+    def tearDown(self):
+        self.MockSCIONTime._custom_time = None
+
+    def test(self):
+        self.MockSCIONTime.set_time_method('time_method')
+        ntools.eq_(self.MockSCIONTime._custom_time, 'time_method')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@kormat 
(For #256)
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/kormat%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/257%23issuecomment-121173970%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-07-14T09%3A08%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Closes%20%23256%20%22%2C%20%22created_at%22%3A%20%222015-07-14T09%3A09%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2058591a2c4546d0b51d3b6f14c1dc77207cf25788%20test/lib_util_test.py%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/257%23discussion_r34472887%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20be%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%20%20%20%20SCIONTime%2C%5Cr%5Cn%29%5Cr%5Cn%60%60%60%5Cr%5CnThat%20way%20adding/removing%20imports%20does%20not%20affect%20other%20lines.%22%2C%20%22created_at%22%3A%20%222015-07-13T15%3A10%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL42-50%22%7D%2C%20%22Pull%206a7560df26155218b0bac2bcef750cafff99748f%20test/lib_util_test.py%2055%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/257%23discussion_r34473781%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Same%20applies%20here.%22%2C%20%22created_at%22%3A%20%222015-07-13T15%3A18%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20one%20is%20Much%20trickier.%20Here%27s%20my%20solution%3A%5Cr%5Cn%60%60%60%5Cr%5Cnclass%20TestSCIONTimeSetTimeMethod%28object%29%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20%5C%22%5C%22%5C%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20Unit%20tests%20for%20lib.util.SCIONTime.set_time_method%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20%5C%22%5C%22%5C%22%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20class%20MockSCIONTime%28SCIONTime%29%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20%20%20%20%20pass%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20def%20setUp%28self%29%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20%20%20%20%20self.MockSCIONTime._custom_time%20%3D%20%27before%27%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20def%20tearDown%28self%29%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20%20%20%20%20self.MockSCIONTime._custom_time%20%3D%20None%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20def%20test%28self%29%3A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%5Cr%5Cn%20%20%20%20%20%20%20%20self.MockSCIONTime.set_time_method%28%27time_method%27%29%5Cr%5Cn%20%20%20%20%20%20%20%20ntools.eq_%28self.MockSCIONTime._custom_time%2C%20%27time_method%27%29%20%20%20%20%20%20%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-07-13T16%3A14%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Why%20wouldn%27t%20just%20patching%20it%20out%20be%20sufficient%3F%22%2C%20%22created_at%22%3A%20%222015-07-13T16%3A31%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4117104%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pratyakshs%22%7D%7D%2C%20%7B%22body%22%3A%20%22Patching%20doesn%27t%20work%2C%20as%20the%20assignment%20in%20%60set_time_method%60%20just%20replaces%20the%20patched%20attribute.%22%2C%20%22created_at%22%3A%20%222015-07-14T08%3A06%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL280-314%22%7D%2C%20%22Pull%206a7560df26155218b0bac2bcef750cafff99748f%20test/lib_util_test.py%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/257%23discussion_r34473425%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20a%20sign%20that%20the%20test%20is%20not%20hermetic.%20You%20need%20to%20patch%20out%20%60SCIONTime._customtime%60%22%2C%20%22created_at%22%3A%20%222015-07-13T15%3A15%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-07-13T16%3A14%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL280-314%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/257%23issuecomment-121173970%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/257%23discussion_r34472887%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/257%23discussion_r34473425%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/257%23discussion_r34473781%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/257%23discussion_r34480188%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/257%23discussion_r34480237%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/257%23discussion_r34481959%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/257%23discussion_r34545439%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/257%23issuecomment-121174078%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/kormat'><img src='https://avatars.githubusercontent.com/u/6919822?v=3' width=34 height=34></a>
- [ ] <a href='#crh-comment-Pull 58591a2c4546d0b51d3b6f14c1dc77207cf25788 test/lib_util_test.py 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/257#discussion_r34472887'>File: test/lib_util_test.py:L42-50</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This should be:

```
SCIONTime,
)
```

That way adding/removing imports does not affect other lines.
- [ ] <a href='#crh-comment-Pull 6a7560df26155218b0bac2bcef750cafff99748f test/lib_util_test.py 55'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/257#discussion_r34473781'>File: test/lib_util_test.py:L280-314</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same applies here.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This one is Much trickier. Here's my solution:

```
class TestSCIONTimeSetTimeMethod(object):
"""
Unit tests for lib.util.SCIONTime.set_time_method
"""
class MockSCIONTime(SCIONTime):
pass
def setUp(self):
self.MockSCIONTime._custom_time = 'before'
def tearDown(self):
self.MockSCIONTime._custom_time = None
def test(self):
self.MockSCIONTime.set_time_method('time_method')
ntools.eq_(self.MockSCIONTime._custom_time, 'time_method')
```
- <a href='https://github.com/pratyakshs'><img border=0 src='https://avatars.githubusercontent.com/u/4117104?v=3' height=16 width=16'></a> Why wouldn't just patching it out be sufficient?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Patching doesn't work, as the assignment in `set_time_method` just replaces the patched attribute.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/257#issuecomment-121173970'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Closes #256
- [x] <a href='#crh-comment-Pull 6a7560df26155218b0bac2bcef750cafff99748f test/lib_util_test.py 45'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/257#discussion_r34473425'>File: test/lib_util_test.py:L280-314</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is a sign that the test is not hermetic. You need to patch out `SCIONTime._customtime`

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/257?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/257?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/257?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/257'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
