### PR TITLE
Add a 'wide' topology, with 5 ISDs.

### DIFF
--- a/topology/Wide.topo
+++ b/topology/Wide.topo
@@ -1,0 +1,52 @@
+---
+defaults:
+  zookeepers:
+    1:
+      manage: false
+      addr: 127.0.0.1
+
+ADs:
+  1-1: {core: true}
+  1-2: {core: true}
+  1-3: {cert_issuer: 1-1}
+  1-4: {cert_issuer: 1-2}
+  2-1: {core: true}
+  2-2: {core: true}
+  2-3: {cert_issuer: 2-2}
+  2-4: {cert_issuer: 2-2}
+  3-1: {core: true}
+  3-3: {cert_issuer: 3-1}
+  3-4: {cert_issuer: 3-3}
+  3-5: {cert_issuer: 3-3}
+  4-1: {core: true}
+  5-1: {core: true}
+  5-2: {core: true}
+  5-3: {core: true}
+  5-4: {cert_issuer: 5-1}
+  5-5: {cert_issuer: 5-3}
+links:
+  - [1-1, ROUTING, 1-2]
+  - [1-1, ROUTING, 2-1]
+  - [1-1, ROUTING, 2-2]
+  - [1-1, PARENT, 1-3]
+  - [1-2, ROUTING, 2-1]
+  - [1-2, PARENT, 1-4]
+  - [1-3, PEER, 1-4]
+  - [1-3, PEER, 3-3]
+  - [2-1, ROUTING, 2-2]
+  - [2-1, ROUTING, 3-1]
+  - [2-1, PARENT, 2-3]
+  - [2-1, PARENT, 2-4]
+  - [2-2, PARENT, 2-3]
+  - [2-2, PARENT, 2-4]
+  - [2-3, PEER, 2-4]
+  - [3-1, ROUTING, 4-1]
+  - [3-1, PARENT, 3-3]
+  - [3-3, PARENT, 3-4]
+  - [3-3, PARENT, 3-5]
+  - [4-1, ROUTING, 5-2]
+  - [5-1, ROUTING, 5-2]
+  - [5-1, PARENT, 5-4]
+  - [5-2, ROUTING, 5-3]
+  - [5-3, PARENT, 5-5]
+


### PR DESCRIPTION
Gives us more variety to test against.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/519%23issuecomment-157415510%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/519%23issuecomment-157415510%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%27s%20interesting%20is%20that%20end2end%20breaks%20on%20this%20topology%3A%5Cr%5Cn%3E%202015-11-17%2016%3A05%3A18.029600%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20Testing%3A%20%285%2C%204%29%20-%3E%20%281%2C%204%29%5Cr%5Cn2015-11-17%2016%3A05%3A18.038905%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20Loaded%3A%20gen/ISD1/AD4/endhost/certs/ISD1-V0.trc%5Cr%5Cn2015-11-17%2016%3A05%3A18.039305%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20Loaded%3A%20gen/ISD1/AD4/endhost/certs/ISD1-AD4-V0.crt%5Cr%5Cn2015-11-17%2016%3A05%3A18.039590%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20sciond%20bound%20to%20127.0.0.3%3A30040%5Cr%5Cn2015-11-17%2016%3A05%3A18.040293%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20Pong%20App%20bound%20to%20127.0.0.3%3A53542%5Cr%5Cn2015-11-17%2016%3A05%3A18.048388%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20Loaded%3A%20gen/ISD5/AD4/endhost/certs/ISD5-V0.trc%5Cr%5Cn2015-11-17%2016%3A05%3A18.048708%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20Loaded%3A%20gen/ISD5/AD4/endhost/certs/ISD5-AD4-V0.crt%5Cr%5Cn2015-11-17%2016%3A05%3A18.048938%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20sciond%20bound%20to%20127.0.0.2%3A41800%5Cr%5Cn2015-11-17%2016%3A05%3A18.049225%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20sciond%20local%20API%20bound%20to%20127.255.255.254%3A3333%5Cr%5Cn2015-11-17%2016%3A05%3A18.049684%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20Sending%20PATH%20request%20for%20%281%2C%204%29%5Cr%5Cn2015-11-17%2016%3A05%3A18.050042%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20Sending%20path%20request%20to%20local%20API.%5Cr%5Cn2015-11-17%2016%3A05%3A18.050384%2B00%3A00%20%5BINFO%5D%20%28SCIONDaemon.run%29%20API%3A%20path%20request%20from%20%28%27127.0.0.1%27%2C%2038291%29.%5Cr%5Cn2015-11-17%2016%3A05%3A18.060729%2B00%3A00%20%5BDEBUG%5D%20%28SCIONDaemon.run%29%20Up%20path%20added%3A%209a091e78d2a8%2C%202015-11-17%2016%3A05%3A14%2B00%3A00%2C%20%285%2C%201%29-%3E%285%2C%204%29%5Cr%5Cn2015-11-17%2016%3A05%3A18.122020%2B00%3A00%20%5BDEBUG%5D%20%28SCIONDaemon.run%29%20Down%20path%20added%3A%2029784c5ad62b%2C%202015-11-17%2016%3A05%3A15%2B00%3A00%2C%20%281%2C%202%29-%3E%281%2C%204%29%5Cr%5Cn2015-11-17%2016%3A05%3A18.149559%2B00%3A00%20%5BDEBUG%5D%20%28SCIONDaemon.run%29%20Core%20path%20added%3A%207f2035cf42ca%2C%202015-11-17%2016%3A05%3A05%2B00%3A00%2C%20%281%2C%202%29-%3E%282%2C%201%29-%3E%283%2C%201%29-%3E%285%2C%202%29-%3E%285%2C%201%29%5Cr%5Cn2015-11-17%2016%3A05%3A18.150090%2B00%3A00%20%5BDEBUG%5D%20%28SCIONDaemon.run%29%20Core%20path%20added%3A%20a53b45b5944c%2C%202015-11-17%2016%3A05%3A05%2B00%3A00%2C%20%281%2C%202%29-%3E%281%2C%201%29-%3E%282%2C%201%29-%3E%283%2C%201%29-%3E%285%2C%202%29-%3E%285%2C%201%29%5Cr%5Cn2015-11-17%2016%3A05%3A18.150540%2B00%3A00%20%5BDEBUG%5D%20%28SCIONDaemon.run%29%20Core%20path%20added%3A%207cdac3a7b785%2C%202015-11-17%2016%3A04%3A59%2B00%3A00%2C%20%281%2C%202%29-%3E%281%2C%201%29-%3E%282%2C%202%29-%3E%282%2C%201%29-%3E%283%2C%201%29-%3E%285%2C%202%29-%3E%285%2C%201%29%5Cr%5Cn2015-11-17%2016%3A05%3A18.154716%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20Ping%20App%20bound%20to%20127.0.0.2%3A46220%5Cr%5Cn2015-11-17%2016%3A05%3A18.155528%2B00%3A00%20%5BCRITICAL%5D%20%28E2E.ping_app%29%20Exception%20in%20E2E.ping_app%20thread%3A%5Cr%5Cn2015-11-17%2016%3A05%3A18.156455%2B00%3A00%20%5BCRITICAL%5D%20%28E2E.ping_app%29%20Traceback%20%28most%20recent%20call%20last%29%3A%5Cr%5Cn2015-11-17%2016%3A05%3A18.156749%2B00%3A00%20%5BCRITICAL%5D%20%28E2E.ping_app%29%20%20%20File%20%5C%22/home/kormat/github/scion/lib/thread.py%5C%22%2C%20line%2048%2C%20in%20thread_safety_net%5Cr%5Cn2015-11-17%2016%3A05%3A18.156945%2B00%3A00%20%5BCRITICAL%5D%20%28E2E.ping_app%29%20%20%20%20%20return%20func%28%2Aargs%2C%20%2A%2Akwargs%29%5Cr%5Cn2015-11-17%2016%3A05%3A18.157124%2B00%3A00%20%5BCRITICAL%5D%20%28E2E.ping_app%29%20%20%20File%20%5C%22test/integration/end2end_test.py%5C%22%2C%20line%20126%2C%20in%20run%5Cr%5Cn2015-11-17%2016%3A05%3A18.157296%2B00%3A00%20%5BCRITICAL%5D%20%28E2E.ping_app%29%20%20%20%20%20self.send%28%29%5Cr%5Cn2015-11-17%2016%3A05%3A18.157464%2B00%3A00%20%5BCRITICAL%5D%20%28E2E.ping_app%29%20%20%20File%20%5C%22test/integration/end2end_test.py%5C%22%2C%20line%20137%2C%20in%20send%5Cr%5Cn2015-11-17%2016%3A05%3A18.157629%2B00%3A00%20%5BCRITICAL%5D%20%28E2E.ping_app%29%20%20%20%20%20assert%20next_hop%20is%20not%20None%5Cr%5Cn2015-11-17%2016%3A05%3A18.157791%2B00%3A00%20%5BCRITICAL%5D%20%28E2E.ping_app%29%20AssertionError%5Cr%5Cn2015-11-17%2016%3A05%3A18.157951%2B00%3A00%20%5BCRITICAL%5D%20%28E2E.ping_app%29%5Cr%5Cn2015-11-17%2016%3A05%3A18.158216%2B00%3A00%20%5BERROR%5D%20%28E2E.MainThread%29%20Received%20SIGINT%5Cr%5Cn2015-11-17%2016%3A05%3A18.158517%2B00%3A00%20%5BINFO%5D%20%28E2E.MainThread%29%20Exiting%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-11-17T16%3A07%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/519#issuecomment-157415510'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> What's interesting is that end2end breaks on this topology:
  > 2015-11-17 16:05:18.029600+00:00 [INFO](E2E.MainThread) Testing: (5, 4) -> (1, 4)
  2015-11-17 16:05:18.038905+00:00 [INFO](E2E.MainThread) Loaded: gen/ISD1/AD4/endhost/certs/ISD1-V0.trc
  2015-11-17 16:05:18.039305+00:00 [INFO](E2E.MainThread) Loaded: gen/ISD1/AD4/endhost/certs/ISD1-AD4-V0.crt
  2015-11-17 16:05:18.039590+00:00 [INFO](E2E.MainThread) sciond bound to 127.0.0.3:30040
  2015-11-17 16:05:18.040293+00:00 [INFO](E2E.MainThread) Pong App bound to 127.0.0.3:53542
  2015-11-17 16:05:18.048388+00:00 [INFO](E2E.MainThread) Loaded: gen/ISD5/AD4/endhost/certs/ISD5-V0.trc
  2015-11-17 16:05:18.048708+00:00 [INFO](E2E.MainThread) Loaded: gen/ISD5/AD4/endhost/certs/ISD5-AD4-V0.crt
  2015-11-17 16:05:18.048938+00:00 [INFO](E2E.MainThread) sciond bound to 127.0.0.2:41800
  2015-11-17 16:05:18.049225+00:00 [INFO](E2E.MainThread) sciond local API bound to 127.255.255.254:3333
  2015-11-17 16:05:18.049684+00:00 [INFO](E2E.MainThread) Sending PATH request for (1, 4)
  2015-11-17 16:05:18.050042+00:00 [INFO](E2E.MainThread) Sending path request to local API.
  2015-11-17 16:05:18.050384+00:00 [INFO](SCIONDaemon.run) API: path request from ('127.0.0.1', 38291).
  2015-11-17 16:05:18.060729+00:00 [DEBUG](SCIONDaemon.run) Up path added: 9a091e78d2a8, 2015-11-17 16:05:14+00:00, (5, 1)->(5, 4)
  2015-11-17 16:05:18.122020+00:00 [DEBUG](SCIONDaemon.run) Down path added: 29784c5ad62b, 2015-11-17 16:05:15+00:00, (1, 2)->(1, 4)
  2015-11-17 16:05:18.149559+00:00 [DEBUG](SCIONDaemon.run) Core path added: 7f2035cf42ca, 2015-11-17 16:05:05+00:00, (1, 2)->(2, 1)->(3, 1)->(5, 2)->(5, 1)
  2015-11-17 16:05:18.150090+00:00 [DEBUG](SCIONDaemon.run) Core path added: a53b45b5944c, 2015-11-17 16:05:05+00:00, (1, 2)->(1, 1)->(2, 1)->(3, 1)->(5, 2)->(5, 1)
  2015-11-17 16:05:18.150540+00:00 [DEBUG](SCIONDaemon.run) Core path added: 7cdac3a7b785, 2015-11-17 16:04:59+00:00, (1, 2)->(1, 1)->(2, 2)->(2, 1)->(3, 1)->(5, 2)->(5, 1)
  2015-11-17 16:05:18.154716+00:00 [INFO](E2E.MainThread) Ping App bound to 127.0.0.2:46220
  2015-11-17 16:05:18.155528+00:00 [CRITICAL](E2E.ping_app) Exception in E2E.ping_app thread:
  2015-11-17 16:05:18.156455+00:00 [CRITICAL](E2E.ping_app) Traceback (most recent call last):
  2015-11-17 16:05:18.156749+00:00 [CRITICAL](E2E.ping_app)   File "/home/kormat/github/scion/lib/thread.py", line 48, in thread_safety_net
  2015-11-17 16:05:18.156945+00:00 [CRITICAL](E2E.ping_app)     return func(_args, *_kwargs)
  2015-11-17 16:05:18.157124+00:00 [CRITICAL](E2E.ping_app)   File "test/integration/end2end_test.py", line 126, in run
  2015-11-17 16:05:18.157296+00:00 [CRITICAL](E2E.ping_app)     self.send()
  2015-11-17 16:05:18.157464+00:00 [CRITICAL](E2E.ping_app)   File "test/integration/end2end_test.py", line 137, in send
  2015-11-17 16:05:18.157629+00:00 [CRITICAL](E2E.ping_app)     assert next_hop is not None
  2015-11-17 16:05:18.157791+00:00 [CRITICAL](E2E.ping_app) AssertionError
  2015-11-17 16:05:18.157951+00:00 [CRITICAL](E2E.ping_app)
  2015-11-17 16:05:18.158216+00:00 [ERROR](E2E.MainThread) Received SIGINT
  2015-11-17 16:05:18.158517+00:00 [INFO](E2E.MainThread) Exiting

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/519?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/519?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/519'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
