### PR TITLE
Handle extensions fix

### DIFF
--- a/infrastructure/router.py
+++ b/infrastructure/router.py
@@ -200,9 +200,9 @@ class Router(SCIONElement):
         for ext_hdr in spkt.hdr.extension_hdrs:
             if ext_nr in handlers:
                 handlers[ext_nr](spkt, next_hop, self.config)
-            ext_nr = ext_hdr.next_ext
             else:
                 logging.warning("No handler for extension type %u", ext_nr)
+            ext_nr = ext_hdr.next_ext
         if ext_nr:
             logging.warning("Extensions terminated incorrectly: last " +
                             "extension has a non-empty next extension field")


### PR DESCRIPTION
Fixed extension handling bug: the previous 'ext' variable was a number and did not have a 'next_ext' field, thus giving an error at runtime.

Added the AD config information as a parameter to the extension handler.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/260%23issuecomment-121571984%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/260%23issuecomment-121585361%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/260%23discussion_r34668507%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/260%23issuecomment-121585472%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/260%23issuecomment-121585821%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/260%23issuecomment-121942712%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/260%23issuecomment-121571984%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22LGTM.%20One%20question%20though%3A%20what%20is%20the%20reason%20the%20extension%20handler%20gets%20the%20config%3F%20Do%20you%20need%20this%20for%20one%20of%20your%20follow%20up%20PRs%3F%22%2C%20%22created_at%22%3A%20%222015-07-15T10%3A42%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Probably%20handler%20needs%20%20a%20key%20or%20smth.%5CnWhat%20about%20passing%20%2A%2Akwargs%20as%20an%20only%20argument%20for%20handler%3F%5Cn%5CnOn%2015%20July%202015%20at%2012%3A42%2C%20shitz%20%3Cnotifications%40github.com%3E%20wrote%3A%5Cn%5Cn%3E%20LGTM.%20One%20question%20though%3A%20what%20is%20the%20reason%20the%20extension%20handler%20gets%5Cn%3E%20the%20config%3F%20Do%20you%20need%20this%20for%20one%20of%20your%20follow%20up%20PRs%3F%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/260%23issuecomment-121571984%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-07-15T11%3A18%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20What%20about%20passing%20%2A%2Akwargs%20as%20an%20only%20argument%20for%20handler%3F%5Cr%5Cn%5Cr%5CnThat%20sounds%20like%20a%20really%20good%20idea.%22%2C%20%22created_at%22%3A%20%222015-07-15T11%3A19%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40cba33%20except%20this%20%60l%60%20it%20lgtm.%20Thanks%21%3B-%29%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-07-15T11%3A22%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20guys%21%20I%20removed%20l.%22%2C%20%22created_at%22%3A%20%222015-07-16T12%3A25%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9415723%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cba33%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20945149c6dd831912e659224cd6a8c6086ff7e73c%20infrastructure/router.py%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/260%23discussion_r34668507%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60l%60%20isn%27t%20needed%20anymore.%22%2C%20%22created_at%22%3A%20%222015-07-15T11%3A18%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/router.py%3AL195-214%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/260#issuecomment-121571984'>General Comment</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> LGTM. One question though: what is the reason the extension handler gets the config? Do you need this for one of your follow up PRs?
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> Probably handler needs  a key or smth.
  What about passing **kwargs as an only argument for handler?
  On 15 July 2015 at 12:42, shitz notifications@github.com wrote:
  > LGTM. One question though: what is the reason the extension handler gets
  > the config? Do you need this for one of your follow up PRs?
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/260#issuecomment-121571984.
  >
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> > What about passing **kwargs as an only argument for handler?
  That sounds like a really good idea.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> @cba33 except this `l` it lgtm. Thanks!;-)
- <a href='https://github.com/cba33'><img border=0 src='https://avatars.githubusercontent.com/u/9415723?v=3' height=16 width=16'></a> Thanks guys! I removed l.
- [ ] <a href='#crh-comment-Pull 945149c6dd831912e659224cd6a8c6086ff7e73c infrastructure/router.py 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/260#discussion_r34668507'>File: infrastructure/router.py:L195-214</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> `l` isn't needed anymore.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/260?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/260?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/260'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
