### PR TITLE
improving the mininet run script

### DIFF
--- a/topology/mininet/run.sh
+++ b/topology/mininet/run.sh
@@ -4,7 +4,6 @@ POX_PID=/tmp/pox.pid
 POX_LOG=/tmp/pox.log
 POX_PORT=6633
 
-echo $PATH
 if [ -e "$POX_PID" ]; then
     echo "ERROR: Pox already running, or $POX_PID is stale"
     exit 1


### PR DESCRIPTION
- looks for pox binary, fails if can't find it
- kills active pox instances before starting to avoid "can't bind to port"
- sleeps for 1 s to avoid "can't connect to controller"
- runs mininet as usual
- kills all remaining pox instances
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/450%23issuecomment-152222596%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/450%23issuecomment-152222947%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/450%23discussion_r43482534%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/450%23discussion_r43483682%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/450%23discussion_r43483739%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/450%23discussion_r43487589%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/450%23issuecomment-152222596%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22A%20lot%20of%20this%20can%20be%20simplified%20by%20using%20a%20pidfile%20for%20pox.%20E.g.%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cn%23%21/bin/bash%5Cr%5Cn%5Cr%5CnPOX_PID%3D/tmp/pox.pid%5Cr%5CnPOX_LOG%3D/tmp/pox.log%5Cr%5CnPOX_PORT%3D6633%5Cr%5Cn%5Cr%5Cnif%20%5B%20-e%20%5C%22%24POX_PID%5C%22%20%5D%3B%20then%5Cr%5Cn%20%20%20%20echo%20%5C%22ERROR%3A%20Pox%20already%20running%2C%20or%20%24POX_PID%20is%20stale%5C%22%5Cr%5Cn%20%20%20%20exit%201%5Cr%5Cnfi%5Cr%5Cn%5Cr%5Cnpox%20forwarding.l2_learning%20misc.pidfile%20--file%3D%24POX_PID%20log%20--no_default%20--file%3D%24POX_LOG%2Cw%20--format%3D%5C%22%25%28asctime%29s%3A%20%25%28message%29s%5C%22%20%26%5Cr%5Cnsleep%201%5Cr%5Cnif%20nc%20-z%20localhost%20%24POX_PORT%3B%20then%5Cr%5Cn%20%20%20%20echo%20%5C%22POX%20running%20on%20localhost%3A%24POX_PORT%5C%22%5Cr%5Cnelse%5Cr%5Cn%20%20%20%20echo%20%5C%22ERROR%3A%20Pox%20not%20running%3A%5C%22%5Cr%5Cn%20%20%20%20echo%20%5C%22%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%3D%5C%22%5Cr%5Cn%20%20%20%20cat%20%5C%22%24POX_LOG%5C%22%5Cr%5Cn%20%20%20%20exit%201%5Cr%5Cnfi%5Cr%5Cn%5Cr%5Cnsudo%20SUPERVISORD%3D%24%28which%20supervisord%29%20python%20topology/mininet/topology.py%5Cr%5Cn%5Cr%5Cnecho%20%5C%22Stopping%20POX%5C%22%5Cr%5Cnkill%20%24%28%3C%20%24POX_PID%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-10-29T15%3A51%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28Ok%20maybe%20%5C%22simplified%5C%22%20is%20the%20wrong%20word%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-10-29T15%3A52%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20028161d4418e8364c185a5624d8ec04a5a4b6050%20topology/mininet/run.sh%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/450%23discussion_r43482534%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20the%20echo%3F%22%2C%20%22created_at%22%3A%20%222015-10-30T09%3A00%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22debug.%20will%20fix.%20%22%2C%20%22created_at%22%3A%20%222015-10-30T09%3A18%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/202203%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/davidbb%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/run.sh%3AL1-28%22%7D%2C%20%22Pull%20028161d4418e8364c185a5624d8ec04a5a4b6050%20topology/mininet/run.sh%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/450%23discussion_r43483739%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20one%20fails%20for%20me%20on%20repeated%20runs%20due%20to%20supervisor%20not%20terminating.%20should%20it%20also%20be%20killed%20like%20pox%3F%20or%20should%20we%20check%20if%20it%27s%20running%20before%20starting%20it%20again%3F%22%2C%20%22created_at%22%3A%20%222015-10-30T09%3A19%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/202203%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/davidbb%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%27s%20a%20good%20point%2C%20i%20have%20a%20fix%20in%20mind%20%28which%20requires%20some%20tweaks%20elsewhere%29%2C%20so%20lets%20merge%20this%20now%2C%20and%20i%27ll%20send%20a%20followup%20PR%20to%20fix%20that.%22%2C%20%22created_at%22%3A%20%222015-10-30T10%3A16%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/run.sh%3AL1-28%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/450#issuecomment-152222596'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> A lot of this can be simplified by using a pidfile for pox. E.g.:

```
#!/bin/bash
POX_PID=/tmp/pox.pid
POX_LOG=/tmp/pox.log
POX_PORT=6633
if [ -e "$POX_PID" ]; then
echo "ERROR: Pox already running, or $POX_PID is stale"
exit 1
fi
pox forwarding.l2_learning misc.pidfile --file=$POX_PID log --no_default --file=$POX_LOG,w --format="%(asctime)s: %(message)s" &
sleep 1
if nc -z localhost $POX_PORT; then
echo "POX running on localhost:$POX_PORT"
else
echo "ERROR: Pox not running:"
echo "======================="
cat "$POX_LOG"
exit 1
fi
sudo SUPERVISORD=$(which supervisord) python topology/mininet/topology.py
echo "Stopping POX"
kill $(< $POX_PID)
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (Ok maybe "simplified" is the wrong word :)
- [x] <a href='#crh-comment-Pull 028161d4418e8364c185a5624d8ec04a5a4b6050 topology/mininet/run.sh 7'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/450#discussion_r43482534'>File: topology/mininet/run.sh:L1-28</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Why the echo?
- <a href='https://github.com/davidbb'><img border=0 src='https://avatars.githubusercontent.com/u/202203?v=3' height=16 width=16'></a> debug. will fix.
- [ ] <a href='#crh-comment-Pull 028161d4418e8364c185a5624d8ec04a5a4b6050 topology/mininet/run.sh 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/450#discussion_r43483739'>File: topology/mininet/run.sh:L1-28</a></b>
- <a href='https://github.com/davidbb'><img border=0 src='https://avatars.githubusercontent.com/u/202203?v=3' height=16 width=16'></a> this one fails for me on repeated runs due to supervisor not terminating. should it also be killed like pox? or should we check if it's running before starting it again?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> That's a good point, i have a fix in mind (which requires some tweaks elsewhere), so lets merge this now, and i'll send a followup PR to fix that.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/450?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/450?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/450'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
