### PR TITLE
Remove ./scion.sh start, add ./scion.sh status

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -31,12 +31,11 @@ cmd_stop() {
     supervisor/supervisor.sh quickstop all
 }
 
-cmd_start(){
-    # placeholder function to run all init functions
-    # cmd_init
-    # cmd_topology
-    # cmd_run
-    echo "This method has not been fully implemented. Please run init, topology and run"
+cmd_status() {
+    supervisor/supervisor.sh status | grep -v RUNNING
+    # If all tasks are running, then return 0. Else return 1.
+    [ $? -eq 1 ]
+    return
 }
 
 cmd_test(){
@@ -69,8 +68,6 @@ cmd_help() {
 	echo
 	cat <<-_EOF
 	Usage:
-	    $PROGRAM start
-	        (not implemented) Performs all tasks (compile crypto lib, creates a topology, adds IP aliases, runs the network)
 	    $PROGRAM init
 	        Compile the SCION crypto library.
 	    $PROGRAM topology
@@ -79,6 +76,8 @@ cmd_help() {
 	        Run network.
 	    $PROGRAM stop
 	        Terminate this run of the SCION infrastructure.
+	    $PROGRAM status
+	        Show all non-running tasks.
 	    $PROGRAM test
 	        Run all unit tests.
 	    $PROGRAM coverage
@@ -96,7 +95,7 @@ COMMAND="$1"
 shift
 
 case "$COMMAND" in
-    coverage|help|init|lint|run|start|stop|test|topology|version)
+    coverage|help|init|lint|run|stop|status|test|topology|version)
         "cmd_$COMMAND" "$@" ;;
     *)  cmd_help ;;
 esac


### PR DESCRIPTION
./scion.sh status makes it Much simpler to see if any tasks have
crashed.

./scion.sh start doesn't do anything, and isn't needed.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/278?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/278'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
