### PR TITLE
Change lib.log to use 1 log file per log level.

### DIFF
--- a/endhost/dummy.py
+++ b/endhost/dummy.py
@@ -13,7 +13,7 @@ from lib.util import handle_signals
 
 def main():
     handle_signals()
-    init_logging("logs/sciond.%s.log" % sys.argv[2])
+    init_logging("logs/sciond.%s" % sys.argv[2])
     SCIONDaemon.start(sys.argv[1], haddr_parse("IPV4", sys.argv[2]),
                       sys.argv[3], len(sys.argv) == 5)
     cdir = os.path.dirname(os.path.realpath(__file__))

--- a/endhost/scion_proxy.py
+++ b/endhost/scion_proxy.py
@@ -88,7 +88,7 @@ VERSION = '0.1.0'
 BUFLEN = 8192
 SERVER_ADDRESS = ('127.0.0.1', 8080)
 SELECT_TIMEOUT = 3  # seconds
-LOG_FILE = 'logs/scion_proxy.log'
+LOG_BASE = 'logs/scion_proxy'
 
 
 class ConnectionHandler(SimpleHTTPRequestHandler):
@@ -268,7 +268,7 @@ class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
     daemon_threads = True
 
 if __name__ == '__main__':
-    init_logging(log_file=LOG_FILE, level=logging.DEBUG, console=True)
+    init_logging(LOG_BASE, file_level=logging.DEBUG, console_level=logging.INFO)
     httpd = ThreadingHTTPServer(SERVER_ADDRESS, ConnectionHandler)
     logging.info("Starting server at (%s, %s), use <Ctrl-C> to stop" %
                  SERVER_ADDRESS)

--- a/lib/main.py
+++ b/lib/main.py
@@ -64,7 +64,7 @@ def main_default(type_, local_type=None, trace_=False, **kwargs):
     parser.add_argument('log_dir', nargs='?', default="logs/",
                         help='Log dir (Default: logs/)')
     args = parser.parse_args()
-    init_logging("%s.log" % os.path.join(args.log_dir, args.server_id))
+    init_logging(os.path.join(args.log_dir, args.server_id))
 
     if local_type is None:
         inst = type_(args.server_id, args.conf_dir, **kwargs)

--- a/supervisor/supervisord.conf
+++ b/supervisor/supervisord.conf
@@ -57,11 +57,11 @@ supervisor.ctl_factory = supervisor_quick:make_quick_controllerplugin
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 environment=PYTHONPATH=.
-command=ad_management/management_daemon.py 0.0.0.0 logs/management_daemon.log
+command=ad_management/management_daemon.py 0.0.0.0 logs/management_daemon
 autostart=false
 autorestart=false
 startretries=0
-stdout_logfile=logs/management_daemon.out
+stdout_logfile=logs/management_daemon.OUT
 
 [include]
 files = ../gen/ISD*/AD*/*/supervisord.conf ../gen/ISD*/AD*/supervisord.conf

--- a/test/integration/bandwidth_test.py
+++ b/test/integration/bandwidth_test.py
@@ -118,7 +118,7 @@ class TestBandwidth(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    init_logging("logs/bw_test.log", console=True)
+    init_logging("logs/bw_test", console_level=logging.DEBUG)
     handle_signals()
     try:
         TestBandwidth().test()

--- a/test/integration/cli_srv_ext_test.py
+++ b/test/integration/cli_srv_ext_test.py
@@ -130,7 +130,7 @@ def main():
     parser.add_argument('srv_ad', nargs='?', help='Server isd,ad',
                         default="2,26")
     args = parser.parse_args()
-    init_logging("logs/c2s_extn.log", console=True)
+    init_logging("logs/c2s_extn", console_level=logging.DEBUG)
 
     if not args.client:
         args.client = "169.254.0.2" if args.mininet else "127.0.0.2"

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -269,7 +269,7 @@ def main():
     parser.add_argument('src_ad', nargs='?', help='Src isd,ad')
     parser.add_argument('dst_ad', nargs='?', help='Dst isd,ad')
     args = parser.parse_args()
-    init_logging("logs/end2end.log", console=True)
+    init_logging("logs/end2end", console_level=logging.DEBUG)
 
     if not args.client:
         args.client = "169.254.0.2" if args.mininet else "127.0.0.2"

--- a/test/lib_log_test.py
+++ b/test/lib_log_test.py
@@ -31,7 +31,7 @@ from lib.log import (
     init_logging,
     log_exception,
 )
-from test.testcommon import SCIONTestError
+from test.testcommon import SCIONTestError, assert_these_calls, create_mock
 
 
 class TestHandleError(object):
@@ -61,31 +61,46 @@ class TestInitLogging(object):
     """
     Unit tests for lib.log.init_logging
     """
+    @patch("lib.log.logging.basicConfig", autospec=True)
     @patch("lib.log._ConsoleErrorHandler", autospec=True)
     @patch("lib.log._RotatingErrorHandler", autospec=True)
-    @patch("lib.log.logging.basicConfig", autospec=True)
     @patch("lib.log._Rfc3339Formatter", autospec=True)
-    def test_full(self, formatter, basic_config, rotate, console):
+    def test_full(self, formatter, rotate, console, basic_config):
+        levels = "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
+        file_handlers = [
+            create_mock(["setLevel", "setFormatter"]),
+            create_mock(["setLevel", "setFormatter"]),
+            create_mock(["setLevel", "setFormatter"]),
+            create_mock(["setLevel", "setFormatter"]),
+            create_mock(["setLevel", "setFormatter"]),
+        ]
+        console_handler = console.return_value
+        rotate.side_effect = file_handlers
         # Call
-        init_logging("logfile", 123, console=True)
+        init_logging("logbase", file_level=logging.DEBUG,
+                     console_level=logging.CRITICAL)
         # Tests
-        rotate.assert_called_once_with(
-            "logfile", maxBytes=LOG_MAX_SIZE, backupCount=LOG_BACKUP_COUNT,
-            encoding="utf-8")
-        console.assert_called_once_with()
-        rotate.return_value.setFormatter.assert_called_once_with(
-            formatter.return_value)
-        console.return_value.setFormatter.assert_called_once_with(
+        rotate_calls = []
+        for lvl in levels:
+            rotate_calls.append(call(
+                "logbase.%s" % lvl, maxBytes=LOG_MAX_SIZE,
+                backupCount=LOG_BACKUP_COUNT, encoding="utf-8"))
+        assert_these_calls(rotate, rotate_calls)
+        for lvl, f_h in zip(levels, file_handlers):
+            f_h.setLevel.assert_called_once_with(logging._nameToLevel[lvl])
+            f_h.setFormatter.assert_called_once_with(formatter.return_value)
+        console_handler.setLevel.assert_called_once_with(logging.CRITICAL)
+        console_handler.setFormatter.assert_called_once_with(
             formatter.return_value)
         basic_config.assert_called_once_with(
-            level=123, handlers=[rotate.return_value, console.return_value],
+            level=logging.DEBUG, handlers=file_handlers + [console_handler]
         )
 
     @patch("lib.log._RotatingErrorHandler", autospec=True)
     @patch("lib.log.logging.basicConfig", autospec=True)
     def test_file(self, basic_config, rotate):
         # Call
-        init_logging("logfile")
+        init_logging("logfile", file_level=logging.CRITICAL)
         # Tests
         basic_config.assert_called_once_with(
             level=logging.DEBUG, handlers=[rotate.return_value],
@@ -95,7 +110,7 @@ class TestInitLogging(object):
     @patch("lib.log.logging.basicConfig", autospec=True)
     def test_console(self, basic_config, console):
         # Call
-        init_logging(console=True)
+        init_logging(console_level=logging.DEBUG)
         # Tests
         basic_config.assert_called_once_with(
             level=logging.DEBUG, handlers=[console.return_value],

--- a/test/lib_main_test.py
+++ b/test/lib_main_test.py
@@ -79,7 +79,7 @@ class TestMainDefault(object):
         argparse.assert_called_once_with()
         ntools.ok_(parser.add_argument.called)
         parser.parse_args.assert_called_once_with()
-        init_log.assert_called_once_with("logging/srvid.log")
+        init_log.assert_called_once_with("logging/srvid")
         type_.assert_called_once_with("srvid", "confdir", kwarg1="kwarg1")
         trace.assert_called_once_with(inst.id)
         inst.run.assert_called_once_with()

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -584,7 +584,7 @@ class SupervisorGenerator(object):
             'redirect_stderr': 'true',
             'environment': 'PYTHONPATH=.',
             'stdout_logfile_maxbytes': 0,
-            'stdout_logfile': "logs/%s.out" % name,
+            'stdout_logfile': "logs/%s.OUT" % name,
             'startretries': 0,
             'startsecs': 5,
             'command': " ".join(['"%s"' % arg for arg in cmd_args]),


### PR DESCRIPTION
Each log file contains all the messages for its own level, as well as
more important levels. I.e., log.CRITICAL contains all critical log
entries, log.WARNING contains all warning/error/critical log entries,
and log.DEBUG contains everything.

This allows much easier monitoring of the level of information you're
interested in. E.g., when running integration tests, tail -F
logs/*.WARNING allows you to easily watch for any failures.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/533%23issuecomment-159923773%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/533%23issuecomment-159936256%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/533%23issuecomment-159937553%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/533%23issuecomment-159923773%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222015-11-26T14%3A07%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22code%20LGTM%2C%20but%20not%20convinced%20about%20the%20idea.%20I%20still%20prefer%20to%20have%20this%20in%20a%20single%20file.%20This%20change%20may%20be%20especially%20annoying%20when%20events%20are%20correlated%20e.g.%20CRITICAL%20is%20caused%20by%20WARNING%2C%20or%20when%20we%20want%20to%20check%20some%20DEBUG%20entries%20that%20occurred%20before%20CRITICAL.%20Joining%20and%20sorting%20files%20to%20determine%20events%20order%20does%20not%20sound%20like%20a%20good%20option.%5Cr%5Cn%5Cr%5CnIn%20general%20%60tail%2Bgrep%60%20is%20fine%20%28at%20least%20to%20me%29%20to%20separate%20debug%20levels.%22%2C%20%22created_at%22%3A%20%222015-11-26T15%3A17%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22ignore%20my%20last%20comment%20%28I%20noticed%20that%20DEBUG%20contains%20everything%29.%22%2C%20%22created_at%22%3A%20%222015-11-26T15%3A25%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/533#issuecomment-159923773'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> code LGTM, but not convinced about the idea. I still prefer to have this in a single file. This change may be especially annoying when events are correlated e.g. CRITICAL is caused by WARNING, or when we want to check some DEBUG entries that occurred before CRITICAL. Joining and sorting files to determine events order does not sound like a good option.
  In general `tail+grep` is fine (at least to me) to separate debug levels.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> ignore my last comment (I noticed that DEBUG contains everything).

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/533?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/533?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/533'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
