### PR TITLE
Add UDP/SCION support.

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -103,10 +103,10 @@ class SCIONDaemon(SCIONElement):
         self._api_socket = None
         self.daemon_thread = None
         if run_local_api:
-            self._api_sock = UDPSocket(bind=(SCIOND_API_HOST, SCIOND_API_PORT),
-                                       addr_type=ADDR_IPV4_TYPE)
+            self._api_sock = UDPSocket(
+                bind=(SCIOND_API_HOST, SCIOND_API_PORT, "sciond local API"),
+                addr_type=ADDR_IPV4_TYPE)
             self._socks.add(self._api_sock)
-            logging.info("Local API %s:%u", SCIOND_API_HOST, SCIOND_API_PORT)
 
     @classmethod
     def start(cls, addr, topo_file, run_local_api=False):

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -16,7 +16,6 @@
 ==================================================
 """
 # Stdlib
-import logging
 import queue
 import threading
 from abc import ABCMeta, abstractmethod
@@ -95,12 +94,10 @@ class SCIONElement(object, metaclass=ABCMeta):
             self._in_buf = queue.Queue()
             self._socks = UDPSocketMgr()
             self._local_sock = UDPSocket(
-                bind=(str(self.addr.host_addr), SCION_UDP_PORT),
+                bind=(str(self.addr.host_addr), SCION_UDP_PORT, self.id),
                 addr_type=self.addr.host_addr.TYPE,
             )
             self._socks.add(self._local_sock)
-            logging.info("%s: bound %s:%u", self.id, self.addr.host_addr,
-                         SCION_UDP_PORT)
 
     def parse_topology(self, topo_file):
         """

--- a/lib/defines.py
+++ b/lib/defines.py
@@ -39,13 +39,13 @@ SCION_UDP_EH_DATA_PORT = 30041
 SCION_DNS_PORT = 30053
 
 #: (Pseudo)supported layer-4 protocols, see /etc/protocols for details
-L4_PROTO = [
-    1,  # ICMP
-    6,  # TCP
-    17,  # UDP
-]
+L4_ICMP = 1
+L4_TCP = 6
+L4_UDP = 17
+L4_RESERVED = 255
+L4_PROTOS = [L4_ICMP, L4_TCP, L4_UDP, L4_RESERVED]
 #: Default layer-4 protocol.
-DEFAULT_L4_PROTO = 17
+L4_DEFAULT = L4_RESERVED
 
 BEACON_SERVICE = "bs"
 CERTIFICATE_SERVICE = "cs"

--- a/lib/packet/scion_udp.py
+++ b/lib/packet/scion_udp.py
@@ -1,0 +1,122 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`scion_udp` --- UDP/SCION packets
+======================================
+"""
+# Stdlib
+import struct
+
+# External
+import scapy.utils
+
+# SCION
+from lib.defines import L4_UDP
+from lib.errors import SCIONParseError
+from lib.packet.packet_base import PacketBase
+from lib.util import Raw
+
+
+class SCIONUDPPacket(PacketBase):
+    """
+    Encapsulates the UDP header and payload for UDP/SCION packets.
+    """
+    HDR_LEN = 8
+    MIN_LEN = HDR_LEN
+
+    def __init__(self, raw=None):
+        """
+
+        :param tuple raw:
+            Tuple of (`SCIONAddr`, `SCIONAddr`, bytes) for the source address,
+            destination address, and raw UDP packet respectively.
+        """
+        super().__init__()
+        self._src_addr = None
+        self.src_port = None
+        self._dst_addr = None
+        self.dst_port = None
+
+        if raw:
+            self.parse(*raw)
+
+    @classmethod
+    def from_values(cls, src_addr, src_port, dst_addr, dst_port, payload=None):
+        """
+        Returns a SCIONUDPPacket with the values specified.
+        """
+        inst = cls()
+        inst._src_addr = src_addr
+        inst.src_port = src_port
+        inst._dst_addr = dst_addr
+        inst.dst_port = dst_port
+        if payload is not None:
+            inst.set_payload(payload)
+        return inst
+
+    def parse(self, src_addr, dst_addr, raw):
+        data = Raw(raw, "SCIONUDPPacket", self.MIN_LEN, min_=True)
+        self._src_addr = src_addr
+        self._dst_addr = dst_addr
+        self.src_port, self.dst_port, payload_len, checksum = \
+            struct.unpack("!HHHH", data.pop(self.HDR_LEN))
+        # Strip off udp header size.
+        payload_len -= self.HDR_LEN
+        if payload_len != len(data):
+            raise SCIONParseError(
+                "SCIONUDPPacket: payload length in header (%d) does not match "
+                "supplied payload (%d)" % (payload_len, len(data)))
+        self.set_payload(data.pop(payload_len), expected=checksum)
+
+    def pack(self):
+        checksum = self._calc_checksum()
+        hdr = struct.pack("!HHHH", self.src_port, self.dst_port, len(self),
+                          checksum)
+        return hdr + self._payload
+
+    def set_payload(self, payload, expected=None):
+        super().set_payload(payload)
+        if expected is None:
+            return
+        checksum = self._calc_checksum()
+        if checksum != expected:
+            raise SCIONParseError(
+                "SCIONUDPPacket: checksum in header (%s) does not match "
+                "checksum of payload (%s)" % (expected, checksum))
+
+    def _calc_checksum(self):
+        """
+        Using a Pseudoheader of:
+            - Source address
+            - Destination address
+            - L4 protocol type (UDP)
+            - Source port
+            - Destination port
+            - Payload length
+        """
+        pseudo_header = b"".join([
+            self._src_addr.pack(),
+            self._dst_addr.pack(),
+            struct.pack("!BHHH", L4_UDP, self.src_port, self.dst_port,
+                        len(self)),
+            self._payload,
+        ])
+        return scapy.utils.checksum(pseudo_header)
+
+    def __len__(self):
+        return self.HDR_LEN + len(self._payload)
+
+    def __str__(self):
+        return "[UDP sport: %s dport: %s len: %s]" % (
+            self.src_port, self.dst_port, len(self))

--- a/lib/socket.py
+++ b/lib/socket.py
@@ -46,8 +46,8 @@ class UDPSocket(object):
         address/port.
 
         :param tuple bind:
-            Optional tuple of (`str`, `int`) describing the address and port to
-            bind to, respectively.
+            Optional tuple of (`str`, `int`, `str`) describing respectively the
+            address and port to bind to, and an optional description.
         :param addr_type:
             Socket domain. Must be one of :const:`~lib.defines.ADDR_IPV4_TYPE`,
             :const:`~lib.defines.ADDR_IPV6_TYPE` (default).
@@ -59,23 +59,27 @@ class UDPSocket(object):
             af_domain = AF_INET
         self.sock = socket(af_domain, SOCK_DGRAM)
         self.sock.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+        self.port = None
         if bind:
             self.bind(*bind)
 
-    def bind(self, addr, port):
+    def bind(self, addr, port, desc=None):
         """
         Bind socket to the specified address & port. If `addr` is ``None``, the
         socket will bind to all interfaces.
 
         :param str addr: Address to bind to (can be ``None``, see above).
         :param int port: Port to bind to.
+        :param str desc: Optional purpose of the port.
         """
         if addr is None:
             addr = "::"
             if self._domain == ADDR_IPV4_TYPE:
                 addr = ""
         self.sock.bind((addr, port))
-        logging.info("Bound to %s:%d", addr, port)
+        self.port = self.sock.getsockname()[1]
+        if desc:
+            logging.info("%s bound to %s:%d", desc, addr, self.port)
 
     def send(self, data, dst):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ pycrypto
 pydblite
 pygments
 python-pytun
+scapy-python3
 sphinxcontrib-napoleon

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -25,13 +25,14 @@ import unittest
 
 # SCION
 from endhost.sciond import SCIOND_API_HOST, SCIOND_API_PORT, SCIONDaemon
-from lib.defines import ADDR_IPV4_TYPE, SCION_UDP_EH_DATA_PORT
+from lib.defines import ADDR_IPV4_TYPE, L4_UDP
 from lib.log import init_logging, log_exception
 from lib.packet.host_addr import haddr_get_type, haddr_parse
 from lib.packet.opaque_field import InfoOpaqueField, OpaqueFieldType as OFT
 from lib.packet.path import CorePath, CrossOverPath, EmptyPath, PeerPath
 from lib.packet.scion import SCIONPacket
 from lib.packet.scion_addr import SCIONAddr, ISD_AD
+from lib.packet.scion_udp import SCIONUDPPacket
 from lib.socket import UDPSocket
 from lib.thread import kill_self, thread_safety_net
 from lib.util import Raw, handle_signals
@@ -45,7 +46,7 @@ def get_paths_via_api(isd, ad):
     """
     Test local API.
     """
-    sock = UDPSocket(bind=("127.0.0.1", 5005), addr_type=ADDR_IPV4_TYPE)
+    sock = UDPSocket(bind=("127.0.0.1", 0), addr_type=ADDR_IPV4_TYPE)
     msg = b'\x00' + ISD_AD(isd, ad).pack()
 
     for _ in range(5):
@@ -86,16 +87,17 @@ class Ping(object):
     """
     Simple ping app.
     """
-    def __init__(self, src, dst, token):
+    def __init__(self, src, dst, dport, token):
         self.src = src
         self.dst = dst
+        self.dport = dport
         self.token = token
         self.pong_received = False
         topo_file = ("../../topology/ISD%d/topologies/ISD:%d-AD:%d.json" %
                      (src.isd, src.isd, src.ad))
         self.sd = SCIONDaemon.start(saddr, topo_file, True)  # API on
         self.get_path()
-        self.sock = UDPSocket(bind=(str(saddr), SCION_UDP_EH_DATA_PORT),
+        self.sock = UDPSocket(bind=(str(saddr), 0, "Ping App"),
                               addr_type=ADDR_IPV4_TYPE)
 
     def get_path(self):
@@ -112,7 +114,10 @@ class Ping(object):
     def send(self):
         dst = SCIONAddr.from_values(self.dst.isd, self.dst.ad, raddr)
         ping = b"ping " + self.token
-        spkt = SCIONPacket.from_values(self.sd.addr, dst, ping, self.path)
+        upkt = SCIONUDPPacket.from_values(self.sd.addr, self.sock.port, dst,
+                                          self.dport, ping)
+        spkt = SCIONPacket.from_values(self.sd.addr, dst, upkt,
+                                       self.path, next_hdr=L4_UDP)
         (next_hop, port) = self.sd.get_first_hop(spkt)
         assert next_hop == self.hop
 
@@ -122,13 +127,16 @@ class Ping(object):
 
     def recv(self):
         packet = self.sock.recv()[0]
+        spkt = SCIONPacket(packet)
+        upkt = spkt.get_payload()
         pong = b"pong " + self.token
-        payload = SCIONPacket(packet).get_payload()
+        payload = upkt.get_payload()
         if payload == pong:
-            logging.info('%s: pong received.', saddr)
+            logging.info('%s:%d: pong received.', saddr, self.sock.port)
             self.pong_received = True
         else:
-            logging.error("Unexpected payload received: %s", payload)
+            logging.error("Unexpected payload received: %s (expected: %s)",
+                          payload, pong)
             kill_self()
         self.sock.close()
         self.sd.stop()
@@ -145,19 +153,28 @@ class Pong(object):
         topo_file = ("../../topology/ISD%d/topologies/ISD:%d-AD:%d.json" %
                      (self.dst.isd, self.dst.isd, self.dst.ad))
         self.sd = SCIONDaemon.start(raddr, topo_file)  # API off
-        self.sock = UDPSocket(bind=(str(raddr), SCION_UDP_EH_DATA_PORT),
+        self.sock = UDPSocket(bind=(str(raddr), 0, "Pong App"),
                               addr_type=ADDR_IPV4_TYPE)
+
+    def get_local_port(self):
+        return self.sock.get_port()
 
     def run(self):
         packet = self.sock.recv()[0]
         spkt = SCIONPacket(packet)
+        upkt = spkt.get_payload()
         ping = b"ping " + self.token
-        if spkt.get_payload() == ping:
+        pong = b"pong " + self.token
+        rpkt = SCIONUDPPacket.from_values(
+            spkt.hdr.dst_addr, upkt.dst_port, spkt.hdr.src_addr, upkt.src_port,
+            pong)
+        if upkt.get_payload() == ping:
             # Reverse the packet and send "pong".
-            logging.info('%s: ping received, sending pong.', raddr)
+            logging.info('%s:%d: ping received, sending pong.', raddr,
+                         self.sock.port)
             self.ping_received = True
             spkt.hdr.reverse()
-            spkt.set_payload(b"pong " + self.token)
+            spkt.set_payload(rpkt)
             (next_hop, port) = self.sd.get_first_hop(spkt)
             self.sd.send(spkt, next_hop, port)
         self.sock.close()
@@ -193,7 +210,7 @@ class TestSCIONDaemon(unittest.TestCase):
                     threading.Thread(
                         target=thread_safety_net, args=(pong_app.run,),
                         name="E2E.pong_app", daemon=True).start()
-                    ping_app = Ping(src, dst, token)
+                    ping_app = Ping(src, dst, pong_app.sock.port, token)
                     threading.Thread(
                         target=thread_safety_net, args=(ping_app.run,),
                         name="E2E.ping_app", daemon=True).start()

--- a/test/lib_packet_scion_udp_test.py
+++ b/test/lib_packet_scion_udp_test.py
@@ -1,0 +1,209 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`lib_packet_scion_udp_test` --- lib.packet.scion_udp unit tests
+====================================================================
+"""
+# Stdlib
+from unittest.mock import patch
+
+# External packages
+import nose
+import nose.tools as ntools
+
+# SCION
+from lib.errors import SCIONParseError
+from lib.packet.scion_udp import (
+    SCIONUDPPacket,
+)
+from test.testcommon import create_mock
+
+
+class TestSCIONUDPPacketInit(object):
+    """
+    Unit tests for lib.packet.scion_udp.SCIONUDPPacket.__init__
+    """
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.parse", autospec=True)
+    @patch("lib.packet.scion_udp.PacketBase.__init__", autospec=True,
+           return_value=None)
+    def test_basic(self, super_init, parse):
+        # Call
+        inst = SCIONUDPPacket()
+        # Tests
+        super_init.assert_called_once_with(inst)
+        ntools.assert_is_none(inst._src_addr)
+        ntools.assert_is_none(inst.src_port)
+        ntools.assert_is_none(inst._dst_addr)
+        ntools.assert_is_none(inst.dst_port)
+        ntools.assert_false(parse.called)
+
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.parse", autospec=True)
+    @patch("lib.packet.scion_udp.PacketBase.__init__", autospec=True,
+           return_value=None)
+    def test_raw(self, super_init, parse):
+        # Call
+        inst = SCIONUDPPacket(raw=("src", "dst", "raw"))
+        # Tests
+        parse.assert_called_once_with(inst, "src", "dst", "raw")
+
+
+class TestSCIONUDPPacketFromValues(object):
+    """
+    Unit tests for lib.packet.scion_udp.SCIONUDPPacket.from_values
+    """
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.set_payload", autospec=True)
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.__init__", autospec=True,
+           return_value=None)
+    def test_full(self, init, set_payload):
+        # Call
+        inst = SCIONUDPPacket.from_values("src_addr", "src_port", "dst_addr",
+                                          "dst_port", "payload")
+        # Tests
+        init.assert_called_once_with(inst)
+        ntools.eq_(inst._src_addr, "src_addr")
+        ntools.eq_(inst.src_port, "src_port")
+        ntools.eq_(inst._dst_addr, "dst_addr")
+        ntools.eq_(inst.dst_port, "dst_port")
+        set_payload.assert_called_once_with(inst, "payload")
+
+
+class TestSCIONUDPPacketParse(object):
+    """
+    Unit tests for lib.packet.scion_udp.SCIONUDPPacket.parse
+    """
+    @patch("lib.packet.scion_udp.Raw", autospec=True)
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.__init__", autospec=True,
+           return_value=None)
+    def test_basic(self, init, raw):
+        inst = SCIONUDPPacket()
+        data = raw.return_value
+        data.pop.side_effect = [bytes.fromhex("0102030405060708"), "payload"]
+        data.__len__.return_value = 0x0506 - inst.HDR_LEN
+        inst.set_payload = create_mock()
+        # Call
+        inst.parse("src", "dst", "raw")
+        # Tests
+        raw.assert_called_once_with("raw", "SCIONUDPPacket", inst.MIN_LEN,
+                                    min_=True)
+        ntools.eq_(inst._src_addr, "src")
+        ntools.eq_(inst._dst_addr, "dst")
+        ntools.eq_(inst.src_port, 0x0102)
+        ntools.eq_(inst.dst_port, 0x0304)
+        inst.set_payload.assert_called_once_with("payload", expected=0x0708)
+
+    @patch("lib.packet.scion_udp.Raw", autospec=True)
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.__init__", autospec=True,
+           return_value=None)
+    def test_bad_length(self, init, raw):
+        inst = SCIONUDPPacket()
+        data = raw.return_value
+        data.pop.side_effect = [bytes.fromhex("0102030405060708"), "payload"]
+        data.__len__.return_value = 0x0507
+        # Call
+        ntools.assert_raises(SCIONParseError, inst.parse, "src", "dst", "raw")
+
+
+class TestSCIONUDPPacketPack(object):
+    """
+    Unit tests for lib.packet.scion_udp.SCIONUDPPacket.pack
+    """
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.__len__", autospec=True,
+           return_value=None)
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.__init__", autospec=True,
+           return_value=None)
+    def test(self, init, len_):
+        inst = SCIONUDPPacket()
+        inst._calc_checksum = create_mock()
+        inst._calc_checksum.return_value = 0x0708
+        inst._payload = b"payload"
+        inst.src_port = 0x0102
+        inst.dst_port = 0x0304
+        len_.return_value = 0x0506
+        expected = bytes.fromhex("0102030405060708") + inst._payload
+        # Call
+        ntools.eq_(inst.pack(), expected)
+
+
+class TestSCIONUDPPacketSetPayload(object):
+    """
+    Unit tests for lib.packet.scion_udp.SCIONUDPPacket.set_payload
+    """
+    @patch("lib.packet.scion_udp.PacketBase.set_payload", autospec=True)
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.__init__", autospec=True,
+           return_value=None)
+    def test_basic(self, init, pb_set_pld):
+        inst = SCIONUDPPacket()
+        inst._calc_checksum = create_mock()
+        # Call
+        inst.set_payload("payload")
+        # Tests
+        pb_set_pld.assert_called_once_with(inst, "payload")
+        ntools.assert_false(inst._calc_checksum.called)
+
+    @patch("lib.packet.scion_udp.PacketBase.set_payload", autospec=True)
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.__init__", autospec=True,
+           return_value=None)
+    def test_expected_match(self, init, pb_set_pld):
+        inst = SCIONUDPPacket()
+        inst._calc_checksum = create_mock()
+        # Call
+        inst.set_payload("payload", expected=inst._calc_checksum.return_value)
+        # Tests
+        inst._calc_checksum.assert_called_once_with()
+
+    @patch("lib.packet.scion_udp.PacketBase.set_payload", autospec=True)
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.__init__", autospec=True,
+           return_value=None)
+    def test_expected_fail(self, init, pb_set_pld):
+        inst = SCIONUDPPacket()
+        inst._calc_checksum = create_mock()
+        # Call
+        ntools.assert_raises(SCIONParseError, inst.set_payload, "payload",
+                             expected="expected")
+
+
+class TestSCIONUDPPacketCalcChecksum(object):
+    """
+    Unit tests for lib.packet.scion_udp.SCIONUDPPacket._calc_checksum
+    """
+    @patch("lib.packet.scion_udp.scapy.utils.checksum", autospec=True)
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.__len__", autospec=True)
+    @patch("lib.packet.scion_udp.SCIONUDPPacket.__init__", autospec=True,
+           return_value=None)
+    def test(self, init, len_, scapy_checksum):
+        inst = SCIONUDPPacket()
+        inst._src_addr = create_mock(["pack"])
+        inst._src_addr.pack.return_value = b"source address"
+        inst._dst_addr = create_mock(["pack"])
+        inst._dst_addr.pack.return_value = b"destination address"
+        inst.src_port = 0x0042
+        inst.dst_port = 0x0302
+        inst._payload = b"payload"
+        len_.return_value = 0x7
+        expected_call = b"".join([
+            b"source address",
+            b"destination address",
+            bytes.fromhex("11 0042 0302 0007"),
+            b"payload",
+        ])
+        # Call
+        ntools.eq_(inst._calc_checksum(), scapy_checksum.return_value)
+        # Tests
+        inst._src_addr.pack.assert_called_once_with()
+        inst._dst_addr.pack.assert_called_once_with()
+        scapy_checksum.assert_called_once_with(expected_call)
+
+
+if __name__ == "__main__":
+    nose.run(defaultTest=__name__)

--- a/test/lib_socket_test.py
+++ b/test/lib_socket_test.py
@@ -50,6 +50,7 @@ class TestUDPSocketInit(object):
         # Tests
         ntools.eq_(inst._addr_type, ADDR_IPV4_TYPE)
         socket_.assert_called_once_with(socket.AF_INET, socket.SOCK_DGRAM)
+        ntools.assert_is_none(inst.port)
         inst.bind.assert_called_once_with("addr", "port")
 
     @patch("lib.socket.UDPSocket.bind", autopatch=True)
@@ -67,20 +68,25 @@ class TestUDPSocketBind(object):
     """
     Unit tests for lib.socket.UDPSocket.bind
     """
+    def _setup(self):
+        inst = UDPSocket()
+        inst.sock = create_mock(["bind", "getsockname"])
+        inst.sock.getsockname.return_value = ["addr", "port"]
+        return inst
+
     @patch("lib.socket.UDPSocket.__init__", autopatch=True, return_value=None)
     def test_addr(self, init):
-        inst = UDPSocket()
-        inst.sock = create_mock(["bind"])
+        inst = self._setup()
         # Call
         inst.bind("addr", 4242)
         # Tests
         inst.sock.bind.assert_called_once_with(("addr", 4242))
+        ntools.eq_(inst.port, "port")
 
     @patch("lib.socket.UDPSocket.__init__", autopatch=True, return_value=None)
     def test_any_v4(self, init):
-        inst = UDPSocket()
+        inst = self._setup()
         inst._domain = ADDR_IPV4_TYPE
-        inst.sock = create_mock(["bind"])
         # Call
         inst.bind(None, 4242)
         # Tests
@@ -88,9 +94,8 @@ class TestUDPSocketBind(object):
 
     @patch("lib.socket.UDPSocket.__init__", autopatch=True, return_value=None)
     def test_any_v6(self, init):
-        inst = UDPSocket()
+        inst = self._setup()
         inst._domain = ADDR_IPV6_TYPE
-        inst.sock = create_mock(["bind"])
         # Call
         inst.bind(None, 4242)
         # Tests


### PR DESCRIPTION
This means that we can now encapsulate UDP packets inside SCION packets.
- Reworked the L4 entries in lib.defines a bit to be more
  useful/consistent.
- Set the default L4 protocol to be 255, which is reserved. When we stop
  encoding payloads directly into SCION packets, we can change this to
  UDP.
- Router will deliver UDP packets directly to the ports in the UDP/SCION
  header.
- The pseudo-header for UDP checksum is created using src/dest host
  addrs (including ISD/AD pairs), as well as the usual ports, payload
  length, and protocol number.
- Change lib.socket.UDPSocket.bind to only log a message if a
  description is provided, to make the startup logs more readable.
- E2E updated to use UDP/SCION, and to no longer use fixed ports.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/356%23discussion_r38860055%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/356%23discussion_r38860138%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/356%23discussion_r38861902%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/356%23issuecomment-138300311%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/356%23issuecomment-138300311%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-09-07T13%3A32%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%205a1cf37b1f456f64a56d129e2dd4273cab83a7ba%20lib/packet/scion.py%2077%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/356%23discussion_r38860138%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20src/dst%20addresses%20go%20to%20packet%27s%20payload%3F%20%22%2C%20%22created_at%22%3A%20%222015-09-07T13%3A00%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Because%20the%20UDP%20checksum%20requires%20them%20as%20input.%22%2C%20%22created_at%22%3A%20%222015-09-07T13%3A27%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/scion.py%3AL546-558%22%7D%2C%20%22Pull%205a1cf37b1f456f64a56d129e2dd4273cab83a7ba%20infrastructure/router.py%2036%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/356%23discussion_r38860055%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22IMO%20it%20is%20fine%20if%20this%20is%20a%20short/mid-term%20solution%20%28eventually%20this%20demultiplexing%20should%20be%20realized%20at%20the%20end-host%29%22%2C%20%22created_at%22%3A%20%222015-09-07T12%3A59%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/router.py%3AL321-331%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 5a1cf37b1f456f64a56d129e2dd4273cab83a7ba infrastructure/router.py 36'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/356#discussion_r38860055'>File: infrastructure/router.py:L321-331</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> IMO it is fine if this is a short/mid-term solution (eventually this demultiplexing should be realized at the end-host)
- [ ] <a href='#crh-comment-Pull 5a1cf37b1f456f64a56d129e2dd4273cab83a7ba lib/packet/scion.py 77'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/356#discussion_r38860138'>File: lib/packet/scion.py:L546-558</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> why src/dst addresses go to packet's payload?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Because the UDP checksum requires them as input.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/356#issuecomment-138300311'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/356?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/356?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/356'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
