### PR TITLE
Set logging backupCount to non-zero, so it actually rotates logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,30 +26,25 @@ Thumbs.db
 
 # SCION generated files #
 #########################
-infrastructure/__pycache__/
-lib/__pycache__/
-lib/packet/__pycache__/
+logs/*
 topology/ISD*
-topology/conf-gen
 topology/SIM
+topology/conf-gen
 traces/*
-*.crt
 
 
 # Python generated files #
 #########################
-*.pyc
+__pycache__
 
 
 # vim generated files #
 #########################
-*.swp
+.*.swp
 
 
 # Crypto library generated files #
 #########################
-*.so
-*.o
 lib/crypto/python-tweetnacl-20140309/build/
 
 

--- a/lib/log.py
+++ b/lib/log.py
@@ -24,7 +24,8 @@ import traceback
 # errors.
 
 #: Bytes
-LOG_MAX_SIZE = 1*1024*1024
+LOG_MAX_SIZE = 1 * 1024 * 1024
+LOG_BACKUP_COUNT = 1
 
 
 class _LoggingErrorHandler(logging.handlers.RotatingFileHandler):
@@ -63,7 +64,7 @@ def init_logging(log_file, level=logging.DEBUG):
     :type level:
     """
     handler = _LoggingErrorHandler(log_file, maxBytes=LOG_MAX_SIZE,
-                                   encoding="utf-8")
+                                   backupCount=1, encoding="utf-8")
     logging.basicConfig(
         level=level, handlers=[handler],
         format='%(asctime)s [%(levelname)s] (%(threadName)s) %(message)s')

--- a/test/lib_log_test.py
+++ b/test/lib_log_test.py
@@ -25,6 +25,7 @@ import nose.tools as ntools
 
 # SCION
 from lib.log import (
+    LOG_BACKUP_COUNT,
     LOG_MAX_SIZE,
     _LoggingErrorHandler,
     init_logging,
@@ -64,7 +65,8 @@ class TestInitLogging(object):
     def test(self, basic_config, handler):
         init_logging("logfile", 123)
         handler.assert_called_once_with(
-            "logfile", maxBytes=LOG_MAX_SIZE, encoding="utf-8")
+            "logfile", maxBytes=LOG_MAX_SIZE, backupCount=LOG_BACKUP_COUNT,
+            encoding="utf-8")
         basic_config.assert_called_once_with(
             level=123, handlers=[handler.return_value],
             format='%(asctime)s [%(levelname)s] '


### PR DESCRIPTION
https://docs.python.org/3/library/logging.handlers.html#logging.handlers.RotatingFileHandler
"if ... backupCount is zero, rollover never occurs." :(
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/293%23discussion_r36391108%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/293%23discussion_r36391827%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2047932771bdeb7e50d98a0f7ce7bfa29b6f09c0ad%20lib/log.py%203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/293%23discussion_r36391108%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22not%20related%20to%20this%20PR%2C%20but%20I%20think%20our%20convention%20is%3A%20%601%20%2A%201024%20%2A%201024%60%5Cr%5Cn%5Cr%5Cnotherwise%20lgtm%22%2C%20%22created_at%22%3A%20%222015-08-06T08%3A26%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%22%2C%20%22created_at%22%3A%20%222015-08-06T08%3A36%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/log.py%3AL25-32%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 47932771bdeb7e50d98a0f7ce7bfa29b6f09c0ad lib/log.py 3'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/293#discussion_r36391108'>File: lib/log.py:L25-32</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> not related to this PR, but I think our convention is: `1 * 1024 * 1024`
  otherwise lgtm
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Fixed

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/293?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/293?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/293'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
