### PR TITLE
mn link param support

### DIFF
--- a/topology/mininet/links.conf
+++ b/topology/mininet/links.conf
@@ -1,0 +1,10 @@
+[er1_11er1_12-1]
+bw=22.5
+delay=39ms
+loss=1
+jitter=12ms
+enable_ecn=True
+
+[ds2_22_1-0]
+delay=50ms
+bw=950


### PR DESCRIPTION
We now allow mininet links to have options parameters such as bandwidth,
loss, latency, jitter, and various other parameters supported by the
Linux tc utility. This patch allows the user to specify a links.conf
file where such parameters are described for each link (technically
these are passed per interface). If mininet does not find any parameters
for the link, defaults are used.

as usual thanks to @kormat for help with this
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44289535%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44289620%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44289963%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44290088%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44290456%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44290520%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44652027%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44652063%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44652077%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44652091%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44652097%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44652172%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23issuecomment-156100945%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23issuecomment-156100945%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22fyi%20tested%20this%20and%20it%20is%20working%20on%20my%20vm%22%2C%20%22created_at%22%3A%20%222015-11-12T13%3A21%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/202203%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/davidbb%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%203b588e10842de4660a34b141e024f659db95e142%20topology/mininet/links.conf%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44289535%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20would%20be%20better%20to%20have%20the%20default%20config%20be%20useful%20with%20the%20default%20topology.%22%2C%20%22created_at%22%3A%20%222015-11-09T15%3A46%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T12%3A39%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/links.conf%3AL1-10%22%7D%2C%20%22Pull%203b588e10842de4660a34b141e024f659db95e142%20topology/mininet/topology.py%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44289620%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Move%20this%20to%20a%20seperate%20method.%22%2C%20%22created_at%22%3A%20%222015-11-09T15%3A47%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Also%2C%20this%20can%20be%20simplified.%20ConfigParser.read%28%29%20will%20try%20to%20find%20files%20to%20load%2C%20but%20won%27t%20throw%20an%20error%20if%20it%20can%27t%20find%20them.%5Cr%5Cn%60%60%60%5Cr%5Cnlinks%20%3D%20configparser.ConfigParser%28interpolation%3DNone%29%5Cr%5Cnlinks.read%28LINKS_CONF%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-11-09T15%3A50%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T12%3A40%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/topology.py%3AL30-59%22%7D%2C%20%22Pull%203b588e10842de4660a34b141e024f659db95e142%20topology/mininet/topology.py%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44290520%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Python%20has%20a%20more%20elegant%20way%20of%20expressing%20this%3A%5Cr%5Cn%60%60%60%5Cr%5Cnif%20tcParam%20in%20%5B%5C%22delay%5C%22%2C%20%5C%22jitter%5C%22%5D%3A%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-11-09T15%3A53%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T12%3A40%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/topology.py%3AL30-59%22%7D%2C%20%22Pull%203b588e10842de4660a34b141e024f659db95e142%20topology/mininet/topology.py%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44290456%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20would%20be%20better%20to%20pass%20in%20the%20items%20into%20the%20method.%20That%20way%20it%20can%20call%20%60getint%60/%60getboolean%60%20directly%20on%20the%20config%20parser%20object.%20Something%20like%3A%5Cr%5Cn%60%60%60%5Cr%5Cnparams.update%28self.tcParamParser%28links.items%28intfName%29%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-11-09T15%3A53%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T12%3A40%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/topology.py%3AL76-89%22%7D%2C%20%22Pull%203b588e10842de4660a34b141e024f659db95e142%20topology/mininet/topology.py%2043%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44290088%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20don%27t%20need%20to%20check%20for%20%60links%60%20with%20the%20above%20change.%20%60if%20intfName%20in%20links.sections%28%29%60%20will%20work%20fine.%22%2C%20%22created_at%22%3A%20%222015-11-09T15%3A50%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T12%3A40%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/topology.py%3AL76-89%22%7D%2C%20%22Pull%201ba6648385a05dc6c0b26d1038bc20121bf2d82b%20topology/mininet/topology.py%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/487%23discussion_r44652172%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20move%20this%20below%20%60_genTopo%60%20%28and%20before%20%60addLink%60%29%2C%20and%20rename%20to%20%60_tcParamParser%60.%22%2C%20%22created_at%22%3A%20%222015-11-12T12%3A41%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20topology/mininet/topology.py%3AL30-63%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 1ba6648385a05dc6c0b26d1038bc20121bf2d82b topology/mininet/topology.py 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/487#discussion_r44652172'>File: topology/mininet/topology.py:L30-63</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Please move this below `_genTopo` (and before `addLink`), and rename to `_tcParamParser`.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/487#issuecomment-156100945'>General Comment</a></b>
- <a href='https://github.com/davidbb'><img border=0 src='https://avatars.githubusercontent.com/u/202203?v=3' height=16 width=16'></a> fyi tested this and it is working on my vm
- [x] <a href='#crh-comment-Pull 3b588e10842de4660a34b141e024f659db95e142 topology/mininet/links.conf 1'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/487#discussion_r44289535'>File: topology/mininet/links.conf:L1-10</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It would be better to have the default config be useful with the default topology.
- [x] <a href='#crh-comment-Pull 3b588e10842de4660a34b141e024f659db95e142 topology/mininet/topology.py 29'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/487#discussion_r44289620'>File: topology/mininet/topology.py:L30-59</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Move this to a seperate method.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Also, this can be simplified. ConfigParser.read() will try to find files to load, but won't throw an error if it can't find them.

```
links = configparser.ConfigParser(interpolation=None)
links.read(LINKS_CONF)
```
- [x] <a href='#crh-comment-Pull 3b588e10842de4660a34b141e024f659db95e142 topology/mininet/topology.py 43'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/487#discussion_r44290088'>File: topology/mininet/topology.py:L76-89</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You don't need to check for `links` with the above change. `if intfName in links.sections()` will work fine.
- [x] <a href='#crh-comment-Pull 3b588e10842de4660a34b141e024f659db95e142 topology/mininet/topology.py 45'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/487#discussion_r44290456'>File: topology/mininet/topology.py:L76-89</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It would be better to pass in the items into the method. That way it can call `getint`/`getboolean` directly on the config parser object. Something like:

```
params.update(self.tcParamParser(links.items(intfName))
```
- [x] <a href='#crh-comment-Pull 3b588e10842de4660a34b141e024f659db95e142 topology/mininet/topology.py 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/487#discussion_r44290520'>File: topology/mininet/topology.py:L30-59</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Python has a more elegant way of expressing this:

```
if tcParam in ["delay", "jitter"]:
```

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/487?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/487?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/487'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
