### PR TITLE
small patchset to improve mininet handling of IPs

### DIFF
--- a/topology/mininet/topology.py
+++ b/topology/mininet/topology.py
@@ -46,8 +46,8 @@ class ScionTopo(Topo):
         for name, section in mnconfig.items():
             for elem, intf_str in section.items():
                 if ipaddress.ip_interface(intf_str).is_loopback:
-                    print("The IP address for %s (%s) is a loopback address"
-                          % (elem, intf_str))
+                    print("""ERROR: The IP address for %s (%s) is a loopback
+                          address""" % (elem, intf_str))
                     print("Try running scion.sh topology -m")
                     sys.exit(1)
                 # The config is utf8, need to convert to a plain string to avoid


### PR DESCRIPTION
*we now check to see if the IPs we're using are loopback
*we use a virtual interface that satisfies the requirements of end2end tests
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/459%23discussion_r43639066%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/459%23issuecomment-153075265%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/459%23discussion_r43728672%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/459%23issuecomment-153075265%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20rest%20LGTM%20though.%22%2C%20%22created_at%22%3A%20%222015-11-02T16%3A33%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%202701a9b2249cc1495899d334759fe8318e61f4b8%20topology/mininet/topology.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/459%23discussion_r43639066%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27d%20add%20an%20%60%5C%22ERROR%3A%5C%22%60%20to%20the%20start%20of%20the%20string.%22%2C%20%22created_at%22%3A%20%222015-11-02T15%3A24%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/topology.py%3AL45-56%22%7D%2C%20%22Pull%202701a9b2249cc1495899d334759fe8318e61f4b8%20topology/mininet/topology.py%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/459%23discussion_r43728672%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20David%2C%20would%20it%20make%20sense%20to%20read%20these%20IP%20addresses%20from%20a%20config%20file%20rather%20than%20hard-coding%20it%20here%20inside%20the%20code%3F%20It%20could%20be%20a%20really%20simple%20config.py%20or%20json%20file.%20This%20link%20contains%20some%20examples%20and%20the%20ones%20towards%20to%20bottom%20of%20the%20page%20could%20be%20useful%3A%20http%3A//stackoverflow.com/questions/5055042/whats-the-best-practice-using-a-settings-file-in-python%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A33%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/topology.py%3AL91-114%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 2701a9b2249cc1495899d334759fe8318e61f4b8 topology/mininet/topology.py 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/459#discussion_r43639066'>File: topology/mininet/topology.py:L45-56</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I'd add an `"ERROR:"` to the start of the string.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/459#issuecomment-153075265'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The rest LGTM though.
- [ ] <a href='#crh-comment-Pull 2701a9b2249cc1495899d334759fe8318e61f4b8 topology/mininet/topology.py 26'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/459#discussion_r43728672'>File: topology/mininet/topology.py:L91-114</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Hi David, would it make sense to read these IP addresses from a config file rather than hard-coding it here inside the code? It could be a really simple config.py or json file. This link contains some examples and the ones towards to bottom of the page could be useful: http://stackoverflow.com/questions/5055042/whats-the-best-practice-using-a-settings-file-in-python

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/459?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/459?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/459'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
