### PR TITLE
Implements error handling for ifid2addr in path server.

### DIFF
--- a/endhost/gateway.py
+++ b/endhost/gateway.py
@@ -113,9 +113,13 @@ class SCIONGateway(object):
                         cmn_hdr, addr_hdr, paths[0],
                         payload=PayloadRaw(raw_packet))
                     (next_hop, port) = self.sd.get_first_hop(spkt)
-                    self.sd.send(spkt, next_hop, port)
-                    logging.info("Sending packet: %s\nFirst hop: %s:%s", spkt,
-                                 next_hop, port)
+                    if next_hop is None:
+                        logging.error("Next hop is None for Interface %d",
+                                      spkt.path.get_fwd_if())
+                    else:
+                        logging.info("Sending packet: %s\nFirst hop: %s:%s",
+                                     spkt, next_hop, port)
+                        self.sd.send(spkt, next_hop, port)
                 else:
                     logging.warning("No path to: %s", scion_addr)
             else:

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -172,7 +172,11 @@ class SCIONElement(object):
                 return spkt.addrs.dst_addr, spkt.l4_hdr.dst_port
             else:
                 return spkt.addrs.dst_addr, SCION_UDP_PORT
-        return self.ifid2addr[spkt.path.get_fwd_if()], SCION_UDP_PORT
+        if_id = spkt.path.get_fwd_if()
+        if if_id in self.ifid2addr:
+            return self.ifid2addr[if_id], SCION_UDP_PORT
+        else:
+            return None, None
 
     def _build_packet(self, dst_host=None, path=None, ext_hdrs=(), dst_isd=None,
                       dst_ad=None, payload=None, dst_port=SCION_UDP_PORT):

--- a/simulator/application/sim_ping_pong.py
+++ b/simulator/application/sim_ping_pong.py
@@ -121,6 +121,10 @@ class SimPingApp(SCIONSimApplication):
         spkt = SCIONL4Packet.from_values(cmn_hdr, addr_hdr, path, [], udp_hdr,
                                          payload)
         (next_hop, port) = self.host.get_first_hop(spkt)
+        if next_hop is None:
+            logging.error("Next hop is None for Interface %d",
+                          spkt.path.get_fwd_if())
+            return
         logging.info("Sending packet: %s\nFirst hop: %s:%s",
                      spkt, next_hop, port)
         self.host.send(spkt, next_hop, port)
@@ -182,4 +186,5 @@ class SimPongApp(SCIONSimApplication):
             spkt.reverse()
             spkt.set_payload(PayloadRaw(b"pong"))
             (next_hop, port) = self.host.get_first_hop(spkt)
+            assert next_hop is not None
             self.host.send(spkt, next_hop, port)

--- a/test/integration/bandwidth_test.py
+++ b/test/integration/bandwidth_test.py
@@ -102,6 +102,7 @@ class TestBandwidth(unittest.TestCase):
             haddr_parse("IPV4", "127.2.26.254"), dst_isd=2, dst_ad=26,
             dst_port=rcv_sock.port, payload=payload, path=paths[0])
         (next_hop, port) = sender.get_first_hop(spkt)
+        assert next_hop is not None
         logging.info("Sending %d payload bytes (%d packets x %d bytes )" %
                      (PACKETS_NO * PAYLOAD_SIZE, PACKETS_NO, PAYLOAD_SIZE))
         for _ in range(PACKETS_NO):

--- a/test/integration/cli_srv_ext_test.py
+++ b/test/integration/cli_srv_ext_test.py
@@ -74,6 +74,7 @@ def client(c_addr, s_addr):
                                      payload)
     # Determine first hop (i.e., local address of border router)
     (next_hop, port) = sd.get_first_hop(spkt)
+    assert next_hop is not None
     logging.info("CLI: Sending packet:\n%s\nFirst hop: %s:%s",
                  spkt, next_hop, port)
     # Send packet to first hop (it is sent through SCIONDaemon)
@@ -110,6 +111,7 @@ def server(addr):
         spkt.set_payload(PayloadRaw(b"response"))
         # Determine first hop (i.e., local address of border router)
         (next_hop, port) = sd.get_first_hop(spkt)
+        assert next_hop is not None
         # Send packet to first hop (it is sent through SCIONDaemon)
         sd.send(spkt, next_hop, port)
     logging.info("SRV: Leaving server.")

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -132,6 +132,7 @@ class Ping(object):
         spkt = SCIONL4Packet.from_values(
             cmn_hdr, addr_hdr, self.path, [], udp_hdr, payload)
         (next_hop, port) = self.sd.get_first_hop(spkt)
+        assert next_hop is not None
         assert next_hop == self.hop
 
         logging.info("Sending packet: \n%s\nFirst hop: %s:%s",
@@ -186,6 +187,7 @@ class Pong(object):
             spkt.reverse()
             spkt.set_payload(PayloadRaw(b"pong " + self.token))
             (next_hop, port) = self.sd.get_first_hop(spkt)
+            assert next_hop is not None
             self.sd.send(spkt, next_hop, port)
         self.sock.close()
         self.sd.stop()


### PR DESCRIPTION
Addresses issue https://github.com/netsec-ethz/scion/issues/492
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/507%23issuecomment-156467084%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/507%23issuecomment-156475859%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/507%23issuecomment-156480218%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/507%23issuecomment-156482171%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/507%23discussion_r44798862%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/507%23discussion_r44798922%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/507%23discussion_r44798978%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/507%23discussion_r44799169%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/507%23issuecomment-156467084%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20%40pszalach%20%22%2C%20%22created_at%22%3A%20%222015-11-13T15%3A40%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%20otherwise.%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A12%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20just%20addressed%20your%20comments.%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A29%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A37%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20eb4b51744b12dbc81f4370645762c94beaa01651%20infrastructure/path_server.py%2068%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/507%23discussion_r44798978%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20could%20still%20be%20calculated%20outside%20the%20loop%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A06%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL496-515%22%7D%2C%20%22Pull%20eb4b51744b12dbc81f4370645762c94beaa01651%20infrastructure/path_server.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/507%23discussion_r44798862%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%20shouldn%27t%20be%20a%20blank%20line%20before%20a%20docstring%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A05%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL54-61%22%7D%2C%20%22Pull%20eb4b51744b12dbc81f4370645762c94beaa01651%20infrastructure/path_server.py%2092%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/507%23discussion_r44799169%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60_send_to_next_hop%60%20doesn%27t%20take%20any%20optional%20arguments%2C%20so%20there%27s%20no%20need%20to%20use%20the%20names%20%28i%27m%20also%20surprised%20that%20it%20even%20works%2C%20heh%29%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A08%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL572-581%22%7D%2C%20%22Pull%20eb4b51744b12dbc81f4370645762c94beaa01651%20infrastructure/path_server.py%2042%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/507%23discussion_r44798922%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ditto%22%2C%20%22created_at%22%3A%20%222015-11-13T16%3A06%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL306-318%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/kormat%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/kormat'><img src='https://avatars.githubusercontent.com/u/6919822?v=3' width=34 height=34></a>
- [ ] <a href='#crh-comment-Pull eb4b51744b12dbc81f4370645762c94beaa01651 infrastructure/path_server.py 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/507#discussion_r44798862'>File: infrastructure/path_server.py:L54-61</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> There shouldn't be a blank line before a docstring
- [ ] <a href='#crh-comment-Pull eb4b51744b12dbc81f4370645762c94beaa01651 infrastructure/path_server.py 42'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/507#discussion_r44798922'>File: infrastructure/path_server.py:L306-318</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ditto
- [ ] <a href='#crh-comment-Pull eb4b51744b12dbc81f4370645762c94beaa01651 infrastructure/path_server.py 68'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/507#discussion_r44798978'>File: infrastructure/path_server.py:L496-515</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This could still be calculated outside the loop
- [ ] <a href='#crh-comment-Pull eb4b51744b12dbc81f4370645762c94beaa01651 infrastructure/path_server.py 92'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/507#discussion_r44799169'>File: infrastructure/path_server.py:L572-581</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `_send_to_next_hop` doesn't take any optional arguments, so there's no need to use the names (i'm also surprised that it even works, heh)
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/507#issuecomment-156467084'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat @pszalach
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM otherwise.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat just addressed your comments.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/507?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/507?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/507?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/507'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
