### PR TITLE
Fix for router crashing when forwarding revocation to PS

### DIFF
--- a/infrastructure/router.py
+++ b/infrastructure/router.py
@@ -395,7 +395,7 @@ class Router(SCIONElement):
                     except SCIONServiceLookupError:
                         logging.error("No local PS to forward revocation to.")
                         return
-                    self.send(mgmt_pkt, ps.addr)
+                    self.send(mgmt_pkt, ps)
         if not from_local_ad and mgmt_pkt.path.is_last_path_hof():
             self.deliver(mgmt_pkt, PT.PATH_MGMT)
         else:


### PR DESCRIPTION
Existing code crashed like so:

Longer version: https://gist.github.com/aznair/46128f6d56e4e742edb0

2015-11-11 16:10:42.923494+00:00 [CRITICAL](MainThread)   File "infrastructure/router.py", line 222, in send
2015-11-11 16:10:42.923565+00:00 [CRITICAL](MainThread)     if addr == self.interface.to_addr:
2015-11-11 16:10:42.923637+00:00 [CRITICAL](MainThread)   File "/home/jason/work/scion/lib/packet/host_addr.py", line 91, in **eq**
2015-11-11 16:10:42.923708+00:00 [CRITICAL](MainThread)     return (self.TYPE == other.TYPE) and (self.addr == other.addr)
2015-11-11 16:10:42.923779+00:00 [CRITICAL](MainThread) AttributeError: 'IPv4Address' object has no attribute 'TYPE'
2015-11-11 16:10:42.923849+00:00 [CRITICAL](MainThread) 
2015-11-11 16:10:42.923923+00:00 [CRITICAL](MainThread) Exiting
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/497%23issuecomment-155838322%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/497%23issuecomment-155839321%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/497%23issuecomment-155839982%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/497%23issuecomment-155838322%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22...%20although%20%60ps_addr%60%20would%20be%20more%20intuitive%22%2C%20%22created_at%22%3A%20%222015-11-11T16%3A39%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Perhaps%20we%20can%20have%20a%20renaming%20PR%20at%20some%20point%20for%20misleading%20stuff%20like%20this%20and%20%5C%22local_socket%5C%22%20%28been%20in%20comments%20in%20sciond.py%20for%20a%20long%20time%29%22%2C%20%22created_at%22%3A%20%222015-11-11T16%3A43%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22fully%20agree%22%2C%20%22created_at%22%3A%20%222015-11-11T16%3A45%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/497#issuecomment-155838322'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> ... although `ps_addr` would be more intuitive
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> Perhaps we can have a renaming PR at some point for misleading stuff like this and "local_socket" (been in comments in sciond.py for a long time)
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> fully agree

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/497?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/497?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/497'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
