### PR TITLE
Run integration test in circleci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,14 +57,13 @@ COPY lib/crypto/python-tweetnacl-20140309/ $BASE/lib/crypto/python-tweetnacl-201
 RUN sudo chown -R scion: $HOME
 RUN ./scion.sh init
 
-RUN echo "PATH=$HOME/.local/bin:/usr/share/zookeeper/bin:$PATH" >> ~/.profile
 # Now copy over the current branch
 COPY . $BASE/
 RUN sudo chown -R scion: $HOME
 # Build topology files
 RUN ./scion.sh topology
-# Copy over init.sh:
-COPY docker/init.sh $HOME/bin/
+# Install bash config
+COPY docker/profile $HOME/.profile
 # Install basic screen config
 COPY docker/screenrc $HOME/.screenrc
 # Install ZK config
@@ -75,4 +74,5 @@ RUN sudo chown -R scion: $HOME
 # Fix some image problems:
 RUN sudo chmod g+s /usr/bin/screen
 
-CMD ["/home/scion/bin/init.sh"]
+CMD []
+ENTRYPOINT ["/bin/bash", "-l"]

--- a/circle.yml
+++ b/circle.yml
@@ -15,9 +15,11 @@ dependencies:
 
 test:
     override:
-        - ./docker.sh run bash -lc "./scion.sh coverage -v"
-        - ./docker.sh run bash -lc "./scion.sh lint"
-        - ./docker.sh run bash -lc "make -C sphinx-doc clean html"
+        - ./docker.sh run -c "./scion.sh coverage -v"
+        - ./docker.sh run -c "./scion.sh lint"
+        - ./docker.sh run -c "make -C sphinx-doc clean html"
+        - ./docker.sh run -c "docker/integration_test.sh"
     post:
         - cp -a htmlcov "$CIRCLE_ARTIFACTS"/coverage
         - cp -a sphinx-doc/_build/html "$CIRCLE_ARTIFACTS"/docs
+        - LOGS="logs.pr${CIRCLE_PR_NUMBER}.build${CIRCLE_BUILD_NUM}"; mv logs/ "$LOGS"; tar czf "${CIRCLE_ARTIFACTS}/$LOGS.tar.gz" "$LOGS"

--- a/docker.sh
+++ b/docker.sh
@@ -73,6 +73,7 @@ cmd_clean_full() {
 cmd_run() {
     local args="-i -t --privileged -h scion"
     args+=" -v $PWD/htmlcov:/home/scion/scion.git/htmlcov"
+    args+=" -v $PWD/logs:/home/scion/scion.git/logs"
     args+=" -v $PWD/sphinx-doc/_build:/home/scion/scion.git/sphinx-doc/_build"
     # Can't use --rm in circleci, their environment doesn't allow it, so it
     # just throws an error
@@ -83,7 +84,7 @@ cmd_run() {
 
 setup_volumes() {
     set -e
-    for i in htmlcov sphinx-doc/_build; do
+    for i in htmlcov logs sphinx-doc/_build; do
         mkdir -p "$i"
         # Check dir exists, and is owned by the current (effective) user. If
         # it's owned by the wrong user, the docker environment won't be able to

--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+log() {
+    echo "========> ($(date -u --rfc-3339=seconds)) $@"
+}
+
+log "Starting scion"
+./scion.sh run || exit 1
+log "Scion started"
+log "Scion status: checking"
+./scion.sh status || exit 1
+log "Scion status: healthy"
+log "Test starting: end2end"
+( cd test/integration; PYTHONPATH=../../ python3 end2end_test.py; )
+log "Test success: end2end"
+log "Scion status: checking"
+./scion.sh status
+log "Scion status: healthy"
+log "Stopping scion"
+./scion.sh stop
+log "Scion stopped"

--- a/docker/profile
+++ b/docker/profile
@@ -1,7 +1,10 @@
-#!/bin/bash
+export PATH="$HOME/.local/bin:/usr/share/zookeeper/bin:$PATH"
 
-# Small script to fully setup environment
+# Properly setup terminal to allow use of screen, etc.
+# Note: you still can't /re-attach/ to a screen session.
+exec >/dev/tty 2>/dev/tty </dev/tty
 
+# Setup environment
 sudo mount -t tmpfs -o size=25% none /run/shm
 sudo mkdir -p /run/shm/host-zk
 sudo chown zookeeper: -R /run/shm/host-zk
@@ -11,5 +14,3 @@ sudo service zookeeper start
 # https://github.com/docker/docker/issues/6828
 sudo chmod g+s /usr/bin/screen
 
-# Properly setup terminal to allow use of screen, etc:
-exec bash -l >/dev/tty 2>/dev/tty </dev/tty

--- a/docker/screenrc
+++ b/docker/screenrc
@@ -1,4 +1,4 @@
-shell -bash
+shell bash
 startup_message off
 hardstatus alwayslastline
 hardstatus string "%-w%{= BW}%50>%n %t%{-}%+w%< %=%{= ck}A%{-}"

--- a/scion.sh
+++ b/scion.sh
@@ -24,7 +24,7 @@ cmd_run() {
     echo "Running the network..."
     supervisor/supervisor.sh reload
     for i in topology/ISD*/zookeeper/ISD*/datalog.*.sh; do
-        bash "$i"
+        [ -e "$i" ] && bash "$i"
     done
     supervisor/supervisor.sh quickstart all
 }
@@ -100,5 +100,5 @@ shift
 case "$COMMAND" in
     coverage|help|init|lint|run|stop|status|test|topology|version)
         "cmd_$COMMAND" "$@" ;;
-    *)  cmd_help ;;
+    *)  cmd_help; exit 1 ;;
 esac


### PR DESCRIPTION
To make this work required a few changes.
- Changing from CMD to ENTRYPOINT in Dockerfile allows us to always run
  bash, with optional arguments.
- By moving setup from init.sh to .profile, the setup will be always be
  run.
- Making screen run a non-login bash shell, so the setup isn't redone
  everytime you open a screen window.

Also a minor change to scion.sh, so that it exits with a non-zero status
if called with an unknown command.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/299%23issuecomment-128739943%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/299%23issuecomment-129368173%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/299%23issuecomment-129480690%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/299%23issuecomment-128739943%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Depends%20on%20%23304%2C%20that%20should%20stop%20end2end%20failing.%22%2C%20%22created_at%22%3A%20%222015-08-07T15%3A41%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Depends%20on%20%23305%20%22%2C%20%22created_at%22%3A%20%222015-08-10T08%3A46%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Success%20%5C%5Co/%22%2C%20%22created_at%22%3A%20%222015-08-10T14%3A52%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/299#issuecomment-128739943'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Depends on #304, that should stop end2end failing.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Depends on #305
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Success \o/

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/299?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/299?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/299'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
