### PR TITLE
Expire old paths from ZK.

### DIFF
--- a/lib/zookeeper.py
+++ b/lib/zookeeper.py
@@ -385,7 +385,6 @@ class Zookeeper(object):
             pass
         if self.have_lock():
             return True
-        logging.debug("Failed to acquire ZK lock")
         return False
 
     def release_lock(self):


### PR DESCRIPTION
This fixes path server load issues by expiring paths that haven't been
updated in 10 propagation periods.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/371%23issuecomment-139494761%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/371%23issuecomment-139496262%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/371%23issuecomment-139496459%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/371%23issuecomment-139512774%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/371%23issuecomment-139494761%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222015-09-11T09%3A12%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%2C%20but%20as%20that%20code%20is%20highly%20redundant%20maybe%20it%20should%20go%20to%20%60PathServer%60%20with%20%60def%20_sync_master%28self%29%3A%20pass%60%20at%20%60LocalPathServer%60%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-11T09%3A16%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22...%20or%20rather%20%60_update_master%28%29%60%20as%20%60pass%60%22%2C%20%22created_at%22%3A%20%222015-09-11T09%3A17%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Good%20point%2C%20updated.%22%2C%20%22created_at%22%3A%20%222015-09-11T10%3A36%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/371#issuecomment-139494761'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm, but as that code is highly redundant maybe it should go to `PathServer` with `def _sync_master(self): pass` at `LocalPathServer` ?
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> ... or rather `_update_master()` as `pass`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Good point, updated.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/371?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/371?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/371'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
