### PR TITLE
Assign fixed IP addresses

### DIFF
--- a/topology/generator.py
+++ b/topology/generator.py
@@ -746,7 +746,7 @@ class SubnetGenerator(object):
     def alloc_subnets(self):
         max_prefix = self._net.max_prefixlen
         networks = {}
-        for subnet in self._subnets.values():
+        for topo, subnet in sorted(self._subnets.items(), key=lambda x: str(x)):
             # Figure out what size subnet we need. If it's a link, then we just
             # need a /31 (or /127), otherwise add 2 to the subnet size to cover
             # the network and broadcast addresses.
@@ -788,7 +788,7 @@ class AddressGenerator(object):
     def alloc_addrs(self, subnet):
         hosts = subnet.hosts()
         interfaces = {}
-        for elem, proxy in self._addrs.items():
+        for elem, proxy in sorted(self._addrs.items()):
             intf = ip_interface("%s/%s" % (next(hosts), subnet.prefixlen))
             interfaces[elem] = intf
             proxy.set_intf(intf)


### PR DESCRIPTION
topology/generator.py randomly assigns IP addresses as follows.

```
    "BeaconServers": {
        "bs1-13-1": {
            "Addr": "127.0.0.25/28"
        },
```

```
    "BeaconServers": {
        "bs1-13-1": {
            "Addr": "127.0.0.81/28"
        },
```

So, each test environment has different IP address assignment, even though they have the same topology.
This patch fixes IP address assignment.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/506%23issuecomment-156428241%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/506%23issuecomment-156436255%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/506%23issuecomment-156441224%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/506%23issuecomment-156428241%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20you%20explain%20the%20reason%20for%20the%20change%3F%20Having%20IP%20addresses%20be%20fluid%20prevents%20anything%20from%20depending%20on%20static%20IPs/allocations.%22%2C%20%22created_at%22%3A%20%222015-11-13T13%3A12%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22To%20integrate%20HSR%20with%20python%20router%2C%20they%20need%20the%20same%20configuration.%20But%2C%20HSR%20runs%20in%20virtual%20box%2C%20so%20it%20does%20not%20share%20the%20gen%20directory%20with%20its%20host.%20%5Cr%5CnThis%20modification%20allow%20to%20generate%20the%20same%20configuration%20in%20virtual%20box%20and%20the%20host.%20%28Otherwise%2C%20we%20have%20to%20copy%20the%20gen%20directory%20using%20scp%20or%20something.%29%5Cr%5CnAnd%20also%2C%20the%20same%20configuration%20may%20help%20to%20reproduce%20bugs.%22%2C%20%22created_at%22%3A%20%222015-11-13T13%3A55%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9196745%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/taka-sasaki%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20that%20makes%20sense.%20Can%20you%20use%20git%20rebase%20-i%20to%20squash%20the%20two%20commits%20into%20one%2C%20please%3F%22%2C%20%22created_at%22%3A%20%222015-11-13T14%3A08%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/506#issuecomment-156428241'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Can you explain the reason for the change? Having IP addresses be fluid prevents anything from depending on static IPs/allocations.
- <a href='https://github.com/taka-sasaki'><img border=0 src='https://avatars.githubusercontent.com/u/9196745?v=3' height=16 width=16'></a> To integrate HSR with python router, they need the same configuration. But, HSR runs in virtual box, so it does not share the gen directory with its host.
  This modification allow to generate the same configuration in virtual box and the host. (Otherwise, we have to copy the gen directory using scp or something.)
  And also, the same configuration may help to reproduce bugs.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok, that makes sense. Can you use git rebase -i to squash the two commits into one, please?

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/506?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/506?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/506'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
