### PR TITLE
Move path traversal into path.py.

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -330,10 +330,7 @@ class SCIONDaemon(SCIONElement):
         for path in paths:
             raw_path = path.pack()
             # assumed IPv4 addr
-            if path.get_first_iof().up_flag:
-                haddr = self.ifid2addr[path.get_first_hof().ingress_if]
-            else:
-                haddr = self.ifid2addr[path.get_first_hof().egress_if]
+            haddr = self.ifid2addr[path.get_fwd_if()]
             path_len = len(raw_path) // 8  # Check whether 8 divides path_len?
             reply.append(struct.pack("B", path_len) + raw_path + haddr.pack())
         self._api_sock.send(b"".join(reply), sender)

--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -1116,8 +1116,7 @@ class LocalBeaconServer(BeaconServer):
         dst_isd_ad = ISD_AD(pcb.get_isd(), pcb.get_first_pcbm().ad_id)
         pkt = PathMgmtPacket.from_values(PMT.RECORDS, records, core_path,
                                          self.addr, dst_isd_ad)
-        if_id = core_path.get_first_hof().ingress_if
-        next_hop = self.ifid2addr[if_id]
+        next_hop = self.ifid2addr[core_path.get_fwd_if()]
         self.send(pkt, next_hop)
 
     def register_segments(self):

--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -506,8 +506,7 @@ class CorePathServer(PathServer):
                     pkt.hdr.set_path(cpath)
                     pkt.hdr.dst_addr.isd_id = isd
                     pkt.hdr.dst_addr.ad_id = ad
-                    if_id = cpath.get_first_hof().ingress_if
-                    next_hop = self.ifid2addr[if_id]
+                    next_hop = self.ifid2addr[cpath.get_fwd_if()]
                     logging.info("Sending packet to CPS in (%d, %d).", isd, ad)
                     self.send(pkt, next_hop)
 
@@ -566,8 +565,7 @@ class CorePathServer(PathServer):
                     path = cpaths[0].get_path(reverse_direction=True)
                     dst_isd_ad = ISD_AD(cpaths[0].get_first_pcbm().isd_id,
                                         cpaths[0].get_first_pcbm().ad_id)
-                    if_id = path.get_first_hof().ingress_if
-                    next_hop = self.ifid2addr[if_id]
+                    next_hop = self.ifid2addr[path.get_fwd_if()]
                     request = PathMgmtPacket.from_values(PMT.REQUEST,
                                                          segment_info, path,
                                                          self.addr, dst_isd_ad)
@@ -825,8 +823,7 @@ class LocalPathServer(PathServer):
             pcb = records.pcbs[0]
             path = pcb.get_path(reverse_direction=True)
             dst_isd_ad = ISD_AD(pcb.get_isd(), pcb.get_first_pcbm().ad_id)
-            if_id = path.get_first_hof().ingress_if
-            next_hop = self.ifid2addr[if_id]
+            next_hop = self.ifid2addr[path.get_fwd_if()]
             targets = copy.copy(self.waiting_targets)
             for (isd, ad, info) in targets:
                 path_request = PathMgmtPacket.from_values(PMT.REQUEST, info,
@@ -1067,11 +1064,9 @@ class LocalPathServer(PathServer):
             # Above comment is from 2015-01-28, f288fb53
             up_seg_info = path.get_ofs_by_label(UP_IOF)[0]
             up_seg_info.up_flag = True
-            if_id = path.get_first_hof().ingress_if
-            next_hop = self.ifid2addr[if_id]
-            path_request = PathMgmtPacket.from_values(PMT.REQUEST, info,
-                                                      path, self.addr,
-                                                      dst_isd_ad)
+            next_hop = self.ifid2addr[path.get_fwd_if()]
+            path_request = PathMgmtPacket.from_values(
+                PMT.REQUEST, info, path, self.addr, dst_isd_ad)
             self.send(path_request, next_hop)
 
     def handle_path_request(self, pkt):

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -153,14 +153,10 @@ class SCIONElement(object, metaclass=ABCMeta):
         :returns:
         :rtype:
         """
-        opaque_field = spkt.hdr.get_path().get_first_hof()
-        if opaque_field is None:  # EmptyPath
-            return (spkt.hdr.dst_addr.host_addr, SCION_UDP_PORT)
-        else:
-            if spkt.hdr.is_on_up_path():
-                return (self.ifid2addr[opaque_field.ingress_if], SCION_UDP_PORT)
-            else:
-                return (self.ifid2addr[opaque_field.egress_if], SCION_UDP_PORT)
+        path = spkt.hdr.get_path()
+        if len(path) == 0:  # EmptyPath
+            return spkt.hdr.dst_addr.host_addr, SCION_UDP_PORT
+        return self.ifid2addr[path.get_fwd_if()], SCION_UDP_PORT
 
     def send(self, packet, dst, dst_port=SCION_UDP_PORT):
         """

--- a/lib/packet/opaque_field.py
+++ b/lib/packet/opaque_field.py
@@ -325,10 +325,10 @@ class OpaqueFieldList(object):
         :class:`OpaqueFieldList` object was created.
 
         :param int idx: The index to fetch.
-        :returns:
-            The OF at that index, or ``None`` if the index was past the end of
-            the labels.
+        :returns: The OF at that index.
         :rtype: :class:`OpaqueField`
+        :raises:
+            SCIONIndexError: if the index is negative, or too large.
         """
         if idx < 0:
             raise SCIONIndexError("Requested OF index (%d) is negative" % idx)
@@ -338,8 +338,8 @@ class OpaqueFieldList(object):
             if offset < len(group):
                 return group[offset]
             offset -= len(group)
-        # FIXME(kormat): is this correct?
-        return None
+        raise SCIONIndexError("Requested OF index (%d) is out of range (max %d)"
+                              % (idx, len(self) - 1))
 
     def get_by_label(self, label, label_idx=None):
         """

--- a/test/lib_packet_opaque_field_test.py
+++ b/test/lib_packet_opaque_field_test.py
@@ -426,14 +426,17 @@ class TestOpaqueFieldListGetByIdx(object):
             (0, "up0"),
             (2, "up2"),
             (3, "core0"),
-            (4, None),
         ):
             yield self._check, idx, expected
 
-    def test_negative(self):
+    def _check_bounds(self, index):
         inst = _of_list_setup()
         # Call
-        ntools.assert_raises(SCIONIndexError, inst.get_by_idx, -1)
+        ntools.assert_raises(SCIONIndexError, inst.get_by_idx, index)
+
+    def test_bounds(self):
+        for i in (-1, 4):
+            yield self._check_bounds, i
 
 
 class TestOpaqueFieldListGetByLabel(object):


### PR DESCRIPTION
This simplifes the router logic, and reduces repeated code.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/358%23issuecomment-138822437%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/358%23issuecomment-138858936%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/358%23issuecomment-138822437%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%28Depends%20on%20%23360%20to%20fix%20flakey%20bw%20test%29%22%2C%20%22created_at%22%3A%20%222015-09-09T08%3A24%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20much%20cleaner.%20%40shitz%20should%20look%20at%20this%20when%20he%20is%20back%2C%20as%20it%20may%20have%20implications%20on%20verifiability.%22%2C%20%22created_at%22%3A%20%222015-09-09T09%3A47%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/358#issuecomment-138822437'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (Depends on #360 to fix flakey bw test)
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> It is much cleaner. @shitz should look at this when he is back, as it may have implications on verifiability.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/358?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/358?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/358'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
