### PR TITLE
Tell Zookeeper to use a tmpfs mount for its journal dir

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -3,6 +3,7 @@
 # Small script to fully setup environment
 
 sudo service zookeeper start
+sudo mount -t tmpfs -o size=25% none /run/shm
 
 # Can't be fixed during build due to
 # https://github.com/docker/docker/issues/6828

--- a/lib/zookeeper.py
+++ b/lib/zookeeper.py
@@ -181,7 +181,8 @@ class Zookeeper(object):
         Handles the Kazoo 'connected' event.
         """
         # Might be first connection, or reconnecting after a problem.
-        logging.debug("Connection to Zookeeper succeeded")
+        logging.debug("Connection to Zookeeper succeeded (Session: %s)",
+                      hex(self._zk.client_id[0]))
         try:
             self.ensure_path(self._prefix, abs=True)
             for path in self._ensure_paths:

--- a/scion.sh
+++ b/scion.sh
@@ -23,6 +23,9 @@ cmd_topology() {
 cmd_run() {
     echo "Running the network..."
     supervisor/supervisor.sh reload
+    for i in topology/ISD*/zookeeper/ISD*/datalog.*.sh; do
+        bash "$i"
+    done
     supervisor/supervisor.sh quickstart all
 }
 

--- a/test/lib_zookeeper_test.py
+++ b/test/lib_zookeeper_test.py
@@ -49,7 +49,8 @@ def mock_wrapper(f):
         self.mocks.add('lib.zookeeper.thread_safety_net', 'thread_safety_net')
         self.mocks.add('lib.zookeeper.kill_self', 'kill_self')
         self.mocks.start()
-        self.mocks.kclient.return_value.mock_add_spec(['Party', 'Lock'])
+        self.mocks.kclient.return_value.mock_add_spec(
+            ['Party', 'Lock', 'client_id'])
         self.mocks.kclient.return_value.Party = self.mocks.kparty
         self.mocks.kclient.return_value.Lock = self.mocks.klock
         try:

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -70,6 +70,7 @@ SIM_CONF_FILE = 'sim.conf'
 
 ZOOKEEPER_DIR = 'zookeeper'
 ZOOKEEPER_CFG = "zoo.cfg"
+ZOOKEEPER_TMPFS_DIR = "/run/shm/scion-zk"
 
 CORE_AD = 'CORE'
 INTERMEDIATE_AD = 'INTERMEDIATE'
@@ -180,13 +181,17 @@ class ConfigGenerator(object):
             return os.path.join(self.out_dir, *paths), \
                 os.path.join('..', SCRIPTS_DIR, *paths)
         gen_paths = self.path_dict(isd_id, ad_id)
+        isd_ad_str = "ISD{}-AD{}".format(isd_id, ad_id)
         p = {}
         p['base_dir_tail'] = os.path.join(
-            gen_paths['isd_name'], ZOOKEEPER_DIR,
-            "ISD{}-AD{}".format(isd_id, ad_id))
+            gen_paths['isd_name'], ZOOKEEPER_DIR, isd_ad_str)
         p['base_dir_abs'], p['base_dir_rel'] = abs_rel(p['base_dir_tail'])
         p['data_dir_abs'], p['data_dir_rel'] = abs_rel(p['base_dir_tail'],
                                                        'data.%s' % zk_id)
+        p['datalog_dir_abs'] = os.path.join(ZOOKEEPER_TMPFS_DIR, isd_ad_str,
+                                            str(zk_id))
+        p['datalog_script_abs'] = os.path.join(p['base_dir_abs'],
+                                               "datalog.%s.sh" % zk_id)
         p['cfg_abs'], p['cfg_rel'] = abs_rel(p['base_dir_tail'],
                                              'zoo.cfg.%s' % zk_id)
         p['myid_abs'] = os.path.join(p['data_dir_abs'], 'myid')
@@ -528,11 +533,16 @@ class ConfigGenerator(object):
             for s in ['tickTime', 'initLimit', 'syncLimit']:
                 text.write("%s=%s\n" % (s, self.zk_config["Default"][s]))
             text.write("dataDir=%s\n" % paths['data_dir_rel'])
+            text.write("dataLogDir=%s\n" % paths['datalog_dir_abs'])
             text.write("clientPort=%d\n" % zk_dict["ClientPort"])
             text.write("clientPortAddress=%s\n" % zk_dict["Addr"])
+            text.write("autopurge.purgeInterval=1\n")
             text.write("%s\n" % server_block)
             write_file(paths['cfg_abs'], text.getvalue())
             write_file(paths['myid_abs'], "%s\n" % zk_id)
+            write_file(paths['datalog_script_abs'],
+                       "#!/bin/bash\n"
+                       "mkdir -p %s\n" % paths['datalog_dir_abs'])
 
     def write_sim_file(self, ad_configs):
         """


### PR DESCRIPTION
This solves the performance issues ZK is having in our test environment.
4+ ZK's journalling to physical disk is enough to cause frequent
timeouts.

As the tmpfs dirs have to exist before ZK is started, i've added
datalog.X.sh scripts to the topology generation. These are run by
`scion.sh run`, and create the necessary dirs.

Docker by default provides a 64M tmpfs on /dev/shm, which isn't big
enough to be useful, so `docker/init.sh` now mounts a much bigger tmpfs
into /run/shm, which is the standard location for a tmpfs.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/288?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/288'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
