### PR TITLE
Major parsing cleanup.

### DIFF
--- a/infrastructure/cert_server.py
+++ b/infrastructure/cert_server.py
@@ -107,8 +107,8 @@ class CertServer(SCIONElement):
         :param cert_chain: certificate chain.
         :type cert_chain: CertificateChain
         """
+        tmp = CertificateChain(cert_chain_file)
         try:
-            tmp = CertificateChain(cert_chain_file)
             self.zk.store_shared_item(self.ZK_CERT_CHAIN_CACHE_PATH,
                                       tmp.certs[0].subject +
                                       "-V:" + str(tmp.certs[0].version),
@@ -213,8 +213,8 @@ class CertServer(SCIONElement):
         :param trc: TRC.
         :type trc: TRC.
         """
+        tmp = TRC(trc_file)
         try:
-            tmp = TRC(trc_file)
             self.zk.store_shared_item(self.ZK_TRC_CACHE_PATH,
                                       "ISD:" + str(tmp.isd_id) +
                                       "-V:" + str(tmp.version),

--- a/infrastructure/dns_server.py
+++ b/infrastructure/dns_server.py
@@ -124,7 +124,6 @@ class ZoneResolver(BaseResolver):
                     return
             logging.warning("Unknown service: %s", qname)
             reply.header.rcode = RCODE.NXDOMAIN
-            return
 
 
 class SCIONDnsTcpServer(TCPServer):

--- a/lib/defines.py
+++ b/lib/defines.py
@@ -17,6 +17,7 @@
 Contains constant definitions used throughout the codebase.
 """
 # Stdlib
+import ipaddress
 import os
 
 #: Max TTL of a PathSegment in realtime seconds.
@@ -37,3 +38,8 @@ SCION_UDP_PORT = 30040
 SCION_UDP_EH_DATA_PORT = 30041
 #: Default DNS UDP/TCP port
 SCION_DNS_PORT = 30053
+
+#: Length of IPV4 address, in bytes
+IPV4BYTES = ipaddress.IPV4LENGTH // 8
+#: Length of IPV6 address, in bytes
+IPV6BYTES = ipaddress.IPV6LENGTH // 8

--- a/lib/errors.py
+++ b/lib/errors.py
@@ -41,8 +41,29 @@ class SCIONIOError(SCIONBaseError):
     pass
 
 
+class SCIONIndexError(SCIONBaseError):
+    """
+    Index error (accessing out of bound index on array)
+    """
+    pass
+
+
 class SCIONJSONError(SCIONBaseError):
     """
     JSON parsing error.
+    """
+    pass
+
+
+class SCIONParseError(SCIONBaseError):
+    """
+    Parsing error.
+    """
+    pass
+
+
+class SCIONTypeError(SCIONBaseError):
+    """
+    Wrong type.
     """
     pass

--- a/lib/packet/ext_hdr.py
+++ b/lib/packet/ext_hdr.py
@@ -16,11 +16,11 @@
 ===========================================
 """
 # Stdlib
-import logging
 import struct
 
 # SCION
 from lib.packet.packet_base import HeaderBase
+from lib.util import Raw
 
 
 class ExtensionHeader(HeaderBase):
@@ -47,7 +47,7 @@ class ExtensionHeader(HeaderBase):
         :param raw:
         :type raw:
         """
-        HeaderBase.__init__(self)
+        super().__init__()
         self.next_ext = 0
         self.hdr_len = 0
         if raw is not None:
@@ -60,13 +60,9 @@ class ExtensionHeader(HeaderBase):
         :param raw:
         :type raw:
         """
-        assert isinstance(raw, bytes)
-        dlen = len(raw)
-        if dlen < self.MIN_LEN:
-            logging.warning("Data too short to parse extension hdr: "
-                            "data len %u", dlen)
-            return
-        self.next_ext, self.hdr_len = struct.unpack("!BB", raw)
+        data = Raw(raw, "ExtensionHeader", self.MIN_LEN)
+        self.next_ext, self.hdr_len = struct.unpack(
+            "!BB", data.pop(self.MIN_LEN))
         self.parsed = True
 
     def pack(self):
@@ -114,7 +110,7 @@ class ICNExtHdr(ExtensionHeader):
         :param raw:
         :type raw:
         """
-        ExtensionHeader.__init__(self)
+        super().__init__()
         self.fwd_flag = 0
         if raw is not None:
             self.parse(raw)
@@ -126,16 +122,10 @@ class ICNExtHdr(ExtensionHeader):
         :param raw:
         :type raw:
         """
-        assert isinstance(raw, bytes)
-        dlen = len(raw)
-        if dlen < self.MIN_LEN:
-            logging.warning("Data too short to parse ICN extension hdr: "
-                            "data len %u", dlen)
-            return
-        (self.next_ext, self.hdr_len, self.fwd_flag, _rsvd1, _rsvd2) = \
-            struct.unpack("!BBBIB", raw)
+        data = Raw(raw, "ICNExtHdr", self.MIN_LEN, min_=True)
+        self.next_ext, self.hdr_len, self.fwd_flag, _rsvd1, _rsvd2 = \
+            struct.unpack("!BBBIB", data.pop(self.MIN_LEN))
         self.parsed = True
-        return
 
     def pack(self):
         """

--- a/lib/packet/packet_base.py
+++ b/lib/packet/packet_base.py
@@ -154,7 +154,7 @@ class PayloadBase(object):
         self.parsed = False
 
     def parse(self, raw):
-        self.raw = raw[:]
+        self.raw = raw
 
     def pack(self):
         return self.raw

--- a/lib/packet/path.py
+++ b/lib/packet/path.py
@@ -25,6 +25,7 @@ from lib.packet.opaque_field import (
     InfoOpaqueField,
     OpaqueFieldType,
 )
+from lib.util import Raw
 
 
 class PathBase(object):
@@ -159,66 +160,31 @@ class CorePath(PathBase):
         """
         Parses the raw data and populates the fields accordingly.
         """
-        assert isinstance(raw, bytes)
+        data = Raw(raw, "CorePath")
         # Parse up-segment
-        offset = self._parse_up_segment(raw)
+        self.up_segment_info = InfoOpaqueField(data.pop(InfoOpaqueField.LEN))
+        self._parse_segment(data, self.up_segment_info.hops,
+                            self.up_segment_hops)
         # Parse core-segment
-        if len(raw) != offset:
-            offset = self._parse_core_segment(raw, offset)
+        if len(data) > 0:
+            self.core_segment_info = InfoOpaqueField(
+                data.pop(InfoOpaqueField.LEN))
+            self._parse_segment(data, self.core_segment_info.hops,
+                                self.core_segment_hops)
         # Parse down-segment
-        if len(raw) != offset:
-            self._parse_down_segment(raw, offset)
-
+        if len(data) > 0:
+            self.down_segment_info = InfoOpaqueField(
+                data.pop(InfoOpaqueField.LEN))
+            self._parse_segment(data, self.down_segment_info.hops,
+                                self.down_segment_hops)
         self.parsed = True
 
-    def _parse_up_segment(self, raw):
+    def _parse_segment(self, data, count, hops):
         """
-        Parses the raw data and populates the up_segment fields.
-
-        :param raw: bytes
-        :return: offset in the raw data till which it has been parsed
+        Parse raw data and populate segment fields
         """
-        self.up_segment_info = InfoOpaqueField(raw[:InfoOpaqueField.LEN])
-        offset = InfoOpaqueField.LEN
-        for _ in range(self.up_segment_info.hops):
-            self.up_segment_hops.append(
-                HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN]))
-            offset += HopOpaqueField.LEN
-        return offset
-
-    def _parse_core_segment(self, raw, offset):
-        """
-        Parses the raw data and populates the core_segment fields.
-
-        :param raw: bytes
-        :param offset: int
-        :return: offset in the raw data till which it has been parsed
-        """
-        self.core_segment_info = \
-            InfoOpaqueField(raw[offset:offset + InfoOpaqueField.LEN])
-        offset += InfoOpaqueField.LEN
-        for _ in range(self.core_segment_info.hops):
-            self.core_segment_hops.append(
-                HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN]))
-            offset += HopOpaqueField.LEN
-        return offset
-
-    def _parse_down_segment(self, raw, offset):
-        """
-        Parses the raw data and populates the down_segment fields.
-
-        :param raw: bytes
-        :param offset: int
-        :return: offset in the raw data till which it has been parsed
-        """
-        self.down_segment_info = \
-            InfoOpaqueField(raw[offset:offset + InfoOpaqueField.LEN])
-        offset += InfoOpaqueField.LEN
-        for _ in range(self.down_segment_info.hops):
-            self.down_segment_hops.append(
-                HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN]))
-            offset += HopOpaqueField.LEN
-        return offset
+        for _ in range(count):
+            hops.append(HopOpaqueField(data.pop(HopOpaqueField.LEN)))
 
     def pack(self):
         """
@@ -379,48 +345,40 @@ class CrossOverPath(PathBase):
         """
         Parses the raw data and populates the fields accordingly.
         """
-        assert isinstance(raw, bytes)
+        data = Raw(raw, "CrossOverPath")
         # Parse up-segment
-        offset = self._parse_up_segment(raw)
+        self._parse_up_segment(data)
         # Parse down-segment
-        self._parse_down_segment(raw, offset)
+        self._parse_down_segment(data)
         self.parsed = True
 
-    def _parse_up_segment(self, raw):
+    def _parse_up_segment(self, data):
         """
         Parses the raw data and populates the up_segment fields.
 
-        :param raw: bytes
-        :type raw:
+        :param data:
+        :type data: :class:`lib.util.Raw`
         """
-        self.up_segment_info = InfoOpaqueField(raw[:InfoOpaqueField.LEN])
-        offset = InfoOpaqueField.LEN
+        self.up_segment_info = InfoOpaqueField(data.pop(InfoOpaqueField.LEN))
         for _ in range(self.up_segment_info.hops):
             self.up_segment_hops.append(
-                HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN]))
-            offset += HopOpaqueField.LEN
-        self.up_segment_upstream_ad = \
-            HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN])
-        offset += HopOpaqueField.LEN
-        return offset
+                HopOpaqueField(data.pop(HopOpaqueField.LEN)))
+        self.up_segment_upstream_ad = HopOpaqueField(
+            data.pop(HopOpaqueField.LEN))
 
-    def _parse_down_segment(self, raw, offset):
+    def _parse_down_segment(self, data):
         """
         Parses the raw data and populates the down_segment fields.
 
-        :param raw: bytes
-        :type raw:
+        :param data:
+        :type data: :class:`lib.util.Raw`
         """
-        self.down_segment_info = \
-            InfoOpaqueField(raw[offset:offset + InfoOpaqueField.LEN])
-        offset += InfoOpaqueField.LEN
-        self.down_segment_upstream_ad = \
-            HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN])
-        offset += HopOpaqueField.LEN
+        self.down_segment_info = InfoOpaqueField(data.pop(InfoOpaqueField.LEN))
+        self.down_segment_upstream_ad = HopOpaqueField(
+            data.pop(HopOpaqueField.LEN))
         for _ in range(self.down_segment_info.hops):
             self.down_segment_hops.append(
-                HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN]))
-            offset += HopOpaqueField.LEN
+                HopOpaqueField(data.pop(HopOpaqueField.LEN)))
 
     def pack(self):
         """
@@ -540,54 +498,44 @@ class PeerPath(PathBase):
         """
         Parses the raw data and populates the fields accordingly.
         """
-        assert isinstance(raw, bytes)
+        data = Raw(raw, "PeerPath")
         # Parse up-segment
-        offset = self._parse_up_segment(raw)
+        self._parse_up_segment(data)
         # Parse down-segment
-        self._parse_down_segment(raw, offset)
+        self._parse_down_segment(data)
         self.parsed = True
 
-    def _parse_up_segment(self, raw):
+    def _parse_up_segment(self, data):
         """
         Parses the raw data and populates the down_segment fields.
 
-        :param raw:
-        :return
+        :param data:
+        :type data: :class:`lib.util.Raw`
         """
-        self.up_segment_info = InfoOpaqueField(raw[:InfoOpaqueField.LEN])
-        offset = InfoOpaqueField.LEN
+        self.up_segment_info = InfoOpaqueField(data.pop(InfoOpaqueField.LEN))
         for _ in range(self.up_segment_info.hops):
             self.up_segment_hops.append(
-                HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN]))
-            offset += HopOpaqueField.LEN
-        self.up_segment_peering_link = \
-            HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN])
-        offset += HopOpaqueField.LEN
-        self.up_segment_upstream_ad = \
-            HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN])
-        offset += HopOpaqueField.LEN
-        return offset
+                HopOpaqueField(data.pop(HopOpaqueField.LEN)))
+        self.up_segment_peering_link = HopOpaqueField(
+            data.pop(HopOpaqueField.LEN))
+        self.up_segment_upstream_ad = HopOpaqueField(
+            data.pop(HopOpaqueField.LEN))
 
-    def _parse_down_segment(self, raw, offset):
+    def _parse_down_segment(self, data):
         """
         Parses the raw data and populates the down_segment fields.
 
-        :param raw:
-        :param offset:
+        :param data:
+        :type data: :class:`lib.util.Raw`
         """
-        self.down_segment_info = \
-            InfoOpaqueField(raw[offset:offset + InfoOpaqueField.LEN])
-        offset += InfoOpaqueField.LEN
+        self.down_segment_info = InfoOpaqueField(data.pop(InfoOpaqueField.LEN))
         self.down_segment_upstream_ad = \
-            HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN])
-        offset += HopOpaqueField.LEN
+            HopOpaqueField(data.pop(HopOpaqueField.LEN))
         self.down_segment_peering_link = \
-            HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN])
-        offset += HopOpaqueField.LEN
+            HopOpaqueField(data.pop(HopOpaqueField.LEN))
         for _ in range(self.down_segment_info.hops):
             self.down_segment_hops.append(
-                HopOpaqueField(raw[offset:offset + HopOpaqueField.LEN]))
-            offset += HopOpaqueField.LEN
+                HopOpaqueField(data.pop(HopOpaqueField.LEN)))
 
     def pack(self):
         """

--- a/lib/packet/path_mgmt.py
+++ b/lib/packet/path_mgmt.py
@@ -22,10 +22,12 @@ import logging
 import struct
 
 # SCION
+from lib.errors import SCIONParseError
 from lib.packet.packet_base import PayloadBase
 from lib.packet.pcb import PathSegment
 from lib.packet.scion import PacketType, SCIONPacket, SCIONHeader
 from lib.packet.scion_addr import ISD_AD, SCIONAddr
+from lib.util import Raw
 
 
 class PathMgmtType:
@@ -72,7 +74,7 @@ class PathSegmentInfo(PayloadBase):
         :param raw:
         :type raw:
         """
-        PayloadBase.__init__(self)
+        super().__init__()
         self.type = 0
         self.src_isd = 0
         self.dst_isd = 0
@@ -86,11 +88,10 @@ class PathSegmentInfo(PayloadBase):
         Populates fields from a raw bytes block.
         """
         PayloadBase.parse(self, raw)
-        (self.type, ) = struct.unpack("!B", raw[:1])
-        raw = raw[1:]
-        (self.src_isd, self.src_ad) = ISD_AD.from_raw(raw[:ISD_AD.LEN])
-        raw = raw[ISD_AD.LEN:]
-        (self.dst_isd, self.dst_ad) = ISD_AD.from_raw(raw[:ISD_AD.LEN])
+        data = Raw(raw, "PathSegmentInfo", self.LEN)
+        self.type = data.pop(1)
+        self.src_isd, self.src_ad = ISD_AD.from_raw(data.pop(ISD_AD.LEN))
+        self.dst_isd, self.dst_ad = ISD_AD.from_raw(data.pop(ISD_AD.LEN))
 
     def pack(self):
         """
@@ -126,6 +127,8 @@ class PathSegmentRecords(PayloadBase):
     represented as objects of the PathSegment class. Type of a path is
     determined through info field (object of PathSegmentInfo).
     """
+    MIN_LEN = PathSegmentInfo.LEN + PathSegment.MIN_LEN
+
     def __init__(self, raw=None):
         """
         Initialize an instance of the class PathSegmentRecords.
@@ -133,7 +136,7 @@ class PathSegmentRecords(PayloadBase):
         :param raw:
         :type raw:
         """
-        PayloadBase.__init__(self)
+        super().__init__()
         self.info = None
         self.pcbs = None
         if raw:
@@ -141,8 +144,9 @@ class PathSegmentRecords(PayloadBase):
 
     def parse(self, raw):
         PayloadBase.parse(self, raw)
-        self.info = PathSegmentInfo(raw[:PathSegmentInfo.LEN])
-        self.pcbs = PathSegment.deserialize(raw[PathSegmentInfo.LEN:])
+        data = Raw(raw, "PathSegmentRecords", self.MIN_LEN, min_=True)
+        self.info = PathSegmentInfo(data.pop(PathSegmentInfo.LEN))
+        self.pcbs = PathSegment.deserialize(data.pop())
 
     def pack(self):
         return self.info.pack() + PathSegment.serialize(self.pcbs)
@@ -167,7 +171,8 @@ class LeaseInfo(PayloadBase):
     """
     Class containing necessary information for a path-segment lease.
     """
-    LEN = 1 + ISD_AD.LEN + 4 + 32
+    EXP_SEG_LEN = 4 + 32
+    LEN = 1 + ISD_AD.LEN + EXP_SEG_LEN
 
     def __init__(self, raw=None):
         """
@@ -176,7 +181,7 @@ class LeaseInfo(PayloadBase):
         :param raw:
         :type raw:
         """
-        PayloadBase.__init__(self)
+        super().__init__()
         self.seg_type = PathSegmentType.DOWN
         self.isd_id = 0
         self.ad_id = 0
@@ -188,14 +193,11 @@ class LeaseInfo(PayloadBase):
 
     def parse(self, raw):
         PayloadBase.parse(self, raw)
-        if len(raw) < LeaseInfo.LEN:
-            logging.error("Not enough data to parse LeaseInfo")
-            return
-        (self.seg_type, ) = struct.unpack("!B", raw[:1])
-        raw = raw[1:]
-        (self.isd_id, self.ad_id) = ISD_AD.from_raw(raw[:ISD_AD.LEN])
-        raw = raw[ISD_AD.LEN:]
-        (self.exp_time, self.seg_id) = struct.unpack("!L32s", raw)
+        data = Raw(raw, "LeaseInfo", self.LEN)
+        self.seg_type = data.pop(1)
+        self.isd_id, self.ad_id = ISD_AD.from_raw(data.pop(ISD_AD.LEN))
+        self.exp_time, self.seg_id = struct.unpack(
+            "!L32s", data.pop(self.EXP_SEG_LEN))
 
     def pack(self):
         return (struct.pack("!B", self.seg_type) +
@@ -237,6 +239,7 @@ class PathSegmentLeases(PayloadBase):
     caching of path-segments. A lease contains a timestamp and the segment id
     of the path segment being cached.
     """
+    MIN_LEN = 1 + LeaseInfo.LEN
 
     def __init__(self, raw=None):
         """
@@ -245,7 +248,7 @@ class PathSegmentLeases(PayloadBase):
         :param raw:
         :type raw:
         """
-        PayloadBase.__init__(self)
+        super().__init__()
         self.nleases = 0  # The number of leases contained in this packet.
         self.leases = []  # List of leases. Tuples (TS, ID)
 
@@ -254,11 +257,10 @@ class PathSegmentLeases(PayloadBase):
 
     def parse(self, raw):
         PayloadBase.parse(self, raw)
-        self.nleases = struct.unpack("!B", raw[0:1])[0]
-        offset = 1
+        data = Raw(raw, "PathSegmentLeases", self.MIN_LEN, min_=True)
+        self.nleases = data.pop(1)
         for _ in range(self.nleases):
-            self.leases.append(LeaseInfo(raw[offset:offset + LeaseInfo.LEN]))
-            offset += LeaseInfo.LEN
+            self.leases.append(LeaseInfo(data.pop(LeaseInfo.LEN)))
 
     def pack(self):
         data = struct.pack("!B", self.nleases)
@@ -306,7 +308,7 @@ class RevocationInfo(PayloadBase):
         :param raw:
         :type raw:
         """
-        PayloadBase.__init__(self)
+        super().__init__()
         self.rev_type = RevocationType.DOWN_SEGMENT
         self.incl_seg_id = False
         self.incl_hop = False
@@ -320,26 +322,18 @@ class RevocationInfo(PayloadBase):
             self.parse(raw)
 
     def parse(self, raw):
-        if len(raw) < RevocationInfo.MIN_LEN:
-            logging.error("Not enough data to parse RevocationInfo")
-            return
-
-        flags = struct.unpack("!B", raw[0:1])[0]
+        data = Raw(raw, "RevocationInfo", self.MIN_LEN, min_=True)
+        flags = data.pop(1)
         self.rev_type = flags & 0x7
         self.incl_seg_id = (flags >> 3) & 0x1
         self.incl_hop = (flags >> 4) & 0x1
-        offset = 1
         if self.incl_seg_id:
-            self.seg_id = struct.unpack("!32s", raw[offset:offset + 32])[0]
-            offset += 32
-        (self.rev_token1, self.proof1) = struct.unpack("!32s32s",
-                                                       raw[offset:offset + 64])
-        offset += 64
+            self.seg_id = struct.unpack("!32s", data.pop(32))[0]
+        self.rev_token1, self.proof1 = struct.unpack("!32s32s", data.pop(64))
         if self.incl_hop:
-            (self.rev_token2, self.proof2) = \
-                struct.unpack("!32s32s", raw[offset:offset + 64])
-            offset += 64
-        self.raw = raw[:offset]
+            self.rev_token2, self.proof2 = struct.unpack("!32s32s",
+                                                         data.pop(64))
+        self.raw = raw[:data.offset()]
         self.parsed = True
 
     def pack(self):
@@ -402,6 +396,8 @@ class RevocationPayload(PayloadBase):
     """
     Payload for revocation messages. List of RevocationInfo objects.
     """
+    MIN_LEN = RevocationInfo.MIN_LEN
+
     def __init__(self, raw=None):
         """
         Initialize an instance of the class RevocationPayload.
@@ -409,7 +405,7 @@ class RevocationPayload(PayloadBase):
         :param raw:
         :type raw:
         """
-        PayloadBase.__init__(self)
+        super().__init__()
         self.rev_infos = []
 
         if raw is not None:
@@ -417,15 +413,12 @@ class RevocationPayload(PayloadBase):
 
     def parse(self, raw):
         PayloadBase.parse(self, raw)
-        dlen = len(raw)
-        offset = 0
-        while offset < dlen:
-            info = RevocationInfo(raw[offset:offset + RevocationInfo.MAX_LEN])
-            if not info.parsed:
-                logging.error("RevocationPayload couldn't be parsed.")
-                return
+        data = Raw(raw, "RevocationPayload", self.MIN_LEN, min_=True)
+        while len(data) > 0:
+            info = RevocationInfo(data.get(RevocationInfo.MAX_LEN,
+                                           bounds=False))
             self.rev_infos.append(info)
-            offset += len(info)
+            data.pop(len(info))
 
     def pack(self):
         return b"".join([info.pack() for info in self.rev_infos])
@@ -458,6 +451,11 @@ class PathMgmtPacket(SCIONPacket):
     """
     Container for all path management packets.
     """
+    MIN_LEN = 1 + min(PathSegmentInfo.LEN,
+                      PathSegmentRecords.MIN_LEN,
+                      PathSegmentLeases.MIN_LEN,
+                      RevocationPayload.MIN_LEN)
+
     def __init__(self, raw=None):
         """
         Initialize an instance of the class PathMgmtPacket.
@@ -465,7 +463,7 @@ class PathMgmtPacket(SCIONPacket):
         :param raw:
         :type raw:
         """
-        SCIONPacket.__init__(self)
+        super().__init__()
         self.type = 0
 
         if raw:
@@ -473,19 +471,21 @@ class PathMgmtPacket(SCIONPacket):
 
     def parse(self, raw):
         SCIONPacket.parse(self, raw)
+        data = Raw(self.payload, "PathMgmtPacket", self.MIN_LEN, min_=True)
         # Get the type of the first byte of the payload and instantiate the
         # corresponding payload class.
-        self.type = struct.unpack("!B", self.payload[0:1])[0]
+        self.type = data.pop(1)
         if self.type == PathMgmtType.REQUEST:
-            self.payload = PathSegmentInfo(self.payload[1:])
+            self.payload = PathSegmentInfo(data.pop(PathSegmentInfo.LEN))
         elif self.type == PathMgmtType.RECORDS:
-            self.payload = PathSegmentRecords(self.payload[1:])
+            self.payload = PathSegmentRecords(data.pop())
         elif self.type == PathMgmtType.LEASES:
-            self.payload = PathSegmentLeases(self.payload[1:])
+            self.payload = PathSegmentLeases(data.pop())
         elif self.type == PathMgmtType.REVOCATIONS:
-            self.payload = RevocationPayload(self.payload[1:])
+            self.payload = RevocationPayload(data.pop())
         else:
-            logging.error("Unsupported path management type: %d", self.type)
+            raise SCIONParseError("Unsupported path management type: %d",
+                                  self.type)
 
     def pack(self):
         if not isinstance(self.payload, bytes):

--- a/lib/packet/scion.py
+++ b/lib/packet/scion.py
@@ -21,6 +21,7 @@ import struct
 from ipaddress import IPv4Address
 
 # SCION
+from lib.errors import SCIONParseError
 from lib.packet.ext_hdr import ExtensionHeader, ICNExtHdr
 from lib.packet.opaque_field import (
     InfoOpaqueField,
@@ -36,6 +37,7 @@ from lib.packet.path import (
     PeerPath,
 )
 from lib.packet.scion_addr import ISD_AD, SCIONAddr
+from lib.util import Raw
 
 
 class PacketType(object):
@@ -114,7 +116,7 @@ class SCIONCommonHdr(HeaderBase):
         """
         Returns a SCIONCommonHdr with the values specified.
         """
-        chdr = SCIONCommonHdr()
+        chdr = cls()
         chdr.src_addr_len = src_addr_len
         chdr.dst_addr_len = dst_addr_len
         chdr.next_hdr = next_hdr
@@ -129,19 +131,13 @@ class SCIONCommonHdr(HeaderBase):
         """
         Parses the raw data and populates the fields accordingly.
         """
-        assert isinstance(raw, bytes)
-        dlen = len(raw)
-        if dlen < self.LEN:
-            logging.warning("Data too short to parse SCION common header: "
-                            "data len %u", dlen)
-            return
+        data = Raw(raw, "SCIONCommonHdr", self.LEN)
         (types, self.total_len, self.curr_iof_p, self.curr_of_p,
-         self.next_hdr, self.hdr_len) = struct.unpack("!HHBBBB", raw)
+         self.next_hdr, self.hdr_len) = struct.unpack("!HHBBBB", data.pop())
         self.version = (types & 0xf000) >> 12
         self.src_addr_len = (types & 0x0fc0) >> 6
         self.dst_addr_len = types & 0x003f
         self.parsed = True
-        return
 
     def pack(self):
         """
@@ -281,84 +277,61 @@ class SCIONHeader(HeaderBase):
         """
         Parses the raw data and populates the fields accordingly.
         """
-        assert isinstance(raw, bytes)
-        dlen = len(raw)
-        if dlen < SCIONHeader.MIN_LEN:
-            logging.warning("Data too short to parse SCION header: "
-                            "data len %u", dlen)
-            return
-        offset = self._parse_common_hdr(raw, 0)
-        # Parse opaque fields.
-        offset = self._parse_opaque_fields(raw, offset)
-        # Parse extensions headers.
-        offset = self._parse_extension_hdrs(raw, offset)
+        data = Raw(raw, "SCIONHeader", self.MIN_LEN, min_=True)
+        self._parse_common_hdr(data)
+        self._parse_opaque_fields(data)
+        self._parse_extension_hdrs(data)
         self.parsed = True
-        return offset
+        return data.offset()
 
-    def _parse_common_hdr(self, raw, offset):
+    def _parse_common_hdr(self, data):
         """
         Parses the raw data and populates the common header fields accordingly.
-        :return: offset in the raw data till which it has been parsed
         """
-        self.common_hdr = \
-            SCIONCommonHdr(raw[offset:offset + SCIONCommonHdr.LEN])
-        assert self.common_hdr.parsed
-        offset += SCIONCommonHdr.LEN
-        # Create appropriate SCIONAddr objects.
-        src_addr_len = self.common_hdr.src_addr_len
-        self.src_addr = SCIONAddr(raw[offset:offset + src_addr_len])
-        offset += src_addr_len
-        dst_addr_len = self.common_hdr.dst_addr_len
-        self.dst_addr = SCIONAddr(raw[offset:offset + dst_addr_len])
-        offset += dst_addr_len
-        return offset
+        self.common_hdr = SCIONCommonHdr(data.pop(SCIONCommonHdr.LEN))
+        self.src_addr = SCIONAddr(data.pop(self.common_hdr.src_addr_len))
+        self.dst_addr = SCIONAddr(data.pop(self.common_hdr.dst_addr_len))
 
-    def _parse_opaque_fields(self, raw, offset):
+    def _parse_opaque_fields(self, data):
         """
         Parses the raw data to opaque fields and populates the path field
         accordingly.
-        :return: offset in the raw data till which it has been parsed
         """
         # PSz: UpPath-only case missing, quick fix:
-        if offset == self.common_hdr.hdr_len:
+        if data.offset() == self.common_hdr.hdr_len:
             self._path = EmptyPath()
+            return
+        info = InfoOpaqueField(data.get(InfoOpaqueField.LEN))
+        path_data = data.pop(self.common_hdr.hdr_len - data.offset())
+        if info.info == OFT.TDC_XOVR:
+            self._path = CorePath(path_data)
+        elif info.info == OFT.NON_TDC_XOVR:
+            self._path = CrossOverPath(path_data)
+        elif info.info in (OFT.INTRATD_PEER, OFT.INTERTD_PEER):
+            self._path = PeerPath(path_data)
         else:
-            info = InfoOpaqueField(raw[offset:offset + InfoOpaqueField.LEN])
-            if info.info == OFT.TDC_XOVR:
-                self._path = CorePath(raw[offset:self.common_hdr.hdr_len])
-            elif info.info == OFT.NON_TDC_XOVR:
-                self._path = CrossOverPath(raw[offset:self.common_hdr.hdr_len])
-            elif info.info == OFT.INTRATD_PEER or info.info == OFT.INTERTD_PEER:
-                self._path = PeerPath(raw[offset:self.common_hdr.hdr_len])
-            else:
-                logging.info("Can not parse path in packet: Unknown type %x",
-                             info.info)
-        return self.common_hdr.hdr_len
+            raise SCIONParseError("SCIONHeader: Can not parse path in "
+                                  "packet: Unknown type %x", info.info)
 
-    def _parse_extension_hdrs(self, raw, offset):
+    def _parse_extension_hdrs(self, data):
         """
         Parses the raw data and populates the extension header fields
         accordingly.
-        :return: offset in the raw data till which it has been parsed
         """
         # FIXME: The last extension header should be a layer 4 protocol header.
-        # At the moment this is not support and we just indicate the end of the
-        # extension headers by a 0 in the type field.
+        # At the moment this is not supported and we just indicate the end of
+        # the extension headers by a 0 in the type field.
         cur_hdr_type = self.common_hdr.next_hdr
         while cur_hdr_type != 0:
-            (next_hdr_type, hdr_len) = \
-                struct.unpack("!BB", raw[offset:offset + 2])
+            next_hdr_type, hdr_len = struct.unpack("!BB", data.get(2))
             logging.info("Found extension hdr of type %u with len %u",
                          cur_hdr_type, hdr_len)
+            hdr_data = data.pop(hdr_len)
             if cur_hdr_type == ICNExtHdr.TYPE:
-                self.extension_hdrs.append(
-                    ICNExtHdr(raw[offset:offset + hdr_len]))
+                self.extension_hdrs.append(ICNExtHdr(hdr_data))
             else:
-                self.extension_hdrs.append(
-                    ExtensionHeader(raw[offset:offset + hdr_len]))
+                self.extension_hdrs.append(ExtensionHeader(hdr_data))
             cur_hdr_type = next_hdr_type
-            offset += hdr_len
-        return offset
 
     def pack(self):
         """
@@ -535,17 +508,12 @@ class SCIONPacket(PacketBase):
         """
         Parses the raw data and populates the fields accordingly.
         """
-        assert isinstance(raw, bytes)
-        dlen = len(raw)
         self.raw = raw
-        if dlen < SCIONPacket.MIN_LEN:
-            logging.warning("Data too short to parse SCION packet: "
-                            "data len %u", dlen)
-            return
-        self.hdr = SCIONHeader(raw)
-        hdr_len = len(self.hdr)
-        self.payload_len = dlen - hdr_len
-        self.payload = raw[len(self.hdr):]
+        data = Raw(raw, "SCIONPacket", self.MIN_LEN, min_=True)
+        self.hdr = SCIONHeader(data.get())
+        data.pop(len(self.hdr))
+        self.payload_len = len(data)
+        self.payload = data.pop(self.payload_len)
         self.parsed = True
 
     def pack(self):
@@ -622,6 +590,7 @@ class CertChainRequest(SCIONPacket):
     :ivar version: Target certificate chain's version.
     :type version: int
     """
+    LEN = 2 + ISD_AD.LEN * 2 + 4
 
     def __init__(self, raw=None):
         """
@@ -648,14 +617,11 @@ class CertChainRequest(SCIONPacket):
         :type raw: bytes
         """
         SCIONPacket.parse(self, raw)
-        raw = self.payload
-        (self.ingress_if, ) = struct.unpack("!H", raw[:2])
-        raw = raw[2:]
-        (self.src_isd, self.src_ad) = ISD_AD.from_raw(raw[:ISD_AD.LEN])
-        raw = raw[ISD_AD.LEN:]
-        (self.isd_id, self.ad_id) = ISD_AD.from_raw(raw[:ISD_AD.LEN])
-        raw = raw[ISD_AD.LEN:]
-        (self.version, ) = struct.unpack("!I", raw)
+        data = Raw(self.payload, "CertChainRequest", self.LEN)
+        self.ingress_if = struct.unpack("!H", data.pop(2))[0]
+        self.src_isd, self.src_ad = ISD_AD.from_raw(data.pop(ISD_AD.LEN))
+        self.isd_id, self.ad_id = ISD_AD.from_raw(data.pop(ISD_AD.LEN))
+        self.version = struct.unpack("!I", data.pop(4))[0]
 
     @classmethod
     def from_values(cls, req_type, src, ingress_if, src_isd, src_ad, isd_id,
@@ -739,10 +705,10 @@ class CertChainReply(SCIONPacket):
         :type raw: bytes
         """
         SCIONPacket.parse(self, raw)
-        (self.isd_id, self.ad_id) = ISD_AD.from_raw(self.payload[:ISD_AD.LEN])
-        (self.version, ) = \
-            struct.unpack("!I", self.payload[ISD_AD.LEN:ISD_AD.LEN + 4])
-        self.cert_chain = self.payload[self.MIN_LEN:]
+        data = Raw(self.payload, "CertChainReply", self.MIN_LEN, min_=True)
+        self.isd_id, self.ad_id = ISD_AD.from_raw(data.pop(ISD_AD.LEN))
+        self.version = struct.unpack("!I", data.pop(4))[0]
+        self.cert_chain = data.pop()
 
     @classmethod
     def from_values(cls, dst, isd_id, ad_id, version, cert_chain):
@@ -789,6 +755,7 @@ class TRCRequest(SCIONPacket):
     :ivar version: Target TRC's version.
     :type version: int
     """
+    LEN = 2 + ISD_AD.LEN + 2 + 4
 
     def __init__(self, raw=None):
         """
@@ -814,14 +781,11 @@ class TRCRequest(SCIONPacket):
         :type raw: bytes
         """
         SCIONPacket.parse(self, raw)
-        raw = self.payload
-        (self.ingress_if, ) = struct.unpack("!H", raw[:2])
-        raw = raw[2:]
-        (self.src_isd, self.src_ad) = ISD_AD.from_raw(raw[:ISD_AD.LEN])
-        raw = raw[ISD_AD.LEN:]
-        (self.isd_id, ) = struct.unpack("!H", raw[:2])
-        raw = raw[2:]
-        (self.version, ) = struct.unpack("!I", raw[:4])
+        data = Raw(self.payload, "TRCRequest", self.LEN)
+        self.ingress_if = struct.unpack("!H", data.pop(2))[0]
+        self.src_isd, self.src_ad = ISD_AD.from_raw(data.pop(ISD_AD.LEN))
+        self.isd_id = struct.unpack("!H", data.pop(2))[0]
+        self.version = struct.unpack("!I", data.pop(4))[0]
 
     @classmethod
     def from_values(cls, req_type, src, ingress_if, src_isd, src_ad, isd_id,
@@ -898,9 +862,9 @@ class TRCReply(SCIONPacket):
         :type raw: bytes
         """
         SCIONPacket.parse(self, raw)
-        (self.isd_id, self.version) = \
-            struct.unpack("!HI", self.payload[:self.MIN_LEN])
-        self.trc = self.payload[self.MIN_LEN:]
+        data = Raw(self.payload, "TRCReply", self.MIN_LEN, min_=True)
+        self.isd_id, self.version = struct.unpack("!HI", data.pop(self.MIN_LEN))
+        self.trc = data.pop()
 
     @classmethod
     def from_values(cls, dst, isd_id, version, trc):

--- a/lib/util.py
+++ b/lib/util.py
@@ -31,7 +31,13 @@ from external.stacktracer import trace_start
 
 # SCION
 from lib.defines import TOPOLOGY_PATH
-from lib.errors import SCIONIOError, SCIONJSONError
+from lib.errors import (
+    SCIONIOError,
+    SCIONIndexError,
+    SCIONJSONError,
+    SCIONParseError,
+    SCIONTypeError,
+)
 
 CERT_DIR = 'certificates'
 SIG_KEYS_DIR = 'signature_keys'
@@ -325,3 +331,99 @@ class SCIONTime(object):
         Set the method used to get time
         """
         cls._custom_time = method
+
+
+class Raw(object):
+    """
+    A class to wrap raw bytes objects
+    """
+    def __init__(self, data, desc="", len_=None, min_=False):
+        self._data = data
+        self._desc = desc
+        self._len = len_
+        self._min = min_
+        self._offset = 0
+        self.check_type()
+        self.check_len()
+
+    def check_type(self):
+        """
+        Check that the data is a `bytes` instance. If not, raise an exception.
+
+        :raises:
+            lib.errors.SCIONTypeError: data is the wrong type
+        """
+        if not isinstance(self._data, bytes):
+            raise SCIONTypeError(
+                "Error parsing raw %s: Expected %s, got %s" %
+                (self._desc, bytes, type(self._data)))
+
+    def check_len(self):
+        """
+        Check that the data is of the expected length. If not, raise an
+        exception.
+
+        :raises:
+            lib.errors.SCIONTypeError: data is the wrong length
+        """
+        if self._len is None:
+            return
+        if self._min:
+            if len(self._data) >= self._len:
+                return
+            else:
+                op = ">="
+        elif len(self._data) == self._len:
+            return
+        else:
+            op = "=="
+        raise SCIONParseError(
+            "Error parsing raw %s: Expected len %s %s, got %s" %
+            (self._desc, op, self._len, len(self._data)))
+
+    def get(self, n=None, bounds=True):
+        """
+        Return next elements from data.
+
+        If `n` is not specified, return all remaining elements of data.
+        If `n` is 1, return the next element of data (as an int).
+        If `n` is > 1, return the next `n` elements of data (as bytes).
+
+        :param n: How many elements to return (see above)
+        :param bool bounds: Perform bounds checking on access if True
+        """
+        dlen = len(self._data)
+        if n and bounds and (self._offset + n) > dlen:
+            raise SCIONIndexError("%s: Attempted to access beyond end of raw "
+                                  "data (len=%d, offset=%d, request=%d)" %
+                                  (self._desc, dlen, self._offset, n))
+        if n is None:
+            return self._data[self._offset:]
+        elif n == 1:
+            return self._data[self._offset]
+        else:
+            return self._data[self._offset:self._offset + n]
+
+    def pop(self, n=None, bounds=True):
+        """
+        Return next elements from data, and advance the internal offset.
+
+        Arguments have the same meaning as for Raw.get
+        """
+        ret = self.get(n, bounds)
+        dlen = len(self._data)
+        if n is None:
+            self._offset = dlen
+        elif n == 1:
+            self._offset += 1
+        else:
+            self._offset += n
+        if self._offset > dlen:
+            self._offset = dlen
+        return ret
+
+    def offset(self):
+        return self._offset
+
+    def __len__(self):
+        return max(0, len(self._data) - self._offset)

--- a/test/lib_packet_packet_base_test.py
+++ b/test/lib_packet_packet_base_test.py
@@ -216,10 +216,9 @@ class TestPayloadBaseParse(object):
     """
     def test_basic(self):
         payload = PayloadBase()
-        raw = [1, 2, 3, 4]
+        raw = b"asdf"
         payload.parse(raw)
         ntools.eq_(payload.raw, raw)
-        ntools.assert_is_not(payload.raw, raw)
 
 
 class TestPayloadBasePack(object):


### PR DESCRIPTION
Add lib.util.Raw, to wrap raw bytes, make offset accounting automatic,
and make parsing code much easier to follow.

All parsing errors should now raise an appropriate exception.

This follows on from #272.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/276%23issuecomment-125601429%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23issuecomment-125603756%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23issuecomment-125919917%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23discussion_r35750329%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23discussion_r35750931%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23discussion_r35750956%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23discussion_r35750993%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23discussion_r35750998%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23discussion_r35751118%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23issuecomment-125934068%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23issuecomment-125935311%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23issuecomment-125601429%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20next%20step%20would%20be%20to%20immediately%20wrap%20all%20%60bytes%60%20values%20in%20%60Raw%60%2C%20and%20only%20pass%20around%20%60Raw%60%20objects.%22%2C%20%22created_at%22%3A%20%222015-07-28T13%3A10%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20breaks%20end2end%2C%20currently%20debugging.%22%2C%20%22created_at%22%3A%20%222015-07-28T13%3A18%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Bugs%20found%20and%20fixed.%20This%20PR%20is%20ready%20for%20review%20now.%20All%20unit%20tests%20pass%2C%20end2end%20works.%22%2C%20%22created_at%22%3A%20%222015-07-29T11%3A00%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-07-29T12%3A18%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20we%20decide%20to%20go%20with%20this%20approach%2C%20LGTM%22%2C%20%22created_at%22%3A%20%222015-07-29T12%3A25%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2073672af98bb7540ef8cbcab2dd5e271a86322d58%20lib/util.py%2081%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23discussion_r35750956%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22whitespaces%20around%20%27%2B%27%22%2C%20%22created_at%22%3A%20%222015-07-29T11%3A57%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed.%22%2C%20%22created_at%22%3A%20%222015-07-29T12%3A00%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/util.py%3AL331-430%22%7D%2C%20%22Pull%2073672af98bb7540ef8cbcab2dd5e271a86322d58%20lib/util.py%20110%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23discussion_r35750931%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20know%20you%20don%27t%20like%20properties%2C%20but%20for%20consistency%20reason%20this%20should%20be%20decorated%20with%20%60%40property%60.%22%2C%20%22created_at%22%3A%20%222015-07-29T11%3A56%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%20%3AP%22%2C%20%22created_at%22%3A%20%222015-07-29T11%3A58%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/util.py%3AL331-430%22%7D%2C%20%22Pull%2073672af98bb7540ef8cbcab2dd5e271a86322d58%20lib/packet/path_mgmt.py%20253%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/276%23discussion_r35750329%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20not%20%60pop%28%29%60%3F%22%2C%20%22created_at%22%3A%20%222015-07-29T11%3A46%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%27s%20the%20only%20type%20with%20a%20known%2C%20fixed%20length.%22%2C%20%22created_at%22%3A%20%222015-07-29T11%3A57%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path_mgmt.py%3AL471-492%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/276#issuecomment-125601429'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The next step would be to immediately wrap all `bytes` values in `Raw`, and only pass around `Raw` objects.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This breaks end2end, currently debugging.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Bugs found and fixed. This PR is ready for review now. All unit tests pass, end2end works.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> If we decide to go with this approach, LGTM
- [ ] <a href='#crh-comment-Pull 73672af98bb7540ef8cbcab2dd5e271a86322d58 lib/packet/path_mgmt.py 253'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/276#discussion_r35750329'>File: lib/packet/path_mgmt.py:L471-492</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> why not `pop()`?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It's the only type with a known, fixed length.
- [ ] <a href='#crh-comment-Pull 73672af98bb7540ef8cbcab2dd5e271a86322d58 lib/util.py 110'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/276#discussion_r35750931'>File: lib/util.py:L331-430</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> I know you don't like properties, but for consistency reason this should be decorated with `@property`.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> No :P
- [ ] <a href='#crh-comment-Pull 73672af98bb7540ef8cbcab2dd5e271a86322d58 lib/util.py 81'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/276#discussion_r35750956'>File: lib/util.py:L331-430</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> whitespaces around '+'
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Fixed.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/276?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/276?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/276'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
