### PR TITLE
log in UTC time (Issue 397)

### DIFF
--- a/lib/log.py
+++ b/lib/log.py
@@ -19,8 +19,9 @@
 import logging
 import logging.handlers
 import traceback
+import time
 
-# This file should not include other SCION libraries, to prevent cirular import
+# This file should not include other SCION libraries, to prevent circular import
 # errors.
 
 #: Bytes
@@ -66,6 +67,8 @@ def init_logging(log_file=None, level=logging.DEBUG, console=False):
                                               backupCount=1, encoding="utf-8"))
     if console:
         handlers.append(_ConsoleErrorHandler())
+
+    logging.Formatter.converter = time.gmtime
     logging.basicConfig(
         level=level, handlers=handlers,
         format='%(asctime)s [%(levelname)s] (%(threadName)s) %(message)s')


### PR DESCRIPTION
@kormat Here is my simple modification to change the logging to UTC time. I'd be glad if you could have a look and possibly give me an idea as to how/where to unit test this. Cheers!
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/424%23discussion_r42358165%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/424%23issuecomment-149184666%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/424%23issuecomment-149184893%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/424%23issuecomment-150029036%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/424%23issuecomment-149184666%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20you%20grep%20the%20codebase%20for%20%60datetime%60%2C%20there%27s%20a%20bunch%20of%20datetime%20calls%20that%20also%20need%20to%20be%20fixed/removed.%20E.g.%20all%20the%20infrastructure%20servers%20log%20a%20%27Started%27%20message%20with%20a%20timestamp.%20The%20timestamp%20is%20redundant%2C%20as%20the%20logging%20system%20already%20timestamps%20the%20line%2C%20so%20it%20can%20be%20removed.%22%2C%20%22created_at%22%3A%20%222015-10-19T10%3A58%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22There%27s%20also%20a%20call%20to%20%60ctime%28%29%60%20in%20%60lib/packet/opaque_field.py%60%22%2C%20%22created_at%22%3A%20%222015-10-19T10%3A59%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Closing%20this%20PR%2C%20will%20open%20a%20new%20one%20based%20on%20the%20feedback%20from%20Stephen.%22%2C%20%22created_at%22%3A%20%222015-10-21T21%3A27%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2066567e11c100ba6e8a0d280a37800052a0aa593a%20lib/log.py%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/424%23discussion_r42358165%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm.%20So%20the%20problem%20here%20is%20that%20now%20the%20timestamps%20don%27t%20have%20any%20TZ%20info%2C%20which%20makes%20them%20open%20to%20misinterpretation.%20Turns%20out%20that%20adding%20TZ%20info%20while%20still%20having%20milliseconds%20output%20is%20hard%20%28aka%20not%20supported%29.%20After%20spending%20a%20bit%20of%20time%20digging%20into%20this%2C%20i%20came%20up%20with%20a%20solution%3A%5Cr%5Cnhttps%3A//gist.github.com/kormat/5175bc136710202b1933%22%2C%20%22created_at%22%3A%20%222015-10-19T10%3A56%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/log.py%3AL67-75%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 66567e11c100ba6e8a0d280a37800052a0aa593a lib/log.py 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/424#discussion_r42358165'>File: lib/log.py:L67-75</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Hmm. So the problem here is that now the timestamps don't have any TZ info, which makes them open to misinterpretation. Turns out that adding TZ info while still having milliseconds output is hard (aka not supported). After spending a bit of time digging into this, i came up with a solution:
  https://gist.github.com/kormat/5175bc136710202b1933
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/424#issuecomment-149184666'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> If you grep the codebase for `datetime`, there's a bunch of datetime calls that also need to be fixed/removed. E.g. all the infrastructure servers log a 'Started' message with a timestamp. The timestamp is redundant, as the logging system already timestamps the line, so it can be removed.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> There's also a call to `ctime()` in `lib/packet/opaque_field.py`
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Closing this PR, will open a new one based on the feedback from Stephen.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/424?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/424?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/424'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
