### PR TITLE
Improve ZK party handling and reliability.

### DIFF
--- a/infrastructure/dns_server.py
+++ b/infrastructure/dns_server.py
@@ -413,37 +413,18 @@ class SCIONDnsServer(SCIONElement):
         """
 
         """
-        while True:
-            logging.debug("Waiting for ZK connection")
-            if not self.zk.wait_connected(timeout=10.0):
-                continue
-            logging.debug("Connected to ZK")
-            try:
-                for i in self.SRV_TYPES:
-                    self._parties[i] = self._setup_party(i)
-                # Join the DNS server party
-                self._parties['ds'].join()
-            except ZkConnectionLoss:
-                logging.info("Connection dropped while "
-                             "registering for parties")
-                # Clear existing parties, start again.
-                self._parties = {}
-                continue
-            else:
-                break
-
-    def _setup_party(self, type_):
-        """
-
-        :param type_:
-        :type type_:
-
-        :returns:
-        :rtype:
-        """
-        prefix = "/ISD%d-AD%d/%s" % (self.topology.isd_id, self.topology.ad_id,
-                                     type_)
-        return self.zk.party_setup(prefix=prefix, join=False)
+        logging.debug("Joining parties")
+        for type_ in self.SRV_TYPES:
+            prefix = "/ISD%d-AD%d/%s" % (self.topology.isd_id,
+                                         self.topology.ad_id, type_)
+            autojoin = False
+            # Join only the DNS service party, for the rest we just want to
+            # setup the party so we can monitor the members.
+            if type_ == "ds":
+                autojoin = True
+            self._parties[type_] = self.zk.retry(
+                "Joining %s party" % type_, self.zk.party_setup, prefix=prefix,
+                autojoin=autojoin)
 
     def _sync_zk_state(self):
         """
@@ -452,16 +433,20 @@ class SCIONDnsServer(SCIONElement):
         # Clear existing state
         self.services = {}
 
+        if not self.zk.wait_connected(timeout=10.0):
+            logging.warning("No connection to Zookeeper, can't update services")
+            return
+
         # Retrieve alive instance details from ZK for each service.
         for srv_type in self.SRV_TYPES:
             srv_domain = self.domain.add(srv_type)
             self.services[srv_domain] = []
             party = self._parties[srv_type]
             try:
-                srvs = self.zk.party_list(party)
+                srvs = party.list()
             except ZkConnectionLoss:
-                # If the connection drops, leave the instance list blank
-                continue
+                # If the connection drops, don't update
+                return
             for i in srvs:
                 self._parse_srv_inst(i, srv_domain)
 


### PR DESCRIPTION
ZK parties need to be re-joined after disconnects, which previously
needed code in everything that used lib.zookeeper. This change re-writes
how ZK parties are handled, including (optionally) autojoining them
after disconnects.

This change also includes a retry method for lib.zookeeper.Zookeeper, to
allow clients to automatically repeat interrupted operations.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/294%23discussion_r36451322%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20a2ad218c86d60eace58bbbf9d212f3c807b04a64%20infrastructure/dns_server.py%2069%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/294%23discussion_r36451322%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22dot%20missing%20at%20the%20end%22%2C%20%22created_at%22%3A%20%222015-08-06T18%3A52%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/dns_server.py%3AL433-453%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull a2ad218c86d60eace58bbbf9d212f3c807b04a64 infrastructure/dns_server.py 69'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/294#discussion_r36451322'>File: infrastructure/dns_server.py:L433-453</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> dot missing at the end

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/294?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/294?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/294'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
