### PR TITLE
Don't query paths for core segment if src == dst

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -235,6 +235,8 @@ class SCIONDaemon(SCIONElement):
                     key = (src_isd, src_core_ad, dst_isd, dst_core_ad)
                     if key in src_dst_sets:
                         continue
+                    if (src_isd, src_core_ad) == (dst_isd, dst_core_ad):
+                        continue
                     self._request_paths(PST.CORE, dst_isd, dst_core_ad,
                                         src_ad=src_core_ad, requester=requester)
                     cs = self.core_segments(last_isd=src_isd,


### PR DESCRIPTION
This check was deleted in my previous PR.
Adding it back in fixes the end2endtest symptom described in #392 
The smarter logic I mentioned there will come later.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/393?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/393'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
