### PR TITLE
Generate Zookeeper configs from ADConfigurations.json

### DIFF
--- a/lib/topology.py
+++ b/lib/topology.py
@@ -191,6 +191,7 @@ class Topology(object):
         self.child_edge_routers = []
         self.peer_edge_routers = []
         self.routing_edge_routers = []
+        self.zookeepers = []
 
     @classmethod
     def from_file(cls, topology_file):
@@ -266,6 +267,8 @@ class Topology(object):
                 self.routing_edge_routers.append(edge_router)
             else:
                 logging.warning("Encountered unknown neighbor type")
+        for zk in topology['Zookeepers'].values():
+            self.zookeepers.append((zk['Addr'], zk['ClientPort']))
 
     def get_all_edge_routers(self):
         """

--- a/test/lib_topology_test.py
+++ b/test/lib_topology_test.py
@@ -221,9 +221,15 @@ class TestTopologyParseDict(object):
         ds = {'i': 'j', 'k': 'l'}
         ps = {'m': 'n', 'o': 'p'}
         er = {'er' + str(i): 'router' + str(i) for i in range(5)}
-        topo_dict = {'Core': 0, 'ISDID': 1, 'ADID': 2, 'DnsDomain': 3,
-                     'BeaconServers': bs, 'CertificateServers': cs,
-                     'DNSServers': ds, 'PathServers': ps, 'EdgeRouters': er}
+        zk = {'zk0': {'Addr': 'zk0.scion', 'ClientPort': 2181},
+              'zk1': {'Addr': 'zk1.scion', 'ClientPort': 2182}}
+        topo_dict = {
+            'Core': 0, 'ISDID': 1, 'ADID': 2,
+            'DnsDomain': 3, 'BeaconServers': bs,
+            'CertificateServers': cs, 'DNSServers': ds,
+            'PathServers': ps, 'EdgeRouters': er,
+            'Zookeepers': zk,
+        }
         server_elem.side_effect = ['bs0', 'bs1', 'cs0', 'cs1', 'ds0', 'ds1',
                                    'ps0', 'ps1']
         routers = [MagicMock(spec_set=['interface']) for i in range(5)]
@@ -256,6 +262,8 @@ class TestTopologyParseDict(object):
         ntools.eq_(topology.child_edge_routers, [6, routers[1]])
         ntools.eq_(topology.peer_edge_routers, [7, routers[2]])
         ntools.eq_(topology.routing_edge_routers, [8, routers[3]])
+        ntools.eq_(sorted(topology.zookeepers),
+                   [('zk0.scion', 2181), ('zk1.scion', 2182)])
         ntools.eq_(log_warning.call_count, 1)
 
 

--- a/topology/ADConfigurations.json
+++ b/topology/ADConfigurations.json
@@ -1,5 +1,11 @@
 {
     "default_subnet": "127.0.0.0/8",
+    "default_zookeepers": {
+        "1": {
+            "manage": false,
+            "addr": "localhost"
+        }
+    },
     "1-11": {
         "level": "CORE",
         "beacon_servers": 1,
@@ -19,6 +25,28 @@
             "1-13": "ROUTING",
             "1-15": "CHILD",
             "2-22": "ROUTING"
+        },
+        "zookeepers": {
+            "1": {
+                "manage": true,
+                "addr": "localhost",
+                "client_port": 4000,
+                "leader_port": 4001,
+                "election_port": 4002
+            },
+            "2": {
+                "manage": true,
+                "addr": "localhost",
+                "client_port": 2184
+            },
+            "3": {
+                "manage": true,
+                "addr": "localhost",
+                "client_port": 2184,
+                "client_port": 4003,
+                "leader_port": 4004,
+                "election_port": 4005
+            }
         }
     },
     "1-13": {

--- a/topology/Zookeeper.json
+++ b/topology/Zookeeper.json
@@ -1,0 +1,15 @@
+{
+    "Default": {
+        "tickTime": 100,
+        "initLimit": 10,
+        "syncLimit": 5,
+        "clientPort": 2181,
+        "leaderPort": 2888,
+        "electionPort": 3888
+    },
+    "Environment": {
+        "CLASSPATH": "/usr/share/java/jline.jar:/usr/share/java/log4j-1.2.jar:/usr/share/java/xercesImpl.jar:/usr/share/java/xmlParserAPIs.jar:/usr/share/java/netty.jar:/usr/share/java/slf4j-api.jar:/usr/share/java/slf4j-log4j12.jar:/usr/share/java/zookeeper.jar",
+        "ZOOMAIN": "org.apache.zookeeper.server.quorum.QuorumPeerMain",
+        "ZOO_LOG4J_PROP": "INFO,ROLLINGFILE"
+    }
+}

--- a/topology/Zookeeper.log4j
+++ b/topology/Zookeeper.log4j
@@ -1,0 +1,4 @@
+log4j.rootLogger=INFO, CONSOLE
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -39,6 +39,7 @@ from lib.crypto.asymcrypto import (
 )
 from lib.crypto.certificate import Certificate, CertificateChain, TRC
 from lib.defines import TOPOLOGY_PATH
+from lib.log import log_exception
 from lib.path_store import PathPolicy
 from lib.topology import Topology
 from lib.util import (
@@ -52,6 +53,8 @@ from lib.util import (
 DEFAULT_ADCONFIGURATIONS_FILE = os.path.join(TOPOLOGY_PATH,
                                              'ADConfigurations.json')
 DEFAULT_PATH_POLICY_FILE = os.path.join(TOPOLOGY_PATH, 'PathPolicy.json')
+DEFAULT_ZK_CONFIG = os.path.join(TOPOLOGY_PATH, "Zookeeper.json")
+DEFAULT_ZK_LOG4J = os.path.join(TOPOLOGY_PATH, "Zookeeper.log4j")
 
 SCRIPTS_DIR = 'topology'
 CERT_DIR = 'certificates'
@@ -63,6 +66,9 @@ PATH_POL_DIR = 'path_policies'
 SUPERVISOR_DIR = 'supervisor'
 SIM_DIR = 'SIM'
 SIM_CONF_FILE = 'sim.conf'
+
+ZOOKEEPER_DIR = 'zookeeper'
+ZOOKEEPER_CFG = "zoo.cfg"
 
 CORE_AD = 'CORE'
 INTERMEDIATE_AD = 'INTERMEDIATE'
@@ -105,6 +111,7 @@ class ConfigGenerator(object):
         self.subnet = subnet
         self.next_ip_address = next_ip_address
         self.is_sim = is_sim
+        self.default_zookeepers = {}
 
     def get_subnet_params(self, ad_config=None):
         """
@@ -166,6 +173,24 @@ class ConfigGenerator(object):
         path_pol_file_abs = os.path.join(self.out_dir, path_pol_path_tail)
         path_pol_file_rel = os.path.join("..", SCRIPTS_DIR, path_pol_path_tail)
         return locals()
+
+    def zk_path_dict(self, isd_id, ad_id, zk_id):
+        def abs_rel(*paths):
+            return os.path.join(self.out_dir, *paths), \
+                os.path.join('..', SCRIPTS_DIR, *paths)
+        gen_paths = self.path_dict(isd_id, ad_id)
+        p = {}
+        p['base_dir_tail'] = os.path.join(
+            gen_paths['isd_name'], ZOOKEEPER_DIR,
+            "ISD{}-AD{}-ZK{}".format(isd_id, ad_id, zk_id))
+        p['base_dir_abs'], p['base_dir_rel'] = abs_rel(p['base_dir_tail'])
+        p['data_dir_abs'], p['data_dir_rel'] = abs_rel(p['base_dir_tail'],
+                                                       'data.%s' % zk_id)
+        p['cfg_abs'], p['cfg_rel'] = abs_rel(p['base_dir_tail'],
+                                             'zoo.cfg.%s' % zk_id)
+        p['myid_abs'] = os.path.join(p['data_dir_abs'], 'myid')
+        p['log4j_abs'] = os.path.join(p['base_dir_abs'], 'log4j.properties')
+        return p
 
     def increment_address(self, ip_addr, mask, increment=1):
         """
@@ -249,9 +274,7 @@ class ConfigGenerator(object):
             paths = [cert_path, conf_path, topo_path, sig_keys_path,
                      enc_keys_path, path_pol_path, supervisor_path]
             for path in paths:
-                full_path = os.path.join(self.out_dir, path)
-                if not os.path.exists(full_path):
-                    os.makedirs(full_path)
+                os.makedirs(os.path.join(self.out_dir, path), exist_ok=True)
         if self.is_sim:
             sim_path = os.path.join(self.out_dir, 'SIM')
             if not os.path.exists(sim_path):
@@ -366,15 +389,18 @@ class ConfigGenerator(object):
                                                             DEFAULT_DNS_DOMAIN))
             dns_domain = dns_domain.add("isd%s" % isd_id).add("ad%s" % ad_id)
             # Write beginning and general structure
-            topo_dict = {'Core': 1 if is_core else 0,
-                         'ISDID': int(isd_id),
-                         'ADID': int(ad_id),
-                         'DnsDomain': str(dns_domain),
-                         'BeaconServers': {},
-                         'CertificateServers': {},
-                         'PathServers': {},
-                         'DNSServers': {},
-                         'EdgeRouters': {}}
+            topo_dict = {
+                'Core': 1 if is_core else 0,
+                'ISDID': int(isd_id),
+                'ADID': int(ad_id),
+                'DnsDomain': str(dns_domain),
+                'BeaconServers': {},
+                'CertificateServers': {},
+                'PathServers': {},
+                'DNSServers': {},
+                'EdgeRouters': {},
+                'Zookeepers': {},
+            }
 
             # Write Beacon Servers
             for b_server in range(1, number_bs + 1):
@@ -434,6 +460,14 @@ class ConfigGenerator(object):
                                   'ToUdpPort': int(PORT)}
                 }
                 edge_router += 1
+            # Write Zookeepers
+            zks = {}
+            for key, val in ad_configs[isd_ad_id].get("zookeepers", {}).items():
+                zks[key] = ZKTopo(val, self.zk_config["Default"])
+            if not zks:
+                zks = self.default_zookeepers
+            for key, zk in zks.items():
+                topo_dict['Zookeepers'][key] = zk.dict_()
 
             topo_file_abs = self.path_dict(isd_id, ad_id)['topo_file_abs']
             with open(topo_file_abs, 'w') as topo_fh:
@@ -455,6 +489,43 @@ class ConfigGenerator(object):
         :return:
         """
         self.write_supervisor_config(topo_dict)
+        self.write_zookeeper_config(topo_dict)
+
+    def write_zookeeper_config(self, topo_dict):
+        """
+        Generate the AD Zookeeper configurations.
+
+        :param topo_dict: topology dictionary of a SCION AD.
+        :type topo_dict: dict
+        """
+        isd_id, ad_id = topo_dict['ISDID'], topo_dict['ADID']
+
+        # Build up server block
+        servers = []
+        for zk_id, zk_dict in topo_dict['Zookeepers'].items():
+            servers.append("server.%s=%s:%d:%d" %
+                           (zk_id, zk_dict['Addr'], zk_dict['LeaderPort'],
+                            zk_dict['ElectionPort']))
+        server_block = "\n".join(sorted(servers))
+
+        for zk_id, zk_dict in topo_dict['Zookeepers'].items():
+            if not zk_dict.get("Manage", False):
+                # We don't manage this zookeeper instance, so no need to
+                # write configs for it.
+                continue
+            paths = self.zk_path_dict(isd_id, ad_id, zk_id)
+            for path in "base_dir_abs", "data_dir_abs":
+                os.makedirs(paths[path], exist_ok=True)
+            shutil.copyfile(DEFAULT_ZK_LOG4J, paths['log4j_abs'])
+            with open(paths['cfg_abs'], 'w') as fh:
+                for s in ['tickTime', 'initLimit', 'syncLimit']:
+                    fh.write("%s=%s\n" % (s, self.zk_config["Default"][s]))
+                fh.write("dataDir=%s\n" % paths['data_dir_rel'])
+                fh.write("clientPort=%d\n" % zk_dict["ClientPort"])
+                fh.write("clientPortAddress=%s\n" % zk_dict["Addr"])
+                fh.write("%s\n" % server_block)
+            with open(paths['myid_abs'], 'w') as fh:
+                fh.write("%s\n" % zk_id)
 
     def write_sim_file(self, ad_configs):
         """
@@ -519,7 +590,8 @@ class ConfigGenerator(object):
         :type topo_dict: dict
         """
         element_types = ['BeaconServers', 'CertificateServers',
-                         'PathServers', 'DNSServers', 'EdgeRouters']
+                         'PathServers', 'DNSServers', 'EdgeRouters',
+                         'Zookeepers']
         for element_type in element_types:
             for element_num, element_dict in topo_dict[element_type].items():
                 yield (element_num, element_dict, element_type)
@@ -541,7 +613,7 @@ class ConfigGenerator(object):
         }
 
         program_group = []
-        supervisor_config = configparser.ConfigParser()
+        supervisor_config = configparser.ConfigParser(interpolation=None)
 
         isd_id, ad_id = topo_dict['ISDID'], topo_dict['ADID']
         dns_domain = topo_dict['DnsDomain']
@@ -550,6 +622,7 @@ class ConfigGenerator(object):
         for (num, element_dict, element_type) \
                 in self._get_typed_elements(topo_dict):
             element_location = 'core' if topo_dict['Core'] else 'local'
+            server_config = supervisor_common.copy()
             if element_type == 'BeaconServers':
                 element_name = 'bs{}-{}-{}'.format(isd_id, ad_id, num)
                 cmd_args = ['beacon_server.py',
@@ -558,7 +631,6 @@ class ConfigGenerator(object):
                             p['topo_file_rel'],
                             p['conf_file_rel'],
                             p['path_pol_file_rel']]
-
             elif element_type == 'CertificateServers':
                 element_name = 'cs{}-{}-{}'.format(isd_id, ad_id, num)
                 cmd_args = ['cert_server.py',
@@ -589,15 +661,30 @@ class ConfigGenerator(object):
                             num,
                             p['topo_file_rel'],
                             p['conf_file_rel']]
+            elif element_type == 'Zookeepers':
+                if not element_dict['Manage']:
+                    continue
+                element_name = 'zk{}-{}-{}'.format(isd_id, ad_id, num)
+                zk_paths = self.zk_path_dict(isd_id, ad_id, num)
+                class_path = ":".join([
+                    zk_paths['base_dir_rel'],
+                    self.zk_config["Environment"]["CLASSPATH"],
+                ])
+                server_config['command'] = ' '.join([
+                    '/usr/bin/java',
+                    '-cp', class_path,
+                    self.zk_config["Environment"]["ZOOMAIN"],
+                    zk_paths["cfg_rel"]
+                ])
             else:
                 assert False, 'Invalid element type'
 
-            command_line = '/usr/bin/python3 '
-            command_line += ' '.join(['"{}"'.format(arg) for arg in cmd_args])
-            log_file = '../logs/{}.log'.format(element_name)
-            server_config = supervisor_common.copy()
-            server_config.update({'command': command_line,
-                                  'stdout_logfile': log_file})
+            if 'command' not in server_config:
+                server_config['command'] = ' '.join(
+                    ['/usr/bin/python3'] +
+                    ['"{}"'.format(arg) for arg in cmd_args])
+            server_config['stdout_logfile'] = \
+                '../logs/{}.log'.format(element_name)
 
             supervisor_config['program:' + element_name] = server_config
             program_group.append(element_name)
@@ -736,7 +823,8 @@ class ConfigGenerator(object):
             if os.path.exists(trc_file):
                 os.remove(trc_file)
 
-    def generate_all(self, adconfigurations_file, path_policy_file):
+    def generate_all(self, adconfigurations_file, path_policy_file,
+                     zk_config_file):
         """
         Generate all needed files.
 
@@ -754,11 +842,20 @@ class ConfigGenerator(object):
         try:
             ad_configs = json.loads(open(adconfigurations_file).read())
         except (ValueError, KeyError, TypeError):
-            logging.error(adconfigurations_file + ": JSON format error.")
-            sys.exit()
+            log_exception(adconfigurations_file + ": JSON format error")
+            sys.exit(1)
+        try:
+            self.zk_config = json.loads(open(zk_config_file).read())
+        except (ValueError, KeyError, TypeError):
+            log_exception(zk_config_file + ": JSON format error")
+            sys.exit(1)
 
         if "default_subnet" in ad_configs:
             self.subnet = ad_configs.pop("default_subnet")
+        for key, val in ad_configs.get("default_zookeepers", {}).items():
+            self.default_zookeepers[key] = ZKTopo(val,
+                                                  self.zk_config["Default"])
+        ad_configs.pop("default_zookeepers", None)
         er_ip_addresses = self.set_er_ip_addresses(ad_configs)
         self.delete_directories()
         self.create_directories(ad_configs)
@@ -770,6 +867,27 @@ class ConfigGenerator(object):
             self.write_beginning_sim_run_files()
             self.write_sim_file(ad_configs)
         self.write_trc_files(ad_configs, keys)
+
+
+class ZKTopo(object):
+    def __init__(self, config, def_config):
+        self.manage = config.get("manage", False)
+        self.addr = config["addr"]
+        self.clientPort = config.get(
+            "client_port", int(def_config["clientPort"]))
+        self.leaderPort = config.get(
+            "leader_port", int(def_config["leaderPort"]))
+        self.electionPort = config.get(
+            "election_port", int(def_config["electionPort"]))
+
+    def dict_(self):
+        return {
+            "Manage": self.manage,
+            "Addr": self.addr,
+            "ClientPort": self.clientPort,
+            "LeaderPort": self.leaderPort,
+            "ElectionPort": self.electionPort,
+        }
 
 
 def main():
@@ -789,10 +907,13 @@ def main():
     parser.add_argument('-o', '--output-dir',
                         default=TOPOLOGY_PATH,
                         help='Output directory')
+    parser.add_argument('-z', '--zk-config',
+                        default=DEFAULT_ZK_CONFIG,
+                        help='Zookeeper configuration file')
     args = parser.parse_args()
     generator = ConfigGenerator(os.path.abspath(args.output_dir),
                                 is_sim=args.sim)
-    generator.generate_all(args.ad_config, args.path_policy)
+    generator.generate_all(args.ad_config, args.path_policy, args.zk_config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Probably need to change `ADConfigurations.json` before submitting, but the code should be pretty much complete.

@pszalach @rev112
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/264%23discussion_r34892546%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/264%23discussion_r34895324%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/264%23discussion_r34899278%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/264%23discussion_r34899457%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/264%23discussion_r34901284%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/264%23discussion_r34901285%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/264%23issuecomment-122317685%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/264%23issuecomment-122320285%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/264%23issuecomment-122317685%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22LGTM%2C%20but%20I%20didn%27t%20test%20this.%22%2C%20%22created_at%22%3A%20%222015-07-17T15%3A41%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1120468%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rev112%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-07-17T15%3A45%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%205d5527a26e60e183119936617dc7526296d92519%20topology/Zookeeper.json%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/264%23discussion_r34892546%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20it%20safe%20to%20assume%20that%20these%20files/directories%20exist%3F%20Are%20they%20all%20installed%20along%20with%20the%20Zookeeper%20package%3F%22%2C%20%22created_at%22%3A%20%222015-07-17T14%3A14%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1120468%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rev112%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20the%20classpath%20used%20by%20ubuntu%2014.04%2C%20listing%20jar%27s%20that%20are%20installed%20as%20dependencies.%20The%20reason%20this%20is%20in%20a%20config%20file%20is%20so%20that%20people%20can%20customise%20it%20for%20whatever%20OS%20they%20run%20on.%20Have%20a%20look%20at%20%60/etc/zookeeper/conf/environment%60%20for%20comparison.%22%2C%20%22created_at%22%3A%20%222015-07-17T15%3A19%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-07-17T15%3A39%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1120468%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rev112%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/Zookeeper.json%3AL1-16%22%7D%2C%20%22Pull%205d5527a26e60e183119936617dc7526296d92519%20topology/generator.py%20276%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/264%23discussion_r34895324%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20is%20it%20formatted%20differently%2C%20comparing%20with%20the%20previous%20two%20statements%3F%20%3B%29%22%2C%20%22created_at%22%3A%20%222015-07-17T14%3A42%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1120468%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rev112%22%7D%7D%2C%20%7B%22body%22%3A%20%22Good%20question.%20Fixed%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-07-17T15%3A21%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-07-17T15%3A39%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1120468%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rev112%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL869-896%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/264#issuecomment-122317685'>General Comment</a></b>
- <a href='https://github.com/rev112'><img border=0 src='https://avatars.githubusercontent.com/u/1120468?v=3' height=16 width=16'></a> LGTM, but I didn't test this.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- [x] <a href='#crh-comment-Pull 5d5527a26e60e183119936617dc7526296d92519 topology/Zookeeper.json 11'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/264#discussion_r34892546'>File: topology/Zookeeper.json:L1-16</a></b>
- <a href='https://github.com/rev112'><img border=0 src='https://avatars.githubusercontent.com/u/1120468?v=3' height=16 width=16'></a> Is it safe to assume that these files/directories exist? Are they all installed along with the Zookeeper package?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is the classpath used by ubuntu 14.04, listing jar's that are installed as dependencies. The reason this is in a config file is so that people can customise it for whatever OS they run on. Have a look at `/etc/zookeeper/conf/environment` for comparison.
- [x] <a href='#crh-comment-Pull 5d5527a26e60e183119936617dc7526296d92519 topology/generator.py 276'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/264#discussion_r34895324'>File: topology/generator.py:L869-896</a></b>
- <a href='https://github.com/rev112'><img border=0 src='https://avatars.githubusercontent.com/u/1120468?v=3' height=16 width=16'></a> Why is it formatted differently, comparing with the previous two statements? ;)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Good question. Fixed :)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/264?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/264?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/264'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
