### PR TITLE
Improve generator.py network support, and some cleanup

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -21,6 +21,7 @@ Various utilities for SCION functionality.
 import json
 import logging
 import os
+import shutil
 import signal
 import sys
 import time
@@ -89,7 +90,7 @@ def get_cert_chain_file_path(loc_isd, loc_ad, isd_id, ad_id, version,
     isd_dir_prefix = _get_isd_prefix(isd_dir)
     return os.path.join(isd_dir_prefix + str(loc_isd), CERT_DIR,
                         'AD{}'.format(loc_ad),
-                        'ISD:{}-AD:{}-V:{}.crt'.format(isd_id, ad_id, version))
+                        'ISD{}-AD{}-V{}.crt'.format(isd_id, ad_id, version))
 
 
 def get_trc_file_path(loc_isd, loc_ad, isd_id, version,
@@ -112,7 +113,7 @@ def get_trc_file_path(loc_isd, loc_ad, isd_id, version,
     isd_dir_prefix = _get_isd_prefix(isd_dir)
     return os.path.join(isd_dir_prefix + str(loc_isd), CERT_DIR,
                         'AD{}'.format(loc_ad),
-                        'ISD:{}-V:{}.crt'.format(isd_id, version))
+                        'ISD{}-V{}.crt'.format(isd_id, version))
 
 
 def get_sig_key_file_path(isd_id, ad_id, isd_dir=TOPOLOGY_PATH):
@@ -129,7 +130,7 @@ def get_sig_key_file_path(isd_id, ad_id, isd_dir=TOPOLOGY_PATH):
     """
     isd_dir_prefix = _get_isd_prefix(isd_dir)
     return os.path.join(isd_dir_prefix + str(isd_id), SIG_KEYS_DIR,
-                        'ISD:{}-AD:{}.key'.format(isd_id, ad_id))
+                        'ISD{}-AD{}.key'.format(isd_id, ad_id))
 
 
 def get_enc_key_file_path(isd_id, ad_id, isd_dir=TOPOLOGY_PATH):
@@ -146,7 +147,7 @@ def get_enc_key_file_path(isd_id, ad_id, isd_dir=TOPOLOGY_PATH):
     """
     isd_dir_prefix = _get_isd_prefix(isd_dir)
     return os.path.join(isd_dir_prefix + str(isd_id), ENC_KEYS_DIR,
-                        'ISD:{}-AD:{}.key'.format(isd_id, ad_id))
+                        'ISD{}-AD{}.key'.format(isd_id, ad_id))
 
 
 def read_file(file_path):
@@ -199,6 +200,20 @@ def write_file(file_path, text):
     except OSError as e:
         raise SCIONIOError("Error moving '%s' to '%s': %s" %
                            (tmp_file, file_path, e.strerror)) from None
+
+
+def copy_file(src, dst):
+    dst_dir = os.path.dirname(dst)
+    try:
+        os.makedirs(dst_dir, exist_ok=True)
+    except OSError as e:
+        raise SCIONIOError("Error creating dir '%s': %s" %
+                           (dst_dir, e.strerror)) from None
+    try:
+        shutil.copyfile(src, dst)
+    except OSError as e:
+        raise SCIONIOError("Error copying '%s' to '%s': %s" %
+                           (src, dst, e.strerror)) from None
 
 
 def load_json_file(file_path):

--- a/test/integration/cli_srv_ext_test.py
+++ b/test/integration/cli_srv_ext_test.py
@@ -48,7 +48,7 @@ def client():
     """
     Simple client
     """
-    topo_file = ("../../topology/ISD%d/topologies/ISD:%d-AD:%d.json" %
+    topo_file = ("../../topology/ISD%d/topologies/ISD%d-AD%d.json" %
                  (CLI_ISD, CLI_ISD, CLI_AD))
     # Start SCIONDaemon
     sd = SCIONDaemon.start(haddr_parse("IPV4", CLI_IP), topo_file)
@@ -95,7 +95,7 @@ def server():
     """
     Simple server.
     """
-    topo_file = ("../../topology/ISD%d/topologies/ISD:%d-AD:%d.json" %
+    topo_file = ("../../topology/ISD%d/topologies/ISD%d-AD%d.json" %
                  (SRV_ISD, SRV_ISD, SRV_AD))
     # Start SCIONDaemon
     sd = SCIONDaemon.start(haddr_parse("IPV4", SRV_IP), topo_file)

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -97,7 +97,7 @@ class Ping(object):
         self.dport = dport
         self.token = token
         self.pong_received = False
-        topo_file = ("../../topology/ISD%d/topologies/ISD:%d-AD:%d.json" %
+        topo_file = ("../../topology/ISD%d/topologies/ISD%d-AD%d.json" %
                      (src.isd, src.isd, src.ad))
         self.sd = SCIONDaemon.start(saddr, topo_file, True)  # API on
         self.get_path()
@@ -157,7 +157,7 @@ class Pong(object):
         self.dst = dst
         self.token = token
         self.ping_received = False
-        topo_file = ("../../topology/ISD%d/topologies/ISD:%d-AD:%d.json" %
+        topo_file = ("../../topology/ISD%d/topologies/ISD%d-AD%d.json" %
                      (self.dst.isd, self.dst.isd, self.dst.ad))
         self.sd = SCIONDaemon.start(raddr, topo_file)  # API off
         self.sock = UDPSocket(bind=(str(raddr), 0, "Pong App"),

--- a/topology/ADConfigurations.json
+++ b/topology/ADConfigurations.json
@@ -1,172 +1,176 @@
 {
-    "default_subnet": "127.0.0.0/8",
-    "default_zookeepers": {
-        "1": {
-            "manage": false,
-            "addr": "localhost"
-        }
-    },
-    "1-11": {
-        "level": "CORE",
-        "beacon_servers": 1,
-        "certificate_servers": 1,
-        "path_servers": 3,
-        "links": {
-            "1-12": "ROUTING",
-            "1-13": "ROUTING",
-            "1-14": "CHILD",
-            "2-21": "ROUTING"
-        }
-    },
-    "1-12": {
-        "level": "CORE",
-        "links": {
-            "1-11": "ROUTING",
-            "1-13": "ROUTING",
-            "1-15": "CHILD",
-            "2-22": "ROUTING"
-        },
+    "defaults": {
+        "subnet": "127.0.0.0/8",
         "zookeepers": {
             "1": {
-                "manage": true,
-                "client_port": 4000,
-                "leader_port": 4001,
-                "election_port": 4002
-            },
-            "2": {
-                "manage": true,
-                "client_port": 4003,
-                "leader_port": 4004,
-                "election_port": 4006
-            },
-            "3": {
-                "manage": true,
-                "client_port": 4007,
-                "leader_port": 4008,
-                "election_port": 4009
+                "manage": false,
+                "addr": "localhost"
             }
         }
     },
-    "1-13": {
-        "level": "CORE",
-        "beacon_servers": 2,
-        "dns_servers": 2,
-        "links": {
-            "1-11": "ROUTING",
-            "1-12": "ROUTING",
-            "1-16": "CHILD"
-        }
-    },
-    "1-14": {
-        "level": "INTERMEDIATE",
-        "path_servers": 1,
-        "cert_issuer": "1-11",
-        "links": {
-            "1-11": "PARENT",
-            "1-15": "PEER",
-            "2-23": "PEER",
-            "1-17": "CHILD"
-        }
-    },
-    "1-15": {
-        "level": "INTERMEDIATE",
-        "cert_issuer": "1-12",
-        "links": {
-            "1-12": "PARENT",
-            "1-14": "PEER",
-            "1-16": "PEER",
-            "1-18": "CHILD"
-        }
-    },
-    "1-16": {
-        "level": "INTERMEDIATE",
-        "beacon_servers": 3,
-        "cert_issuer": "1-13",
-        "links": {
-            "1-13": "PARENT",
-            "1-15": "PEER",
-            "1-19": "CHILD"
-        }
-    },
-    "1-17": {
-        "level": "LEAF",
-        "cert_issuer": "1-14",
-        "links": {
-            "1-14": "PARENT"
-        }
-    },
-    "1-18": {
-        "level": "LEAF",
-        "cert_issuer": "1-15",
-        "links": {
-            "1-15": "PARENT"
-        }
-    },
-    "1-19": {
-        "level": "INTERMEDIATE",
-        "path_servers": 2,
-        "cert_issuer": "1-16",
-        "links": {
-            "1-16": "PARENT",
-            "1-10": "CHILD"
-        }
-    },
-    "1-10": {
-        "level": "LEAF",
-        "cert_issuer": "1-19",
-        "links": {
-            "1-19": "PARENT"
-        }
-    },
-    "2-21": {
-        "level": "CORE",
-        "links": {
-            "1-11": "ROUTING",
-            "2-22": "ROUTING",
-            "2-23": "CHILD"
-        }
-    },
-    "2-22": {
-        "level": "CORE",
-        "links": {
-            "1-12": "ROUTING",
-            "2-21": "ROUTING",
-            "2-24": "CHILD"
-        }
-    },
-    "2-23": {
-        "level": "INTERMEDIATE",
-        "cert_issuer": "2-21",
-        "links": {
-            "2-21": "PARENT",
-            "2-24": "PEER",
-            "1-14": "PEER",
-            "2-25": "CHILD",
-            "2-26": "CHILD"
-        }
-    },
-    "2-24": {
-        "level": "INTERMEDIATE",
-        "cert_issuer": "2-22",
-        "links": {
-            "2-22": "PARENT",
-            "2-23": "PEER",
-            "2-26": "CHILD"
-        }
-    },
-    "2-25": {
-        "level": "LEAF",
-        "cert_issuer": "2-23",
-        "links": {
-            "2-23": "PARENT"
-        }
-    },
-    "2-26": {
-        "level": "LEAF",
-        "cert_issuer": "2-24",
-        "links": {
-            "2-23": "PARENT",
-            "2-24": "PARENT"
+    "ADs": {
+        "1-11": {
+            "level": "CORE",
+            "beacon_servers": 1,
+            "certificate_servers": 1,
+            "path_servers": 3,
+            "links": {
+                "1-12": "ROUTING",
+                "1-13": "ROUTING",
+                "1-14": "CHILD",
+                "2-21": "ROUTING"
+            }
+        },
+        "1-12": {
+            "level": "CORE",
+            "links": {
+                "1-11": "ROUTING",
+                "1-13": "ROUTING",
+                "1-15": "CHILD",
+                "2-22": "ROUTING"
+            },
+            "zookeepers": {
+                "1": {
+                    "manage": true,
+                    "client_port": 4000,
+                    "leader_port": 4001,
+                    "election_port": 4002
+                },
+                "2": {
+                    "manage": true,
+                    "client_port": 4003,
+                    "leader_port": 4004,
+                    "election_port": 4005
+                },
+                "3": {
+                    "manage": true,
+                    "client_port": 4006,
+                    "leader_port": 4007,
+                    "election_port": 4008
+                }
+            }
+        },
+        "1-13": {
+            "level": "CORE",
+            "beacon_servers": 2,
+            "dns_servers": 2,
+            "links": {
+                "1-11": "ROUTING",
+                "1-12": "ROUTING",
+                "1-16": "CHILD"
+            }
+        },
+        "1-14": {
+            "level": "INTERMEDIATE",
+            "path_servers": 1,
+            "cert_issuer": "1-11",
+            "links": {
+                "1-11": "PARENT",
+                "1-15": "PEER",
+                "2-23": "PEER",
+                "1-17": "CHILD"
+            }
+        },
+        "1-15": {
+            "level": "INTERMEDIATE",
+            "cert_issuer": "1-12",
+            "links": {
+                "1-12": "PARENT",
+                "1-14": "PEER",
+                "1-16": "PEER",
+                "1-18": "CHILD"
+            }
+        },
+        "1-16": {
+            "level": "INTERMEDIATE",
+            "beacon_servers": 3,
+            "cert_issuer": "1-13",
+            "links": {
+                "1-13": "PARENT",
+                "1-15": "PEER",
+                "1-19": "CHILD"
+            }
+        },
+        "1-17": {
+            "level": "LEAF",
+            "cert_issuer": "1-14",
+            "links": {
+                "1-14": "PARENT"
+            }
+        },
+        "1-18": {
+            "level": "LEAF",
+            "cert_issuer": "1-15",
+            "links": {
+                "1-15": "PARENT"
+            }
+        },
+        "1-19": {
+            "level": "INTERMEDIATE",
+            "path_servers": 2,
+            "cert_issuer": "1-16",
+            "links": {
+                "1-16": "PARENT",
+                "1-10": "CHILD"
+            }
+        },
+        "1-10": {
+            "level": "LEAF",
+            "cert_issuer": "1-19",
+            "links": {
+                "1-19": "PARENT"
+            }
+        },
+        "2-21": {
+            "level": "CORE",
+            "links": {
+                "1-11": "ROUTING",
+                "2-22": "ROUTING",
+                "2-23": "CHILD"
+            }
+        },
+        "2-22": {
+            "level": "CORE",
+            "links": {
+                "1-12": "ROUTING",
+                "2-21": "ROUTING",
+                "2-24": "CHILD"
+            }
+        },
+        "2-23": {
+            "level": "INTERMEDIATE",
+            "cert_issuer": "2-21",
+            "links": {
+                "2-21": "PARENT",
+                "2-24": "PEER",
+                "1-14": "PEER",
+                "2-25": "CHILD",
+                "2-26": "CHILD"
+            }
+        },
+        "2-24": {
+            "level": "INTERMEDIATE",
+            "cert_issuer": "2-22",
+            "links": {
+                "2-22": "PARENT",
+                "2-23": "PEER",
+                "2-26": "CHILD"
+            }
+        },
+        "2-25": {
+            "level": "LEAF",
+            "cert_issuer": "2-23",
+            "links": {
+                "2-23": "PARENT"
+            }
+        },
+        "2-26": {
+            "level": "LEAF",
+            "cert_issuer": "2-24",
+            "links": {
+                "2-23": "PARENT",
+                "2-24": "PARENT"
+            }
         }
     }
 }


### PR DESCRIPTION
- Remove ":"s from topology path and file names, for better readability.
- Remove unneeded directory creation code.
- Add lib.util.copy_file() to create dirs as needed when copying.
- Cleaned up the ADConfigurations.json format a bit:
  - ADs are no longer top-level entries.
  - Moved default values into a top-level 'defaults' category.
- Moved init code from generate_all into init.
- Stop passing the ad config dict to every single method.
- Replaced path_dict method with small utility methods.
- Network can be passed in on the command-line, and over-rides the
  ADConfigurations setting.
- Replaced network addressing code and set_er_ip_addresses with a simple
  set of factory classes.
  - Per-ad subnets in the config file weren't used, so support for this
    is dropped, for now at least.
- Use temp directory for TRC temporary file.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/shitz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23issuecomment-147425705%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-12T15%3A02%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20131b4b30d1657278de6b3e8c76fde370a1666bcf%20topology/generator.py%20991%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41764543%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20raise%20an%20exception%20when%20the%20generator%20cannot%20allocate%20more%20addresses%20within%20the%20subnet.%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A54%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20added%20error%20logging%20for%20these%20cases%3A%5Cr%5Cn%5Cr%5CnCRITICAL%3Aroot%3ANetwork%2010.0.0.0/31%20is%20too%20small%20to%20accomadate%20/27%20subnets%5Cr%5CnCRITICAL%3Aroot%3AUnable%20to%20allocate%20any%20more%20subnets%20from%2010.0.0.0/26%5Cr%5CnCRITICAL%3Aroot%3AUnable%20to%20allocate%20any%20more%20addresses%20from%2010.0.0.0/31%22%2C%20%22created_at%22%3A%20%222015-10-12T15%3A00%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-10-12T15%3A01%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL782-808%22%7D%2C%20%22Pull%20259b61c9afef32547c3828c2ec05d1c6436c3ac2%20topology/generator.py%20405%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41762985%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20condition%20seems%20a%20bit%20arbitrary%20to%20me.%20I%20don%27t%20think%20we%20should%20_disallow_%20intermediate%20ASes%20to%20have%20path%20servers.%20I%27d%20only%20do%20a%20%60if%20%5C%22path_servers%5C%22%20in%20ad_conf%3A%60%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A40%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20would%20prefer%20if%20that%20was%20changed%20in%20a%20different%20PR%20%28it%20also%20probably%20affects%202%20other%20places%20in%20generator.py%29.%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A44%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok.%20I%20see%20that%20the%20generator%20needs%20some%20major%20overhaul%20anyway.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A53%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL320-408%22%7D%2C%20%22Pull%20259b61c9afef32547c3828c2ec05d1c6436c3ac2%20topology/generator.py%20132%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41762268%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20we%20name%20this%20%60_write_path_policy_files%28%29%60%20please%3F%20Similar%20for%20%60topo%60%20below.%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A33%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20sure.%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A37%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A53%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL116-182%22%7D%2C%20%22Pull%20259b61c9afef32547c3828c2ec05d1c6436c3ac2%20topology/ADConfigurations.json%20206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41761835%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20there%20a%20reason%20why%20you%20left%20out%20port%20%604005%60%3F%20It%20probably%20doesn%27t%20matter%20at%20all%2C%20but%20it%20looks%20like%20an%20unintentional%20thing%20to%20me.%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A29%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Haha%2C%20nope.%20I%27ll%20change%20it.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A36%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A53%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/ADConfigurations.json%3AL1-177%22%7D%2C%20%22Pull%20259b61c9afef32547c3828c2ec05d1c6436c3ac2%20topology/generator.py%20327%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41762716%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20rename%20to%20%60_write_sim_run_preamble%28%29%60%20or%20something%20like%20that.%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A38%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%2C%20gladly.%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A43%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-12T14%3A53%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/generator.py%3AL271-278%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/415%23issuecomment-147425705%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41761835%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41762268%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41762597%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41762605%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41762716%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41762985%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41763280%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41763362%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41764387%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41764408%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41764426%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41764441%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41764543%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41765316%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/415%23discussion_r41765438%22%5D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/shitz'><img src='https://avatars.githubusercontent.com/u/3840858?v=3' width=34 height=34></a>
- [x] <a href='#crh-comment-Pull 259b61c9afef32547c3828c2ec05d1c6436c3ac2 topology/ADConfigurations.json 206'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/415#discussion_r41761835'>File: topology/ADConfigurations.json:L1-177</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Is there a reason why you left out port `4005`? It probably doesn't matter at all, but it looks like an unintentional thing to me.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Haha, nope. I'll change it.
- [x] <a href='#crh-comment-Pull 259b61c9afef32547c3828c2ec05d1c6436c3ac2 topology/generator.py 132'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/415#discussion_r41762268'>File: topology/generator.py:L116-182</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Can we name this `_write_path_policy_files()` please? Similar for `topo` below.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Yeah sure.
- [x] <a href='#crh-comment-Pull 259b61c9afef32547c3828c2ec05d1c6436c3ac2 topology/generator.py 327'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/415#discussion_r41762716'>File: topology/generator.py:L271-278</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Please rename to `_write_sim_run_preamble()` or something like that.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Done, gladly.
- [x] <a href='#crh-comment-Pull 259b61c9afef32547c3828c2ec05d1c6436c3ac2 topology/generator.py 405'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/415#discussion_r41762985'>File: topology/generator.py:L320-408</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> This condition seems a bit arbitrary to me. I don't think we should _disallow_ intermediate ASes to have path servers. I'd only do a `if "path_servers" in ad_conf:`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I would prefer if that was changed in a different PR (it also probably affects 2 other places in generator.py).
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Ok. I see that the generator needs some major overhaul anyway. :+1:
- [x] <a href='#crh-comment-Pull 131b4b30d1657278de6b3e8c76fde370a1666bcf topology/generator.py 991'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/415#discussion_r41764543'>File: topology/generator.py:L782-808</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> This should raise an exception when the generator cannot allocate more addresses within the subnet.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I've added error logging for these cases:
  CRITICAL:root:Network 10.0.0.0/31 is too small to accomadate /27 subnets
  CRITICAL:root:Unable to allocate any more subnets from 10.0.0.0/26
  CRITICAL:root:Unable to allocate any more addresses from 10.0.0.0/31

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/415?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/415?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/415?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/415'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
