### PR TITLE
Exit status and signal improvement

### DIFF
--- a/lib/thread.py
+++ b/lib/thread.py
@@ -28,9 +28,10 @@ from lib.log import log_exception
 
 def kill_self():
     """
-    Send SIGTERM to self, to allow quitting the process from threads.
+    Send SIGINT to self, to allow quitting the process from threads when fatal
+    errors occur.
     """
-    os.kill(os.getpid(), signal.SIGTERM)
+    os.kill(os.getpid(), signal.SIGINT)
 
 
 def thread_safety_net(func, *args, **kwargs):

--- a/lib/util.py
+++ b/lib/util.py
@@ -310,8 +310,13 @@ def _signal_handler(signum, _):
     :param signum:
     :type signum:
     """
-    logging.info("Received %s", _SIG_MAP[signum])
-    sys.exit(0)
+    text = "Received %s" % _SIG_MAP[signum]
+    if signum == signal.SIGTERM:
+        logging.info(text)
+        sys.exit(0)
+    else:
+        logging.error(text)
+        sys.exit(1)
 
 
 class SCIONTime(object):

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -33,7 +33,7 @@ from lib.packet.path import CorePath, CrossOverPath, EmptyPath, PeerPath
 from lib.packet.scion import SCIONPacket
 from lib.packet.scion_addr import SCIONAddr, ISD_AD
 from lib.log import init_logging, log_exception
-from lib.util import Raw
+from lib.util import Raw, handle_signals
 from lib.thread import kill_self, thread_safety_net
 
 saddr = IPv4Address("127.1.19.254")
@@ -210,6 +210,7 @@ class TestSCIONDaemon(unittest.TestCase):
 
 if __name__ == "__main__":
     init_logging("../../logs/end2end.log", console=True)
+    handle_signals()
     if len(sys.argv) == 3:
         isd, ad = sys.argv[1].split(',')
         sources = [(int(isd), int(ad))]

--- a/test/lib_thread_test.py
+++ b/test/lib_thread_test.py
@@ -41,7 +41,7 @@ class TestKillSelf(object):
         pid_mock.return_value = "test_pid_val"
         kill_self()
         pid_mock.assert_called_once_with()
-        kill_mock.assert_called_once_with("test_pid_val", signal.SIGTERM)
+        kill_mock.assert_called_once_with("test_pid_val", signal.SIGINT)
 
 
 class TestThreadSafetyNet(object):

--- a/test/lib_util_test.py
+++ b/test/lib_util_test.py
@@ -17,6 +17,7 @@
 """
 # Stdlib
 import builtins
+from signal import SIGUSR1, SIGTERM
 from unittest.mock import patch, call, mock_open, MagicMock
 
 # External packages
@@ -324,9 +325,16 @@ class TestSignalHandler(object):
     @patch("lib.util.sys.exit", autospec=True)
     @patch("lib.util.logging.info", autospec=True)
     def test_basic(self, info, exit):
-        _signal_handler(1, 2)
-        info.assert_called_once_with("Received %s", _SIG_MAP[1])
+        _signal_handler(SIGTERM, "")
+        ntools.ok_(info.called)
         exit.assert_called_once_with(0)
+
+    @patch("lib.util.sys.exit", autospec=True)
+    @patch("lib.util.logging.error", autospec=True)
+    def test_error(self, error, exit):
+        _signal_handler(SIGUSR1, "")
+        ntools.ok_(error.called)
+        exit.assert_called_once_with(1)
 
 
 class TestSCIONTimeGetTime(object):


### PR DESCRIPTION
- Use SIGINT to signal there's an error.
- Check errors properly in integration_test.sh
- Setup signal handling in end2end
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/314%23issuecomment-130316572%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23discussion_r36856803%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23discussion_r36856901%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23discussion_r36856993%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23discussion_r36863203%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23discussion_r36863270%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23discussion_r36867900%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23discussion_r36867901%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23discussion_r36867902%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23issuecomment-130326885%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23issuecomment-130354859%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23issuecomment-130316572%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Tests%20failed%20due%20to%20%23316.%22%2C%20%22created_at%22%3A%20%222015-08-12T14%3A07%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-08-12T14%3A44%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Tests%20fixed%20now%2C%20merging.%22%2C%20%22created_at%22%3A%20%222015-08-12T15%3A58%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2007cd74773a5ac9e3dbb1a71595823342f5d77c92%20test/lib_util_test.py%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23discussion_r36856993%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22SIGINT%20again%3F%20and%20for%20the%20import%3F%22%2C%20%22created_at%22%3A%20%222015-08-12T13%3A10%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-12T14%3A44%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_util_test.py%3AL311-328%22%7D%2C%20%22Pull%2007cd74773a5ac9e3dbb1a71595823342f5d77c92%20lib/util.py%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23discussion_r36856901%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22SIGINT%3F%22%2C%20%22created_at%22%3A%20%222015-08-12T13%3A09%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60SIGTERM%60%20is%20the%20normal%20shutdown%20signal%2C%20sent%20from%20supervisor.%20Anything%20else%20is%20an%20error%2C%20and%20is%20handled%20differently.%20This%20is%20why%20%60kill_self%60%20now%20sends%20%60SIGINT%60%20instead.%22%2C%20%22created_at%22%3A%20%222015-08-12T14%3A06%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-12T14%3A44%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/util.py%3AL303-316%22%7D%2C%20%22Pull%2007cd74773a5ac9e3dbb1a71595823342f5d77c92%20lib/thread.py%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/314%23discussion_r36856803%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22SIGINT%22%2C%20%22created_at%22%3A%20%222015-08-12T13%3A08%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%22%2C%20%22created_at%22%3A%20%222015-08-12T14%3A07%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-12T14%3A44%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/thread.py%3AL30-37%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/314#issuecomment-130316572'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Tests failed due to #316.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Tests fixed now, merging.
- [x] <a href='#crh-comment-Pull 07cd74773a5ac9e3dbb1a71595823342f5d77c92 lib/thread.py 2'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/314#discussion_r36856803'>File: lib/thread.py:L30-37</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> SIGINT
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Fixed
- [x] <a href='#crh-comment-Pull 07cd74773a5ac9e3dbb1a71595823342f5d77c92 lib/util.py 7'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/314#discussion_r36856901'>File: lib/util.py:L303-316</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> SIGINT?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `SIGTERM` is the normal shutdown signal, sent from supervisor. Anything else is an error, and is handled differently. This is why `kill_self` now sends `SIGINT` instead.
- [x] <a href='#crh-comment-Pull 07cd74773a5ac9e3dbb1a71595823342f5d77c92 test/lib_util_test.py 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/314#discussion_r36856993'>File: test/lib_util_test.py:L311-328</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> SIGINT again? and for the import?

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/314?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/314?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/314'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
