### PR TITLE
Improve ZK lock handling

### DIFF
--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -797,21 +797,12 @@ class CoreBeaconServer(BeaconServer):
         """
         Generate a new beacon or gets ready to forward the one received.
         """
-        master = False
         while True:
             # Wait until we have enough context to be a useful master
             # candidate.
             self._state_synced.wait()
-            if not master:
-                logging.debug("Trying to become master")
             if not self.zk.get_lock():
-                if master:
-                    logging.debug("No longer master")
-                    master = False
                 continue
-            if not master:
-                logging.debug("Became master")
-                master = True
             start_propagation = SCIONTime.get_time()
             # Create beacon for downstream ADs.
             downstream_pcb = PathSegment()
@@ -1229,21 +1220,12 @@ class LocalBeaconServer(BeaconServer):
         Main loop to propagate received beacons.
         """
         # TODO: define function that dispatches the pcbs among the interfaces
-        master = False
         while True:
             # Wait until we have enough context to be a useful master
             # candidate.
             self._state_synced.wait()
-            if not master:
-                logging.debug("Trying to become master")
             if not self.zk.get_lock():
-                if master:
-                    logging.debug("No longer master")
-                    master = False
                 continue
-            if not master:
-                logging.debug("Became master")
-                master = True
             start_propagation = SCIONTime.get_time()
             best_segments = self.beacons.get_best_segments()
             for pcb in best_segments:

--- a/test/lib_zookeeper_test.py
+++ b/test/lib_zookeeper_test.py
@@ -193,10 +193,12 @@ class TestZookeeperStateListener(BaseZookeeper):
         # Setup
         inst = self._init_basic_setup()
         inst._state_events = create_mock(["put"])
+        inst.conn_epoch = 47
         # Call
         ntools.eq_(inst._state_listener("statist"), False)
         # Tests
         inst._state_events.put.assert_called_once_with("statist")
+        ntools.eq_(inst.conn_epoch, 48)
 
 
 class TestZookeeperStateHandler(BaseZookeeper):
@@ -327,7 +329,6 @@ class TestZookeeperStateDisconnected(BaseZookeeper):
     def _check(self, f_name, init, test_callback=False):
         inst = self._init_basic_setup()
         inst._connected = create_mock(["clear"])
-        inst._lock = create_mock(["clear"])
         inst._on_disconnect = None
         if test_callback:
             inst._on_disconnect = create_mock()
@@ -335,7 +336,6 @@ class TestZookeeperStateDisconnected(BaseZookeeper):
         getattr(inst, f_name)()
         # Tests
         inst._connected.clear.assert_called_once_with()
-        inst._lock.clear.assert_called_once_with()
         if test_callback:
             inst._on_disconnect.assert_called_once_with()
 
@@ -477,60 +477,66 @@ class TestZookeeperGetLock(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.get_lock
     """
-    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
-    def test_no_lock(self, init):
+    def _setup(self, is_conn=True, wait_conn=True, l_epoch=1, c_epoch=1):
         inst = self._init_basic_setup()
-        inst._zk_lock = None
-        inst._prefix = "/prefix"
+        inst._zk_lock = create_mock(["acquire"])
         inst._zk = create_mock(["Lock"])
-        inst._srv_id = "srvid"
-        # Short-circuit the rest of get_lock() by making is_connected raise
-        # StopIteration.
         inst.is_connected = create_mock()
-        inst.is_connected.side_effect = []
-        # Call
-        ntools.assert_raises(StopIteration, inst.get_lock)
-        # Tests
-        inst._zk.Lock.assert_called_once_with("/prefix/lock", "srvid")
+        inst.is_connected.return_value = is_conn
+        inst.release_lock = create_mock()
+        inst.wait_connected = create_mock()
+        inst.wait_connected.return_value = wait_conn
+        inst._lock_epoch = l_epoch
+        inst.conn_epoch = c_epoch
+        inst._lock = create_mock(["is_set", "set"])
+        inst.have_lock = create_mock()
+        return inst
 
     @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
-    def test_not_connected(self, init):
-        inst = self._init_basic_setup()
-        inst._zk_lock = True
-        inst.is_connected = create_mock()
-        inst.is_connected.return_value = False
-        inst.release_lock = create_mock()
+    def test_no_lock_not_conn(self, init):
+        inst = self._setup(is_conn=False, wait_conn=False)
+        inst._zk_lock = None
+        inst._prefix = "/prefix"
+        inst._srv_id = "srvid"
         # Call
-        ntools.assert_false(inst.get_lock())
+        ntools.assert_false(inst.get_lock(conn_timeout="conn t/o"))
         # Tests
+        inst._zk.Lock.assert_called_once_with("/prefix/lock", "srvid")
         inst.is_connected.assert_called_once_with()
         inst.release_lock.assert_called_once_with()
+        inst.wait_connected.assert_called_once_with(timeout="conn t/o")
 
     @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
     def test_have_lock(self, init):
-        inst = self._init_basic_setup()
-        inst._zk_lock = True
-        inst.is_connected = create_mock()
-        inst._lock = create_mock(["is_set"])
+        inst = self._setup()
         # Call
         ntools.assert_true(inst.get_lock())
         # Tests
         inst._lock.is_set.assert_called_once_with()
 
     @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
-    def test_acquire(self, init):
-        inst = self._init_basic_setup()
-        inst._zk_lock = create_mock(["acquire"])
-        inst.is_connected = create_mock()
-        inst._lock = create_mock(["is_set", "set"])
-        inst._lock.is_set.return_value = False
-        inst.have_lock = create_mock()
+    def test_stale_epoch_acquire(self, init):
+        inst = self._setup(l_epoch=0)
         # Call
-        ntools.eq_(inst.get_lock(), inst.have_lock.return_value)
+        ntools.eq_(inst.get_lock(lock_timeout="lock t/o"),
+                   inst.have_lock.return_value)
         # Tests
-        inst._zk_lock.acquire.assert_called_once_with(timeout=60.0)
+        inst.release_lock.assert_called_once_with()
+        ntools.eq_(inst._lock_epoch, inst.conn_epoch)
+        inst._zk_lock.acquire.assert_called_once_with(timeout="lock t/o")
         inst._lock.set.assert_called_once_with()
         inst.have_lock.assert_called_once_with()
+
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_acquire_fail(self, init):
+        inst = self._setup(l_epoch=0)
+        inst._zk_lock.acquire.return_value = False
+        # Call
+        ntools.eq_(inst.get_lock(lock_timeout="lock t/o"),
+                   inst.have_lock.return_value)
+        # Tests
+        inst._zk_lock.acquire.assert_called_once_with(timeout="lock t/o")
+        ntools.assert_false(inst._lock.set.called)
 
     @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
     def _check_exception(self, exception, init):
@@ -538,13 +544,15 @@ class TestZookeeperGetLock(BaseZookeeper):
         inst._zk_lock = create_mock(["acquire"])
         inst._zk_lock.acquire.side_effect = exception
         inst.is_connected = create_mock()
+        inst.wait_connected = create_mock()
+        inst._lock_epoch = inst.conn_epoch = 22
         inst._lock = create_mock(["is_set"])
         inst._lock.is_set.return_value = False
         inst.have_lock = create_mock()
         # Call
         ntools.eq_(inst.get_lock(), inst.have_lock.return_value)
         # Tests
-        inst._zk_lock.acquire.assert_called_once_with(timeout=60.0)
+        inst._zk_lock.acquire.assert_called_once_with(timeout=None)
 
     def test_exceptions(self):
         for excp in (LockTimeout, ConnectionLoss,
@@ -556,6 +564,18 @@ class TestZookeeperReleaseLock(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.release_lock
     """
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_no_lock(self, init):
+        inst = self._init_basic_setup()
+        inst._lock = create_mock(["clear"])
+        inst._zk_lock = None
+        inst.is_connected = create_mock()
+        # Call
+        inst.release_lock()
+        # Tests
+        inst._lock.clear.assert_called_once_with()
+        ntools.assert_false(inst.is_connected.called)
+
     @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
     def test_not_connected(self, init):
         inst = self._init_basic_setup()
@@ -605,29 +625,42 @@ class TestZookeeperHaveLock(BaseZookeeper):
     """
     Unit tests for lib.zookeeper.Zookeeper.have_lock
     """
-    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
-    def _check(self, connected, have_lock, init):
+    def _setup(self, connected, l_epoch, c_epoch, lock_is_set):
         inst = self._init_basic_setup()
         inst.is_connected = create_mock()
         inst.is_connected.return_value = connected
+        inst._lock_epoch = l_epoch
+        inst.conn_epoch = c_epoch
         inst._lock = create_mock(["is_set"])
-        inst._lock.is_set.return_value = have_lock
-        expected = connected and have_lock
+        inst._lock.is_set.return_value = lock_is_set
+        inst.release_lock = create_mock()
+        return inst
+
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_have(self, init):
+        inst = self._setup(True, 1, 1, True)
         # Call
-        ntools.eq_(inst.have_lock(), expected)
+        ntools.ok_(inst.have_lock())
         # Tests
         inst.is_connected.assert_called_once_with()
-        if connected:
-            inst._lock.is_set.assert_called_once_with()
+        inst._lock.is_set.assert_called_once_with()
+        ntools.assert_false(inst.release_lock.called)
 
-    def test(self):
-        for connected, have_lock in (
-                (False, False),
-                (False, True),
-                (True, False),
-                (True, True)
+    @patch("lib.zookeeper.Zookeeper.__init__", autospec=True, return_value=None)
+    def _check_not_have(self, connected, l_epoch, c_epoch, lock_is_set, init):
+        inst = self._setup(connected, l_epoch, c_epoch, lock_is_set)
+        # Call
+        ntools.assert_false(inst.have_lock())
+        # Tests
+        inst.release_lock.assert_called_once_with()
+
+    def test_not_have(self):
+        for connected, l_epoch, c_epoch, lock_is_set in (
+                (False, 1, 1, True),
+                (True, 0, 1, True),
+                (True, 1, 1, False),
         ):
-            yield self._check, connected, have_lock
+            yield self._check_not_have, connected, l_epoch, c_epoch, lock_is_set
 
 
 class TestZookeeperWaitLock(BaseZookeeper):


### PR DESCRIPTION
By adding a connection 'epoch', we can tell when our local lock state is
stale.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/339%23issuecomment-134170581%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/339%23issuecomment-134170581%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%28Not%20ready%20for%20merging%20yet%29%22%2C%20%22created_at%22%3A%20%222015-08-24T12%3A21%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/339#issuecomment-134170581'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (Not ready for merging yet)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/339?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/339?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/339'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
