### PR TITLE
Run supervisor on all mininet hosts.

### DIFF
--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -525,9 +525,8 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
                 mgmt_packet = self._build_packet(payload=payload)
                 for er in self.topology.get_all_edge_routers():
                     if er.interface.if_id != ifid:
-                        mgmt_packet.addrs.dst_addr = er.interface.addr
-                        self.send(mgmt_packet, er.interface.addr,
-                                  er.interface.udp_port)
+                        mgmt_packet.addrs.dst_addr = er.addr
+                        self.send(mgmt_packet, er.addr)
 
     def run(self):
         """
@@ -808,8 +807,8 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         payload = IFStatePayload.from_values([info])
         state_pkt = self._build_packet(payload=payload)
         for er in self.topology.get_all_edge_routers():
-            state_pkt.addrs.dst_addr = er.interface.addr
-            self.send(state_pkt, er.interface.addr, er.interface.udp_port)
+            state_pkt.addrs.dst_addr = er.addr
+            self.send(state_pkt, er.addr)
         self._process_revocation(rev_info, if_id)
 
     def _process_revocation(self, rev_info, if_id):

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -137,6 +137,8 @@ class ConfigGenerator(object):
                 def_network = DEFAULT_NETWORK
         self.subnet_gen = SubnetGenerator(def_network)
         for key, val in defaults.get("zookeepers", {}).items():
+            if self.mininet and val['addr'] == "127.0.0.1":
+                val['addr'] = "169.254.0.1"
             self.default_zookeepers[key] = ZKTopo(
                 val, self.zk_config)
 
@@ -726,39 +728,53 @@ class SubnetGenerator(object):
                              network)
             sys.exit(1)
         self._subnets = defaultdict(lambda: AddressGenerator())
+        self._allocations = defaultdict(list)
+        # Initialise the allocations with the supplied network, making sure to
+        # exclude 127.0.0.0/31 if it's contained in the network. 127.0.0.0 is
+        # treated as a broadcast address by the kernel, and 127.0.0.1 is the
+        # normal loopback address, so it's best to avoid it too.
+        v4_lo = ip_network("127.0.0.0/31")
+        if self._net.overlaps(v4_lo):
+            self._exclude_net(self._net, v4_lo)
+        else:
+            self._allocations[self._net.prefixlen].append(self._net)
 
     def register(self, location):
         return self._subnets[location]
 
     def alloc_subnets(self):
-        allocations = defaultdict(list)
-        # Initialise the allocations with the supplied network
-        allocations[self._net.prefixlen].append(self._net)
         max_prefix = self._net.max_prefixlen
         networks = {}
         for subnet in self._subnets.values():
-            # Figure out what size subnet we need. Add 2 to the subnet size to
-            # cover the network and broadcast addresses.
-            req_prefix = max_prefix - math.ceil(math.log2(len(subnet) + 2))
+            # Figure out what size subnet we need. If it's a link, then we just
+            # need a /31 (or /127), otherwise add 2 to the subnet size to cover
+            # the network and broadcast addresses.
+            if len(subnet) == 2:
+                req_prefix = max_prefix - 1
+            else:
+                req_prefix = max_prefix - math.ceil(math.log2(len(subnet) + 2))
             # Search all subnets from that size upwards
             for prefix in range(req_prefix, -1, -1):
-                if not allocations[prefix]:
+                if not self._allocations[prefix]:
                     # No subnets available at this size
                     continue
-                alloc = allocations[prefix].pop()
+                alloc = self._allocations[prefix].pop()
                 # Carve out subnet of the required size
                 new_net = next(alloc.subnets(new_prefix=req_prefix))
                 logging.debug("Allocating %s from %s for subnet size %d" %
                               (new_net, alloc, len(subnet)))
                 networks[new_net] = subnet.alloc_addrs(new_net)
                 # Repopulate the allocations list with the left-over space
-                for net in alloc.address_exclude(new_net):
-                    allocations[net.prefixlen].append(net)
+                self._exclude_net(alloc, new_net)
                 break
             else:
                 logging.critical("Unable to allocate /%d subnet" % req_prefix)
                 sys.exit(1)
         return networks
+
+    def _exclude_net(self, alloc, net):
+        for net in alloc.address_exclude(net):
+            self._allocations[net.prefixlen].append(net)
 
 
 class AddressGenerator(object):

--- a/topology/mininet/run.sh
+++ b/topology/mininet/run.sh
@@ -11,11 +11,13 @@ POX_PORT=6633
 log() {
     echo "=====> $@"
 }
+bash gen/zk_datalog_dirs.sh || exit 1
 
 if [ -e "$POX_PID" ]; then
     log "ERROR: Pox already running, or $POX_PID is stale"
     exit 1
 fi
+
 
 PYTHONPATH=topology/mininet pox \
     pox_signal \

--- a/topology/mininet/topology.py
+++ b/topology/mininet/topology.py
@@ -8,7 +8,7 @@ import configparser
 import ipaddress
 from mininet.cli import CLI
 from mininet.link import Link
-from mininet.log import lg, info
+from mininet.log import lg
 from mininet.net import Mininet
 from mininet.node import RemoteController, OVSKernelSwitch
 from mininet.topo import Topo
@@ -47,22 +47,28 @@ class ScionTopo(Topo):
                 # The config is utf8, need to convert to a plain string to avoid
                 # tickling bugs in mininet.
                 elem = str(elem)
+                elem_name = elem.replace("-", "_")
                 if elem not in host_map:
-                    host_map[elem] = self.addHost(
-                        elem.replace("-", "_"), ip=None)
+                    host_map[elem] = self.addHost(elem_name, ip=None)
                 intf = ipaddress.ip_interface(intf_str)
-                self.addLink(host_map[elem], self.switch_map[name],
-                             params={'ip': str(intf)})
+                is_link = False
+                if intf.network.prefixlen == intf.max_prefixlen - 1:
+                    is_link = True
+                self.addLink(
+                    host_map[elem], self.switch_map[name],
+                    params={'ip': str(intf)},
+                    intfName="%s-%d" % (elem_name, is_link),
+                )
 
-    def addLink(self, node1, node2, params=None):
+    def addLink(self, node1, node2, params=None, intfName=None):
         self.addPort(node1, node2, None, None)
         key = tuple(self.sorted([node1, node2]))
         # Map the supplied params to the node1 interface, even if sorting turns
         # it into the second interface.
         if key[0] == node1:
-            self.link_info[key] = {"params1": params}
+            self.link_info[key] = {"params1": params, "intfName1": intfName}
         else:
-            self.link_info[key] = {"params2": params}
+            self.link_info[key] = {"params2": params, "intfName2": intfName}
         self.g.add_edge(*key)
         return key
 
@@ -77,16 +83,17 @@ def main():
     net = Mininet(topo=topo, controller=RemoteController, link=ScionLink,
                   switch=OVSKernelSwitch)
     for host in net.hosts:
-        host.cmd('ip route add 169.254.0.1 dev '+host.intf().name)
+        host.cmd('ip route add 169.254.0.0/16 dev '+host.intf().name)
     net.start()
+    os.system('ip addr add 169.254.0.1/16 dev eth0')
     for switch in net.switches:
-        os.system('ip addr add 169.254.0.1 dev %s' % switch.name)
         for k, v in topo.switch_map.items():
             if v == switch.name:
                 os.system('ip route add %s dev %s' % (k, switch.name))
-    host = net.hosts[0]
-    info(host.cmd("%s -c gen/mininet/%s.conf" %
-                  (supervisord, host.name.replace("_", "-"))))
+    for host in net.hosts:
+        elem_name = host.name.replace("_", "-")
+        print("Starting supervisord on %s" % elem_name)
+        host.cmd("%s -c gen/mininet/%s.conf" % (supervisord, elem_name))
     CLI(net)
     net.stop()
 


### PR DESCRIPTION
- Allow ZK access from mininet hosts.
- Route the entire 169.254.0.0/16 subnet to the host, to allow multiple
  IPs to be used for things like end2end test.
- Just add 169.254.0.1 once, to eth0, instead of to all switch
  interfaces.
- Fix beacon_server to send messages to the internal IP of ERs.
- Allocate /31 (or /127) subnets for links.
- Fix interface naming to be consistent (-0 is always internal, -1 is
  always external).
- Create ZK data dirs in run.sh.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/457%23discussion_r43606671%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/457%23discussion_r43606909%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/457%23issuecomment-152974166%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%209c56c859ef00b93753e1ca3873715eccecfb07ac%20topology/mininet/topology.py%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/457%23discussion_r43606671%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20just%20making%20sure%3A%20for%20hosts%20with%20interfaces%2C%20like%20edge%20routers%2C%20this%20route%20should%20be%20added%20to%20only%20the%20-0%20one%20which%20is%20the%20internal%20AS%20interface%20right%3F%20the%20route%20to%20the%20remote%20edge%20router%20should%20work%20without%20a%20static%20route%20because%20they%20are%20on%20the%20same%20network.%20%22%2C%20%22created_at%22%3A%20%222015-11-02T08%3A49%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/202203%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/davidbb%22%7D%7D%2C%20%7B%22body%22%3A%20%22Correct.%22%2C%20%22created_at%22%3A%20%222015-11-02T08%3A52%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/topology.py%3AL83-100%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/457%23issuecomment-152974166%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-02T09%3A54%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/202203%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/davidbb%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 9c56c859ef00b93753e1ca3873715eccecfb07ac topology/mininet/topology.py 50'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/457#discussion_r43606671'>File: topology/mininet/topology.py:L83-100</a></b>
- <a href='https://github.com/davidbb'><img border=0 src='https://avatars.githubusercontent.com/u/202203?v=3' height=16 width=16'></a> @kormat just making sure: for hosts with interfaces, like edge routers, this route should be added to only the -0 one which is the internal AS interface right? the route to the remote edge router should work without a static route because they are on the same network.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Correct.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/457?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/457?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/457'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
