### PR TITLE
Convert beacon server to using DNS

### DIFF
--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -29,9 +29,10 @@ import socket
 
 # SCION
 from lib.config import Config
-from lib.dnsclient import DNSCachingClient
+from lib.dnsclient import DNSCachingClient, DNSLibMajorError, DNSLibMinorError
 from lib.defines import SCION_BUFLEN, SCION_UDP_PORT
 from lib.packet.scion_addr import SCIONAddr
+from lib.log import log_exception
 from lib.topology import Topology
 
 
@@ -231,3 +232,16 @@ class SCIONElement(object):
         """
         for s in self._sockets:
             s.close()
+
+    def dns_query(self, qname, default):
+        """
+        Query dns for an answer. If an error occurs, return the default static
+        valid instead.
+        """
+        try:
+            return self.dns.query(qname)[0]
+        except DNSLibMinorError as e:
+            logging.warning("Falling back to static value: %s", e)
+        except DNSLibMajorError as e:
+            log_exception("Falling back to static value:")
+        return default


### PR DESCRIPTION
(Depends on #295)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/298%23discussion_r36453755%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/298%23issuecomment-128618248%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/298%23discussion_r36498718%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/298%23discussion_r36498934%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/298%23discussion_r36500275%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/298%23issuecomment-128618248%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22otherwise%20lgtm%22%2C%20%22created_at%22%3A%20%222015-08-07T07%3A04%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20483c7e6c28a4413e067f00091e58b28a102faec0%20infrastructure/scion_elem.py%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/298%23discussion_r36453755%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60...query%28query%29%5B0%5D%60%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-06T19%3A14%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%22%2C%20%22created_at%22%3A%20%222015-08-07T08%3A08%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22btw%20shouldn%27t%20./scion.sh%20lint%20catch%20that%3F%5Cn%5CnOn%207%20August%202015%20at%2010%3A08%2C%20Stephen%20Shirley%20%3Cnotifications%40github.com%3E%20wrote%3A%5Cn%5Cn%3E%20In%20infrastructure/scion_elem.py%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/298%23discussion_r36498718%3E%3A%5Cn%3E%5Cn%3E%20%3E%20%40%40%20-230%2C3%20%2B231%2C16%20%40%40%20def%20clean%28self%29%3A%5Cn%3E%20%3E%20%20%20%20%20%20%20%20%20%20%5C%22%5C%22%5C%22%5Cn%3E%20%3E%20%20%20%20%20%20%20%20%20%20for%20s%20in%20self._sockets%3A%5Cn%3E%20%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20s.close%28%29%5Cn%3E%20%3E%20%2B%5Cn%3E%20%3E%20%2B%20%20%20%20def%20dns_query%28self%2C%20query%2C%20default%29%3A%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%5C%22%5C%22%5C%22%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20Query%20dns%20for%20an%20answer.%20If%20an%20error%20occurs%2C%20return%20the%20default%20static%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20valid%20instead.%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%5C%22%5C%22%5C%22%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20try%3A%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20return%20self.dns.query%28%5C%22ps%5C%22%29%5B0%5D%5Cn%3E%5Cn%3E%20Fixed%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/298/files%23r36498718%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-07T08%3A12%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Lint%20doesn%27t%20catch%20unused%20arguments%2C%20as%20there%20are%20legitimate%20reasons%20for%20having%20them.%22%2C%20%22created_at%22%3A%20%222015-08-07T08%3A37%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/scion_elem.py%3AL231-247%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 483c7e6c28a4413e067f00091e58b28a102faec0 infrastructure/scion_elem.py 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/298#discussion_r36453755'>File: infrastructure/scion_elem.py:L231-247</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> `...query(query)[0]` ?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Fixed
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> btw shouldn't ./scion.sh lint catch that?
  On 7 August 2015 at 10:08, Stephen Shirley notifications@github.com wrote:
  > In infrastructure/scion_elem.py
  > https://github.com/netsec-ethz/scion/pull/298#discussion_r36498718:
  >
  > > @@ -230,3 +231,16 @@ def clean(self):
  > >          """
  > >          for s in self._sockets:
  > >              s.close()
  > > +
  > > +    def dns_query(self, query, default):
  > > +        """
  > > +        Query dns for an answer. If an error occurs, return the default static
  > > +        valid instead.
  > > +        """
  > > +        try:
  > > +            return self.dns.query("ps")[0]
  >
  > Fixed
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/298/files#r36498718.
  >
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Lint doesn't catch unused arguments, as there are legitimate reasons for having them.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/298#issuecomment-128618248'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> otherwise lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/298?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/298?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/298'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
