### PR TITLE
Support crossover at core AD

### DIFF
--- a/lib/packet/path.py
+++ b/lib/packet/path.py
@@ -759,11 +759,10 @@ class PathCombinator(object):
         :returns: List of :any:`PathBase`\s.
         """
         paths = []
-        if not core_segments:
-            path = cls._build_core_path(up_segment, [], down_segment)
-            if path:
-                paths.append(path)
-        else:
+        path = cls._build_core_path(up_segment, [], down_segment)
+        if path:
+            paths.append(path)
+        if core_segments:
             for core_segment in core_segments:
                 path = cls._build_core_path(up_segment, core_segment,
                                             down_segment)

--- a/test/lib_packet_path_test.py
+++ b/test/lib_packet_path_test.py
@@ -1116,10 +1116,11 @@ class TestPathCombinatorBuildCorePaths(object):
            new_callable=create_mock)
     def test_with_core(self, build_path):
         core_segments = ['core0', 'core1', 'core2', 'core3']
-        build_path.side_effect = ['path0', 'path1', None, 'path1']
+        build_path.side_effect = [None, 'path0', 'path1', None, 'path1']
         ntools.eq_(PathCombinator.build_core_paths('up', 'down', core_segments),
                    ['path0', 'path1'])
-        calls = [call('up', cs, 'down') for cs in core_segments]
+        calls = [call('up', [], 'down')]
+        calls += [call('up', cs, 'down') for cs in core_segments]
         assert_these_calls(build_path, calls)
 
 


### PR DESCRIPTION
Finds core paths with no core segment - i.e. crossover at core AD.

Note: In this case the path will be parsed as one with an up segment + core segment and no down segment (as opposed to up + down), but that's a parsing issue beyond the scope of this PR and doesn't seem to affect packet delivery.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/511%23issuecomment-157329571%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/511%23issuecomment-157329571%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-11-17T10%3A23%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/511#issuecomment-157329571'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/511?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/511?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/511'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
