### PR TITLE
Clean up and simplify path header handling.

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -330,10 +330,10 @@ class SCIONDaemon(SCIONElement):
         for path in paths:
             raw_path = path.pack()
             # assumed IPv4 addr
-            if path.get_first_info_of().up_flag:
-                haddr = self.ifid2addr[path.get_first_hop_of().ingress_if]
+            if path.get_first_iof().up_flag:
+                haddr = self.ifid2addr[path.get_first_hof().ingress_if]
             else:
-                haddr = self.ifid2addr[path.get_first_hop_of().egress_if]
+                haddr = self.ifid2addr[path.get_first_hof().egress_if]
             path_len = len(raw_path) // 8  # Check whether 8 divides path_len?
             reply.append(struct.pack("B", path_len) + raw_path + haddr.pack())
         self._api_sock.send(b"".join(reply), sender)

--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -1116,7 +1116,7 @@ class LocalBeaconServer(BeaconServer):
         dst_isd_ad = ISD_AD(pcb.get_isd(), pcb.get_first_pcbm().ad_id)
         pkt = PathMgmtPacket.from_values(PMT.RECORDS, records, core_path,
                                          self.addr, dst_isd_ad)
-        if_id = core_path.get_first_hop_of().ingress_if
+        if_id = core_path.get_first_hof().ingress_if
         next_hop = self.ifid2addr[if_id]
         self.send(pkt, next_hop)
 

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -156,7 +156,7 @@ class SCIONElement(object, metaclass=ABCMeta):
         :returns:
         :rtype:
         """
-        opaque_field = spkt.hdr.get_path().get_first_hop_of()
+        opaque_field = spkt.hdr.get_path().get_first_hof()
         if opaque_field is None:  # EmptyPath
             return (spkt.hdr.dst_addr.host_addr, SCION_UDP_PORT)
         else:

--- a/lib/errors.py
+++ b/lib/errors.py
@@ -48,6 +48,13 @@ class SCIONIndexError(SCIONBaseError):
     pass
 
 
+class SCIONKeyError(SCIONBaseError):
+    """
+    Key error (trying to access invalid entry in dictionary)
+    """
+    pass
+
+
 class SCIONJSONError(SCIONBaseError):
     """
     JSON parsing error.

--- a/lib/packet/opaque_field.py
+++ b/lib/packet/opaque_field.py
@@ -18,8 +18,10 @@
 # Stdlib
 import struct
 from abc import ABCMeta, abstractmethod
+from binascii import hexlify
 
 # SCION
+from lib.errors import SCIONIndexError, SCIONKeyError
 from lib.util import Raw
 
 
@@ -37,6 +39,19 @@ class OpaqueFieldType(object):
     SHORTCUT = 0b1100000
     INTRA_ISD_PEER = 0b1111000
     INTER_ISD_PEER = 0b1111100
+
+    _to_str_map = {
+        NORMAL_OF: "NORMAL",
+        XOVR_POINT: "XOVR_POINT",
+        CORE: "CORE",
+        SHORTCUT: "SHORTCUT",
+        INTRA_ISD_PEER: "INTRA_ISD_PEER",
+        INTER_ISD_PEER: "INTER_ISD_PEER",
+    }
+
+    @classmethod
+    def to_str(cls, type_):  # pragma: no cover
+        return cls._to_str_map.get(type_, "UNKNOWN")
 
 
 class OpaqueField(object, metaclass=ABCMeta):
@@ -86,12 +101,12 @@ class OpaqueField(object, metaclass=ABCMeta):
         """
         return not (self.info & (1 << 4) == 0)
 
+    def __len__(self):  # pragma: no cover
+        return self.LEN
+
     @abstractmethod
     def __str__(self):
         raise NotImplementedError
-
-    def __repr__(self):
-        return self.__str__()
 
     # TODO test: one __eq__ breaks router when two SOFs in a path are identical
     def __eq__(self, other):
@@ -125,7 +140,7 @@ class HopOpaqueField(OpaqueField):
         self.exp_time = 0
         self.ingress_if = 0
         self.egress_if = 0
-        self.mac = b"\x00" * self.MAC_LEN
+        self.mac = bytes(self.MAC_LEN)
         if raw is not None:
             self.parse(raw)
 
@@ -183,11 +198,10 @@ class HopOpaqueField(OpaqueField):
             return False
 
     def __str__(self):
-        hof_str = ("[Hop OF info: %u, exp_time: %d, ingress if: %u, "
-                   "egress if: %u, mac: %s]" % (
-                       self.info, self.exp_time, self.ingress_if,
-                       self.egress_if, self.mac))
-        return hof_str
+        return ("[Hop OF info: %s, exp_time: %d, ingress if: %d, "
+                "egress if: %d, mac: %s]" %
+                (OpaqueFieldType.to_str(self.info), self.exp_time,
+                 self.ingress_if, self.egress_if, hexlify(self.mac)))
 
 
 class InfoOpaqueField(OpaqueField):
@@ -256,10 +270,9 @@ class InfoOpaqueField(OpaqueField):
         return data
 
     def __str__(self):
-        iof_str = ("[Info OF info: %x, up: %r, TS: %u, ISD ID: %u, hops: %u]" %
-                   (self.info, self.up_flag, self.timestamp, self.isd_id,
-                    self.hops))
-        return iof_str
+        return "[Info OF info: %s, up: %r, TS: %d, ISD ID: %d, hops: %d]" % (
+            OpaqueFieldType.to_str(self.info), self.up_flag,
+            self.timestamp, self.isd_id, self.hops)
 
     def __eq__(self, other):
         if type(other) is type(self):
@@ -270,3 +283,171 @@ class InfoOpaqueField(OpaqueField):
                     self.hops == other.hops)
         else:
             return False
+
+
+class OpaqueFieldList(object):
+    """
+    Encapsulates lists of Opaque Fields (OFs).
+
+    The lists are stored under labels, where each label describes the contents
+    of the list. Some label will only ever have 1 entry, such as an up segment
+    IOF. Others can have many, such as a down segment HOF list.
+    """
+    def __init__(self, order):
+        """
+        :param list order:
+            A list of tokens that define the order of the opaque field labels.
+            E.g. ``[UP_IOF, UP_HOFS]`` defines that the up-segment info opaque
+            field comes before the up-segment hop opaque fields.
+        """
+        self._order = order
+        self._labels = {}
+        for label in order:
+            self._labels[label] = []
+
+    def set(self, label, ofs):
+        """
+        Sets an OF label to the supplied value.
+
+        :param str label: OF label to change. E.g. ``UP_IOF``.
+        :param list ofs: List of opaque fields to store in the label.
+        :raises:
+            :any:`SCIONKeyError`: if the label is unknown.
+        """
+        assert isinstance(ofs, list)
+        if label not in self._labels:
+            raise SCIONKeyError("Opaque field label (%s) unknown" % label)
+        self._labels[label] = ofs
+
+    def get_by_idx(self, idx):
+        """
+        Get an OF by index. The index follows the order supplied when the
+        :class:`OpaqueFieldList` object was created.
+
+        :param int idx: The index to fetch.
+        :returns:
+            The OF at that index, or ``None`` if the index was past the end of
+            the labels.
+        :rtype: :class:`OpaqueField`
+        """
+        if idx < 0:
+            raise SCIONIndexError("Requested OF index (%d) is negative" % idx)
+        offset = idx
+        for label in self._order:
+            group = self._labels[label]
+            if offset < len(group):
+                return group[offset]
+            offset -= len(group)
+        # FIXME(kormat): is this correct?
+        return None
+
+    def get_by_label(self, label, label_idx=None):
+        """
+        Get an OF list by label. If a label index is supplied, use that to index
+        into the label and return a single OF instead.
+
+        :param str label: The label to fetch. E.g. ``UP_HOFS``.
+        :param int label_idx:
+            (Optional) an index of an OF in the specified label.
+        :returns:
+            A list of OFs (or if `label_idx` was specified, a single OF).
+        :raises:
+            :any:`SCIONKeyError`: if the label is unknown.
+            :any:`SCIONIndexError`: if the specified label index is out of range
+        """
+        try:
+            group = self._labels[label]
+        except KeyError:
+            raise SCIONKeyError("Opaque field label (%s) unknown"
+                                % label) from None
+        if label_idx is None:
+            return group
+        try:
+            return group[label_idx]
+        except IndexError:
+            raise SCIONIndexError(
+                "Opaque field label index (%d) for label %s out of range" %
+                (label_idx, label)) from None
+
+    def swap(self, label_a, label_b):
+        """
+        Swap the contents of two labels. The order of the parameters doesn't
+        matter.
+
+        :param str label_a: The first label.
+        :param str label_b: The second label.
+        :raises:
+            :any:`SCIONKeyError`: if either label is unknown.
+        """
+        try:
+            self._labels[label_a], self._labels[label_b] = \
+                self._labels[label_b], self._labels[label_a]
+        except KeyError as e:
+            raise SCIONKeyError("Opaque field label (%s) unknown"
+                                % e.args[0]) from None
+
+    def reverse_label(self, label):
+        """
+        Reverse the contents of a label.
+
+        :param str label: The label to reverse.
+        :raises:
+            :any:`SCIONKeyError`: if the label is unknown.
+        """
+        try:
+            self._labels[label].reverse()
+        except KeyError:
+            raise SCIONKeyError("Opaque field label (%s) unknown"
+                                % label) from None
+
+    def reverse_up_flag(self, label):
+        """
+        Reverse the Up flag of the first OF in a label, assuming the label isn't
+        empty. Used to change direction of IOFs.
+
+        :param str label: The label to modify.
+        :raises:
+            :any:`SCIONKeyError`: if the label is unknown.
+        """
+        try:
+            group = self._labels[label]
+        except KeyError:
+            raise SCIONKeyError("Opaque field label (%s) unknown"
+                                % label) from None
+        if len(group) > 0:
+            group[0].up_flag ^= True
+
+    def pack(self):
+        """
+        Pack all of the OFs into a single bytestring.
+
+        :returns: A bytestring containing all the OFs, in order.
+        :rtype: bytes
+        """
+        ret = []
+        for label in self._order:
+            for of in self._labels[label]:
+                ret.append(of.pack())
+        return b"".join(ret)
+
+    def count(self, label):
+        """
+        Return the number of OFs in a label.
+
+        :param str label: The label to count.
+        :returns: The number of OFs in the label.
+        :rtype: int
+        :raises:
+            :any:`SCIONKeyError`: if the label is unknown.
+        """
+        try:
+            return len(self._labels[label])
+        except KeyError:
+            raise SCIONKeyError("Opaque field label (%s) unknown"
+                                % label) from None
+
+    def __len__(self):
+        count = 0
+        for values in self._labels.values():
+            count += len(values)
+        return count

--- a/lib/packet/packet_base.py
+++ b/lib/packet/packet_base.py
@@ -51,9 +51,6 @@ class HeaderBase(object, metaclass=ABCMeta):
     def __str__(self):
         raise NotImplementedError
 
-    def __repr__(self):
-        return self.__str__()
-
 
 class PacketBase(object, metaclass=ABCMeta):
     """
@@ -111,9 +108,6 @@ class PacketBase(object, metaclass=ABCMeta):
         s.append(str(self.hdr) + "\n")
         s.append("Payload:\n" + str(self._payload))
         return "".join(s)
-
-    def __repr__(self):
-        return self.__str__()
 
     def __hash__(self):
         return hash(self.pack())

--- a/sphinx-doc/lib/packet/opaque_field.rst
+++ b/sphinx-doc/lib/packet/opaque_field.rst
@@ -2,3 +2,4 @@
 .. automodule:: lib.packet.opaque_field
    :special-members: __init__
    :members:
+   :member-order: bysource

--- a/sphinx-doc/lib/packet/path.rst
+++ b/sphinx-doc/lib/packet/path.rst
@@ -2,3 +2,4 @@
 .. automodule:: lib.packet.path
    :special-members: __init__
    :members:
+   :member-order: bysource

--- a/test/lib_packet_opaque_field_test.py
+++ b/test/lib_packet_opaque_field_test.py
@@ -23,11 +23,14 @@ import nose
 import nose.tools as ntools
 
 # SCION
+from lib.errors import SCIONIndexError, SCIONKeyError
 from lib.packet.opaque_field import (
     HopOpaqueField,
     InfoOpaqueField,
     OpaqueField,
+    OpaqueFieldList,
 )
+from test.testcommon import create_mock
 
 
 # To allow testing of OpaqueField, despite it having abstract methods.
@@ -362,6 +365,224 @@ class TestInfoOpaqueFieldEq(object):
         inf_op_fld1 = InfoOpaqueField()
         inf_op_fld2 = b'test'
         ntools.assert_not_equals(inf_op_fld1, inf_op_fld2)
+
+
+class TestOpaqueFieldListInit(object):
+    """
+    Unit tests for lib.packet.opaque_field.OpaqueFieldList.__init__
+    """
+    def test(self):
+        order = ["up", "down", "core"]
+        # Call
+        inst = OpaqueFieldList(order)
+        # Tests
+        ntools.eq_(inst._order, order)
+        ntools.eq_(inst._labels, {
+            "up": [],
+            "down": [],
+            "core": [],
+        })
+
+
+def _of_list_setup():
+    order = ["up", "down", "core"]
+    inst = OpaqueFieldList(order)
+    inst._labels = {
+        "up": ["up0", "up1", "up2"],
+        "down": [],
+        "core": ["core0"],
+    }
+    return inst
+
+
+class TestOpaqueFieldListSet(object):
+    """
+    Unit tests for lib.packet.opaque_field.OpaqueFieldList.set
+    """
+    def test_success(self):
+        inst = _of_list_setup()
+        # Call
+        inst.set("down", ["there"])
+        # Tests
+        ntools.eq_(inst._labels["down"], ["there"])
+
+    def test_failure(self):
+        inst = _of_list_setup()
+        # Call
+        ntools.assert_raises(SCIONKeyError, inst.set, "oops", ["there"])
+
+
+class TestOpaqueFieldListGetByIdx(object):
+    """
+    Unit tests for lib.packet.opaque_field.OpaqueFieldList.get_by_idx
+    """
+    def _check(self, idx, expected):
+        inst = _of_list_setup()
+        # Call
+        ntools.eq_(inst.get_by_idx(idx), expected)
+
+    def test(self):
+        for idx, expected in (
+            (0, "up0"),
+            (2, "up2"),
+            (3, "core0"),
+            (4, None),
+        ):
+            yield self._check, idx, expected
+
+    def test_negative(self):
+        inst = _of_list_setup()
+        # Call
+        ntools.assert_raises(SCIONIndexError, inst.get_by_idx, -1)
+
+
+class TestOpaqueFieldListGetByLabel(object):
+    """
+    Unit tests for lib.packet.opaque_field.OpaqueFieldList.get_by_label
+    """
+    def test_basic(self):
+        inst = _of_list_setup()
+        # Call
+        ntools.eq_(inst.get_by_label("core"), ["core0"])
+
+    def test_with_idx(self):
+        inst = _of_list_setup()
+        # Call
+        ntools.eq_(inst.get_by_label("up", 2), "up2")
+
+    def test_label_error(self):
+        inst = _of_list_setup()
+        # Call
+        ntools.assert_raises(SCIONKeyError, inst.get_by_label, "nope")
+
+    def test_idx_error(self):
+        inst = _of_list_setup()
+        # Call
+        ntools.assert_raises(SCIONIndexError, inst.get_by_label, "core", 4)
+
+
+class TestOpaqueFieldListSwap(object):
+    """
+    Unit tests for lib.packet.opaque_field.OpaqueFieldList.swap
+    """
+    def test_basic(self):
+        inst = _of_list_setup()
+        # Call
+        inst.swap("up", "core")
+        # Tests
+        ntools.eq_(inst._labels, {
+            "up": ["core0"],
+            "down": [],
+            "core": ["up0", "up1", "up2"],
+        })
+
+    def test_one_empty(self):
+        inst = _of_list_setup()
+        # Call
+        inst.swap("down", "core")
+        # Tests
+        ntools.eq_(inst._labels, {
+            "up": ["up0", "up1", "up2"],
+            "down": ["core0"],
+            "core": [],
+        })
+
+    def test_label_error(self):
+        inst = _of_list_setup()
+        # Call
+        ntools.assert_raises(SCIONKeyError, inst.swap, "up", "nope")
+
+
+class TestOpaqueFieldListReverseLabel(object):
+    """
+    Unit tests for lib.packet.opaque_field.OpaqueFieldList.reverse_label
+    """
+    def test_basic(self):
+        inst = _of_list_setup()
+        # Call
+        inst.reverse_label("up")
+        # Tests
+        ntools.eq_(inst._labels["up"], ["up2", "up1", "up0"])
+
+    def test_label_error(self):
+        inst = _of_list_setup()
+        # Call
+        ntools.assert_raises(SCIONKeyError, inst.reverse_label, "nope")
+
+
+class TestOpaqueFieldListReverseUpFlag(object):
+    """
+    Unit tests for lib.packet.opaque_field.OpaqueFieldList.reverse_up_flag
+    """
+    def test_basic(self):
+        inst = _of_list_setup()
+        iof = create_mock(["up_flag"])
+        iof.up_flag = True
+        inst._labels["down"] = [iof]
+        # Call
+        inst.reverse_up_flag("down")
+        # Tests
+        ntools.assert_false(iof.up_flag)
+
+    def test_empty(self):
+        inst = _of_list_setup()
+        # Call
+        inst.reverse_up_flag("down")
+
+    def test_label_error(self):
+        inst = _of_list_setup()
+        # Call
+        ntools.assert_raises(SCIONKeyError, inst.reverse_up_flag, "nope")
+
+
+class TestOpaqueFieldListPack(object):
+    """
+    Unit tests for lib.packet.opaque_field.OpaqueFieldList.pack
+    """
+    def test_basic(self):
+        order = ["a", "b", "c", "d"]
+        inst = OpaqueFieldList(order)
+        ofs = []
+        for i in range(5):
+            of = create_mock(["pack"])
+            of.pack.return_value = bytes([i])
+            ofs.append(of)
+        inst._labels = {
+            "a": ofs[:2],
+            "b": [],
+            "c": [ofs[2]],
+            "d": ofs[3:],
+        }
+        # Call
+        ntools.eq_(inst.pack(), bytes(range(5)))
+        # Tests
+        for of in ofs:
+            of.pack.assert_called_once_with()
+
+
+class TestOpaqueFieldListCount(object):
+    """
+    Unit tests for lib.packet.opaque_field.OpaqueFieldList.count
+    """
+    def test_basic(self):
+        inst = _of_list_setup()
+        # Call
+        ntools.eq_(inst.count("up"), 3)
+
+    def test_label_error(self):
+        inst = _of_list_setup()
+        # Call
+        ntools.assert_raises(SCIONKeyError, inst.count, "nope")
+
+
+class TestOpaqueFieldListLen(object):
+    """
+    Unit tests for lib.packet.opaque_field.OpaqueFieldList.__len__
+    """
+    def test_basic(self):
+        inst = _of_list_setup()
+        # Call
+        ntools.eq_(len(inst), 4)
 
 if __name__ == "__main__":
     nose.run(defaultTest=__name__)

--- a/test/testcommon.py
+++ b/test/testcommon.py
@@ -19,6 +19,9 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
+# External
+import nose.tools as ntools
+
 # SCION
 from lib.errors import SCIONBaseError
 
@@ -98,3 +101,8 @@ def create_mock(attrs=None):
     for attr in attrs:
         setattr(m, attr, MagicMock(spec_set=[]))
     return m
+
+
+def assert_these_calls(mock, calls, any_order=False):
+    mock.assert_has_calls(calls)
+    ntools.eq_(mock.call_count, len(calls))


### PR DESCRIPTION
- Switch to using indexes instead of offsets /and/ indexes to address
  opaque fields.
- lib.packet.path.\* now use a new OpaqueFieldList class, which manages
  the opaque fields for them. It handles indexing, packing, reversing.
  This grealy simplifies the path.py code.
- Consolidated IOF/OF pointer methods in lib.packet.scion to 4 simple
  functions, replacing 9 existing ones.
- Lots of consolidation of path handling methods in path.py.
- Cleanup of path.PathConstructor, including switching everything from
  staticmethod to classmethod, to allow much cleaner self-referencing.
- Rewrote unit tests for path.py to be much cleaner.

Minor stuff:
- Print the actual OF info type name.
- Cleanup of OF str formatting.
- Removed unhelpful **repr** methods that screw up unit testing errors.
- Cleanup of comments and docstrings in path.py.

Everything seems to work, including end2end_test.py.

(Depends on #350 and #351)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38855329%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38855706%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38856347%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38856468%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38856783%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38856952%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38856968%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38857184%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38857209%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23issuecomment-138282084%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38857859%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38857993%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38858712%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23issuecomment-138282084%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22much%20cleaner%2C%20lgtm%20%21%22%2C%20%22created_at%22%3A%20%222015-09-07T12%3A18%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%207a418a3892c52fdaf1b62f60775b7d6f5a1a1f6f%20lib/packet/opaque_field.py%2098%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38855706%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20I%20don%27t%20understand%20but%20IOF%20without%20following%20HOFs%20is%20incorrect.%20Do%20we%20encapsulate%20IOF%20and%20HOFs%20separately%3F%22%2C%20%22created_at%22%3A%20%222015-09-07T11%3A45%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22the%20code%20clarified%20that.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-07T11%3A57%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/opaque_field.py%3AL283-453%22%7D%2C%20%22Pull%207a418a3892c52fdaf1b62f60775b7d6f5a1a1f6f%20lib/packet/scion.py%20154%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38856952%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22btw.%20at%20some%20point%20we%20should%20agree%20on%20when%20to%20use%20%60assert%60%20and%20when%20exceptions.%22%2C%20%22created_at%22%3A%20%222015-09-07T12%3A08%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20should%2C%20this%20particular%20one%20shouldn%27t%20be%20an%20assertion%20though%2C%20so%20i%27ll%20go%20fix%20it%20%3A%29%20%5Cr%5Cn%5Cr%5Cn%28Roughly%2C%20my%20thinking%20is%20that%20exceptions%20should%20be%20for%20errors%20that%20can%20be%20caused%20by%20bad/malicious%20data%2C%20assertions%20for%20things%20that%20only%20code%20bugs%20could%20trigger.%20This%20is%20what%20myself%20and%20%40shitz%20negotiated%20when%20reviewing%20his%20rewritten%20router%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-09-07T12%3A13%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed.%22%2C%20%22created_at%22%3A%20%222015-09-07T12%3A25%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/scion.py%3AL379-433%22%7D%2C%20%22Pull%207a418a3892c52fdaf1b62f60775b7d6f5a1a1f6f%20lib/packet/scion.py%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38857209%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22actually%2C%20in%20a%20following%20PR%20we%20should%20pack%20%60_idx%60%20values%20directly%20%28not%20calculated%20byte%20offset%29.%22%2C%20%22created_at%22%3A%20%222015-09-07T12%3A13%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20we%20define%20that%20all%20OFs%20have%20a%20fixed%20size%2C%20this%20works%20great%2C%20and%20simplifes%20things%20nicely.%20Some%20of%20the%20existing%20code%20assumes%20IOFs%20and%20HOFs%20could%20have%20different%20sizes%2C%20and%20some%20assumed%20they%20had%20the%20same.%22%2C%20%22created_at%22%3A%20%222015-09-07T12%3A27%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22IMO%20it%20is%20enough%20if%20we%20assume%20that%20they%20are%20padded%20to%208B%5Cn%5CnOn%207%20September%202015%20at%2014%3A27%2C%20Stephen%20Shirley%20%3Cnotifications%40github.com%3E%5Cnwrote%3A%5Cn%5Cn%3E%20In%20lib/packet/scion.py%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38857993%3E%3A%5Cn%3E%5Cn%3E%20%3E%20%20%20%20%20%20%20%20%20%20return%20struct.pack%28%5C%22%21HHBBBB%5C%22%2C%20types%2C%20self.total_len%2C%5Cn%3E%20%3E%20-%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20self.curr_iof_p%2C%20self.curr_of_p%2C%5Cn%3E%20%3E%20%2B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20curr_iof_p%2C%20curr_of_p%2C%5Cn%3E%5Cn%3E%20If%20we%20define%20that%20all%20OFs%20have%20a%20fixed%20size%2C%20this%20works%20great%2C%20and%5Cn%3E%20simplifes%20things%20nicely.%20Some%20of%20the%20existing%20code%20assumes%20IOFs%20and%20HOFs%5Cn%3E%20could%20have%20different%20sizes%2C%20and%20some%20assumed%20they%20had%20the%20same.%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/353/files%23r38857993%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-07T12%3A39%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/scion.py%3AL168-199%22%7D%2C%20%22Pull%207a418a3892c52fdaf1b62f60775b7d6f5a1a1f6f%20lib/packet/path.py%201474%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38856783%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22yes%2C%20i%20think%20it%20is%20possible%22%2C%20%22created_at%22%3A%20%222015-09-07T12%3A06%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok.%20We%27d%20need%20additional%20logic%20to%20handle%20that%20properly%20in%20the%20future%2C%20right%20now%20we%27ll%20just%20end%20up%20one%20randomly.%22%2C%20%22created_at%22%3A%20%222015-09-07T12%3A09%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL604-828%22%7D%2C%20%22Pull%207a418a3892c52fdaf1b62f60775b7d6f5a1a1f6f%20lib/errors.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/353%23discussion_r38855329%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22what%27s%20an%20advantage%20of%20own%20classes%20for%20errors%2C%20instead%20of%20using%20just%20KeyError%3F%22%2C%20%22created_at%22%3A%20%222015-09-07T11%3A38%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20provides%20more%20information%20about%20the%20context.%20You%20can%20do%20things%20like%3A%5Cr%5Cn%60%60%60%5Cr%5Cntry%3A%5Cr%5Cn%20%20%20thing%5Cr%5Cnexcept%20SCIONBaseError%20as%20e%3A%5Cr%5Cn%20%20%20...%20ok%2C%20we%20raised%20an%20exception%2C%20do%20stuff%20...%5Cr%5Cnexcept%20Exception%3A%5Cr%5Cn%20%20%20...%20this%20is%20really%20bad%2C%20this%20is%20an%20unhandled%20exception%2C%20do%20emergency%20stuff%20...%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-09-07T12%3A00%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/errors.py%3AL48-61%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 7a418a3892c52fdaf1b62f60775b7d6f5a1a1f6f lib/errors.py 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/353#discussion_r38855329'>File: lib/errors.py:L48-61</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> what's an advantage of own classes for errors, instead of using just KeyError?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It provides more information about the context. You can do things like:

```
try:
thing
except SCIONBaseError as e:
... ok, we raised an exception, do stuff ...
except Exception:
... this is really bad, this is an unhandled exception, do emergency stuff ...
```
- [ ] <a href='#crh-comment-Pull 7a418a3892c52fdaf1b62f60775b7d6f5a1a1f6f lib/packet/path.py 1474'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/353#discussion_r38856783'>File: lib/packet/path.py:L604-828</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> yes, i think it is possible
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok. We'd need additional logic to handle that properly in the future, right now we'll just end up one randomly.
- [ ] <a href='#crh-comment-Pull 7a418a3892c52fdaf1b62f60775b7d6f5a1a1f6f lib/packet/scion.py 154'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/353#discussion_r38856952'>File: lib/packet/scion.py:L379-433</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> btw. at some point we should agree on when to use `assert` and when exceptions.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> We should, this particular one shouldn't be an assertion though, so i'll go fix it :)
  (Roughly, my thinking is that exceptions should be for errors that can be caused by bad/malicious data, assertions for things that only code bugs could trigger. This is what myself and @shitz negotiated when reviewing his rewritten router :)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Fixed.
- [ ] <a href='#crh-comment-Pull 7a418a3892c52fdaf1b62f60775b7d6f5a1a1f6f lib/packet/scion.py 50'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/353#discussion_r38857209'>File: lib/packet/scion.py:L168-199</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> actually, in a following PR we should pack `_idx` values directly (not calculated byte offset).
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> If we define that all OFs have a fixed size, this works great, and simplifes things nicely. Some of the existing code assumes IOFs and HOFs could have different sizes, and some assumed they had the same.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> IMO it is enough if we assume that they are padded to 8B
  On 7 September 2015 at 14:27, Stephen Shirley notifications@github.com
  wrote:
  > In lib/packet/scion.py
  > https://github.com/netsec-ethz/scion/pull/353#discussion_r38857993:
  >
  > >          return struct.pack("!HHBBBB", types, self.total_len,
  > > -                           self.curr_iof_p, self.curr_of_p,
  > > +                           curr_iof_p, curr_of_p,
  >
  > If we define that all OFs have a fixed size, this works great, and
  > simplifes things nicely. Some of the existing code assumes IOFs and HOFs
  > could have different sizes, and some assumed they had the same.
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/353/files#r38857993.
  >
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/353#issuecomment-138282084'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> much cleaner, lgtm !
- [x] <a href='#crh-comment-Pull 7a418a3892c52fdaf1b62f60775b7d6f5a1a1f6f lib/packet/opaque_field.py 98'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/353#discussion_r38855706'>File: lib/packet/opaque_field.py:L283-453</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> Maybe I don't understand but IOF without following HOFs is incorrect. Do we encapsulate IOF and HOFs separately?
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> the code clarified that. :+1:

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/353?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/353?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/353'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
