### PR TITLE
Generate AD list, for use by tests.

### DIFF
--- a/lib/defines.py
+++ b/lib/defines.py
@@ -36,6 +36,8 @@ AD_CONF_FILE = "ad.yml"
 PATH_POLICY_FILE = "path_policy.yml"
 #: Networks config
 NETWORKS_FILE = "networks.conf"
+#: AD list
+AD_LIST_FILE = "ad_list.yml"
 
 #: Buffer size for receiving packets
 SCION_BUFLEN = 65535


### PR DESCRIPTION
The topology generator will now create gen/ad_list.yml, which contains a
list of AD by level (CORE/INTERMEDIATE/LEAF). The end2end test then
reads this file, and uses all non-core ADs as endpoints. This means that
end2end will work against any topology, and doesn't need any hard-coded
ADs.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/514%23discussion_r45063758%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/514%23issuecomment-157381207%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/514%23discussion_r45064122%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/514%23issuecomment-157381207%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-11-17T14%3A14%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%207baabaf83004f600a9c0353f8f2fdb9ac3c0f755%20test/integration/end2end_test.py%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/514%23discussion_r45063758%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22it%27d%20be%20great%20if%20we%20can%20get%20rid%20off%20%5C%22INTERMEDIATE%5C%22%20and%20%5C%22LEAF%5C%22%20completely%22%2C%20%22created_at%22%3A%20%222015-11-17T14%3A14%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Agreed%2C%20will%20send%20a%20follow-up%20PR%20for%20that.%22%2C%20%22created_at%22%3A%20%222015-11-17T14%3A18%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/integration/end2end_test.py%3AL241-264%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 7baabaf83004f600a9c0353f8f2fdb9ac3c0f755 test/integration/end2end_test.py 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/514#discussion_r45063758'>File: test/integration/end2end_test.py:L241-264</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> it'd be great if we can get rid off "INTERMEDIATE" and "LEAF" completely
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Agreed, will send a follow-up PR for that.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/514#issuecomment-157381207'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/514?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/514?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/514'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
