### PR TITLE
Put supervisor log in logs/, don't restart ad_management

### DIFF
--- a/supervisor/supervisord.conf
+++ b/supervisor/supervisord.conf
@@ -19,7 +19,7 @@ port=127.0.0.1:9011        ; (ip_address:port specifier, *:port for all iface)
 ;password=123               ; (default is no password (open server))
 
 [supervisord]
-logfile=/tmp/supervisord.log ; (main log file;default $CWD/supervisord.log)
+logfile=../logs/supervisord.log ; (main log file;default $CWD/supervisord.log)
 logfile_maxbytes=50MB        ; (max main logfile bytes b4 rotation;default 50MB)
 logfile_backups=10           ; (num of main logfile rotation backups;default 10)
 loglevel=info                ; (log level;default info; others: debug,warn,trace)
@@ -54,12 +54,14 @@ serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 supervisor.ctl_factory = supervisor_quick:make_quick_controllerplugin
 
 [program:monitoring_daemon]
-command=/usr/bin/python3 ../ad_management/monitoring_daemon.py 127.0.0.1
-stdout_logfile=../logs/monitoring_daemon.log
-autostart=false
+stdout_logfile_maxbytes=0
 redirect_stderr=true
 environment=PYTHONPATH=..
-stdout_logfile_maxbytes=0
+command=/usr/bin/python3 ../ad_management/monitoring_daemon.py 127.0.0.1
+autostart=false
+autorestart=false
+startretries=0
+stdout_logfile=../logs/monitoring_daemon.log
 
 [include]
 files = ../topology/ISD*/supervisor/*.conf


### PR DESCRIPTION
Having all logs in the same place helps debugging,
and making the ad management daemon use the same supervisor config as
the rest of the processes makes for a more predictable system.
