### PR TITLE
Start improving error handling.

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -17,8 +17,9 @@
 """
 # Stdlib
 import base64
-import json
-import logging
+
+# SCION
+from lib.util import load_json_file
 
 
 class Config(object):
@@ -75,15 +76,9 @@ class Config(object):
         :type config_file: str
 
         :returns: the newly created Config instance
-        :rtype: :class: `Config`
+        :rtype: :class:`Config`
         """
-        try:
-            with open(config_file) as conf_fh:
-                config_dict = json.load(conf_fh)
-        except (ValueError, KeyError, TypeError):
-            logging.error("Config: JSON format error.")
-            return
-        return cls.from_dict(config_dict)
+        return cls.from_dict(load_json_file(config_file))
 
     @classmethod
     def from_dict(cls, config_dict):

--- a/lib/crypto/certificate.py
+++ b/lib/crypto/certificate.py
@@ -25,6 +25,7 @@ import time
 # SCION
 from lib.crypto.nacl import crypto_sign_ed25519_open
 from lib.crypto.asymcrypto import sign, verify
+from lib.util import load_json_file
 
 
 def verify_sig_chain_trc(msg, sig, subject, chain, trc, trc_version):
@@ -159,12 +160,7 @@ class Certificate(object):
         :param certificate_file: the name of the certificate file.
         :type certificate_file: str
         """
-        try:
-            with open(certificate_file) as cert_fh:
-                cert = json.load(cert_fh)
-        except (ValueError, KeyError, TypeError):
-            logging.error("Certificate: JSON format error.")
-            return
+        cert = load_json_file(certificate_file)
         self.subject = cert['subject']
         self.subject_sig_key = base64.b64decode(cert['subject_sig_key'])
         self.subject_enc_key = base64.b64decode(cert['subject_enc_key'])
@@ -320,12 +316,7 @@ class CertificateChain(object):
         :param chain_file: the name of the certificate chain file.
         :type chain_file: str
         """
-        try:
-            with open(chain_file) as chain_fh:
-                chain = json.load(chain_fh)
-        except (ValueError, KeyError, TypeError):
-            logging.error("Certificate Chain: JSON format error.")
-            return
+        chain = load_json_file(chain_file)
         for index in range(1, len(chain) + 1):
             cert_dict = chain[str(index)]
             cert_dict['subject_sig_key'] = \
@@ -513,12 +504,7 @@ class TRC(object):
         :param trc_file: the name of the TRC file.
         :type trc_file: str
         """
-        try:
-            with open(trc_file) as trc_fh:
-                trc = json.load(trc_fh)
-        except (ValueError, KeyError, TypeError):
-            logging.error("TRC: JSON format error.")
-            return
+        trc = load_json_file(trc_file)
         self.isd_id = trc['isd_id']
         self.version = trc['version']
         self.time = trc['time']

--- a/lib/dnsclient.py
+++ b/lib/dnsclient.py
@@ -27,13 +27,27 @@ from dns.resolver import Resolver
 
 # SCION
 from lib.defines import SCION_DNS_PORT
+from lib.errors import SCIONBaseError
 
 
-class DNSLibException(Exception):
+class DNSLibError(SCIONBaseError):
+    """
+    DNSLibError: Base lib.dns exception
+    """
     pass
 
 
-class DNSLibTimeout(DNSLibException):
+class DNSLibTimeout(DNSLibError):
+    """
+    DNSLibTimeout
+    """
+    pass
+
+
+class DNSLibNxDomain(DNSLibError):
+    """
+    DNSLibNxDomain: name doesn't exist.
+    """
     pass
 
 
@@ -62,6 +76,10 @@ class DNSClient(object):
         :param string qname: A relative DNS record to query. E.g. ``"bs"``
         :returns: A list of IP address objects
         :rtype: :class:`ipaddress._BaseAddress`
+        :raises:
+            DNSLibTimeout: No responses received.
+            DNSLibNxDomain: Name doesn't exist.
+            DNSLibError: Unexpected error.
         """
         try:
             results = self.resolver.query(qname)
@@ -69,8 +87,8 @@ class DNSClient(object):
             raise DNSLibTimeout("No responses within %ss" %
                                 self.resolver.lifetime) from None
         except dns.resolver.NXDOMAIN:
-            raise DNSLibException("Name (%s) does not exist" % qname) from None
+            raise DNSLibNxDomain("Name (%s) does not exist" % qname) from None
         except Exception as e:
-            raise DNSLibException("Unhandled exception in resolver.") from e
+            raise DNSLibError("Unhandled exception in resolver.") from e
         shuffle(results)
         return [ip_address(addr) for addr in results]

--- a/lib/errors.py
+++ b/lib/errors.py
@@ -1,0 +1,48 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`errors` --- SCION Errors
+==============================
+"""
+
+
+class SCIONBaseException(Exception):
+    """
+    Root SCION Exception. All other exceptions derive from this.
+
+    It should probably not be raised directly.
+    """
+
+
+class SCIONBaseError(SCIONBaseException):
+    """
+    Root SCION Error exception. All other error exceptions derive from this.
+
+    It should probably not be raised directly.
+    """
+    pass
+
+
+class SCIONIOError(SCIONBaseError):
+    """
+    IO error.
+    """
+    pass
+
+
+class SCIONJSONError(SCIONBaseError):
+    """
+    JSON parsing error.
+    """
+    pass

--- a/lib/path_store.py
+++ b/lib/path_store.py
@@ -22,7 +22,7 @@ from collections import defaultdict, deque
 
 # SCION
 from lib.packet.pcb import PathSegment
-from lib.util import SCIONTime
+from lib.util import SCIONTime, load_json_file
 
 
 class PathPolicy(object):
@@ -138,13 +138,7 @@ class PathPolicy(object):
         :returns: the newly created PathPolicy instance
         :rtype: :class: `PathPolicy`
         """
-        try:
-            with open(policy_file) as path_policy_fh:
-                policy_dict = json.load(path_policy_fh)
-        except (ValueError, KeyError, TypeError):
-            logging.error("PathPolicy: JSON format error.")
-            return
-        return cls.from_dict(policy_dict)
+        return cls.from_dict(load_json_file(policy_file))
 
     @classmethod
     def from_dict(cls, policy_dict):

--- a/lib/topology.py
+++ b/lib/topology.py
@@ -17,8 +17,10 @@
 """
 # Stdlib
 from ipaddress import ip_address
-import json
 import logging
+
+# SCION
+from lib.util import load_json_file
 
 
 class Element(object):
@@ -204,13 +206,7 @@ class Topology(object):
         :returns: the newly created Topology instance
         :rtype: :class: `Topology`
         """
-        try:
-            with open(topology_file) as topo_fh:
-                topology_dict = json.load(topo_fh)
-        except (ValueError, KeyError, TypeError):
-            logging.error("Topology: JSON format error.")
-            return
-        return cls.from_dict(topology_dict)
+        return cls.from_dict(load_json_file(topology_file))
 
     @classmethod
     def from_dict(cls, topology_dict):

--- a/lib/zookeeper.py
+++ b/lib/zookeeper.py
@@ -31,16 +31,24 @@ from kazoo.exceptions import (
 from kazoo.handlers.threading import KazooTimeoutError
 
 # SCION
+from lib.errors import SCIONBaseError
 from lib.thread import kill_self, thread_safety_net
 from lib.util import timed
 
 
-class ZkConnectionLoss(Exception):
+class ZkBaseError(SCIONBaseError):
+    """
+    Base exception class for all lib.zookeeper exceptions
+    """
+    pass
+
+
+class ZkConnectionLoss(ZkBaseError):
     """Connection to Zookeeper is lost"""
     pass
 
 
-class ZkNoNodeError(Exception):
+class ZkNoNodeError(ZkBaseError):
     """A node doesn't exist"""
     pass
 

--- a/sphinx-doc/lib/errors.rst
+++ b/sphinx-doc/lib/errors.rst
@@ -1,0 +1,3 @@
+
+.. automodule:: lib.errors
+   :members:

--- a/sphinx-doc/lib/util.rst
+++ b/sphinx-doc/lib/util.rst
@@ -1,3 +1,4 @@
 
 .. automodule:: lib.util
    :members:
+   :member-order: bysource

--- a/test/infrastructure_dns_server_test.py
+++ b/test/infrastructure_dns_server_test.py
@@ -28,7 +28,7 @@ from dnslib import DNSLabel, DNSRecord, QTYPE, RCODE
 from infrastructure.dns_server import SCIONDnsServer, ZoneResolver
 from lib.defines import SCION_DNS_PORT
 from lib.zookeeper import ZkConnectionLoss, ConnectionLoss, SessionExpiredError
-from test.testcommon import MockCollection, SCIONTestException
+from test.testcommon import MockCollection, SCIONTestError
 
 
 class BaseDNSServer(object):
@@ -78,7 +78,7 @@ class TestZoneResolverResolve(BaseDNSServer):
         # Setup
         inst = self._setup_zoneresolver()
         inst.resolve_forward = MagicMock(spec_set=[])
-        inst.resolve_forward.side_effect = SCIONTestException(
+        inst.resolve_forward.side_effect = SCIONTestError(
             "Shouldn't be called")
         request = MagicMock(spec_set=DNSRecord)
         reply = request.reply.return_value = MagicMock(spec_set=["header"])
@@ -100,7 +100,7 @@ class TestZoneResolverResolveForward(BaseDNSServer):
         inst = self._setup_zoneresolver()
         reply = MagicMock(spec_set=["header"])
         reply.header = MagicMock(spec_set=["rcode"])
-        self.lock.__enter__.side_effect = SCIONTestException(
+        self.lock.__enter__.side_effect = SCIONTestError(
             "This should not have been reached")
         # Call
         inst.resolve_forward(DNSLabel("anotherdomain"), "A", reply)
@@ -265,7 +265,7 @@ class TestSCIONDnsJoinParties(BaseDNSServer):
         # Setup
         server = self._setup_server()
         server.zk.wait_connected.side_effect = [False]
-        server._join_party.side_effect = SCIONTestException(
+        server._join_party.side_effect = SCIONTestError(
             "_join_party should not have been called")
         # Call
         ntools.assert_raises(StopIteration, server._join_parties)

--- a/test/lib_config_test.py
+++ b/test/lib_config_test.py
@@ -21,11 +21,10 @@ import base64
 # External packages
 import nose
 import nose.tools as ntools
-from unittest.mock import patch, mock_open
+from unittest.mock import patch
 
 # SCION
 from lib.config import Config
-from test.testcommon import SCIONTestException
 
 
 class BaseLibConfig(object):
@@ -62,28 +61,11 @@ class TestConfigFromFile(BaseLibConfig):
     Unit tests for lib.config.Config.from_file
     """
     @patch("lib.config.Config.from_dict")
-    @patch("lib.config.json.load")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_success(self, io_open, load, from_dict):
+    @patch("lib.config.load_json_file")
+    def test_success(self, load, from_dict):
         from_dict.return_value = "All ok"
         ntools.eq_(Config.from_file("path"), "All ok")
-        io_open.assert_called_once_with("path")
-        load.assert_called_once_with(io_open.return_value)
-
-    @patch("lib.config.Config.from_dict")
-    @patch("lib.config.json.load")
-    @patch("builtins.open", new_callable=mock_open)
-    def _check_error(self, excp, _, load, from_dict):
-        # Setup
-        load.side_effect = excp  # Raise an exception when json.load() is called
-        from_dict.side_effect = SCIONTestException("from_dict should not "
-                                                   "have been called")
-        # Call
-        ntools.eq_(Config.from_file("path"), None)
-
-    def test_error(self):
-        for excp in (ValueError, KeyError, TypeError):
-            yield self._check_error, excp
+        load.assert_called_once_with("path")
 
 
 class TestConfigFromDict(BaseLibConfig):

--- a/test/lib_dnsclient_test.py
+++ b/test/lib_dnsclient_test.py
@@ -27,7 +27,8 @@ import nose.tools as ntools
 from lib.defines import SCION_DNS_PORT
 from lib.dnsclient import (
     DNSClient,
-    DNSLibException,
+    DNSLibError,
+    DNSLibNxDomain,
     DNSLibTimeout,
 )
 
@@ -106,10 +107,10 @@ class TestDNSClientQuery(object):
     def test_exceptions(self):
         for error, excp in (
             (dns.exception.Timeout, DNSLibTimeout),
-            (dns.resolver.NXDOMAIN, DNSLibException),
-            (dns.resolver.YXDOMAIN, DNSLibException),
-            (dns.resolver.NoAnswer, DNSLibException),
-            (dns.resolver.NoNameservers, DNSLibException),
+            (dns.resolver.NXDOMAIN, DNSLibNxDomain),
+            (dns.resolver.YXDOMAIN, DNSLibError),
+            (dns.resolver.NoAnswer, DNSLibError),
+            (dns.resolver.NoNameservers, DNSLibError),
         ):
             yield self._check_exceptions, error, excp
 

--- a/test/lib_log_test.py
+++ b/test/lib_log_test.py
@@ -29,7 +29,7 @@ from lib.log import (
     init_logging,
     log_exception,
 )
-from test.testcommon import SCIONTestException
+from test.testcommon import SCIONTestError
 
 
 class TestStreamErrorHandlerHandleError(object):
@@ -46,9 +46,9 @@ class TestStreamErrorHandlerHandleError(object):
         format_exc.return_value = MagicMock(spec_set=['split'])
         format_exc.return_value.split.return_value = ['line0', 'line1']
         try:
-            raise SCIONTestException
+            raise SCIONTestError
         except:
-            ntools.assert_raises(SCIONTestException, handler.handleError, "hi")
+            ntools.assert_raises(SCIONTestError, handler.handleError, "hi")
         ntools.eq_(handler.stream.write.call_count, 3)
         handler.flush.assert_called_once_with()
 

--- a/test/lib_path_store_test.py
+++ b/test/lib_path_store_test.py
@@ -16,7 +16,7 @@
 ==========================================================================
 """
 # Stdlib
-from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import patch, MagicMock
 
 # External packages
 import nose
@@ -218,26 +218,13 @@ class TestPathPolicyFromFile(object):
     """
     @patch("lib.path_store.PathPolicy.from_dict", spec_set=[],
            new_callable=MagicMock)
-    @patch("lib.path_store.json.load", autospec=True)
+    @patch("lib.path_store.load_json_file", autospec=True)
     def test_basic(self, load, from_dict):
         load.return_value = "policy_dict"
         from_dict.return_value = "from_dict"
-        with patch('lib.path_store.open', mock_open(), create=True) as open_f:
-            ntools.eq_(PathPolicy.from_file("policy_file"), "from_dict")
-            open_f.assert_called_once_with("policy_file")
-            load.assert_called_once_with(open_f.return_value)
-            from_dict.assert_called_once_with("policy_dict")
-
-    @patch("lib.path_store.logging.error", autospec=True)
-    def _check_error(self, key, error_):
-        with patch('lib.path_store.open', mock_open(), create=True) as open_f:
-            open_f.side_effect = key
-            ntools.assert_is_none(PathPolicy.from_file("policy_file"))
-            ntools.eq_(error_.call_count, 1)
-
-    def test_error(self):
-        for key in (ValueError, KeyError, TypeError):
-            yield self._check_error, key
+        ntools.eq_(PathPolicy.from_file("policy_file"), "from_dict")
+        load.assert_called_once_with("policy_file")
+        from_dict.assert_called_once_with("policy_dict")
 
 
 class TestPathPolicyFromDict(object):

--- a/test/lib_topology_test.py
+++ b/test/lib_topology_test.py
@@ -16,7 +16,7 @@
 =================================================
 """
 # Stdlib
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock
 
 # External packages
 import nose
@@ -172,29 +172,13 @@ class TestTopologyFromFile(object):
     """
     @patch("lib.topology.Topology.from_dict", spec_set=[],
            new_callable=MagicMock)
-    @patch("lib.topology.json.load", autospec=True)
-    def test(self, json_load, from_dict):
-        json_load.return_value = 'topo_dict'
+    @patch("lib.topology.load_json_file", autospec=True)
+    def test(self, load, from_dict):
+        load.return_value = 'topo_dict'
         from_dict.return_value = 'topology'
-        with patch('lib.topology.open', mock_open(), create=True) as open_f:
-            topology = Topology.from_file('filename')
-            open_f.assert_called_once_with('filename')
-            json_load.assert_called_once_with(open_f.return_value)
-            from_dict.assert_called_once_with('topo_dict')
-            ntools.eq_(topology, 'topology')
-
-    @patch("lib.topology.logging.error", autospec=True)
-    @patch("lib.topology.json.load", autospec=True)
-    def _check_fail(self, error, json_load, log_error):
-        json_load.side_effect = error
-        with patch('lib.topology.open', mock_open(), create=True):
-            topology = Topology.from_file('filename')
-            ntools.assert_is_none(topology)
-            ntools.eq_(log_error.call_count, 1)
-
-    def test_fail(self):
-        for error in [ValueError, KeyError, TypeError]:
-            yield self._check_fail, error
+        ntools.eq_(Topology.from_file('filename'), 'topology')
+        load.assert_called_once_with('filename')
+        from_dict.assert_called_once_with('topo_dict')
 
 
 class TestTopologyFromDict(object):

--- a/test/lib_zookeeper_test.py
+++ b/test/lib_zookeeper_test.py
@@ -27,7 +27,7 @@ from kazoo.protocol.states import ZnodeStat
 
 # SCION
 import lib.zookeeper as libzk
-from test.testcommon import MockCollection, SCIONTestException
+from test.testcommon import MockCollection, SCIONTestError
 
 
 def mock_wrapper(f):
@@ -224,7 +224,7 @@ class TestLibZookeeperStateHandler(BaseLibZookeeper):
         elif new_state == libzk.KazooState.LOST:
             lost = 1
         else:
-            raise SCIONTestException("Invalid new state")
+            raise SCIONTestError("Invalid new state")
         ntools.eq_(inst._state_connected.call_count, connected)
         ntools.eq_(inst._state_suspended.call_count, suspended)
         ntools.eq_(inst._state_lost.call_count, lost)
@@ -499,7 +499,7 @@ class TestLibZookeeperGetLock(BaseLibZookeeper):
         inst = self._init_basic_setup()
         inst.is_connected = MagicMock(spec_set=[], return_value=False)
         inst.release_lock = MagicMock(spec_set=[])
-        inst._lock.is_set.side_effect = SCIONTestException(
+        inst._lock.is_set.side_effect = SCIONTestError(
             "this should not have been reached")
         # Call
         ntools.assert_false(inst.get_lock())
@@ -516,7 +516,7 @@ class TestLibZookeeperGetLock(BaseLibZookeeper):
         inst.is_connected = MagicMock(spec_set=[], return_value=True)
         inst._lock.is_set.return_value = True
         inst._zk_lock = self.mocks.klock
-        inst._zk_lock.acquire.side_effect = SCIONTestException(
+        inst._zk_lock.acquire.side_effect = SCIONTestError(
             "_zk_lock.acquire should not have been reached")
         # Call
         ntools.assert_true(inst.get_lock())
@@ -582,7 +582,7 @@ class TestLibZookeeperReleaseLock(BaseLibZookeeper):
         inst.is_connected = MagicMock(spec_set=[], return_value=False)
         inst._zk_lock = self.mocks.klock
         inst._zk_lock.is_acquired = True
-        inst._zk_lock.release.side_effect = SCIONTestException(
+        inst._zk_lock.release.side_effect = SCIONTestError(
             "_zk_lock.release() shouldn't have been called")
         # Call
         inst.release_lock()
@@ -706,7 +706,7 @@ class TestLibZookeeperStoreSharedItems(BaseLibZookeeper):
         """
         inst = self._init_basic_setup()
         inst.is_connected = MagicMock(spec_set=[], return_value=True)
-        inst._zk.create.side_effect = SCIONTestException(
+        inst._zk.create.side_effect = SCIONTestError(
             "_zk.create shouldn't have been called")
         # Call
         inst.store_shared_item('p', 'n', 'v')
@@ -852,7 +852,7 @@ class TestLibZookeeperGetSharedMetadata(BaseLibZookeeper):
         """
         inst = self._init_basic_setup()
         inst.is_connected = MagicMock(spec_set=[], return_value=False)
-        inst._zk.get_children.side_effect = SCIONTestException(
+        inst._zk.get_children.side_effect = SCIONTestError(
             "_zk.get_children should not have been reached")
         # Call
         ntools.eq_(inst.get_shared_metadata("path"), [])
@@ -942,7 +942,7 @@ class TestLibZookeeperExpireSharedItems(BaseLibZookeeper):
         inst = self._init_basic_setup()
         inst.is_connected = MagicMock(spec_set=[], return_value=False)
         inst.get_shared_metadata = MagicMock(
-            spec_set=[], side_effect=SCIONTestException(
+            spec_set=[], side_effect=SCIONTestError(
                 "get_shared_metadata shouldn't have been called"))
         # Call
         ntools.assert_is_none(inst.expire_shared_items("path", 100))
@@ -956,7 +956,7 @@ class TestLibZookeeperExpireSharedItems(BaseLibZookeeper):
         inst.is_connected = MagicMock(spec_set=[], return_value=True)
         inst.get_shared_metadata = MagicMock(spec_set=[], return_value=[])
         inst._zk.delete = MagicMock(
-            spec_set=[], side_effect=SCIONTestException(
+            spec_set=[], side_effect=SCIONTestError(
                 "_zk.delete shouldn't have been called"))
         # Call
         ntools.eq_(inst.expire_shared_items("path", 100), 0)

--- a/test/testcommon.py
+++ b/test/testcommon.py
@@ -19,10 +19,13 @@
 import unittest
 from unittest.mock import patch
 
+# SCION
+from lib.errors import SCIONBaseError
 
-class SCIONTestException(Exception):
+
+class SCIONTestError(SCIONBaseError):
     """
-    SCIONTestException class.
+    SCIONTestError class.
     """
     pass
 


### PR DESCRIPTION
- Add lib.errors, contains base exception all SCION errors should
  inherit from.
- Standardise file i/o into lib.util, update code to use it.
- Add lib.util.load_json_file, to replace the multiple places in the
  code that reads json from a file and parses it.

For #271 

@pszalach @shitz
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/272%23discussion_r35621313%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/272%23issuecomment-125485496%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/272%23discussion_r35624584%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/272%23discussion_r35626078%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/272%23discussion_r35626686%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/272%23issuecomment-125546766%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/272%23issuecomment-125485496%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Looking%20good%2C%20except%20the%20naming.%22%2C%20%22created_at%22%3A%20%222015-07-28T07%3A43%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-07-28T10%3A29%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f28f267eb6455b83690be2987d38b6573d34185f%20lib/errors.py%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/272%23discussion_r35621313%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20would%20rename%20%60Error%60%20to%20%60Exception%60%20since%5Cr%5Cna%29%20The%20widely%20used%20term%20for%20this%20construct%20is%20Exception%5Cr%5Cnb%29%20Exceptions%20don%27t%20necessarily%20have%20to%20be%20errors%22%2C%20%22created_at%22%3A%20%222015-07-28T07%3A38%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22As%20discussed%2C%20i%27ve%20added%20a%20new%20%60SCIONBaseException%60%2C%20and%20derived%20%60SCIONBaseError%60%20from%20it.%22%2C%20%22created_at%22%3A%20%222015-07-28T08%3A27%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20seems%20like%20%60SCIONBaseError%60%20subclass%20%60Exception%60%20instead%20of%20%60SCIONBaseException%60.%22%2C%20%22created_at%22%3A%20%222015-07-28T08%3A46%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oops%2C%20fixed.%22%2C%20%22created_at%22%3A%20%222015-07-28T08%3A53%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/errors.py%3AL1-41%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull f28f267eb6455b83690be2987d38b6573d34185f lib/errors.py 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/272#discussion_r35621313'>File: lib/errors.py:L1-41</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> I would rename `Error` to `Exception` since
  a) The widely used term for this construct is Exception
  b) Exceptions don't necessarily have to be errors
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> As discussed, i've added a new `SCIONBaseException`, and derived `SCIONBaseError` from it.
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> It seems like `SCIONBaseError` subclass `Exception` instead of `SCIONBaseException`.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Oops, fixed.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/272#issuecomment-125485496'>General Comment</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Looking good, except the naming.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/272?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/272?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/272'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
