### PR TITLE
Fix a race-condition with generating /etc/hosts

### DIFF
--- a/docker/profile
+++ b/docker/profile
@@ -11,8 +11,7 @@ sudo chown zookeeper: -R /run/shm/host-zk
 sudo service zookeeper start
 
 cat /etc/hosts topology/ISD*/hosts > /tmp/hosts
-sudo umount /etc/hosts
-sudo mv /tmp/hosts /etc/hosts
+sudo bash -c "umount /etc/hosts && mv /tmp/hosts /etc/hosts"
 
 # Can't be fixed during build due to
 # https://github.com/docker/docker/issues/6828


### PR DESCRIPTION
The previous script used seperate sudo commands, and the second fails as
sudo consults /etc/hosts, which is empty when it starts. Instead we just
do both actions in one sudo invocation.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/325?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/325'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
