### PR TITLE
Allow supervisord to run inside mininet

### DIFF
--- a/lib/socket.py
+++ b/lib/socket.py
@@ -30,6 +30,7 @@ from socket import (
 
 # SCION
 from lib.defines import SCION_BUFLEN
+from lib.thread import kill_self
 from lib.types import AddrType
 
 
@@ -73,7 +74,11 @@ class UDPSocket(object):
             addr = "::"
             if self._addr_type == AddrType.IPV4:
                 addr = ""
-        self.sock.bind((addr, port))
+        try:
+            self.sock.bind((addr, port))
+        except OSError as e:
+            logging.critical("Error binding to [%s]:%s: %s", addr, port, e)
+            kill_self()
         self.port = self.sock.getsockname()[1]
         if desc:
             logging.info("%s bound to %s:%d", desc, addr, self.port)

--- a/topology/mininet/run.sh
+++ b/topology/mininet/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo SUPERVISORD=$(which supervisord) python topology/mininet/topology.py

--- a/topology/mininet/supervisord.conf
+++ b/topology/mininet/supervisord.conf
@@ -1,0 +1,13 @@
+[supervisord]
+logfile=logs/supervisord-${elem}.log
+user=${user}
+pidfile=/tmp/supervisord-${elem}.pid
+
+[unix_http_server]
+file = /tmp/supervisord-${elem}.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[include]
+files = ${conf_path}


### PR DESCRIPTION
- Currently this just starts supervisord inside the first host
  (bs1_10_1), which runs the beacon server. (This fails, as it can't
  contact zookeeper).
- Special handling is needed to run supervisord, as topology.py must be
  run as root, whereas the software inside the mininet hosts should be
  run as a normal user.
- run.sh is a small wrapper script to pass the supervisord binary's path
  into the python script, as root may not have it in its path.
- Custom supervisord configs are written to gen/mininet to provide the
  basic configuration for each element's supervisord.
- Elements are set to auto-start in mininet, as each supervisord are
  entirely independant.

Also:
- Add useful error reporting in lib.socket.UDPSocket.bind()
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/448%23issuecomment-152177203%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/448%23issuecomment-152177203%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-29T13%3A21%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/202203%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/davidbb%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
  <a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/448?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/448'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
  <a href='#crh-end'></a>
