### PR TITLE
Error handling of an invalid IFID in PCB.

### DIFF
--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -1255,11 +1255,12 @@ class LocalBeaconServer(BeaconServer):
         pkt = self._build_packet(
             PT.PATH_MGMT, dst_isd=pcb.get_isd(),
             dst_ad=pcb.get_first_pcbm().ad_id, path=core_path, payload=records)
-        if core_path.get_fwd_if() not in self.ifid2addr:
+        fwd_if = core_path.get_fwd_if()
+        if fwd_if not in self.ifid2addr:
             raise SCIONKeyError(
-                "Invalid IF %d in CorePath" % core_path.get_fwd_if())
+                "Invalid IF %d in CorePath" % fwd_if)
 
-        next_hop = self.ifid2addr[core_path.get_fwd_if()]
+        next_hop = self.ifid2addr[fwd_if]
         self.send(pkt, next_hop)
 
     def register_segments(self):


### PR DESCRIPTION
In case that PCB includes an invalid IFID, beacon server causes KeyError.
This patch raises an exception and outputs an error message when the IFID is invalid.

```
2015-11-10 15:29:39.576702+00:00 [INFO] (BS.worker) Up path registered: 4cc97be069dd, 2015-11-10 15:29:39+00:00, (1, 11)->(1, 13)
2015-11-10 15:29:39.577415+00:00 [CRITICAL] (BS.worker) Exception in BS.worker thread:
2015-11-10 15:29:39.593711+00:00 [CRITICAL] (BS.worker) Traceback (most recent call last):
2015-11-10 15:29:39.593808+00:00 [CRITICAL] (BS.worker)   File "/home/t-sasaki/hsr/git/scion/lib/thread.py", line 48, in thread_safety_net
2015-11-10 15:29:39.593867+00:00 [CRITICAL] (BS.worker)     return func(*args, **kwargs)
2015-11-10 15:29:39.593917+00:00 [CRITICAL] (BS.worker)   File "infrastructure/beacon_server.py", line 580, in worker
2015-11-10 15:29:39.593963+00:00 [CRITICAL] (BS.worker)     self.register_segments()
2015-11-10 15:29:39.594007+00:00 [CRITICAL] (BS.worker)   File "infrastructure/beacon_server.py", line 1262, in register_segments
2015-11-10 15:29:39.594050+00:00 [CRITICAL] (BS.worker)     self.register_down_segments()
2015-11-10 15:29:39.594093+00:00 [CRITICAL] (BS.worker)   File "infrastructure/beacon_server.py", line 1363, in register_down_segments
2015-11-10 15:29:39.594135+00:00 [CRITICAL] (BS.worker)     self.register_down_segment(pcb)
2015-11-10 15:29:39.594177+00:00 [CRITICAL] (BS.worker)   File "infrastructure/beacon_server.py", line 1254, in register_down_segment
2015-11-10 15:29:39.594229+00:00 [CRITICAL] (BS.worker)     next_hop = self.ifid2addr[core_path.get_fwd_if()]
2015-11-10 15:29:39.594280+00:00 [CRITICAL] (BS.worker) KeyError: 12345
```

<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/495%23discussion_r44530367%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/495%23issuecomment-155783378%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/495%23issuecomment-156052254%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/495%23issuecomment-156052429%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/495%23issuecomment-155783378%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22otherwise%20lgtm%21%22%2C%20%22created_at%22%3A%20%222015-11-11T13%3A15%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%20too%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A50%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20related%20to%20%23492%20%22%2C%20%22created_at%22%3A%20%222015-11-12T09%3A51%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20de51ad37f3cc950d00586bcd07871c56475d08b5%20infrastructure/beacon_server.py%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/495%23discussion_r44530367%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22instead%20of%20calling%20%60get_fwd_if%28%29%60%20twice%2C%20use%20%60fwd_if%20%3D%20core_path.get_fwd_if%28%29%60%22%2C%20%22created_at%22%3A%20%222015-11-11T13%3A15%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/beacon_server.py%3AL1255-1265%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull de51ad37f3cc950d00586bcd07871c56475d08b5 infrastructure/beacon_server.py 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/495#discussion_r44530367'>File: infrastructure/beacon_server.py:L1255-1265</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> instead of calling `get_fwd_if()` twice, use `fwd_if = core_path.get_fwd_if()`
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/495#issuecomment-155783378'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> otherwise lgtm!
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM too
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is related to #492

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/495?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/495?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/495'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
