### PR TITLE
Fix broken error handling in router.py

### DIFF
--- a/infrastructure/router.py
+++ b/infrastructure/router.py
@@ -547,13 +547,13 @@ class Router(SCIONElement):
             logging.error("Dropping packet due to incorrect MAC.\n"
                           "Header:\n%s\nInvalid OF: %s\nPrev OF: %s",
                           spkt.hdr, e.args[0], e.args[1])
-        except SCIONOFExpiredError:
-            logging.error("Dropping packet due to expired OF:")
-            logging.error("Header:\n%s", spkt.hdr)
-            logging.error("Expired OF: %s", e)
+        except SCIONOFExpiredError as e:
+            logging.error("Dropping packet due to expired OF.\n"
+                          "Header:\n%s\nExpired OF: %s",
+                          spkt.hdr, e)
         except SCIONPacketHeaderCorruptedError:
-            logging.error("Dropping packet due to invalid header state:")
-            logging.error("Header:\n%s", spkt.hdr)
+            logging.error("Dropping packet due to invalid header state.\n"
+                          "Header:\n%s", spkt.hdr)
 
     def handle_request(self, packet, sender, from_local_socket=True):
         """


### PR DESCRIPTION
The exception handler for SCIONOFExpiredError referenced the exception,
but hadn't actually created the variable.

Also fixed up formatting a bit.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/shitz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/369%23issuecomment-139493441%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-09-11T09%3A03%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/369%23issuecomment-139493441%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/shitz'><img src='https://avatars.githubusercontent.com/u/3840858?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/369?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/369?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/369'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
