### PR TITLE
Initial commit of mininet support

### DIFF
--- a/topology/mininet_topo.py
+++ b/topology/mininet_topo.py
@@ -70,24 +70,24 @@ class ScionTopo(Topo):
                     self.addLink(name, switchname, intfName1=ifName1,
                                  intfName2=ifName2, params1={'ip': str(hostip)})
                     hostcounter = hostcounter + 1
+
+
 def runMininet():
     lg.setLogLevel('info')
     topology = configparser.ConfigParser(interpolation=None)
     if os.path.isfile('../gen/networks.conf'):
         topology.read('../gen/networks.conf')
         # should also check if this is a 127.0.x.x file, or a 100.64.x.x
-        if ( ipaddress.IPv4Interface(topology.sections()[0]).is_loopback ):
-            print "gen/networks appears to be using loopback addresses. Try running scion.sh topology -m"
+        if (ipaddress.IPv4Interface(topology.sections()[0]).is_loopback):
             sys.exit(-1)
     else:
-        print "gen/networks.conf does not exist. Have you run scion.sh topology -m?"
         sys.exit(-1)
 
     topo = ScionTopo(topology)
     net = Mininet(topo=topo, switch=OVSKernelSwitch, controller=OVSController)
     net.start()
-    #net.pingAll()
-    #CLI = CLI(net)
+    # net.pingAll()
+    CLI(net)
     # flush()
     net.stop()
 


### PR DESCRIPTION
This intial commit reads in a generator.py mininet config file and
creates an equivalen network on mininet. The script requires the
installation of mininet 2.1.0, and has to be run as root (!).

I learned python last week so be nice with your code review
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/437%23discussion_r42998028%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23issuecomment-151166459%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23issuecomment-151422915%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23discussion_r43101332%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23discussion_r43101401%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23discussion_r43101421%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23discussion_r43101502%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23discussion_r43102310%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23issuecomment-151166459%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40davidbb%3A%20Please%20have%20a%20look%20at%20https%3A//github.com/netsec-ethz/scion/wiki/Coding-Guidelines%20on%20how%20to%20format%20your%20code.%22%2C%20%22created_at%22%3A%20%222015-10-26T15%3A02%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40shitz%20kormat%20helped%20me%20turn%20back%20time%20and%20amend%20my%20commit.%20it%20now%20passes%20lint%20checks%20like%20a%20boss.%20not%20sure%20if%20you%20should%20merge%20this%20in%20and%20i%27ll%20submit%20a%20new%20pull%20for%20the%20networks.conf%20sanity%20checks%2C%20or%20i%20should%20merge%20all%20the%20changes%20as%20part%20of%20this%20pull.%20%22%2C%20%22created_at%22%3A%20%222015-10-27T09%3A14%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/202203%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/davidbb%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208c5b1800bbca31a4ef2d0a9da4fc4f881f4de292%20topology/mininet_topo.py%2059%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23discussion_r43101502%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20bad%20style%20to%20have%20lots%20of%20code%20in%20this%20section.%20It%27s%20much%20cleaner%20to%20have%20a%20%60main%28%29%60%20function%2C%20and%20to%20call%20it%20from%20here%20instead.%20I.e.%5Cr%5Cn%60%60%60%5Cr%5Cnif%20__name__%20%3D%3D%20%27__main__%27%3A%5Cr%5Cn%20%20main%28%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-10-27T10%3A00%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet_topo.py%3AL1-70%22%7D%2C%20%22Pull%208c5b1800bbca31a4ef2d0a9da4fc4f881f4de292%20topology/mininet_topo.py%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23discussion_r43102310%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20method%20is%20too%20long.%20My%20suggestion%20would%20be%20to%20break%20it%20into%202%20methods.%20and%20call%20them%20from%20%60__init__%60%22%2C%20%22created_at%22%3A%20%222015-10-27T10%3A08%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet_topo.py%3AL1-70%22%7D%2C%20%22Pull%208c5b1800bbca31a4ef2d0a9da4fc4f881f4de292%20topology/mininet_topo.py%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23discussion_r43101332%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Needs%20the%20license%20and%20preamble%20at%20the%20top%20of%20the%20file.%20Check%20pretty%20much%20any%20other%20python%20file%20for%20reference.%20Make%20sure%20the%20copyright%20year%20is%202015.%22%2C%20%22created_at%22%3A%20%222015-10-27T09%3A59%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet_topo.py%3AL1-70%22%7D%2C%20%22Pull%202108a4ee9e82d07efa1022374faa6a1a1b9e31bc%20topology/mininet.py%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23discussion_r42998028%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20needs%20python2.%20should%20i%20put%20that%20up%20here%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T14%3A17%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/202203%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/davidbb%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet.py%3AL1-65%22%7D%2C%20%22Pull%208c5b1800bbca31a4ef2d0a9da4fc4f881f4de292%20topology/mininet_topo.py%203%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23discussion_r43101401%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20have%20a%20specific%20format%20for%20imports%20in%20the%20codebase.%20We%20seperate%20out%20stdlib%2C%20external%2C%20and%20scion%20imports%20into%20seconds.%20Have%20a%20look%20at%20another%20python%20file%20for%20reference.%22%2C%20%22created_at%22%3A%20%222015-10-27T09%3A59%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet_topo.py%3AL1-70%22%7D%2C%20%22Pull%208c5b1800bbca31a4ef2d0a9da4fc4f881f4de292%20topology/mininet_topo.py%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/437%23discussion_r43101421%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20isn%27t%20used%20%28and%20is%20bad%20style%29%2C%20please%20remove.%22%2C%20%22created_at%22%3A%20%222015-10-27T10%3A00%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet_topo.py%3AL1-70%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 2108a4ee9e82d07efa1022374faa6a1a1b9e31bc topology/mininet.py 1'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/437#discussion_r42998028'>File: topology/mininet.py:L1-65</a></b>
- <a href='https://github.com/davidbb'><img border=0 src='https://avatars.githubusercontent.com/u/202203?v=3' height=16 width=16'></a> this needs python2. should i put that up here?
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/437#issuecomment-151166459'>General Comment</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> @davidbb: Please have a look at https://github.com/netsec-ethz/scion/wiki/Coding-Guidelines on how to format your code.
- <a href='https://github.com/davidbb'><img border=0 src='https://avatars.githubusercontent.com/u/202203?v=3' height=16 width=16'></a> @shitz kormat helped me turn back time and amend my commit. it now passes lint checks like a boss. not sure if you should merge this in and i'll submit a new pull for the networks.conf sanity checks, or i should merge all the changes as part of this pull.
- [x] <a href='#crh-comment-Pull 8c5b1800bbca31a4ef2d0a9da4fc4f881f4de292 topology/mininet_topo.py 2'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/437#discussion_r43101332'>File: topology/mininet_topo.py:L1-70</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Needs the license and preamble at the top of the file. Check pretty much any other python file for reference. Make sure the copyright year is 2015.
- [x] <a href='#crh-comment-Pull 8c5b1800bbca31a4ef2d0a9da4fc4f881f4de292 topology/mininet_topo.py 3'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/437#discussion_r43101401'>File: topology/mininet_topo.py:L1-70</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> We have a specific format for imports in the codebase. We seperate out stdlib, external, and scion imports into seconds. Have a look at another python file for reference.
- [x] <a href='#crh-comment-Pull 8c5b1800bbca31a4ef2d0a9da4fc4f881f4de292 topology/mininet_topo.py 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/437#discussion_r43101421'>File: topology/mininet_topo.py:L1-70</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This isn't used (and is bad style), please remove.
- [x] <a href='#crh-comment-Pull 8c5b1800bbca31a4ef2d0a9da4fc4f881f4de292 topology/mininet_topo.py 59'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/437#discussion_r43101502'>File: topology/mininet_topo.py:L1-70</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It's bad style to have lots of code in this section. It's much cleaner to have a `main()` function, and to call it from here instead. I.e.

```
if __name__ == '__main__':
main()
```
- [ ] <a href='#crh-comment-Pull 8c5b1800bbca31a4ef2d0a9da4fc4f881f4de292 topology/mininet_topo.py 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/437#discussion_r43102310'>File: topology/mininet_topo.py:L1-70</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This method is too long. My suggestion would be to break it into 2 methods. and call them from `__init__`

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/437?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/437?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/437'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
