### PR TITLE
improve pox detection robustness

### DIFF
--- a/topology/mininet/run.sh
+++ b/topology/mininet/run.sh
@@ -18,25 +18,23 @@ if [ -e "$POX_PID" ]; then
     exit 1
 fi
 
-
 PYTHONPATH=topology/mininet pox \
+    openflow.of_01 --port="$POX_PORT" \
     pox_signal \
     forwarding.l2_learning \
     misc.pidfile --file=$POX_PID \
     log --no_default --file="$POX_LOG" --format="%(asctime)s: %(message)s" \
     &> "$POX_OUT" &
 
-#wait for pox to start to avoid "can't connect to controller errors"
-sleep 1
-if nc -z localhost $POX_PORT; then
-    log "POX running on localhost:$POX_PORT"
-else
-    log "ERROR: Pox not running:"
-    cat "$POX_LOG"
-    exit 1
-fi
+log "Waiting for POX to load on localhost:$POX_PORT"
+while ! nc -4 -z localhost "$POX_PORT"
+do
+    sleep 1
+done
 
+log "POX running on localhost:$POX_PORT"
 log "Starting mininet"
+
 sudo SUPERVISORD=$(which supervisord) python topology/mininet/topology.py
 
 for i in "$TMP_DIR"/*.pid; do


### PR DESCRIPTION
we used to sleep for 1s and assume that pox would load, but it turns out on a fesh boot it might take longer than that. this new way of doing it sleeps as long as pox hasn't loaded, which ensures pox is always running prior to doing mininet things.

oh yeah and also specify the port number as a pox parameter, and pass -4 to netcat to avoid an unnecessary tcp6 connection.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/473?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/473'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
