### PR TITLE
Stop hard-coding service names everywhere

### DIFF
--- a/ad_management/monitoring_daemon.py
+++ b/ad_management/monitoring_daemon.py
@@ -43,7 +43,12 @@ from ad_management.common import (
     UPDATE_SCRIPT_PATH,
 )
 from ad_management.secure_rpc_server import XMLRPCServerTLS
-from lib.defines import PROJECT_ROOT
+from lib.defines import (
+    BEACON_SERVICE,
+    CERTIFICATE_SERVICE,
+    PATH_SERVICE,
+    PROJECT_ROOT,
+)
 from lib.log import init_logging
 from topology.generator import ConfigGenerator
 
@@ -306,7 +311,8 @@ class MonitoringDaemon(object):
 
         Get the id of the current master process for a given server type.
         """
-        if server_type not in ['bs', 'cs', 'ps']:
+        if server_type not in [BEACON_SERVICE, CERTIFICATE_SERVICE,
+                               PATH_SERVICE]:
             return response_failure('Invalid server type')
         kc = KazooClient(hosts="localhost:2181")
         lock_path = '/ISD{}-AD{}/{}/lock'.format(isd_id, ad_id, server_type)

--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -23,6 +23,7 @@ import threading
 
 # SCION
 from infrastructure.scion_elem import SCIONElement
+from lib.defines import PATH_SERVICE
 from lib.packet.path import PathCombinator
 from lib.packet.path_mgmt import (
     PathMgmtPacket,
@@ -158,7 +159,7 @@ class SCIONDaemon(SCIONElement):
         path_request = PathMgmtPacket.from_values(PMT.REQUEST, info,
                                                   None, self.addr,
                                                   ISD_AD(src_isd, src_ad))
-        dst = self.dns_query("ps", self.topology.path_servers[0].addr)
+        dst = self.dns_query(PATH_SERVICE, self.topology.path_servers[0].addr)
         self.send(path_request, dst)
         # Wait for path reply and clear us from the waiting list when we got it.
         cycle_cnt = 0

--- a/infrastructure/cert_server.py
+++ b/infrastructure/cert_server.py
@@ -29,7 +29,7 @@ import time
 # SCION
 from infrastructure.scion_elem import SCIONElement
 from lib.crypto.certificate import CertificateChain, TRC
-from lib.defines import SCION_UDP_PORT
+from lib.defines import CERTIFICATE_SERVICE, SCION_UDP_PORT
 from lib.log import init_logging, log_exception
 from lib.packet.scion import (
     CertChainReply,
@@ -77,8 +77,9 @@ class CertServer(SCIONElement):
         :param is_sim: running in simulator
         :type is_sim: bool
         """
-        SCIONElement.__init__(self, "cs", topo_file, server_id=server_id,
-                              config_file=config_file, is_sim=is_sim)
+        SCIONElement.__init__(self, CERTIFICATE_SERVICE, topo_file,
+                              server_id=server_id, config_file=config_file,
+                              is_sim=is_sim)
         self.trc = TRC(trc_file)
         self.cert_chain_requests = collections.defaultdict(list)
         self.trc_requests = collections.defaultdict(list)
@@ -95,7 +96,8 @@ class CertServer(SCIONElement):
             # incoming cert chains and TRCs
             self._state_synced = threading.Event()
             self.zk = Zookeeper(self.topology.isd_id, self.topology.ad_id,
-                                "cs", name_addrs, self.topology.zookeepers,
+                                CERTIFICATE_SERVICE, name_addrs,
+                                self.topology.zookeepers,
                                 ensure_paths=(self.ZK_CERT_CHAIN_CACHE_PATH,
                                               self.ZK_TRC_CACHE_PATH,))
             self.zk.retry("Joining party", self.zk.party_setup)

--- a/infrastructure/dns_server.py
+++ b/infrastructure/dns_server.py
@@ -41,7 +41,13 @@ from dnslib.server import (
 
 # SCION
 from infrastructure.scion_elem import SCIONElement
-from lib.defines import SCION_DNS_PORT
+from lib.defines import (
+    BEACON_SERVICE,
+    CERTIFICATE_SERVICE,
+    DNS_SERVICE,
+    PATH_SERVICE,
+    SCION_DNS_PORT,
+)
 from lib.log import init_logging, log_exception
 from lib.thread import kill_self
 from lib.util import handle_signals, trace
@@ -370,7 +376,7 @@ class SCIONDnsServer(SCIONElement):
     #: How frequently (in seconds) to update the shared instance data from ZK.
     SYNC_TIME = 1.0
     #: Service types to monitor/export
-    SRV_TYPES = ["bs", "cs", "ds", "ps"]
+    SRV_TYPES = (BEACON_SERVICE, CERTIFICATE_SERVICE, DNS_SERVICE, PATH_SERVICE)
 
     def __init__(self, server_id, domain, topo_file):
         """
@@ -383,7 +389,7 @@ class SCIONDnsServer(SCIONElement):
         :param topo_file:
         :type topo_file:
         """
-        super().__init__("ds", topo_file, server_id=server_id)
+        super().__init__(DNS_SERVICE, topo_file, server_id=server_id)
         self.domain = DNSLabel(domain)
         self.lock = threading.Lock()
         self.services = {}
@@ -405,7 +411,7 @@ class SCIONDnsServer(SCIONElement):
                                      str(self.addr.host_addr)])
         self.zk = Zookeeper(
             self.topology.isd_id, self.topology.ad_id,
-            "ds", self.name_addrs, self.topology.zookeepers)
+            DNS_SERVICE, self.name_addrs, self.topology.zookeepers)
         self._parties = {}
         self._setup_parties()
 
@@ -420,7 +426,7 @@ class SCIONDnsServer(SCIONElement):
             autojoin = False
             # Join only the DNS service party, for the rest we just want to
             # setup the party so we can monitor the members.
-            if type_ == "ds":
+            if type_ == DNS_SERVICE:
                 autojoin = True
             self._parties[type_] = self.zk.retry(
                 "Joining %s party" % type_, self.zk.party_setup, prefix=prefix,

--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -29,7 +29,7 @@ from external.expiring_dict import ExpiringDict
 # SCION
 from infrastructure.scion_elem import SCIONElement
 from lib.crypto.hash_chain import HashChain
-from lib.defines import SCION_UDP_PORT
+from lib.defines import PATH_SERVICE, SCION_UDP_PORT
 from lib.log import init_logging, log_exception
 from lib.packet.path_mgmt import (
     LeaseInfo,
@@ -68,8 +68,9 @@ class PathServer(SCIONElement):
         :param is_sim: running in simulator
         :type is_sim: bool
         """
-        SCIONElement.__init__(self, "ps", topo_file, server_id=server_id,
-                              config_file=config_file, is_sim=is_sim)
+        SCIONElement.__init__(self, PATH_SERVICE, topo_file,
+                              server_id=server_id, config_file=config_file,
+                              is_sim=is_sim)
         # TODO replace by pathstore instance
         self.down_segments = PathSegmentDB()
         self.core_segments = PathSegmentDB()  # Direction of the propagation.
@@ -85,8 +86,8 @@ class PathServer(SCIONElement):
             name_addrs = "\0".join([self.id, str(SCION_UDP_PORT),
                                     str(self.addr.host_addr)])
             self.zk = Zookeeper(
-                self.topology.isd_id, self.topology.ad_id, "ps", name_addrs,
-                self.topology.zookeepers)
+                self.topology.isd_id, self.topology.ad_id, PATH_SERVICE,
+                name_addrs, self.topology.zookeepers)
             self.zk.retry("Joining party", self.zk.party_setup)
 
     def _add_if_mappings(self, pcb):

--- a/infrastructure/router.py
+++ b/infrastructure/router.py
@@ -27,7 +27,12 @@ import time
 # SCION
 from infrastructure.scion_elem import SCIONElement
 from lib.crypto.symcrypto import get_roundkey_cache, verify_of_mac
-from lib.defines import EXP_TIME_UNIT, SCION_UDP_EH_DATA_PORT, SCION_UDP_PORT
+from lib.defines import (
+    EXP_TIME_UNIT,
+    ROUTER_SERVICE,
+    SCION_UDP_EH_DATA_PORT,
+    SCION_UDP_PORT,
+)
 from lib.errors import SCIONBaseError
 from lib.log import init_logging, log_exception
 from lib.packet.opaque_field import (
@@ -100,8 +105,9 @@ class Router(SCIONElement):
         :param is_sim: running in simulator
         :type is_sim: bool
         """
-        SCIONElement.__init__(self, "er", topo_file, server_id=router_id,
-                              config_file=config_file, is_sim=is_sim)
+        SCIONElement.__init__(self, ROUTER_SERVICE, topo_file,
+                              server_id=router_id, config_file=config_file,
+                              is_sim=is_sim)
         self.interface = None
         for edge_router in self.topology.get_all_edge_routers():
             if edge_router.addr == self.addr.host_addr:

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -58,8 +58,8 @@ class SCIONElement(object):
         """
         Create a new ServerBase instance.
 
-        :param server_type: a shorthand of the server type, e.g. "bs" for a
-                            beacon server.
+        :param server_type: a service type from
+                            :const:`lib.defines.SERVICE_TYPES`
         :type server_type: str
         :param topo_file: the name of the topology file.
         :type topo_file: str

--- a/lib/defines.py
+++ b/lib/defines.py
@@ -43,3 +43,17 @@ SCION_DNS_PORT = 30053
 IPV4BYTES = ipaddress.IPV4LENGTH // 8
 #: Length of IPV6 address, in bytes
 IPV6BYTES = ipaddress.IPV6LENGTH // 8
+
+BEACON_SERVICE = "bs"
+CERTIFICATE_SERVICE = "cs"
+DNS_SERVICE = "ds"
+PATH_SERVICE = "ps"
+ROUTER_SERVICE = "er"
+#: All the service types
+SERVICE_TYPES = (
+    BEACON_SERVICE,
+    CERTIFICATE_SERVICE,
+    DNS_SERVICE,
+    PATH_SERVICE,
+    ROUTER_SERVICE,
+)

--- a/lib/topology.py
+++ b/lib/topology.py
@@ -20,6 +20,13 @@ from ipaddress import ip_address
 import logging
 
 # SCION
+from lib.defines import (
+    BEACON_SERVICE,
+    CERTIFICATE_SERVICE,
+    DNS_SERVICE,
+    PATH_SERVICE,
+    ROUTER_SERVICE,
+)
 from lib.util import load_json_file
 
 
@@ -290,15 +297,15 @@ class Topology(object):
         :type server_id:
         """
         target = None
-        if server_type == "bs":
+        if server_type == BEACON_SERVICE:
             target = self.beacon_servers
-        elif server_type == "cs":
+        elif server_type == CERTIFICATE_SERVICE:
             target = self.certificate_servers
-        elif server_type == "ds":
+        elif server_type == DNS_SERVICE:
             target = self.dns_servers
-        elif server_type == "ps":
+        elif server_type == PATH_SERVICE:
             target = self.path_servers
-        elif server_type == "er":
+        elif server_type == ROUTER_SERVICE:
             target = self.get_all_edge_routers()
         else:
             logging.error("Unknown server type: \"%s\"", server_type)

--- a/lib/zookeeper.py
+++ b/lib/zookeeper.py
@@ -86,8 +86,8 @@ class Zookeeper(object):
 
         :param int isd_id: The ID of the current ISD.
         :param int ad_id: The ID of the current AD.
-        :param str srv_type: Short description of the service. E.g. ``"bs"``
-                             for Beacon server.
+        :param str srv_type: a service type from
+                             :const:`lib.defines.SERVICE_TYPES`
         :param str srv_id: Service instance identifier.
         :param list zk_hosts: List of Zookeeper instances to connect to, in the
                               form of ``["host:port"..]``.

--- a/test/lib_topology_test.py
+++ b/test/lib_topology_test.py
@@ -23,6 +23,13 @@ import nose
 import nose.tools as ntools
 
 # SCION
+from lib.defines import (
+    BEACON_SERVICE,
+    CERTIFICATE_SERVICE,
+    DNS_SERVICE,
+    PATH_SERVICE,
+    ROUTER_SERVICE,
+)
 from lib.topology import (
     Element,
     InterfaceElement,
@@ -204,7 +211,7 @@ class TestTopologyParseDict(object):
         cs = {'e': 'f', 'g': 'h'}
         ds = {'i': 'j', 'k': 'l'}
         ps = {'m': 'n', 'o': 'p'}
-        er = {'er' + str(i): 'router' + str(i) for i in range(5)}
+        er = {ROUTER_SERVICE + str(i): 'router' + str(i) for i in range(5)}
         zk = {'zk0': {'Addr': 'zk0.scion', 'ClientPort': 2181},
               'zk1': {'Addr': 'zk1.scion', 'ClientPort': 2182}}
         topo_dict = {
@@ -286,7 +293,8 @@ class TestTopologyGetOwnConfig(object):
         topology.dns_servers[2].name = 'name'
         topology.path_servers = [MagicMock(spec_set=['name']) for i in range(4)]
         topology.path_servers[2].name = 'name'
-        server_types = ['bs', 'cs', 'ds', 'ps'] * 2
+        server_types = [BEACON_SERVICE, CERTIFICATE_SERVICE, DNS_SERVICE,
+                        PATH_SERVICE] * 2
         server_ids = ['name'] * 4 + ['bad_name'] * 4
         servers = [topology.beacon_servers[2],
                    topology.certificate_servers[2],
@@ -301,7 +309,8 @@ class TestTopologyGetOwnConfig(object):
         edge_routers = [MagicMock(spec_set=['name']) for i in range(4)]
         edge_routers[2].name = 'name'
         get_edge_routers.return_value = edge_routers
-        ntools.eq_(topology.get_own_config('er', 'name'), edge_routers[2])
+        ntools.eq_(topology.get_own_config(ROUTER_SERVICE, 'name'),
+                   edge_routers[2])
         get_edge_routers.assert_called_once_with(topology)
 
     @patch("lib.topology.logging.error", autospec=True)
@@ -310,7 +319,7 @@ class TestTopologyGetOwnConfig(object):
         topology = Topology()
         edge_routers = [MagicMock(spec_set=['name']) for i in range(4)]
         get_edge_routers.return_value = edge_routers
-        ntools.assert_is_none(topology.get_own_config('er', 'name'))
+        ntools.assert_is_none(topology.get_own_config(ROUTER_SERVICE, 'name'))
         ntools.eq_(log_error.call_count, 1)
 
     @patch("lib.topology.logging.error", autospec=True)

--- a/web_scion/ad_manager/models.py
+++ b/web_scion/ad_manager/models.py
@@ -16,6 +16,12 @@ from ad_management.common import (
     PACKAGE_DIR_PATH,
 )
 from ad_manager.util import monitoring_client
+from lib.defines import (
+    BEACON_SERVICE,
+    CERTIFICATE_SERVICE,
+    DNS_SERVICE,
+    PATH_SERVICE,
+)
 from lib.topology import Topology
 from topology.generator import PORT
 
@@ -225,7 +231,7 @@ class SCIONWebElement(models.Model):
 
 
 class BeaconServerWeb(SCIONWebElement):
-    prefix = 'bs'
+    prefix = BEACON_SERVICE
 
     class Meta:
         verbose_name = 'Beacon server'
@@ -233,7 +239,7 @@ class BeaconServerWeb(SCIONWebElement):
 
 
 class CertificateServerWeb(SCIONWebElement):
-    prefix = 'cs'
+    prefix = CERTIFICATE_SERVICE
 
     class Meta:
         verbose_name = 'Certificate server'
@@ -241,7 +247,7 @@ class CertificateServerWeb(SCIONWebElement):
 
 
 class PathServerWeb(SCIONWebElement):
-    prefix = 'ps'
+    prefix = PATH_SERVICE
 
     class Meta:
         verbose_name = 'Path server'
@@ -249,7 +255,7 @@ class PathServerWeb(SCIONWebElement):
 
 
 class DnsServerWeb(SCIONWebElement):
-    prefix = 'ds'
+    prefix = DNS_SERVICE
 
     class Meta:
         verbose_name = 'DNS server'

--- a/web_scion/ad_manager/views.py
+++ b/web_scion/ad_manager/views.py
@@ -37,6 +37,7 @@ from ad_manager.forms import (
 from ad_manager.models import AD, ISD, PackageVersion, ConnectionRequest
 from ad_manager.util import monitoring_client
 from ad_manager.util.ad_connect import create_new_ad, link_ads
+from lib.defines import BEACON_SERVICE
 from lib.topology import Topology
 
 
@@ -103,7 +104,7 @@ def get_group_master(request, pk):
     """
     ad = get_object_or_404(AD, id=pk)
     server_type = request.GET.get('server_type', '')
-    if server_type != 'bs':
+    if server_type != BEACON_SERVICE:
         return HttpResponseNotFound('Invalid server type')
 
     md_host = ad.get_monitoring_daemon_host()


### PR DESCRIPTION
Also provide an authorative list of all service types.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/323%23discussion_r37389746%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/323%23discussion_r37405090%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2004c91205013384785499ad458d19d391481c6dc7%20endhost/sciond.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/323%23discussion_r37389746%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22btw.%20for%20every%20%60_request_paths%28%29%60%20server%20does%20dns%20query%3F%22%2C%20%22created_at%22%3A%20%222015-08-19T08%3A16%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20using%20a%20caching%20DNS%20client%2C%20so%20nope.%22%2C%20%22created_at%22%3A%20%222015-08-19T11%3A43%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/sciond.py%3AL159-166%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 04c91205013384785499ad458d19d391481c6dc7 endhost/sciond.py 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/323#discussion_r37389746'>File: endhost/sciond.py:L159-166</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> btw. for every `_request_paths()` server does dns query?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is using a caching DNS client, so nope.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/323?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/323?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/323'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
