### PR TITLE
WIP for downstream dissemination of revocations.

### DIFF
--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -208,6 +208,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         """
         rev_token = rev_info.rev_token
         for _ in range(self.N_TOKENS_CHECK):
+            rev_token = SHA256.new(rev_token).digest()
             segments = self.iftoken2seg[rev_token]
             while segments:
                 sid = segments.pop()
@@ -216,7 +217,6 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
                 self.core_segments.delete(sid)
             if rev_token in self.iftoken2seg:
                 del self.iftoken2seg[rev_token]
-            rev_token = SHA256.new(rev_token).digest()
 
     def send_path_segments(self, pkt, paths):
         """

--- a/lib/packet/pcb.py
+++ b/lib/packet/pcb.py
@@ -32,7 +32,7 @@ from lib.errors import SCIONParseError
 from lib.packet.opaque_field import HopOpaqueField, InfoOpaqueField
 from lib.packet.packet_base import SCIONPayloadBase
 from lib.packet.path import CorePath
-from lib.packet.pcb_ext import MTUExtension
+from lib.packet.pcb_ext import MTUExtension, REVExtension
 from lib.packet.scion_addr import ISD_AD
 from lib.types import PayloadClass, PCBType
 from lib.util import Raw
@@ -43,6 +43,7 @@ REV_TOKEN_LEN = 32
 # Dictionary of supported extensions
 PCB_EXTENSION_MAP = {
     (MTUExtension.EXT_TYPE): MTUExtension,
+    (REVExtension.EXT_TYPE): REVExtension,
 }
 
 

--- a/lib/packet/pcb_ext.py
+++ b/lib/packet/pcb_ext.py
@@ -20,6 +20,7 @@ import struct
 
 # SCION
 from lib.packet.packet_base import HeaderBase
+from lib.packet.rev_info import RevocationInfo
 from lib.types import TypeBase
 
 
@@ -28,6 +29,7 @@ class BeaconExtType(TypeBase):
     Constants for two types of beacon extensions.
     """
     MTU = 0
+    REV = 1
 
 
 class BeaconExtension(HeaderBase):
@@ -77,3 +79,42 @@ class MTUExtension(BeaconExtension):  # pragma: no cover
 
     def __str__(self):
         return "MTU Ext(%dB): MTU is %dB" % (len(self), self.mtu)
+
+
+class REVExtension(BeaconExtension):
+    """
+    Length of REVExtension
+    """
+    EXT_TYPE = BeaconExtType.REV
+    LEN = 32
+
+    def __init__(self, raw=None):
+        """
+        Initialize an instance of the class REVExtension
+
+        :param raw:
+        :type raw:
+        """
+        self.rev_info = None
+        super().__init__(raw)
+
+    @classmethod
+    def from_values(cls, rev):
+        """
+        Construct extension with `rev` value.
+        """
+        inst = cls()
+        inst.rev_info = rev
+        return inst
+
+    def _parse(self, raw):
+        self.rev_info = RevocationInfo(raw)
+
+    def pack(self):
+        return self.rev_info.pack()
+
+    def __len__(self):
+        return len(self.rev_info)
+
+    def __str__(self):
+        return str(self.rev_info)


### PR DESCRIPTION
https://github.com/netsec-ethz/scion/issues/108
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/490%23issuecomment-155438316%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23issuecomment-155460037%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23issuecomment-155717805%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23issuecomment-155739019%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44421064%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44421771%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44430432%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44510493%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44511383%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44523014%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44523015%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23issuecomment-155740376%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44529795%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44530053%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23issuecomment-155782711%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23issuecomment-155784220%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23issuecomment-155784629%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23issuecomment-155438316%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40shitz%20%40pszalach%20%40kormat%20This%20the%20WIP%20for%20downstream%20dissemination.%20I%20would%20be%20glad%20if%20you%20could%20tell%20me%20what%20you%20think%20of%20it.%20I%27d%20be%20very%20happy%20if%20you%20could%20also%20give%20me%20some%20ideas%20as%20to%20how%20to%20test%20this%20code%20as%20well.%20Cheers%21%22%2C%20%22created_at%22%3A%20%222015-11-10T14%3A43%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looks%20generally%20good%20to%20me.%20I%20don%27t%20think%20we%20have%20any%20good%20way%20of%20testing%20this%20right%20now%2C%20apart%20from%20maybe%20in%20the%20simulator.%20Have%20a%20look%20at%20%60test/integration/revocation_sim_test.py%60.%20We%20definitely%20do%20need%20a%20test%20framework%20to%20test%20things%20like%20this%20though%2C%20sooner%20rather%20than%20later.%22%2C%20%22created_at%22%3A%20%222015-11-10T15%3A50%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40shitz%20addressed%20your%20comments.%22%2C%20%22created_at%22%3A%20%222015-11-11T09%3A45%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40shitz%20%40kormat%20%40pszalach%20I%20have%20tested%20this%20manually%20and%20observed%20it%20works.%20Started%20the%20infrastructure%2C%20killed%20one%20router%2C%20and%20verified%20that%20Revocations%20are%20received%20and%20processed%20in%20downstream%20ADs.%20%5Cr%5CnI%20think%20that%20in%20the%20future%20it%20would%20be%20very%20useful%20to%20invest%20some%20effort%20in%20developing%20a%20testing%20framework%20which%20lets%20us%20create%20a%20%5C%22test%20topology%5C%22%2C%20bring%20down%20some%20links%20and%20observe%20a%20certain%20outcome.%20%22%2C%20%22created_at%22%3A%20%222015-11-11T11%3A16%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20%40shitz%20%40kormat%20%40pszalach%20I%20have%20tested%20this%20manually%20and%20observed%20it%20works.%20Started%20the%20infrastructure%2C%20killed%20one%20router%2C%20and%20verified%20that%20Revocations%20are%20received%20and%20processed%20in%20downstream%20ADs.%20%5Cr%5Cn%3E%20I%20think%20that%20in%20the%20future%20it%20would%20be%20very%20useful%20to%20invest%20some%20effort%20in%20developing%20a%20testing%20framework%20which%20lets%20us%20create%20a%20%5C%22test%20topology%5C%22%2C%20bring%20down%20some%20links%20and%20observe%20a%20certain%20outcome.%5Cr%5Cn%5Cr%5CnI%20agree%20and%20I%20think%20we%20should%20have%20a%20design%20meeting%20or%20another%20meeting%20about%20this.%20LGTM%22%2C%20%22created_at%22%3A%20%222015-11-11T11%3A26%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22otherwise%20lgtm%21%22%2C%20%22created_at%22%3A%20%222015-11-11T13%3A11%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40pszalach%20addressed%20your%20comments%22%2C%20%22created_at%22%3A%20%222015-11-11T13%3A20%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22thx%21%22%2C%20%22created_at%22%3A%20%222015-11-11T13%3A23%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2058d508e20580a64e8b589d85eeed1fb3327682e8%20infrastructure/beacon_server.py%2067%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44421064%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20can%20be%20simplified%20slightly%20to%3A%5Cr%5Cn%60%60%60%5Cr%5Cnextensions.append%28MTUExtension.from_values%28self.config.mtu%29%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-11-10T15%3A41%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/beacon_server.py%3AL488-503%22%7D%2C%20%22Pull%2058d508e20580a64e8b589d85eeed1fb3327682e8%20infrastructure/beacon_server.py%2088%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44421771%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20wondering%20about%20the%20%60path_servers%60%20check.%20We%20should%20rely%20on%20the%20topology%20file%20as%20little%20as%20possible.%20It%20would%20probably%20be%20better%20to%20use%20a%20setting%20from%20the%20AD%20configuration%2C%20maybe%20%60RegisterPaths%60%3F%22%2C%20%22created_at%22%3A%20%222015-11-10T15%3A47%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20was%20an%20existing%20piece%20of%20code%20which%20I%20moved%20into%20this%20function.%20As%20discussed%2C%20we%20will%20get%20this%20information%20from%20AD%20settings%20in%20a%20future%20PR.%22%2C%20%22created_at%22%3A%20%222015-11-10T16%3A42%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/beacon_server.py%3AL836-858%22%7D%2C%20%22Pull%2098ba4e0076650e01deddfb4f00c52c7cd502e64b%20infrastructure/beacon_server.py%2068%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44529795%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60rev_token%60%20is%20unused%2C%20so%20maybe%20to%20signal%20that%20%60for%20_%2C%20rev_info%20in...%60%20is%20better.%22%2C%20%22created_at%22%3A%20%222015-11-11T13%3A07%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/beacon_server.py%3AL488-502%22%7D%2C%20%22Pull%2098ba4e0076650e01deddfb4f00c52c7cd502e64b%20lib/packet/pcb_ext.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44530053%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22sort%20imports%20%28this%20line%20should%20be%20before%20%60lib.types%60%29%22%2C%20%22created_at%22%3A%20%222015-11-11T13%3A10%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/pcb_ext.py%3AL21-28%22%7D%2C%20%22Pull%200262b47ec685c06a8690885c46a875940c2e8bef%20infrastructure/beacon_server.py%20144%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44511383%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20comment%20applies%20to%20the%20line%20after%20%60if%20if_id%20is%20not%20None%60%20and%20should%20be%20moved.%22%2C%20%22created_at%22%3A%20%222015-11-11T08%3A37%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-11-11T11%3A25%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/beacon_server.py%3AL887-930%22%7D%2C%20%22Pull%200262b47ec685c06a8690885c46a875940c2e8bef%20infrastructure/beacon_server.py%2053%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/490%23discussion_r44510493%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5C%5C%23%20...%20which%20contain%20the%20revoked%20interface.%22%2C%20%22created_at%22%3A%20%222015-11-11T08%3A23%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-11-11T11%3A25%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/beacon_server.py%3AL418-435%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/490#issuecomment-155438316'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @shitz @pszalach @kormat This the WIP for downstream dissemination. I would be glad if you could tell me what you think of it. I'd be very happy if you could also give me some ideas as to how to test this code as well. Cheers!
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Looks generally good to me. I don't think we have any good way of testing this right now, apart from maybe in the simulator. Have a look at `test/integration/revocation_sim_test.py`. We definitely do need a test framework to test things like this though, sooner rather than later.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @shitz addressed your comments.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @shitz @kormat @pszalach I have tested this manually and observed it works. Started the infrastructure, killed one router, and verified that Revocations are received and processed in downstream ADs.
  I think that in the future it would be very useful to invest some effort in developing a testing framework which lets us create a "test topology", bring down some links and observe a certain outcome.
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> > @shitz @kormat @pszalach I have tested this manually and observed it works. Started the infrastructure, killed one router, and verified that Revocations are received and processed in downstream ADs.
  > I think that in the future it would be very useful to invest some effort in developing a testing framework which lets us create a "test topology", bring down some links and observe a certain outcome.
  I agree and I think we should have a design meeting or another meeting about this. LGTM
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> otherwise lgtm!
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @pszalach addressed your comments
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> thx!
- [ ] <a href='#crh-comment-Pull 58d508e20580a64e8b589d85eeed1fb3327682e8 infrastructure/beacon_server.py 67'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/490#discussion_r44421064'>File: infrastructure/beacon_server.py:L488-503</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This can be simplified slightly to:

```
extensions.append(MTUExtension.from_values(self.config.mtu))
```
- [ ] <a href='#crh-comment-Pull 58d508e20580a64e8b589d85eeed1fb3327682e8 infrastructure/beacon_server.py 88'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/490#discussion_r44421771'>File: infrastructure/beacon_server.py:L836-858</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I'm wondering about the `path_servers` check. We should rely on the topology file as little as possible. It would probably be better to use a setting from the AD configuration, maybe `RegisterPaths`?
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> This was an existing piece of code which I moved into this function. As discussed, we will get this information from AD settings in a future PR.
- [ ] <a href='#crh-comment-Pull 98ba4e0076650e01deddfb4f00c52c7cd502e64b infrastructure/beacon_server.py 68'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/490#discussion_r44529795'>File: infrastructure/beacon_server.py:L488-502</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> `rev_token` is unused, so maybe to signal that `for _, rev_info in...` is better.
- [ ] <a href='#crh-comment-Pull 98ba4e0076650e01deddfb4f00c52c7cd502e64b lib/packet/pcb_ext.py 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/490#discussion_r44530053'>File: lib/packet/pcb_ext.py:L21-28</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> sort imports (this line should be before `lib.types`)
- [x] <a href='#crh-comment-Pull 0262b47ec685c06a8690885c46a875940c2e8bef infrastructure/beacon_server.py 53'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/490#discussion_r44510493'>File: infrastructure/beacon_server.py:L418-435</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> # ... which contain the revoked interface.
- [x] <a href='#crh-comment-Pull 0262b47ec685c06a8690885c46a875940c2e8bef infrastructure/beacon_server.py 144'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/490#discussion_r44511383'>File: infrastructure/beacon_server.py:L887-930</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> This comment applies to the line after `if if_id is not None` and should be moved.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/490?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/490?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/490'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
