### PR TITLE
Change ZKSharedCache to not rely on timestamps.

### DIFF
--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -102,8 +102,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
                 name_addrs, self.topology.zookeepers)
             self.zk.retry("Joining party", self.zk.party_setup)
             self.path_cache = ZkSharedCache(self.zk, self.ZK_PATH_CACHE_PATH,
-                                            self._cached_entries_handler,
-                                            self.config.propagation_time)
+                                            self._cached_entries_handler)
 
     def worker(self):
         """
@@ -282,7 +281,8 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         pkt_packed = pkt.pack()
         pkt_hash = SHA256.new(pkt_packed).hexdigest()
         try:
-            self.path_cache.store(pkt_hash, pkt_packed)
+            self.path_cache.store("%s-%s" % (pkt_hash, SCIONTime.get_time()),
+                                  pkt_packed)
             logging.debug("Segment stored in ZK: %s...", pkt_hash[:5])
         except ZkNoConnection:
             logging.warning("Unable to store segment in shared path: "

--- a/test/testcommon.py
+++ b/test/testcommon.py
@@ -111,5 +111,5 @@ def create_mock(attrs=None, class_=None):
 
 
 def assert_these_calls(mock, calls, any_order=False):
-    mock.assert_has_calls(calls)
+    mock.assert_has_calls(calls, any_order=any_order)
     ntools.eq_(mock.call_count, len(calls))


### PR DESCRIPTION
Due to ZK consistency issues, it's possible for multiple entries with
the same timestamp to become visible at different times. This means that
using the latest timestamp of a processed entry to discard all older
entries on the next read can cause updated entries to be missed.

Switching instead to unique entry names allows us to determine just on
the children list which entries are new, no need to fetch the metadata
of every entry each run.

Instead of caching the zk timestamp of an entry, we now cache the
timestamp of the first time we read (or wrote) the entry. This means
that expiry is very simple.

By storing the timestamp on write, it also allows us to avoid reading
PCBs that we have written.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/396%23issuecomment-144373650%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/396%23issuecomment-144445629%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/396%23discussion_r40835371%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/396%23issuecomment-144373650%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20isn%27t%20quite%20ready%20yet%2C%20need%20to%20update%20unit%20tests%20and%20probably%20doc%20strings.%20Integration%20tests%20however%20do%20pass.%22%2C%20%22created_at%22%3A%20%222015-09-30T11%3A52%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Everything%20should%20be%20ready%20now.%20%40pszalach%20%22%2C%20%22created_at%22%3A%20%222015-09-30T15%3A25%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%204d08b858e25810e2e0f3fad695ca9c4d371b5488%20lib/zookeeper.py%2065%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/396%23discussion_r40835371%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22drop%20%5C%22/updated%5C%22%20from%20the%20docstring.%22%2C%20%22created_at%22%3A%20%222015-09-30T18%3A53%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/zookeeper.py%3AL592-611%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/396#issuecomment-144373650'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This isn't quite ready yet, need to update unit tests and probably doc strings. Integration tests however do pass.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Everything should be ready now. @pszalach
- [ ] <a href='#crh-comment-Pull 4d08b858e25810e2e0f3fad695ca9c4d371b5488 lib/zookeeper.py 65'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/396#discussion_r40835371'>File: lib/zookeeper.py:L592-611</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> drop "/updated" from the docstring.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/396?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/396?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/396'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
