### PR TITLE
Reduce Core PCB spam.

### DIFF
--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -791,6 +791,16 @@ class CoreBeaconServer(BeaconServer):
         ingress_if = pcb.if_id
         count = 0
         for core_router in self.topology.routing_edge_routers:
+            skip = False
+            for ad in pcb.ads:
+                if (ad.pcbm.isd_id == core_router.interface.neighbor_isd and
+                        ad.pcbm.ad_id == core_router.interface.neighbor_ad):
+                    # Don't propagate a Core PCB back to an AD we know has
+                    # already seen it.
+                    skip = True
+                    break
+            if skip:
+                continue
             new_pcb = copy.deepcopy(pcb)
             egress_if = core_router.interface.if_id
             last_pcbm = new_pcb.get_last_pcbm()


### PR DESCRIPTION
If a Core beacon has already gone through an AD, don't send it back to
that AD.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/349?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/349'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
