### PR TITLE
Shutdown supervisord when regenerating the topology

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -5,10 +5,15 @@ export PYTHONPATH=.
 # BEGIN subcommand functions
 
 cmd_topology() {
-    echo "Create topology, configuration, and execution files."
+    echo "Shutting down supervisord: $(supervisor/supervisor.sh shutdown)"
     mkdir -p logs traces
     [ -e gen ] && rm -r gen
-    [ -e /run/shm/scion-zk ] && rm -r /run/shm/scion-zk
+    if [ "$1" = "zkclean" ]; then
+        shift
+        echo "Deleting all Zookeeper state"
+        tools/zkcleanslate
+    fi
+    echo "Create topology, configuration, and execution files."
     topology/generator.py "$@"
 }
 
@@ -110,8 +115,10 @@ cmd_help() {
 	echo
 	cat <<-_EOF
 	Usage:
-	    $PROGRAM topology
-	        Create topology, configuration, and execution files.
+	    $PROGRAM topology [zkclean]
+	        Create topology, configuration, and execution files. With the
+	        'zkclean' option, also reset all local Zookeeper state. Another
+	        other arguments or options are passed to topology/generator.py
 	    $PROGRAM run
 	        Run network.
 	    $PROGRAM stop


### PR DESCRIPTION
This keeps supervisord in sync with the on-disk topology, and implicitly
stops all existing processes when the topology changes.

Also add a 'zkclean' argument to optionally clean local zookeeper state.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/542?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/542'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
