### PR TITLE
Improve path server logging.

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -84,7 +84,8 @@ class SCIONDaemon(SCIONElement):
     # Time a path segment is cached at a host (in seconds).
     SEGMENT_TTL = 300
 
-    def __init__(self, addr, topo_file, run_local_api=False, is_sim=False):
+    def __init__(self, addr, topo_file, run_local_api=False,
+                 port=SCION_UDP_PORT, is_sim=False):
         """
         Initialize an instance of the class SCIONDaemon.
 
@@ -97,8 +98,8 @@ class SCIONDaemon(SCIONElement):
         :param is_sim: running on simulator
         :type is_sim: bool
         """
-        SCIONElement.__init__(self, "sciond", topo_file, host_addr=addr,
-                              is_sim=is_sim)
+        super().__init__("sciond", topo_file, host_addr=addr, port=port,
+                         is_sim=is_sim)
         # TODO replace by pathstore instance
         self.up_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL)
         self.down_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL)
@@ -123,7 +124,7 @@ class SCIONDaemon(SCIONElement):
             self._socks.add(self._api_sock)
 
     @classmethod
-    def start(cls, addr, topo_file, run_local_api=False):
+    def start(cls, addr, topo_file, run_local_api=False, port=SCION_UDP_PORT):
         """
         Initializes, starts, and returns a SCIONDaemon object.
 
@@ -138,7 +139,7 @@ class SCIONDaemon(SCIONElement):
         :param :
         :type :
         """
-        sd = cls(addr, topo_file, run_local_api)
+        sd = cls(addr, topo_file, run_local_api, port=port)
         sd.daemon_thread = threading.Thread(
             target=thread_safety_net, args=(sd.run,), name="SCIONDaemon.run",
             daemon=True)

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -101,7 +101,9 @@ class Ping(object):
         self.pong_received = False
         topo_file = ("%s/ISD%d/topologies/ISD%d-AD%d.json" %
                      (GEN_PATH, src.isd, src.isd, src.ad))
-        self.sd = SCIONDaemon.start(saddr, topo_file, True)  # API on
+        # Local api on, random port:
+        self.sd = SCIONDaemon.start(
+            saddr, topo_file, run_local_api=True, port=0)
         self.get_path()
         self.sock = UDPSocket(bind=(str(saddr), 0, "Ping App"),
                               addr_type=AddrType.IPV4)
@@ -161,7 +163,7 @@ class Pong(object):
         self.ping_received = False
         topo_file = ("%s/ISD%d/topologies/ISD%d-AD%d.json" %
                      (GEN_PATH, self.dst.isd, self.dst.isd, self.dst.ad))
-        self.sd = SCIONDaemon.start(raddr, topo_file)  # API off
+        self.sd = SCIONDaemon.start(raddr, topo_file)  # API off, standard port.
         self.sock = UDPSocket(bind=(str(raddr), 0, "Pong App"),
                               addr_type=AddrType.IPV4)
 


### PR DESCRIPTION
This should make it easier to debug
https://github.com/netsec-ethz/scion/issues/434

Also:
- Allow scion elements to run on arbitrary ports.
- Switch end2end.Ping to use an arbitrary port for its sciond, so that
  delayed path server responses won't go to later sciond's.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/435%23issuecomment-151058410%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/435%23issuecomment-151058410%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-10-26T08%3A28%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/435#issuecomment-151058410'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/435?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/435?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/435'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
