### PR TITLE
Add SIBRA pcb extension

### DIFF
--- a/lib/packet/pcb.py
+++ b/lib/packet/pcb.py
@@ -34,6 +34,7 @@ from lib.packet.packet_base import SCIONPayloadBase
 from lib.packet.path import CorePath
 from lib.packet.pcb_ext.mtu import MtuPcbExt
 from lib.packet.pcb_ext.rev import RevPcbExt
+from lib.packet.pcb_ext.sibra import SibraPcbExt
 from lib.packet.scion_addr import ISD_AD
 from lib.types import PayloadClass, PCBType
 from lib.util import Raw
@@ -45,6 +46,7 @@ REV_TOKEN_LEN = 32
 PCB_EXTENSION_MAP = {
     (MtuPcbExt.EXT_TYPE): MtuPcbExt,
     (RevPcbExt.EXT_TYPE): RevPcbExt,
+    (SibraPcbExt.EXT_TYPE): SibraPcbExt,
 }
 
 

--- a/lib/packet/pcb_ext/__init__.py
+++ b/lib/packet/pcb_ext/__init__.py
@@ -26,6 +26,7 @@ class BeaconExtType(TypeBase):
     """
     MTU = 0
     REV = 1
+    SIBRA = 2
 
 
 class BeaconExtension(HeaderBase):

--- a/lib/packet/pcb_ext/sibra.py
+++ b/lib/packet/pcb_ext/sibra.py
@@ -1,0 +1,70 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`sibra` --- Beacon SIBRA extension
+=======================================
+"""
+# Stdlib
+import struct
+
+# SCION
+from lib.packet.pcb_ext import BeaconExtType, BeaconExtension
+from lib.util import Raw
+
+
+class SibraPcbExt(BeaconExtension):
+    """
+    SIBRA PCB extension, to attach available steady/ephemeral bandwidth for each
+    link on a path segment.
+    At a granularity of 1kbps, the steady bandwidth requires 10 bits to
+    describe, and ephemeral b/w requires 17 bits. So, we can pack both into a
+    32bit value. The top 5 bits are reserved.
+    """
+    NAME = "SibraPcbExt"
+    EXT_TYPE = BeaconExtType.SIBRA
+    LEN = 4
+    STEADY_BW_BITS = 10
+    EPHEMERAL_BW_BITS = 17
+
+    def __init__(self, raw=None):  # pragma: no cover
+        self.s_bw = None
+        self.e_bw = None
+        super().__init__(raw)
+
+    def _parse(self, raw):
+        data = Raw(raw, self.NAME, self.LEN)
+        bw = struct.unpack("!I", data.pop(self.LEN))[0]
+        self.s_bw = (bw >> self.EPHEMERAL_BW_BITS) & 0x3ff
+        self.e_bw = bw & 0x1ffff
+
+    @classmethod
+    def from_values(cls, s_bw, e_bw):  # pragma: no cover
+        inst = cls()
+        assert s_bw < 2**cls.STEADY_BW_BITS
+        assert e_bw < 2**cls.EPHEMERAL_BW_BITS
+        inst.s_bw = s_bw
+        inst.e_bw = e_bw
+        return inst
+
+    def pack(self):
+        bw = self.s_bw << self.EPHEMERAL_BW_BITS
+        bw += self.e_bw
+        return struct.pack("!I", bw)
+
+    def __len__(self):  # pragma: no cover
+        return self.LEN
+
+    def __str__(self):  # pragma: no cover
+        return "B/W available (kbps): steady: %s ephemeral: %s" % (
+            self.s_bw, self.e_bw)

--- a/test/lib_packet_pcb_ext_sibra_test.py
+++ b/test/lib_packet_pcb_ext_sibra_test.py
@@ -1,0 +1,62 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`lib_packet_pcb_ext_sibra_test` --- lib.packet.pcb_ext.sibra unit tests
+============================================================================
+"""
+# Stdlib
+from unittest.mock import patch
+
+# External packages
+import nose
+import nose.tools as ntools
+
+# SCION
+from lib.packet.pcb_ext.sibra import SibraPcbExt
+from test.testcommon import create_mock
+
+
+class TestSibraPcbExtParse(object):
+    """
+    Unit tests for lib.packet.pcb_ext.sibra.SibraPcbExt._parse
+    """
+    @patch("lib.packet.pcb_ext.sibra.Raw", autospec=True)
+    def test(self, raw):
+        inst = SibraPcbExt()
+        data = create_mock(["pop"])
+        data.pop.return_value = bytes(
+            [0b00000100, 0b00000011, 0b00000000, 0b00000001])
+        raw.return_value = data
+        # Call
+        inst._parse("data")
+        # Tests
+        raw.assert_called_once_with("data", "SibraPcbExt", SibraPcbExt.LEN)
+        ntools.eq_(inst.s_bw, 2**9 + 1)
+        ntools.eq_(inst.e_bw, 2**16 + 1)
+
+
+class TestSibraPcbExtPack(object):
+    """
+    Unit tests for lib.packet.pcb_ext.sibra.SibraPcbExt.pack
+    """
+    def test(self):
+        inst = SibraPcbExt()
+        inst.s_bw = 2**9 + 1
+        inst.e_bw = 2**16 + 1
+        expected = bytes([0b00000100, 0b00000011, 0b00000000, 0b00000001])
+        # Call
+        ntools.eq_(inst.pack(), expected)
+
+if __name__ == "__main__":
+    nose.run(defaultTest=__name__)


### PR DESCRIPTION
SIBRA requires that available steady & ephemeral path bandwidth is
propagated in beacons. This change adds a small PCB extension to
encapsulate that data for every hop.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/537%23issuecomment-160115298%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/537%23issuecomment-160115298%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-11-27T11%3A05%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/537#issuecomment-160115298'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/537?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/537?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/537'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
