### PR TITLE
Make scion code l2-address-agnostic, introduce SVC

### DIFF
--- a/endhost/gateway.py
+++ b/endhost/gateway.py
@@ -155,6 +155,7 @@ def main():
     if len(sys.argv) != 3:
         logging.error("run: %s addr topology_file", sys.argv[0])
         sys.exit()
+    # FIXME(kormat): make IP-version agnostic
     sgw = SCIONGateway(IPv4Address(sys.argv[1]), sys.argv[2], SCION_HOSTS)
     try:
         sgw.run()

--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -315,6 +315,8 @@ class SCIONDaemon(SCIONElement):
           |path1_len(1B)|path1(path1_len*8B)|first_hop_IP(4B)|path2_len(1B)...
          or b"" when no path found. Only IPv4 supported currently.
 
+        FIXME(kormat): make IP-version independant
+
         :param packet:
         :type packet:
         :param sender:
@@ -331,11 +333,11 @@ class SCIONDaemon(SCIONElement):
             raw_path = path.pack()
             # assumed IPv4 addr
             if path.get_first_info_of().up_flag:
-                hop = self.ifid2addr[path.get_first_hop_of().ingress_if]
+                haddr = self.ifid2addr[path.get_first_hop_of().ingress_if]
             else:
-                hop = self.ifid2addr[path.get_first_hop_of().egress_if]
+                haddr = self.ifid2addr[path.get_first_hop_of().egress_if]
             path_len = len(raw_path) // 8  # Check whether 8 divides path_len?
-            reply.append(struct.pack("B", path_len) + raw_path + hop.packed)
+            reply.append(struct.pack("B", path_len) + raw_path + haddr.pack())
         self._api_socket.sendto(b"".join(reply), sender)
 
     def api_handle_request(self, packet, sender):

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -36,8 +36,8 @@ from lib.dnsclient import DNSCachingClient, DNSLibMajorError, DNSLibMinorError
 from lib.errors import SCIONServiceLookupError
 from lib.log import log_exception
 from lib.packet.scion_addr import SCIONAddr
-from lib.topology import Topology
 from lib.thread import kill_self
+from lib.topology import Topology
 
 
 class SCIONElement(object):
@@ -45,41 +45,29 @@ class SCIONElement(object):
     Base class for the different kind of servers the SCION infrastructure
     provides.
 
-    :ivar topology: the topology of the AD as seen by the server.
-    :type topology: :class:`Topology`
-    :ivar config: the configuration of the AD in which the server is located.
-    :type config: :class:`lib.config.Config`
-    :ivar ifid2addr: a dictionary mapping interface identifiers to the
-                     corresponding border router addresses in the server's AD.
-    :type ifid2addr: dict
-    :ivar addr: a `SCIONAddr` object representing the server address.
-    :type addr: :class:`lib.packet.scion_addr.SCIONAddr`
+    :ivar `Topology` topology: the topology of the AD as seen by the server.
+    :ivar `Config` config:
+        the configuration of the AD in which the server is located.
+    :ivar dict ifid2addr:
+        a dictionary mapping interface identifiers to the corresponding border
+        router addresses in the server's AD.
+    :ivar `SCIONAddr` addr: the server's address.
     """
 
     def __init__(self, server_type, topo_file, config_file=None, server_id=None,
                  host_addr=None, is_sim=False):
         """
-        Create a new ServerBase instance.
-
-        :param server_type: a service type from
-                            :const:`lib.defines.SERVICE_TYPES`
-        :type server_type: str
-        :param topo_file: the name of the topology file.
-        :type topo_file: str
-        :param config_file: the name of the configuration file.
-        :type config_file: str
-        :param server_id: the local id of the server, e.g. for bs1-10-3, the id
-                          would be '3'. Used to look up config from topology
-                          file.
-        :type server_id: str
-        :param host_addr: the interface to bind to. Only used if server_id isn't
-                          specified.
-        :type host_addr: :class:`ipaddress._BaseAddress`
-
-        :returns: the newly-created ServerBase instance
-        :rtype: ServerBase
-        :param is_sim: running in simulator
-        :type is_sim: bool
+        :param str server_type:
+            a service type from :const:`lib.defines.SERVICE_TYPES`. E.g.
+            ``"bs"``.
+        :param str topo_file: path name of the topology file.
+        :param str config_file: path name of the configuration file.
+        :param str server_id:
+            the local id of the server. E.g. for `bs1-10-3`, the id would be
+            ``"3"``. Used to look up config from topology file.
+        :param `HostAddrBase` host_addr:
+            the interface to bind to. Only used if `server_id` isn't specified.
+        :param bool is_sim: running in simulator
         """
         self._addr = None
         self.topology = None
@@ -223,7 +211,7 @@ class SCIONElement(object):
         try:
             self._local_socket.sendto(packet.pack(), (str(dst), dst_port))
         except socket.gaierror:
-            log_exception("Addressing error when trying to send to %s:" %
+            log_exception("Addressing error when trying to send to %s:%s :" %
                           (dst, dst_port))
             kill_self()
 

--- a/lib/defines.py
+++ b/lib/defines.py
@@ -17,7 +17,6 @@
 Contains constant definitions used throughout the codebase.
 """
 # Stdlib
-import ipaddress
 import os
 
 #: Max TTL of a PathSegment in realtime seconds.
@@ -47,11 +46,6 @@ L4_PROTO = [
 ]
 #: Default layer-4 protocol.
 DEFAULT_L4_PROTO = 17
-
-#: Length of IPV4 address, in bytes
-IPV4BYTES = ipaddress.IPV4LENGTH // 8
-#: Length of IPV6 address, in bytes
-IPV6BYTES = ipaddress.IPV6LENGTH // 8
 
 BEACON_SERVICE = "bs"
 CERTIFICATE_SERVICE = "cs"

--- a/lib/dnsclient.py
+++ b/lib/dnsclient.py
@@ -12,47 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-:mod:`lib.dnsclient` --- SCION DNS client library
-=================================================
+:mod:`dnsclient` --- SCION DNS client library
+=============================================
 """
 # Stdlib
-from ipaddress import ip_address
+import logging
 from random import shuffle
 
 # External
 import dns.exception
-import dns.resolver
 import dns.name
+import dns.resolver
 from dns.resolver import Resolver
 from external.expiring_dict import ExpiringDict
 
 # SCION
 from lib.defines import SCION_DNS_PORT
 from lib.errors import SCIONBaseError
+from lib.packet.host_addr import haddr_parse
 
-#: Number of records to cache
+#: Number of records to cache.
 DNS_CACHE_MAX_SIZE = 100
-#: Seconds
+#: Cache validity in seconds. Probably should use DNS TTL in future.
 DNS_CACHE_MAX_AGE = 60
 
 
 class DNSLibBaseError(SCIONBaseError):
     """
-    Base lib.dns exception
+    Base lib.dnsclient exception.
     """
     pass
 
 
 class DNSLibMajorError(SCIONBaseError):
     """
-    Base lib.dns major exception
+    Base lib.dnsclient major exception.
     """
     pass
 
 
 class DNSLibNoServersError(DNSLibMajorError):
     """
-    No working servers
+    No working servers.
     """
     pass
 
@@ -66,33 +67,36 @@ class DNSLibNxDomain(DNSLibMajorError):
 
 class DNSLibMinorError(SCIONBaseError):
     """
-    Base lib.dns minor exception
+    Base lib.dnsclient minor exception.
     """
     pass
 
 
 class DNSLibTimeout(DNSLibMinorError):
     """
-    Timeout
+    DNS Timeout.
     """
     pass
 
 
 class DNSClient(object):
     """
-    DNS client class. Allows querying of dns_server for service instances.
+    DNS client class. Allows querying of `dns_server` for service discovery.
     """
-    def __init__(self, dns_servers, domain, lifetime=5.0):
+    def __init__(self, dns_servers, domain, lifetime=5.0, port=SCION_DNS_PORT):
         """
-        :param [string] dns_servers: List of DNS servers IP addresses
+        :param list dns_servers:
+            DNS server IP addresses as strings. E.g. ``["127.0.0.1",
+            "8.8.8.8"]``
         :param string domain: The DNS domain to query.
-        :param float lifetime: Number of seconds in total to try resolving
-                               before failing
+        :param float lifetime:
+            Number of seconds in total to try resolving before failing.
+        :param int port: DNS server port.
         """
         self.resolver = Resolver(configure=False)
         self.resolver.nameservers = dns_servers
-        self.resolver.port = SCION_DNS_PORT
         self.resolver.search = [dns.name.from_text(domain)]
+        self.resolver.port = port
         self.resolver.timeout = 1.0
         self.resolver.lifetime = lifetime
 
@@ -101,15 +105,17 @@ class DNSClient(object):
         Lookup a DNS record via the Resolver.
 
         :param string qname: A relative DNS record to query. E.g. ``"bs"``
-        :returns: A list of IP address objects
-        :rtype: :class:`ipaddress._BaseAddress`
+        :returns: A list of `Host address <HostAddrBase>`_ objects.
         :raises:
             DNSLibTimeout: No responses received.
             DNSLibNxDomain: Name doesn't exist.
             DNSLibError: Unexpected error.
         """
         try:
-            answer = self.resolver.query(qname)
+            # TODO(kormat): This needs to be more general, ideally using `ANY`,
+            # but dnspython's resolver currently does not support it :/
+            # https://github.com/rthalley/dnspython/issues/117
+            answer = self.resolver.query(qname, "A")
         except dns.exception.Timeout:
             raise DNSLibTimeout("No responses within %ss" %
                                 self.resolver.lifetime) from None
@@ -120,7 +126,24 @@ class DNSClient(object):
                 from None
         except Exception as e:
             raise DNSLibMajorError("Unhandled exception in resolver.") from e
-        addrs = [ip_address(addr) for addr in answer]
+        return self._parse_answer(answer)
+
+    def _parse_answer(self, answer):
+        """
+        Parse DNS answer into host addresses.
+
+        :param `dnslib.resolver.Answer` answer:
+        :returns: List of `Host addresses <HostAddrBase>`_ objects.
+        """
+        addrs = []
+        for record in answer:
+            if record.rdtype == dns.rdatatype.A:
+                addrs.append(haddr_parse("IPv4", str(record)))
+            elif record.rdtype == dns.rdatatype.AAAA:
+                addrs.append(haddr_parse("IPv6", str(record)))
+            else:
+                logging.debug("Ignoring unsupported dns record type (%s): %r",
+                              dns.rdatatype._by_value[record.rdtype], record)
         shuffle(addrs)
         return addrs
 
@@ -131,10 +154,12 @@ class DNSCachingClient(DNSClient):
     """
     def __init__(self, dns_servers, domain, lifetime=5.0):
         """
-        :param [string] dns_servers: List of DNS servers IP addresses
+        :param list dns_servers:
+            DNS server IP addresses as strings. E.g. ``["127.0.0.1",
+            "8.8.8.8"]``
         :param string domain: The DNS domain to query.
-        :param float lifetime: Number of seconds in total to try resolving
-                               before failing
+        :param float lifetime:
+            Number of seconds in total to try resolving before failing.
         """
         super().__init__(dns_servers, domain, lifetime=lifetime)
         self.cache = ExpiringDict(max_len=DNS_CACHE_MAX_SIZE,
@@ -143,7 +168,14 @@ class DNSCachingClient(DNSClient):
     def query(self, qname):
         """
         Check if the answer is already in the cache. If not, pass it along to
-        the DNS client to query and cache the result.
+        the DNS client and cache the result.
+
+        :param string qname: A relative DNS record to query. E.g. ``"bs"``
+        :returns: A list of `Host address <HostAddrBase>`_ objects.
+        :raises:
+            DNSLibTimeout: No responses received.
+            DNSLibNxDomain: Name doesn't exist.
+            DNSLibError: Unexpected error.
         """
         answer = self.cache.get(qname)
         if answer is None:

--- a/lib/packet/host_addr.py
+++ b/lib/packet/host_addr.py
@@ -1,0 +1,227 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`host_addr` --- L2 host address library
+============================================
+"""
+
+# Stdlib
+import struct
+from ipaddress import (
+    AddressValueError,
+    IPV4LENGTH,
+    IPV6LENGTH,
+    IPv4Address,
+    IPv6Address,
+)
+
+# SCION
+from lib.errors import SCIONBaseError, SCIONParseError
+from lib.util import Raw
+
+ADDR_NONE_TYPE = 0
+ADDR_IPV4_TYPE = 1
+ADDR_IPV6_TYPE = 2
+ADDR_SVC_TYPE = 3
+
+ADDR_NONE_BYTES = 0
+ADDR_IPV4_BYTES = IPV4LENGTH // 8
+ADDR_IPV6_BYTES = IPV6LENGTH // 8
+ADDR_SVC_BYTES = 2
+
+ADDR_NONE_NAME = "NONE"
+ADDR_IPV4_NAME = "IPv4"
+ADDR_IPV6_NAME = "IPv6"
+ADDR_SVC_NAME = "SVC"
+
+
+class HostAddrBaseError(SCIONBaseError):
+    """
+    Base exception for HostAddr errors.
+    """
+    pass
+
+
+class HostAddrInvalidType(SCIONBaseError):
+    """
+    HostAddr type is invalid.
+    """
+    pass
+
+
+class HostAddrBase(object):
+    """
+    Base HostAddr class. Should not be used directly.
+    """
+    TYPE = None
+    LEN = None
+    NAME = None
+
+    def __init__(self, addr, raw=True):
+        """
+        :param addr: Address to parse/store.
+        :param bool raw: Does the address need to be parsed?
+        """
+        self.addr = None
+        if raw:
+            self._parse(addr)
+        else:
+            self.addr = addr
+
+    def _parse(self, raw):  # pragma: no cover
+        raise NotImplemented
+
+    def pack(self):  # pragma: no cover
+        """
+        :return: a packed representation of the host address
+        :rtype: bytes
+        """
+        raise NotImplemented
+
+    def __str__(self):
+        return str(self.addr)
+
+    def __len__(self):
+        return self.LEN
+
+    def __eq__(self, other):
+        return (self.TYPE == other.TYPE) and (self.addr == other.addr)
+
+
+class HostAddrNone(object):
+    """
+    Host "None" address. Used to indicate there's no address.
+    """
+    TYPE = ADDR_NONE_TYPE
+    LEN = ADDR_NONE_BYTES
+    NAME = ADDR_NONE_NAME
+
+    def __init__(self):
+        self.addr = None
+
+    def pack(self):
+        return b""
+
+
+class HostAddrIPv4(HostAddrBase):
+    """
+    Host IPv4 address.
+    """
+    TYPE = ADDR_IPV4_TYPE
+    LEN = ADDR_IPV4_BYTES
+    NAME = ADDR_IPV4_NAME
+
+    def _parse(self, raw):
+        """
+        Parse IPv4 address
+
+        :param raw: Can be either `bytes` or `str`
+        """
+        try:
+            self.addr = IPv4Address(raw)
+        except AddressValueError as e:
+            raise SCIONParseError("Unable to parse %s address: %s" % (self.NAME, e)) \
+                from None
+
+    def pack(self):
+        return self.addr.packed
+
+
+class HostAddrIPv6(HostAddrBase):
+    """
+    Host IPv6 address.
+    """
+    TYPE = ADDR_IPV6_TYPE
+    LEN = ADDR_IPV6_BYTES
+    NAME = ADDR_IPV6_NAME
+
+    def _parse(self, raw):
+        """
+        Parse IPv6 address
+
+        :param raw: Can be either `bytes` or `str`
+        """
+        try:
+            self.addr = IPv6Address(raw)
+        except AddressValueError as e:
+            raise SCIONParseError("Unable to parse %s address: %s" % (self.NAME, e)) \
+                from None
+
+    def pack(self):
+        return self.addr.packed
+
+
+class HostAddrSVC(HostAddrBase):
+    """
+    Host "SVC" address. This is a pseudo- address type used for SCION services.
+    """
+    TYPE = ADDR_SVC_TYPE
+    LEN = ADDR_SVC_BYTES
+    NAME = ADDR_SVC_NAME
+
+    def _parse(self, raw):
+        """
+        Parse SVC address
+
+        :param bytes raw: Raw SVC address
+        """
+        data = Raw(raw, "HostAddrSVC", self.LEN)
+        self.addr = struct.unpack("!H", data.pop(self.LEN))[0]
+
+    def pack(self):
+        return struct.pack("!H", self.addr)
+
+
+_map = {
+    # By type
+    ADDR_NONE_TYPE: HostAddrNone,
+    ADDR_IPV4_TYPE: HostAddrIPv4,
+    ADDR_IPV6_TYPE: HostAddrIPv6,
+    ADDR_SVC_TYPE: HostAddrSVC,
+    # By name
+    ADDR_NONE_NAME: HostAddrNone,
+    ADDR_IPV4_NAME: HostAddrIPv4,
+    ADDR_IPV6_NAME: HostAddrIPv6,
+    ADDR_SVC_NAME: HostAddrSVC,
+}
+
+
+def haddr_get_type(type_):
+    """
+    Look up host address class by type.
+
+    :param type\_: host address type. E.g. ``1`` or ``"IPv4"``.
+    :type type\_: int or string
+    """
+    try:
+        return _map[type_]
+    except KeyError:
+        raise HostAddrInvalidType("Unknown host addr type '%s'" % type_)
+
+
+def haddr_parse(type_, *args, **kwargs):
+    """
+    Parse host address and return object.
+
+    :param type\_: host address type. E.g. ``1`` or ``"IPv4"``.
+    :type type\_: int or string
+    :param \*args:
+        Arguments to pass to the host address object constructor. E.g.
+        ``"127.0.0.1"``.
+    :param \*\*kwargs:
+        Keyword args to pass to the host address object constructor. E.g.
+        ``raw=False``.
+    """
+    typecls = haddr_get_type(type_)
+    return typecls(*args, **kwargs)

--- a/lib/packet/scion_addr.py
+++ b/lib/packet/scion_addr.py
@@ -18,11 +18,12 @@
 # Stdlib
 import struct
 from collections import namedtuple
-from ipaddress import ip_address
 
 # SCION
-from lib.defines import IPV4BYTES, IPV6BYTES
-from lib.errors import SCIONParseError
+from lib.packet.host_addr import (
+    HostAddrBase,
+    haddr_get_type,
+)
 from lib.util import Raw
 
 
@@ -30,10 +31,8 @@ class ISD_AD(namedtuple('ISD_AD', 'isd ad')):
     """
     Class for representing isd,ad pair.
 
-    :ivar isd: ISD identifier.
-    :type isd: int
-    :ivar ad: AD identifier.
-    :type ad: int
+    :ivar int isd: ISD identifier.
+    :ivar int ad: AD identifier.
     """
     LEN = 4
 
@@ -42,12 +41,11 @@ class ISD_AD(namedtuple('ISD_AD', 'isd ad')):
         """
         Create an instance of the class ISD_AD.
 
-        :param raw: a byte string containing ISD ID, AD ID. ISD and AD are
-                    respectively represented as 12 and 20 most significant bits.
-        :type isd_id: bytes
-
+        :param bytes raw:
+            a byte string containing ISD ID, AD ID. ISD and AD are respectively
+            represented as 12 and 20 most significant bits.
         :returns: ISD, AD tuple.
-        :rtype: :class:`ISD_AD`
+        :rtype: ISD_AD
         """
         data = Raw(raw, "ISD_AD", cls.LEN)
         isd_ad = struct.unpack("!I", data.pop(cls.LEN))[0]
@@ -59,8 +57,9 @@ class ISD_AD(namedtuple('ISD_AD', 'isd ad')):
         """
         Pack the class variables into a byte string.
 
-        :returns: a 4B long byte string containing ISD ID (first 12 bits),
-                  AD ID (remaining 20 bits).
+        :returns:
+            a 4B byte string containing ISD ID (first 12 bits), AD ID
+            (remaining 20 bits).
         :rtype: bytes
         """
         isd = self.isd << 20
@@ -72,69 +71,56 @@ class SCIONAddr(object):
     """
     Class for complete SCION addresses.
 
-    :ivar isd_id: ISD identifier.
-    :type isd_id: int
-    :ivar ad_id: AD identifier.
-    :type ad_id: int
-    :ivar host_addr: host address.
-    :type host_addr: IPv4Address or IPv6Address
-    :ivar addr_len: address length.
-    :type addr_len: int
+    :ivar int isd_id: ISD identifier.
+    :ivar int ad_id: AD identifier.
+    :ivar HostAddrBase host_addr: host address.
+    :ivar int addr_len: address length.
     """
-    MIN_LEN = ISD_AD.LEN + min(IPV4BYTES, IPV6BYTES)
-
-    def __init__(self, raw=None):
+    def __init__(self, addr_info=()):
         """
         Initialize an instance of the class SCIONAddr.
 
-        :param raw: raw bytes.
-        :type raw: bytes
+        :param addr_info: Tuple of (addr_type, addr) for the host address
         """
         self.isd_id = None
         self.ad_id = None
         self.host_addr = None
         self.addr_len = 0
-        if raw:
-            self.parse(raw)
+        if addr_info:
+            self.parse(*addr_info)
 
     @classmethod
     def from_values(cls, isd_id, ad_id, host_addr):
         """
         Create an instance of the class SCIONAddr.
 
-        :param isd_id: ISD identifier.
-        :type isd_id: int
-        :param ad_id: AD identifier.
-        :type ad_id: int
-        :param host_addr: host IP addresses.
-        :type host_addr: IPv4Address or IPv6Address
+        :param int isd_id: ISD identifier.
+        :param int ad_id: AD identifier.
+        :param HostAddrBase host_addr: host address
 
         :returns: SCION address.
-        :rtype: :class:`SCIONAddr`
+        :rtype: SCIONAddr
         """
-        addr = SCIONAddr()
+        assert isinstance(host_addr, HostAddrBase)
+        addr = cls()
         addr.isd_id = isd_id
         addr.ad_id = ad_id
         addr.host_addr = host_addr
-        addr.addr_len = ISD_AD.LEN + len(addr.host_addr.packed)
+        addr.addr_len = ISD_AD.LEN + len(addr.host_addr)
         return addr
 
-    def parse(self, raw):
+    def parse(self, addr_type, raw):
         """
         Parse a raw byte string.
 
-        :param raw: raw bytes.
-        :type raw: bytes
+        :param int addr_type: Host address type
+        :param bytes raw: raw bytes.
         """
-        data = Raw(raw, "SCIONAddr", self.MIN_LEN, min_=True)
-        self.addr_len = len(data)
+        haddr_type = haddr_get_type(addr_type)
+        self.addr_len = ISD_AD.LEN + haddr_type.LEN
+        data = Raw(raw, "SCIONAddr (%s)" % haddr_type.NAME, self.addr_len)
         self.isd_id, self.ad_id = ISD_AD.from_raw(data.pop(ISD_AD.LEN))
-        host_addr_len = len(data)
-        if host_addr_len in (IPV4BYTES, IPV6BYTES):
-            self.host_addr = ip_address(data.pop())
-        else:
-            raise SCIONParseError(
-                "SCIONAddr: host address unsupported, len: %u" % host_addr_len)
+        self.host_addr = haddr_type(data.pop(haddr_type.LEN))
 
     def pack(self):
         """
@@ -143,7 +129,10 @@ class SCIONAddr(object):
         :returns: a byte string containing ISD ID, AD ID, and host address.
         :rtype: bytes
         """
-        return ISD_AD(self.isd_id, self.ad_id).pack() + self.host_addr.packed
+        return ISD_AD(self.isd_id, self.ad_id).pack() + self.host_addr.pack()
+
+    def __len__(self):
+        return self.addr_len
 
     def __str__(self):
         """

--- a/sphinx-doc/lib/packet/host_addr.rst
+++ b/sphinx-doc/lib/packet/host_addr.rst
@@ -1,0 +1,5 @@
+
+.. automodule:: lib.packet.host_addr
+   :special-members: __init__
+   :members:
+   :member-order: bysource

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -23,21 +23,21 @@ import sys
 import threading
 import time
 import unittest
-from ipaddress import IPv4Address
 
 # SCION
 from endhost.sciond import SCIOND_API_HOST, SCIOND_API_PORT, SCIONDaemon
-from lib.defines import IPV4BYTES, SCION_BUFLEN, SCION_UDP_EH_DATA_PORT
+from lib.defines import SCION_BUFLEN, SCION_UDP_EH_DATA_PORT
 from lib.packet.opaque_field import InfoOpaqueField, OpaqueFieldType as OFT
 from lib.packet.path import CorePath, CrossOverPath, EmptyPath, PeerPath
 from lib.packet.scion import SCIONPacket
+from lib.packet.host_addr import haddr_get_type, haddr_parse
 from lib.packet.scion_addr import SCIONAddr, ISD_AD
 from lib.log import init_logging, log_exception
 from lib.util import Raw, handle_signals
 from lib.thread import kill_self, thread_safety_net
 
-saddr = IPv4Address("127.1.19.254")
-raddr = IPv4Address("127.2.26.254")
+saddr = haddr_parse("IPv4", "127.1.19.254")
+raddr = haddr_parse("IPv4", "127.2.26.254")
 TOUT = 10  # How long wait for response.
 
 
@@ -76,7 +76,9 @@ def get_paths_via_api(isd, ad):
         else:
             logging.critical("Can not parse path: Unknown type %x", info.info)
             kill_self()
-        hop = IPv4Address(data.pop(IPV4BYTES))
+        haddr_type = haddr_get_type("IPv4")
+        hop = haddr_type(data.get(haddr_type.LEN))
+        data.pop(len(hop))
         paths_hops.append((path, hop))
     sock.close()
     return paths_hops

--- a/test/lib_dnsclient_test.py
+++ b/test/lib_dnsclient_test.py
@@ -16,12 +16,13 @@
 ======================================================
 """
 # Stdlib
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 # External packages
 import dns
 import nose
 import nose.tools as ntools
+from dns.rdatatype import A, AAAA, AXFR
 
 # SCION
 from lib.defines import SCION_DNS_PORT
@@ -35,6 +36,7 @@ from lib.dnsclient import (
     DNS_CACHE_MAX_AGE,
     DNS_CACHE_MAX_SIZE,
 )
+from test.testcommon import create_mock
 
 
 class TestDNSClientInit(object):
@@ -43,19 +45,19 @@ class TestDNSClientInit(object):
     """
     @patch("lib.dnsclient.dns.name.from_text", autospec=True)
     @patch("lib.dnsclient.Resolver", autospec=True)
-    def test(self, resolver, from_text):
+    def test_full(self, resolver, from_text):
         # Setup
-        attrs = ["nameservers", "port", "search", "timeout", "lifetime"]
-        res_inst = MagicMock(spec_set=attrs)
+        res_inst = create_mock(
+            ["nameservers", "port", "search", "timeout", "lifetime"])
         resolver.return_value = res_inst
         # Call
-        client = DNSClient(["ip1", "ip2"], "domain", lifetime=30.0)
+        client = DNSClient(["ip1", "ip2"], "domain", lifetime=30.0, port=102)
         # Tests
         resolver.assert_called_once_with(configure=False)
         ntools.eq_(client.resolver, res_inst)
         ntools.eq_(res_inst.nameservers, ["ip1", "ip2"])
-        ntools.eq_(res_inst.port, SCION_DNS_PORT)
         ntools.eq_(res_inst.search, [from_text.return_value])
+        ntools.eq_(res_inst.port, 102)
         ntools.eq_(res_inst.timeout, 1.0)
         ntools.eq_(res_inst.lifetime, 30.0)
 
@@ -63,45 +65,40 @@ class TestDNSClientInit(object):
     @patch("lib.dnsclient.Resolver", autospec=True)
     def test_less_args(self, resolver, from_text):
         # Setup
-        attrs = ["nameservers", "port", "search", "timeout", "lifetime"]
-        res_inst = MagicMock(spec_set=attrs)
+        res_inst = create_mock(
+            ["nameservers", "port", "search", "timeout", "lifetime"])
         resolver.return_value = res_inst
         # Call
         DNSClient(["ip1", "ip2"], "domain")
         # Tests
         ntools.eq_(res_inst.lifetime, 5.0)
+        ntools.eq_(res_inst.port, SCION_DNS_PORT)
 
 
 class TestDNSClientQuery(object):
     """
     Unit tests for lib.dnsclient.DNSClient.query
     """
-    @patch("lib.dnsclient.dns.name.from_text", autospec=True)
-    @patch("lib.dnsclient.Resolver", autospec=True)
-    def _setup(self, resolver, from_text, addrs=None):
-        attrs = ["nameservers", "port", "query", "search", "timeout",
-                 "lifetime"]
-        res_inst = MagicMock(spec_set=attrs)
-        res_inst.query = MagicMock(spec_set=[])
-        resolver.return_value = res_inst
-        if not addrs:
-            addrs = ["ip1", "ip2"]
-        return DNSClient(addrs, "domain")
+    def _setup(self):
+        inst = DNSClient(["ip1", "ip2"], "domain")
+        inst.resolver = create_mock(["nameservers", "port", "search", "timeout",
+                                     "lifetime", "query"])
+        return inst
 
-    @patch("lib.dnsclient.ip_address", spec_set=[], new_callable=MagicMock)
-    def test_basic(self, ipaddr):
+    @patch("lib.dnsclient.DNSClient._parse_answer", autospec=True)
+    @patch("lib.dnsclient.DNSClient.__init__", autospec=True, return_value=None)
+    def test_basic(self, init, parse_ans):
         # Setup
         client = self._setup()
-        client.resolver.query.return_value = ["result0", "result1"]
-        ipaddr.side_effect = ["ip0", "ip1"]
         # Call
-        ntools.eq_(set(client.query("search string")), {"ip0", "ip1"})
+        ntools.eq_(client.query("search string"), parse_ans.return_value)
         # Tests
-        client.resolver.query.assert_called_once_with("search string")
-        ipaddr.assert_has_calls([call("result0"), call("result1")],
-                                any_order=True)
+        client.resolver.query.assert_called_once_with("search string", "A")
+        parse_ans.assert_called_once_with(client,
+                                          client.resolver.query.return_value)
 
-    def _check_exceptions(self, error, excp):
+    @patch("lib.dnsclient.DNSClient.__init__", autospec=True, return_value=None)
+    def _check_exceptions(self, error, excp, init):
         # Setup
         client = self._setup()
         client.resolver.query.side_effect = error
@@ -117,6 +114,32 @@ class TestDNSClientQuery(object):
             (dns.resolver.NoNameservers, DNSLibNoServersError),
         ):
             yield self._check_exceptions, error, excp
+
+
+class TestDNSClientParseAnswer(object):
+    """
+    Unit tests for lib.dnsclient.DNSClient._parse_answer
+    """
+    @patch("lib.dnsclient.logging.debug", autospec=True)
+    @patch("lib.dnsclient.shuffle", autospec=True)
+    @patch("lib.dnsclient.haddr_parse", autospec=True)
+    @patch("lib.dnsclient.DNSClient.__init__", autospec=True, return_value=None)
+    def test(self, init, hparse, shuffle, debug):
+        inst = DNSClient("servers", "domain")
+        answer = []
+        types = [A, AAAA, A, A, AXFR, AAAA]
+        for i, type_ in enumerate(types):
+            ans_mock = create_mock(["__str__", "rdtype"])
+            ans_mock.rdtype = type_
+            ans_mock.__str__.return_value = "r%s" % i
+            answer.append(ans_mock)
+        hparse.side_effect = lambda type_, addr: "%s:%s" % (type_, addr)
+        results = ["IPv4:r0", "IPv6:r1", "IPv4:r2", "IPv4:r3", "IPv6:r5"]
+        # Call
+        ntools.eq_(inst._parse_answer(answer), results)
+        # Tests
+        ntools.eq_(debug.call_count, 1)
+        shuffle.assert_called_once_with(results)
 
 
 class TestDNSCachingClientInit(object):
@@ -146,7 +169,7 @@ class TestDNSCachingClientQuery(object):
     def test_miss(self, init, client_query):
         # Setup
         client = DNSCachingClient("servers", "domain", "lifetime")
-        client.cache = MagicMock(spec_set=["get", "__setitem__"])
+        client.cache = create_mock(["get", "__setitem__"])
         client.cache.get.return_value = None
         client_query.return_value = ["ip0", "ip1"]
         # Call
@@ -161,7 +184,7 @@ class TestDNSCachingClientQuery(object):
     def test_hit(self, init):
         # Setup
         client = DNSCachingClient("servers", "domain", "lifetime")
-        client.cache = MagicMock(spec_set=["get"])
+        client.cache = create_mock(["get"])
         # Call
         ntools.eq_(client.query("blah"), client.cache.get.return_value)
 

--- a/test/lib_packet_host_addr_test.py
+++ b/test/lib_packet_host_addr_test.py
@@ -1,0 +1,293 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`lib_packet_host_addr_test` --- lib.packet.host_addr unit tests
+====================================================================
+"""
+# Stdlib
+import ipaddress
+from unittest.mock import patch
+
+# External packages
+import nose
+import nose.tools as ntools
+
+# SCION
+from lib.errors import SCIONParseError
+from lib.packet.host_addr import (
+    HostAddrInvalidType,
+    HostAddrBase,
+    HostAddrNone,
+    HostAddrIPv4,
+    HostAddrIPv6,
+    HostAddrSVC,
+    haddr_get_type,
+    haddr_parse,
+)
+from test.testcommon import create_mock
+
+
+class TestHostAddrBaseInit(object):
+    """
+    Unit tests for lib.packet.host_addr.HostAddrBase.__init__
+    """
+    @patch("lib.packet.host_addr.HostAddrBase._parse", autospec=True)
+    def test_raw(self, parse):
+        # Call
+        inst = HostAddrBase("raw")
+        # Tests
+        ntools.assert_is_none(inst.addr)
+        parse.assert_called_once_with(inst, "raw")
+
+    def test_not_raw(self):
+        # Call
+        inst = HostAddrBase("addr", raw=False)
+        # Tests
+        ntools.eq_(inst.addr, "addr")
+
+
+class TestHostAddrBaseStr(object):
+    """
+    Unit tests for lib.packet.host_addr.HostAddrBase.__str__
+    """
+    @patch("lib.packet.host_addr.HostAddrBase.__init__", autospec=True,
+           return_value=None)
+    def test(self, init):
+        inst = HostAddrBase("")
+        inst.addr = create_mock(["__str__"])
+        inst.addr.__str__.return_value = "str(addr)"
+        # Call
+        ntools.eq_(str(inst), "str(addr)")
+        # Tests
+        inst.addr.__str__.assert_called_once_with()
+
+
+class TestHostAddrBaseLen(object):
+    """
+    Unit tests for lib.packet.host_addr.HostAddrBase.__len__
+    """
+    @patch("lib.packet.host_addr.HostAddrBase.__init__", autospec=True,
+           return_value=None)
+    def test(self, init):
+        inst = HostAddrBase("")
+        inst.LEN = 42
+        # Call
+        ntools.eq_(len(inst), 42)
+
+
+class TestHostAddrBaseEq(object):
+    """
+    Unit tests for lib.packet.host_addr.HostAddrBase.__eq__
+    """
+    @patch("lib.packet.host_addr.HostAddrBase.__init__", autospec=True,
+           return_value=None)
+    def test_eq(self, init):
+        inst = HostAddrBase("")
+        other = create_mock(["TYPE", "addr"])
+        inst.TYPE = other.TYPE = 42
+        inst.addr = other.addr = "addr"
+        # Call
+        ntools.assert_true(inst == other)
+
+    @patch("lib.packet.host_addr.HostAddrBase.__init__", autospec=True,
+           return_value=None)
+    def test_neq_type(self, init):
+        inst = HostAddrBase("")
+        other = create_mock(["TYPE", "addr"])
+        inst.TYPE = 41
+        other.TYPE = 42
+        inst.addr = other.addr = "addr"
+        # Call
+        ntools.assert_false(inst == other)
+
+    @patch("lib.packet.host_addr.HostAddrBase.__init__", autospec=True,
+           return_value=None)
+    def test_neq_addr(self, init):
+        inst = HostAddrBase("")
+        other = create_mock(["TYPE", "addr"])
+        inst.TYPE = other.TYPE = 42
+        inst.addr = "addr0"
+        other.addr = "addr1"
+        # Call
+        ntools.assert_false(inst == other)
+
+
+class TestHostAddrNoneInit(object):
+    """
+    Unit tests for lib.packet.host_addr.HostAddrNone.__init__
+    """
+    def test(self):
+        # Call
+        inst = HostAddrNone()
+        # Tests
+        ntools.assert_is_none(inst.addr)
+
+
+class TestHostAddrNonePack(object):
+    """
+    Unit tests for lib.packet.host_addr.HostAddrNone.pack
+    """
+    def test(self):
+        # Call
+        inst = HostAddrNone()
+        # Tests
+        ntools.eq_(inst.pack(), b"")
+
+
+class TestHostAddrIPv4Parse(object):
+    """
+    Unit tests for lib.packet.host_addr.HostAddrIPv4._parse
+    """
+    @patch("lib.packet.host_addr.IPv4Address", autospec=True)
+    @patch("lib.packet.host_addr.HostAddrIPv4.__init__", autospec=True,
+           return_value=None)
+    def test(self, init, ipv4):
+        inst = HostAddrIPv4("")
+        # Call
+        inst._parse("raw")
+        # Tests
+        ipv4.assert_called_once_with("raw")
+        ntools.eq_(inst.addr, ipv4.return_value)
+
+    @patch("lib.packet.host_addr.IPv4Address", autospec=True)
+    @patch("lib.packet.host_addr.HostAddrIPv4.__init__", autospec=True,
+           return_value=None)
+    def test_wrong_len(self, init, ipv4):
+        inst = HostAddrIPv4("")
+        ipv4.side_effect = ipaddress.AddressValueError
+        # Call
+        ntools.assert_raises(SCIONParseError, inst._parse, "raw")
+
+
+class TestHostAddrIPv4Pack(object):
+    """
+    Unit tests for lib.packet.host_addr.HostAddrIPv4.pack
+    """
+    @patch("lib.packet.host_addr.HostAddrIPv4.__init__", autospec=True,
+           return_value=None)
+    def test(self, init):
+        inst = HostAddrIPv4("")
+        inst.addr = create_mock(["packed"])
+        # Call
+        ntools.eq_(inst.pack(), inst.addr.packed)
+
+
+class TestHostAddrIPv6Parse(object):
+    """
+    Unit tests for lib.packet.host_addr.HostAddrIPv6._parse
+    """
+    @patch("lib.packet.host_addr.IPv6Address", autospec=True)
+    @patch("lib.packet.host_addr.HostAddrIPv6.__init__", autospec=True,
+           return_value=None)
+    def test(self, init, ipv6):
+        inst = HostAddrIPv6("")
+        # Call
+        inst._parse("raw")
+        # Tests
+        ipv6.assert_called_once_with("raw")
+        ntools.eq_(inst.addr, ipv6.return_value)
+
+    @patch("lib.packet.host_addr.IPv6Address", autospec=True)
+    @patch("lib.packet.host_addr.HostAddrIPv6.__init__", autospec=True,
+           return_value=None)
+    def test_wrong_len(self, init, ipv6):
+        inst = HostAddrIPv6("")
+        ipv6.side_effect = ipaddress.AddressValueError
+        # Call
+        ntools.assert_raises(SCIONParseError, inst._parse, "raw")
+
+
+class TestHostAddrIPv6Pack(object):
+    """
+    Unit tests for lib.packet.host_addr.HostAddrIPv6.pack
+    """
+    @patch("lib.packet.host_addr.HostAddrIPv6.__init__", autospec=True,
+           return_value=None)
+    def test(self, init):
+        inst = HostAddrIPv6("")
+        inst.addr = create_mock(["packed"])
+        # Call
+        ntools.eq_(inst.pack(), inst.addr.packed)
+
+
+class TestHostAddrSVCParse(object):
+    """
+    Unit tests for lib.packet.host_addr.HostAddrSVC._parse
+    """
+    @patch("lib.packet.host_addr.Raw", autospec=True)
+    @patch("lib.packet.host_addr.HostAddrSVC.__init__", autospec=True,
+           return_value=None)
+    def test(self, init, raw):
+        inst = HostAddrSVC("")
+        pop = raw.return_value.pop
+        pop.return_value = bytes.fromhex("01 0f")
+        # Call
+        inst._parse("raw")
+        # Tests
+        raw.assert_called_once_with("raw", "HostAddrSVC", inst.LEN)
+        ntools.eq_(inst.addr, 0x010f)
+
+
+class TestHostAddrSVCPack(object):
+    """
+    Unit tests for lib.packet.host_addr.HostAddrSVC.pack
+    """
+    @patch("lib.packet.host_addr.HostAddrSVC.__init__", autospec=True,
+           return_value=None)
+    def test(self, init):
+        inst = HostAddrSVC("")
+        inst.addr = 0x010f
+        # Call
+        ntools.eq_(inst.pack(), bytes.fromhex("01 0f"))
+
+
+class TestHaddrGetType(object):
+    """
+    Unit tests for lib.packet.host_addr.haddr_get_type
+    """
+    def _check(self, type_, expected):
+        ntools.eq_(haddr_get_type(type_), expected)
+
+    def test(self):
+        for type_, expected in (
+            (0, HostAddrNone),
+            ("NONE", HostAddrNone),
+            (1, HostAddrIPv4),
+            ("IPv4", HostAddrIPv4),
+            (2, HostAddrIPv6),
+            ("IPv6", HostAddrIPv6),
+            (3, HostAddrSVC),
+            ("SVC", HostAddrSVC),
+        ):
+            yield self._check, type_, expected
+
+    def test_invalid(self):
+        ntools.assert_raises(HostAddrInvalidType, haddr_get_type, "invalid")
+
+
+class TestHaddrParse(object):
+    """
+    Unit tests for lib.packet.host_addr.haddr_parse
+    """
+    @patch("lib.packet.host_addr.haddr_get_type", autospec=True)
+    def test(self, get_type):
+        # Call
+        ntools.eq_(haddr_parse("type", "args"),
+                   get_type.return_value.return_value)
+        # Tests
+        get_type.assert_called_once_with("type")
+        get_type.return_value.assert_called_once_with("args")
+
+if __name__ == "__main__":
+    nose.run(defaultTest=__name__)


### PR DESCRIPTION
- Add lib.packet.host_addr to encapsulate all host addresses.
- Update lib.dnsclient to return host addresses.
- Add new "SVC" pseudo-address space, for sending packets to SCION /services/.
- Update the scion common header to store address /types/ rather than lengths.
- Update lib.topology to present addresses as host address.

More work needed:
- Add network library, so that packet sending/receiving can be address-agnostic.
- DNS client needs to support AAAA records.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/327%23issuecomment-132188068%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23issuecomment-132235819%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23issuecomment-132498828%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23issuecomment-132649348%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37392094%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37431517%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37513164%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37513621%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37513888%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37513918%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37521116%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37521211%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37521234%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37522400%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37522453%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37522454%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37526090%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37530157%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23issuecomment-133012359%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23issuecomment-133013132%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23issuecomment-132188068%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22HostAddrType%20of%20management%20packets%20%28non-data%20packets%29%20is%20SVC%2C%20and%20HostAddrType%20of%20Data%20packet%20is%20IPv4%20or%20IPv6.%20Is%20it%20right%3F%5Cr%5CnCan%20the%20router%20treat%20the%20packet%20as%20Data%20packet%20without%20checking%20the%20%20src/dst%20addresses%20%20in%20case%20that%20HostAddrType%20is%20IPv4%20or%20IPv6%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-18T12%3A08%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9196745%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/taka-sasaki%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20HostAddrType%20of%20management%20packets%20%28non-data%20packets%29%20is%20SVC%2C%20and%20HostAddrType%20of%20Data%20packet%20is%20IPv4%20or%20IPv6.%20Is%20it%20right%3F%5Cr%5Cn%5Cr%5CnYep%2C%20correct.%5Cr%5Cn%5Cr%5Cn%3E%20Can%20the%20router%20treat%20the%20packet%20as%20Data%20packet%20without%20checking%20the%20%20src/dst%20addresses%20%20in%20case%20that%20HostAddrType%20is%20IPv4%20or%20IPv6%3F%5Cr%5Cn%5Cr%5CnI%20believe%20so%2C%20yes.%22%2C%20%22created_at%22%3A%20%222015-08-18T14%3A42%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-08-19T08%3A56%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20substantially%20rewritten%20this%20since%20you%20last%20looked%2C%20so%20if%20you%20can%20give%20it%20another%20pass%2C%20that%20would%20be%20great.%22%2C%20%22created_at%22%3A%20%222015-08-19T15%3A58%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-08-20T13%3A46%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5C%5Co/%22%2C%20%22created_at%22%3A%20%222015-08-20T13%3A49%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a67e58fd27f83302dfdf742e57abfe871b615854%20lib/dnsclient.py%2031%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37513164%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22maybe%20a%20comment%20that%20we%20should%20respect%20DNS%20TTL%20at%20some%20point%22%2C%20%22created_at%22%3A%20%222015-08-20T09%3A57%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%22%2C%20%22created_at%22%3A%20%222015-08-20T12%3A00%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-20T12%3A21%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/dnsclient.py%3AL12-60%22%7D%2C%20%22Pull%2088b8ee4690cc72b46cc1df518e20affe28317ca7%20infrastructure/scion_elem.py%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37392094%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22does%20not%20look%20too%20agnostic%20%3B-%29%22%2C%20%22created_at%22%3A%20%222015-08-19T08%3A46%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20updated%20code%20adds%20a%20comment%20here%20explaining%20the%20problem.%22%2C%20%22created_at%22%3A%20%222015-08-19T15%3A54%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-08-20T10%3A07%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/scion_elem.py%3AL251-258%22%7D%2C%20%22Pull%20a67e58fd27f83302dfdf742e57abfe871b615854%20topology/generator.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37513888%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22not%20sure%20with%20this%20%60ToAddrType%60.%20This%20is%20ER2ER%20communication%2C%20and%20addressing%20here%20has%20to%20be%20consistent.%22%2C%20%22created_at%22%3A%20%222015-08-20T10%3A07%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%2C%20you%27re%20saying%20that%20the%20type%20of%20%60ToAddr%60%20is%20implicitly%20the%20same%20as%20for%20%60Addr%60%3F%22%2C%20%22created_at%22%3A%20%222015-08-20T12%3A01%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%5Cn%5CnOn%2020%20August%202015%20at%2014%3A01%2C%20Stephen%20Shirley%20%3Cnotifications%40github.com%3E%5Cnwrote%3A%5Cn%5Cn%3E%20In%20topology/generator.py%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37521234%3E%3A%5Cn%3E%5Cn%3E%20%3E%20%40%40%20-467%2C6%20%2B467%2C7%20%40%40%20def%20write_topo_files%28self%2C%20ad_configs%2C%20er_ip_addresses%29%3A%5Cn%3E%20%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%27NeighborType%27%3A%20nbr_type%2C%5Cn%3E%20%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%27AddrType%27%3A%20%27IPv4%27%2C%5Cn%3E%20%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%27Addr%27%3A%20ip_address_pub%2C%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%27ToAddrType%27%3A%20%27IPv4%27%2C%5Cn%3E%5Cn%3E%20Ah%2C%20you%27re%20saying%20that%20the%20type%20of%20ToAddr%20is%20implicitly%20the%20same%20as%20for%5Cn%3E%20Addr%3F%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/327/files%23r37521234%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-20T12%3A20%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%20cool%2C%20fixed%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-08-20T13%3A05%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-08-20T13%3A46%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL467-474%22%7D%2C%20%22Pull%20a67e58fd27f83302dfdf742e57abfe871b615854%20lib/topology.py%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/327%23discussion_r37513621%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20not%20%60None%60%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-20T10%3A03%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Any%20immutable%20object%20works%2C%20i%20just%20went%20with%20tuple%20here%20as%20it%20helps%20indicate%20the%20expected%20type.%22%2C%20%22created_at%22%3A%20%222015-08-20T12%3A01%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-08-20T12%3A21%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/topology.py%3AL35-55%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/327#issuecomment-132188068'>General Comment</a></b>
- <a href='https://github.com/taka-sasaki'><img border=0 src='https://avatars.githubusercontent.com/u/9196745?v=3' height=16 width=16'></a> HostAddrType of management packets (non-data packets) is SVC, and HostAddrType of Data packet is IPv4 or IPv6. Is it right?
  Can the router treat the packet as Data packet without checking the  src/dst addresses  in case that HostAddrType is IPv4 or IPv6?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> > HostAddrType of management packets (non-data packets) is SVC, and HostAddrType of Data packet is IPv4 or IPv6. Is it right?
  Yep, correct.
  > Can the router treat the packet as Data packet without checking the  src/dst addresses  in case that HostAddrType is IPv4 or IPv6?
  I believe so, yes.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I've substantially rewritten this since you last looked, so if you can give it another pass, that would be great.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> \o/
- [x] <a href='#crh-comment-Pull 88b8ee4690cc72b46cc1df518e20affe28317ca7 infrastructure/scion_elem.py 35'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/327#discussion_r37392094'>File: infrastructure/scion_elem.py:L251-258</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> does not look too agnostic ;-)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The updated code adds a comment here explaining the problem.
- [x] <a href='#crh-comment-Pull a67e58fd27f83302dfdf742e57abfe871b615854 lib/dnsclient.py 31'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/327#discussion_r37513164'>File: lib/dnsclient.py:L12-60</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> maybe a comment that we should respect DNS TTL at some point
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Done
- [x] <a href='#crh-comment-Pull a67e58fd27f83302dfdf742e57abfe871b615854 lib/topology.py 29'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/327#discussion_r37513621'>File: lib/topology.py:L35-55</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> why not `None` ?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Any immutable object works, i just went with tuple here as it helps indicate the expected type.
- [x] <a href='#crh-comment-Pull a67e58fd27f83302dfdf742e57abfe871b615854 topology/generator.py 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/327#discussion_r37513888'>File: topology/generator.py:L467-474</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> not sure with this `ToAddrType`. This is ER2ER communication, and addressing here has to be consistent.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ah, you're saying that the type of `ToAddr` is implicitly the same as for `Addr`?
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> Yes
  On 20 August 2015 at 14:01, Stephen Shirley notifications@github.com
  wrote:
  > In topology/generator.py
  > https://github.com/netsec-ethz/scion/pull/327#discussion_r37521234:
  >
  > > @@ -467,6 +467,7 @@ def write_topo_files(self, ad_configs, er_ip_addresses):
  > >                                    'NeighborType': nbr_type,
  > >                                    'AddrType': 'IPv4',
  > >                                    'Addr': ip_address_pub,
  > > +                                  'ToAddrType': 'IPv4',
  >
  > Ah, you're saying that the type of ToAddr is implicitly the same as for
  > Addr?
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/327/files#r37521234.
  >
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok cool, fixed :)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/327?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/327?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/327'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
