### PR TITLE
Simplify thread_safety_net a little, extend usage

### DIFF
--- a/endhost/gateway.py
+++ b/endhost/gateway.py
@@ -33,6 +33,7 @@ from lib.defines import SCION_UDP_EH_DATA_PORT, SCION_BUFLEN
 from lib.log import init_logging
 from lib.packet.scion import SCIONPacket
 from lib.packet.scion_addr import SCIONAddr
+from lib.thread import thread_safety_net
 
 
 # Dictionary of destinations that should be reached via SCION.
@@ -79,7 +80,10 @@ class SCIONGateway(object):
         """
         Start the Gateway.
         """
-        threading.Thread(target=self.handle_ip_packets).start()
+        threading.Thread(
+            target=thread_safety_net, args=(self.handle_ip_packets,),
+            name="SCIONGateway.handle_ip_packets",
+            daemon=True).start()
         while True:
             packet, _ = self._data_socket.recvfrom(SCION_BUFLEN)
             self.handle_scion_packet(SCIONPacket(packet))

--- a/external/stacktracer.py
+++ b/external/stacktracer.py
@@ -67,7 +67,7 @@ class TraceDumper(threading.Thread):
         threading.Thread.__init__(self, name="TraceDumper")
     
     def run(self):
-        thread_safety_net("stacktracer", self._run)
+        thread_safety_net(self._run)
 
     def _run(self):
         while not self.stop_requested.isSet():

--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -436,25 +436,17 @@ class BeaconServer(SCIONElement):
         Run an instance of the Beacon Server.
         """
         threading.Thread(
-            target=thread_safety_net,
-            args=("handle_pcbs_propagation", self.handle_pcbs_propagation),
-            name="BS PCB propagation",
-            daemon=True).start()
+            target=thread_safety_net, args=(self.handle_pcbs_propagation,),
+            name="BS.handle_pcbs_propagation", daemon=True).start()
         threading.Thread(
-            target=thread_safety_net,
-            args=("register_segments", self.register_segments),
-            name="BS register segments",
-            daemon=True).start()
+            target=thread_safety_net, args=(self.register_segments,),
+            name="BS.register_segments", daemon=True).start()
         threading.Thread(
-            target=thread_safety_net,
-            args=("handle_shared_pcbs", self.handle_shared_pcbs),
-            name="BS shared pcbs",
-            daemon=True).start()
+            target=thread_safety_net, args=(self.handle_shared_pcbs,),
+            name="BS.handle_shared_pcbs", daemon=True).start()
         threading.Thread(
-            target=thread_safety_net,
-            args=("_handle_if_timeouts", self._handle_if_timeouts),
-            name="BS IF timeouts",
-            daemon=True).start()
+            target=thread_safety_net, args=(self._handle_if_timeouts,),
+            name="BS._handle_if_timeouts", daemon=True).start()
         SCIONElement.run(self)
 
     def _try_to_verify_beacon(self, pcb):

--- a/infrastructure/cert_server.py
+++ b/infrastructure/cert_server.py
@@ -520,10 +520,8 @@ class CertServer(SCIONElement):
         Run an instance of the Certificate Server.
         """
         threading.Thread(
-            target=thread_safety_net,
-            args=("handle_shared_certs", self.handle_shared_certs),
-            name="CS shared certs",
-            daemon=True).start()
+            target=thread_safety_net, args=(self.handle_shared_certs,),
+            name="CS.handle_shared_certs", daemon=True).start()
         SCIONElement.run(self)
 
 

--- a/infrastructure/router.py
+++ b/infrastructure/router.py
@@ -151,10 +151,8 @@ class Router(SCIONElement):
         Run the router threads.
         """
         threading.Thread(
-            target=thread_safety_net,
-            args=("sync_interface", self.sync_interface),
-            name="Sync Interfaces",
-            daemon=True).start()
+            target=thread_safety_net, args=(self.sync_interface,),
+            name="ER.sync_interface", daemon=True).start()
         SCIONElement.run(self)
 
     def send(self, packet, next_hop, use_local_socket=True):

--- a/lib/thread.py
+++ b/lib/thread.py
@@ -20,6 +20,7 @@ Threading utilities for SCION.
 # Stdlib
 import os
 import signal
+import threading
 
 # SCION
 from lib.log import log_exception
@@ -32,16 +33,16 @@ def kill_self():
     os.kill(os.getpid(), signal.SIGTERM)
 
 
-def thread_safety_net(name, func, *args, **kwargs):
+def thread_safety_net(func, *args, **kwargs):
     """
     Wrapper function to handle uncaught thread exceptions, log them, then kill
     the process.
 
-    :param name: thread name.
     :type name: string
     :param func: function to call
     :type func: function
     """
+    name = threading.current_thread().name
     try:
         return func(*args, **kwargs)
     except:

--- a/lib/zookeeper.py
+++ b/lib/zookeeper.py
@@ -132,9 +132,8 @@ class Zookeeper(object):
         # Use a thread to respond to state changes, as the listener callback
         # must not block.
         threading.Thread(
-            target=thread_safety_net,
-            args=("_state_handler", self._state_handler),
-            name="ZK state handler", daemon=True).start()
+            target=thread_safety_net, args=(self._state_handler,),
+            name="libZK._state_handler", daemon=True).start()
         # Listener called every time connection state changes
         self._zk.add_listener(self._state_listener)
 

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -32,6 +32,7 @@ from lib.packet.opaque_field import InfoOpaqueField, OpaqueFieldType as OFT
 from lib.packet.path import CorePath, CrossOverPath, EmptyPath, PeerPath
 from lib.packet.scion import SCIONPacket
 from lib.packet.scion_addr import SCIONAddr, ISD_AD
+from lib.thread import thread_safety_net
 
 ping_received = False
 pong_received = False
@@ -160,9 +161,11 @@ class TestSCIONDaemon(unittest.TestCase):
                 if src != dst:
                     SRC = ISD_AD(src[0], src[1])
                     DST = ISD_AD(dst[0], dst[1])
-                    threading.Thread(target=pong_app).start()
+                    threading.Thread(target=thread_safety_net, args=(pong_app,),
+                                     name="E2E.pong_app", daemon=True).start()
                     time.sleep(0.1)
-                    threading.Thread(target=ping_app).start()
+                    threading.Thread(target=thread_safety_net, args=(ping_app,),
+                                     name="E2E.ping_app", daemon=True).start()
                     print("\nTesting:", src, "->", dst)
                     for _ in range(TOUT * 10):
                         time.sleep(0.1)

--- a/test/lib_thread_test.py
+++ b/test/lib_thread_test.py
@@ -58,12 +58,13 @@ class TestThreadSafetyNet(object):
     @patch("lib.thread.kill_self", autospec=True)
     @patch("lib.thread.log_exception", autospec=True)
     def test_exception(self, log_test, kill_test):
-        ntools.assert_is_none(thread_safety_net("exp", self.exception_f))
-        log_test.assert_called_once_with("Exception in %s thread:", "exp")
+        ntools.assert_is_none(thread_safety_net(self.exception_f))
+        log_test.assert_called_once_with("Exception in %s thread:",
+                                         "MainThread")
         kill_test.assert_called_once_with()
 
     def test_no_exception(self):
-        ntools.eq_(thread_safety_net("n_exp", self.no_exception_f), "test_data")
+        ntools.eq_(thread_safety_net(self.no_exception_f), "test_data")
 
 if __name__ == "__main__":
     nose.run(defaultTest=__name__)

--- a/test/lib_zookeeper_test.py
+++ b/test/lib_zookeeper_test.py
@@ -118,9 +118,8 @@ class TestLibZookeeperInit(BaseLibZookeeper):
         self.mocks.pysemaphore.assert_called_with(value=0)
         ntools.assert_false(inst._state_event.called)
         self.mocks.pythread.assert_called_with(
-            target=self.mocks.thread_safety_net,
-            args=('_state_handler', inst._state_handler,),
-            name="ZK state handler", daemon=True)
+            target=self.mocks.thread_safety_net, args=(inst._state_handler,),
+            name="libZK._state_handler", daemon=True)
         inst._zk.add_listener.assert_called_with(inst._state_listener)
         inst._zk.start.assert_called_with()
 


### PR DESCRIPTION
There's no need to pass a name string into thread_safety_net when it can
just grab the thread name instead.

This fixes the issue where end2end would keep running even if the rest
of scion was down.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/285?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/285'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
