### PR TITLE
Specify links only once in topology config

### DIFF
--- a/topology/Default.topo
+++ b/topology/Default.topo
@@ -10,18 +10,8 @@ ADs:
     beacon_servers: 1
     certificate_servers: 3
     path_servers: 3
-    links:
-      1-12: ROUTING
-      1-13: ROUTING
-      1-14: CHILD
-      2-21: ROUTING
   1-12:
     core: true
-    links:
-      1-11: ROUTING
-      1-13: ROUTING
-      1-15: CHILD
-      2-22: ROUTING
     zookeepers:
       1:
         manage: true
@@ -43,86 +33,59 @@ ADs:
     beacon_servers: 2
     certificate_servers: 3
     dns_servers: 2
-    links:
-      1-11: ROUTING
-      1-12: ROUTING
-      1-16: CHILD
   1-14:
     path_servers: 1
     cert_issuer: 1-11
     certificate_servers: 3
-    links:
-      1-11: PARENT
-      1-15: PEER
-      2-23: PEER
-      1-17: CHILD
   1-15:
     cert_issuer: 1-12
-    links:
-      1-12: PARENT
-      1-14: PEER
-      1-16: PEER
-      1-18: CHILD
   1-16:
     beacon_servers: 3
     certificate_servers: 3
     cert_issuer: 1-13
-    links:
-      1-13: PARENT
-      1-15: PEER
-      1-19: CHILD
   1-17:
     cert_issuer: 1-14
-    links:
-      1-14: PARENT
   1-18:
     cert_issuer: 1-15
-    links:
-      1-15: PARENT
   1-19:
     path_servers: 2
     certificate_servers: 3
     cert_issuer: 1-16
-    links:
-      1-16: PARENT
-      1-10: CHILD
   1-10:
     cert_issuer: 1-19
-    links:
-      1-19: PARENT
   2-21:
     core: true
-    links:
-      1-11: ROUTING
-      2-22: ROUTING
-      2-23: CHILD
   2-22:
     core: true
-    links:
-      1-12: ROUTING
-      2-21: ROUTING
-      2-24: CHILD
   2-23:
     cert_issuer: 2-21
-    links:
-      2-21: PARENT
-      2-24: PEER
-      1-14: PEER
-      2-25: CHILD
-      2-26: CHILD
   2-24:
     cert_issuer: 2-22
     certificate_servers: 3
-    links:
-      2-22: PARENT
-      2-23: PEER
-      2-26: CHILD
   2-25:
     cert_issuer: 2-23
-    links:
-      2-23: PARENT
   2-26:
     cert_issuer: 2-24
-    links:
-      2-23: PARENT
-      2-24: PARENT
+links:
+  - [1-11, ROUTING, 1-12]
+  - [1-11, ROUTING, 1-13]
+  - [1-11, ROUTING, 2-21]
+  - [1-11, PARENT, 1-14]
+  - [1-12, ROUTING, 1-13]
+  - [1-12, ROUTING, 2-22]
+  - [1-12, PARENT, 1-15]
+  - [1-13, PARENT, 1-16]
+  - [1-14, PEER, 1-15]
+  - [1-14, PEER, 2-23]
+  - [1-14, PARENT, 1-17]
+  - [1-15, PEER, 1-16]
+  - [1-15, PARENT, 1-18]
+  - [1-16, PARENT, 1-19]
+  - [1-19, PARENT, 1-10]
+  - [2-21, ROUTING, 2-22]
+  - [2-21, PARENT, 2-23]
+  - [2-22, PARENT, 2-24]
+  - [2-23, PEER, 2-24]
+  - [2-23, PARENT, 2-25]
+  - [2-23, PARENT, 2-26]
+  - [2-24, PARENT, 2-26]

--- a/topology/Tiny.topo
+++ b/topology/Tiny.topo
@@ -7,14 +7,10 @@ defaults:
 ADs:
   1-11:
     core: true
-    links:
-      1-12: CHILD
-      1-13: CHILD
   1-12:
     cert_issuer: 1-11
-    links:
-      1-11: PARENT
   1-13:
     cert_issuer: 1-11
-    links:
-      1-11: PARENT
+links:
+  - [1-11, PARENT, 1-12]
+  - [1-11, PARENT, 1-13]


### PR DESCRIPTION
By moving links out of the AD block, we can specific a link once, rather
than in both the ADs it connects, making it much easier to
add/remove links.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/518%23issuecomment-157410586%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/518%23issuecomment-157410586%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22that%20change%20is%20really%20good%21%22%2C%20%22created_at%22%3A%20%222015-11-17T15%3A50%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/518#issuecomment-157410586'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> that change is really good!

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/518?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/518?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/518'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
