### PR TITLE
Refreshed CS

### DIFF
--- a/infrastructure/cert_server.py
+++ b/infrastructure/cert_server.py
@@ -17,14 +17,18 @@
 ===============================================
 """
 # Stdlib
-import collections
 import logging
-import os
-import re
+import threading
+from collections import defaultdict
+
+# External packages
+from Crypto.Hash import SHA256
 
 # SCION
 from infrastructure.scion_elem import SCIONElement
 from lib.defines import CERTIFICATE_SERVICE, SCION_UDP_PORT
+from lib.errors import SCIONParseError
+from lib.log import log_exception
 from lib.main import main_default, main_wrapper
 from lib.packet.cert_mgmt import (
     CertChainReply,
@@ -32,15 +36,14 @@ from lib.packet.cert_mgmt import (
     TRCReply,
     TRCRequest,
 )
-from lib.packet.scion import PacketType as PT
+from lib.packet.scion import PacketType as PT, SCIONL4Packet
+from lib.thread import thread_safety_net
 from lib.types import CertMgmtType, PayloadClass
 from lib.util import (
-    get_cert_chain_file_path,
-    get_trc_file_path,
-    read_file,
-    write_file,
+    SCIONTime,
+    sleep_interval,
 )
-from lib.zookeeper import Zookeeper
+from lib.zookeeper import ZkNoConnection, ZkSharedCache, Zookeeper
 
 
 class CertServer(SCIONElement):
@@ -49,7 +52,7 @@ class CertServer(SCIONElement):
     """
     SERVICE_TYPE = CERTIFICATE_SERVICE
     # ZK path for incoming cert chains
-    ZK_CERT_CHAIN_CACHE_PATH = "cert_chain_cache"
+    ZK_CC_CACHE_PATH = "cert_chain_cache"
     # ZK path for incoming TRCs
     ZK_TRC_CACHE_PATH = "trc_cache"
 
@@ -60,13 +63,8 @@ class CertServer(SCIONElement):
         :param bool is_sim: running on simulator
         """
         super().__init__(server_id, conf_dir, is_sim=is_sim)
-        self.trc = self.trust_store.get_trc(self.topology.isd_id)
-        self.cert_chain_requests = collections.defaultdict(list)
-        self.trc_requests = collections.defaultdict(list)
-        self.cert_chains = {}
-        self.trcs = {}
-        self._latest_entry_cert_chains = 0
-        self._latest_entry_trcs = 0
+        self.cc_pend_requests = defaultdict(list)
+        self.trc_pend_requests = defaultdict(list)
 
         self.PLD_CLASS_MAP = {
             PayloadClass.CERT: {
@@ -81,186 +79,196 @@ class CertServer(SCIONElement):
             # Add more IPs here if we support dual-stack
             name_addrs = "\0".join([self.id, str(SCION_UDP_PORT),
                                     str(self.addr.host_addr)])
-            self.zk = Zookeeper(self.topology.isd_id, self.topology.ad_id,
-                                CERTIFICATE_SERVICE, name_addrs,
-                                self.topology.zookeepers)
+            self.zk = Zookeeper(
+                self.topology.isd_id, self.topology.ad_id, CERTIFICATE_SERVICE,
+                name_addrs, self.topology.zookeepers)
             self.zk.retry("Joining party", self.zk.party_setup)
+            self.trc_cache = ZkSharedCache(self.zk, self.ZK_TRC_CACHE_PATH,
+                                           self._cached_entries_handler)
+            self.cc_cache = ZkSharedCache(self.zk, self.ZK_CC_CACHE_PATH,
+                                          self._cached_entries_handler)
+
+    def worker(self):
+        """
+        Worker thread that takes care of reading shared entries from ZK, and
+        handling master election.
+        """
+        worker_cycle = 1.0
+        start = SCIONTime.get_time()
+        while True:
+            sleep_interval(start, worker_cycle, "CS.worker cycle")
+            start = SCIONTime.get_time()
+            try:
+                self.zk.wait_connected()
+                self.trc_cache.process()
+                self.cc_cache.process()
+                # Try to become a master.
+                if self.zk.get_lock(lock_timeout=0, conn_timeout=0):
+                    self.trc_cache.expire(worker_cycle * 10)
+                    self.cc_cache.expire(worker_cycle * 10)
+            except ZkNoConnection:
+                logging.warning('worker(): ZkNoConnection')
+                pass
+
+    def _cached_entries_handler(self, raw_entries):
+        """
+        Handles cached (through ZK) TRCs and Cert Chains.
+        """
+        for entry in raw_entries:
+            try:
+                pkt = SCIONL4Packet(raw=entry)
+                pkt.parse_payload()
+                # FIXME(PSz): some checks are necessary, as filesystem may not
+                # be synced with ZK. Also, when we change topology, new TRCs and
+                # certs are generated, while old ones are still in ZK. It looks
+                # to CS like an attack.  This will be fixed when more elements
+                # of trust infrastructure are specified and implemented (like
+                # TRC cross-signing).
+            except SCIONParseError:
+                log_exception("Error parsing cached entry: %s" % entry,
+                              level=logging.ERROR)
+                continue
+            payload = pkt.get_payload()
+            if isinstance(payload, CertChainReply):
+                self.process_cert_chain_reply(pkt, from_zk=True)
+            elif isinstance(payload, TRCReply):
+                self.process_trc_reply(pkt, from_zk=True)
+            else:
+                logging.warning("Entry with unsupported type: %s" % entry)
+
+    def _share_object(self, pkt, is_trc):
+        """
+        Share path segments (via ZK) with other path servers.
+        """
+        pkt_packed = pkt.pack()
+        pkt_hash = SHA256.new(pkt_packed).hexdigest()
+        try:
+            if is_trc:
+                self.trc_cache.store("%s-%s" % (pkt_hash, SCIONTime.get_time()),
+                                     pkt_packed)
+            else:
+                self.cc_cache.store("%s-%s" % (pkt_hash, SCIONTime.get_time()),
+                                    pkt_packed)
+        except ZkNoConnection:
+            logging.warning("Unable to store %s in shared path: "
+                            "no connection to ZK" % "TRC" if is_trc else "CC")
+            return
+        logging.debug("%s stored in ZK: %s" % ("TRC" if is_trc else "CC",
+                                               pkt_hash))
+
+    def _send_reply(self, pkt, reply):
+        src_isd, src_ad = pkt.addrs.src_isd, pkt.addrs.src_ad
+        if (src_isd, src_ad == self.addr.get_isd_ad()):
+            # Local request
+            next_hop = pkt.addrs.src_addr
+        else:
+            # Remote request
+            next_hop = self._get_next_hop(src_isd, src_ad, False, True, True)
+
+        if next_hop:
+            rep_pkt = self._build_packet(PT.CERT_MGMT, dst_isd=src_isd,
+                                         dst_ad=src_ad, payload=reply)
+            self.send(rep_pkt, next_hop)
+            logging.info("Reply sent to (%d, %d)", src_isd, src_ad)
+        else:
+            logging.warning("Reply not sent: no destination found")
 
     def process_cert_chain_request(self, pkt):
         """
         Process a certificate chain request.
 
-        :param cert_chain_req: certificate chain request.
-        :type cert_chain_req: CertChainRequest
+        :param cc_req: certificate chain request.
+        :type cc_req: CertChainRequest
         """
-        cert_chain_req = pkt.get_payload()
-        assert isinstance(cert_chain_req, CertChainRequest)
-        logging.info("Certificate chain request received for %s",
-                     cert_chain_req.short_desc())
-        cert_chain = self.cert_chains.get((cert_chain_req.isd_id,
-                                           cert_chain_req.ad_id,
-                                           cert_chain_req.version))
-        if not cert_chain:
-            # Try loading file from disk
-            cert_chain_file = get_cert_chain_file_path(
-                self.conf_dir, cert_chain_req.isd_id, cert_chain_req.ad_id,
-                cert_chain_req.version)
-            if os.path.exists(cert_chain_file):
-                cert_chain = read_file(cert_chain_file).encode('utf-8')
-                self.cert_chains[(cert_chain_req.isd_id, cert_chain_req.ad_id,
-                                  cert_chain_req.version)] = cert_chain
-        if not cert_chain:
+        cc_req = pkt.get_payload()
+        assert isinstance(cc_req, CertChainRequest)
+        logging.info("Cert chain request received for %s", cc_req.short_desc())
+        isd, ad, ver = cc_req.isd_id, cc_req.ad_id, cc_req.version
+        cert_chain = self.trust_store.get_cert(isd, ad, ver)
+        local = (pkt.addrs.src_isd, pkt.addrs.src_ad == self.addr.get_isd_ad())
+        if not cert_chain and local:
+            logging.debug('Cert chain not found for %s', cc_req.short_desc())
+            self.cc_pend_requests[(isd, ad, ver)].append(pkt.addrs.src_addr)
             # Requesting certificate chain file from parent's cert server
-            logging.debug('Certificate chain not found for %s',
-                          cert_chain_req.short_desc())
-            cert_chain_tuple = (cert_chain_req.isd_id, cert_chain_req.ad_id,
-                                cert_chain_req.version)
-            self.cert_chain_requests[cert_chain_tuple].append(
-                pkt.addrs.src_addr)
-            new_cert_chain_req = CertChainRequest.from_values(
-                cert_chain_req.ingress_if, cert_chain_req.src_isd,
-                cert_chain_req.src_ad, cert_chain_req.isd_id,
-                cert_chain_req.ad_id, cert_chain_req.version)
-            req_pkt = self._build_packet(PT.CERT_MGMT,
-                                         payload=new_cert_chain_req)
-            dst_addr = self.ifid2addr.get(cert_chain_req.ingress_if)
-            if dst_addr:
-                self.send(req_pkt, dst_addr)
-                logging.info("New certificate chain request sent for %s",
-                             cert_chain_req.short_desc())
-            else:
-                logging.warning("Certificate chain request (for %s) not sent: "
-                                "no destination found",
-                                cert_chain_req.short_desc())
+            self._request_cc(cc_req)
+        elif cert_chain:
+            logging.debug('Cert chain found for %s', cc_req.short_desc())
+            cert_chain_rep = CertChainReply.from_values(cert_chain)
+            self._send_reply(pkt, cert_chain_rep)
         else:
-            logging.debug('Certificate chain found for %s',
-                          cert_chain_req.short_desc())
-            dst_addr = None
-            cert_chain_rep = CertChainReply.from_values(
-                cert_chain_req.isd_id, cert_chain_req.ad_id,
-                cert_chain_req.version, cert_chain)
-            rep_pkt = pkt.reversed_copy()
-            rep_pkt.set_payload(cert_chain_rep)
-            rep_pkt.addrs.src_addr = self.addr.host_addr
-            if (cert_chain_req.src_isd == self.topology.isd_id and
-                    cert_chain_req.src_ad == self.topology.ad_id):
-                # Local request, local response
-                first_hop = pkt.addrs.src_addr
-                port = pkt.l4_hdr.src_port
-            else:
-                for router in self.topology.child_edge_routers:
-                    if (cert_chain_req.src_isd ==
-                            router.interface.neighbor_isd) and (
-                            cert_chain_req.src_ad ==
-                            router.interface.neighbor_ad):
-                        first_hop = router.addr
-                        port = SCION_UDP_PORT
-                        rep_pkt.addrs.dst_addr = PT.CERT_MGMT
-                        break
-            if first_hop:
-                self.send(rep_pkt, first_hop, port)
-                logging.info("Certificate chain reply sent for %s",
-                             cert_chain_req.short_desc())
-            else:
-                logging.warning("Certificate chain reply (for %s) not sent: "
-                                "no destination found",
-                                cert_chain_req.short_desc())
+            logging.warning("Dropping CC request (CC not found && not local)")
 
-    def process_cert_chain_reply(self, pkt):
+    def _request_cc(self, cc_req):
+        req_pkt = self._build_packet(PT.CERT_MGMT, payload=cc_req)
+        dst_addr = self._get_next_hop(cc_req.isd_id, cc_req.ad_id, True)
+        if dst_addr:
+            self.send(req_pkt, dst_addr)
+            logging.info("Cert chain request sent for %s", cc_req.short_desc())
+        else:
+            logging.warning("Cert chain request (for %s) not sent: "
+                            "no destination found", cc_req.short_desc())
+
+    def process_cert_chain_reply(self, pkt, from_zk=False):
         """
         Process a certificate chain reply.
 
-        :param cert_chain_rep: certificate chain reply.
-        :type cert_chain_rep: CertChainReply
+        :param pkt: certificate chain reply.
+        :type pkt: CertChainReply
         """
-        cert_chain_rep = pkt.get_payload()
-        assert isinstance(cert_chain_rep, CertChainReply)
-        logging.info("Certificate chain reply received for %s",
-                     cert_chain_rep.short_desc())
-        cert_chain = cert_chain_rep.cert_chain
-        self.cert_chains[(cert_chain_rep.isd_id, cert_chain_rep.ad_id,
-                          cert_chain_rep.version)] = cert_chain
-        cert_chain_file = get_cert_chain_file_path(
-            self.conf_dir, cert_chain_rep.isd_id, cert_chain_rep.ad_id,
-            cert_chain_rep.version)
-        write_file(cert_chain_file, cert_chain.decode('utf-8'))
+        cc_rep = pkt.get_payload()
+        assert isinstance(cc_rep, CertChainReply)
+        logging.info("Cert chain reply received for %s, ZK: %s" %
+                     (cc_rep.short_desc(), from_zk))
+        self.trust_store.add_cert(cc_rep.cert_chain)
+        if not from_zk:
+            self._share_object(pkt, is_trc=False)
         # Reply to all requests for this certificate chain
-        for dst_addr in self.cert_chain_requests[
-                (cert_chain_rep.isd_id, cert_chain_rep.ad_id,
-                 cert_chain_rep.version)]:
-            new_cert_chain_rep = CertChainReply.from_values(
-                cert_chain_rep.isd_id, cert_chain_rep.ad_id,
-                cert_chain_rep.version, cert_chain_rep.cert_chain)
-            rep_pkt = self._build_packet(dst_addr, payload=new_cert_chain_rep)
+        isd, ad, ver = cc_rep.cert_chain.get_leaf_isd_ad_ver()
+        for dst_addr in self.cc_pend_requests[(isd, ad, ver)]:
+            new_cc_rep = CertChainReply.from_values(cc_rep.cert_chain)
+            rep_pkt = self._build_packet(dst_addr, payload=new_cc_rep)
             self.send(rep_pkt, dst_addr)
-        del self.cert_chain_requests[
-            (cert_chain_rep.isd_id,
-             cert_chain_rep.ad_id,
-             cert_chain_rep.version)]
-        logging.info("Certificate chain reply sent for %s",
-                     cert_chain_rep.short_desc())
+        del self.cc_pend_requests[(isd, ad, ver)]
+        logging.info("Cert chain reply sent for %s", cc_rep.short_desc())
 
     def process_trc_request(self, pkt):
         """
         Process a TRC request.
 
-        :param trc_req: TRC request.
-        :type trc_req: TRCRequest.
+        :param pkt: TRC request.
+        :type pkt: SCIONL4Packet.
         """
         trc_req = pkt.get_payload()
         assert isinstance(trc_req, TRCRequest)
         logging.info("TRC request received for ISD %d", trc_req.isd_id)
-        trc = self.trcs.get((trc_req.isd_id, trc_req.version))
-        if not trc:
-            # Try loading file from disk
-            trc_file = get_trc_file_path(
-                self.conf_dir, trc_req.isd_id, trc_req.version)
-            if os.path.exists(trc_file):
-                trc = read_file(trc_file).encode('utf-8')
-                self.trcs[(trc_req.isd_id, trc_req.version)] = trc
-        if not trc:
-            # Requesting TRC file from parent's cert server
+        trc = self.trust_store.get_trc(trc_req.isd_id, trc_req.version)
+        local = (pkt.addrs.src_isd, pkt.addrs.src_ad == self.addr.get_isd_ad())
+        if not trc and local:
             logging.debug('TRC not found for ISD %d.', trc_req.isd_id)
             trc_tuple = (trc_req.isd_id, trc_req.version)
-            self.trc_requests[trc_tuple].append(pkt.addrs.src_addr)
-            new_trc_req = TRCRequest.from_values(
-                trc_req.ingress_if, trc_req.src_isd, trc_req.src_ad,
-                trc_req.isd_id, trc_req.version, local=False)
-            req_pkt = self._build_packet(PT.CERT_MGMT, payload=new_trc_req)
-            dst_addr = self.ifid2addr.get(trc_req.ingress_if)
-            if dst_addr:
-                self.send(req_pkt, dst_addr)
-                logging.info("New TRC request sent for ISD %d.", trc_req.isd_id)
-            else:
-                logging.warning("TRC request not sent for ISD %d: "
-                                "no destination found.", trc_req.isd_id)
-        else:
+            self.trc_pend_requests[trc_tuple].append(pkt.addrs.src_addr)
+            # Requesting TRC file from parent's cert server
+            self._request_trc(trc_req)
+        elif trc:
             logging.debug('TRC found for ISD %d.', trc_req.isd_id)
-            trc_rep = TRCReply.from_values(trc_req.isd_id, trc_req.version, trc)
-            next_hop = None
-            if trc_req.local:
-                next_hop = pkt.addrs.src_addr
-            else:
-                for router in (self.topology.child_edge_routers +
-                               self.topology.routing_edge_routers):
-                    if (trc_req.src_isd == router.interface.neighbor_isd and
-                            trc_req.src_ad == router.interface.neighbor_ad):
-                        next_hop = router.addr
-                        break
-            if next_hop:
-                # FIXME(kormat): this only works when there's one CS in an ad.
-                # https://github.com/netsec-ethz/scion/issues/389 is needed for
-                # when there's more.
-                rep_pkt = self._build_packet(
-                    PT.CERT_MGMT, dst_isd=trc_req.src_isd,
-                    dst_ad=trc_req.src_ad, payload=trc_rep)
-                self.send(rep_pkt, next_hop)
-                logging.info("TRC reply sent to (%d, %d)", trc_req.src_isd,
-                             trc_req.src_ad)
-            else:
-                logging.warning("TRC reply not sent: no destination found")
+            trc_rep = TRCReply.from_values(trc)
+            self._send_reply(pkt, trc_rep)
+        else:
+            logging.warning("Dropping TRC request (TRC not found && not local)")
 
-    def process_trc_reply(self, pkt):
+    def _request_trc(self, trc_req):
+        isd, ad, ver = trc_req.isd_id, trc_req.ad_id, trc_req.version
+        new_trc_req = TRCRequest.from_values(isd, ad, ver)
+        req_pkt = self._build_packet(PT.CERT_MGMT, payload=new_trc_req)
+        next_hop = self._get_next_hop(isd, ad, True, False, True)
+        if next_hop:
+            self.send(req_pkt, next_hop)
+            logging.info("TRC request sent for ISD %d.", isd)
+        else:
+            logging.warning("TRC request not sent for ISD %d: "
+                            "no destination found.", isd)
+
+    def process_trc_reply(self, pkt, from_zk=False):
         """
         Process a TRC reply.
 
@@ -269,48 +277,43 @@ class CertServer(SCIONElement):
         """
         trc_rep = pkt.get_payload()
         assert isinstance(trc_rep, TRCReply)
-        logging.info("TRC reply received for ISD %d", trc_rep.isd_id)
-        trc = trc_rep.trc
-        self.trcs[(trc_rep.isd_id, trc_rep.version)] = trc
-        trc_file = get_trc_file_path(
-            self.conf_dir, trc_rep.isd_id, trc_rep.version)
-        write_file(trc_file, trc.decode('utf-8'))
+        isd, ver = trc_rep.trc.get_isd_ver()
+        logging.info("TRCReply received for ISD %d, ZK: %s" % (isd, from_zk))
+        self.trust_store.add_trc(trc_rep.trc)
+        if not from_zk:
+            self._share_object(pkt, is_trc=True)
         count = 0
         # Reply to all requests for this TRC
-        for dst_addr in self.trc_requests[(trc_rep.isd_id, trc_rep.version)]:
-            new_trc_rep = TRCReply.from_values(trc_rep.isd_id, trc_rep.version,
-                                               trc_rep.trc)
+        for dst_addr in self.trc_pend_requests[(isd, ver)]:
+            new_trc_rep = TRCReply.from_values(trc_rep.trc)
             rep_pkt = self._build_packet(dst_addr, payload=new_trc_rep)
             self.send(rep_pkt, dst_addr)
             count += 1
-        del self.trc_requests[(trc_rep.isd_id, trc_rep.version)]
-        logging.info("TRC replies (%d) sent for ISD %d.", count, trc_rep.isd_id)
+        del self.trc_pend_requests[(isd, ver)]
+        logging.info("TRC replies (%d) sent for ISD %d.", count, isd)
 
-    def _get_cert_chain_identifiers(self, entry):
+    def _get_next_hop(self, isd, ad, parent=False, child=False, routing=False):
+        routers = []
+        if parent:
+            routers += self.topology.parent_edge_routers
+        if child:
+            routers += self.topology.child_edge_routers
+        if routing:
+            routers += self.topology.routing_edge_routers
+        for r in routers:
+            if (isd, ad) == (r.interface.neighbor_isd, r.interface.neighbor_ad):
+                return r.addr
+        return None
+
+    def run(self):
         """
-        Get the isd_id, ad_id, and version values from the entry name.
-
-        :param entry: certificate chain full name.
-        :type entry: string
-
-        :returns: certificate chain identifiers.
-        :rtype: tuple
+        Run an instance of the Cert Server.
         """
-        identifiers = re.split(':|-', entry)
-        return (int(identifiers[1]), int(identifiers[3]), int(identifiers[5]))
+        threading.Thread(
+            target=thread_safety_net, args=(self.worker,),
+            name="CS.worker", daemon=True).start()
 
-    def _get_trc_identifiers(self, entry):
-        """
-        Get the isd_id and version values from the entry name.
-
-        :param entry: TRC full name
-        :type entry: string
-
-        :returns: TRC identifiers.
-        :rtype: tuple
-        """
-        identifiers = re.split(':|-', entry)
-        return (int(identifiers[1]), int(identifiers[3]))
+        super().run()
 
 
 if __name__ == "__main__":

--- a/lib/crypto/certificate.py
+++ b/lib/crypto/certificate.py
@@ -374,9 +374,16 @@ class CertificateChain(object):
             return False
         return True
 
-    def __str__(self):
+    def get_leaf_isd_ad_ver(self):
+        if not self.certs:
+            return None
+        leaf_cert = self.certs[0]
+        isd, ad = map(int, leaf_cert.subject.split('-'))
+        return isd, ad, leaf_cert.version
+
+    def to_json(self):
         """
-        Convert the instance in a readable format.
+        Convert the instance to json format.
 
         :returns: the CertificateChain information.
         :rtype: str
@@ -395,6 +402,12 @@ class CertificateChain(object):
             index += 1
         chain_str = json.dumps(chain_dict, sort_keys=True, indent=4)
         return chain_str
+
+    def pack(self):
+        return self.to_json().encode('utf-8')
+
+    def __str__(self):
+        return self.to_json()
 
 
 class TRC(object):
@@ -459,6 +472,9 @@ class TRC(object):
         self.signatures = {}
         if trc_raw:
             self.parse(trc_raw)
+
+    def get_isd_ver(self):
+        return self.isd_id, self.version
 
     def get_trc_dict(self, with_signatures):
         """
@@ -592,7 +608,7 @@ class TRC(object):
         :returns: True or False whether the verification succeeds or fails.
         :rtype: bool
         """
-        msg = self.__str__(with_signatures=False).encode('utf-8')
+        msg = self.to_json(with_signatures=False).encode('utf-8')
         for signer in self.signatures:
             if signer not in self.core_ads:
                 logging.warning("A signature could not be verified.")
@@ -603,9 +619,9 @@ class TRC(object):
                 return False
         return True
 
-    def __str__(self, with_signatures=True):
+    def to_json(self, with_signatures=True):
         """
-        Convert the instance in a readable format.
+        Convert the instance to json format.
 
         :param with_signatures:
         :type with_signatures:
@@ -625,3 +641,9 @@ class TRC(object):
                     base64.b64encode(signature).decode('utf-8')
         trc_str = json.dumps(trc_dict, sort_keys=True, indent=4)
         return trc_str
+
+    def pack(self):
+        return self.to_json().encode('utf-8')
+
+    def __str__(self):
+        return self.to_json()

--- a/test/lib_trust_store_test.py
+++ b/test/lib_trust_store_test.py
@@ -1,0 +1,137 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`lib_trust_store_test` --- lib.trust_store unit tests
+==========================================================
+"""
+# External packages
+import nose.tools as ntools
+
+# SCION
+from lib.trust_store import TrustStore
+from test.testcommon import create_mock
+
+
+class TestTrustStoreGetTrc(object):
+    """
+    Unit tests for lib.trust_store.TrustStore.get_trc
+    """
+    def _init(self):
+        inst = TrustStore("conf_dir")
+        inst._trcs[1] = [(1, 'trc1'), (3, 'trc3'), (0, 'trc0')]
+        return inst
+
+    def test_non_existing_isd(self):
+        inst = self._init()
+        # Call
+        ntools.eq_(inst.get_trc(2), None)
+
+    def test_non_existing_version(self):
+        inst = self._init()
+        # Call
+        ntools.eq_(inst.get_trc(1, 2), None)
+
+    def test_default_version(self):
+        inst = self._init()
+        # Call
+        ntools.eq_(inst.get_trc(1), 'trc3')
+
+    def test_existing_version(self):
+        inst = self._init()
+        # Call
+        ntools.eq_(inst.get_trc(1, 1), 'trc1')
+
+
+class TestTrustStoreGetCert(object):
+    """
+    Unit tests for lib.trust_store.TrustStore.get_cert
+    """
+    def _init(self):
+        inst = TrustStore("conf_dir")
+        inst._certs[(1, 1)] = [(1, 'cert1'), (3, 'cert3'), (0, 'cert0')]
+        return inst
+
+    def test_non_existing_isd(self):
+        inst = self._init()
+        # Call
+        ntools.eq_(inst.get_cert(2, 2), None)
+
+    def test_non_existing_version(self):
+        inst = self._init()
+        # Call
+        ntools.eq_(inst.get_cert(1, 1, 2), None)
+
+    def test_default_version(self):
+        inst = self._init()
+        # Call
+        ntools.eq_(inst.get_cert(1, 1), 'cert3')
+
+    def test_existing_version(self):
+        inst = self._init()
+        # Call
+        ntools.eq_(inst.get_cert(1, 1, 1), 'cert1')
+
+
+class TestTrustStoreAddTrc(object):
+    """
+    Unit tests for lib.trust_store.TrustStore.add_trc
+    """
+    def test_add_unique_version(self):
+        inst = TrustStore("conf_dir")
+        inst._trcs[1] = [(0, 'trc0'), (1, 'trc1')]
+        trcs_before = inst._trcs[1][:]
+        trc = create_mock(['get_isd_ver'])
+        trc.get_isd_ver.return_value = (1, 2)
+        # Call
+        inst.add_trc(trc)
+        # Tests
+        ntools.eq_(inst._trcs[1], trcs_before + [(2, trc)])
+
+    def test_add_non_unique_version(self):
+        inst = TrustStore("conf_dir")
+        inst._trcs[1] = [(0, 'trc0'), (1, 'trc1')]
+        trcs_before = inst._trcs[1][:]
+        trc = create_mock(['get_isd_ver'])
+        trc.get_isd_ver.return_value = (1, 1)
+        # Call
+        inst.add_trc(trc)
+        # Tests
+        ntools.eq_(inst._trcs[1], trcs_before)
+
+
+class TestTrustStoreAddCert(object):
+    """
+    Unit tests for lib.trust_store.TrustStore.add_cert
+    """
+    def test_add_unique_version(self):
+        inst = TrustStore("conf_dir")
+        inst._certs[(1, 1)] = [(0, 'cert0'), (1, 'cert1')]
+        certs_before = inst._certs[(1, 1)][:]
+        cert = create_mock(['get_leaf_isd_ad_ver'])
+        cert.get_leaf_isd_ad_ver.return_value = (1, 1, 2)
+        # Call
+        inst.add_cert(cert)
+        # Tests
+        ntools.eq_(inst._certs[(1, 1)], certs_before + [(2, cert)])
+
+    def test_add_non_unique_version(self):
+        inst = TrustStore("conf_dir")
+        inst._certs[(1, 1)] = [(0, 'cert0'), (1, 'cert1')]
+        certs_before = inst._certs[(1, 1)][:]
+        cert = create_mock(['get_leaf_isd_ad_ver'])
+        cert.get_leaf_isd_ad_ver.return_value = (1, 1, 1)
+        # Call
+        inst.add_cert(cert)
+        # Tests
+        ntools.eq_(inst._certs[(1, 1)], certs_before)

--- a/topology/ADConfigurations.json
+++ b/topology/ADConfigurations.json
@@ -11,7 +11,7 @@
         "1-11": {
             "level": "CORE",
             "beacon_servers": 1,
-            "certificate_servers": 1,
+            "certificate_servers": 3,
             "path_servers": 3,
             "links": {
                 "1-12": "ROUTING",
@@ -52,6 +52,7 @@
         "1-13": {
             "level": "CORE",
             "beacon_servers": 2,
+            "certificate_servers": 3,
             "dns_servers": 2,
             "links": {
                 "1-11": "ROUTING",
@@ -63,6 +64,7 @@
             "level": "INTERMEDIATE",
             "path_servers": 1,
             "cert_issuer": "1-11",
+            "certificate_servers": 3,
             "links": {
                 "1-11": "PARENT",
                 "1-15": "PEER",
@@ -83,6 +85,7 @@
         "1-16": {
             "level": "INTERMEDIATE",
             "beacon_servers": 3,
+            "certificate_servers": 3,
             "cert_issuer": "1-13",
             "links": {
                 "1-13": "PARENT",
@@ -107,6 +110,7 @@
         "1-19": {
             "level": "INTERMEDIATE",
             "path_servers": 2,
+            "certificate_servers": 3,
             "cert_issuer": "1-16",
             "links": {
                 "1-16": "PARENT",
@@ -150,6 +154,7 @@
         "2-24": {
             "level": "INTERMEDIATE",
             "cert_issuer": "2-22",
+            "certificate_servers": 3,
             "links": {
                 "2-22": "PARENT",
                 "2-23": "PEER",

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -313,7 +313,7 @@ class CertGenerator(object):
         if ad_conf['level'] != CORE_AD:
             return
         trc = self.trcs[topo_id.isd]
-        trc_str = trc.__str__(with_signatures=False).encode('utf-8')
+        trc_str = trc.to_json(with_signatures=False).encode('utf-8')
         trc.signatures[str(topo_id)] = sign(
             trc_str, self.sig_priv_keys[topo_id])
 


### PR DESCRIPTION
Should be fine for 0.1, however trust infrastructure in general needs to be (re)designed.
Changes:
- using trust store in CS
- removed writing/reading from filesystem
- added support for ZK
- support for  multiple CSes within AD (fixing #389)
- saner {TRC,CertChain}{Request,Reply} classes
- multiple CSes added to topology

Next PR:
- unit tests for trust store
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/505%23issuecomment-156393419%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23issuecomment-156416115%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23issuecomment-156473218%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23issuecomment-156475997%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23issuecomment-156483198%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44773846%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44774030%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44774048%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44774060%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44776195%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44776201%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44776209%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44777743%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44777845%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44778105%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44778499%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44778693%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44778729%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44778840%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44778957%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44779048%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44779620%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44779885%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44779912%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44781862%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44782541%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44783095%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44792272%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44792400%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44792469%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797413%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797450%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797489%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797520%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797548%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797570%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797639%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797668%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797698%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797758%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797812%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797824%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797869%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44797921%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44798115%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44800112%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23issuecomment-156393419%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20%22%2C%20%22created_at%22%3A%20%222015-11-13T10%3A38%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22unit%20tests%20added%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A15%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Please%20squash%20to%20a%20single%20commit%20%28https%3A//github.com/netsec-ethz/scion/wiki/How-to-use-Git-and-Github%23code-reviews%29%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A01%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done.%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A12%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A42%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20267705a10723994b760703b2707f4a1db8d22b7c%20test/lib_trust_store_test.py%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44783095%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T13%3A47%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_trust_store_test.py%3AL1-138%22%7D%2C%20%22Pull%20267705a10723994b760703b2707f4a1db8d22b7c%20infrastructure/cert_server.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44777743%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Sort%20imports%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A38%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A55%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/cert_server.py%3AL19-35%22%7D%2C%20%22Pull%2021f39359c5ae61acef43c88a5e19e3bc9ad44d20%20test/lib_packet_cert_mgmt_test.py%20131%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44798115%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20testcase%20can%20be%20removed%20now%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A00%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22ping%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A14%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_cert_mgmt_test.py%3AL109-120%22%7D%2C%20%22Pull%20267705a10723994b760703b2707f4a1db8d22b7c%20infrastructure/cert_server.py%20111%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44778105%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22s/no%20be/not%20be/%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A43%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A56%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/cert_server.py%3AL79-297%22%7D%2C%20%22Pull%20759cb070618a441092642c377dcbd001536f851b%20lib/crypto/certificate.py%2069%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44774060%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ditto%20re%3A%20%60bytes%60%22%2C%20%22created_at%22%3A%20%222015-11-13T11%3A42%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A15%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A55%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/crypto/certificate.py%3AL641-650%22%7D%2C%20%22Pull%20267705a10723994b760703b2707f4a1db8d22b7c%20infrastructure/cert_server.py%20267%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44779620%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20order%20of%20the%20methods%20is%20a%20bit%20random%3A%5Cr%5Cn-%20_request_cc%5Cr%5Cn-%20process_cert_chain_request%5Cr%5Cn-%20_get_next_hop%5Cr%5Cn-%20process_cert_chain_reply%5Cr%5Cn-%20process_trc_request%5Cr%5Cn-%20_request_trc%5Cr%5Cn-%20process_trc_reply%5Cr%5Cn-%20run%5Cr%5Cn%5Cr%5CnMy%20suggestion%20would%20be%20to%20group%20them%20more%20methodically%20%28heh%29%3A%5Cr%5Cn-%20process_cert_chain_request%5Cr%5Cn-%20_request_cc%5Cr%5Cn-%20process_cert_chain_reply%5Cr%5Cn-%20process_trc_request%5Cr%5Cn-%20_request_trc%5Cr%5Cn-%20process_trc_reply%5Cr%5Cn-%20_get_next_hop%5Cr%5Cn-%20run%22%2C%20%22created_at%22%3A%20%222015-11-13T13%3A03%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A57%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/cert_server.py%3AL79-297%22%7D%2C%20%22Pull%20759cb070618a441092642c377dcbd001536f851b%20lib/crypto/certificate.py%2056%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44774048%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T11%3A42%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/crypto/certificate.py%3AL619-628%22%7D%2C%20%22Pull%20267705a10723994b760703b2707f4a1db8d22b7c%20lib/packet/cert_mgmt.py%20152%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44782541%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%23pragma%3A%20no%20cover%60%2C%20IMO.%22%2C%20%22created_at%22%3A%20%222015-11-13T13%3A40%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A58%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/cert_mgmt.py%3AL99-154%22%7D%2C%20%22Pull%20759cb070618a441092642c377dcbd001536f851b%20lib/crypto/certificate.py%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44774030%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Calling%20%60.encode%60%20already%20converts%20it%20to%20%60bytes%60%22%2C%20%22created_at%22%3A%20%222015-11-13T11%3A42%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A15%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A55%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/crypto/certificate.py%3AL403-415%22%7D%2C%20%22Pull%20759cb070618a441092642c377dcbd001536f851b%20lib/crypto/certificate.py%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44773846%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20slightly%20easier%20to%20read%20like%20this%3A%5Cr%5Cn%60%60%60%5Cr%5Cnif%20not%20self.certs%3A%5Cr%5Cn%20%20return%20None%5Cr%5Cnleaf_cert%20%3D%20self.certs%5B0%5D%5Cr%5Cn...%5Cr%5Cnreturn%20isd%2C%20ad%2C%20leaf_cert.version%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-11-13T11%3A38%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22fixed%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A15%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A54%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/crypto/certificate.py%3AL374-390%22%7D%2C%20%22Pull%20267705a10723994b760703b2707f4a1db8d22b7c%20infrastructure/cert_server.py%20161%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44778729%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20method%20really%20needs%20to%20be%20split%20up.%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A51%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A57%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/cert_server.py%3AL79-297%22%7D%2C%20%22Pull%20267705a10723994b760703b2707f4a1db8d22b7c%20test/lib_packet_cert_mgmt_test.py%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44781862%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20don%27t%20need%20to%20use%20%60assert_these_calls%60%20when%20there%27s%20only%20one%20call.%20%60isd_ad.assert_called_once_with%28%5C%22target%20ISD-AD%5C%22%29%60%20would%20be%20sufficient.%22%2C%20%22created_at%22%3A%20%222015-11-13T13%3A31%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A58%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_cert_mgmt_test.py%3AL48-65%22%7D%2C%20%22Pull%20267705a10723994b760703b2707f4a1db8d22b7c%20infrastructure/cert_server.py%20235%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44778957%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20might%20make%20more%20sense%20just%20to%20use%20%60pkt.reversed_copy%28%29%60%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A54%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22and%20change%20%60_get_next_hop%60%20to%20work%20for%20local%20addresses.%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A56%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sure%2C%20how%20would%20it%20help.%20Case%20of%20CS%20is%20somehow%20special.%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A18%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A57%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/cert_server.py%3AL79-297%22%7D%2C%20%22Pull%20267705a10723994b760703b2707f4a1db8d22b7c%20infrastructure/cert_server.py%20151%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44778499%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Given%20you%27re%20just%20making%20an%20identical%20object%2C%20why%20not%20just%20use%20it%20directly%3F%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A48%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A56%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/cert_server.py%3AL79-297%22%7D%2C%20%22Pull%20267705a10723994b760703b2707f4a1db8d22b7c%20infrastructure/cert_server.py%20193%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44778693%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20throws%20away%20the%20source%20isd/ad.%20Is%20that%20intentional%3F%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A51%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60pkt.addrs.get_src_addr%28%29%60%20is%20probably%20more%20appropriate%2C%20it%20returns%20a%20SCIONAddr%20value.%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A53%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20intentional.%20Only%20local%20requests%20should%20be%20in%20a%20pending%20list.%20I%20changed%20that%20a%20little%20bit.%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A17%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A56%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/cert_server.py%3AL79-297%22%7D%2C%20%22Pull%20267705a10723994b760703b2707f4a1db8d22b7c%20infrastructure/cert_server.py%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44777845%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Importing%20%60defaultdict%60%20from%20%60collections%60%20would%20be%20more%20consistent%20with%20elsewhere.%22%2C%20%22created_at%22%3A%20%222015-11-13T12%3A39%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A55%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/cert_server.py%3AL19-35%22%7D%2C%20%22Pull%20267705a10723994b760703b2707f4a1db8d22b7c%20infrastructure/cert_server.py%20443%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/505%23discussion_r44779885%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%27s%20now%20two%20methods%20which%20send%20replies%20to%20TRCs%2C%20%60process_trc_request%60%20%28when%20a%20request%20can%20be%20fulfilled%20immediately%29%20and%20%60process_trc_reply%60%20%28when%20it%20can%27t%29.%20It%20would%20make%20more%20sense%20to%20have%20a%20single%20method%20for%20sending%20the%20replies%2C%20and%20call%20it%20from%20both.%22%2C%20%22created_at%22%3A%20%222015-11-13T13%3A06%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Same%20applies%20to%20CC%20requests%22%2C%20%22created_at%22%3A%20%222015-11-13T13%3A06%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22These%20cases%20are%20different%2C%20and%20IMO%20it%27s%20fine%20to%20have%20it%20as%20it%20is.%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A18%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A58%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/cert_server.py%3AL299-329%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/kormat%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/kormat'><img src='https://avatars.githubusercontent.com/u/6919822?v=3' width=34 height=34></a>
- [ ] <a href='#crh-comment-Pull 21f39359c5ae61acef43c88a5e19e3bc9ad44d20 test/lib_packet_cert_mgmt_test.py 131'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44798115'>File: test/lib_packet_cert_mgmt_test.py:L109-120</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This testcase can be removed now
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> ping
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#issuecomment-156393419'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> @kormat
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> unit tests added
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Please squash to a single commit (https://github.com/netsec-ethz/scion/wiki/How-to-use-Git-and-Github#code-reviews)
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> Done.
- [x] <a href='#crh-comment-Pull 759cb070618a441092642c377dcbd001536f851b lib/crypto/certificate.py 10'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44773846'>File: lib/crypto/certificate.py:L374-390</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It's slightly easier to read like this:

```
if not self.certs:
return None
leaf_cert = self.certs[0]
...
return isd, ad, leaf_cert.version
```
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> fixed
- [x] <a href='#crh-comment-Pull 759cb070618a441092642c377dcbd001536f851b lib/crypto/certificate.py 24'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44774030'>File: lib/crypto/certificate.py:L403-415</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Calling `.encode` already converts it to `bytes`
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> fixed
- [x] <a href='#crh-comment-Pull 759cb070618a441092642c377dcbd001536f851b lib/crypto/certificate.py 69'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44774060'>File: lib/crypto/certificate.py:L641-650</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ditto re: `bytes`
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> fixed
- [x] <a href='#crh-comment-Pull 267705a10723994b760703b2707f4a1db8d22b7c infrastructure/cert_server.py 13'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44777743'>File: infrastructure/cert_server.py:L19-35</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Sort imports
- [x] <a href='#crh-comment-Pull 267705a10723994b760703b2707f4a1db8d22b7c infrastructure/cert_server.py 2'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44777845'>File: infrastructure/cert_server.py:L19-35</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Importing `defaultdict` from `collections` would be more consistent with elsewhere.
- [x] <a href='#crh-comment-Pull 267705a10723994b760703b2707f4a1db8d22b7c infrastructure/cert_server.py 111'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44778105'>File: infrastructure/cert_server.py:L79-297</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> s/no be/not be/
- [x] <a href='#crh-comment-Pull 267705a10723994b760703b2707f4a1db8d22b7c infrastructure/cert_server.py 151'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44778499'>File: infrastructure/cert_server.py:L79-297</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Given you're just making an identical object, why not just use it directly?
- [x] <a href='#crh-comment-Pull 267705a10723994b760703b2707f4a1db8d22b7c infrastructure/cert_server.py 193'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44778693'>File: infrastructure/cert_server.py:L79-297</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This throws away the source isd/ad. Is that intentional?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `pkt.addrs.get_src_addr()` is probably more appropriate, it returns a SCIONAddr value.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> It is intentional. Only local requests should be in a pending list. I changed that a little bit.
- [x] <a href='#crh-comment-Pull 267705a10723994b760703b2707f4a1db8d22b7c infrastructure/cert_server.py 161'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44778729'>File: infrastructure/cert_server.py:L79-297</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This method really needs to be split up.
- [x] <a href='#crh-comment-Pull 267705a10723994b760703b2707f4a1db8d22b7c infrastructure/cert_server.py 235'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44778957'>File: infrastructure/cert_server.py:L79-297</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It might make more sense just to use `pkt.reversed_copy()`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> and change `_get_next_hop` to work for local addresses.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> I'm not sure, how would it help. Case of CS is somehow special.
- [x] <a href='#crh-comment-Pull 267705a10723994b760703b2707f4a1db8d22b7c infrastructure/cert_server.py 267'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44779620'>File: infrastructure/cert_server.py:L79-297</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The order of the methods is a bit random:
- _request_cc
- process_cert_chain_request
- _get_next_hop
- process_cert_chain_reply
- process_trc_request
- _request_trc
- process_trc_reply
- run
  My suggestion would be to group them more methodically (heh):
- process_cert_chain_request
- _request_cc
- process_cert_chain_reply
- process_trc_request
- _request_trc
- process_trc_reply
- _get_next_hop
- run
- [x] <a href='#crh-comment-Pull 267705a10723994b760703b2707f4a1db8d22b7c infrastructure/cert_server.py 443'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44779885'>File: infrastructure/cert_server.py:L299-329</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> There's now two methods which send replies to TRCs, `process_trc_request` (when a request can be fulfilled immediately) and `process_trc_reply` (when it can't). It would make more sense to have a single method for sending the replies, and call it from both.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same applies to CC requests
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> These cases are different, and IMO it's fine to have it as it is.
- [x] <a href='#crh-comment-Pull 267705a10723994b760703b2707f4a1db8d22b7c test/lib_packet_cert_mgmt_test.py 30'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44781862'>File: test/lib_packet_cert_mgmt_test.py:L48-65</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You don't need to use `assert_these_calls` when there's only one call. `isd_ad.assert_called_once_with("target ISD-AD")` would be sufficient.
- [x] <a href='#crh-comment-Pull 267705a10723994b760703b2707f4a1db8d22b7c lib/packet/cert_mgmt.py 152'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/505#discussion_r44782541'>File: lib/packet/cert_mgmt.py:L99-154</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `#pragma: no cover`, IMO.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/505?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/505?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/505?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/505'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
