### PR TITLE
Fixed a bug: Simulator creates two instances of a router

### DIFF
--- a/simulator/infrastructure/router_sim.py
+++ b/simulator/infrastructure/router_sim.py
@@ -108,8 +108,7 @@ class RouterSim(Router):
                 0., cb=self.sync_interface)
             self.event_id_map["request_ifstates"] = self.simulator.add_event(
                 0., cb=self.request_ifstates)
-        if self.stopped:
-            logging.info("Router %s restarted", str(self.addr.host_addr))
+            logging.info("Router %s started", str(self.addr.host_addr))
         self.stopped = False
 
     def stop(self):


### PR DESCRIPTION
- Since two elements are being added into simulator's element list corresponding to one router, two instances of a router were being generated.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/405%23issuecomment-145842435%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/405%23issuecomment-145853568%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/405%23issuecomment-145856519%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/405%23discussion_r41359146%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/405%23issuecomment-145842435%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20you%20elaborate%20what%20was%20the%20issue%20and%20how%20your%20PR%20fixes%20it%3F%22%2C%20%22created_at%22%3A%20%222015-10-06T12%3A31%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20issue%20is%20that%20since%20we%20add%202%20elements%20using%20add_element%20during%20the%5Cnrouters%20initialisation%2C%20the%20run%20function%20used%20to%20be%20called%20twice..%20So%20when%5Cnwe%20call%20the%20stop%20function%2C%20only%20one%20of%20the%20instances%20of%20router%20used%20to%5Cnstop..%5Cn%5CnFrom%20now%2C%20during%20the%20second%20call%20of%20run%20function%2C%20routers%20functions%20will%5Cnnot%20be%20called%20again..%5CnOn%206%20Oct%202015%2018%3A01%2C%20%5C%22shitz%5C%22%20%3Cnotifications%40github.com%3E%20wrote%3A%5Cn%5Cn%3E%20Can%20you%20elaborate%20what%20was%20the%20issue%20and%20how%20your%20PR%20fixes%20it%3F%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/405%23issuecomment-145842435%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-10-06T13%3A17%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6560106%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mskd96%22%7D%7D%2C%20%7B%22body%22%3A%20%22Then%20I%27d%20rather%20have%20an%20%60is_running%60%20flag%20within%20the%20infrastructure%20classes%20and%20%60run%28%29%60%20checks%20whether%20it%27s%20already%20running%20and%20returns%20if%20that%20is%20the%20case.%20You%20can%20also%20use%20the%20%60stopped%60%20flag%20that%20you%20already%20introduced%20in%20the%20router.%22%2C%20%22created_at%22%3A%20%222015-10-06T13%3A30%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20829120a1de4cd6a0ac905ef954a366ca7a716001%20simulator/infrastructure/router_sim.py%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/405%23discussion_r41359146%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20if%20isn%27t%20needed%20anymore.%22%2C%20%22created_at%22%3A%20%222015-10-07T07%3A27%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20simulator/infrastructure/router_sim.py%3AL103-114%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/405#issuecomment-145842435'>General Comment</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Can you elaborate what was the issue and how your PR fixes it?
- <a href='https://github.com/mskd96'><img border=0 src='https://avatars.githubusercontent.com/u/6560106?v=3' height=16 width=16'></a> The issue is that since we add 2 elements using add_element during the
  routers initialisation, the run function used to be called twice.. So when
  we call the stop function, only one of the instances of router used to
  stop..
  From now, during the second call of run function, routers functions will
  not be called again..
  On 6 Oct 2015 18:01, "shitz" notifications@github.com wrote:
  > Can you elaborate what was the issue and how your PR fixes it?
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/405#issuecomment-145842435.
  >
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Then I'd rather have an `is_running` flag within the infrastructure classes and `run()` checks whether it's already running and returns if that is the case. You can also use the `stopped` flag that you already introduced in the router.
- [ ] <a href='#crh-comment-Pull 829120a1de4cd6a0ac905ef954a366ca7a716001 simulator/infrastructure/router_sim.py 22'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/405#discussion_r41359146'>File: simulator/infrastructure/router_sim.py:L103-114</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> This if isn't needed anymore.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/405?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/405?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/405'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
