### PR TITLE
Retry getting paths

### DIFF
--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -32,7 +32,7 @@ from lib.packet.opaque_field import InfoOpaqueField, OpaqueFieldType as OFT
 from lib.packet.path import CorePath, CrossOverPath, EmptyPath, PeerPath
 from lib.packet.scion import SCIONPacket
 from lib.packet.scion_addr import SCIONAddr, ISD_AD
-from lib.log import init_logging
+from lib.log import init_logging, log_exception
 from lib.util import Raw
 from lib.thread import kill_self, thread_safety_net
 
@@ -49,13 +49,18 @@ def get_paths_via_api(isd, ad):
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(("127.0.0.1", 5005))
     msg = b'\x00' + ISD_AD(isd, ad).pack()
-    logging.info("Sending path request to local API.")
-    sock.sendto(msg, (SCIOND_API_HOST, SCIOND_API_PORT))
 
-    data = Raw(sock.recvfrom(SCION_BUFLEN)[0], "Path response")
-    if len(data) == 0:
-        logging.critical("Empty response from local api.")
+    for _ in range(5):
+        logging.info("Sending path request to local API.")
+        sock.sendto(msg, (SCIOND_API_HOST, SCIOND_API_PORT))
+        data = Raw(sock.recvfrom(SCION_BUFLEN)[0], "Path response")
+        if data:
+            break
+        logging.warning("Empty response from local api.")
+    else:
+        logging.critical("Unable to get path from local api.")
         kill_self()
+
     paths_hops = []
     while len(data) > 0:
         path_len = data.pop(1) * 8
@@ -81,14 +86,18 @@ class Ping(object):
     """
     Simple ping app.
     """
-    def __init__(self, src, dst):
+    def __init__(self, src, dst, token):
         self.src = src
         self.dst = dst
+        self.token = token
         self.pong_received = False
         topo_file = ("../../topology/ISD%d/topologies/ISD:%d-AD:%d.json" %
                      (src.isd, src.isd, src.ad))
         self.sd = SCIONDaemon.start(saddr, topo_file, True)  # API on
         self.get_path()
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind((str(saddr), SCION_UDP_EH_DATA_PORT))
 
     def get_path(self):
         logging.info("Sending PATH request for (%d, %d)",
@@ -103,7 +112,8 @@ class Ping(object):
 
     def send(self):
         dst = SCIONAddr.from_values(self.dst.isd, self.dst.ad, raddr)
-        spkt = SCIONPacket.from_values(self.sd.addr, dst, b"ping", self.path)
+        ping = b"ping " + self.token
+        spkt = SCIONPacket.from_values(self.sd.addr, dst, ping, self.path)
         (next_hop, port) = self.sd.get_first_hop(spkt)
         assert next_hop == self.hop
 
@@ -112,14 +122,16 @@ class Ping(object):
         self.sd.send(spkt, next_hop, port)
 
     def recv(self):
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind((str(saddr), SCION_UDP_EH_DATA_PORT))
-        packet, _ = sock.recvfrom(SCION_BUFLEN)
-        if SCIONPacket(packet).payload == b"pong":
+        packet, _ = self.sock.recvfrom(SCION_BUFLEN)
+        pong = b"pong " + self.token
+        payload = SCIONPacket(packet).payload
+        if payload == pong:
             logging.info('%s: pong received.', saddr)
             self.pong_received = True
-        sock.close()
+        else:
+            logging.error("Unexpected payload received: %s", payload)
+            kill_self()
+        self.sock.close()
         self.sd.stop()
 
 
@@ -127,12 +139,13 @@ class Pong(object):
     """
     Simple pong app.
     """
-    def __init__(self, dst):
+    def __init__(self, dst, token):
         self.dst = dst
+        self.token = token
         self.ping_received = False
         topo_file = ("../../topology/ISD%d/topologies/ISD:%d-AD:%d.json" %
                      (self.dst.isd, self.dst.isd, self.dst.ad))
-        self.sd = SCIONDaemon.start(raddr, topo_file)
+        self.sd = SCIONDaemon.start(raddr, topo_file)  # API off
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.sock.bind((str(raddr), SCION_UDP_EH_DATA_PORT))
@@ -140,12 +153,13 @@ class Pong(object):
     def run(self):
         packet, _ = self.sock.recvfrom(SCION_BUFLEN)
         spkt = SCIONPacket(packet)
-        if spkt.payload == b"ping":
+        ping = b"ping " + self.token
+        if spkt.payload == ping:
             # Reverse the packet and send "pong".
             logging.info('%s: ping received, sending pong.', raddr)
             self.ping_received = True
             spkt.hdr.reverse()
-            spkt.payload = b"pong"
+            spkt.payload = b"pong " + self.token
             (next_hop, port) = self.sd.get_first_hop(spkt)
             self.sd.send(spkt, next_hop, port)
         self.sock.close()
@@ -164,17 +178,23 @@ class TestSCIONDaemon(unittest.TestCase):
         placed in every AD from `sources`, and receiver is 127.2.26.1 from
         every AD from `destinations`.
         """
+        thread = threading.current_thread()
+        thread.name = "E2E.MainThread"
         for src in sources:
             for dst in destinations:
                 if src != dst:
                     logging.info("Testing: %s -> %s", src, dst)
                     src = ISD_AD(src[0], src[1])
                     dst = ISD_AD(dst[0], dst[1])
-                    pong_app = Pong(dst)
+                    token = (
+                        "%s-%s<->%s-%s" % (src[0], src[1], dst[0],
+                                           dst[1])
+                    ).encode("UTF-8")
+                    pong_app = Pong(dst, token)
                     threading.Thread(
                         target=thread_safety_net, args=(pong_app.run,),
                         name="E2E.pong_app", daemon=True).start()
-                    ping_app = Ping(src, dst)
+                    ping_app = Ping(src, dst, token)
                     threading.Thread(
                         target=thread_safety_net, args=(ping_app.run,),
                         name="E2E.ping_app", daemon=True).start()
@@ -182,6 +202,9 @@ class TestSCIONDaemon(unittest.TestCase):
                         time.sleep(0.1)
                         if pong_app.ping_received and ping_app.pong_received:
                             break
+                    else:
+                        logging.error("Test timed out")
+                        continue
                     self.assertTrue(pong_app.ping_received)
                     self.assertTrue(ping_app.pong_received)
 
@@ -202,4 +225,12 @@ if __name__ == "__main__":
         random.shuffle(sources)
         random.shuffle(destinations)
 
-    TestSCIONDaemon().test(sources, destinations)
+    try:
+        TestSCIONDaemon().test(sources, destinations)
+    except SystemExit:
+        logging.info("Exiting")
+        raise
+    except:
+        log_exception("Exception in main process:")
+        logging.critical("Exiting")
+        sys.exit(1)


### PR DESCRIPTION
This should insulate us reasonably well from slow startup time of scion
infrastructure.

Also:
- Add exception handling to main process
- Use unique token per test
- Setup the pong_app socket before starting the test
- Name main thread
  <a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
  <a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/305?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/305'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
  <a href='#crh-end'></a>
