### PR TITLE
Increase SCION_BUFLEN to max size.

### DIFF
--- a/lib/defines.py
+++ b/lib/defines.py
@@ -30,7 +30,7 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 GEN_PATH = 'gen'
 
 #: Buffer size for receiving packets
-SCION_BUFLEN = 8092
+SCION_BUFLEN = 65535
 #: Default SCION server data port
 SCION_UDP_PORT = 30040
 #: Default SCION endhost data port

--- a/lib/socket.py
+++ b/lib/socket.py
@@ -46,8 +46,8 @@ class UDPSocket(object):
             Optional tuple of (`str`, `int`, `str`) describing respectively the
             address and port to bind to, and an optional description.
         :param addr_type:
-            Socket domain. Must be one of :const:`~lib.defines.AddrType.IPV4`,
-            :const:`~lib.defines.AddrType.IPV6` (default).
+            Socket domain. Must be one of :const:`~lib.types.AddrType.IPV4`,
+            :const:`~lib.types.AddrType.IPV6` (default).
         """
         assert addr_type in (AddrType.IPV4, AddrType.IPV6)
         self._addr_type = addr_type
@@ -71,7 +71,7 @@ class UDPSocket(object):
         """
         if addr is None:
             addr = "::"
-            if self._domain == AddrType.IPV4:
+            if self._addr_type == AddrType.IPV4:
                 addr = ""
         self.sock.bind((addr, port))
         self.port = self.sock.getsockname()[1]
@@ -87,7 +87,10 @@ class UDPSocket(object):
             Tuple of (`str`, `int`) describing the destination address and port,
             respectively.
         """
-        self.sock.sendto(data, dst)
+        try:
+            self.sock.sendto(data, dst)
+        except OSError as e:
+            logging.error("Error sending %dB to %s: %s", len(data), dst, e)
 
     def recv(self, block=True):
         """

--- a/test/lib_socket_test.py
+++ b/test/lib_socket_test.py
@@ -83,7 +83,7 @@ class TestUDPSocketBind(object):
     @patch("lib.socket.UDPSocket.__init__", autopatch=True, return_value=None)
     def test_any_v4(self, init):
         inst = self._setup()
-        inst._domain = AddrType.IPV4
+        inst._addr_type = AddrType.IPV4
         # Call
         inst.bind(None, 4242)
         # Tests
@@ -92,7 +92,7 @@ class TestUDPSocketBind(object):
     @patch("lib.socket.UDPSocket.__init__", autopatch=True, return_value=None)
     def test_any_v6(self, init):
         inst = self._setup()
-        inst._domain = AddrType.IPV6
+        inst._addr_type = AddrType.IPV6
         # Call
         inst.bind(None, 4242)
         # Tests
@@ -104,13 +104,24 @@ class TestUDPSocketSend(object):
     Unit tests for lib.socket.UDPSocket.send
     """
     @patch("lib.socket.UDPSocket.__init__", autopatch=True, return_value=None)
-    def test(self, init):
+    def test_basic(self, init):
         inst = UDPSocket()
         inst.sock = create_mock(["sendto"])
         # Call
         inst.send("data", "dst")
         # Tests
         inst.sock.sendto.assert_called_once_with("data", "dst")
+
+    @patch("lib.socket.logging.error", autopatch=True)
+    @patch("lib.socket.UDPSocket.__init__", autopatch=True, return_value=None)
+    def test_error(self, init, logging):
+        inst = UDPSocket()
+        inst.sock = create_mock(["sendto"])
+        inst.sock.sendto.side_effect = OSError
+        # Call
+        inst.send("data", "dst")
+        # Tests
+        ntools.ok_(logging.called)
 
 
 class TestUDPSocketRecv(object):


### PR DESCRIPTION
Packets larger than 8092 were being truncated. At the max size, the
sending side will now log an error, so the problem is clear.

Also fixed a minor issue in socket.py with a mis-named attribute.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/428%23issuecomment-149515308%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/428%23issuecomment-149516633%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/428%23issuecomment-149515308%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20caused%20https%3A//circleci.com/gh/netsec-ethz/scion/1664%20to%20fail.%22%2C%20%22created_at%22%3A%20%222015-10-20T10%3A27%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-10-20T10%3A33%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/shitz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/shitz'><img src='https://avatars.githubusercontent.com/u/3840858?v=3' width=34 height=34></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/428#issuecomment-149515308'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This caused https://circleci.com/gh/netsec-ethz/scion/1664 to fail.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/428?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/428?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/428?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/428'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
