### PR TITLE
Remove 'level' from topo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Notes about `topology/Default.topo`:
 
 * `defaults.subnet` (optional): override the default subnet of `127.0.0.0/8`.
 
-* `level`: can either be `CORE`, `INTERMEDIATE`, or `LEAF`.
+* `core` (optional): specify if this is a core AD or not (defaults to 'false').
 
 * `beacon_servers`, `certificate_servers`, `path_servers`, `dns_servers` (all
   optional): number of such servers in a specific AD (override the default

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -244,12 +244,9 @@ class TestSCIONDaemon(unittest.TestCase):
 def _load_ad_list():
     ad_dict = load_yaml_file(os.path.join(GEN_PATH, AD_LIST_FILE))
     ad_list = []
-    for level in "INTERMEDIATE", "LEAF":
-        if level not in ad_dict:
-            continue
-        for ad_str in ad_dict[level]:
-            isd, ad = ad_str.split("-")
-            ad_list.append((int(isd), int(ad)))
+    for ad_str in ad_dict.get("Non-core", []):
+        isd, ad = ad_str.split("-")
+        ad_list.append((int(isd), int(ad)))
     return ad_list
 
 

--- a/topology/Default.topo
+++ b/topology/Default.topo
@@ -6,7 +6,7 @@ defaults:
       addr: 127.0.0.1
 ADs:
   1-11:
-    level: CORE
+    core: true
     beacon_servers: 1
     certificate_servers: 3
     path_servers: 3
@@ -16,7 +16,7 @@ ADs:
       1-14: CHILD
       2-21: ROUTING
   1-12:
-    level: CORE
+    core: true
     links:
       1-11: ROUTING
       1-13: ROUTING
@@ -39,7 +39,7 @@ ADs:
         leaderPort: 4007
         electionPort: 4008
   1-13:
-    level: CORE
+    core: true
     beacon_servers: 2
     certificate_servers: 3
     dns_servers: 2
@@ -48,7 +48,6 @@ ADs:
       1-12: ROUTING
       1-16: CHILD
   1-14:
-    level: INTERMEDIATE
     path_servers: 1
     cert_issuer: 1-11
     certificate_servers: 3
@@ -58,7 +57,6 @@ ADs:
       2-23: PEER
       1-17: CHILD
   1-15:
-    level: INTERMEDIATE
     cert_issuer: 1-12
     links:
       1-12: PARENT
@@ -66,7 +64,6 @@ ADs:
       1-16: PEER
       1-18: CHILD
   1-16:
-    level: INTERMEDIATE
     beacon_servers: 3
     certificate_servers: 3
     cert_issuer: 1-13
@@ -75,17 +72,14 @@ ADs:
       1-15: PEER
       1-19: CHILD
   1-17:
-    level: LEAF
     cert_issuer: 1-14
     links:
       1-14: PARENT
   1-18:
-    level: LEAF
     cert_issuer: 1-15
     links:
       1-15: PARENT
   1-19:
-    level: INTERMEDIATE
     path_servers: 2
     certificate_servers: 3
     cert_issuer: 1-16
@@ -93,24 +87,22 @@ ADs:
       1-16: PARENT
       1-10: CHILD
   1-10:
-    level: LEAF
     cert_issuer: 1-19
     links:
       1-19: PARENT
   2-21:
-    level: CORE
+    core: true
     links:
       1-11: ROUTING
       2-22: ROUTING
       2-23: CHILD
   2-22:
-    level: CORE
+    core: true
     links:
       1-12: ROUTING
       2-21: ROUTING
       2-24: CHILD
   2-23:
-    level: INTERMEDIATE
     cert_issuer: 2-21
     links:
       2-21: PARENT
@@ -119,7 +111,6 @@ ADs:
       2-25: CHILD
       2-26: CHILD
   2-24:
-    level: INTERMEDIATE
     cert_issuer: 2-22
     certificate_servers: 3
     links:
@@ -127,12 +118,10 @@ ADs:
       2-23: PEER
       2-26: CHILD
   2-25:
-    level: LEAF
     cert_issuer: 2-23
     links:
       2-23: PARENT
   2-26:
-    level: LEAF
     cert_issuer: 2-24
     links:
       2-23: PARENT

--- a/topology/Tiny.topo
+++ b/topology/Tiny.topo
@@ -6,17 +6,15 @@ defaults:
       addr: 127.0.0.1
 ADs:
   1-11:
-    level: CORE
+    core: true
     links:
       1-12: CHILD
       1-13: CHILD
   1-12:
-    level: LEAF
     cert_issuer: 1-11
     links:
       1-11: PARENT
   1-13:
-    level: LEAF
     cert_issuer: 1-11
     links:
       1-11: PARENT


### PR DESCRIPTION
Instead, just indicate if an AD is in the core, or not. If the 'core'
value is unspecified, it defaults to 'false'.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/517%23issuecomment-157391103%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/517%23issuecomment-157391103%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22LGTM.%5Cr%5Cn...%20finally%20%3B-%29%22%2C%20%22created_at%22%3A%20%222015-11-17T14%3A51%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/517#issuecomment-157391103'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> LGTM.
  ... finally ;-)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/517?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/517?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/517'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
