### PR TITLE
Initial implementation of the SCION HTTP(S) Proxy.

### DIFF
--- a/endhost/scion_proxy.py
+++ b/endhost/scion_proxy.py
@@ -1,0 +1,278 @@
+#!/usr/bin/python3
+# Copyright (c) 2009 Fabio Domingues - fnds3000 in gmail.com
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+:mod:`scion_proxy` --- SCION Simple HTTP(S) Proxy
+=================================================
+
+This is a heavily modified version of the MIT Licensed Python Proxy.
+The implementation by Fabio Domingues was used as a starting point
+to implement the custom SCION HTTP(S) Proxy.
+
+Currently supported HTTP(S) methods:
+ - OPTIONS;
+ - GET;
+ - HEAD;
+ - POST;
+ - PUT;
+ - DELETE;
+ - TRACE;
+ - CONNECT.
+
+Usage:
+
+Simple usage of the proxy would be as follows:
+1) Start the proxy server from the top level SCION directory:
+
+endhost/scion_proxy.py
+
+By default, the proxy will start at port 8080 on the localhost.
+
+2) Set up your browser to point to the proxy. In Firefox v42, it can
+be done by going to the configuration:
+
+Preferences -> Advanced -> Network -> Settings -> Manual Proxy Configuration
+
+and setting the following fields:
+
+HTTP Proxy: 127.0.0.1, Port: 8080
+"""
+
+# Stdlib
+import logging
+import select
+import socket
+from http.server import SimpleHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+from urllib.parse import urlparse, urlunparse
+
+# SCION
+from lib.log import init_logging, log_exception
+
+VERSION = '0.1.0'
+BUFLEN = 8192
+SERVER_ADDRESS = ('127.0.0.1', 8080)
+SELECT_TIMEOUT = 3  # seconds
+LOG_FILE = 'logs/scion_proxy.log'
+
+
+class ConnectionHandler(SimpleHTTPRequestHandler):
+    """
+    Handler class for the connection to be proxied.
+    """
+    server_version = "SCION HTTP Proxy/" + VERSION
+
+    def do_CONNECT(self):
+        """
+        Handles the CONNECT method: Connects to the target address,
+        and responds to the client (i.e. browser) with a 200
+        Connection established response and starts proxying.
+        """
+        logging.info("%s %s" % (self.requestline, self.client_address))
+        soc = self._connect_to(self.path)
+        if not soc:
+            return
+        try:
+            reply = self.protocol_version + \
+                " 200 Connection established\n" + \
+                "Proxy-agent: %s\n\n" % self.version_string()
+            self.wfile.write(bytes(reply, 'ascii'))
+            self._read_write(soc)
+        finally:
+            soc.close()
+
+    def handle_others(self):
+        """
+        Handles the rest of the supported HTTP methods: Parses the path,
+        connects to the target address, sends the complete request
+        to the target and starts proxying.
+        """
+        logging.info("%s %s" % (self.requestline, self.client_address))
+        (scm, netloc, path, params, query, _) = urlparse(
+            self.path, 'http')
+        if scm != 'http' or not netloc:
+            self.send_error(400, "Bad URL %s" % self.path)
+            logging.error("Bad URL %s" % self.path)
+            return
+        soc = self._connect_to(netloc)
+        if not soc:
+            return
+        try:
+            self._send_request(soc, path, params, query)
+            self._read_write(soc)
+        finally:
+            soc.close()
+
+    def _connect_to(self, netloc):
+        """
+        Establishes a connection to the target host.
+        :param netloc: The hostname (and port) of the target to be connected to.
+        :type netloc: string
+        :returns: The socket that is used to connect.
+        :rtype: socket
+        """
+        soc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if ':' in netloc:
+            host, port = netloc.split(':')
+        else:
+            host, port = netloc, 80
+        logging.debug("Connecting to %s:%s" % (host, port))
+        try:
+            soc.connect((host, int(port)))
+        except OSError:
+            self.send_error(404, "Error during connect.")
+            log_exception("Error while connecting to %s:%s" % (host, port))
+            return False
+        logging.debug("Connected to %s:%s" % (host, port))
+        return soc
+
+    def _send_request(self, soc, path, params, query):
+        """
+        Helper function that prepares and sends the request on the
+        given socket.
+        :param soc: The socket the request is going to be sent on.
+        :type soc: socket
+        :param path: The path of the HTTP request.
+        :type path: String
+        :param params: Parameters of the request (if any).
+        :type params: String
+        :param query: Query section of the HTTP request (if any).
+        :type query: String
+        """
+        h = []
+        h.append("%s %s %s" % (
+            self.command,
+            urlunparse(('', '', path, params, query, '')),
+            self.request_version))
+        for key_val in self.headers.items():
+            h.append("%s: %s" % key_val)
+        header = "%s\n\n" % "\n".join(h)
+        content_len = int(self.headers.get('content-length', 0))
+        body = self.rfile.read(content_len)
+        req_bytes = []
+        req_bytes.append(bytes(header, 'ascii'))
+        req_bytes.append(body)
+        logging.debug("Sending a request: %s", req_bytes)
+        soc.send(b''.join(req_bytes))
+
+    def _read_write(self, target_sock, max_idling=60):
+        """
+        The main loop for the proxying operation. Listens for incoming data
+        on both client (i.e. browser) and server sockets and relays them
+        accordingly between each other.
+        :param target_sock: The socket belonging to the remote target.
+        :type target_sock: socket
+        :param max_idling: Inactivity timeout (in seconds) on the sockets.
+        :type max_idling: int
+        """
+        max_tries = max_idling / SELECT_TIMEOUT
+        socks = [self.connection, target_sock]
+        target_sock.setblocking(False)
+        self.connection.setblocking(False)
+        inactivity_count = 0
+        while inactivity_count < max_tries:
+            inactivity_count += 1
+            (ins, _, err) = select.select(socks, [],
+                                          socks, SELECT_TIMEOUT)
+            if err:
+                logging.error("Error occurred during Select.")
+                break
+            for incoming in ins:
+                inactivity_count = 0
+                if not self._proxy(incoming, target_sock):
+                    return
+
+    def _proxy(self, incoming, target_sock):
+        """
+        Helper function to go through the incoming data and proxy
+        them between client and target.
+        :param incoming: Socket that data arrived at.
+        :type incoming: socket.
+        :param target_sock: Socket to the remote host.
+        :type target_sock: socket.
+        :returns: Whether successfully proxied between to sockets.
+        :rtype: boolean
+        """
+        if incoming is target_sock:
+            input_ = "remote"
+            output = "local"
+            out = self.connection
+        else:
+            input_ = "local"
+            output = "remote"
+            out = target_sock
+        try:
+            data = incoming.recv(BUFLEN)
+        except OSError as e:
+            logging.error("Error occurred during recv from %s socket: %s",
+                          input_, e)
+            return False
+        if not data:
+            logging.error("Read 0 bytes from %s socket.", input_)
+            return False
+        try:
+            out.sendall(data)
+        except OSError as e:
+            logging.error("Error occurred during sendall on %s socket: %s",
+                          output, e)
+            return False
+        return True
+
+    # override the handler methods of the SimpleHTTPRequestHandler class
+    do_DELETE = handle_others
+    do_GET = handle_others
+    do_HEAD = handle_others
+    do_POST = handle_others
+    do_PUT = handle_others
+    do_TRACE = handle_others
+    do_OPTIONS = handle_others
+
+
+class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    """Handle requests in a separate thread."""
+    daemon_threads = True
+
+if __name__ == '__main__':
+    init_logging(log_file=LOG_FILE, level=logging.DEBUG, console=True)
+    httpd = ThreadingHTTPServer(SERVER_ADDRESS, ConnectionHandler)
+    logging.info("Starting server at (%s, %s), use <Ctrl-C> to stop" %
+                 SERVER_ADDRESS)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        logging.info("Exiting")

--- a/sphinx-doc/endhost/scion_proxy.rst
+++ b/sphinx-doc/endhost/scion_proxy.rst
@@ -1,0 +1,3 @@
+.. automodule:: endhost.scion_proxy
+   :special-members: __init__
+   :members:


### PR DESCRIPTION
It will be integrated with the SCION Multi-path socket and
be used for the Swisscom SCION deployment.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/516%23issuecomment-157386226%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23issuecomment-157389846%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45079592%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45079894%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45080835%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45080895%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45081237%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23issuecomment-157460174%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23issuecomment-157664334%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23issuecomment-158056417%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23issuecomment-158062767%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45451872%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45451890%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45451913%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45451989%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45452001%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45452213%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45452393%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45452458%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45454601%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45454905%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45454970%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45455055%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45455076%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45455246%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45456378%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45456536%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45458375%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45458572%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45458604%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45458934%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45459110%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45459589%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45459631%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45459641%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45459652%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45459671%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23issuecomment-158411663%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473276%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473335%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473348%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473433%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473446%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473465%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473481%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473494%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473526%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473554%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473588%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473602%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45473629%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23issuecomment-158416194%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23issuecomment-158417985%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20ba893af052a11caec75410335616d4df8a08f669%20endhost/scion_proxy.py%2093%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45081237%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20about%20using%20https%3A//docs.python.org/3/library/http.server.html%20instead%20of%20implementing%20http%20support%3F%22%2C%20%22created_at%22%3A%20%222015-11-17T16%3A24%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T09%3A56%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-282%22%7D%2C%20%22Pull%20ba893af052a11caec75410335616d4df8a08f669%20endhost/scion_proxy.py%20105%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45080895%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20this%20program%20has%20its%20own%20log%20file%2C%20there%27s%20no%20need%20to%20mention%20the%20name%20in%20log%20entries.%22%2C%20%22created_at%22%3A%20%222015-11-17T16%3A21%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T09%3A56%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-282%22%7D%2C%20%22Pull%20ba893af052a11caec75410335616d4df8a08f669%20endhost/scion_proxy.py%2077%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45079894%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20%60threading%60%20rather%20than%20the%20lower-level%20%60_thread%60.%22%2C%20%22created_at%22%3A%20%222015-11-17T16%3A15%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T09%3A55%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-282%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20156%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45458375%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20quite%20a%20lot%20of%20nested%20code.%20I%27d%20suggest%20putting%20the%20body%20of%20this%20if%20statement%20into%20a%20separate%20method%22%2C%20%22created_at%22%3A%20%222015-11-20T11%3A09%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A29%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20199%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45458934%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60recv%60%20should%20be%20called%20non-blocking%2C%20just%20in%20case.%20It%20also%20needs%20error%20handling.%22%2C%20%22created_at%22%3A%20%222015-11-20T11%3A17%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A28%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23issuecomment-157386226%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20%40aznair%20%40pszalach%20This%20is%20the%20first%20version%20of%20the%20SCION%20HTTP%28S%29%20proxy.%20Would%20be%20glad%20to%20get%20your%20feedback%20on%20it.%22%2C%20%22created_at%22%3A%20%222015-11-17T14%3A30%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20pull%20request%20is%20now%20managed%20with%20CodeReviewHub.%20%3Ca%20href%3D%27https%3A//github.com/netsec-ethz/scion/pull/516%27%3ERefresh%3C/a%3E.%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-11-17T14%3A46%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%2C%20but%20as%20%40kormat%20pointed%20out%20maybe%20it%20is%20better%20to%20use%20some%20standard%20libs%20%3F%5Cr%5Cnbtw.%20I%27m%20not%20sure%20how%20much%20of%20Twisted%20is%20ported%20to%20python3%20but%20it%20has%20modules%20for%20http%20proxying%20etc..%20https%3A//wiki.python.org/moin/Twisted-Examples%22%2C%20%22created_at%22%3A%20%222015-11-17T18%3A25%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20and%20%40pszalach%20Sure%2C%20I%20can%20look%20at%20what%20I%20can%20use%20from%20the%20standard%20libraries%20%28especially%20for%20parsing%20the%20request%20etc.%29.%20However%2C%20please%20also%20bear%20in%20mind%20that%20this%20proxy%20implementation%20needs%20relatively%20low%20level%20access%20to%20the%20underlying%20socket%20objects%20%28for%20doing%20send%28%29%2C%20recv%28%29%2C%20select%28%29%20calls%20on%20them%29%20and%20standard%20libraries%20usually%20do%20tend%20to%20encapsulate%20such%20information.%20The%20socket%20objects%20later%20will%20soon%20be%20replaced%20with%20the%20SCION%20multi-path%20socket.%20By%20the%20way%2C%20I%20have%20used%20Twisted%20before%20and%20since%20it%20is%20an%20event%20driven%20system%2C%20its%20performance%20was%20not%20great.%20%5Cr%5CnAnyhow%20I%20will%20work%20on%20trying%20to%20standardize%20as%20much%20of%20the%20code%20as%20I%20can%20and%20update%20the%20PR%20today..%20Cheers%21%22%2C%20%22created_at%22%3A%20%222015-11-18T10%3A05%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20and%20%40pszalach%20I%20re-wrote%20most%20of%20the%20proxy%20using%20python3%20standard%20libraries%20as%20much%20as%20possible.%20The%20amount%20of%20code%20is%20reduced%20now.%20I%20would%20be%20happy%20to%20see%20what%20you%20think%20of%20this%20one.%20Cheers%21%22%2C%20%22created_at%22%3A%20%222015-11-19T13%3A26%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-11-19T13%3A55%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20I%20believe%20I%20addressed%20all%20your%20comments.%20Please%20let%20me%20know%20what%20you%20think%20of%20it.%20Thanks%21%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A11%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A31%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22thx%21%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A38%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20175%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45456536%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20sure%20about%20this%20-%20by%20default%20http.server%20will%20close%20the%20connection%20when%20the%20handler%20returns.%20If%20we%20close%20it%20here%2C%20that%20might%20cause%20the%20httpd%20to%20error%20out.%22%2C%20%22created_at%22%3A%20%222015-11-20T10%3A48%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A29%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20116%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45454905%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Doing%20a%20catch-all%20exception%20is%20really%20bad%20style.%20Always%20catch%20specific%20exceptions%20%28or%20groups%20of%20exceptions%29.%20In%20this%20case%2C%20i%20would%20do%3A%5Cr%5Cn%60%60%60%5Cr%5Cnexcept%20OSError%3A%5Cr%5Cn%20%20log_exception%28%5C%22Error%20while%20connecting%20to%20%25s%3A%25s%5C%22%2C%20host%2C%20port%29%5Cr%5Cn%20%20self.send_error%28404%2C%20%5C%22Error%20during%20connect.%5C%22%29%5Cr%5Cn%60%60%60%5Cr%5CnThat%20way%20we%20get%20the%20exception%20logged%20at%20a%20minimum.%5Cr%5Cn%5Cr%5CnI%20would%20also%20move%20the%20%5C%22Connected%20to%5C%22%20log%20command%20to%20just%20before%20%60return%20True%60%2C%20to%20minimize%20the%20amount%20of%20code%20run%20in%20the%20%60try%60%20block.%22%2C%20%22created_at%22%3A%20%222015-11-20T10%3A31%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60log_exception%60%20is%20in%20%60lib.log%60%22%2C%20%22created_at%22%3A%20%222015-11-20T10%3A33%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A27%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%2090%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45452213%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60scion_proxy%60%20would%20be%20more%20consistent%20with%20the%20module%20name.%22%2C%20%22created_at%22%3A%20%222015-11-20T09%3A58%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T11%3A27%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20111%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45454601%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20logic%20here%20would%20be%20cleaner%20like%20this%3A%5Cr%5Cn%60%60%60%5Cr%5Cnif%20%27%3A%27%20in%20netloc%3A%5Cr%5Cn%20%20host%2C%20port%20%3D%20netloc.split%28%27%3A%27%29%5Cr%5Cnelse%3A%5Cr%5Cn%20%20host%2C%20port%20%3D%20netloc%2C%2080%5Cr%5Cn...%5Cr%5Cn%20%20%20soc.connect%28host%2C%20int%28port%29%29%5Cr%5Cn...%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-11-20T10%3A27%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A26%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20155%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45456378%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20be%20at%20the%20top%20of%20the%20handler%2C%20and%20include%20the%20client%20address%22%2C%20%22created_at%22%3A%20%222015-11-20T10%3A46%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A28%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%20ba893af052a11caec75410335616d4df8a08f669%20endhost/scion_proxy.py%20134%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45080835%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20really%20inefficient%20to%20do%20in%20python.%20You%27d%20be%20much%20better%20off%20letting%20a%20lower-level%20handle%20this%20for%20you.%20Why%20not%20%60fdopen%60%20and%20%60readline%60%3F%22%2C%20%22created_at%22%3A%20%222015-11-17T16%3A21%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T09%3A55%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-282%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20149%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45455246%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20is%20a%20fragment%20an%20error%3F%22%2C%20%22created_at%22%3A%20%222015-11-20T10%3A35%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A29%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45459110%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%27s%20no%20guarantee%20that%20this%20will%20have%20sent%20all%20the%20data%2C%20unfortunately.%20You%20need%20to%20check%20the%20return%20value%2C%20and%20handle%20it%20appropriately.%20It%20also%20needs%20error%20handling%20-%20i%27ve%20seen%20a%20BrokenPipeError%20when%20one%20end%20disconnected.%22%2C%20%22created_at%22%3A%20%222015-11-20T11%3A19%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A28%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20226%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45452458%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20would%20be%20better%20to%20use%20a%20logging%20statement%20for%20this%2C%20so%20that%20all%20relevant%20information%20is%20in%20the%20log%20file.%20You%20could%20potentially%20pass%20%60console%3DTrue%60%20to%20%60init_logging%60%2C%20which%20makes%20it%20log%20to%20the%20console%20also.%20Passing%20%60level%3Dlogging.INFO%60%20probably%20makes%20sense%20in%20that%20case%2C%20too.%22%2C%20%22created_at%22%3A%20%222015-11-20T10%3A02%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T11%3A27%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20227%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45452393%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Add%20a%20handler%20for%20ctrl-c%20around%20this.%5Cr%5Cn%60%60%60%5Cr%5Cntry%3A%5Cr%5Cn%20%20httpd.serve_forever%28%29%5Cr%5Cnexcept%20KeyboardInterrupt%3A%5Cr%5Cn%20%20logging.info%28%5C%22Exiting%5C%22%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-11-20T10%3A01%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T11%3A27%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20163%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45458572%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20better%20to%20use%20a%20list%20to%20collect%20string%20fragments%2C%20and%20then%20use%20join%20at%20the%20end.%20E.g.%3A%5Cr%5Cn%60%60%60%5Cr%5Cnh%20%3D%20%5B%5D%5Cr%5Cnh.append%28%5C%22%25s%20%25s%20%25s%5C%22%20%25%20%28...%29%29%5Cr%5Cnfor%20key_val%20in%20self.headers.items%28%29%3A%5Cr%5Cn%20%20h.append%28%5C%22%25s%3A%20%25s%5C%22%20%25%20key_val%29%5Cr%5Cnheader%20%3D%20%5C%22%25s%5C%5Cn%5C%5Cn%5C%22%20%25%20%5C%22%5C%5Cn%5C%22.join%28h%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-11-20T11%3A12%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A29%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%20ba893af052a11caec75410335616d4df8a08f669%20endhost/scion_proxy.py%2062%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45079592%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20the%20file%20has%20the%20%23%21%20at%20the%20start%2C%20you%20don%27t%20need%20to%20use%20python3%20on%20the%20cmdline.%20%28Also%20the%20name%20of%20the%20script%20is%20wrong%2C%20it%20%20has%20an%20%60_%60%2C%20rather%20than%20a%20%60-%60%29.%20Just%20make%20sure%20you%27ve%20set%20the%20file%20executable%20in%20git.%22%2C%20%22created_at%22%3A%20%222015-11-17T16%3A13%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20still%20need%20to%20remove%20the%20%60python%60%20from%20the%20cmdline.%22%2C%20%22created_at%22%3A%20%222015-11-20T09%3A54%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T11%3A26%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-282%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%2081%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45455055%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Our%20convention%20for%20imports%20is%20that%20all%20%60import%20x%60%20statements%20come%20before%20all%20%60from%20x%20import%20y%60%20statements%2C%20with%20alphabetical%20sorting%20within%20those%20two%20categories%22%2C%20%22created_at%22%3A%20%222015-11-20T10%3A33%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A28%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20168%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45458604%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%20two%20lines%20could%20be%20combined.%22%2C%20%22created_at%22%3A%20%222015-11-20T11%3A12%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A28%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%208b367204e179065f758bf09b3631e96ad3b2a06e%20endhost/scion_proxy.py%20130%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45454970%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20would%20be%20good%20to%20include%20the%20client%20host/port%20in%20this%20log%20entry.%22%2C%20%22created_at%22%3A%20%222015-11-20T10%3A32%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A27%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-228%22%7D%2C%20%22Pull%20f6bf1d4f6ed35365b5fb4ca6c9ca6ab91ac2e189%20endhost/scion_proxy.py%20221%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/516%23discussion_r45459589%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Add%20%60daemon_threads%20%3D%20True%60%20here%2C%20so%20that%20threads%20won%27t%20prevent%20the%20process%20from%20exiting.%22%2C%20%22created_at%22%3A%20%222015-11-20T11%3A26%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-20T14%3A28%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL1-232%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#issuecomment-157386226'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat @aznair @pszalach This is the first version of the SCION HTTP(S) proxy. Would be glad to get your feedback on it.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This pull request is now managed with CodeReviewHub. <a href='https://github.com/netsec-ethz/scion/pull/516'>Refresh</a>.<a href='#crh-update-none'></a>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm, but as @kormat pointed out maybe it is better to use some standard libs ?
  btw. I'm not sure how much of Twisted is ported to python3 but it has modules for http proxying etc.. https://wiki.python.org/moin/Twisted-Examples
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat and @pszalach Sure, I can look at what I can use from the standard libraries (especially for parsing the request etc.). However, please also bear in mind that this proxy implementation needs relatively low level access to the underlying socket objects (for doing send(), recv(), select() calls on them) and standard libraries usually do tend to encapsulate such information. The socket objects later will soon be replaced with the SCION multi-path socket. By the way, I have used Twisted before and since it is an event driven system, its performance was not great.
  Anyhow I will work on trying to standardize as much of the code as I can and update the PR today.. Cheers!
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat and @pszalach I re-wrote most of the proxy using python3 standard libraries as much as possible. The amount of code is reduced now. I would be happy to see what you think of this one. Cheers!
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat I believe I addressed all your comments. Please let me know what you think of it. Thanks!
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM :)
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> thx!
- [x] <a href='#crh-comment-Pull ba893af052a11caec75410335616d4df8a08f669 endhost/scion_proxy.py 62'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45079592'>File: endhost/scion_proxy.py:L1-282</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> As the file has the #! at the start, you don't need to use python3 on the cmdline. (Also the name of the script is wrong, it  has an `_`, rather than a `-`). Just make sure you've set the file executable in git.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You still need to remove the `python` from the cmdline.
- [x] <a href='#crh-comment-Pull ba893af052a11caec75410335616d4df8a08f669 endhost/scion_proxy.py 77'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45079894'>File: endhost/scion_proxy.py:L1-282</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Use `threading` rather than the lower-level `_thread`.
- [x] <a href='#crh-comment-Pull ba893af052a11caec75410335616d4df8a08f669 endhost/scion_proxy.py 134'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45080835'>File: endhost/scion_proxy.py:L1-282</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is really inefficient to do in python. You'd be much better off letting a lower-level handle this for you. Why not `fdopen` and `readline`?
- [x] <a href='#crh-comment-Pull ba893af052a11caec75410335616d4df8a08f669 endhost/scion_proxy.py 105'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45080895'>File: endhost/scion_proxy.py:L1-282</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> As this program has its own log file, there's no need to mention the name in log entries.
- [x] <a href='#crh-comment-Pull ba893af052a11caec75410335616d4df8a08f669 endhost/scion_proxy.py 93'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45081237'>File: endhost/scion_proxy.py:L1-282</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> What about using https://docs.python.org/3/library/http.server.html instead of implementing http support?
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 90'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45452213'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `scion_proxy` would be more consistent with the module name.
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 227'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45452393'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Add a handler for ctrl-c around this.

```
try:
httpd.serve_forever()
except KeyboardInterrupt:
logging.info("Exiting")
```
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 226'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45452458'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It would be better to use a logging statement for this, so that all relevant information is in the log file. You could potentially pass `console=True` to `init_logging`, which makes it log to the console also. Passing `level=logging.INFO` probably makes sense in that case, too.
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 111'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45454601'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The logic here would be cleaner like this:

```
if ':' in netloc:
host, port = netloc.split(':')
else:
host, port = netloc, 80
...
soc.connect(host, int(port))
...
```
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 116'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45454905'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Doing a catch-all exception is really bad style. Always catch specific exceptions (or groups of exceptions). In this case, i would do:

```
except OSError:
log_exception("Error while connecting to %s:%s", host, port)
self.send_error(404, "Error during connect.")
```

That way we get the exception logged at a minimum.
I would also move the "Connected to" log command to just before `return True`, to minimize the amount of code run in the `try` block.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `log_exception` is in `lib.log`
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 130'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45454970'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It would be good to include the client host/port in this log entry.
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 81'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45455055'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Our convention for imports is that all `import x` statements come before all `from x import y` statements, with alphabetical sorting within those two categories
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 149'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45455246'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Why is a fragment an error?
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 155'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45456378'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This should be at the top of the handler, and include the client address
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 175'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45456536'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I'm not sure about this - by default http.server will close the connection when the handler returns. If we close it here, that might cause the httpd to error out.
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 156'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45458375'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is quite a lot of nested code. I'd suggest putting the body of this if statement into a separate method
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 163'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45458572'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It's better to use a list to collect string fragments, and then use join at the end. E.g.:

```
h = []
h.append("%s %s %s" % (...))
for key_val in self.headers.items():
h.append("%s: %s" % key_val)
header = "%s\n\n" % "\n".join(h)
```
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 168'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45458604'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> These two lines could be combined.
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 199'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45458934'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `recv` should be called non-blocking, just in case. It also needs error handling.
- [x] <a href='#crh-comment-Pull 8b367204e179065f758bf09b3631e96ad3b2a06e endhost/scion_proxy.py 205'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45459110'>File: endhost/scion_proxy.py:L1-228</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> There's no guarantee that this will have sent all the data, unfortunately. You need to check the return value, and handle it appropriately. It also needs error handling - i've seen a BrokenPipeError when one end disconnected.
- [x] <a href='#crh-comment-Pull f6bf1d4f6ed35365b5fb4ca6c9ca6ab91ac2e189 endhost/scion_proxy.py 221'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/516#discussion_r45459589'>File: endhost/scion_proxy.py:L1-232</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Add `daemon_threads = True` here, so that threads won't prevent the process from exiting.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/516?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/516?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/516'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
