### PR TITLE
Restructure lib.dns exceptions a bit, add self.dns to scion_elem

### DIFF
--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -29,6 +29,7 @@ import socket
 
 # SCION
 from lib.config import Config
+from lib.dnsclient import DNSClient
 from lib.defines import SCION_BUFLEN, SCION_UDP_PORT
 from lib.packet.scion_addr import SCIONAddr
 from lib.topology import Topology
@@ -89,6 +90,8 @@ class SCIONElement(object):
             self.id = server_type
         self.addr = SCIONAddr.from_values(self.topology.isd_id,
                                           self.topology.ad_id, host_addr)
+        self.dns = DNSClient([str(s.addr) for s in self.topology.dns_servers],
+                             self.topology.dns_domain)
         if config_file:
             self.parse_config(config_file)
         self.construct_ifid2addr_map()

--- a/lib/dnsclient.py
+++ b/lib/dnsclient.py
@@ -30,23 +30,44 @@ from lib.defines import SCION_DNS_PORT
 from lib.errors import SCIONBaseError
 
 
-class DNSLibError(SCIONBaseError):
+class DNSLibBaseError(SCIONBaseError):
     """
-    DNSLibError: Base lib.dns exception
-    """
-    pass
-
-
-class DNSLibTimeout(DNSLibError):
-    """
-    DNSLibTimeout
+    Base lib.dns exception
     """
     pass
 
 
-class DNSLibNxDomain(DNSLibError):
+class DNSLibMajorError(SCIONBaseError):
     """
-    DNSLibNxDomain: name doesn't exist.
+    Base lib.dns major exception
+    """
+    pass
+
+
+class DNSLibNoServersError(DNSLibMajorError):
+    """
+    No working servers
+    """
+    pass
+
+
+class DNSLibNxDomain(DNSLibMajorError):
+    """
+    Name doesn't exist.
+    """
+    pass
+
+
+class DNSLibMinorError(SCIONBaseError):
+    """
+    Base lib.dns minor exception
+    """
+    pass
+
+
+class DNSLibTimeout(DNSLibMinorError):
+    """
+    Timeout
     """
     pass
 
@@ -88,7 +109,10 @@ class DNSClient(object):
                                 self.resolver.lifetime) from None
         except dns.resolver.NXDOMAIN:
             raise DNSLibNxDomain("Name (%s) does not exist" % qname) from None
+        except dns.resolver.NoNameservers:
+            raise DNSLibNoServersError("Unable to reach any working nameservers") \
+                from None
         except Exception as e:
-            raise DNSLibError("Unhandled exception in resolver.") from e
+            raise DNSLibMajorError("Unhandled exception in resolver.") from e
         shuffle(results)
         return [ip_address(addr) for addr in results]

--- a/test/lib_dnsclient_test.py
+++ b/test/lib_dnsclient_test.py
@@ -27,7 +27,8 @@ import nose.tools as ntools
 from lib.defines import SCION_DNS_PORT
 from lib.dnsclient import (
     DNSClient,
-    DNSLibError,
+    DNSLibMajorError,
+    DNSLibNoServersError,
     DNSLibNxDomain,
     DNSLibTimeout,
 )
@@ -108,9 +109,9 @@ class TestDNSClientQuery(object):
         for error, excp in (
             (dns.exception.Timeout, DNSLibTimeout),
             (dns.resolver.NXDOMAIN, DNSLibNxDomain),
-            (dns.resolver.YXDOMAIN, DNSLibError),
-            (dns.resolver.NoAnswer, DNSLibError),
-            (dns.resolver.NoNameservers, DNSLibError),
+            (dns.resolver.YXDOMAIN, DNSLibMajorError),
+            (dns.resolver.NoAnswer, DNSLibMajorError),
+            (dns.resolver.NoNameservers, DNSLibNoServersError),
         ):
             yield self._check_exceptions, error, excp
 


### PR DESCRIPTION
Code which uses dnsclient probably only needs to care about catching
DNSLibMinorError and DNSLibMajorError, which simplifies things a bit.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/286?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/286'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
