### PR TITLE
Move PCB extensions into lib.packet.pcb_ext

### DIFF
--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -72,7 +72,8 @@ from lib.packet.pcb import (
     PCBMarking,
     PathSegment,
 )
-from lib.packet.pcb_ext import MTUExtension, REVExtension
+from lib.packet.pcb_ext.mtu import MtuPcbExt
+from lib.packet.pcb_ext.rev import RevPcbExt
 from lib.packet.scion import PacketType as PT
 from lib.path_store import PathPolicy, PathStore
 from lib.thread import thread_safety_net
@@ -402,9 +403,9 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         """
         for ad in pcb.ads:
             for ext in ad.ext:
-                if ext.EXT_TYPE == MTUExtension.EXT_TYPE:
+                if ext.EXT_TYPE == MtuPcbExt.EXT_TYPE:
                     self.mtu_ext_handler(ext, ad)
-                elif ext.EXT_TYPE == REVExtension.EXT_TYPE:
+                elif ext.EXT_TYPE == RevPcbExt.EXT_TYPE:
                     self.rev_ext_handler(ext, ad)
                 else:
                     logging.warning("PCB extension %d not supported" % ext.TYPE)
@@ -486,9 +487,9 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
 
         # Add extensions.
         extensions = []
-        extensions.append(MTUExtension.from_values(self.config.mtu))
+        extensions.append(MtuPcbExt.from_values(self.config.mtu))
         for _, rev_info in self.revs_to_downstream.items():
-            rev_ext = REVExtension.from_values(rev_info)
+            rev_ext = RevPcbExt.from_values(rev_info)
             extensions.append(rev_ext)
         return ADMarking.from_values(pcbm, peer_markings,
                                      self._get_if_rev_token(egress_if),

--- a/lib/packet/pcb.py
+++ b/lib/packet/pcb.py
@@ -32,7 +32,8 @@ from lib.errors import SCIONParseError
 from lib.packet.opaque_field import HopOpaqueField, InfoOpaqueField
 from lib.packet.packet_base import SCIONPayloadBase
 from lib.packet.path import CorePath
-from lib.packet.pcb_ext import MTUExtension, REVExtension
+from lib.packet.pcb_ext.mtu import MtuPcbExt
+from lib.packet.pcb_ext.rev import RevPcbExt
 from lib.packet.scion_addr import ISD_AD
 from lib.types import PayloadClass, PCBType
 from lib.util import Raw
@@ -42,8 +43,8 @@ REV_TOKEN_LEN = 32
 
 # Dictionary of supported extensions
 PCB_EXTENSION_MAP = {
-    (MTUExtension.EXT_TYPE): MTUExtension,
-    (REVExtension.EXT_TYPE): REVExtension,
+    (MtuPcbExt.EXT_TYPE): MtuPcbExt,
+    (RevPcbExt.EXT_TYPE): RevPcbExt,
 }
 
 

--- a/lib/packet/pcb_ext/__init__.py
+++ b/lib/packet/pcb_ext/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`pcb_ext` --- Beacon extensions
+====================================
+"""
+# SCION
+from lib.packet.packet_base import HeaderBase
+from lib.types import TypeBase
+
+
+class BeaconExtType(TypeBase):
+    """
+    Constants for two types of beacon extensions.
+    """
+    MTU = 0
+    REV = 1
+
+
+class BeaconExtension(HeaderBase):
+    """
+    Base class for beacon extensions.
+    """
+    EXT_TYPE = None
+    EXT_TYPE_STR = None
+    LEN = None

--- a/lib/packet/pcb_ext/mtu.py
+++ b/lib/packet/pcb_ext/mtu.py
@@ -12,36 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-:mod:`pcb_ext` --- Beacon extensions
-====================================
+:mod:`mtu` --- Beacon MTU extension
+===================================
 """
 # Stdlib
 import struct
 
 # SCION
-from lib.packet.packet_base import HeaderBase
-from lib.packet.rev_info import RevocationInfo
-from lib.types import TypeBase
+from lib.packet.pcb_ext import BeaconExtType, BeaconExtension
 
 
-class BeaconExtType(TypeBase):
-    """
-    Constants for two types of beacon extensions.
-    """
-    MTU = 0
-    REV = 1
-
-
-class BeaconExtension(HeaderBase):
-    """
-    Base class for beacon extensions.
-    """
-    EXT_TYPE = None
-    EXT_TYPE_STR = None
-    LEN = None
-
-
-class MTUExtension(BeaconExtension):  # pragma: no cover
+class MtuPcbExt(BeaconExtension):  # pragma: no cover
     """
     0        8        16
     |       MTU        |
@@ -79,42 +60,3 @@ class MTUExtension(BeaconExtension):  # pragma: no cover
 
     def __str__(self):
         return "MTU Ext(%dB): MTU is %dB" % (len(self), self.mtu)
-
-
-class REVExtension(BeaconExtension):
-    """
-    Length of REVExtension
-    """
-    EXT_TYPE = BeaconExtType.REV
-    LEN = 32
-
-    def __init__(self, raw=None):
-        """
-        Initialize an instance of the class REVExtension
-
-        :param raw:
-        :type raw:
-        """
-        self.rev_info = None
-        super().__init__(raw)
-
-    @classmethod
-    def from_values(cls, rev):
-        """
-        Construct extension with `rev` value.
-        """
-        inst = cls()
-        inst.rev_info = rev
-        return inst
-
-    def _parse(self, raw):
-        self.rev_info = RevocationInfo(raw)
-
-    def pack(self):
-        return self.rev_info.pack()
-
-    def __len__(self):
-        return len(self.rev_info)
-
-    def __str__(self):
-        return str(self.rev_info)

--- a/lib/packet/pcb_ext/rev.py
+++ b/lib/packet/pcb_ext/rev.py
@@ -1,0 +1,59 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`rev` --- Beacon revocation extension
+==========================================
+"""
+# SCION
+from lib.packet.pcb_ext import BeaconExtType, BeaconExtension
+from lib.packet.rev_info import RevocationInfo
+
+
+class RevPcbExt(BeaconExtension):
+    """
+    Length of REVExtension
+    """
+    EXT_TYPE = BeaconExtType.REV
+    LEN = 32
+
+    def __init__(self, raw=None):
+        """
+        Initialize an instance of the class REVExtension
+
+        :param raw:
+        :type raw:
+        """
+        self.rev_info = None
+        super().__init__(raw)
+
+    @classmethod
+    def from_values(cls, rev):
+        """
+        Construct extension with `rev` value.
+        """
+        inst = cls()
+        inst.rev_info = rev
+        return inst
+
+    def _parse(self, raw):
+        self.rev_info = RevocationInfo(raw)
+
+    def pack(self):
+        return self.rev_info.pack()
+
+    def __len__(self):
+        return len(self.rev_info)
+
+    def __str__(self):
+        return str(self.rev_info)


### PR DESCRIPTION
As more PCB extensions are created, keeping them all in pcb_ext.py
becomes impractical, and splitting them across multiple modules directly
in lib.packet becomes messy. So, instead this change moves them into a
new subdir, and changes to 1-extension-per-module.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/535%23issuecomment-159935146%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/535%23issuecomment-159937823%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/535%23issuecomment-159935146%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222015-11-26T15%3A10%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-11-26T15%3A26%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/535#issuecomment-159935146'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/535?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/535?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/535'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
