### PR TITLE
Log directly to disk

### DIFF
--- a/ad_management/monitoring_daemon.py
+++ b/ad_management/monitoring_daemon.py
@@ -330,5 +330,5 @@ class MonitoringDaemon(object):
 
 
 if __name__ == "__main__":
-    init_logging()
+    init_logging(sys.argv[2])
     MonitoringDaemon(sys.argv[1])

--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -1349,7 +1349,6 @@ def main():
     """
     Main function.
     """
-    init_logging()
     handle_signals()
     parser = argparse.ArgumentParser()
     parser.add_argument('type', choices=['core', 'local'],
@@ -1358,7 +1357,9 @@ def main():
     parser.add_argument('topo_file', help='Topology file')
     parser.add_argument('conf_file', help='AD configuration file')
     parser.add_argument('path_policy_file', help='AD path policy file')
+    parser.add_argument('log_file', help='Log file')
     args = parser.parse_args()
+    init_logging(args.log_file)
 
     if args.type == "core":
         beacon_server = CoreBeaconServer(args.server_id, args.topo_file,

--- a/infrastructure/cert_server.py
+++ b/infrastructure/cert_server.py
@@ -529,14 +529,15 @@ def main():
     """
     Main function.
     """
-    init_logging()
     handle_signals()
     parser = argparse.ArgumentParser()
     parser.add_argument('server_id', help='Server identifier')
     parser.add_argument('topo_file', help='Topology file')
     parser.add_argument('conf_file', help='AD configuration file')
     parser.add_argument('trc_file', help='TRC file')
+    parser.add_argument('log_file', help='Log file')
     args = parser.parse_args()
+    init_logging(args.log_file)
 
     cert_server = CertServer(args.server_id, args.topo_file, args.conf_file,
                              args.trc_file)

--- a/infrastructure/dns_server.py
+++ b/infrastructure/dns_server.py
@@ -499,13 +499,14 @@ def main():
     """
     Main function.
     """
-    init_logging()
     handle_signals()
     parser = argparse.ArgumentParser()
     parser.add_argument('server_id', help='Server identifier')
     parser.add_argument('domain', help='DNS Domain')
     parser.add_argument('topology', help='Topology file')
+    parser.add_argument('log_file', help='Log file')
     args = parser.parse_args()
+    init_logging(args.log_file)
 
     scion_dns_server = SCIONDnsServer(args.server_id, args.domain,
                                       args.topology)

--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -1087,7 +1087,6 @@ def main():
     """
     Main function.
     """
-    init_logging()
     handle_signals()
     parser = argparse.ArgumentParser()
     parser.add_argument('type', choices=['core', 'local'],
@@ -1095,7 +1094,9 @@ def main():
     parser.add_argument('server_id', help='Server identifier')
     parser.add_argument('topo_file', help='Topology file')
     parser.add_argument('conf_file', help='AD configuration file')
+    parser.add_argument('log_file', help='Log file')
     args = parser.parse_args()
+    init_logging(args.log_file)
 
     if args.type == "core":
         path_server = CorePathServer(args.server_id, args.topo_file,

--- a/infrastructure/router.py
+++ b/infrastructure/router.py
@@ -547,13 +547,14 @@ def main():
     """
     Initializes and starts router.
     """
-    init_logging()
     handle_signals()
     parser = argparse.ArgumentParser()
     parser.add_argument('router_id', help='Router identifier')
     parser.add_argument('topo_file', help='Topology file')
     parser.add_argument('conf_file', help='AD configuration file')
+    parser.add_argument('log_file', help='Log file')
     args = parser.parse_args()
+    init_logging(args.log_file)
 
     router = Router(args.router_id, args.topo_file, args.conf_file)
 

--- a/lib/log.py
+++ b/lib/log.py
@@ -17,15 +17,19 @@
 """
 # Stdlib
 import logging
+import logging.handlers
 import traceback
 
 # This file should not include other SCION libraries, to prevent cirular import
 # errors.
 
+#: Bytes
+LOG_MAX_SIZE = 1*1024*1024
 
-class _StreamErrorHandler(logging.StreamHandler):
+
+class _LoggingErrorHandler(logging.handlers.RotatingFileHandler):
     """
-    A logging StreamHandler that will exit the application if there's a logging
+    A logging Handler that will exit the application if there's a logging
     exception.
 
     We don't try to use the normal logging system at this point because we
@@ -51,17 +55,18 @@ class _StreamErrorHandler(logging.StreamHandler):
         raise
 
 
-def init_logging(level=logging.DEBUG):
+def init_logging(log_file, level=logging.DEBUG):
     """
     Configure logging for components (servers, routers, gateways).
 
     :param level:
     :type level:
     """
-    logging.basicConfig(level=level,
-                        handlers=[_StreamErrorHandler()],
-                        format='%(asctime)s [%(levelname)s]\t'
-                               '(%(threadName)s) %(message)s')
+    handler = _LoggingErrorHandler(log_file, maxBytes=LOG_MAX_SIZE,
+                                   encoding="utf-8")
+    logging.basicConfig(
+        level=level, handlers=[handler],
+        format='%(asctime)s [%(levelname)s] (%(threadName)s) %(message)s')
 
 
 def log_exception(msg, *args, level=logging.CRITICAL, **kwargs):

--- a/supervisor/supervisord.conf
+++ b/supervisor/supervisord.conf
@@ -57,11 +57,11 @@ supervisor.ctl_factory = supervisor_quick:make_quick_controllerplugin
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 environment=PYTHONPATH=..
-command=/usr/bin/python3 ../ad_management/monitoring_daemon.py 127.0.0.1
+command=/usr/bin/python3 ../ad_management/monitoring_daemon.py 127.0.0.1 ../logs/monitoring_daemon.log
 autostart=false
 autorestart=false
 startretries=0
-stdout_logfile=../logs/monitoring_daemon.log
+stdout_logfile=../logs/monitoring_daemon.out
 
 [include]
 files = ../topology/ISD*/supervisor/*.conf

--- a/test/lib_log_test.py
+++ b/test/lib_log_test.py
@@ -25,21 +25,23 @@ import nose.tools as ntools
 
 # SCION
 from lib.log import (
-    _StreamErrorHandler,
+    LOG_MAX_SIZE,
+    _LoggingErrorHandler,
     init_logging,
     log_exception,
 )
 from test.testcommon import SCIONTestError
 
 
-class TestStreamErrorHandlerHandleError(object):
+class TestLoggingErrorHandlerHandleError(object):
     """
-    Unit tests for lib.log._StreamErrorHandler.handleError
+    Unit tests for lib.log._LoggingErrorHandler.handleError
     """
     @patch("lib.log.traceback.format_exc", autospec=True)
-    @patch("lib.log.logging.StreamHandler", autospec=True)
-    def test(self, log_sh, format_exc):
-        handler = _StreamErrorHandler()
+    @patch("lib.log._LoggingErrorHandler.__init__", autospec=True)
+    def test(self, init, format_exc):
+        init.return_value = None
+        handler = _LoggingErrorHandler("logfile")
         handler.stream = MagicMock(spec_set=['write'])
         handler.stream.write = MagicMock(spec_set=[])
         handler.flush = MagicMock(spec_set=[])
@@ -57,23 +59,27 @@ class TestInitLogging(object):
     """
     Unit tests for lib.log.init_logging
     """
-    @patch("lib.log._StreamErrorHandler", autospec=True)
+    @patch("lib.log._LoggingErrorHandler", autospec=True)
     @patch("lib.log.logging.basicConfig", autospec=True)
-    def test(self, basic_config, stream_error_handler):
-        stream_error_handler.return_value = 'stream_error_handler'
-        init_logging(123)
-        basic_config.assert_called_once_with(level=123, handlers=[
-            'stream_error_handler'], format='%(asctime)s [%(levelname)s]\t'
-                                            '(%(threadName)s) %(message)s')
+    def test(self, basic_config, handler):
+        init_logging("logfile", 123)
+        handler.assert_called_once_with(
+            "logfile", maxBytes=LOG_MAX_SIZE, encoding="utf-8")
+        basic_config.assert_called_once_with(
+            level=123, handlers=[handler.return_value],
+            format='%(asctime)s [%(levelname)s] '
+                   '(%(threadName)s) %(message)s'
+        )
 
-    @patch("lib.log._StreamErrorHandler", autospec=True)
+    @patch("lib.log._LoggingErrorHandler", autospec=True)
     @patch("lib.log.logging.basicConfig", autospec=True)
-    def test_less_arg(self, basic_config, stream_error_handler):
-        stream_error_handler.return_value = 'stream_error_handler'
-        init_logging()
-        basic_config.assert_called_once_with(level=logging.DEBUG, handlers=[
-            'stream_error_handler'], format='%(asctime)s [%(levelname)s]\t'
-                                            '(%(threadName)s) %(message)s')
+    def test_less_arg(self, basic_config, handler):
+        init_logging("logfile")
+        basic_config.assert_called_once_with(
+            level=logging.DEBUG, handlers=[handler.return_value],
+            format='%(asctime)s [%(levelname)s] '
+                   '(%(threadName)s) %(message)s'
+        )
 
 
 class TestLogException(object):

--- a/topology/Zookeeper.log4j
+++ b/topology/Zookeeper.log4j
@@ -1,4 +1,7 @@
-log4j.rootLogger=INFO, CONSOLE
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n
+log4j.rootLogger=INFO, ROLLINGFILE
+log4j.appender.ROLLINGFILE=org.apache.log4j.RollingFileAppender
+log4j.appender.ROLLINGFILE.File=${zookeeper.log.file}
+log4j.appender.ROLLINGFILE.MaxFileSize=1MB
+log4j.appender.ROLLINGFILE.MaxBackupIndex=0
+log4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -642,27 +642,31 @@ class ConfigGenerator(object):
                             num,
                             p['topo_file_rel'],
                             p['conf_file_rel'],
-                            p['path_pol_file_rel']]
+                            p['path_pol_file_rel'],
+                            '../logs/{}.log'.format(element_name)]
             elif element_type == 'CertificateServers':
                 element_name = 'cs{}-{}-{}'.format(isd_id, ad_id, num)
                 cmd_args = ['cert_server.py',
                             num,
                             p['topo_file_rel'],
                             p['conf_file_rel'],
-                            p['trc_file_rel']]
+                            p['trc_file_rel'],
+                            '../logs/{}.log'.format(element_name)]
             elif element_type == 'PathServers':
                 element_name = 'ps{}-{}-{}'.format(isd_id, ad_id, num)
                 cmd_args = ['path_server.py',
                             element_location,
                             num,
                             p['topo_file_rel'],
-                            p['conf_file_rel']]
+                            p['conf_file_rel'],
+                            '../logs/{}.log'.format(element_name)]
             elif element_type == 'DNSServers':
                 element_name = 'ds{}-{}-{}'.format(isd_id, ad_id, num)
                 cmd_args = ['dns_server.py',
                             num,
                             str(dns_domain),
-                            p['topo_file_rel']]
+                            p['topo_file_rel'],
+                            '../logs/{}.log'.format(element_name)]
             elif element_type == 'EdgeRouters':
                 interface_dict = element_dict['Interface']
                 nbr_isd_id = interface_dict['NeighborISD']
@@ -672,7 +676,8 @@ class ConfigGenerator(object):
                 cmd_args = ['router.py',
                             num,
                             p['topo_file_rel'],
-                            p['conf_file_rel']]
+                            p['conf_file_rel'],
+                            '../logs/{}.log'.format(element_name)]
             elif element_type == 'Zookeepers':
                 if not element_dict['Manage']:
                     continue
@@ -685,6 +690,7 @@ class ConfigGenerator(object):
                 server_config['command'] = ' '.join([
                     '/usr/bin/java',
                     '-cp', class_path,
+                    '-Dzookeeper.log.file=../logs/{}.log'.format(element_name),
                     self.zk_config["Environment"]["ZOOMAIN"],
                     zk_paths["cfg_rel"]
                 ])
@@ -696,7 +702,7 @@ class ConfigGenerator(object):
                     ['/usr/bin/python3'] +
                     ['"{}"'.format(arg) for arg in cmd_args])
             server_config['stdout_logfile'] = \
-                '../logs/{}.log'.format(element_name)
+                '../logs/{}.out'.format(element_name)
 
             supervisor_config['program:' + element_name] = server_config
             program_group.append(element_name)


### PR DESCRIPTION
supervisord was causing substantial system load just reading the stdout
of all processes and logging it to disk. Also, by doing it this way we
get bounded logfile sizes (10MB).

logs/X.log -> the log file for X
logs/X.out -> the stdout/stderror of X. This is only used before logging
is set up.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/289?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/289'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
