### PR TITLE
Implement basic mininet support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 # Python generated files #
 #########################
 __pycache__
+topology/mininet/pox_signal.pyc
 
 
 # vim generated files #

--- a/pkgs_debian.txt
+++ b/pkgs_debian.txt
@@ -6,8 +6,8 @@ net-tools
 netcat-openbsd
 python-minimal
 python-pip
-python3-minimal
 python3-dev
+python3-minimal
 python3-pip
 screen
 zookeeperd

--- a/test/integration/cli_srv_ext_test.py
+++ b/test/integration/cli_srv_ext_test.py
@@ -17,44 +17,43 @@
 ======================================================================
 """
 # Stdlib
+import argparse
 import logging
-import socket
 import threading
 import time
-import sys
 
 # SCION
 from endhost.sciond import SCIONDaemon
-from lib.defines import GEN_PATH, SCION_BUFLEN, SCION_UDP_EH_DATA_PORT
-from lib.log import init_logging, log_exception
+from lib.defines import GEN_PATH, SCION_UDP_EH_DATA_PORT
+from lib.log import init_logging
+from lib.main import main_wrapper
 from lib.packet.ext.traceroute import TracerouteExt
-from lib.packet.host_addr import haddr_parse
+from lib.packet.host_addr import haddr_parse_interface
 from lib.packet.packet_base import PayloadRaw
 from lib.packet.scion import SCIONL4Packet, build_base_hdrs
 from lib.packet.scion_addr import SCIONAddr
 from lib.packet.scion_udp import SCIONUDPHeader
+from lib.socket import UDPSocket
 from lib.thread import thread_safety_net
 from lib.util import handle_signals
 
 TOUT = 10  # How long wait for response.
-CLI_ISD = 1
-CLI_AD = 19
-CLI_IP = "127.1.19.254"
-SRV_ISD = 2
-SRV_AD = 26
-SRV_IP = "127.1.26.254"
 
 
-def client():
+def client(c_addr, s_addr):
     """
     Simple client
     """
-    conf_dir = "%s/ISD%d/AD%d/endhost" % (GEN_PATH, CLI_ISD, CLI_AD)
+    conf_dir = "%s/ISD%d/AD%d/endhost" % (GEN_PATH, c_addr.isd_id, c_addr.ad_id)
     # Start SCIONDaemon
-    sd = SCIONDaemon.start(conf_dir, haddr_parse("IPV4", CLI_IP))
-    logging.info("CLI: Sending PATH request for (%d, %d)", SRV_ISD, SRV_AD)
+    sd = SCIONDaemon.start(conf_dir, c_addr.host_addr)
+    logging.info("CLI: Sending PATH request for (%d, %d)",
+                 s_addr.isd_id, s_addr.ad_id)
+    # Open a socket for incomming DATA traffic
+    sock = UDPSocket(bind=(str(c_addr.host_addr), 0, "Client"),
+                     addr_type=c_addr.host_addr.TYPE)
     # Get paths to server through function call
-    paths = sd.get_paths(SRV_ISD, SRV_AD)
+    paths = sd.get_paths(s_addr.isd_id, s_addr.ad_id)
     assert paths
     # Get a first path
     path = paths[0]
@@ -64,14 +63,13 @@ def client():
     routers_no *= 2
     # Create empty Traceroute extensions with allocated space
     ext = TracerouteExt.from_values(routers_no)
-    # Create a SCION address to the destination
-    dst = SCIONAddr.from_values(SRV_ISD, SRV_AD, haddr_parse("IPV4", SRV_IP))
     # Set payload
     payload = PayloadRaw(b"request to server")
     # Create a SCION packet with the extensions
-    cmn_hdr, addr_hdr = build_base_hdrs(sd.addr, dst)
+    cmn_hdr, addr_hdr = build_base_hdrs(c_addr, s_addr)
     udp_hdr = SCIONUDPHeader.from_values(
-        sd.addr, SCION_UDP_EH_DATA_PORT, dst, SCION_UDP_EH_DATA_PORT, payload)
+        c_addr, sock.port, s_addr, SCION_UDP_EH_DATA_PORT, payload,
+    )
     spkt = SCIONL4Packet.from_values(cmn_hdr, addr_hdr, path, [ext], udp_hdr,
                                      payload)
     # Determine first hop (i.e., local address of border router)
@@ -80,30 +78,27 @@ def client():
                  spkt, next_hop, port)
     # Send packet to first hop (it is sent through SCIONDaemon)
     sd.send(spkt, next_hop, port)
-    # Open a socket for incomming DATA traffic
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind((CLI_IP, SCION_UDP_EH_DATA_PORT))
     # Waiting for a response
-    raw, _ = sock.recvfrom(SCION_BUFLEN)
+    raw, _ = sock.recv()
     logging.info('CLI: Received response:\n%s', SCIONL4Packet(raw))
     logging.info("CLI: leaving.")
     sock.close()
 
 
-def server():
+def server(addr):
     """
     Simple server.
     """
-    conf_dir = "%s/ISD%d/AD%d/endhost" % (GEN_PATH, SRV_ISD, SRV_AD)
+    conf_dir = "%s/ISD%d/AD%d/endhost" % (GEN_PATH, addr.isd_id, addr.ad_id)
     # Start SCIONDaemon
-    sd = SCIONDaemon.start(conf_dir, haddr_parse("IPV4", SRV_IP))
+    sd = SCIONDaemon.start(conf_dir, addr.host_addr)
     # Open a socket for incomming DATA traffic
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind((SRV_IP, SCION_UDP_EH_DATA_PORT))
+    sock = UDPSocket(
+        bind=(str(addr.host_addr), SCION_UDP_EH_DATA_PORT, "Server"),
+        addr_type=addr.host_addr.TYPE
+    )
     # Waiting for a request
-    raw, _ = sock.recvfrom(SCION_BUFLEN)
+    raw, _ = sock.recv()
     # Request received, instantiating SCION packet
     spkt = SCIONL4Packet(raw)
     logging.info('SRV: received: %s', spkt)
@@ -121,29 +116,42 @@ def server():
     sock.close()
 
 
-if __name__ == "__main__":
-    init_logging("logs/c2s_extn.log", console=True)
+def main():
     handle_signals()
-    # if len(sys.argv) == 3:
-    #     isd, ad = sys.argv[1].split(',')
-    #     sources = [(int(isd), int(ad))]
-    #     isd, ad = sys.argv[2].split(',')
-    #     destinations = [(int(isd), int(ad))]
-    # TestSCIONDaemon().test(sources, destinations)
-    try:
-        threading.Thread(
-            target=thread_safety_net, args=(server,),
-            name="C2S_extn.server", daemon=True).start()
-        time.sleep(0.5)
-        t_client = threading.Thread(
-            target=thread_safety_net, args=(client,),
-            name="C2S_extn.client", daemon=True)
-        t_client.start()
-        t_client.join()
-    except SystemExit:
-        logging.info("Exiting")
-        raise
-    except:
-        log_exception("Exception in main process:")
-        logging.critical("Exiting")
-        sys.exit(1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--client', help='Client address')
+    parser.add_argument('-s', '--server', help='Server address')
+    parser.add_argument('-m', '--mininet', action='store_true',
+                        help="Running under mininet")
+    parser.add_argument('cli_ad', nargs='?', help='Client isd,ad',
+                        default="1,19")
+    parser.add_argument('srv_ad', nargs='?', help='Server isd,ad',
+                        default="2,26")
+    args = parser.parse_args()
+    init_logging("logs/c2s_extn.log", console=True)
+
+    if not args.client:
+        args.client = "169.254.0.2" if args.mininet else "127.0.0.2"
+    if not args.server:
+        args.server = "169.254.0.3" if args.mininet else "127.0.0.3"
+
+    srv_isd, srv_ad = map(int, args.srv_ad.split(","))
+    srv_addr = SCIONAddr.from_values(srv_isd, srv_ad,
+                                     haddr_parse_interface(args.server))
+    threading.Thread(
+        target=thread_safety_net, args=(server, srv_addr),
+        name="C2S_extn.server", daemon=True).start()
+    time.sleep(0.5)
+
+    cli_isd, cli_ad = map(int, args.cli_ad.split(","))
+    cli_addr = SCIONAddr.from_values(cli_isd, cli_ad,
+                                     haddr_parse_interface(args.client))
+    t_client = threading.Thread(
+        target=thread_safety_net, args=(
+            client, cli_addr, srv_addr,
+        ), name="C2S_extn.client", daemon=True)
+    t_client.start()
+    t_client.join()
+
+if __name__ == "__main__":
+    main_wrapper(main)

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -17,6 +17,7 @@
 ===========================================
 """
 # Stdlib
+import argparse
 import logging
 import random
 import sys
@@ -27,8 +28,13 @@ import unittest
 # SCION
 from endhost.sciond import SCIOND_API_HOST, SCIOND_API_PORT, SCIONDaemon
 from lib.defines import GEN_PATH
-from lib.log import init_logging, log_exception
-from lib.packet.host_addr import haddr_get_type, haddr_parse
+from lib.log import init_logging
+from lib.main import main_wrapper
+from lib.packet.host_addr import (
+    haddr_get_type,
+    haddr_parse,
+    haddr_parse_interface,
+)
 from lib.packet.opaque_field import InfoOpaqueField
 from lib.packet.packet_base import PayloadRaw
 from lib.packet.path import CorePath, CrossOverPath, EmptyPath, PeerPath
@@ -40,8 +46,6 @@ from lib.thread import kill_self, thread_safety_net
 from lib.types import AddrType, OpaqueFieldType as OFT
 from lib.util import Raw, handle_signals
 
-saddr = haddr_parse("IPV4", "127.1.19.254")
-raddr = haddr_parse("IPV4", "127.2.26.254")
 TOUT = 10  # How long wait for response.
 
 
@@ -99,34 +103,32 @@ class Ping(object):
         self.dport = dport
         self.token = token
         self.pong_received = False
-        conf_dir = "%s/ISD%d/AD%d/endhost" % (GEN_PATH, src.isd, src.ad)
+        conf_dir = "%s/ISD%d/AD%d/endhost" % (GEN_PATH, src.isd_id, src.ad_id)
         # Local api on, random port:
         self.sd = SCIONDaemon.start(
-            conf_dir, saddr, run_local_api=True, port=0)
+            conf_dir, self.src.host_addr, run_local_api=True, port=0)
         self.get_path()
-        self.sock = UDPSocket(bind=(str(saddr), 0, "Ping App"),
+        self.sock = UDPSocket(bind=(str(self.src.host_addr), 0, "Ping App"),
                               addr_type=AddrType.IPV4)
 
     def get_path(self):
         logging.info("Sending PATH request for (%d, %d)",
-                     self.dst.isd, self.dst.ad)
+                     self.dst.isd_id, self.dst.ad_id)
         # Get paths through local API.
-        paths_hops = get_paths_via_api(self.dst.isd, self.dst.ad)
+        paths_hops = get_paths_via_api(self.dst.isd_id, self.dst.ad_id)
         (self.path, self.hop) = paths_hops[0]
         if isinstance(self.path, EmptyPath):
-            self.hop = raddr
+            self.hop = self.dst.host_addr
 
     def run(self):
         self.send()
         self.recv()
 
     def send(self):
-        dst_addr = SCIONAddr.from_values(self.dst.isd, self.dst.ad, raddr)
-        src_addr = SCIONAddr.from_values(self.src.isd, self.src.ad, saddr)
-        cmn_hdr, addr_hdr = build_base_hdrs(src_addr, dst_addr)
+        cmn_hdr, addr_hdr = build_base_hdrs(self.src, self.dst)
         payload = PayloadRaw(b"ping " + self.token)
         udp_hdr = SCIONUDPHeader.from_values(
-            src_addr, self.sock.port, dst_addr, self.dport, payload)
+            self.src, self.sock.port, self.dst, self.dport, payload)
         spkt = SCIONL4Packet.from_values(
             cmn_hdr, addr_hdr, self.path, [], udp_hdr, payload)
         (next_hop, port) = self.sd.get_first_hop(spkt)
@@ -142,7 +144,8 @@ class Ping(object):
         payload = spkt.get_payload()
         pong = PayloadRaw(b"pong " + self.token)
         if payload == pong:
-            logging.info('%s:%d: pong received.', saddr, self.sock.port)
+            logging.info('%s:%d: pong received.', self.src.host_addr,
+                         self.sock.port)
             self.pong_received = True
         else:
             logging.error("Unexpected payload received: %s (expected: %s)",
@@ -161,9 +164,10 @@ class Pong(object):
         self.token = token
         self.ping_received = False
         conf_dir = "%s/ISD%d/AD%d/endhost" % (
-            GEN_PATH, self.dst.isd, self.dst.ad)
-        self.sd = SCIONDaemon.start(conf_dir, raddr)  # API off, standard port.
-        self.sock = UDPSocket(bind=(str(raddr), 0, "Pong App"),
+            GEN_PATH, self.dst.isd_id, self.dst.ad_id)
+        # API off, standard port.
+        self.sd = SCIONDaemon.start(conf_dir, self.dst.host_addr)
+        self.sock = UDPSocket(bind=(str(self.dst.host_addr), 0, "Pong App"),
                               addr_type=AddrType.IPV4)
 
     def get_local_port(self):
@@ -176,8 +180,8 @@ class Pong(object):
         ping = PayloadRaw(b"ping " + self.token)
         if payload == ping:
             # Reverse the packet and send "pong".
-            logging.info('%s:%d: ping received, sending pong.', raddr,
-                         self.sock.port)
+            logging.info('%s:%d: ping received, sending pong.',
+                         self.dst.host_addr, self.sock.port)
             self.ping_received = True
             spkt.reverse()
             spkt.set_payload(PayloadRaw(b"pong " + self.token))
@@ -192,24 +196,26 @@ class TestSCIONDaemon(unittest.TestCase):
     Unit tests for sciond.py. For this test a infrastructure must be running.
     """
 
-    def test(self, sources, destinations):
+    def test(self, client, server, sources, destinations):
         """
         Testing function. Creates an instance of SCIONDaemon, then verifies path
-        requesting, and finally sends packet through SCION. Sender is 127.1.19.1
-        placed in every AD from `sources`, and receiver is 127.2.26.1 from
-        every AD from `destinations`.
+        requesting, and finally sends packet through SCION. Sender is placed in
+        every AD from `sources`, and receiver is from every AD from
+        `destinations`.
         """
         thread = threading.current_thread()
         thread.name = "E2E.MainThread"
+        client_ip = haddr_parse_interface(client)
+        server_ip = haddr_parse_interface(server)
         failures = 0
         for src_id in sources:
             for dst_id in destinations:
                 logging.info("Testing: %s -> %s", src_id, dst_id)
-                src = ISD_AD(*src_id)
-                dst = ISD_AD(*dst_id)
+                src = SCIONAddr.from_values(src_id[0], src_id[1], client_ip)
+                dst = SCIONAddr.from_values(dst_id[0], dst_id[1], server_ip)
                 token = (
-                    "%s-%s<->%s-%s" % (src[0], src[1], dst[0],
-                                       dst[1])
+                    "%s-%s<->%s-%s" % (src.isd_id, src.ad_id, dst.isd_id,
+                                       dst.ad_id)
                 ).encode("UTF-8")
                 pong_app = Pong(dst, token)
                 threading.Thread(
@@ -230,30 +236,38 @@ class TestSCIONDaemon(unittest.TestCase):
                 self.assertTrue(ping_app.pong_received)
         sys.exit(failures)
 
-if __name__ == "__main__":
-    init_logging("logs/end2end.log", console=True)
-    handle_signals()
-    if len(sys.argv) == 3:
-        isd, ad = sys.argv[1].split(',')
-        sources = [(int(isd), int(ad))]
-        isd, ad = sys.argv[2].split(',')
-        destinations = [(int(isd), int(ad))]
-    else:
-        # You can specify src and dst by giving 'sISD,sAD dISD,dAD' as
-        # the arguments. E.g.: python3 end2end_test.py 1,19 2,26
-        sources = [(1, 17), (1, 19), (1, 10), (2, 25)]
-        sources += [(2, 26), (1, 14), (1, 18)]
-        destinations = sources[:]
-        # Randomize order of the connections.
-        random.shuffle(sources)
-        random.shuffle(destinations)
 
-    try:
-        TestSCIONDaemon().test(sources, destinations)
-    except SystemExit:
-        logging.info("Exiting")
-        raise
-    except:
-        log_exception("Exception in main process:")
-        logging.critical("Exiting")
-        sys.exit(1)
+def _parse_tuple(ad_str):
+    def_ads = [(1, 17), (1, 19), (1, 10), (2, 25), (2, 26), (1, 14), (1, 18)]
+    if not ad_str:
+        random.shuffle(def_ads)
+        return def_ads
+    isd, ad = ad_str.split(",")
+    return [(int(isd), int(ad))]
+
+
+def main():
+    handle_signals()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--client', help='Client address')
+    parser.add_argument('-s', '--server', help='Server address')
+    parser.add_argument('-m', '--mininet', action='store_true',
+                        help="Running under mininet")
+    parser.add_argument('src_ad', nargs='?', help='Src isd,ad')
+    parser.add_argument('dst_ad', nargs='?', help='Dst isd,ad')
+    args = parser.parse_args()
+    init_logging("logs/end2end.log", console=True)
+
+    if not args.client:
+        args.client = "169.254.0.2" if args.mininet else "127.0.0.2"
+    if not args.server:
+        args.server = "169.254.0.3" if args.mininet else "127.0.0.3"
+
+    srcs = _parse_tuple(args.src_ad)
+    dsts = _parse_tuple(args.dst_ad)
+
+    TestSCIONDaemon().test(args.client, args.server, srcs, dsts)
+
+
+if __name__ == "__main__":
+    main_wrapper(main)

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -20,6 +20,7 @@
 import argparse
 import base64
 import configparser
+import getpass
 import json
 import logging
 import math
@@ -28,6 +29,7 @@ import sys
 from collections import defaultdict
 from io import StringIO
 from ipaddress import ip_interface, ip_network
+from string import Template
 
 # External packages
 from Crypto import Random
@@ -49,6 +51,7 @@ from lib.util import (
     get_sig_key_file_path,
     get_trc_file_path,
     load_json_file,
+    read_file,
     write_file,
 )
 
@@ -134,6 +137,8 @@ class ConfigGenerator(object):
                 def_network = DEFAULT_NETWORK
         self.subnet_gen = SubnetGenerator(def_network)
         for key, val in defaults.get("zookeepers", {}).items():
+            if self.mininet and val['addr'] == "127.0.0.1":
+                val['addr'] = "169.254.0.1"
             self.default_zookeepers[key] = ZKTopo(
                 val, self.zk_config)
 
@@ -162,7 +167,7 @@ class ConfigGenerator(object):
 
     def _generate_supervisor(self, topo_dicts, zookeepers):
         super_gen = SupervisorGenerator(self.out_dir, topo_dicts, zookeepers,
-                                        self.zk_config)
+                                        self.zk_config, self.mininet)
         super_gen.generate()
 
     def _generate_sim_conf(self, topo_dicts):
@@ -327,7 +332,6 @@ class TopoGenerator(object):
         self.topo_dicts = {}
         self.hosts = []
         self.zookeepers = defaultdict(dict)
-        self.networks = defaultdict(dict)
         self.virt_addrs = set()
 
     def _reg_addr(self, topo_id, elem_id):
@@ -457,11 +461,12 @@ class TopoGenerator(object):
 
 
 class SupervisorGenerator(object):
-    def __init__(self, out_dir, topo_dicts, zookeepers, zk_config):
+    def __init__(self, out_dir, topo_dicts, zookeepers, zk_config, mininet):
         self.out_dir = out_dir
         self.topo_dicts = topo_dicts
         self.zookeepers = zookeepers
         self.zk_config = zk_config
+        self.mininet = mininet
 
     def generate(self):
         for topo_id, topo in self.topo_dicts.items():
@@ -506,6 +511,8 @@ class SupervisorGenerator(object):
             conf_path = os.path.join(base, elem, SUPERVISOR_CONF)
             includes.append(os.path.join(elem, SUPERVISOR_CONF))
             self._write_elem_conf(elem, entry, conf_path)
+            if self.mininet:
+                self._write_elem_mininet_conf(elem, conf_path)
         config["group:ad%s" % topo_id] = {"programs": ",".join(names)}
         text = StringIO()
         config.write(text)
@@ -520,12 +527,21 @@ class SupervisorGenerator(object):
         config.write(text)
         write_file(conf_path, text.getvalue())
 
+    def _write_elem_mininet_conf(self, elem, conf_path):
+        tmpl = Template(read_file("topology/mininet/supervisord.conf"))
+        mn_conf_path = os.path.join(self.out_dir, "mininet", "%s.conf" % elem)
+        rel_conf_path = os.path.relpath(
+            conf_path, os.path.join(self.out_dir, "mininet"))
+        write_file(mn_conf_path,
+                   tmpl.substitute(elem=elem, conf_path=rel_conf_path,
+                                   user=getpass.getuser()))
+
     def _get_base_path(self, topo_id):
         return os.path.join(self.out_dir, topo_id.ISD(), topo_id.AD())
 
     def _common_entry(self, name, cmd_args):
-        return {
-            'autostart': 'false',
+        entry = {
+            'autostart': 'false' if self.mininet else 'false',
             'autorestart': 'false',
             'redirect_stderr': 'true',
             'environment': 'PYTHONPATH=.',
@@ -535,6 +551,9 @@ class SupervisorGenerator(object):
             'startsecs': 5,
             'command': " ".join(['"%s"' % arg for arg in cmd_args]),
         }
+        if self.mininet:
+            entry['autostart'] = 'true'
+        return entry
 
 
 class SimulatorGenerator(SupervisorGenerator):
@@ -709,39 +728,54 @@ class SubnetGenerator(object):
                              network)
             sys.exit(1)
         self._subnets = defaultdict(lambda: AddressGenerator())
+        self._allocations = defaultdict(list)
+        # Initialise the allocations with the supplied network, making sure to
+        # exclude 127.0.0.0/30 if it's contained in the network.
+        # - 127.0.0.0 is treated as a broadcast address by the kernel
+        # - 127.0.0.1 is the normal loopback address
+        # - 127.0.0.[23] are used for clients to bind to for testing purposes.
+        v4_lo = ip_network("127.0.0.0/30")
+        if self._net.overlaps(v4_lo):
+            self._exclude_net(self._net, v4_lo)
+        else:
+            self._allocations[self._net.prefixlen].append(self._net)
 
     def register(self, location):
         return self._subnets[location]
 
     def alloc_subnets(self):
-        allocations = defaultdict(list)
-        # Initialise the allocations with the supplied network
-        allocations[self._net.prefixlen].append(self._net)
         max_prefix = self._net.max_prefixlen
         networks = {}
         for subnet in self._subnets.values():
-            # Figure out what size subnet we need. Add 2 to the subnet size to
-            # cover the network and broadcast addresses.
-            req_prefix = max_prefix - math.ceil(math.log2(len(subnet) + 2))
+            # Figure out what size subnet we need. If it's a link, then we just
+            # need a /31 (or /127), otherwise add 2 to the subnet size to cover
+            # the network and broadcast addresses.
+            if len(subnet) == 2:
+                req_prefix = max_prefix - 1
+            else:
+                req_prefix = max_prefix - math.ceil(math.log2(len(subnet) + 2))
             # Search all subnets from that size upwards
             for prefix in range(req_prefix, -1, -1):
-                if not allocations[prefix]:
+                if not self._allocations[prefix]:
                     # No subnets available at this size
                     continue
-                alloc = allocations[prefix].pop()
+                alloc = self._allocations[prefix].pop()
                 # Carve out subnet of the required size
                 new_net = next(alloc.subnets(new_prefix=req_prefix))
                 logging.debug("Allocating %s from %s for subnet size %d" %
                               (new_net, alloc, len(subnet)))
                 networks[new_net] = subnet.alloc_addrs(new_net)
                 # Repopulate the allocations list with the left-over space
-                for net in alloc.address_exclude(new_net):
-                    allocations[net.prefixlen].append(net)
+                self._exclude_net(alloc, new_net)
                 break
             else:
                 logging.critical("Unable to allocate /%d subnet" % req_prefix)
                 sys.exit(1)
         return networks
+
+    def _exclude_net(self, alloc, net):
+        for net in alloc.address_exclude(net):
+            self._allocations[net.prefixlen].append(net)
 
 
 class AddressGenerator(object):

--- a/topology/mininet/README.md
+++ b/topology/mininet/README.md
@@ -1,0 +1,23 @@
+# SCION on Mininet
+
+SCION can be run inside [Mininet](http://mininet.org), which is a virtual network emulation environment. Running SCION in Mininet enables the use of custom topologies and link characteristics (e.g., specifying link bandwidth between two ASes). 
+
+## Getting started
+You'll need a few base packages to get started. We currently support only Mininet 2.1.0 installed from the Ubuntu 14.04 repositories. Due to the limited number of switches (16) supported by `openvswitch-controller`, we also require the use of a custom OpenFlow controller, [POX](http://www.noxrepo.org/pox/about-pox). The list of required packages can be found [here](pkgs_debian.txt) for manual installation or installed automatically using the [setup.sh](setup.sh) script we provide. Once you have all packages installed, you're ready to run SCION.
+
+### Creating a Mininet-compatible topology
+You need to generate a topology with Mininet support enabled. To do this, run the following command:
+```
+user@ubuntu:~/scion$ ./scion.sh topology -m
+```
+### Running the network
+Now run the network:
+```
+user@ubuntu:~/scion$ topology/mininet/run.sh
+```
+You'll be dropped into a Mininet shell where you can list the nodes (`nodes`), show the topology (`net`), or launch xterms on one of the hosts (`xterm bs1_11_1`). You can also run commands directly on the hosts (`bs1_11_1 tcpdump -ni any`). 
+
+Once you're done looking around, you can type Ctrl+D to shutdown the Mininet environment. If something goes wrong and you have leftover network interfaces, you can clean them up by running
+```
+user@ubuntu:~/scion$ sudo mn -c
+```

--- a/topology/mininet/pkgs_debian.txt
+++ b/topology/mininet/pkgs_debian.txt
@@ -1,0 +1,4 @@
+iputils-ping
+mininet
+unzip
+wget

--- a/topology/mininet/pox_signal.py
+++ b/topology/mininet/pox_signal.py
@@ -1,0 +1,15 @@
+import signal
+
+from pox.core import core
+
+# Create a logger for this component
+log = core.getLogger()
+
+
+def launch():
+    signal.signal(signal.SIGTERM, _term)
+
+
+def _term(signum, _):
+    log.info("Got signal, quitting")
+    core.quit()

--- a/topology/mininet/requirements.txt
+++ b/topology/mininet/requirements.txt
@@ -1,0 +1,2 @@
+ipaddress
+configparser

--- a/topology/mininet/run.sh
+++ b/topology/mininet/run.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+TMP_DIR=/tmp/mininet
+mkdir -p "$TMP_DIR"
+
+POX_PID="$TMP_DIR/pox.pid"
+POX_LOG="logs/pox.log"
+POX_OUT="logs/pox.out"
+POX_PORT=6633
+
+log() {
+    echo "=====> $@"
+}
+bash gen/zk_datalog_dirs.sh || exit 1
+
+if [ -e "$POX_PID" ]; then
+    log "ERROR: Pox already running, or $POX_PID is stale"
+    exit 1
+fi
+
+PYTHONPATH=topology/mininet pox \
+    pox_signal \
+    forwarding.l2_learning \
+    misc.pidfile --file=$POX_PID \
+    log --no_default --file="$POX_LOG" --format="%(asctime)s: %(message)s" \
+    &> "$POX_OUT" &
+
+count=0
+while ! nc -4 -z localhost "$POX_PORT"; do
+    log "Waiting for POX to load on localhost:$POX_PORT"
+    sleep 1
+    ((count++))
+    if [ $count -ge 5 ]; then
+        log "ERROR: POX not running after 5 seconds:"
+        tail -n 20 "$POX_LOG"
+        exit 1
+    fi
+done
+
+log "POX running on localhost:$POX_PORT"
+log "Starting mininet"
+
+sudo SUPERVISORD=$(which supervisord) python topology/mininet/topology.py
+
+for i in "$TMP_DIR"/*.pid; do
+    log "Killing $(basename $i | cut -d. -f -1)"
+    kill $(< $i)
+done

--- a/topology/mininet/setup.sh
+++ b/topology/mininet/setup.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+
+MN_DIR=$(dirname $0)
+APTARGS="$1"
+SITE_PKGS=~/.local/lib/python2.7/site-packages
+POX_DIR="$SITE_PKGS/pox-carp"
+POX_LINK="$SITE_PKGS/pox"
+
+log() {
+    echo "=====> $@"
+}
+
+log "Checking for necessary debian packages"
+for pkg in $(< "$MN_DIR/pkgs_debian.txt"); do
+    if ! dpkg-query -W --showformat='${Status}\n' $pkg 2> /dev/null | \
+        grep -q "install ok installed"; then
+        pkgs+="$pkg "
+    fi
+done
+if [ -n "$pkgs" ]; then
+    log "Installing missing necessary packages: $pkgs"
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install $APTARGS --no-install-recommends $pkgs
+    log "Starting the openvswitch-switch service"
+    sudo service openvswitch-switch start
+fi
+
+log "Installing any necessary python packages via pip"
+pip2 install --user -r "$MN_DIR/requirements.txt"
+
+if ! which pox > /dev/null; then
+    if [ ! -d "$POX_DIR" ]; then
+        log "Installing POX (https://github.com/noxrepo/pox) to $POX_DIR"
+        wget -nv -O - https://github.com/noxrepo/pox/archive/carp.tar.gz | tar xzf - -C "$SITE_PKGS"
+        ln -sf pox-carp/pox "$POX_LINK"
+    fi
+    log "Installing POX symlink into ~/.local/bin"
+    ln -sf "$POX_DIR/pox.py" ~/.local/bin/pox
+fi
+if ! which pox > /dev/null; then
+    log "Error: no 'pox' in \$PATH, POX not installed correctly"
+    exit 1
+fi
+if ! python2 -c "import pox" &> /dev/null; then
+    log "Error: unable to import 'pox' module in python2"
+    exit 1
+fi

--- a/topology/mininet/supervisord.conf
+++ b/topology/mininet/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+logfile=logs/supervisord-${elem}.log
+user=${user}
+pidfile=/tmp/mininet/supervisord-${elem}.pid
+
+[unix_http_server]
+file = /tmp/mininet/supervisord-${elem}.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[ctlplugin:quick]
+supervisor.ctl_factory = supervisor_quick:make_quick_controllerplugin
+
+[include]
+files = ${conf_path}

--- a/topology/mininet/topology.py
+++ b/topology/mininet/topology.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python2
+
+# Stdlib
+import os
+import sys
+
+# External
+import configparser
+import ipaddress
+from mininet.cli import CLI
+from mininet.log import lg
+from mininet.net import Mininet
+from mininet.node import RemoteController
+from mininet.topo import Topo
+
+MAX_INTF_LEN = 15
+NETWORKS_CONF = "gen/networks.conf"
+
+
+class ScionTopo(Topo):
+    """
+    Topology built from a SCION network config."
+    """
+    def __init__(self, mnconfig, **params):
+
+        # Initialize topology
+        Topo.__init__(self, **params)
+        self.switch_map = {}
+        self._genTopo(mnconfig)
+
+    def _genTopo(self, mnconfig):
+        for i, name in enumerate(mnconfig.sections()):
+            self.switch_map[name] = self.addSwitch("s%s" % i)
+
+        host_map = {}
+        for name, section in mnconfig.items():
+            for elem, intf_str in section.items():
+                if ipaddress.ip_interface(intf_str).is_loopback:
+                    print("""ERROR: The IP address for %s (%s) is a loopback
+                          address""" % (elem, intf_str))
+                    print("Try running scion.sh topology -m")
+                    sys.exit(1)
+                # The config is utf8, need to convert to a plain string to avoid
+                # tickling bugs in mininet.
+                elem = str(elem)
+                elem_name = elem.replace("-", "_")
+                if elem not in host_map:
+                    host_map[elem] = self.addHost(elem_name, ip=None)
+                intf = ipaddress.ip_interface(intf_str)
+                is_link = False
+                if intf.network.prefixlen == intf.max_prefixlen - 1:
+                    is_link = True
+                intfName = "%s-%d" % (elem_name, is_link)
+                assert intfName <= MAX_INTF_LEN
+                self.addLink(
+                    host_map[elem], self.switch_map[name],
+                    params={'ip': str(intf)},
+                    intfName=intfName,
+                )
+
+    def addLink(self, node1, node2, params=None, intfName=None):
+        self.addPort(node1, node2, None, None)
+        key = tuple(self.sorted([node1, node2]))
+        # Map the supplied params to the node1 interface, even if sorting turns
+        # it into the second interface.
+        if key[0] == node1:
+            self.link_info[key] = {"params1": params, "intfName1": intfName}
+        else:
+            self.link_info[key] = {"params2": params, "intfName2": intfName}
+        self.g.add_edge(*key)
+        return key
+
+
+def main():
+    lg.setLogLevel('info')
+    supervisord = os.getenv("SUPERVISORD")
+    assert supervisord
+    topology = configparser.ConfigParser(interpolation=None)
+    topology.read_file(open(NETWORKS_CONF), source=NETWORKS_CONF)
+    topo = ScionTopo(topology)
+    net = Mininet(topo=topo, controller=RemoteController)
+    for host in net.hosts:
+        host.cmd('ip route add 169.254.0.0/16 dev %s-0' % host.name)
+    net.start()
+    os.system('ip link add name mininet type dummy')
+    os.system('ip addr add 169.254.0.1/16 dev mininet')
+    os.system('ip addr add 169.254.0.2/16 dev mininet')
+    os.system('ip addr add 169.254.0.3/16 dev mininet')
+
+    for switch in net.switches:
+        for k, v in topo.switch_map.items():
+            if v == switch.name:
+                os.system('ip route add %s dev %s src 169.254.0.1'
+                          % (k, switch.name))
+    for host in net.hosts:
+        elem_name = host.name.replace("_", "-")
+        print("Starting supervisord on %s" % elem_name)
+        host.cmd("%s -c gen/mininet/%s.conf" % (supervisord, elem_name))
+    CLI(net)
+    net.stop()
+    os.system('ip link delete mininet')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This brings mininet support to the point where the infrastructure runs,
and end2end and cli_srv_ext integration tests succeed.

Notable topology/mininet/ contents:
- README.md - how to run SCION on mininet
- setup.sh - installs the prerequisites for mininet support
- run.sh - runs SCION inside mininet
- topology.py - python2 script that creates and runs the mininet topology

Mininet support is a combined effort of @davidbb and @kormat.
# Detailed changes:

topology/generator:
- Use the link-local host address for the host's zookeeper when running
  under mininet.
- Generate per-element supervisord configs in gen/mininet
- Auto-start elements when running in mininet, as the supervisords are
  completely independant.
- Reserve certain IPs in 127.0.0.0/8 when running normally, to avoid
  routing issues.
- Fix link networks to use /31 or /127's as appropriate.

topology/mininet/topology.py (moved from topology/mininet.py):
- Add a 'mininet' interface to the host, with 3 link-local IP addresses.
  169.254.0.1 is used for elements to contact the host, .2 and .3 are
  used for test applications to bind to.
- Generate readable interface names for elements, with name-0 being the
  internal interface, and name-1 being the external interface for routers.
- Enforce that interface names are of legal length, avoiding the bug where
  longer names would cause mininet to silently fail.
- Run supervisord for each element.
- Switch from using openvswitch-controller, which is hard-limited to 16
  switches, to POX (http://www.noxrepo.org/pox/about-pox/), a
  self-contained OpenFlow Controller implementation.

pox_signal.py:
- Add a tiny POX extension to allow graceful shutdown via signal.

cli_srv_ext_test and end2end_test:
- Refactored to use lib.socket and lib.main
- Cmdline arguments to set src/dst ISD/AD/address, including mininet
  flag to use preset addresses.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/481%23issuecomment-154341403%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/481%23issuecomment-154341403%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22LGTM%22%2C%20%22created_at%22%3A%20%222015-11-06T08%3A14%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/481#issuecomment-154341403'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> LGTM

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/481?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/481?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/481'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
