### PR TITLE
Populate /etc/hosts in docker with dns servers

### DIFF
--- a/docker/profile
+++ b/docker/profile
@@ -10,6 +10,10 @@ sudo mkdir -p /run/shm/host-zk
 sudo chown zookeeper: -R /run/shm/host-zk
 sudo service zookeeper start
 
+cat /etc/hosts topology/ISD*/hosts > /tmp/hosts
+sudo umount /etc/hosts
+sudo mv /tmp/hosts /etc/hosts
+
 # Can't be fixed during build due to
 # https://github.com/docker/docker/issues/6828
 sudo chmod g+s /usr/bin/screen


### PR DESCRIPTION
This makes it much easier to manually test dns, investiage service
discovery, etc.

$ dig -p 30053 +short @ds.ad13.isd1.scion ps.ad13.isd1.scion
127.0.0.132

Note - this only works in docker, as changing /etc/hosts on a real
machine is far too dangerous.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/320?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/320'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
