### PR TITLE
Correct get_lock's handling of timeouts.

### DIFF
--- a/lib/zookeeper.py
+++ b/lib/zookeeper.py
@@ -374,11 +374,14 @@ class Zookeeper(object):
                 logging.info("Successfully acquired ZK lock (epoch %d)",
                              self._lock_epoch)
                 self._lock.set()
-            else:
-                logging.debug("Failed to acquire ZK lock")
-        except (LockTimeout, ConnectionLoss, SessionExpiredError):
+        except (ConnectionLoss, SessionExpiredError):
             raise ZkNoConnection from None
-        return self.have_lock()
+        except LockTimeout:
+            pass
+        if self.have_lock():
+            return True
+        logging.debug("Failed to acquire ZK lock")
+        return False
 
     def release_lock(self):
         """


### PR DESCRIPTION
@pszalach
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/362?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/362'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
