### PR TITLE
Generate per-element topology/configs.

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -84,21 +84,12 @@ class SCIONDaemon(SCIONElement):
     # Time a path segment is cached at a host (in seconds).
     SEGMENT_TTL = 300
 
-    def __init__(self, addr, topo_file, run_local_api=False,
+    def __init__(self, conf_dir, addr, run_local_api=False,
                  port=SCION_UDP_PORT, is_sim=False):
         """
         Initialize an instance of the class SCIONDaemon.
-
-        :param addr:
-        :type addr:
-        :param topo_file:
-        :type topo_file:
-        :param run_local_api:
-        :type run_local_api:
-        :param is_sim: running on simulator
-        :type is_sim: bool
         """
-        super().__init__("sciond", topo_file, host_addr=addr, port=port,
+        super().__init__("sciond", conf_dir, host_addr=addr, port=port,
                          is_sim=is_sim)
         # TODO replace by pathstore instance
         self.up_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL)

--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -17,14 +17,11 @@
 ============================================
 """
 # Stdlib
-import argparse
 import base64
 import copy
-import datetime
 import logging
 import os
 import struct
-import sys
 import threading
 from _collections import defaultdict, deque
 from abc import ABCMeta, abstractmethod
@@ -51,7 +48,7 @@ from lib.errors import (
     SCIONParseError,
     SCIONServiceLookupError,
 )
-from lib.log import init_logging, log_exception
+from lib.main import main_default, main_wrapper
 from lib.packet.cert_mgmt import (
     CertChainRequest,
     TRCRequest,
@@ -77,7 +74,6 @@ from lib.packet.pcb_ext import MTUExtension
 from lib.packet.scion import PacketType as PT
 from lib.path_store import PathPolicy, PathStore
 from lib.thread import thread_safety_net
-from lib.topology import Topology
 from lib.types import (
     CertMgmtType,
     IFIDType,
@@ -93,10 +89,8 @@ from lib.util import (
     get_cert_chain_file_path,
     get_sig_key_file_path,
     get_trc_file_path,
-    handle_signals,
     read_file,
     sleep_interval,
-    trace,
     write_file,
 )
 from lib.zookeeper import ZkNoConnection, ZkSharedCache, Zookeeper
@@ -238,11 +232,10 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
     The SCION PathConstructionBeacon Server.
 
     Attributes:
-        beacons: A FIFO queue containing the beacons for processing and
-            propagation.
         if2rev_tokens: Contains the currently used revocation token
             hash-chain for each interface.
     """
+    SERVICE_TYPE = BEACON_SERVICE
     # Amount of time units a HOF is valid (time unit is EXP_TIME_UNIT).
     HOF_EXP_TIME = 63
     # Timeout for TRC or Certificate requests.
@@ -256,31 +249,20 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
     # Interval to checked for timed out interfaces.
     IF_TIMEOUT_INTERVAL = 1
 
-    def __init__(self, server_id, topo_file, config_file, path_policy_file,
-                 is_sim=False):
-        super().__init__(BEACON_SERVICE, topo_file, server_id=server_id,
-                         config_file=config_file, is_sim=is_sim)
+    def __init__(self, server_id, conf_dir, is_sim=False):
         """
-        Initialize an instance of the class BeaconServer.
-
-        :param server_id: server identifier.
-        :type server_id: int
-        :param topo_file: topology file.
-        :type topo_file: string
-        :param config_file: configuration file.
-        :type config_file: string
-        :param path_policy_file: path policy file.
-        :type path_policy_file: string
-        :param is_sim: running on simulator
-        :type is_sim: bool
+        :param str server_id: server identifier.
+        :param str conf_dir: configuration directory.
+        :param bool is_sim: running on simulator
         """
+        super().__init__(server_id, conf_dir, is_sim=is_sim)
         # TODO: add 2 policies
-        self.path_policy = PathPolicy.from_file(path_policy_file)
+        self.path_policy = PathPolicy.from_file(
+            os.path.join(conf_dir, "path_policy.conf"))
         self.unverified_beacons = deque()
         self.trc_requests = {}
         self.trcs = {}
-        sig_key_file = get_sig_key_file_path(self.topology.isd_id,
-                                             self.topology.ad_id)
+        sig_key_file = get_sig_key_file_path(self.conf_dir)
         self.signing_key = read_file(sig_key_file)
         self.signing_key = base64.b64decode(self.signing_key)
         self.of_gen_key = get_roundkey_cache(self.config.master_ad_key)
@@ -464,7 +446,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         :param prev_hof:
         :type prev_hof:
         """
-        hof = HopOpaqueField.from_values(BeaconServer.HOF_EXP_TIME,
+        hof = HopOpaqueField.from_values(self.HOF_EXP_TIME,
                                          ingress_if, egress_if)
         if prev_hof is None:
             hof.info = OFT.XOVR_POINT
@@ -477,7 +459,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
             if not self.ifid_state[if_id].is_active():
                 logging.warning('Peer ifid:%d inactive (not added).', if_id)
                 continue
-            peer_hof = HopOpaqueField.from_values(BeaconServer.HOF_EXP_TIME,
+            peer_hof = HopOpaqueField.from_values(self.HOF_EXP_TIME,
                                                   if_id, egress_if)
             peer_hof.info = OFT.XOVR_POINT
             peer_hof.mac = gen_of_mac(self.of_gen_key, peer_hof, hof, ts)
@@ -622,10 +604,8 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
             else:
                 logging.warning("Invalid beacon. %s", pcb)
         else:
-            first = pcb.get_first_pcbm()
             logging.warning(
-                "Certificate(s) or TRC missing for pcb from (%d, %d)",
-                first.isd_id, first.ad_id)
+                "Certificate(s) or TRC missing for pcb: %s", pcb.short_desc())
             self.unverified_beacons.append(pcb)
 
     @abstractmethod
@@ -661,9 +641,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         trc = self.trcs.get((isd_id, trc_ver))
         if not trc:
             # Try loading file from disk
-            trc_file = get_trc_file_path(self.topology.isd_id,
-                                         self.topology.ad_id,
-                                         isd_id, trc_ver)
+            trc_file = get_trc_file_path(self.conf_dir, isd_id, trc_ver)
             if os.path.exists(trc_file):
                 trc = TRC(trc_file)
                 self.trcs[(isd_id, trc_ver)] = trc
@@ -673,7 +651,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
             now = int(SCIONTime.get_time())
             if (trc_tuple not in self.trc_requests or
                 (now - self.trc_requests[trc_tuple] >
-                    BeaconServer.REQUESTS_TIMEOUT)):
+                    self.REQUESTS_TIMEOUT)):
                 trc_req = TRCRequest.from_values(
                     if_id, self.topology.isd_id, self.topology.ad_id, isd_id,
                     trc_ver)
@@ -704,14 +682,12 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         trc_ver = pcb.trc_ver
         subject = "%s-%s" % (cert_chain_isd, cert_chain_ad)
         cert_chain_file = get_cert_chain_file_path(
-            self.topology.isd_id, self.topology.ad_id,
-            cert_chain_isd, cert_chain_ad, cert_ver)
+            self.conf_dir, cert_chain_isd, cert_chain_ad, cert_ver)
         if os.path.exists(cert_chain_file):
             chain = CertificateChain(cert_chain_file)
         else:
             chain = CertificateChain.from_values([])
-        trc_file = get_trc_file_path(self.topology.isd_id, self.topology.ad_id,
-                                     cert_chain_isd, trc_ver)
+        trc_file = get_trc_file_path(self.conf_dir, cert_chain_isd, trc_ver)
         trc = TRC(trc_file)
 
         new_pcb = copy.deepcopy(pcb)
@@ -761,11 +737,9 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         :type trc_rep: TRCReply
         """
         rep = pkt.get_payload()
-        logging.info("TRC reply received.")
+        logging.info("TRC reply received for %s", rep.isd_id)
         rep_key = rep.isd_id, rep.version
-        trc_file = get_trc_file_path(
-            self.topology.isd_id, self.topology.ad_id,
-            *rep_key)
+        trc_file = get_trc_file_path(self.conf_dir, *rep_key)
         write_file(trc_file, rep.trc.decode('utf-8'))
         self.trcs[rep_key] = TRC(trc_file)
         if rep_key in self.trc_requests:
@@ -953,24 +927,13 @@ class CoreBeaconServer(BeaconServer):
     Starts broadcasting beacons down-stream within an ISD and across ISDs
     towards other core beacon servers.
     """
-    def __init__(self, server_id, topo_file, config_file, path_policy_file,
-                 is_sim=False):
-        BeaconServer.__init__(self, server_id, topo_file, config_file,
-                              path_policy_file, is_sim=is_sim)
+    def __init__(self, server_id, conf_dir, is_sim=False):
         """
-        Initialize an instance of the class CoreBeaconServer.
-
-        :param server_id: server identifier.
-        :type server_id: int
-        :param topo_file: topology file.
-        :type topo_file: string
-        :param config_file: configuration file.
-        :type config_file: string
-        :param path_policy_file: path policy file.
-        :type path_policy_file: string
-        :param is_sim: running on simulator
-        :type is_sim: bool
+        :param str server_id: server identifier.
+        :param str conf_dir: configuration directory.
+        :param bool is_sim: running on simulator
         """
+        super().__init__(server_id, conf_dir, is_sim=is_sim)
         # Sanity check that we should indeed be a core beacon server.
         assert self.topology.is_core_ad, "This shouldn't be a core BS!"
         self.core_beacons = defaultdict(self._ps_factory)
@@ -1185,24 +1148,13 @@ class LocalBeaconServer(BeaconServer):
     servers.
     """
 
-    def __init__(self, server_id, topo_file, config_file, path_policy_file,
-                 is_sim=False):
+    def __init__(self, server_id, conf_dir, is_sim=False):
         """
-        Initialize an instance of the class LocalBeaconServer.
-
-        :param server_id: server identifier.
-        :type server_id: int
-        :param topo_file: topology file.
-        :type topo_file: string
-        :param config_file: configuration file.
-        :type config_file: string
-        :param path_policy_file: path policy file.
-        :type path_policy_file: string
-        :param is_sim: running on simulator
-        :type is_sim: bool
+        :param str server_id: server identifier.
+        :param str conf_dir: configuration directory.
+        :param bool is_sim: running on simulator
         """
-        BeaconServer.__init__(self, server_id, topo_file, config_file,
-                              path_policy_file, is_sim=is_sim)
+        super().__init__(server_id, conf_dir, is_sim=is_sim)
         # Sanity check that we should indeed be a local beacon server.
         assert not self.topology.is_core_ad, "This shouldn't be a local BS!"
         self.beacons = PathStore(self.path_policy)
@@ -1211,8 +1163,8 @@ class LocalBeaconServer(BeaconServer):
         self.cert_chain_requests = {}
         self.cert_chains = {}
         cert_chain_file = get_cert_chain_file_path(
-            self.topology.isd_id, self.topology.ad_id, self.topology.isd_id,
-            self.topology.ad_id, self.config.cert_ver)
+            self.conf_dir, self.topology.isd_id, self.topology.ad_id,
+            self.config.cert_ver)
         self.cert_chain = CertificateChain(cert_chain_file)
 
     def _check_certs_trc(self, isd_id, ad_id, cert_ver, trc_ver, if_id):
@@ -1240,8 +1192,7 @@ class LocalBeaconServer(BeaconServer):
             if not cert_chain:
                 # Try loading file from disk
                 cert_chain_file = get_cert_chain_file_path(
-                    self.topology.isd_id, self.topology.ad_id,
-                    isd_id, ad_id, cert_ver)
+                    self.conf_dir, isd_id, ad_id, cert_ver)
                 if os.path.exists(cert_chain_file):
                     cert_chain = CertificateChain(cert_chain_file)
                     self.cert_chains[(isd_id, ad_id, cert_ver)] = cert_chain
@@ -1330,10 +1281,11 @@ class LocalBeaconServer(BeaconServer):
         :type cert_chain_rep: CertChainReply
         """
         rep = pkt.get_payload()
-        logging.info("Certificate chain reply received.")
+        logging.info("Certificate chain reply received for %s",
+                     rep.short_desc())
         rep_key = rep.isd_id, rep.ad_id, rep.version
         cert_chain_file = get_cert_chain_file_path(
-            self.topology.isd_id, self.topology.ad_id, *rep_key)
+            self.conf_dir, *rep_key)
         write_file(cert_chain_file, rep.cert_chain.decode('utf-8'))
         self.cert_chains[rep_key] = CertificateChain(cert_chain_file)
         if rep_key in self.cert_chain_requests:
@@ -1410,40 +1362,5 @@ class LocalBeaconServer(BeaconServer):
             logging.info("Down path registered: %s", pcb.get_hops_hash())
 
 
-def main():
-    """
-    Main function.
-    """
-    handle_signals()
-    parser = argparse.ArgumentParser()
-    parser.add_argument('server_id', help='Server identifier')
-    parser.add_argument('topo_file', help='Topology file')
-    parser.add_argument('conf_file', help='AD configuration file')
-    parser.add_argument('path_policy_file', help='AD path policy file')
-    parser.add_argument('log_file', help='Log file')
-    args = parser.parse_args()
-    init_logging(args.log_file)
-
-    topo = Topology.from_file(args.topo_file)
-    if topo.is_core_ad:
-        beacon_server = CoreBeaconServer(args.server_id, args.topo_file,
-                                         args.conf_file, args.path_policy_file)
-    else:
-        beacon_server = LocalBeaconServer(args.server_id, args.topo_file,
-                                          args.conf_file,
-                                          args.path_policy_file)
-
-    trace(beacon_server.id)
-    logging.info("Started: %s", datetime.datetime.now())
-    beacon_server.run()
-
 if __name__ == "__main__":
-    try:
-        main()
-    except SystemExit:
-        logging.info("Exiting")
-        raise
-    except:
-        log_exception("Exception in main process:")
-        logging.critical("Exiting")
-        sys.exit(1)
+    main_wrapper(main_default, CoreBeaconServer, LocalBeaconServer)

--- a/infrastructure/cert_server.py
+++ b/infrastructure/cert_server.py
@@ -17,19 +17,16 @@
 ===============================================
 """
 # Stdlib
-import argparse
 import collections
-import datetime
 import logging
 import os
 import re
-import sys
 
 # SCION
 from infrastructure.scion_elem import SCIONElement
 from lib.crypto.certificate import TRC
 from lib.defines import CERTIFICATE_SERVICE, SCION_UDP_PORT
-from lib.log import init_logging, log_exception
+from lib.main import main_default, main_wrapper
 from lib.packet.cert_mgmt import (
     CertChainReply,
     CertChainRequest,
@@ -41,7 +38,6 @@ from lib.types import CertMgmtType, PayloadClass
 from lib.util import (
     get_cert_chain_file_path,
     get_trc_file_path,
-    handle_signals,
     read_file,
     write_file,
 )
@@ -52,30 +48,22 @@ class CertServer(SCIONElement):
     """
     The SCION Certificate Server.
     """
+    SERVICE_TYPE = CERTIFICATE_SERVICE
     # ZK path for incoming cert chains
     ZK_CERT_CHAIN_CACHE_PATH = "cert_chain_cache"
     # ZK path for incoming TRCs
     ZK_TRC_CACHE_PATH = "trc_cache"
 
-    def __init__(self, server_id, topo_file, config_file, trc_file,
-                 is_sim=False):
+    def __init__(self, server_id, conf_dir, is_sim=False):
         """
-        Initialize an instance of the class CertServer.
-
-        :param server_id: server identifier.
-        :type server_id: int
-        :param topo_file: topology file.
-        :type topo_file: string
-        :param config_file: configuration file.
-        :type config_file: string
-        :param trc_file: TRC file.
-        :type trc_file: string
-        :param is_sim: running in simulator
-        :type is_sim: bool
+        :param str server_id: server identifier.
+        :param str conf_dir: configuration directory.
+        :param bool is_sim: running on simulator
         """
-        super().__init__(CERTIFICATE_SERVICE, topo_file, server_id=server_id,
-                         config_file=config_file, is_sim=is_sim)
-        self.trc = TRC(trc_file)
+        super().__init__(server_id, conf_dir, is_sim=is_sim)
+        # FIXME(kormat): this doesn't cope with trc versioning
+        self.trc = TRC(get_trc_file_path(self.conf_dir,
+                                         self.topology.isd_id, 0))
         self.cert_chain_requests = collections.defaultdict(list)
         self.trc_requests = collections.defaultdict(list)
         self.cert_chains = {}
@@ -110,15 +98,15 @@ class CertServer(SCIONElement):
         """
         cert_chain_req = pkt.get_payload()
         assert isinstance(cert_chain_req, CertChainRequest)
-        logging.info("Certificate chain request received.")
+        logging.info("Certificate chain request received for %s",
+                     cert_chain_req.short_desc())
         cert_chain = self.cert_chains.get((cert_chain_req.isd_id,
                                            cert_chain_req.ad_id,
                                            cert_chain_req.version))
         if not cert_chain:
             # Try loading file from disk
             cert_chain_file = get_cert_chain_file_path(
-                self.topology.isd_id, self.topology.ad_id,
-                cert_chain_req.isd_id, cert_chain_req.ad_id,
+                self.conf_dir, cert_chain_req.isd_id, cert_chain_req.ad_id,
                 cert_chain_req.version)
             if os.path.exists(cert_chain_file):
                 cert_chain = read_file(cert_chain_file).encode('utf-8')
@@ -126,7 +114,8 @@ class CertServer(SCIONElement):
                                   cert_chain_req.version)] = cert_chain
         if not cert_chain:
             # Requesting certificate chain file from parent's cert server
-            logging.debug('Certificate chain not found.')
+            logging.debug('Certificate chain not found for %s',
+                          cert_chain_req.short_desc())
             cert_chain_tuple = (cert_chain_req.isd_id, cert_chain_req.ad_id,
                                 cert_chain_req.version)
             self.cert_chain_requests[cert_chain_tuple].append(
@@ -140,12 +129,15 @@ class CertServer(SCIONElement):
             dst_addr = self.ifid2addr.get(cert_chain_req.ingress_if)
             if dst_addr:
                 self.send(req_pkt, dst_addr)
-                logging.info("New certificate chain request sent.")
+                logging.info("New certificate chain request sent for %s",
+                             cert_chain_req.short_desc())
             else:
-                logging.warning("Certificate chain request not sent: "
-                                "no destination found")
+                logging.warning("Certificate chain request (for %s) not sent: "
+                                "no destination found",
+                                cert_chain_req.short_desc())
         else:
-            logging.debug('Certificate chain found.')
+            logging.debug('Certificate chain found for %s',
+                          cert_chain_req.short_desc())
             dst_addr = None
             cert_chain_rep = CertChainReply.from_values(
                 cert_chain_req.isd_id, cert_chain_req.ad_id,
@@ -162,10 +154,12 @@ class CertServer(SCIONElement):
             if dst_addr:
                 rep_pkt = self._build_packet(dst_addr, payload=cert_chain_rep)
                 self.send(rep_pkt, dst_addr)
-                logging.info("Certificate chain reply sent.")
+                logging.info("Certificate chain reply sent for %s",
+                             cert_chain_req.short_desc())
             else:
-                logging.warning("Certificate chain reply not sent: "
-                                "no destination found")
+                logging.warning("Certificate chain reply (for %s) not sent: "
+                                "no destination found",
+                                cert_chain_req.short_desc())
 
     def process_cert_chain_reply(self, pkt):
         """
@@ -176,13 +170,14 @@ class CertServer(SCIONElement):
         """
         cert_chain_rep = pkt.get_payload()
         assert isinstance(cert_chain_rep, CertChainReply)
-        logging.info("Certificate chain reply received")
+        logging.info("Certificate chain reply received for %s",
+                     cert_chain_rep.short_desc())
         cert_chain = cert_chain_rep.cert_chain
         self.cert_chains[(cert_chain_rep.isd_id, cert_chain_rep.ad_id,
                           cert_chain_rep.version)] = cert_chain
         cert_chain_file = get_cert_chain_file_path(
-            self.topology.isd_id, self.topology.ad_id, cert_chain_rep.isd_id,
-            cert_chain_rep.ad_id, cert_chain_rep.version)
+            self.conf_dir, cert_chain_rep.isd_id, cert_chain_rep.ad_id,
+            cert_chain_rep.version)
         write_file(cert_chain_file, cert_chain.decode('utf-8'))
         # Reply to all requests for this certificate chain
         for dst_addr in self.cert_chain_requests[
@@ -197,7 +192,8 @@ class CertServer(SCIONElement):
             (cert_chain_rep.isd_id,
              cert_chain_rep.ad_id,
              cert_chain_rep.version)]
-        logging.info("Certificate chain reply sent.")
+        logging.info("Certificate chain reply sent for %s",
+                     cert_chain_rep.short_desc())
 
     def process_trc_request(self, pkt):
         """
@@ -213,8 +209,7 @@ class CertServer(SCIONElement):
         if not trc:
             # Try loading file from disk
             trc_file = get_trc_file_path(
-                self.topology.isd_id, self.topology.ad_id,
-                trc_req.isd_id, trc_req.version)
+                self.conf_dir, trc_req.isd_id, trc_req.version)
             if os.path.exists(trc_file):
                 trc = read_file(trc_file).encode('utf-8')
                 self.trcs[(trc_req.isd_id, trc_req.version)] = trc
@@ -273,8 +268,7 @@ class CertServer(SCIONElement):
         trc = trc_rep.trc
         self.trcs[(trc_rep.isd_id, trc_rep.version)] = trc
         trc_file = get_trc_file_path(
-            self.topology.isd_id, self.topology.ad_id,
-            trc_rep.isd_id, trc_rep.version)
+            self.conf_dir, trc_rep.isd_id, trc_rep.version)
         write_file(trc_file, trc.decode('utf-8'))
         count = 0
         # Reply to all requests for this TRC
@@ -314,33 +308,5 @@ class CertServer(SCIONElement):
         return (int(identifiers[1]), int(identifiers[3]))
 
 
-def main():
-    """
-    Main function.
-    """
-    handle_signals()
-    parser = argparse.ArgumentParser()
-    parser.add_argument('server_id', help='Server identifier')
-    parser.add_argument('topo_file', help='Topology file')
-    parser.add_argument('conf_file', help='AD configuration file')
-    parser.add_argument('trc_file', help='TRC file')
-    parser.add_argument('log_file', help='Log file')
-    args = parser.parse_args()
-    init_logging(args.log_file)
-
-    cert_server = CertServer(args.server_id, args.topo_file, args.conf_file,
-                             args.trc_file)
-
-    logging.info("Started: %s", datetime.datetime.now())
-    cert_server.run()
-
 if __name__ == "__main__":
-    try:
-        main()
-    except SystemExit:
-        logging.info("Exiting")
-        raise
-    except:
-        log_exception("Exception in main process:")
-        logging.critical("Exiting")
-        sys.exit(1)
+    main_wrapper(main_default, CertServer)

--- a/infrastructure/router.py
+++ b/infrastructure/router.py
@@ -17,11 +17,8 @@
 ===========================================
 """
 # Stdlib
-import argparse
 import copy
-import datetime
 import logging
-import sys
 import threading
 import time
 import zlib
@@ -47,7 +44,8 @@ from lib.errors import (
     SCIONBaseException,
     SCIONServiceLookupError,
 )
-from lib.log import init_logging, log_exception
+from lib.log import log_exception
+from lib.main import main_default, main_wrapper
 from lib.packet.ext.traceroute import TracerouteExt, traceroute_ext_handler
 from lib.packet.path_mgmt import (
     RevocationInfo,
@@ -69,7 +67,7 @@ from lib.types import (
     PathMgmtType as PMT,
     PayloadClass,
 )
-from lib.util import handle_signals, SCIONTime, sleep_interval
+from lib.util import SCIONTime, sleep_interval
 
 
 MAX_EXT = 4  # Maximum number of hop-by-hop extensions processed by router.
@@ -142,31 +140,24 @@ class Router(SCIONElement):
     :ivar interface: the router's inter-AD interface, if any.
     :type interface: :class:`lib.topology.InterfaceElement`
     """
+    SERVICE_TYPE = ROUTER_SERVICE
     FWD_REVOCATION_TIMEOUT = 5
     IFSTATE_REQ_INTERVAL = 30
 
-    def __init__(self, router_id, topo_file, config_file, pre_ext_handlers=None,
+    def __init__(self, server_id, conf_dir, pre_ext_handlers=None,
                  post_ext_handlers=None, is_sim=False):
         """
-        Initialize an instance of the class Router.
-
-        :param router_id:
-        :type router_id:
-        :param topo_file: the topology file name.
-        :type topo_file: str
-        :param config_file: the configuration file name.
-        :type config_file: str
-        :ivar pre_ext_handlers: a map of extension header types to handlers for
-                            those extensions that execute before routing.
-        :type pre_ext_handlers: dict
-        :ivar post_ext_handlers: a map of extension header types to handlers for
-                             those extensions that execute after routing.
-        :type post_ext_handlers: dict
-        :param is_sim: running in simulator
-        :type is_sim: bool
+        :param str server_id: server identifier.
+        :param str conf_dir: configuration directory.
+        :param dict pre_ext_handlers:
+            a map of extension header types to handlers for those extensions
+            that execute before routing.
+        :param dict post_ext_handlers:
+            a map of extension header types to handlers for those extensions
+            that execute after routing.
+        :param bool is_sim: running on simulator
         """
-        super().__init__(ROUTER_SERVICE, topo_file, server_id=router_id,
-                         config_file=config_file, is_sim=is_sim)
+        super().__init__(server_id, conf_dir, is_sim=is_sim)
         self.interface = None
         for edge_router in self.topology.get_all_edge_routers():
             if edge_router.addr == self.addr.host_addr:
@@ -773,34 +764,8 @@ class Router(SCIONElement):
 
 
 def main():
-    """
-    Initializes and starts router.
-    """
-    handle_signals()
-    parser = argparse.ArgumentParser()
-    parser.add_argument('router_id', help='Router identifier')
-    parser.add_argument('topo_file', help='Topology file')
-    parser.add_argument('conf_file', help='AD configuration file')
-    parser.add_argument('log_file', help='Log file')
-    args = parser.parse_args()
-    init_logging(args.log_file)
-    # Run router without extensions handling:
-    # router = Router(args.router_id, args.topo_file, args.conf_file)
-    # Run router with an extension handler:
     pre_handlers = {TracerouteExt.EXT_TYPE: traceroute_ext_handler}
-    router = Router(args.router_id, args.topo_file, args.conf_file,
-                    pre_ext_handlers=pre_handlers)
-
-    logging.info("Started: %s", datetime.datetime.now())
-    router.run()
+    main_default(Router, pre_ext_handlers=pre_handlers)
 
 if __name__ == "__main__":
-    try:
-        main()
-    except SystemExit:
-        logging.info("Exiting")
-        raise
-    except:
-        log_exception("Exception in main process:")
-        logging.critical("Exiting")
-        sys.exit(1)
+    main_wrapper(main)

--- a/lib/main.py
+++ b/lib/main.py
@@ -1,0 +1,80 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`main` --- Main functions for SCION
+========================================
+"""
+# Stdlib
+import argparse
+import logging
+import os
+import sys
+
+# SCION
+from lib.log import init_logging, log_exception
+from lib.topology import Topology
+from lib.util import handle_signals, trace
+
+
+def main_wrapper(main, *args, **kwargs):
+    """
+    Run the supplied function with any args and kwargs specified, catching any
+    raised exceptions and dealing with them appropriately.
+    """
+    try:
+        main(*args, **kwargs)
+    except SystemExit:
+        logging.info("Exiting")
+        raise
+    except:
+        log_exception("Exception in main process:")
+        logging.critical("Exiting")
+        sys.exit(1)
+
+
+def main_default(type_, local_type=None, trace_=False, **kwargs):
+    """
+    Default main() method. Parses cmdline args, setups up signal handling,
+    logging, creates the appropriate object and runs it.
+
+    :param type type_: Primary type to instantiate.
+    :param type local_type:
+        If not `None`, load the topology to check if this is a core or local AD.
+        If it's a core AD, instantiate the primary type, otherwise the local
+        type.
+    :param bool trace_: Should a periodic thread stacktrace report be created?
+    """
+    handle_signals()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('server_id', help='Server identifier')
+    parser.add_argument('conf_dir', nargs='?', default='.',
+                        help='Configuration directory (Default: ./)')
+    parser.add_argument('log_dir', nargs='?', default="logs/",
+                        help='Log dir (Default: logs/)')
+    args = parser.parse_args()
+    init_logging("%s.log" % os.path.join(args.log_dir, args.server_id))
+
+    if local_type is None:
+        inst = type_(args.server_id, args.conf_dir, **kwargs)
+    else:
+        # Load the topology to check if this is a core AD or not
+        topo = Topology.from_file(os.path.join(args.conf_dir, "topology.conf"))
+        if topo.is_core_ad:
+            inst = type_(args.server_id, args.conf_dir, **kwargs)
+        else:
+            inst = local_type(args.server_id, args.conf_dir, **kwargs)
+    if trace_:
+        trace(inst.id)
+    logging.info("Started %s", args.server_id)
+    inst.run()

--- a/lib/packet/cert_mgmt.py
+++ b/lib/packet/cert_mgmt.py
@@ -83,6 +83,9 @@ class CertChainRequest(CertMgmtBase):
         packed.append(struct.pack("!B", self.local))
         return b"".join(packed)
 
+    def short_desc(self):  # pragma: no cover
+        return "%s-%sv%s" % (self.isd_id, self.ad_id, self.version)
+
     def __len__(self):  # pragma: no cover
         return self.LEN
 
@@ -171,6 +174,9 @@ class CertChainReply(CertMgmtBase):
         packed.append(struct.pack("!I", self.version))
         packed.append(self.cert_chain)
         return b"".join(packed)
+
+    def short_desc(self):  # pragma: no cover
+        return "%s-%sv%s" % (self.isd_id, self.ad_id, self.version)
 
     def __len__(self):  # pragma: no cover
         return self.MIN_LEN + len(self.cert_chain)

--- a/lib/util.py
+++ b/lib/util.py
@@ -31,7 +31,6 @@ from functools import wraps
 from external.stacktracer import trace_start
 
 # SCION
-from lib.defines import GEN_PATH
 from lib.errors import (
     SCIONIOError,
     SCIONIndexError,
@@ -40,9 +39,8 @@ from lib.errors import (
     SCIONTypeError,
 )
 
-CERT_DIR = 'certificates'
-SIG_KEYS_DIR = 'signature_keys'
-ENC_KEYS_DIR = 'encryption_keys'
+CERT_DIR = 'certs'
+KEYS_DIR = 'keys'
 TRACE_DIR = 'traces'
 
 _SIG_MAP = {
@@ -55,99 +53,27 @@ _SIG_MAP = {
 }
 
 
-def _get_isd_prefix(isd_dir):
+def get_cert_chain_file_path(conf_dir, isd_id, ad_id,
+                             version):  # pragma: no cover
     """
-
-
-    :param isd_dir:
-    :type isd_dir:
-
-    :returns:
-    :rtype:
+    Return the certificate chain file path for a given ISD.
     """
-    return os.path.join(isd_dir, 'ISD')
+    return os.path.join(conf_dir, CERT_DIR,
+                        'ISD%s-AD%s-V%s.crt' % (isd_id, ad_id, version))
 
 
-def get_cert_chain_file_path(loc_isd, loc_ad, isd_id, ad_id, version,
-                             isd_dir=GEN_PATH):
+def get_trc_file_path(conf_dir, isd_id, version):  # pragma: no cover
     """
-    Return the certificate chain file path.
-
-    :param loc_isd: the caller's ISD identifier.
-    :type loc_isd: int
-    :param loc_ad: the caller's AD identifier.
-    :type loc_ad: int
-    :param isd_id: the certificate chain's ISD identifier.
-    :type isd_id: int
-    :param ad_id: the certificate chain's AD identifier.
-    :type ad_id: int
-    :param version: the certificate chain's version.
-    :type version: int
-
-    :returns: the certificate chain file path.
-    :rtype: str
+    Return the TRC file path for a given ISD.
     """
-    isd_dir_prefix = _get_isd_prefix(isd_dir)
-    return os.path.join(isd_dir_prefix + str(loc_isd), CERT_DIR,
-                        'AD{}'.format(loc_ad),
-                        'ISD{}-AD{}-V{}.crt'.format(isd_id, ad_id, version))
+    return os.path.join(conf_dir, CERT_DIR, 'ISD%s-V%s.crt' % (isd_id, version))
 
 
-def get_trc_file_path(loc_isd, loc_ad, isd_id, version,
-                      isd_dir=GEN_PATH):
-    """
-    Return the TRC file path.
-
-    :param loc_isd: the caller's ISD identifier.
-    :type loc_isd: int
-    :param loc_ad: the caller's AD identifier.
-    :type loc_ad: int
-    :param isd_id: the TRC's ISD identifier.
-    :type isd_id: int
-    :param version: the TRC's version.
-    :type version: int
-
-    :returns: the TRC file path.
-    :rtype: str
-    """
-    isd_dir_prefix = _get_isd_prefix(isd_dir)
-    return os.path.join(isd_dir_prefix + str(loc_isd), CERT_DIR,
-                        'AD{}'.format(loc_ad),
-                        'ISD{}-V{}.crt'.format(isd_id, version))
-
-
-def get_sig_key_file_path(isd_id, ad_id, isd_dir=GEN_PATH):
+def get_sig_key_file_path(conf_dir):  # pragma: no cover
     """
     Return the signing key file path.
-
-    :param isd_id: the signing key ISD identifier.
-    :type isd_id: int
-    :param ad_id: the signing key AD identifier.
-    :type ad_id: int
-
-    :returns: the signing key file path.
-    :rtype: str
     """
-    isd_dir_prefix = _get_isd_prefix(isd_dir)
-    return os.path.join(isd_dir_prefix + str(isd_id), SIG_KEYS_DIR,
-                        'ISD{}-AD{}.key'.format(isd_id, ad_id))
-
-
-def get_enc_key_file_path(isd_id, ad_id, isd_dir=GEN_PATH):
-    """
-    Return the encryption key file path.
-
-    :param isd_id: the encryption key ISD identifier.
-    :type isd_id: int
-    :param ad_id: the encryption key AD identifier.
-    :type ad_id: int
-
-    :returns: the encryption key file path.
-    :rtype: str
-    """
-    isd_dir_prefix = _get_isd_prefix(isd_dir)
-    return os.path.join(isd_dir_prefix + str(isd_id), ENC_KEYS_DIR,
-                        'ISD{}-AD{}.key'.format(isd_id, ad_id))
+    return os.path.join(conf_dir, KEYS_DIR, "ad-sig.key")
 
 
 def read_file(file_path):

--- a/supervisor/supervisord.conf
+++ b/supervisor/supervisord.conf
@@ -64,4 +64,4 @@ startretries=0
 stdout_logfile=logs/management_daemon.out
 
 [include]
-files = ../gen/ISD*/supervisor/*.conf
+files = ../gen/ISD*/AD*/*/supervisord.conf ../gen/ISD*/AD*/supervisord.conf

--- a/test/infrastructure_dns_server_test.py
+++ b/test/infrastructure_dns_server_test.py
@@ -222,24 +222,6 @@ class TestSCIONDnsProtocolServerHandleError(object):
         self._check(SCIONDnsUdpServer("srvaddr", "reqhndlcls"))
 
 
-class TestSCIONDnsServerInit(BaseDNSServer):
-    """
-    Unit tests for infrastructure.dns_server.SCIONDnsServer.__init__
-    """
-    @patch('infrastructure.dns_server.threading.Lock', autospec=True)
-    @patch('infrastructure.dns_server.SCIONElement.__init__', autospec=True,
-           return_value=None)
-    def test(self, elem_init, lock):
-        # Call
-        server = SCIONDnsServer("srvid", self.DOMAIN, "topofile")
-        # Tests
-        elem_init.assert_called_once_with(server, DNS_SERVICE, "topofile",
-                                          server_id="srvid")
-        ntools.eq_(server.domain, self.DOMAIN)
-        ntools.eq_(server.lock, lock.return_value)
-        ntools.eq_(server.services, {})
-
-
 class TestSCIONDnsServerSetup(BaseDNSServer):
     """
     Unit tests for infrastructure.dns_server.SCIONDnsServer.setup
@@ -253,7 +235,7 @@ class TestSCIONDnsServerSetup(BaseDNSServer):
     def test(self, init, zone_resolver, dns_server, dns_logger,
              zookeeper):
         # Setup
-        server = SCIONDnsServer("srvid", "domain", "topofile")
+        server = SCIONDnsServer("srvid", "conf_dir")
         server.lock = "lock"
         server.domain = "domain"
         server.addr = create_mock(["host_addr"])
@@ -291,7 +273,7 @@ class TestSCIONDnsSetupParties(BaseDNSServer):
     @patch("infrastructure.dns_server.SCIONDnsServer.__init__", autospec=True,
            return_value=None)
     def test(self, _):
-        server = SCIONDnsServer("server_id", "domain", "topo_file")
+        server = SCIONDnsServer("srvid", "conf_dir")
         server.zk = create_mock(["retry", "party_setup"])
         server.topology = create_mock(["isd_id", "ad_id"])
         server.topology.isd_id = 30
@@ -324,7 +306,7 @@ class TestSCIONDnsSyncZkState(BaseDNSServer):
             DNS_SERVICE: ["ds1", "ds2"],
             PATH_SERVICE: [],
         }
-        server = SCIONDnsServer("srvid", "domain", "topofile")
+        server = SCIONDnsServer("srvid", "conf_dir")
         server.zk = create_mock(['wait_connected'])
         server.domain = self.DOMAIN
         server._parties = {}
@@ -353,7 +335,7 @@ class TestSCIONDnsSyncZkState(BaseDNSServer):
            return_value=None)
     def test_no_conn(self, init):
         # Setup
-        server = SCIONDnsServer("srvid", "domain", "topofile")
+        server = SCIONDnsServer("srvid", "conf_dir")
         server.zk = create_mock(['wait_connected'])
         server.zk.wait_connected.side_effect = ZkNoConnection
         # Call
@@ -366,7 +348,7 @@ class TestSCIONDnsSyncZkState(BaseDNSServer):
            return_value=None)
     def test_connloss(self, init):
         # Setup
-        server = SCIONDnsServer("srvid", "domain", "topofile")
+        server = SCIONDnsServer("srvid", "conf_dir")
         server.zk = create_mock(['wait_connected'])
         server.domain = self.DOMAIN
         party = create_mock(["list"])
@@ -386,7 +368,7 @@ class TestSCIONDnsParseSrvInst(BaseDNSServer):
            return_value=None)
     def test(self, init):
         # Setup
-        server = SCIONDnsServer("srvid", "domain", "topofile")
+        server = SCIONDnsServer("srvid", "conf_dir")
         srv_domain = self.DOMAIN.add(BEACON_SERVICE)
         server.services = {srv_domain: ["addr0"]}
         # Call
@@ -404,7 +386,7 @@ class TestSCIONDnsRun(BaseDNSServer):
            return_value=None)
     def test(self, init, sleep):
         # Setup
-        server = SCIONDnsServer("srvid", "domain", "topofile")
+        server = SCIONDnsServer("srvid", "conf_dir")
         server._sync_zk_state = create_mock()
         server.udp_server = create_mock(["start_thread", "isAlive"])
         server.tcp_server = create_mock(["start_thread", "isAlive"])

--- a/test/integration/cli_srv_ext_test.py
+++ b/test/integration/cli_srv_ext_test.py
@@ -49,10 +49,9 @@ def client():
     """
     Simple client
     """
-    topo_file = ("%s/ISD%d/topologies/ISD%d-AD%d.json" %
-                 (GEN_PATH, CLI_ISD, CLI_ISD, CLI_AD))
+    conf_dir = "%s/ISD%d/AD%d/common" % (GEN_PATH, CLI_ISD, CLI_AD)
     # Start SCIONDaemon
-    sd = SCIONDaemon.start(haddr_parse("IPV4", CLI_IP), topo_file)
+    sd = SCIONDaemon.start(conf_dir, haddr_parse("IPV4", CLI_IP))
     logging.info("CLI: Sending PATH request for (%d, %d)", SRV_ISD, SRV_AD)
     # Get paths to server through function call
     paths = sd.get_paths(SRV_ISD, SRV_AD)
@@ -96,10 +95,9 @@ def server():
     """
     Simple server.
     """
-    topo_file = ("%s/ISD%d/topologies/ISD%d-AD%d.json" %
-                 (GEN_PATH, SRV_ISD, SRV_ISD, SRV_AD))
+    conf_dir = "%s/ISD%d/AD%d/common" % (GEN_PATH, SRV_ISD, SRV_AD)
     # Start SCIONDaemon
-    sd = SCIONDaemon.start(haddr_parse("IPV4", SRV_IP), topo_file)
+    sd = SCIONDaemon.start(conf_dir, haddr_parse("IPV4", SRV_IP))
     # Open a socket for incomming DATA traffic
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -99,11 +99,10 @@ class Ping(object):
         self.dport = dport
         self.token = token
         self.pong_received = False
-        topo_file = ("%s/ISD%d/topologies/ISD%d-AD%d.json" %
-                     (GEN_PATH, src.isd, src.isd, src.ad))
+        conf_dir = "%s/ISD%d/AD%d/common" % (GEN_PATH, src.isd, src.ad)
         # Local api on, random port:
         self.sd = SCIONDaemon.start(
-            saddr, topo_file, run_local_api=True, port=0)
+            conf_dir, saddr, run_local_api=True, port=0)
         self.get_path()
         self.sock = UDPSocket(bind=(str(saddr), 0, "Ping App"),
                               addr_type=AddrType.IPV4)
@@ -161,9 +160,9 @@ class Pong(object):
         self.dst = dst
         self.token = token
         self.ping_received = False
-        topo_file = ("%s/ISD%d/topologies/ISD%d-AD%d.json" %
-                     (GEN_PATH, self.dst.isd, self.dst.isd, self.dst.ad))
-        self.sd = SCIONDaemon.start(raddr, topo_file)  # API off, standard port.
+        conf_dir = "%s/ISD%d/AD%d/common" % (
+            GEN_PATH, self.dst.isd, self.dst.ad)
+        self.sd = SCIONDaemon.start(conf_dir, raddr)  # API off, standard port.
         self.sock = UDPSocket(bind=(str(raddr), 0, "Pong App"),
                               addr_type=AddrType.IPV4)
 

--- a/test/lib_main_test.py
+++ b/test/lib_main_test.py
@@ -1,0 +1,108 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`lib_main_test` --- lib.main unit tests
+============================================
+"""
+# Stdlib
+from unittest.mock import patch
+
+# External packages
+import nose
+import nose.tools as ntools
+
+# SCION
+from lib.main import main_default, main_wrapper
+from test.testcommon import create_mock
+
+
+class TestMainWrapper(object):
+    """
+    Unit tests for lib.main.main_wrapper
+    """
+    def test_basic(self):
+        main = create_mock()
+        # Call
+        main_wrapper(main, "arg1", arg2="arg2")
+        # Tests
+        main.assert_called_once_with("arg1", arg2="arg2")
+
+    def test_sysexit(self):
+        main = create_mock()
+        main.side_effect = SystemExit
+        # Call
+        ntools.assert_raises(SystemExit, main_wrapper, main)
+
+    @patch("lib.main.sys.exit", autospec=True)
+    @patch("lib.main.log_exception", autospec=True)
+    def test_excp(self, log_excp, exit):
+        main = create_mock()
+        main.side_effect = KeyError
+        # Call
+        main_wrapper(main)
+        # Tests
+        ntools.ok_(log_excp.called)
+        ntools.ok_(exit.called)
+
+
+class TestMainDefault(object):
+    """
+    Unit tests for lib.main.main_default
+    """
+    @patch("lib.main.trace", autospec=True)
+    @patch("lib.main.init_logging", autospec=True)
+    @patch("lib.main.argparse.ArgumentParser", autospec=True)
+    @patch("lib.main.handle_signals", autospec=True)
+    def test_trace(self, signals, argparse, init_log, trace):
+        type_ = create_mock()
+        inst = type_.return_value = create_mock(["id", "run"])
+        parser = argparse.return_value
+        args = parser.parse_args.return_value
+        args.log_dir = "logging"
+        args.server_id = "srvid"
+        args.conf_dir = "confdir"
+        # Call
+        main_default(type_, trace_=True, kwarg1="kwarg1")
+        # Tests
+        signals.assert_called_once_with()
+        argparse.assert_called_once_with()
+        ntools.ok_(parser.add_argument.called)
+        parser.parse_args.assert_called_once_with()
+        init_log.assert_called_once_with("logging/srvid.log")
+        type_.assert_called_once_with("srvid", "confdir", kwarg1="kwarg1")
+        trace.assert_called_once_with(inst.id)
+        inst.run.assert_called_once_with()
+
+    @patch("lib.main.Topology.from_file", new_callable=create_mock)
+    @patch("lib.main.init_logging", autospec=True)
+    @patch("lib.main.argparse.ArgumentParser", autospec=True)
+    @patch("lib.main.handle_signals", autospec=True)
+    def _check_core_local(self, is_core, core_called, local_called, signals,
+                          argparse, init_log, topo):
+        core_type = create_mock()
+        local_type = create_mock()
+        topo.return_value = create_mock(["is_core_ad"])
+        topo.return_value.is_core_ad = is_core
+        # Call
+        main_default(core_type, local_type)
+        # Tests
+        ntools.eq_(core_type.called, core_called)
+        ntools.eq_(local_type.called, local_called)
+
+    def test_core_local(self):
+        yield self._check_core_local, True, True, False
+        yield self._check_core_local, False, False, True
+
+if __name__ == "__main__":
+    nose.run(defaultTest=__name__)

--- a/test/lib_util_test.py
+++ b/test/lib_util_test.py
@@ -25,7 +25,6 @@ import nose
 import nose.tools as ntools
 
 # SCION
-from lib.defines import GEN_PATH
 from lib.errors import (
     SCIONIOError,
     SCIONIndexError,
@@ -34,21 +33,13 @@ from lib.errors import (
     SCIONTypeError,
 )
 from lib.util import (
-    CERT_DIR,
-    ENC_KEYS_DIR,
     Raw,
     SCIONTime,
-    SIG_KEYS_DIR,
     TRACE_DIR,
     _SIG_MAP,
-    _get_isd_prefix,
     _signal_handler,
     calc_padding,
     copy_file,
-    get_cert_chain_file_path,
-    get_enc_key_file_path,
-    get_sig_key_file_path,
-    get_trc_file_path,
     handle_signals,
     load_json_file,
     read_file,
@@ -58,90 +49,6 @@ from lib.util import (
     update_dict,
     write_file,
 )
-
-
-class TestGetIsdPrefix(object):
-    """
-    Unit tests for lib.util._get_isd_prefix
-    """
-    @patch("lib.util.os.path.join", autospec=True)
-    def test_basic(self, join):
-        join.return_value = "data1"
-        ntools.eq_(_get_isd_prefix("data2"), "data1")
-        join.assert_any_call("data2", 'ISD')
-
-
-@patch("lib.util.os.path.join", autospec=True)
-@patch("lib.util._get_isd_prefix", autospec=True)
-class TestGetCertChainFilePath(object):
-    """
-    Unit tests for lib.util.get_cert_chain_file_path
-    """
-    def test_basic(self, isd_prefix, join):
-        isd_prefix.return_value = "isd_prefix"
-        join.return_value = "data2"
-        ntools.eq_(get_cert_chain_file_path(1, 2, 3, 4, 5, 6), "data2")
-        isd_prefix.assert_called_once_with(6)
-        join.assert_any_call("isd_prefix1", CERT_DIR, 'AD2',
-                             'ISD3-AD4-V5.crt')
-
-    def test_len(self, isd_prefix, join):
-        get_cert_chain_file_path(1, 2, 3, 4, 5)
-        isd_prefix.assert_called_once_with(GEN_PATH)
-
-
-@patch("lib.util.os.path.join", autospec=True)
-@patch("lib.util._get_isd_prefix", autospec=True)
-class TestGetTRCFilePath(object):
-    """
-    Unit tests for lib.util.get_trc_file_path
-    """
-    def test_basic(self, isd_prefix, join):
-        isd_prefix.return_value = "isd_prefix"
-        join.return_value = "data2"
-        ntools.eq_(get_trc_file_path(1, 2, 3, 4, 5), "data2")
-        isd_prefix.assert_called_once_with(5)
-        join.assert_any_call("isd_prefix1", CERT_DIR, 'AD2', 'ISD3-V4.crt')
-
-    def test_len(self, isd_prefix, join):
-        get_trc_file_path(1, 2, 3, 4)
-        isd_prefix.assert_called_once_with(GEN_PATH)
-
-
-@patch("lib.util.os.path.join", autospec=True)
-@patch("lib.util._get_isd_prefix", autospec=True)
-class TestGetSigKeyFilePath(object):
-    """
-    Unit tests for lib.util.et_sig_key_file_path
-    """
-    def test_basic(self, isd_prefix, join):
-        isd_prefix.return_value = "isd_prefix"
-        join.return_value = "data2"
-        ntools.eq_(get_sig_key_file_path(1, 2, 3), "data2")
-        isd_prefix.assert_called_once_with(3)
-        join.assert_any_call("isd_prefix1", SIG_KEYS_DIR, 'ISD1-AD2.key')
-
-    def test_len(self, isd_prefix, join):
-        get_sig_key_file_path(1, 2)
-        isd_prefix.assert_called_once_with(GEN_PATH)
-
-
-@patch("lib.util.os.path.join", autospec=True)
-@patch("lib.util._get_isd_prefix", autospec=True)
-class TestGetEncKeyFilePath(object):
-    """
-    Unit tests for lib.util.get_enc_key_file_path
-    """
-    def test_basic(self, isd_prefix, join):
-        isd_prefix.return_value = "isd_prefix"
-        join.return_value = "data2"
-        ntools.eq_(get_enc_key_file_path(1, 2, 3), "data2")
-        isd_prefix.assert_called_once_with(3)
-        join.assert_any_call("isd_prefix1", ENC_KEYS_DIR, 'ISD1-AD2.key')
-
-    def test_len(self, isd_prefix, join):
-        get_enc_key_file_path(1, 2)
-        isd_prefix.assert_called_once_with(GEN_PATH)
 
 
 class TestReadFile(object):

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -47,7 +47,6 @@ from lib.topology import Topology
 from lib.util import (
     copy_file,
     get_cert_chain_file_path,
-    get_enc_key_file_path,
     get_sig_key_file_path,
     get_trc_file_path,
     load_json_file,
@@ -59,27 +58,17 @@ DEFAULT_PATH_POLICY_FILE = "topology/PathPolicy.json"
 DEFAULT_ZK_CONFIG = "topology/Zookeeper.json"
 DEFAULT_ZK_LOG4J = "topology/Zookeeper.log4j"
 
-GEN_DIR = 'gen'
-CERT_DIR = 'certificates'
-CONF_DIR = 'configurations'
-TOPO_DIR = 'topologies'
-SIG_KEYS_DIR = 'signature_keys'
-ENC_KEYS_DIR = 'encryption_keys'
-PATH_POL_DIR = 'path_policies'
-SUPERVISOR_DIR = 'supervisor'
 SIM_DIR = 'SIM'
 SIM_CONF_FILE = 'sim.conf'
 HOSTS_FILE = 'hosts'
 NETWORKS_CONF = 'networks.conf'
+SUPERVISOR_CONF = 'supervisord.conf'
+COMMON_DIR = 'common'
 
-ZOOKEEPER_DIR = 'zookeeper'
-ZOOKEEPER_CFG = "zoo.cfg"
 ZOOKEEPER_HOST_TMPFS_DIR = "/run/shm/host-zk"
 ZOOKEEPER_TMPFS_DIR = "/run/shm/scion-zk"
 
 CORE_AD = 'CORE'
-INTERMEDIATE_AD = 'INTERMEDIATE'
-LEAF_AD = 'LEAF'
 
 DEFAULT_BEACON_SERVERS = 1
 DEFAULT_CERTIFICATE_SERVERS = 1
@@ -91,7 +80,14 @@ DEFAULT_DNS_DOMAIN = DNSLabel("scion")
 
 DEFAULT_NETWORK = "127.0.0.0/8"
 DEFAULT_MININET_NETWORK = "100.64.0.0/10"
-DEFAULT_SUBNET_PREFIX = 26
+
+SCION_SERVICE_NAMES = (
+    "BeaconServers",
+    "CertificateServers",
+    "DNSServers",
+    "EdgeRouters",
+    "PathServers",
+)
 
 
 class ConfigGenerator(object):
@@ -140,25 +136,25 @@ class ConfigGenerator(object):
         self.subnet_gen = SubnetGenerator(def_network)
         for key, val in defaults.get("zookeepers", {}).items():
             self.default_zookeepers[key] = ZKTopo(
-                val, self.zk_config["Default"])
+                val, self.zk_config)
 
     def generate_all(self):
         """
         Generate all needed files.
         """
-        self._generate_certs()
+        cert_files = self._generate_certs()
         topo_dicts, zookeepers, networks = self._generate_topology()
         self._generate_supervisor(topo_dicts, zookeepers)
         if self.is_sim:
             self._generate_sim_conf(topo_dicts)
         self._generate_zk_conf(zookeepers)
-        self._write_conf_files()
-        self._write_path_policy_files()
+        self._write_cert_files(topo_dicts, cert_files)
+        self._write_conf_policies(topo_dicts)
         self._write_networks_conf(networks)
 
     def _generate_certs(self):
-        certgen = CertGenerator(self.ad_configs, self.out_dir)
-        certgen.generate()
+        certgen = CertGenerator(self.ad_configs)
+        return certgen.generate()
 
     def _generate_topology(self):
         topo_gen = TopoGenerator(self.ad_configs, self.out_dir, self.subnet_gen,
@@ -178,44 +174,41 @@ class ConfigGenerator(object):
         zk_gen = ZKConfGenerator(self.out_dir, zookeepers)
         zk_gen.generate()
 
-    def _write_conf_files(self):
-        """
-        Generate the AD configurations and store them into files.
-        """
-        for isd_ad_id, ad_conf in self.ad_configs["ADs"].items():
-            topo_id = TopoID(isd_ad_id)
-            conf_file = os.path.join(self.out_dir, topo_id.ISD(), CONF_DIR,
-                                     "%s.conf" % topo_id.ISD_AD())
-            master_ad_key = base64.b64encode(Random.new().read(16))
-            conf_dict = {'MasterADKey': master_ad_key.decode("utf-8"),
-                         'RegisterTime': 5,
-                         'PropagateTime': 5,
-                         'MTU': 1500,
-                         'CertChainVersion': 0}
-            if self.is_sim:
-                conf_dict['PropagateTime'] = 10
-                conf_dict['RegisterTime'] = 10
-            if (ad_conf['level'] != INTERMEDIATE_AD or
-                    "path_servers" in ad_conf):
-                conf_dict['RegisterPath'] = 1
-            else:
-                conf_dict['RegisterPath'] = 0
-            write_file(conf_file, "%s\n" %
-                       json.dumps(conf_dict, sort_keys=True, indent=4))
-            # Test if parser works
-            Config.from_file(conf_file)
+    def _write_cert_files(self, topo_dicts, cert_files):
+        for topo_id, ad_topo, base in _srv_iter(
+                topo_dicts, self.out_dir):
+            for path, value in cert_files[topo_id].items():
+                write_file(os.path.join(base, path), value)
 
-    def _write_path_policy_files(self):
+    def _write_conf_policies(self, topo_dicts):
         """
-        Generate the AD path policies and store them into files.
+        Write AD configurations and path policies.
         """
-        for isd_ad_id in self.ad_configs["ADs"]:
-            topo_id = TopoID(isd_ad_id)
-            dst = os.path.join(self.out_dir, topo_id.ISD(), PATH_POL_DIR,
-                               "%s.json" % topo_id.ISD_AD())
-            copy_file(self.path_policy_file, dst)
-            # Test if parser works
-            PathPolicy.from_file(dst)
+        ad_confs = {}
+        for topo_id, ad_topo, base in _srv_iter(
+                topo_dicts, self.out_dir, common=True):
+            ad_confs.setdefault(topo_id, "%s\n" % json.dumps(
+                self._gen_ad_conf(ad_topo), sort_keys=True, indent=4))
+            conf_file = os.path.join(base, "ad.conf")
+            write_file(conf_file, ad_confs[topo_id])
+            # Confirm that config parses cleanly.
+            Config.from_file(conf_file)
+            copy_file(self.path_policy_file,
+                      os.path.join(base, "path_policy.conf"))
+        # Confirm that parser actually works on path policy file
+        PathPolicy.from_file(self.path_policy_file)
+
+    def _gen_ad_conf(self, ad_topo):
+        master_ad_key = base64.b64encode(Random.new().read(16))
+        return {
+            'MasterADKey': master_ad_key.decode("utf-8"),
+            'RegisterTime': 10 if self.is_sim else 5,
+            'PropagateTime': 10 if self.is_sim else 5,
+            'MTU': 1500,
+            'CertChainVersion': 0,
+            # FIXME(kormat): This seems to always be true..:
+            'RegisterPath': True if ad_topo["PathServers"] else False,
+        }
 
     def _write_networks_conf(self, networks):
         config = configparser.ConfigParser(interpolation=None)
@@ -230,25 +223,24 @@ class ConfigGenerator(object):
 
 
 class CertGenerator(object):
-    def __init__(self, ad_configs, out_dir):
+    def __init__(self, ad_configs):
         self.ad_configs = ad_configs
-        self.out_dir = out_dir
         self.sig_priv_keys = {}
         self.sig_pub_keys = {}
         self.enc_pub_keys = {}
         self.certs = {}
-        self.chains = {}
         self.trcs = {}
+        self.cert_files = defaultdict(dict)
 
     def generate(self):
         self._self_sign_keys()
-        self._iterate(self._write_ad_keys)
-        self._iterate(self._generate_ad_certs)
+        self._iterate(self._gen_ad_keys)
+        self._iterate(self._gen_ad_certs)
         self._build_chains()
-        self._write_ad_certs()
-        self._iterate(self._generate_trc_entry)
+        self._iterate(self._gen_trc_entry)
         self._iterate(self._sign_trc)
-        self._iterate(self._write_trc)
+        self._iterate(self._gen_trc_files)
+        return self.cert_files
 
     def _self_sign_keys(self):
         topo_id = TopoID.from_values(0, 0)
@@ -260,20 +252,16 @@ class CertGenerator(object):
         for isd_ad_id, ad_conf in self.ad_configs["ADs"].items():
             f(TopoID(isd_ad_id), ad_conf)
 
-    def _write_ad_keys(self, topo_id, ad_conf):
+    def _gen_ad_keys(self, topo_id, ad_conf):
         sig_pub, sig_priv = generate_signature_keypair()
         enc_pub, enc_priv = generate_cryptobox_keypair()
         self.sig_priv_keys[topo_id] = sig_priv
         self.sig_pub_keys[topo_id] = sig_pub
         self.enc_pub_keys[topo_id] = enc_pub
-        sig_key_file = get_sig_key_file_path(
-            topo_id.isd, topo_id.ad, self.out_dir)
-        enc_key_file = get_enc_key_file_path(
-            topo_id.isd, topo_id.ad, self.out_dir)
-        write_file(sig_key_file, base64.b64encode(sig_priv).decode())
-        write_file(enc_key_file, base64.b64encode(enc_priv).decode())
+        sig_path = get_sig_key_file_path("")
+        self.cert_files[topo_id][sig_path] = base64.b64encode(sig_priv).decode()
 
-    def _generate_ad_certs(self, topo_id, ad_conf):
+    def _gen_ad_certs(self, topo_id, ad_conf):
         if ad_conf['level'] == CORE_AD:
             return
         if 'cert_issuer' not in ad_conf:
@@ -294,19 +282,12 @@ class CertGenerator(object):
                 cert = self.certs[issuer]
                 chain.append(cert)
                 issuer = TopoID(cert.issuer)
-            self.chains[topo_id] = CertificateChain.from_values(chain)
+            cert_path = get_cert_chain_file_path(
+                "", topo_id.isd, topo_id.ad, INITIAL_CERT_VERSION)
+            self.cert_files[topo_id][cert_path] = \
+                str(CertificateChain.from_values(chain))
 
-    def _write_ad_certs(self):
-        for topo_id, chain in self.chains.items():
-            cert_file = get_cert_chain_file_path(
-                topo_id.isd, topo_id.ad, topo_id.isd, topo_id.ad,
-                INITIAL_CERT_VERSION, isd_dir=self.out_dir
-            )
-            write_file(cert_file, str(chain))
-            # Test if parser works
-            CertificateChain(cert_file)
-
-    def _generate_trc_entry(self, topo_id, ad_conf):
+    def _gen_trc_entry(self, topo_id, ad_conf):
         if ad_conf['level'] != CORE_AD:
             return
         cert = Certificate.from_values(
@@ -332,13 +313,9 @@ class CertGenerator(object):
         trc.signatures[str(topo_id)] = sign(
             trc_str, self.sig_priv_keys[topo_id])
 
-    def _write_trc(self, topo_id, _):
-        trc = self.trcs[topo_id.isd]
-        dst_path = get_trc_file_path(
-            topo_id.isd, topo_id.ad, topo_id.isd, 0, self.out_dir)
-        write_file(dst_path, str(trc))
-        # Test if parser works
-        TRC(dst_path).verify()
+    def _gen_trc_files(self, topo_id, _):
+        trc_path = get_trc_file_path("", topo_id.isd, INITIAL_TRC_VERSION)
+        self.cert_files[topo_id][trc_path] = str(self.trcs[topo_id.isd])
 
 
 class TopoGenerator(object):
@@ -372,7 +349,7 @@ class TopoGenerator(object):
     def generate(self):
         self._iterate(self._generate_ad_topo)
         networks = self.subnet_gen.alloc_subnets()
-        self._iterate(self._write_ad_topo)
+        self._write_ad_topos()
         self._write_hosts()
         return self.topo_dicts, self.zookeepers, networks
 
@@ -383,11 +360,10 @@ class TopoGenerator(object):
         self.topo_dicts[topo_id] = {
             'Core': ad_conf['level'] == CORE_AD,
             'ISDID': int(topo_id.isd), 'ADID': int(topo_id.ad),
-            'DnsDomain': str(dns_domain),
-            'BeaconServers': {}, 'CertificateServers': {},
-            'PathServers': {}, 'DNSServers': {},
-            'EdgeRouters': {}, 'Zookeepers': {},
+            'DnsDomain': str(dns_domain), 'Zookeepers': {},
         }
+        for i in SCION_SERVICE_NAMES:
+            self.topo_dicts[topo_id][i] = {}
         self._gen_srv_entries(topo_id, ad_conf, dns_domain)
         self._gen_er_entries(topo_id, ad_conf)
         self._gen_zk_entries(topo_id, ad_conf)
@@ -409,7 +385,7 @@ class TopoGenerator(object):
         count = ad_conf.get(conf_key, def_num)
         for i in range(1, count + 1):
             elem_id = "%s%s-%s" % (nick, topo_id, i)
-            self.topo_dicts[topo_id][topo_key][i] = {
+            self.topo_dicts[topo_id][topo_key][elem_id] = {
                 "Addr": self._reg_addr(topo_id, elem_id),
             }
 
@@ -424,11 +400,11 @@ class TopoGenerator(object):
             er_id += 1
 
     def _gen_er_entry(self, local, er_id, remote, remote_type):
-        local_if = "er%ser%s" % (local, remote)
+        elem_id = "er%ser%s" % (local, remote)
         public_addr, remote_addr = self._reg_link_addrs(
             local, remote)
-        self.topo_dicts[local]["EdgeRouters"][er_id] = {
-            'Addr': self._reg_addr(local, local_if),
+        self.topo_dicts[local]["EdgeRouters"][elem_id] = {
+            'Addr': self._reg_addr(local, elem_id),
             'Interface': {
                 'IFID': er_id,
                 'NeighborISD': int(remote.isd),
@@ -451,11 +427,11 @@ class TopoGenerator(object):
             self._gen_zk_entry(topo_id, key, val)
 
     def _gen_zk_entry(self, topo_id, zk_id, zk_conf):
-        zk = ZKTopo(zk_conf, self.zk_config["Default"])
+        zk = ZKTopo(zk_conf, self.zk_config)
         if zk.manage:
             elem_id = "zk%s-%s" % (topo_id, zk_id)
             addr = zk.addr = self._reg_addr(topo_id, elem_id)
-            self.zookeepers[topo_id][zk_id] = zk
+            self.zookeepers[topo_id][elem_id] = zk_id, zk
         else:
             addr = str(zk.addr)
         self.topo_dicts[topo_id]["Zookeepers"][zk_id] = {
@@ -463,17 +439,20 @@ class TopoGenerator(object):
             'Port': zk.clientPort,
         }
 
-    def _write_ad_topo(self, topo_id, _):
-        path = os.path.join(self.out_dir, topo_id.ISD(), TOPO_DIR, "%s.json" %
-                            topo_id.ISD_AD())
-        write_file(path, JSONAddrEncoder(sort_keys=True, indent=4).encode(
-            self.topo_dicts[topo_id]))
-        Topology.from_file(path)
+    def _write_ad_topos(self):
+        for topo_id, ad_topo, base in _srv_iter(
+                self.topo_dicts, self.out_dir, common=True):
+            path = os.path.join(base, "topology.conf")
+            contents = JSONAddrEncoder(sort_keys=True, indent=4).encode(
+                self.topo_dicts[topo_id])
+            write_file(path, contents)
+            # Test if topo file parses cleanly
+            Topology.from_file(path)
 
     def _write_hosts(self):
         text = StringIO()
-        for addr, domain in self.hosts:
-            text.write("%s\tds.%s\n" % (addr, str(domain).rstrip(".")))
+        for intf, domain in self.hosts:
+            text.write("%s\tds.%s\n" % (intf.ip, str(domain).rstrip(".")))
         hosts_path = os.path.join(self.out_dir, HOSTS_FILE)
         write_file(hosts_path, text.getvalue())
 
@@ -491,96 +470,59 @@ class SupervisorGenerator(object):
 
     def _ad_conf(self, topo_id, topo):
         entries = []
-        topo_path = self._topo_path(topo_id)
-        conf_path = self._conf_path(topo_id)
-        path_pol_path = self._path_policy_path(topo_id)
-        trc_path = self._trc_path(topo_id)
-        entries.extend(self._std_entries(
-            topo_id, topo, "BeaconServers", "bs", "beacon_server.py",
-            [topo_path, conf_path, path_pol_path]))
-        entries.extend(self._std_entries(
-            topo_id, topo, "CertificateServers", "cs", "cert_server.py",
-            [topo_path, conf_path, trc_path]))
-        entries.extend(self._std_entries(
-            topo_id, topo, "PathServers", "ps", "path_server.py",
-            [topo_path, conf_path]))
-        entries.extend(self._std_entries(
-            topo_id, topo, "DNSServers", "ds", "dns_server.py",
-            [topo["DnsDomain"], topo_path]))
-        entries.extend(self._er_entries(topo_id, topo, [topo_path, conf_path]))
+        base = self._get_base_path(topo_id)
+        for key, cmd in (
+            ("BeaconServers", "beacon_server.py"),
+            ("CertificateServers", "cert_server.py"),
+            ("PathServers", "path_server.py"),
+            ("DNSServers", "dns_server.py"),
+            ("EdgeRouters", "router.py"),
+        ):
+            entries.extend(self._std_entries(topo, key, cmd, base))
         entries.extend(self._zk_entries(topo_id))
         self._write_ad_conf(topo_id, entries)
 
-    def _std_entries(self, topo_id, topo, topo_key, short, cmd, args):
+    def _std_entries(self, topo, topo_key, cmd, base):
         entries = []
-        for id_ in topo.get(topo_key, {}):
-            name = "%s%s-%s-%s" % (short, topo_id.isd, topo_id.ad, id_)
-            cmd_args = ["infrastructure/%s" % cmd, id_] + args + \
-                ["logs/%s.log" % name]
-            entries.append((name, cmd_args))
-        return entries
-
-    def _er_entries(self, topo_id, topo, args):
-        entries = []
-        for id_, val in topo.get("EdgeRouters", {}).items():
-            neigh_isd = val["Interface"]["NeighborISD"]
-            neigh_ad = val["Interface"]["NeighborAD"]
-            name = "er%s-%ser%s-%s" % (topo_id.isd, topo_id.ad,
-                                       neigh_isd, neigh_ad)
-            cmd_args = ["infrastructure/router.py", id_] + args + \
-                ["logs/%s.log" % name]
-            entries.append((name, cmd_args))
+        for elem in topo.get(topo_key, {}):
+            conf_dir = os.path.join(base, elem)
+            entries.append((elem, ["infrastructure/%s" % cmd, elem, conf_dir]))
         return entries
 
     def _zk_entries(self, topo_id):
         if topo_id not in self.zookeepers:
             return []
         entries = []
-        base_dir = os.path.join(self.out_dir, topo_id.ISD(), ZOOKEEPER_DIR,
-                                topo_id.ISD_AD())
-        for id_, zk in self.zookeepers[topo_id].items():
-            name = "zk%s-%s-%s" % (topo_id.isd, topo_id.ad, id_)
-            cfg_path = os.path.join(base_dir, "zoo.cfg.%s" % id_)
-            class_path = ":".join([
-                base_dir, self.zk_config["Environment"]["CLASSPATH"],
-            ])
-            cmd_args = [
-                "java", "-cp", class_path,
-                '-Dzookeeper.log.file=logs/%s.log' % name,
-                self.zk_config["Environment"]["ZOOMAIN"], cfg_path,
-            ]
-            entries.append((name, cmd_args))
+        for name, (_, zk) in self.zookeepers[topo_id].items():
+            entries.append((name, zk.super_conf(topo_id, name, self.out_dir)))
         return entries
 
     def _write_ad_conf(self, topo_id, entries):
         config = configparser.ConfigParser(interpolation=None)
         names = []
-        for name, entry in sorted(entries, key=lambda x: x[0]):
-            names.append(name)
-            config["program:%s" % name] = self._common_entry(name, entry)
+        includes = []
+        base = os.path.join(self.out_dir, topo_id.ISD(), topo_id.AD())
+        for elem, entry in sorted(entries, key=lambda x: x[0]):
+            names.append(elem)
+            conf_path = os.path.join(base, elem, SUPERVISOR_CONF)
+            includes.append(os.path.join(elem, SUPERVISOR_CONF))
+            self._write_elem_conf(elem, entry, conf_path)
         config["group:ad%s" % topo_id] = {"programs": ",".join(names)}
         text = StringIO()
         config.write(text)
-        conf_path = os.path.join(self.out_dir, topo_id.ISD(), SUPERVISOR_DIR,
-                                 "%s.conf" % topo_id.ISD_AD())
+        conf_path = os.path.join(self.out_dir, topo_id.ISD(), topo_id.AD(),
+                                 SUPERVISOR_CONF)
         write_file(conf_path, text.getvalue())
 
-    def _get_path(self, topo_id, subdir, suffix):
-        return os.path.join(self.out_dir, topo_id.ISD(),
-                            subdir, "%s.%s" % (topo_id.ISD_AD(), suffix))
+    def _write_elem_conf(self, elem, entry, conf_path):
+        config = configparser.ConfigParser(interpolation=None)
+        config["program:%s" % elem] = self._common_entry(elem, entry)
+        text = StringIO()
+        config.write(text)
+        write_file(conf_path, text.getvalue())
 
-    def _topo_path(self, topo_id):
-        return self._get_path(topo_id, TOPO_DIR, "json")
-
-    def _conf_path(self, topo_id):
-        return self._get_path(topo_id, CONF_DIR, "conf")
-
-    def _path_policy_path(self, topo_id):
-        return self._get_path(topo_id, PATH_POL_DIR, "json")
-
-    def _trc_path(self, topo_id):
-        return get_trc_file_path(topo_id.isd, topo_id.ad, topo_id.isd,
-                                 INITIAL_TRC_VERSION, isd_dir=self.out_dir)
+    def _get_base_path(self, topo_id):
+        return os.path.join(self.out_dir, topo_id.ISD(), topo_id.AD())
 
     def _common_entry(self, name, cmd_args):
         return {
@@ -645,26 +587,22 @@ class ZKConfGenerator(object):
     def _write_ad_zk_configs(self, topo_id, zks):
         # Build up server block
         servers = []
-        for id_, zk in zks.items():
+        for id_, zk in zks.values():
             servers.append("server.%s=%s:%d:%d" %
-                           (id_, zk.addr.ip, zk.leaderPort,
-                            zk.electionPort))
+                           (id_, zk.addr.ip, zk.leaderPort, zk.electionPort))
         server_block = "\n".join(sorted(servers))
-        base_dir = os.path.join(self.out_dir, topo_id.ISD(), ZOOKEEPER_DIR,
-                                topo_id.ISD_AD())
-        copy_file(DEFAULT_ZK_LOG4J, os.path.join(base_dir, "log4j.properties"))
-        for id_, zk in zks.items():
+        base_dir = os.path.join(self.out_dir, topo_id.ISD(), topo_id.AD())
+        for name, (id_, zk) in zks.items():
+            copy_file(DEFAULT_ZK_LOG4J,
+                      os.path.join(base_dir, name, "log4j.properties"))
             text = StringIO()
-            datalog_dir = os.path.join(ZOOKEEPER_TMPFS_DIR, topo_id.ISD_AD(),
-                                       id_)
-            text.write("%s\n\n" % zk.config(
-                os.path.join(base_dir, "data.%s" % id_),
-                datalog_dir,
+            datalog_dir = os.path.join(ZOOKEEPER_TMPFS_DIR, name)
+            text.write("%s\n\n" % zk.zk_conf(
+                os.path.join(base_dir, name, "data"), datalog_dir,
             ))
             text.write("%s\n" % server_block)
-            write_file(os.path.join(base_dir, 'zoo.cfg.%s' % id_),
-                       text.getvalue())
-            write_file(os.path.join(base_dir, "data.%s" % id_, "myid"),
+            write_file(os.path.join(base_dir, name, 'zoo.cfg'), text.getvalue())
+            write_file(os.path.join(base_dir, name, "data", "myid"),
                        "%s\n" % id_)
             self.datalog_dirs.append(datalog_dir)
 
@@ -696,8 +634,8 @@ class TopoID(object):
     def ISD(self):
         return "ISD%s" % self.isd
 
-    def ISD_AD(self):
-        return "ISD%s-AD%s" % (self.isd, self.ad)
+    def AD(self):
+        return "AD%s" % self.ad
 
     def __lt__(self, other):
         return str(self) < str(other)
@@ -716,32 +654,44 @@ class TopoID(object):
 
 
 class ZKTopo(object):
-    def __init__(self, config, def_config):
+    def __init__(self, topo_config, zk_config):
         self.addr = None
-        self.def_config = def_config
-        self.manage = config.get("manage", False)
+        self.topo_config = topo_config
+        self.zk_config = zk_config
+        self.manage = self.topo_config.get("manage", False)
         if not self.manage:
             # A ZK we don't manage must have an assigned IP in the topology
-            self.addr = ip_interface(config["addr"])
-        self.clientPort = config.get(
-            "clientPort", def_config["clientPort"])
-        self.leaderPort = config.get(
-            "leaderPort", def_config["leaderPort"])
-        self.electionPort = config.get(
-            "electionPort", def_config["electionPort"])
-        self.maxClientCnxns = config.get(
-            "maxClientCnxns", def_config["maxClientCnxns"])
+            self.addr = ip_interface(self.topo_config["addr"])
+        self.clientPort = self._get_def("clientPort")
+        self.leaderPort = self._get_def("leaderPort")
+        self.electionPort = self._get_def("electionPort")
+        self.maxClientCnxns = self._get_def("maxClientCnxns")
 
-    def config(self, data_dir, data_log_dir):
+    def _get_def(self, key):
+        return self.topo_config.get(key, self.zk_config["Default"][key])
+
+    def zk_conf(self, data_dir, data_log_dir):
         c = []
         for s in ('tickTime', 'initLimit', 'syncLimit', 'maxClientCnxns'):
-            c.append("%s=%s" % (s, self.def_config[s]))
+            c.append("%s=%s" % (s, self._get_def(s)))
         c.append("dataDir=%s" % data_dir)
         c.append("dataLogDir=%s" % data_log_dir)
         c.append("clientPort=%s" % self.clientPort)
         c.append("clientPortAddress=%s" % self.addr.ip)
         c.append("autopurge.purgeInterval=1")
         return "\n".join(c)
+
+    def super_conf(self, topo_id, name, out_dir):
+        base_dir = os.path.join(out_dir, topo_id.ISD(), topo_id.AD(), name)
+        cfg_path = os.path.join(base_dir, "zoo.cfg")
+        class_path = ":".join([
+            base_dir, self.zk_config["Environment"]["CLASSPATH"],
+        ])
+        return [
+            "java", "-cp", class_path,
+            '-Dzookeeper.log.file=logs/%s.log' % name,
+            self.zk_config["Environment"]["ZOOMAIN"], cfg_path,
+        ]
 
 
 class JSONAddrEncoder(json.JSONEncoder):
@@ -828,10 +778,14 @@ class AddressProxy(object):
         return str(self._intf)
 
 
-def _addr_type(addr):
-    if addr.version == 4:
-        return "IPV4"
-    return "IPV6"
+def _srv_iter(topo_dicts, out_dir, common=False):
+    for topo_id, ad_topo in topo_dicts.items():
+        base = os.path.join(out_dir, topo_id.ISD(), topo_id.AD())
+        for service in SCION_SERVICE_NAMES:
+            for elem in ad_topo[service]:
+                yield topo_id, ad_topo, os.path.join(base, elem)
+        if common:
+            yield topo_id, ad_topo, os.path.join(base, COMMON_DIR)
 
 
 def main():


### PR DESCRIPTION
The generated directory structure looks like this:

```
gen/
    ISD1/
        AD10/
            bs1-10-1/       # Configuration for bs1-10-1 element
                ad.conf
                path_policy.conf
                supervisord.conf
                topology.conf
                certs/      # Certs for AD1-10
                    ISD1-V0.crt
                    ISD1-AD10-V0.crt
                keys/
                    ad-sig.key  # Signing key for AD1-10
            common/    # Common ad.conf and topology.conf
```

Each element has its own fully independant config directory, with copies
of the AD's configs/certs/keys, and a supervisord.conf that lists only
the element. This allows easy deployment of an element on a machine.

There's a common/ subdir at the AD level, for use by sciond and anything
else that needs access to AD-wide config.

Also:
- Make all servers only require a server id, and an optional config dir
  argument, on the command line.
- Unify main() for all servers.
- Improved cert chain request/reply logging
- Simplify Topology.get_own_config, and improve error handling.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/439%23issuecomment-151196865%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/439%23issuecomment-151207172%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/439%23discussion_r43094363%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/439%23discussion_r43094664%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/439%23issuecomment-151417475%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/439%23discussion_r43098693%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/439%23discussion_r43098698%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/439%23issuecomment-151196865%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Still%20needs%20unit%20tests%20for%20%60lib.main%60%2C%20working%20on%20them%20now.%22%2C%20%22created_at%22%3A%20%222015-10-26T16%3A27%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60lib.main%60%20unit%20tests%20added.%22%2C%20%22created_at%22%3A%20%222015-10-26T16%3A53%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22otherwise%20lgtm%21%22%2C%20%22created_at%22%3A%20%222015-10-27T08%3A54%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20fca7936aa2c66f69e55c08cafa4a499c20555355%20infrastructure/beacon_server.py%2020%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/439%23discussion_r43094363%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22sort%20imports%22%2C%20%22created_at%22%3A%20%222015-10-27T08%3A39%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%22%2C%20%22created_at%22%3A%20%222015-10-27T09%3A31%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/beacon_server.py%3AL48-55%22%7D%2C%20%22Pull%20fca7936aa2c66f69e55c08cafa4a499c20555355%20infrastructure/cert_server.py%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/439%23discussion_r43094664%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ditto.%22%2C%20%22created_at%22%3A%20%222015-10-27T08%3A44%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done%22%2C%20%22created_at%22%3A%20%222015-10-27T09%3A31%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/cert_server.py%3AL17-44%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/439#issuecomment-151196865'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Still needs unit tests for `lib.main`, working on them now.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `lib.main` unit tests added.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> otherwise lgtm!
- [ ] <a href='#crh-comment-Pull fca7936aa2c66f69e55c08cafa4a499c20555355 infrastructure/beacon_server.py 20'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/439#discussion_r43094363'>File: infrastructure/beacon_server.py:L48-55</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> sort imports
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Done
- [ ] <a href='#crh-comment-Pull fca7936aa2c66f69e55c08cafa4a499c20555355 infrastructure/cert_server.py 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/439#discussion_r43094664'>File: infrastructure/cert_server.py:L17-44</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> ditto.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Done

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/439?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/439?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/439'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
