### PR TITLE
Use topology file to determine core/local

### DIFF
--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -76,6 +76,7 @@ from lib.packet.pcb_ext import MTUExtension
 from lib.packet.scion import PacketType as PT
 from lib.path_store import PathPolicy, PathStore
 from lib.thread import thread_safety_net
+from lib.topology import Topology
 from lib.types import (
     CertMgmtType,
     IFIDType,
@@ -1414,8 +1415,6 @@ def main():
     """
     handle_signals()
     parser = argparse.ArgumentParser()
-    parser.add_argument('type', choices=['core', 'local'],
-                        help='Core or local path server')
     parser.add_argument('server_id', help='Server identifier')
     parser.add_argument('topo_file', help='Topology file')
     parser.add_argument('conf_file', help='AD configuration file')
@@ -1424,7 +1423,8 @@ def main():
     args = parser.parse_args()
     init_logging(args.log_file)
 
-    if args.type == "core":
+    topo = Topology.from_file(args.topo_file)
+    if topo.is_core_ad:
         beacon_server = CoreBeaconServer(args.server_id, args.topo_file,
                                          args.conf_file, args.path_policy_file)
     else:

--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -45,6 +45,7 @@ from lib.packet.path_mgmt import (
 from lib.packet.scion import PacketType as PT, SCIONL4Packet
 from lib.path_db import DBResult, PathSegmentDB
 from lib.thread import thread_safety_net
+from lib.topology import Topology
 from lib.types import PathMgmtType as PMT, PathSegmentType as PST, PayloadClass
 from lib.util import (
     SCIONTime,
@@ -917,8 +918,6 @@ def main():
     """
     handle_signals()
     parser = argparse.ArgumentParser()
-    parser.add_argument('type', choices=['core', 'local'],
-                        help='Core or local path server')
     parser.add_argument('server_id', help='Server identifier')
     parser.add_argument('topo_file', help='Topology file')
     parser.add_argument('conf_file', help='AD configuration file')
@@ -926,15 +925,13 @@ def main():
     args = parser.parse_args()
     init_logging(args.log_file)
 
-    if args.type == "core":
+    topo = Topology.from_file(args.topo_file)
+    if topo.is_core_ad:
         path_server = CorePathServer(args.server_id, args.topo_file,
                                      args.conf_file)
-    elif args.type == "local":
+    else:
         path_server = LocalPathServer(args.server_id, args.topo_file,
                                       args.conf_file)
-    else:
-        logging.error("First parameter can only be 'local' or 'core'!")
-        sys.exit()
 
     trace(path_server.id)
     logging.info("Started: %s", datetime.datetime.now())

--- a/lib/topology.py
+++ b/lib/topology.py
@@ -213,7 +213,7 @@ class Topology(object):
         :param topology: dictionary representation of a topology
         :type topology: dict
         """
-        self.is_core_ad = (topology['Core'] == 1)
+        self.is_core_ad = topology['Core']
         self.isd_id = topology['ISDID']
         self.ad_id = topology['ADID']
         self.dns_domain = topology['DnsDomain']

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -189,18 +189,17 @@ class ConfigGenerator(object):
         isd_str = "ISD{}".format(isd_id)
         isd_ad_str = "ISD{}-AD{}".format(isd_id, ad_id)
         p = {}
-        p['base_dir_tail'] = os.path.join(isd_str, ZOOKEEPER_DIR, isd_ad_str)
-        p['base_dir_abs'], p['base_dir_rel'] = abs_rel(p['base_dir_tail'])
-        p['data_dir_abs'], p['data_dir_rel'] = abs_rel(p['base_dir_tail'],
-                                                       'data.%s' % zk_id)
+        base_dir_tail = os.path.join(isd_str, ZOOKEEPER_DIR, isd_ad_str)
+        base_dir_abs, _ = abs_rel(base_dir_tail)
+        data_dir_abs, p['data_dir_rel'] = abs_rel(
+            base_dir_tail, 'data.%s' % zk_id)
         p['datalog_dir_abs'] = os.path.join(ZOOKEEPER_TMPFS_DIR, isd_ad_str,
                                             str(zk_id))
-        p['datalog_script_abs'] = os.path.join(p['base_dir_abs'],
-                                               "datalog.%s.sh" % zk_id)
-        p['cfg_abs'], p['cfg_rel'] = abs_rel(p['base_dir_tail'],
-                                             'zoo.cfg.%s' % zk_id)
-        p['myid_abs'] = os.path.join(p['data_dir_abs'], 'myid')
-        p['log4j_abs'] = os.path.join(p['base_dir_abs'], 'log4j.properties')
+        p['datalog_script_abs'] = os.path.join(
+            base_dir_abs, "datalog.%s.sh" % zk_id)
+        p['cfg_abs'], _ = abs_rel(base_dir_tail, 'zoo.cfg.%s' % zk_id)
+        p['myid_abs'] = os.path.join(data_dir_abs, 'myid')
+        p['log4j_abs'] = os.path.join(base_dir_abs, 'log4j.properties')
         return p
 
     def _delete_directories(self):
@@ -239,7 +238,7 @@ class ConfigGenerator(object):
                 conf_dict['RegisterPath'] = 1
             else:
                 conf_dict['RegisterPath'] = 0
-            write_file(conf_file,
+            write_file(conf_file, "%s\n" %
                        json.dumps(conf_dict, sort_keys=True, indent=4))
             # Test if parser works
             Config.from_file(conf_file)
@@ -436,11 +435,10 @@ class ConfigGenerator(object):
 
         for (num, element_dict, element_type) \
                 in self._get_typed_elements(topo_dict):
-            element_location = 'core' if topo_dict['Core'] else 'local'
             server_config = supervisor_common.copy()
             if element_type == 'BeaconServers':
                 element_name = 'bs{}-{}-{}'.format(isd_id, ad_id, num)
-                cmd_args = ['beacon_server.py', element_location, num,
+                cmd_args = ['beacon_server.py', num,
                             topo_file, conf_file, path_pol_file,
                             '../logs/{}.log'.format(element_name)]
             elif element_type == 'CertificateServers':
@@ -450,8 +448,7 @@ class ConfigGenerator(object):
                             '../logs/{}.log'.format(element_name)]
             elif element_type == 'PathServers':
                 element_name = 'ps{}-{}-{}'.format(isd_id, ad_id, num)
-                cmd_args = ['path_server.py', element_location, num,
-                            topo_file, conf_file,
+                cmd_args = ['path_server.py', num, topo_file, conf_file,
                             '../logs/{}.log'.format(element_name)]
             elif element_type == 'DNSServers':
                 element_name = 'ds{}-{}-{}'.format(isd_id, ad_id, num)
@@ -562,10 +559,6 @@ class ConfigGenerator(object):
         text = StringIO()
         for isd_ad_id, ad_conf in self.ad_configs["ADs"].items():
             isd_id, ad_id = isd_ad_id.split(ISD_AD_ID_DIVISOR)
-            if ad_conf['level'] == CORE_AD:
-                element_location = "core"
-            else:
-                element_location = "local"
 
             topo_file = self._path_gen(isd_id, ad_id, TOPO_DIR, ".json", False)
             conf_file = self._path_gen(isd_id, ad_id, CONF_DIR, ".conf", False)
@@ -583,8 +576,8 @@ class ConfigGenerator(object):
             for b_server in range(1, number_bs + 1):
                 element_name = 'bs{}-{}-{}'.format(isd_id, ad_id, b_server)
                 text.write(' '.join([
-                    'beacon_server', element_name, element_location,
-                    str(b_server), topo_file, conf_file, path_pol_file]) + '\n')
+                    'beacon_server', element_name, str(b_server), topo_file,
+                    conf_file, path_pol_file]) + '\n')
             # Certificate Servers
             for c_server in range(1, number_cs + 1):
                 element_name = 'cs{}-{}-{}'.format(isd_id, ad_id, c_server)
@@ -597,8 +590,8 @@ class ConfigGenerator(object):
                 for p_server in range(1, number_ps + 1):
                     element_name = 'ps{}-{}-{}'.format(isd_id, ad_id, p_server)
                     text.write(' '.join([
-                        'path_server', element_name, element_location,
-                        str(p_server), topo_file, conf_file]) + '\n')
+                        'path_server', element_name, str(p_server), topo_file,
+                        conf_file]) + '\n')
             # Edge Routers
             edge_router = 1
             for nbr_isd_ad_id in ad_conf.get("links", []):


### PR DESCRIPTION
Also clean up _zk_path_dict() a bit.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/419%23issuecomment-147733838%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/419%23issuecomment-147734646%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/419%23issuecomment-148364602%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/419%23issuecomment-147733838%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40shitz%20%22%2C%20%22created_at%22%3A%20%222015-10-13T14%3A34%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20does%20mean%20we%20are%20parsing%20the%20topology%20file%20twice%2C%20but%20the%20other%20options%20i%20see%20are%20all%20worse.%22%2C%20%22created_at%22%3A%20%222015-10-13T14%3A37%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20guess%20determining%20core/local%20from%20the%20topology%20file%20is%20cleaner%20than%20passing%20it%20from%20the%20cmd.%20LGTM%22%2C%20%22created_at%22%3A%20%222015-10-15T11%3A50%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/419#issuecomment-147733838'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @shitz
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This does mean we are parsing the topology file twice, but the other options i see are all worse.
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> I guess determining core/local from the topology file is cleaner than passing it from the cmd. LGTM

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/419?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/419?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/419'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
