### PR TITLE
Always run apt-get update before installing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN bash -c 'DEBIAN_FRONTEND=noninteractive apt-get purge --auto-remove -y $(< d
 # deps.sh changes for any reason.
 RUN apt-get update
 COPY docker/pkgs_preinstall.txt $BASE/docker/
-RUN bash -c 'DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y $(< docker/pkgs_preinstall.txt)'
+RUN bash -c 'apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y $(< docker/pkgs_preinstall.txt)'
 
 ################################################################################
 # Handle installing all dependancies up-front. That way code changes don't cause
@@ -32,7 +32,7 @@ COPY deps.sh $BASE/
 # Copy over pkgs_debian.txt. If it has changed, then re-run the remaining steps.
 COPY pkgs_debian.txt $BASE/
 RUN sudo chown -R scion: $HOME
-RUN APTARGS=-y ./deps.sh pkgs
+RUN sudo apt-get update && APTARGS=-y ./deps.sh pkgs
 
 # Copy over requirements.txt. If it has changed, then re-run the remaining steps.
 COPY requirements.txt $BASE/


### PR DESCRIPTION
It makes the build more reliable, though a little slower the first time
or when the package list changes.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/338?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/338'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
