### PR TITLE
Adding a readme for the Mininet dir

### DIFF
--- a/topology/mininet/README.md
+++ b/topology/mininet/README.md
@@ -3,7 +3,7 @@
 SCION can be run inside [Mininet](http://mininet.org), which is a virtual network emulation environment. Running SCION in Mininet enables the use of custom topologies and link characteristics (e.g., specifying link bandwidth between two ASes). 
 
 ## Getting started
-You'll need a few base packages to get started. We currently support only Mininet 2.1.0 installed from the Ubuntu 14.04 repositories. Due to the limited number of switches (16) supported by `openvswitch-controller`, we also require the use of a custom OpenFlow controller, [POX](http://www.noxrepo.org/pox/about-pox). The list of required packages can be found [here](https://github.com/netsec-ethz/scion/blob/mininet/topology/mininet/pkgs_debian.txt) for manual installation or installed automatically using the [setup.sh](https://github.com/netsec-ethz/scion/blob/mininet/topology/mininet/setup.sh) script we provide. Once you have all packages installed, you're ready to run SCION.
+You'll need a few base packages to get started. We currently support only Mininet 2.1.0 installed from the Ubuntu 14.04 repositories. Due to the limited number of switches (16) supported by `openvswitch-controller`, we also require the use of a custom OpenFlow controller, [POX](http://www.noxrepo.org/pox/about-pox). The list of required packages can be found [here](pkgs_debian.txt) for manual installation or installed automatically using the [setup.sh](setup.sh) script we provide. Once you have all packages installed, you're ready to run SCION.
 
 ### Creating a Mininet-compatible topology
 You need to generate a topology with Mininet support enabled. To do this, run the following command:


### PR DESCRIPTION
I suspect people will like this way to run SCION, so we should probably document this in addition to our existing documentation. This is just a quick draft, feel free to propose improvements.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/461%23discussion_r43730344%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/461%23discussion_r43730386%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/461%23discussion_r43730744%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/461%23discussion_r43733672%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2072f01093a47ad4af34557a7ce993d1230f724586%20topology/mininet/README.md%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/461%23discussion_r43730744%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%22Due%20to%20the%20limited%20number%20of%20switches%20%2816%29%20supported%20by%20%60openvswitch-controller%60%2C%20we%20also%20require%20the%20use%20of%20a%20custom%20OpenFlow%20controller%2C%20%5BPOX%5D%28http%3A//www.noxrepo.org/pox/about-pox/%29.%5C%22%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A59%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/README.md%3AL1-24%22%7D%2C%20%22Pull%2072f01093a47ad4af34557a7ce993d1230f724586%20topology/mininet/README.md%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/461%23discussion_r43730386%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20needs%20a%20%60sudo%60%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A55%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/README.md%3AL1-24%22%7D%2C%20%22Pull%2085ce87cf36b87d16942a48620ae17ffe947be72c%20topology/mininet/README.md%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/461%23discussion_r43733672%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Github%20supports%20relative%20links%20in%20markdown%2C%20so%20you%20can%20simplify%3A%5Cr%5Cn%60%5Bhere%5D%28https%3A//github.com/netsec-ethz/scion/blob/mininet/topology/mininet/pkgs_debian.txt%29%60%5Cr%5Cnto%20just%5Cr%5Cn%60%5Bhere%5D%28pkgs_debian.txt%29%60%5Cr%5Cn%5Cr%5Cnand%20the%20same%20for%20the%20%60setup.sh%60%20link.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-11-03T10%3A35%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/README.md%3AL1-24%22%7D%2C%20%22Pull%2072f01093a47ad4af34557a7ce993d1230f724586%20topology/mininet/README.md%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/461%23discussion_r43730344%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20wording%20isn%27t%20quite%20correct%20%28as%20%60gen/networks.conf%60%20is%20always%20created%29.%20A%20better%20description%20might%20be%20%5Cr%5Cn%60%5C%22You%20need%20to%20generate%20a%20topology%20with%20mininet%20support%20enabled.%20To%20do%20this...%5C%22%60%22%2C%20%22created_at%22%3A%20%222015-11-03T09%3A55%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/README.md%3AL1-24%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 72f01093a47ad4af34557a7ce993d1230f724586 topology/mininet/README.md 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/461#discussion_r43730344'>File: topology/mininet/README.md:L1-24</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This wording isn't quite correct (as `gen/networks.conf` is always created). A better description might be
  `"You need to generate a topology with mininet support enabled. To do this..."`
- [x] <a href='#crh-comment-Pull 72f01093a47ad4af34557a7ce993d1230f724586 topology/mininet/README.md 22'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/461#discussion_r43730386'>File: topology/mininet/README.md:L1-24</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This needs a `sudo`
- [x] <a href='#crh-comment-Pull 72f01093a47ad4af34557a7ce993d1230f724586 topology/mininet/README.md 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/461#discussion_r43730744'>File: topology/mininet/README.md:L1-24</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> "Due to the limited number of switches (16) supported by `openvswitch-controller`, we also require the use of a custom OpenFlow controller, [POX](http://www.noxrepo.org/pox/about-pox/)."
- [x] <a href='#crh-comment-Pull 85ce87cf36b87d16942a48620ae17ffe947be72c topology/mininet/README.md 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/461#discussion_r43733672'>File: topology/mininet/README.md:L1-24</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Github supports relative links in markdown, so you can simplify:
  `[here](https://github.com/netsec-ethz/scion/blob/mininet/topology/mininet/pkgs_debian.txt)`
  to just
  `[here](pkgs_debian.txt)`
  and the same for the `setup.sh` link.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/461?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/461?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/461'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
