### PR TITLE
Adding lib.requests.RequestHandler

### DIFF
--- a/lib/requests.py
+++ b/lib/requests.py
@@ -1,0 +1,103 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`requests` --- Request handling library
+============================================
+"""
+# Stdlib
+import logging
+import threading
+import queue
+from collections import defaultdict
+
+# SCION
+from lib.thread import thread_safety_net
+from lib.util import SCIONTime
+
+
+class RequestHandler(object):
+    """
+    Small utility class to queue requests, check if they've been fulfilled, and
+    send replies. Requests are expired after a certain period.
+
+    This class is intended to be used in a seperate thread (run via
+    RequestHandler.start()), and monitors a queue.Queue for notifications. To
+    add a new request, the client code adds a key and request object to the
+    queue. To signal that the RequestHandler should check for fulfilled queries
+    for a given key, the client can simply send `None` instead of a request
+    object.
+    """
+    TTL = 2.0
+    MAX_LEN = 16
+
+    def __init__(self, queue, check, fetch, reply, ttl=TTL):  # pragma: no cover
+        self._queue = queue
+        self._check = check
+        self._fetch = fetch
+        self._reply = reply
+        self._ttl = ttl
+        self._req_map = defaultdict(list)
+
+    @classmethod
+    def start(cls, name, *args, **kwargs):  # pragma: no cover
+        q = queue.Queue()
+        inst = cls(q, *args, **kwargs)
+        threading.Thread(
+            target=thread_safety_net, args=(inst.run,),
+            name=name, daemon=True).start()
+        return q
+
+    def run(self):
+        while True:
+            key, req = self._queue.get()
+            if req:
+                # Add a new request
+                self._add_req(key, req)
+            # Answer existing requests, if possible.
+            self._answer_reqs(key)
+
+    def _add_req(self, key, request):
+        self._req_map.setdefault(key, [])
+        self._expire_reqs(key)
+        if not self._check(key) and len(self._req_map[key]) == 0:
+            # Don't already have the answer, and there were no outstanding
+            # requests, so send a new query
+            self._fetch(key)
+        self._req_map[key].append((SCIONTime.get_time(), request))
+
+    def _answer_reqs(self, key):
+        if not self._check(key):
+            # Don't have the answer yet.
+            return
+        if key not in self._req_map:
+            # No requests to fulfil.
+            return
+        self._expire_reqs(key)
+        reqs = self._req_map[key]
+        while reqs:
+            _, req = reqs.pop(0)
+            self._reply(req)
+        del self._req_map[key]
+
+    def _expire_reqs(self, key):
+        if key not in self._req_map:
+            return
+        now = SCIONTime.get_time()
+        count = 0
+        for ts, req in self._req_map[key][:]:
+            if now - ts > self._ttl:
+                count += 1
+                self._req_map[key].remove((ts, req))
+        if count:
+            logging.debug("Expired %d requests for %s", count, key)

--- a/test/lib_requests_test.py
+++ b/test/lib_requests_test.py
@@ -1,0 +1,156 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`lib_requests_test` --- lib.requests unit tests
+====================================================
+"""
+
+# Stdlib
+from unittest.mock import call, patch
+
+# External packages
+import nose
+import nose.tools as ntools
+
+# SCION
+from lib.requests import (
+    RequestHandler,
+)
+from test.testcommon import assert_these_calls, create_mock
+
+
+class TestRequestHandlerRun(object):
+    """
+    Unit tests for lib.requests.RequestHandler.run
+    """
+    def test(self):
+        q = create_mock(["get"])
+        q.get.side_effect = [("key0", "req0"), ("key1", None)]
+        inst = RequestHandler(q, "check", "fetch", "reply")
+        inst._add_req = create_mock()
+        inst._answer_reqs = create_mock()
+        # Call
+        ntools.assert_raises(StopIteration, inst.run)
+        # Tests
+        inst._add_req.assert_called_once_with("key0", "req0")
+        assert_these_calls(inst._answer_reqs, [call("key0"), call("key1")])
+
+
+class TestRequestHandlerAddReq(object):
+    """
+    Unit tests for lib.requests.RequestHandler._add_req
+    """
+    def _setup(self, time_, check_ret=False):
+        check = create_mock()
+        check.return_value = check_ret
+        fetch = create_mock()
+        inst = RequestHandler("queue", check, fetch, "reply")
+        inst._expire_reqs = create_mock()
+        time_.return_value = 2
+        return inst
+
+    @patch("lib.requests.SCIONTime.get_time", newcallable=create_mock)
+    def test_no_ans_no_query(self, time_):
+        inst = self._setup(time_)
+        # Call
+        inst._add_req("key", "req")
+        # Tests
+        inst._expire_reqs.assert_called_once_with("key")
+        inst._check.assert_called_once_with("key")
+        inst._fetch.assert_called_once_with("key")
+        ntools.eq_(inst._req_map["key"], [(2, "req")])
+
+    @patch("lib.requests.SCIONTime.get_time", newcallable=create_mock)
+    def test_no_ans_query(self, time_):
+        inst = self._setup(time_)
+        inst._req_map["key"] = [(1, "oldreq")]
+        # Call
+        inst._add_req("key", "req")
+        # Tests
+        ntools.assert_false(inst._fetch.called)
+        ntools.eq_(inst._req_map["key"], [(1, "oldreq"), (2, "req")])
+
+    @patch("lib.requests.SCIONTime.get_time", newcallable=create_mock)
+    def test_ans(self, time_):
+        inst = self._setup(time_)
+        inst._req_map["key"] = [(1, "oldreq")]
+        # Call
+        inst._add_req("key", "req")
+        # Tests
+        ntools.assert_false(inst._fetch.called)
+        ntools.eq_(inst._req_map["key"], [(1, "oldreq"), (2, "req")])
+
+
+class TestRequestHandlerAnswerReqs(object):
+    """
+    Unit tests for lib.requests.RequestHandler._answer_reqs
+    """
+    def _setup(self, check_ret=True):
+        check = create_mock()
+        check.return_value = check_ret
+        reply = create_mock()
+        inst = RequestHandler("queue", check, "fetch", reply)
+        inst._expire_reqs = create_mock()
+        return inst
+
+    def test_no_ans(self):
+        inst = self._setup(False)
+        inst._req_map["key"] = ["req0"]
+        # Call
+        inst._answer_reqs("key")
+        # Tests
+        ntools.eq_(inst._req_map["key"], ["req0"])
+        ntools.assert_false(inst._expire_reqs.called)
+
+    def test_no_reqs(self):
+        inst = self._setup()
+        # Call
+        inst._answer_reqs("key")
+        # Tests
+        ntools.assert_false(inst._expire_reqs.called)
+
+    def test_reqs(self):
+        inst = self._setup()
+        inst._req_map["key"] = [(0, "req0"), (1, "req1"), (2, "req2")]
+        # Call
+        inst._answer_reqs("key")
+        # Tests
+        inst._expire_reqs.assert_called_once_with("key")
+        assert_these_calls(inst._reply,
+                           [call("req0"), call("req1"), call("req2")])
+        ntools.assert_not_in("key", inst._req_map)
+
+
+class TestRequestHandlerExpireReqs(object):
+    """
+    Unit tests for lib.requests.RequestHandler._expire_reqs
+    """
+    def test_no_reqs(self):
+        inst = RequestHandler("queue", "check", "fetch", "reply")
+        # Call
+        inst._expire_reqs("key")
+
+    @patch("lib.requests.SCIONTime.get_time", newcallable=create_mock)
+    def test_reqs(self, time_):
+        inst = RequestHandler("queue", "check", "fetch", "reply", ttl=5)
+        inst._req_map["key"] = [(0, "req0"), (1, "req1"), (2, "req2")]
+        time_.return_value = 6
+        # Call
+        inst._expire_reqs("key")
+        # Tests
+        ntools.eq_(inst._req_map["key"], [(1, "req1"), (2, "req2")])
+
+
+if __name__ == "__main__":
+    nose.run(defaultTest=__name__)


### PR DESCRIPTION
RequestHandler is a small class to take care of tracking incoming
requests, checking to see if they've been fulfiled, and sending back the
responses.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/501%23issuecomment-156137446%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23discussion_r44670860%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23discussion_r44670930%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23discussion_r44672568%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23discussion_r44673071%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23discussion_r44673229%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23discussion_r44673269%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23discussion_r44674077%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23discussion_r44674642%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23issuecomment-156137446%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22For%20%23499%20%22%2C%20%22created_at%22%3A%20%222015-11-12T15%3A25%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2097151959d4ca85bab56ebf0b6d35460ba5d42e52%20lib/requests.py%2053%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23discussion_r44672568%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20definitely%20include%20an%20explanation%20and%20possibly%20a%20usage%20example%20of%20what%20%2Aargs%20and%20%2A%2Akwargs%20can%20and/or%20should%20include.%20%22%2C%20%22created_at%22%3A%20%222015-11-12T15%3A46%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Documenting%20args/kwargs%20here%20is%20a%20bad%20idea%2C%20as%20they%20are%20passed%20directly%20to%20%60__init__%60%2C%20so%20i%27ve%20added%20a%20docstring%20mentioning%20this.%22%2C%20%22created_at%22%3A%20%222015-11-12T15%3A51%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/requests.py%3AL1-104%22%7D%2C%20%22Pull%2097151959d4ca85bab56ebf0b6d35460ba5d42e52%20lib/requests.py%2063%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23discussion_r44674077%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22So%20how%20does%20this%20work%3F%20You%20remove%20an%20entry%20from%20the%20queue%2C%20but%20if%20you%20haven%27t%20received%20an%20answer%20yet%20it%20will%20just%20get%20lost%3F%20%22%2C%20%22created_at%22%3A%20%222015-11-12T15%3A56%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20queue%20is%20for%20communication.%20The%20pending%20requests%20are%20stored%20in%20%60._req_map%60.%22%2C%20%22created_at%22%3A%20%222015-11-12T16%3A00%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/requests.py%3AL1-104%22%7D%2C%20%22Pull%2097151959d4ca85bab56ebf0b6d35460ba5d42e52%20lib/requests.py%2062%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23discussion_r44673071%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20you%20add%20some%20sleep%3F%20Imho%2C%20this%20will%20consume%20100%25%20CPU.%22%2C%20%22created_at%22%3A%20%222015-11-12T15%3A49%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60Queue.get%28%29%60%20is%20blocking.%22%2C%20%22created_at%22%3A%20%222015-11-12T15%3A51%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/requests.py%3AL1-104%22%7D%2C%20%22Pull%2097151959d4ca85bab56ebf0b6d35460ba5d42e52%20lib/requests.py%20101%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/501%23discussion_r44670860%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60if%20not%20self._req_map%5Bkey%5D%3A%20del%20self._req_map%5Bkey%5D%60%20after%20%60for%60%20%3F%22%2C%20%22created_at%22%3A%20%222015-11-12T15%3A35%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22ah%2C%20just%20saw%20it%20is%20executed%20within%20%60_answer_reqs%60%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-12T15%3A36%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/requests.py%3AL1-104%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/501#issuecomment-156137446'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> For #499
- [ ] <a href='#crh-comment-Pull 97151959d4ca85bab56ebf0b6d35460ba5d42e52 lib/requests.py 53'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/501#discussion_r44672568'>File: lib/requests.py:L1-104</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> This should definitely include an explanation and possibly a usage example of what _args and *_kwargs can and/or should include.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Documenting args/kwargs here is a bad idea, as they are passed directly to `__init__`, so i've added a docstring mentioning this.
- [ ] <a href='#crh-comment-Pull 97151959d4ca85bab56ebf0b6d35460ba5d42e52 lib/requests.py 62'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/501#discussion_r44673071'>File: lib/requests.py:L1-104</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Shouldn't you add some sleep? Imho, this will consume 100% CPU.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `Queue.get()` is blocking.
- [ ] <a href='#crh-comment-Pull 97151959d4ca85bab56ebf0b6d35460ba5d42e52 lib/requests.py 63'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/501#discussion_r44674077'>File: lib/requests.py:L1-104</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> So how does this work? You remove an entry from the queue, but if you haven't received an answer yet it will just get lost?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This queue is for communication. The pending requests are stored in `._req_map`.
- [x] <a href='#crh-comment-Pull 97151959d4ca85bab56ebf0b6d35460ba5d42e52 lib/requests.py 101'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/501#discussion_r44670860'>File: lib/requests.py:L1-104</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> `if not self._req_map[key]: del self._req_map[key]` after `for` ?
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> ah, just saw it is executed within `_answer_reqs`
  :+1:

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/501?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/501?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/501'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
