### PR TITLE
Rewrite lib.zookeeper tests

### DIFF
--- a/lib/zookeeper.py
+++ b/lib/zookeeper.py
@@ -106,9 +106,32 @@ class Zookeeper(object):
         self._on_connect = on_connect
         self._on_disconnect = on_disconnect
         self._ensure_paths = ensure_paths
+        self._prefix = "/ISD%d-AD%d/%s" % (
+            self._isd_id, self._ad_id, srv_type)
+        # Keep track of our connection state
+        self._connected = threading.Event()
+        # Keep track of the kazoo lock
+        self._lock = threading.Event()
+        # Used to signal connection state changes
+        self._state_event = threading.Semaphore(value=0)
+        # Kazoo parties
+        self._parties = {}
+        # Kazoo lock (initialised later)
+        self._zk_lock = None
 
+        self._kazoo_setup(zk_hosts)
+        self._setup_state_listener()
+        self._kazoo_start()
+
+    def _kazoo_setup(self, zk_hosts):
+        """
+        Create and configure Kazoo client
+
+        :param list zk_hosts: List of Zookeeper instances to connect to, in the
+                              form of ``["host:port"..]``.
+        """
         # Disable exponential back-off
-        retry = KazooRetry(max_tries=-1, max_delay=1)
+        kretry = KazooRetry(max_tries=-1, max_delay=1)
         # Stop kazoo from drowning the log with debug spam:
         logger = logging.getLogger("KazooClient")
         logger.setLevel(logging.ERROR)
@@ -116,32 +139,15 @@ class Zookeeper(object):
         # import kazoo.loggingsupport
         # logger.setLevel(kazoo.loggingsupport.BLATHER)
 
-        self._prefix = "/ISD%d-AD%d/%s" % (self._isd_id,
-                                           self._ad_id,
-                                           srv_type)
         self._zk = KazooClient(hosts=",".join(zk_hosts),
                                timeout=self._timeout,
-                               connection_retry=retry,
+                               connection_retry=kretry,
                                logger=logger)
 
-        # Keep track of our connection state
-        self._connected = threading.Event()
-        # Kazoo party (initialised later)
-        self._parties = {}
-        # Keep track of the kazoo lock
-        self._lock = threading.Event()
-        # Kazoo lock (initialised later)
-        self._zk_lock = None
-        # Used to signal connection state changes
-        self._state_event = threading.Semaphore(value=0)
-        # Use a thread to respond to state changes, as the listener callback
-        # must not block.
-        threading.Thread(
-            target=thread_safety_net, args=(self._state_handler,),
-            name="libZK._state_handler", daemon=True).start()
-        # Listener called every time connection state changes
-        self._zk.add_listener(self._state_listener)
-
+    def _kazoo_start(self):
+        """
+        Connect the Kazoo client to Zookeeper
+        """
         logging.info("Connecting to Zookeeper")
         try:
             self._zk.start()
@@ -149,6 +155,17 @@ class Zookeeper(object):
             logging.critical(
                 "Timed out connecting to Zookeeper on startup, exiting")
             kill_self()
+
+    def _setup_state_listener(self):
+        """
+        Spawn state listener thread, to respond to state change notifications
+        from Kazoo. We use a thread, as the listener callback must not block.
+        """
+        threading.Thread(
+            target=thread_safety_net, args=(self._state_handler,),
+            name="libZK._state_handler", daemon=True).start()
+        # Listener called every time connection state changes
+        self._zk.add_listener(self._state_listener)
 
     def _state_listener(self, new_state):
         """
@@ -195,7 +212,7 @@ class Zookeeper(object):
             for party in self._parties.values():
                 party.autojoin()
         except ZkConnectionLoss:
-            return False
+            return
         self._connected.set()
         if self._on_connect:
             self._on_connect()
@@ -309,6 +326,9 @@ class Zookeeper(object):
         return ret
 
     def release_lock(self):
+        """
+        Release the lock
+        """
         self._lock.clear()
         if self.is_connected():
             try:
@@ -473,14 +493,14 @@ class ZkParty(object):
     A wrapper for a `Kazoo Party
     <https://kazoo.readthedocs.org/en/latest/api/recipe/party.html>`_.
     """
-    def __init__(self, zk, path, id_, autojoin):
+    def __init__(self, zk, path, id_, autojoin_):
         """
         :param zk: A kazoo instance
         :param str path: The absolute path of the party
         :param str id_: The service id value to use in the party
-        :param bool autojoin: Join the party automatically
+        :param bool autojoin_: Join the party automatically
         """
-        self._autojoin = autojoin
+        self._autojoin = autojoin_
         self._path = path
         try:
             self._party = zk.Party(path, id_)

--- a/test/lib_zookeeper_test.py
+++ b/test/lib_zookeeper_test.py
@@ -17,198 +17,206 @@
 """
 # Stdlib
 import logging
-from functools import wraps
 from unittest.mock import MagicMock, PropertyMock, call, patch
 
 # External packages
 import nose
 import nose.tools as ntools
+from kazoo.client import KazooState
+from kazoo.exceptions import (
+    ConnectionLoss,
+    LockTimeout,
+    NoNodeError,
+    SessionExpiredError,
+)
+from kazoo.handlers.threading import KazooTimeoutError
 from kazoo.protocol.states import ZnodeStat
 
 # SCION
-import lib.zookeeper as libzk
-from test.testcommon import MockCollection, SCIONTestError
-
-
-def mock_wrapper(f):
-    """
-    Decorator to automate the patching/unpatching of the specific objects we
-    need to mock for testing.
-    """
-    @wraps(f)
-    def wrap(self, *args, **kwargs):
-        if not hasattr(self, "mocks"):
-            self.mocks = MockCollection()
-        self.mocks.add('lib.zookeeper.KazooClient', 'kclient')
-        self.mocks.add('lib.zookeeper.KazooRetry', 'kretry')
-        self.mocks.add('kazoo.recipe.party.Party', 'kparty')
-        self.mocks.add('kazoo.recipe.lock.Lock', 'klock')
-        self.mocks.add('lib.zookeeper.threading.Thread', 'pythread')
-        self.mocks.add('lib.zookeeper.threading.Event', 'pyevent')
-        self.mocks.add('lib.zookeeper.threading.Semaphore', 'pysemaphore')
-        self.mocks.add('lib.zookeeper.thread_safety_net', 'thread_safety_net')
-        self.mocks.add('lib.zookeeper.kill_self', 'kill_self')
-        self.mocks.start()
-        self.mocks.kclient.return_value.mock_add_spec(
-            ['Party', 'Lock', 'client_id'])
-        self.mocks.kclient.return_value.Party = self.mocks.kparty
-        self.mocks.kclient.return_value.Lock = self.mocks.klock
-        try:
-            return f(self, *args, **kwargs)
-        finally:
-            if hasattr(self, "mocks"):
-                self.mocks.stop()
-                del self.mocks
-    return wrap
+from lib.thread import thread_safety_net
+from lib.zookeeper import (
+    ZkConnectionLoss,
+    ZkNoNodeError,
+    ZkParty,
+    ZkRetryLimit,
+    Zookeeper,
+)
+from test.testcommon import SCIONTestError, create_mock
 
 
 class BaseZookeeper(object):
     """
     Base class for lib.zookeeper.Zookeeper unit tests
-
-    :cvar default_args:
-    :type default_args:
-    :cvar default_hosts:
-    :type default_hosts:
-    :cvar default_retry:
-    :type default_retry:
-    :ivar mocks:
-    :type mocks:
     """
-    default_args = [1, 2, "srvname", "srvid"]
+    default_args = [1, 2, "srvtype", "srvid"]
     default_hosts = ["host1:9521", "host2:339"]
-    default_retry = "asdfas"
 
     def _init_basic_setup(self, **kwargs):
-        """
-        Initiator.
-
-        :param kwargs: keyword arguments and their values.
-        :type kwargs: dictionary
-        """
-        self.mocks.kretry.return_value = self.default_retry
         all_args = self.default_args + [self.default_hosts]
-        return libzk.Zookeeper(*all_args, **kwargs)
+        return Zookeeper(*all_args, **kwargs)
 
 
 class TestZookeeperInit(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.__init__
     """
-
-    @mock_wrapper
-    def test_basic(self):
-        """
-        Test ZK's basic functionalities.
-        """
+    @patch("lib.zookeeper.Zookeeper._kazoo_start", autospec=True)
+    @patch("lib.zookeeper.Zookeeper._setup_state_listener", autospec=True)
+    @patch("lib.zookeeper.Zookeeper._kazoo_setup", autospec=True)
+    @patch("lib.zookeeper.threading.Semaphore", autospec=True)
+    @patch("lib.zookeeper.threading.Event", autospec=True)
+    def test_full(self, event, semaphore, ksetup, listener, kstart):
         # Setup and call
-        inst = self._init_basic_setup()
+        event.side_effect = ["event0", "event1"]
+        inst = self._init_basic_setup(
+            timeout=4.5, on_connect="on_conn", on_disconnect="on_dis",
+            ensure_paths="paths")
         # Tests
-        self.mocks.kretry.assert_called_with(max_tries=-1, max_delay=1)
-        ntools.eq_(inst._prefix, "/ISD%s-AD%s/%s" % (self.default_args[0],
-                                                     self.default_args[1],
-                                                     self.default_args[2]))
-        self.mocks.kclient.assert_called_with(
-            hosts=",".join(self.default_hosts), timeout=1.0,
-            connection_retry=self.default_retry,
-            logger=logging.getLogger("KazooClient"))
-        ntools.assert_false(inst._connected.called)
+        ntools.eq_(inst._isd_id, 1)
+        ntools.eq_(inst._ad_id, 2)
+        ntools.eq_(inst._srv_id, "srvid")
+        ntools.eq_(inst._timeout, 4.5)
+        ntools.eq_(inst._on_connect, "on_conn")
+        ntools.eq_(inst._on_disconnect, "on_dis")
+        ntools.eq_(inst._ensure_paths, "paths")
+        ntools.eq_(inst._prefix, "/ISD1-AD2/srvtype")
+        ntools.eq_(inst._connected, "event0")
+        ntools.eq_(inst._lock, "event1")
+        semaphore.assert_called_once_with(value=0)
+        ntools.eq_(inst._state_event, semaphore.return_value)
         ntools.eq_(inst._parties, {})
-        ntools.assert_false(inst._lock.called)
         ntools.eq_(inst._zk_lock, None)
-        self.mocks.pysemaphore.assert_called_with(value=0)
-        ntools.assert_false(inst._state_event.called)
-        self.mocks.pythread.assert_called_with(
-            target=self.mocks.thread_safety_net, args=(inst._state_handler,),
-            name="libZK._state_handler", daemon=True)
-        inst._zk.add_listener.assert_called_with(inst._state_listener)
-        inst._zk.start.assert_called_with()
+        ksetup.assert_called_once_with(inst, self.default_hosts)
+        listener.assert_called_once_with(inst)
+        kstart.assert_called_once_with(inst)
 
-    @mock_wrapper
-    def test_timeout(self):
-        """
-        Test ZK timeout.
-        """
-        # Setup and call
-        self._init_basic_setup(timeout=4.5)
-        # Tests
-        self.mocks.kclient.assert_called_with(
-            hosts=",".join(self.default_hosts), timeout=4.5,
-            connection_retry=self.default_retry,
-            logger=logging.getLogger("KazooClient"))
-
-    @mock_wrapper
-    def test_timeout_error(self):
-        """
-        Test timeout error.
-        """
-        # Raise a TimeoutError when self._zk.start() is called in __init__
-        self.mocks.kclient.return_value.start.side_effect = \
-            libzk.KazooTimeoutError
+    @patch("lib.zookeeper.Zookeeper._kazoo_start", autospec=True)
+    @patch("lib.zookeeper.Zookeeper._setup_state_listener", autospec=True)
+    @patch("lib.zookeeper.Zookeeper._kazoo_setup", autospec=True)
+    @patch("lib.zookeeper.threading.Semaphore", autospec=True)
+    @patch("lib.zookeeper.threading.Event", autospec=True)
+    def test_defaults(self, event, semaphore, ksetup, listener, kstart):
         # Setup and call
         inst = self._init_basic_setup()
         # Tests
-        inst._zk.start.assert_called_with()
-        self.mocks.kill_self.assert_called_with()
+        ntools.eq_(inst._timeout, 1.0)
+        ntools.eq_(inst._on_connect, None)
+        ntools.eq_(inst._on_disconnect, None)
+        ntools.eq_(inst._ensure_paths, ())
+
+
+class TestZookeeperKazooSetup(BaseZookeeper):
+    """
+    Unit tests for lib.zookeeper.Zookeeper._kazoo_setup
+    """
+    @patch("lib.zookeeper.KazooClient", autospec=True)
+    @patch("lib.zookeeper.logging.getLogger", autospec=True)
+    @patch("lib.zookeeper.KazooRetry", autospec=True)
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test(self, init, kretry, getlogger, kclient):
+        # Setup
+        inst = self._init_basic_setup()
+        inst._timeout = 7.9
+        logger = create_mock(["setLevel"])
+        getlogger.return_value = logger
+        # Call
+        inst._kazoo_setup(["host0", "host1"])
+        # Tests
+        kretry.assert_called_once_with(max_tries=-1, max_delay=1)
+        getlogger.assert_called_once_with("KazooClient")
+        logger.setLevel.assert_called_once_with(logging.ERROR)
+        kclient.assert_called_once_with(
+            hosts="host0,host1", timeout=7.9,
+            connection_retry=kretry.return_value, logger=getlogger.return_value)
+        ntools.eq_(inst._zk, kclient.return_value)
+
+
+class TestZookeeperKazooStart(BaseZookeeper):
+    """
+    Unit tests for lib.zookeeper.Zookeeper._kazoo_start
+    """
+    @patch("lib.zookeeper.logging", autospec=True)
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test(self, init, logging_):
+        # Setup
+        inst = self._init_basic_setup()
+        inst._zk = create_mock(["start"])
+        # Call
+        inst._kazoo_start()
+        # Tests
+        inst._zk.start.assert_called_once_with()
+
+    @patch("lib.zookeeper.kill_self", autospec=True)
+    @patch("lib.zookeeper.logging", autospec=True)
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_timeout(self, init, logging_, kill_self):
+        # Setup
+        inst = self._init_basic_setup()
+        inst._zk = create_mock(["start"])
+        inst._zk.start.side_effect = KazooTimeoutError
+        # Call
+        inst._kazoo_start()
+        # Tests
+        kill_self.assert_called_once_with()
+
+
+class TestZookeeperSetupStateListener(BaseZookeeper):
+    """
+    Unit tests for lib.zookeeper.Zookeeper._setup_state_listener
+    """
+    @patch("lib.zookeeper.threading.Thread", autospec=True)
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test(self, init, thread):
+        # Setup
+        inst = self._init_basic_setup()
+        thread.return_value = create_mock(["start"])
+        inst._zk = create_mock(["add_listener"])
+        # Call
+        inst._setup_state_listener()
+        # Tests
+        thread.assert_called_once_with(target=thread_safety_net,
+                                       args=(inst._state_handler,),
+                                       name="libZK._state_handler", daemon=True)
+        thread.return_value.start.assert_called_once_with()
+        inst._zk.add_listener(inst._state_listener)
 
 
 class TestZookeeperStateListener(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper._state_listener
     """
-
-    @mock_wrapper
-    def test(self):
-        """
-        Test basic functionalities.
-        """
-        # Setup and call
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test(self, init):
+        # Setup
         inst = self._init_basic_setup()
-        # Call, and make sure it returns False
+        inst._state_event = create_mock(["release"])
+        # Call
         ntools.eq_(inst._state_listener("statist"), False)
         # Tests
-        inst._state_event.release.assert_called_with()
+        inst._state_event.release.assert_called_once_with()
 
 
 class TestZookeeperStateHandler(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper._state_handler
     """
-
-    def _setup(self, initial_state, new_state):
-        """
-        Initialize the ZK state.
-
-        :param initial_state:
-        :type initial_state:
-        :param new_state:
-        :type new_state:
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check(self, old_state, new_state, init):
+        # Setup
         inst = self._init_basic_setup()
+        inst._state_event = create_mock(["acquire"])
         # Setup inst._state_event to allow a single iteration of the loop
-        inst._state_event.acquire = MagicMock(spec_set=[], side_effect=[0])
+        inst._state_event.acquire.side_effect = [0]
+        inst._zk = create_mock(["state"])
         # Make inst._zk.state a PropertyMock, so we can check that it is read
         mock_state = PropertyMock(spec_set=[], return_value=new_state)
         # Required to attach a property to a mock:
         # http://www.voidspace.org.uk/python/mock/mock.html#mock.PropertyMock
         type(inst._zk).state = mock_state
-        # Mock out the state change handlers
-        inst._state_connected = MagicMock(spec_set=[])
-        inst._state_suspended = MagicMock(spec_set=[])
-        inst._state_lost = MagicMock(spec_set=[])
-        return inst
-
-    @mock_wrapper
-    def _check(self, old_state, new_state):
-        """
-        Compare ZK states.
-
-        :param old_state:
-        :type old_state:
-        :param new_state:
-        :type new_state:
-        """
-        inst = self._setup(old_state, new_state)
+        inst._zk.state = create_mock()
+        inst._state_connected = create_mock()
+        inst._state_suspended = create_mock()
+        inst._state_lost = create_mock()
         # Call
         ntools.assert_raises(StopIteration, inst._state_handler,
                              initial_state=old_state)
@@ -217,11 +225,11 @@ class TestZookeeperStateHandler(BaseZookeeper):
         if old_state == new_state:
             # In this case none of the state change handlers should be called
             pass
-        elif new_state == libzk.KazooState.CONNECTED:
+        elif new_state == KazooState.CONNECTED:
             connected = 1
-        elif new_state == libzk.KazooState.SUSPENDED:
+        elif new_state == KazooState.SUSPENDED:
             suspended = 1
-        elif new_state == libzk.KazooState.LOST:
+        elif new_state == KazooState.LOST:
             lost = 1
         else:
             raise SCIONTestError("Invalid new state")
@@ -230,17 +238,14 @@ class TestZookeeperStateHandler(BaseZookeeper):
         ntools.eq_(inst._state_lost.call_count, lost)
 
     def test(self):
-        """
-        Run main tests.
-        """
         test_inputs = (
-            (libzk.KazooState.CONNECTED, libzk.KazooState.CONNECTED),
-            ("startup", libzk.KazooState.CONNECTED),
-            (libzk.KazooState.CONNECTED, libzk.KazooState.SUSPENDED),
-            (libzk.KazooState.CONNECTED, libzk.KazooState.LOST),
-            (libzk.KazooState.SUSPENDED, libzk.KazooState.CONNECTED),
-            (libzk.KazooState.SUSPENDED, libzk.KazooState.LOST),
-            (libzk.KazooState.LOST, libzk.KazooState.CONNECTED),
+            (KazooState.CONNECTED, KazooState.CONNECTED),
+            ("startup", KazooState.CONNECTED),
+            (KazooState.CONNECTED, KazooState.SUSPENDED),
+            (KazooState.CONNECTED, KazooState.LOST),
+            (KazooState.SUSPENDED, KazooState.CONNECTED),
+            (KazooState.SUSPENDED, KazooState.LOST),
+            (KazooState.LOST, KazooState.CONNECTED),
         )
         for old_state, new_state, in test_inputs:
             yield self._check, old_state, new_state
@@ -250,72 +255,51 @@ class TestZookeeperStateConnected(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper._state_connected
     """
-
-    @mock_wrapper
-    def test_basic(self):
-        """
-        Test basic functionalities.
-        """
+    def _setup(self):
         inst = self._init_basic_setup()
-        inst.ensure_path = MagicMock(spec_set=[])
+        inst._zk = MagicMock(spec_set=["client_id"])
+        inst._zk.client_id = MagicMock(spec_set=["__getitem__"])
+        inst.ensure_path = create_mock()
+        inst._prefix = "/prefix"
+        inst._ensure_paths = ["ensure0", "ensure1"]
         inst._parties = {
-            "/patha": MagicMock(spec_set=["autojoin"]),
-            "/pathb": MagicMock(spec_set=["autojoin"]),
+            "/patha": create_mock(["autojoin"]),
+            "/pathb": create_mock(["autojoin"]),
         }
-        # Call
-        inst._state_connected()
-        # Tests
-        inst.ensure_path.assert_called_once_with(inst._prefix, abs=True)
-        inst._parties["/patha"].autojoin.assert_called_once_with()
-        inst._parties["/pathb"].autojoin.assert_called_once_with()
-        inst._connected.set.assert_called_with()
+        inst._connected = create_mock(["set"])
+        inst._on_connect = None
+        return inst
 
-    @mock_wrapper
-    def test_ensure_paths(self):
-        """
-        Test ...
-        """
-        inst = self._init_basic_setup(ensure_paths=("asfw", "weasg"))
-        inst.ensure_path = MagicMock(spec_set=[])
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_basic(self, init):
+        inst = self._setup()
         # Call
         inst._state_connected()
         # Tests
         inst.ensure_path.assert_has_calls([
-            call(inst._prefix, abs=True), call("asfw"), call("weasg")])
+            call(inst._prefix, abs=True),
+            call("ensure0"), call("ensure1")])
+        inst._parties["/patha"].autojoin.assert_called_once_with()
+        inst._parties["/pathb"].autojoin.assert_called_once_with()
+        inst._connected.set.assert_called_once_with()
 
-    @mock_wrapper
-    def test_connectionloss(self):
-        """
-        Test ...
-        """
-        inst = self._init_basic_setup()
-        # Raise ConnectionLoss when _zk.ensure_path() is called
-        inst._zk.ensure_path.side_effect = [libzk.ConnectionLoss]
-        # Call
-        ntools.assert_false(inst._state_connected())
-
-    @mock_wrapper
-    def test_sessionexpired(self):
-        """
-        Test ...
-        """
-        inst = self._init_basic_setup()
-        # Raise SessionExpiredError when _zk.ensure_path() is called
-        inst._zk.ensure_path.side_effect = [libzk.SessionExpiredError]
-        # Call
-        ntools.assert_false(inst._state_connected())
-
-    @mock_wrapper
-    def test_on_connect(self):
-        """
-        Test ...
-        """
-        on_c = MagicMock(spec_set=[])
-        inst = self._init_basic_setup(on_connect=on_c)
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_connloss(self, init):
+        inst = self._setup()
+        inst.ensure_path.side_effect = ZkConnectionLoss
         # Call
         inst._state_connected()
         # Tests
-        on_c.assert_called_with()
+        ntools.assert_false(inst._connected.called)
+
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_on_connect(self, init):
+        inst = self._setup()
+        inst._on_connect = create_mock()
+        # Call
+        inst._state_connected()
+        # Tests
+        inst._on_connect.assert_called_once_with()
 
 
 class TestZookeeperStateDisconnected(BaseZookeeper):
@@ -326,28 +310,21 @@ class TestZookeeperStateDisconnected(BaseZookeeper):
     _state_suspended and _state_lost currently have almost identical code, so
     test them both in the same way.
     """
-
-    @mock_wrapper
-    def _check(self, f_name, test_callback=False):
-        """
-        Test ...
-
-        :param f_name:
-        :type f_name:
-        :param test_callback:
-        :type test_callback:
-        """
-        on_d = None
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check(self, f_name, init, test_callback=False):
+        inst = self._init_basic_setup()
+        inst._connected = create_mock(["clear"])
+        inst._lock = create_mock(["clear"])
+        inst._on_disconnect = None
         if test_callback:
-            on_d = MagicMock(spec_set=[])
-        inst = self._init_basic_setup(on_disconnect=on_d)
+            inst._on_disconnect = create_mock()
         # Call
         getattr(inst, f_name)()
         # Tests
-        inst._connected.clear.assert_called_with()
-        inst._lock.clear.assert_called_with()
+        inst._connected.clear.assert_called_once_with()
+        inst._lock.clear.assert_called_once_with()
         if test_callback:
-            on_d.assert_called_with()
+            inst._on_disconnect.assert_called_once_with()
 
     def test(self):
         """
@@ -358,90 +335,82 @@ class TestZookeeperStateDisconnected(BaseZookeeper):
             yield self._check, f
 
 
-class TestZookeeperConnection(BaseZookeeper):
+class TestZookeeperIsConnected(BaseZookeeper):
     """
-    Unit tests for lib.zookeeper connection methods.
+    Unit tests for lib.zookeeper.Zookeeper.is_connected
     """
-
-    @mock_wrapper
-    def _is_connected_check(self, connected):
-        """
-        Test ...
-
-        :param connected:
-        :type connected:
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check(self, connected, init):
         inst = self._init_basic_setup()
+        inst._connected = create_mock(["is_set"])
         inst._connected.is_set.return_value = connected
         # Call
         ntools.eq_(inst.is_connected(), connected)
         # Tests
-        inst._connected.is_set.assert_called_with()
+        inst._connected.is_set.assert_called_once_with()
 
-    def test_is_connected(self):
-        """
-        Test ...
-        """
+    def test(self):
         for connected in True, False:
-            yield self._is_connected_check, connected
+            yield self._check, connected
 
-    @mock_wrapper
-    def _wait_connected_check(self, timeout):
-        """
-        Test ...
 
-        :param timeout:
-        :type timeout:
-        """
+class TestZookeeperWaitConnected(BaseZookeeper):
+    """
+    Unit tests for lib.zookeeper.Zookeeper.wait_connected
+    """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check(self, timeout, init):
         inst = self._init_basic_setup()
+        inst._connected = create_mock(["wait"])
         inst._connected.wait.return_value = 33
         # Call
         ntools.eq_(inst.wait_connected(timeout=timeout), 33)
         # Tests
-        inst._connected.wait.assert_called_with(timeout=timeout)
+        inst._connected.wait.assert_called_once_with(timeout=timeout)
 
-    def test_wait_connected(self):
-        """
-        Test ...
-        """
+    def test(self):
         for timeout in None, 1, 15:
-            yield self._wait_connected_check, timeout
+            yield self._check, timeout
 
 
 class TestZookeeperEnsurePath(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.ensure_path
     """
-    @mock_wrapper
-    def test_basic(self):
-        # Setup
+    def _setup(self):
         inst = self._init_basic_setup()
+        inst._prefix = "/prefix"
+        inst._zk = create_mock(["ensure_path"])
+        return inst
+
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_basic(self, init):
+        # Setup
+        inst = self._setup()
         # Call
         inst.ensure_path("pathness")
         # Tests
-        inst._zk.ensure_path.assert_called_once_with(
-            "%s/%s" % (inst._prefix, "pathness"))
+        inst._zk.ensure_path.assert_called_once_with("/prefix/pathness")
 
-    @mock_wrapper
-    def test_abs(self):
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_abs(self, init):
         # Setup
-        inst = self._init_basic_setup()
+        inst = self._setup()
         # Call
         inst.ensure_path("/path/to/stuff", abs=True)
         # Tests
-        inst._zk.ensure_path.assert_called_once_with(
-            "/path/to/stuff")
+        inst._zk.ensure_path.assert_called_once_with("/path/to/stuff")
 
-    @mock_wrapper
-    def _check_error(self, excp):
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check_error(self, excp, init):
         # Setup
-        inst = self._init_basic_setup()
+        inst = self._setup()
         inst._zk.ensure_path.side_effect = excp
         # Call
-        ntools.assert_raises(libzk.ZkConnectionLoss, inst.ensure_path, "asdwaf")
+        ntools.assert_raises(ZkConnectionLoss, inst.ensure_path, "asdwaf")
 
     def test_errors(self):
-        for excp in libzk.ConnectionLoss, libzk.SessionExpiredError:
+        for excp in ConnectionLoss, SessionExpiredError:
             yield self._check_error, excp
 
 
@@ -449,31 +418,41 @@ class TestZookeeperPartySetup(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.party_setup
     """
-    @mock_wrapper
-    def test_not_connected(self):
+    def _setup(self, connected=True):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=False)
+        inst.is_connected = create_mock()
+        inst.is_connected.return_value = connected
+        inst._prefix = "/prefix"
+        inst._zk = create_mock()
+        inst.ensure_path = create_mock()
+        inst._srv_id = "srvid"
+        inst._parties = {}
+        return inst
+
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_not_connected(self, init):
+        inst = self._setup(connected=False)
         # Call
-        ntools.assert_raises(libzk.ZkConnectionLoss, inst.party_setup)
+        ntools.assert_raises(ZkConnectionLoss, inst.party_setup)
         # Tests
         inst.is_connected.assert_called_once_with()
 
     @patch("lib.zookeeper.ZkParty", autospec=True)
-    @mock_wrapper
-    def test_basic(self, zkparty):
-        inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_basic(self, init, zkparty):
+        inst = self._setup()
         # Call
         inst.party_setup()
         # Tests
-        zkparty.assert_called_once_with(inst._zk, "%s/party" % inst._prefix,
+        inst.ensure_path.assert_called_once_with("/prefix/party", abs=True)
+        zkparty.assert_called_once_with(inst._zk, "/prefix/party",
                                         inst._srv_id, True)
+        ntools.eq_(inst._parties, {"/prefix/party": zkparty.return_value})
 
     @patch("lib.zookeeper.ZkParty", autospec=True)
-    @mock_wrapper
-    def test_full(self, zkparty):
-        inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_full(self, init, zkparty):
+        inst = self._setup()
         # Call
         inst.party_setup("/pref", False)
         # Tests
@@ -485,115 +464,93 @@ class TestZookeeperGetLock(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.get_lock
     """
-
-    @mock_wrapper
-    def test_no_lock(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_no_lock(self, init):
         inst = self._init_basic_setup()
+        inst._zk_lock = None
+        inst._prefix = "/prefix"
+        inst._zk = create_mock(["Lock"])
+        inst._srv_id = "srvid"
         # Short-circuit the rest of get_lock() by making is_connected raise
         # StopIteration.
-        inst.is_connected = MagicMock(spec_set=[], side_effect=[])
+        inst.is_connected = create_mock()
+        inst.is_connected.side_effect = []
         # Call
         ntools.assert_raises(StopIteration, inst.get_lock)
         # Tests
-        self.mocks.klock.assert_called_once_with("%s/lock" % inst._prefix,
-                                                 inst._srv_id)
+        inst._zk.Lock.assert_called_once_with("/prefix/lock", "srvid")
 
-    @mock_wrapper
-    def test_not_connected(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_not_connected(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=False)
-        inst.release_lock = MagicMock(spec_set=[])
-        inst._lock.is_set.side_effect = SCIONTestError(
-            "this should not have been reached")
+        inst._zk_lock = True
+        inst.is_connected = create_mock()
+        inst.is_connected.return_value = False
+        inst.release_lock = create_mock()
         # Call
         ntools.assert_false(inst.get_lock())
         # Tests
         inst.is_connected.assert_called_once_with()
         inst.release_lock.assert_called_once_with()
 
-    @mock_wrapper
-    def test_have_lock(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_have_lock(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
-        inst._lock.is_set.return_value = True
-        inst._zk_lock = self.mocks.klock
-        inst._zk_lock.acquire.side_effect = SCIONTestError(
-            "_zk_lock.acquire should not have been reached")
+        inst._zk_lock = True
+        inst.is_connected = create_mock()
+        inst._lock = create_mock(["is_set"])
         # Call
         ntools.assert_true(inst.get_lock())
         # Tests
         inst._lock.is_set.assert_called_once_with()
 
-    @mock_wrapper
-    def test_acquire(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_acquire(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
+        inst._zk_lock = create_mock(["acquire"])
+        inst.is_connected = create_mock()
+        inst._lock = create_mock(["is_set", "set"])
         inst._lock.is_set.return_value = False
-        inst._zk_lock = self.mocks.klock
-        inst._zk_lock.acquire.return_value = True
-        inst.have_lock = MagicMock(spec_set=[], return_value=True)
+        inst.have_lock = create_mock()
         # Call
-        ntools.assert_true(inst.get_lock())
+        ntools.eq_(inst.get_lock(), inst.have_lock.return_value)
         # Tests
         inst._zk_lock.acquire.assert_called_once_with(timeout=60.0)
         inst._lock.set.assert_called_once_with()
         inst.have_lock.assert_called_once_with()
 
-    @mock_wrapper
-    def _acquire_exception_check(self, exception):
-        """
-        Test ...
-
-        :param exception:
-        :type exception:
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check_exception(self, exception, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
-        inst._lock.is_set.return_value = False
-        inst._zk_lock = self.mocks.klock
+        inst._zk_lock = create_mock(["acquire"])
         inst._zk_lock.acquire.side_effect = exception
+        inst.is_connected = create_mock()
+        inst._lock = create_mock(["is_set"])
+        inst._lock.is_set.return_value = False
+        inst.have_lock = create_mock()
         # Call
-        ntools.assert_false(inst.get_lock())
+        ntools.eq_(inst.get_lock(), inst.have_lock.return_value)
         # Tests
         inst._zk_lock.acquire.assert_called_once_with(timeout=60.0)
 
-    def test_acquire_exceptions(self):
-        """
-        Test ...
-        """
-        for excp in (libzk.LockTimeout, libzk.ConnectionLoss,
-                     libzk.SessionExpiredError):
-            yield self._acquire_exception_check, excp
+    def test_exceptions(self):
+        for excp in (LockTimeout, ConnectionLoss,
+                     SessionExpiredError):
+            yield self._check_exception, excp
 
 
 class TestZookeeperReleaseLock(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.release_lock
     """
-
-    @mock_wrapper
-    def test_not_connected(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_not_connected(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=False)
-        inst._zk_lock = self.mocks.klock
+        inst._lock = create_mock(["clear"])
+        inst.is_connected = create_mock()
+        inst.is_connected.return_value = False
+        inst._zk_lock = create_mock(["is_acquired"])
         inst._zk_lock.is_acquired = True
-        inst._zk_lock.release.side_effect = SCIONTestError(
-            "_zk_lock.release() shouldn't have been called")
         # Call
         inst.release_lock()
         # Tests
@@ -601,63 +558,46 @@ class TestZookeeperReleaseLock(BaseZookeeper):
         inst.is_connected.assert_called_once_with()
         ntools.assert_false(inst._zk_lock.is_acquired)
 
-    @mock_wrapper
-    def test_release(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_release(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
-        inst._zk_lock = self.mocks.klock
+        inst._lock = create_mock(["clear"])
+        inst.is_connected = create_mock()
+        inst._zk_lock = create_mock(["is_acquired", "release"])
         # Call
         inst.release_lock()
         # Tests
         inst._zk_lock.release.assert_called_once_with()
 
-    @mock_wrapper
-    def _exception_check(self, exception):
-        """
-        Test ...
-
-        :param exception:
-        :type exception:
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check_exception(self, exception, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
-        inst._zk_lock = self.mocks.klock
-        inst._zk_lock.is_acquired = True
+        inst._lock = create_mock(["clear"])
+        inst.is_connected = create_mock()
+        inst._zk_lock = create_mock(["is_acquired", "release"])
         inst._zk_lock.release.side_effect = exception
+        inst._zk_lock.is_acquired = True
         # Call
         inst.release_lock()
         # Tests
         ntools.assert_false(inst._zk_lock.is_acquired)
 
     def test_exceptions(self):
-        """
-        Test ...
-        """
-        for excp in (libzk.NoNodeError, libzk.ConnectionLoss,
-                     libzk.SessionExpiredError):
-            yield self._exception_check, excp
+        for excp in (NoNodeError, ConnectionLoss,
+                     SessionExpiredError):
+            yield self._check_exception, excp
 
 
-class TestZookeeperLockUtilities(BaseZookeeper):
+class TestZookeeperHaveLock(BaseZookeeper):
     """
-    Unit tests for lib.zookeeper locking utility methods.
+    Unit tests for lib.zookeeper.Zookeeper.have_lock
     """
-
-    @mock_wrapper
-    def _have_lock_check(self, connected, have_lock):
-        """
-        Test ...
-
-        :param connected:
-        :type connected:
-        :param have_lock:
-        :type have_lock:
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check(self, connected, have_lock, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=connected)
+        inst.is_connected = create_mock()
+        inst.is_connected.return_value = connected
+        inst._lock = create_mock(["is_set"])
         inst._lock.is_set.return_value = have_lock
         expected = connected and have_lock
         # Call
@@ -667,24 +607,24 @@ class TestZookeeperLockUtilities(BaseZookeeper):
         if connected:
             inst._lock.is_set.assert_called_once_with()
 
-    def test_have_lock(self):
-        """
-        Test ...
-        """
+    def test(self):
         for connected, have_lock in (
                 (False, False),
                 (False, True),
                 (True, False),
-                (True, True)):
-            yield self._have_lock_check, connected, have_lock
+                (True, True)
+        ):
+            yield self._check, connected, have_lock
 
-    @mock_wrapper
-    def test_wait_lock(self):
-        """
-        Test ...
-        """
+
+class TestZookeeperWaitLock(BaseZookeeper):
+    """
+    Unit tests for lib.zookeeper.Zookeeper.wait_lock
+    """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test(self, init):
         inst = self._init_basic_setup()
-        inst._lock = self.mocks.pyevent
+        inst._lock = create_mock(["wait"])
         # Call
         inst.wait_lock()
         # Tests
@@ -695,344 +635,241 @@ class TestZookeeperStoreSharedItems(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.store_shared_item
     """
-
-    @mock_wrapper
-    def test_not_connected(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_not_connected(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=False)
+        inst.is_connected = create_mock()
+        inst.is_connected.return_value = False
         # Call
-        ntools.assert_raises(libzk.ZkConnectionLoss,
+        ntools.assert_raises(ZkConnectionLoss,
                              inst.store_shared_item, 'p', 'n', 'v')
         # Tests
         inst.is_connected.assert_called_once_with()
 
-    @mock_wrapper
-    def test_exists(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_exists(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
-        inst._zk.create.side_effect = SCIONTestError(
-            "_zk.create shouldn't have been called")
+        inst.is_connected = create_mock()
+        inst._prefix = "/prefix"
+        inst._zk = create_mock(["set"])
         # Call
         inst.store_shared_item('p', 'n', 'v')
         # Tests
-        inst._zk.set.assert_called_once_with("%s/p/n" % inst._prefix, "v")
+        inst._zk.set.assert_called_once_with("/prefix/p/n", "v")
 
-    @mock_wrapper
-    def _exists_exception_check(self, exception):
-        """
-        Test ...
-
-        :param exception:
-        :type exception:
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check_set_exception(self, exception, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
+        inst.is_connected = create_mock()
+        inst._prefix = "/prefix"
+        inst._zk = create_mock(["set"])
         inst._zk.set.side_effect = exception
         # Call
-        ntools.assert_raises(libzk.ZkConnectionLoss,
+        ntools.assert_raises(ZkConnectionLoss,
                              inst.store_shared_item, 'p', 'n', 'v')
         # Tests
-        inst._zk.set.assert_called_once_with("%s/p/n" % inst._prefix, "v")
+        inst._zk.set.assert_called_once_with("/prefix/p/n", "v")
 
-    def test_exists_exception(self):
-        """
-        Test ...
-        """
-        for i in libzk.ConnectionLoss, libzk.SessionExpiredError:
-            yield self._exists_exception_check, i
+    def test_set_exception(self):
+        for i in ConnectionLoss, SessionExpiredError:
+            yield self._check_set_exception, i
 
-    @mock_wrapper
-    def test_create(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_create(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
-        inst._zk.set.side_effect = libzk.NoNodeError
+        inst.is_connected = create_mock()
+        inst._prefix = "/prefix"
+        inst._zk = create_mock(["create", "set"])
+        inst._zk.set.side_effect = NoNodeError
         # Call
         inst.store_shared_item('p', 'n', 'v')
         # Tests
-        inst._zk.create.assert_called_once_with("%s/p/n" % inst._prefix, "v")
+        inst._zk.create.assert_called_once_with("/prefix/p/n", "v")
 
-    @mock_wrapper
-    def _create_exception_check(self, exception):
-        """
-        Test ...
-
-        :param exception:
-        :type exception:
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check_create_exception(self, exception, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
-        inst._zk.set.side_effect = libzk.NoNodeError
+        inst.is_connected = create_mock()
+        inst._prefix = "/prefix"
+        inst._zk = create_mock(["create", "set"])
+        inst._zk.set.side_effect = NoNodeError
         inst._zk.create.side_effect = exception
         # Call
-        ntools.assert_raises(libzk.ZkConnectionLoss,
+        ntools.assert_raises(ZkConnectionLoss,
                              inst.store_shared_item, 'p', 'n', 'v')
         # Tests
         inst._zk.create.assert_called_once_with("%s/p/n" % inst._prefix, "v")
 
     def test_create_exception(self):
-        """
-        Test ...
-        """
-        for i in libzk.ConnectionLoss, libzk.SessionExpiredError:
-            yield self._create_exception_check, i
+        for i in ConnectionLoss, SessionExpiredError:
+            yield self._check_create_exception, i
 
 
 class TestZookeeperGetSharedItem(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.get_shared_item
     """
-
-    @mock_wrapper
-    def test_not_connected(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_not_connected(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=False)
+        inst.is_connected = create_mock()
+        inst.is_connected.return_value = False
         # Call
-        ntools.assert_raises(libzk.ZkConnectionLoss,
-                             inst.get_shared_item,
+        ntools.assert_raises(ZkConnectionLoss, inst.get_shared_item,
                              "path", "entry")
         # Tests
         inst.is_connected.assert_called_once_with()
 
-    @mock_wrapper
-    def test_success(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_success(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
+        inst.is_connected = create_mock()
+        inst._prefix = "/prefix"
+        inst._zk = create_mock(["get"])
         inst._zk.get.return_value = ("nodedata", "metadata")
         # Call
         ntools.assert_equals(inst.get_shared_item("path", "entry"), "nodedata")
         # Tests
-        inst._zk.get.assert_called_once_with("%s/%s/%s" %
-                                             (inst._prefix, "path", "entry"))
+        inst._zk.get.assert_called_once_with("/prefix/path/entry")
 
-    @mock_wrapper
-    def _exception_check(self, exception, result):
-        """
-        Test ...
-
-        :param exception:
-        :type exception:
-        :param result:
-        :type result:
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check_exception(self, exception, result, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
+        inst.is_connected = create_mock()
+        inst._prefix = "/prefix"
+        inst._zk = create_mock(["get"])
         inst._zk.get.side_effect = exception
         # Call
-        ntools.assert_raises(result,
-                             inst.get_shared_item, 'path', 'entry')
-        # Tests
-        inst._zk.get.assert_called_once_with("%s/%s/%s" %
-                                             (inst._prefix, "path", "entry"))
+        ntools.assert_raises(result, inst.get_shared_item, 'path', 'entry')
 
     def test_exception(self):
-        """
-        Test ...
-        """
         for excp, result in (
-                (libzk.NoNodeError, libzk.ZkNoNodeError),
-                (libzk.ConnectionLoss, libzk.ZkConnectionLoss),
-                (libzk.SessionExpiredError, libzk.ZkConnectionLoss)):
-            yield self._exception_check, excp, result
+                (NoNodeError, ZkNoNodeError),
+                (ConnectionLoss, ZkConnectionLoss),
+                (SessionExpiredError, ZkConnectionLoss)):
+            yield self._check_exception, excp, result
 
 
 class TestZookeeperGetSharedMetadata(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.get_shared_metadata
     """
-
-    @mock_wrapper
-    def test_not_connected(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_not_connected(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=False)
-        inst._zk.get_children.side_effect = SCIONTestError(
-            "_zk.get_children should not have been reached")
+        inst.is_connected = create_mock()
+        inst.is_connected.return_value = False
         # Call
         ntools.eq_(inst.get_shared_metadata("path"), [])
         # Tests
         inst.is_connected.assert_called_once_with()
 
-    @mock_wrapper
-    def test_get(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_basic(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
+        inst.is_connected = create_mock()
+        inst._prefix = "/prefix"
+        inst._zk = create_mock(["exists", "get_children"])
         inst._zk.get_children.return_value = ["entry1", "entry2"]
         inst._zk.exists.side_effect = ["meta1", "meta2"]
         # Call
         ntools.eq_(inst.get_shared_metadata("path"),
                    [("entry1", "meta1"), ("entry2", "meta2")])
         # Tests
-        inst._zk.get_children.assert_called_once_with("%s/path" % inst._prefix)
+        inst._zk.get_children.assert_called_once_with("/prefix/path")
         inst._zk.exists.assert_has_calls([
-            call("%s/path/entry1" % inst._prefix),
-            call("%s/path/entry2" % inst._prefix)])
+            call("/prefix/path/entry1"),
+            call("/prefix/path/entry2")])
 
-    @mock_wrapper
-    def _get_children_exception_check(self, exception):
-        """
-        Test ...
-
-        :param exception:
-        :type exception:
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check_exception(self, exception, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
+        inst.is_connected = create_mock()
+        inst._prefix = "/prefix"
+        inst._zk = create_mock(["get_children"])
         inst._zk.get_children.side_effect = exception
         # Call
-        ntools.assert_raises(libzk.ZkConnectionLoss,
+        ntools.assert_raises(ZkConnectionLoss,
                              inst.get_shared_metadata, "path")
-        # Tests
-        inst._zk.get_children.assert_called_once_with("%s/path" % inst._prefix)
 
-    def test_get_children_exception(self):
-        """
-        Test ...
-        """
-        for excp in libzk.ConnectionLoss, libzk.SessionExpiredError:
-            yield self._get_children_exception_check, excp
-
-    @mock_wrapper
-    def _exists_exception_check(self, exception):
-        """
-        Test ...
-
-        :param exception:
-        :type exception:
-        """
-        inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
-        inst._zk.get_children.return_value = ["entry1", "entry2"]
-        inst._zk.exists.side_effect = exception
-        # Call
-        ntools.assert_raises(libzk.ZkConnectionLoss,
-                             inst.get_shared_metadata, "path")
-        # Tests
-        inst._zk.get_children.assert_called_once_with("%s/path" % inst._prefix)
-        inst._zk.exists.assert_called_once_with(
-            "%s/path/entry1" % inst._prefix)
-
-    def test_exists_exception(self):
-        """
-        Test ...
-        """
-        for excp in libzk.ConnectionLoss, libzk.SessionExpiredError:
-            yield self._exists_exception_check, excp
+    def test_exception(self):
+        for excp in ConnectionLoss, SessionExpiredError:
+            yield self._check_exception, excp
 
 
 class TestZookeeperExpireSharedItems(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.expire_shared_items
     """
-
-    @mock_wrapper
-    def test_not_connected(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_not_connected(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=False)
-        inst.get_shared_metadata = MagicMock(
-            spec_set=[], side_effect=SCIONTestError(
-                "get_shared_metadata shouldn't have been called"))
+        inst.is_connected = create_mock()
+        inst.is_connected.return_value = False
         # Call
         ntools.assert_is_none(inst.expire_shared_items("path", 100))
 
-    @mock_wrapper
-    def test_no_entries(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_no_entries(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
-        inst.get_shared_metadata = MagicMock(spec_set=[], return_value=[])
-        inst._zk.delete = MagicMock(
-            spec_set=[], side_effect=SCIONTestError(
-                "_zk.delete shouldn't have been called"))
+        inst.is_connected = create_mock()
+        inst.get_shared_metadata = create_mock()
+        inst.get_shared_metadata.return_value = []
         # Call
         ntools.eq_(inst.expire_shared_items("path", 100), 0)
 
-    @mock_wrapper
-    def test_expire(self):
-        """
-        Test ...
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_expire(self, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
+        inst.is_connected = create_mock()
+        inst.get_shared_metadata = create_mock()
         metadata = [
             ["entry1", MagicMock(spec_set=ZnodeStat, last_modified=1)],
             ["entry2", MagicMock(spec_set=ZnodeStat, last_modified=99)],
             ["entry3", MagicMock(spec_set=ZnodeStat, last_modified=101)],
             ["entry4", MagicMock(spec_set=ZnodeStat, last_modified=10000)],
         ]
-        inst.get_shared_metadata = MagicMock(
-            spec_set=[], return_value=metadata)
+        inst.get_shared_metadata.return_value = metadata
+        inst._zk = create_mock(["delete"])
+        inst._prefix = "/prefix"
         # Call
         ntools.eq_(inst.expire_shared_items("path", 100), 2)
         # Tests
-        inst._zk.delete.assert_has_calls([
-            call("%s/path/entry1" % inst._prefix),
-            call("%s/path/entry2" % inst._prefix)])
+        inst._zk.delete.assert_has_calls([call("/prefix/path/entry1"),
+                                          call("/prefix/path/entry2")])
 
-    @mock_wrapper
-    def _exception_check(self, exception, result):
-        """
-        Test ...
-
-        :param exception:
-        :type exception:
-        :param result:
-        :type result:
-        """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check_exception(self, exception, result, init):
         inst = self._init_basic_setup()
-        inst.is_connected = MagicMock(spec_set=[], return_value=True)
+        inst.is_connected = create_mock()
+        inst.get_shared_metadata = create_mock()
         metadata = [["entry1", MagicMock(spec_set=ZnodeStat, last_modified=1)]]
-        inst.get_shared_metadata = MagicMock(
-            spec_set=[], return_value=metadata)
+        inst.get_shared_metadata.return_value = metadata
+        inst._zk = create_mock(["delete"])
         inst._zk.delete.side_effect = exception
+        inst._prefix = "/prefix"
         # Call
         ntools.assert_raises(
             result, inst.expire_shared_items, "path", 100)
 
     def test_exceptions(self):
-        """
-        Test ...
-        """
         for excp, result in (
-                (libzk.ConnectionLoss, libzk.ZkConnectionLoss),
-                (libzk.SessionExpiredError, libzk.ZkConnectionLoss),
-                (libzk.NoNodeError, libzk.ZkNoNodeError)):
-            yield self._exception_check, excp, result
+                (NoNodeError, ZkNoNodeError),
+                (ConnectionLoss, ZkConnectionLoss),
+                (SessionExpiredError, ZkConnectionLoss),
+        ):
+            yield self._check_exception, excp, result
 
 
 class TestZookeeperRetry(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.retry
     """
-    @mock_wrapper
-    def test_basic(self):
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_basic(self, init):
         inst = self._init_basic_setup()
-        inst.wait_connected = MagicMock(spec_set=[])
-        f = MagicMock(spec_set=[])
+        inst.wait_connected = create_mock()
+        f = create_mock()
         # Call
         ntools.eq_(inst.retry("desc", f, "arg1", _timeout=5.4, kwarg1="k"),
                    f.return_value)
@@ -1040,37 +877,37 @@ class TestZookeeperRetry(BaseZookeeper):
         inst.wait_connected.assert_called_once_with(timeout=5.4)
         f.assert_called_once_with("arg1", kwarg1="k")
 
-    @mock_wrapper
-    def test_no_conn(self):
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_no_conn(self, init):
         inst = self._init_basic_setup()
-        inst.wait_connected = MagicMock(spec_set=[])
+        inst.wait_connected = create_mock()
         inst.wait_connected.return_value = False
-        f = MagicMock(spec_set=[])
+        f = create_mock()
         # Call
-        ntools.assert_raises(libzk.ZkRetryLimit, inst.retry, "desc", f)
+        ntools.assert_raises(ZkRetryLimit, inst.retry, "desc", f)
         # Tests
         inst.wait_connected.assert_has_calls([call(timeout=10.0)] * 5)
         ntools.eq_(inst.wait_connected.call_count, 5)
         ntools.assert_false(f.called)
 
-    @mock_wrapper
-    def test_no_retries(self):
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_no_retries(self, init):
         inst = self._init_basic_setup()
-        inst.wait_connected = MagicMock(spec_set=[])
+        inst.wait_connected = create_mock()
         inst.wait_connected.return_value = False
-        f = MagicMock(spec_set=[])
+        f = create_mock()
         # Call
-        ntools.assert_raises(libzk.ZkRetryLimit, inst.retry, "desc", f,
+        ntools.assert_raises(ZkRetryLimit, inst.retry, "desc", f,
                              _retries=0)
         # Tests
         inst.wait_connected.assert_called_once_with(timeout=10.0)
 
-    @mock_wrapper
-    def test_inf_retries(self):
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_inf_retries(self, init):
         inst = self._init_basic_setup()
-        inst.wait_connected = MagicMock(spec_set=[])
+        inst.wait_connected = create_mock()
         inst.wait_connected.side_effect = [False] * 20
-        f = MagicMock(spec_set=[])
+        f = create_mock()
         # Call
         ntools.assert_raises(StopIteration, inst.retry, "desc", f,
                              _retries=None)
@@ -1078,13 +915,13 @@ class TestZookeeperRetry(BaseZookeeper):
         inst.wait_connected.assert_has_calls([call(timeout=10.0)] * 21)
         ntools.eq_(inst.wait_connected.call_count, 21)
 
-    @mock_wrapper
-    def test_conn_drop(self):
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_conn_drop(self, init):
         inst = self._init_basic_setup()
-        inst.wait_connected = MagicMock(spec_set=[])
+        inst.wait_connected = create_mock()
         inst.wait_connected.return_value = True
-        f = MagicMock(spec_set=[])
-        f.side_effect = [libzk.ZkConnectionLoss, "success"]
+        f = create_mock()
+        f.side_effect = [ZkConnectionLoss, "success"]
         # Call
         ntools.eq_(inst.retry("desc", f), "success")
         # Tests
@@ -1098,9 +935,9 @@ class TestZkPartyInit(object):
     """
     @patch("lib.zookeeper.ZkParty.autojoin", autospec=True)
     def test_basic(self, autojoin):
-        zk = MagicMock(spec_set=["Party"])
+        zk = create_mock(["Party"])
         # Call
-        p = libzk.ZkParty(zk, "path", "id", "autojoin")
+        p = ZkParty(zk, "path", "id", "autojoin")
         # Tests
         ntools.eq_(p._autojoin, "autojoin")
         ntools.eq_(p._path, "path")
@@ -1110,14 +947,14 @@ class TestZkPartyInit(object):
 
     @patch("lib.zookeeper.ZkParty.autojoin", autospec=True)
     def _check_error(self, excp, autojoin):
-        zk = MagicMock(spec_set=["Party"])
+        zk = create_mock(["Party"])
         zk.Party.side_effect = excp
         # Call
-        ntools.assert_raises(libzk.ZkConnectionLoss, libzk.ZkParty, zk, "path",
+        ntools.assert_raises(ZkConnectionLoss, ZkParty, zk, "path",
                              "id", True)
 
     def test_error(self):
-        for excp in libzk.ConnectionLoss, libzk.SessionExpiredError:
+        for excp in ConnectionLoss, SessionExpiredError:
             yield self._check_error, excp
 
 
@@ -1127,9 +964,9 @@ class TestZkPartyJoin(object):
     """
     @patch("lib.zookeeper.ZkParty.__init__", autospec=True, return_value=None)
     def test_basic(self, init):
-        p = libzk.ZkParty("zk", "path", "id", "autojoin")
-        p._party = MagicMock(spec_set=["join"])
-        p.list = MagicMock(spec_set=[])
+        p = ZkParty("zk", "path", "id", "autojoin")
+        p._party = create_mock(["join"])
+        p.list = create_mock()
         # Call
         p.join()
         # Tests
@@ -1137,14 +974,14 @@ class TestZkPartyJoin(object):
 
     @patch("lib.zookeeper.ZkParty.__init__", autospec=True, return_value=None)
     def _check_error(self, excp, init):
-        p = libzk.ZkParty("zk", "path", "id", "autojoin")
-        p._party = MagicMock(spec_set=["join"])
+        p = ZkParty("zk", "path", "id", "autojoin")
+        p._party = create_mock(["join"])
         p._party.join.side_effect = excp
         # Call
-        ntools.assert_raises(libzk.ZkConnectionLoss, p.join)
+        ntools.assert_raises(ZkConnectionLoss, p.join)
 
     def test_error(self):
-        for excp in libzk.ConnectionLoss, libzk.SessionExpiredError:
+        for excp in ConnectionLoss, SessionExpiredError:
             yield self._check_error, excp
 
 
@@ -1155,9 +992,9 @@ class TestZkPartyAutoJoin(object):
     @patch("lib.zookeeper.ZkParty.list", autospec=True)
     @patch("lib.zookeeper.ZkParty.__init__", autospec=True, return_value=None)
     def test_auto(self, init, list_):
-        p = libzk.ZkParty("zk", "path", "id", "autojoin")
+        p = ZkParty("zk", "path", "id", "autojoin")
         p._autojoin = True
-        p.join = MagicMock(spec_set=[])
+        p.join = create_mock()
         p._path = "path"
         # Call
         p.autojoin()
@@ -1167,9 +1004,9 @@ class TestZkPartyAutoJoin(object):
     @patch("lib.zookeeper.ZkParty.list", autospec=True)
     @patch("lib.zookeeper.ZkParty.__init__", autospec=True, return_value=None)
     def test_noauto(self, init, list_):
-        p = libzk.ZkParty("zk", "path", "id", "autojoin")
+        p = ZkParty("zk", "path", "id", "autojoin")
         p._autojoin = False
-        p.join = MagicMock(spec_set=[])
+        p.join = create_mock()
         p._path = "path"
         # Call
         p.autojoin()
@@ -1183,7 +1020,7 @@ class TestZkPartyList(object):
     """
     @patch("lib.zookeeper.ZkParty.__init__", autospec=True, return_value=None)
     def test_basic(self, init):
-        p = libzk.ZkParty("zk", "path", "id", "autojoin")
+        p = ZkParty("zk", "path", "id", "autojoin")
         p._party = MagicMock(spec_set=["__iter__"])
         p._party.__iter__.return_value = [1, 2, 3]
         # Call
@@ -1191,14 +1028,14 @@ class TestZkPartyList(object):
 
     @patch("lib.zookeeper.ZkParty.__init__", autospec=True, return_value=None)
     def _check_error(self, excp, init):
-        p = libzk.ZkParty("zk", "path", "id", "autojoin")
-        p._party = MagicMock(spec_set=["__iter__"])
+        p = ZkParty("zk", "path", "id", "autojoin")
+        p._party = create_mock(["__iter__"])
         p._party.__iter__.side_effect = excp
         # Call
-        ntools.assert_raises(libzk.ZkConnectionLoss, p.list)
+        ntools.assert_raises(ZkConnectionLoss, p.list)
 
     def test_error(self):
-        for excp in libzk.ConnectionLoss, libzk.SessionExpiredError:
+        for excp in ConnectionLoss, SessionExpiredError:
             yield self._check_error, excp
 
 

--- a/test/testcommon.py
+++ b/test/testcommon.py
@@ -17,7 +17,7 @@
 """
 # Stdlib
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 # SCION
 from lib.errors import SCIONBaseError
@@ -89,3 +89,12 @@ class MockCollection(object):
         for name, patcher in self._patcher.items():
             patcher.stop()
             delattr(self, name)
+
+
+def create_mock(attrs=None):
+    if attrs is None:
+        attrs = []
+    m = MagicMock(spec_set=attrs)
+    for attr in attrs:
+        setattr(m, attr, MagicMock(spec_set=[]))
+    return m


### PR DESCRIPTION
Tests are now simpler, run Much faster, and can serve as decent examples
for unit testing.

Refactored Zookeeper.**init** a bit, to make it more testable.

Before: ./scion.sh test: Ran 704 tests in 8.351s
After: ./scion.sh test: Ran 703 tests in 1.979s
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/307?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/307'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
