### PR TITLE
Use lib.requests in Certifcate Server

### DIFF
--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -1205,6 +1205,7 @@ class LocalBeaconServer(BeaconServer):
         self.cert_chains = {}
         self.cert_chain = self.trust_store.get_cert(self.topology.isd_id,
                                                     self.topology.ad_id)
+        assert self.cert_chain
 
     def _check_certs_trc(self, isd_id, ad_id, cert_ver, trc_ver):
         """

--- a/test/lib_requests_test.py
+++ b/test/lib_requests_test.py
@@ -68,7 +68,7 @@ class TestRequestHandlerAddReq(object):
         # Tests
         inst._expire_reqs.assert_called_once_with("key")
         inst._check.assert_called_once_with("key")
-        inst._fetch.assert_called_once_with("key")
+        inst._fetch.assert_called_once_with("key", "req")
         ntools.eq_(inst._req_map["key"], [(2, "req")])
 
     @patch("lib.requests.SCIONTime.get_time", newcallable=create_mock)
@@ -127,8 +127,9 @@ class TestRequestHandlerAnswerReqs(object):
         inst._answer_reqs("key")
         # Tests
         inst._expire_reqs.assert_called_once_with("key")
-        assert_these_calls(inst._reply,
-                           [call("req0"), call("req1"), call("req2")])
+        assert_these_calls(inst._reply, [
+            call("key", "req0"), call("key", "req1"), call("key", "req2")
+        ])
         ntools.assert_not_in("key", inst._req_map)
 
 


### PR DESCRIPTION
All request queuing and reply is now handled in a single thread,
removing some race conditions.

Also fleshed out the docstrings in lib.requests
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/510%23issuecomment-157077498%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/510%23discussion_r45042014%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/510%23discussion_r45042045%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/510%23issuecomment-157329399%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/510%23discussion_r45043145%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/510%23discussion_r45043153%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/510%23issuecomment-157077498%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Tested%20this%20by%20removing%20all%20trc%20files%20from%20the%20infrastructure%20elements%20that%20aren%27t%20CS%2C%20works%20fine.%22%2C%20%22created_at%22%3A%20%222015-11-16T15%3A56%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM.%20Actually%20I%20like%20that%21%2C%20although%20I%27m%20not%20100%25%20convinced%20how%20well%20it%20would%20fit%20to%20other%20scion%20elements.%5Cr%5CnBut%20let%27s%20go%20this%20way.%22%2C%20%22created_at%22%3A%20%222015-11-17T10%3A22%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206aeb36d796e96a2961ccd7d0a71b1d8d4896508b%20infrastructure/cert_server.py%20219%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/510%23discussion_r45042045%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ditto%22%2C%20%22created_at%22%3A%20%222015-11-17T10%3A16%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Changed.%22%2C%20%22created_at%22%3A%20%222015-11-17T10%3A28%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/cert_server.py%3AL277-317%22%7D%2C%20%22Pull%206aeb36d796e96a2961ccd7d0a71b1d8d4896508b%20infrastructure/cert_server.py%20122%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/510%23discussion_r45042014%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60False%60%20is%20IMO%20more%20intuitive%22%2C%20%22created_at%22%3A%20%222015-11-17T10%3A15%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Changed.%22%2C%20%22created_at%22%3A%20%222015-11-17T10%3A28%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/cert_server.py%3AL215-249%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/510#issuecomment-157077498'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Tested this by removing all trc files from the infrastructure elements that aren't CS, works fine.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> LGTM. Actually I like that!, although I'm not 100% convinced how well it would fit to other scion elements.
  But let's go this way.
- [ ] <a href='#crh-comment-Pull 6aeb36d796e96a2961ccd7d0a71b1d8d4896508b infrastructure/cert_server.py 122'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/510#discussion_r45042014'>File: infrastructure/cert_server.py:L215-249</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> `False` is IMO more intuitive
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Changed.
- [ ] <a href='#crh-comment-Pull 6aeb36d796e96a2961ccd7d0a71b1d8d4896508b infrastructure/cert_server.py 219'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/510#discussion_r45042045'>File: infrastructure/cert_server.py:L277-317</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> ditto
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Changed.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/510?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/510?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/510'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
