### PR TITLE
Possible fix for random end2end failures

### DIFF
--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -263,7 +263,8 @@ class SCIONElement(object):
                         packet, addr = sock.recv(block=False)
                     except BlockingIOError:
                         break
-                self.packet_put(packet, addr, sock == self._local_sock)
+                    else:
+                        self.packet_put(packet, addr, sock == self._local_sock)
 
         self.stopped_flag.set()
 


### PR DESCRIPTION
If you've created a PR or run an integration test recently you may have seen end2end fail for no apparent reason.

This patch is a possible fix - I say possible because logically I still don't see how the previous code caused packet loss (with no log messages either) but with this patch so far the test has been running repeatedly for an hour and a half without failing.

If the test continues to succeed for the rest of the day I think it would be safe to call the issue fixed and merge this patch.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/520%23issuecomment-157673070%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/520%23issuecomment-157678756%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/520%23issuecomment-158407040%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/520%23issuecomment-157673070%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20has%20already%20been%20merged%2C%20but%20now%20I%20actually%20have%20an%20explanation%20for%20why%20it%20works%20%3A%29%5Cr%5CnThe%20previous%20code%20would%20miss%20packets%20if%20a%20socket%20returned%20from%20recv%20more%20than%20once%20without%20blocking%20because%20the%20call%20to%20packet_put%20was%20outside%20the%20while%20loop.%5Cr%5CnSo%20if%20by%20chance%20a%20router%20read%20in%20a%20packet%20then%20tried%20to%20read%20from%20the%20socket%20again%20and%20succeeded%2C%20the%20first%20packet%20would%20have%20been%20lost.%5Cr%5Cn%5Cr%5CnIn%20conclusion%2C%20my%20bad.%22%2C%20%22created_at%22%3A%20%222015-11-18T10%3A31%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22oh%2C%20I%20see%2C%20looks%20really%20tricky%20to%20find%20%3B-%29%22%2C%20%22created_at%22%3A%20%222015-11-18T10%3A58%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nice%20find%21%22%2C%20%22created_at%22%3A%20%222015-11-20T13%3A46%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/520#issuecomment-157673070'>General Comment</a></b>
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> This has already been merged, but now I actually have an explanation for why it works :)
  The previous code would miss packets if a socket returned from recv more than once without blocking because the call to packet_put was outside the while loop.
  So if by chance a router read in a packet then tried to read from the socket again and succeeded, the first packet would have been lost.
  In conclusion, my bad.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> oh, I see, looks really tricky to find ;-)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Nice find!

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/520?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/520?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/520'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
