### PR TITLE
Add stop method to SCIONElement

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -23,7 +23,6 @@ import threading
 
 # SCION
 from infrastructure.scion_elem import SCIONElement
-from lib.dnsclient import DNSLibMajorError, DNSLibMinorError
 from lib.packet.path import PathCombinator
 from lib.packet.path_mgmt import (
     PathMgmtPacket,
@@ -34,7 +33,6 @@ from lib.packet.path_mgmt import (
 from lib.packet.scion_addr import ISD_AD
 from lib.path_db import PathSegmentDB
 from lib.thread import thread_safety_net
-from lib.log import log_exception
 from lib.util import update_dict
 
 WAIT_CYCLES = 3
@@ -87,6 +85,7 @@ class SCIONDaemon(SCIONElement):
                                  PST.CORE: {},
                                  PST.UP_DOWN: {}}
         self._api_socket = None
+        self.daemon_thread = None
         if run_local_api:
             self._api_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             self._api_socket.setsockopt(socket.SOL_SOCKET,
@@ -112,10 +111,19 @@ class SCIONDaemon(SCIONElement):
         :type :
         """
         sd = cls(addr, topo_file, run_local_api)
-        threading.Thread(
-            target=thread_safety_net, args=(sd.run,),
-            name="SCIONDaemon.run", daemon=True).start()
+        sd.daemon_thread = threading.Thread(
+            target=thread_safety_net, args=(sd.run,), name="SCIONDaemon.run",
+            daemon=True)
+        sd.daemon_thread.start()
         return sd
+
+    def stop(self):
+        """
+        Stop SCIONDaemon thread
+        """
+        logging.debug("Stopping SCIONDaemon")
+        super().stop()
+        self.daemon_thread.join()
 
     def _request_paths(self, ptype, dst_isd, dst_ad, src_isd=None, src_ad=None,
                        requester=None):
@@ -150,18 +158,12 @@ class SCIONDaemon(SCIONElement):
         path_request = PathMgmtPacket.from_values(PMT.REQUEST, info,
                                                   None, self.addr,
                                                   ISD_AD(src_isd, src_ad))
-        dst = self.topology.path_servers[0].addr
-        try:
-            dst = self.dns.query("ps")[0]
-        except DNSLibMinorError as e:
-            logging.warning("Falling back to topology file: %s", e)
-        except DNSLibMajorError as e:
-            log_exception("Falling back to topology file:")
+        dst = self.dns_query("ps", self.topology.path_servers[0].addr)
         self.send(path_request, dst)
         # Wait for path reply and clear us from the waiting list when we got it.
         cycle_cnt = 0
         while cycle_cnt < WAIT_CYCLES:
-            event.wait(SCIONDaemon.TIMEOUT)
+            event.wait(self.TIMEOUT)
             # Check that we got all the requested paths.
             if ((ptype == PST.UP and len(self.up_segments)) or
                 (ptype == PST.DOWN and

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -26,6 +26,7 @@ Module docstring here.
 import logging
 import select
 import socket
+import threading
 
 # SCION
 from lib.config import Config
@@ -98,6 +99,9 @@ class SCIONElement(object):
             self.parse_config(config_file)
         self.construct_ifid2addr_map()
         if not is_sim:
+            self.run_flag = threading.Event()
+            self.stopped_flag = threading.Event()
+            self.stopped_flag.set()
             self._local_socket = socket.socket(socket.AF_INET,
                                                socket.SOCK_DGRAM)
             self._local_socket.setsockopt(socket.SOL_SOCKET,
@@ -220,11 +224,24 @@ class SCIONElement(object):
         Main routine to receive packets and pass them to
         :func:`handle_request()`.
         """
-        while True:
+        self.stopped_flag.clear()
+        self.run_flag.set()
+        while self.run_flag.is_set():
             recvlist, _, _ = select.select(self._sockets, [], [])
             for sock in recvlist:
                 packet, addr = sock.recvfrom(SCION_BUFLEN)
                 self.handle_request(packet, addr, sock == self._local_socket)
+        self.stopped_flag.set()
+
+    def stop(self):
+        """
+        Shut down the daemon thread
+        """
+        # Signal that the thread should stop
+        self.run_flag.clear()
+        # Wait for the thread to finish
+        self.stopped_flag.wait()
+        self.clean()
 
     def clean(self):
         """


### PR DESCRIPTION
Add support for this to sciond, and also update sciond to use
SCIONElement.dns_query.

This makes things like end2end_test cleaner, as there aren't lots of
stale threads hanging around.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/303?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/303'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
