### PR TITLE
Make down-path propagation in the core more reliable

### DIFF
--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -396,8 +396,12 @@ class CorePathServer(PathServer):
             dst_isd = pcb.get_last_pcbm().isd_id
             res = self.down_segments.update(pcb, src_isd, src_ad,
                                             dst_isd, dst_ad)
-            if res != DBResult.NONE:
+            if (dst_isd == pkt.hdr.src_addr.isd_id and
+                    dst_ad == pkt.hdr.src_addr.ad_id):
+                # Only propagate this path if it was registered with us by the
+                # down-stream AD.
                 paths_to_propagate.append(pcb)
+            if res != DBResult.NONE:
                 logging.info("Down-Segment registered (%d, %d) -> (%d, %d)",
                              src_isd, src_ad, dst_isd, dst_ad)
                 if res == DBResult.ENTRY_ADDED:


### PR DESCRIPTION
Instead of just propagating a down-path when it's registered, propagate it
every time it's updated, but only if it was registered with us by the
down-stream AD.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/335?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/335'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
