### PR TITLE
Run supervisor on all mininet hosts.

### DIFF
--- a/topology/generator.py
+++ b/topology/generator.py
@@ -137,6 +137,8 @@ class ConfigGenerator(object):
                 def_network = DEFAULT_NETWORK
         self.subnet_gen = SubnetGenerator(def_network)
         for key, val in defaults.get("zookeepers", {}).items():
+            if self.mininet and val['addr'] == "127.0.0.1":
+                val['addr'] = "169.254.0.1"
             self.default_zookeepers[key] = ZKTopo(
                 val, self.zk_config)
 


### PR DESCRIPTION
- All ZK access from mininet hosts.
- Route the entire 169.254.0.0/16 subnet to the host, to allow multiple
  IPs to be used for things like end2end test.
- Just add 169.254.0.1 once, to eth0, instead of to all switch
  interfaces.
  <a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
  <a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/456?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/456'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
  <a href='#crh-end'></a>
