### PR TITLE
Make libzk's join_party more general, and add ensure_paths

### DIFF
--- a/infrastructure/dns_server.py
+++ b/infrastructure/dns_server.py
@@ -25,7 +25,6 @@ import argparse
 import binascii
 import datetime
 import logging
-import os
 import sys
 import threading
 from time import sleep
@@ -446,10 +445,9 @@ class SCIONDnsServer(SCIONElement):
         :returns:
         :rtype:
         """
-        prefix = "/ISD%d-AD%d" % (self.topology.isd_id, self.topology.ad_id)
-        path = os.path.join(prefix, type_, 'party')
-        self.zk._zk.ensure_path(path)
-        return self.zk._zk.Party(path, self.name_addrs)
+        prefix = "/ISD%d-AD%d/%s" % (self.topology.isd_id, self.topology.ad_id,
+                                     type_)
+        return self.zk.join_party(prefix=prefix)
 
     def _sync_zk_state(self):
         """

--- a/test/infrastructure_dns_server_test.py
+++ b/test/infrastructure_dns_server_test.py
@@ -309,19 +309,16 @@ class TestSCIONDnsJoinParty(BaseDNSServer):
     def test(self):
         # Setup
         server = SCIONDnsServer("srvid", self.DOMAIN, "topofile")
-        server.name_addrs = "nameaddrs"
         server.topology = MagicMock(spec_set=["isd_id", "ad_id"])
         server.topology.isd_id = 30
         server.topology.ad_id = 10
-        server.zk = MagicMock(spec_set=["_zk"])
-        server.zk._zk = MagicMock(spec_set=["Party", "ensure_path"])
-        path = "/ISD30-AD10/tst/party"
+        server.zk = MagicMock(spec_set=["join_party"])
+        prefix = "/ISD30-AD10/tst"
         # Call
         ret = server._join_party("tst")
         # Tests
-        server.zk._zk.ensure_path.assert_called_once_with(path)
-        server.zk._zk.Party.assert_called_once_with(path, "nameaddrs")
-        ntools.eq_(server.zk._zk.Party.return_value, ret)
+        server.zk.join_party.assert_called_once_with(prefix=prefix)
+        ntools.eq_(server.zk.join_party.return_value, ret)
 
 
 class TestSCIONDnsSyncZkState(BaseDNSServer):


### PR DESCRIPTION
This reduces the duplication of code in dns_server, and unifies error
handling.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/287?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/287'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
