### PR TITLE
Fix assertion about mininet i/f name length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ Thumbs.db
 # Python generated files #
 #########################
 __pycache__
-topology/mininet/pox_signal.pyc
+topology/mininet/*.pyc
 
 
 # vim generated files #

--- a/topology/mininet/topology.py
+++ b/topology/mininet/topology.py
@@ -51,7 +51,7 @@ class ScionTopo(Topo):
                 if intf.network.prefixlen == intf.max_prefixlen - 1:
                     is_link = True
                 intfName = "%s-%d" % (elem_name, is_link)
-                assert intfName <= MAX_INTF_LEN
+                assert len(intfName) <= MAX_INTF_LEN
                 self.addLink(
                     host_map[elem], self.switch_map[name],
                     params={'ip': str(intf)},


### PR DESCRIPTION
Also ignore all .pyc files in topology/mininet, just in case, as mininet
uses python2.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/482%23issuecomment-154345941%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/482%23issuecomment-154345941%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20lgtm%20please%20merge%20please%22%2C%20%22created_at%22%3A%20%222015-11-06T08%3A46%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/202203%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/davidbb%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/482#issuecomment-154345941'>General Comment</a></b>
- <a href='https://github.com/davidbb'><img border=0 src='https://avatars.githubusercontent.com/u/202203?v=3' height=16 width=16'></a> :+1: lgtm please merge please

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/482?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/482?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/482'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
