### PR TITLE
Update DB expiration time when new PCB comes in

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -340,14 +340,14 @@ class SCIONDaemon(SCIONElement):
         """
         ptype, src_isd, src_ad, dst_isd, dst_ad = key
         if ptype == PST.UP:
-            return len(self.up_segments)
+            return len(self.up_segments())
         elif ptype == PST.DOWN:
             return self.down_segments(last_isd=dst_isd, last_ad=dst_ad)
         elif ptype == PST.CORE:
             return self.core_segments(last_isd=src_isd, last_ad=src_ad,
                                       first_isd=dst_isd, first_ad=dst_ad)
         elif ptype == PST.UP_DOWN:
-            return (len(self.up_segments) and
+            return (len(self.up_segments()) and
                     self.down_segments(last_isd=dst_isd, last_ad=dst_ad))
 
     def _fetch_segments(self, key, _):

--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -827,7 +827,7 @@ class LocalPathServer(PathServer):
             src_ad = self.topology.ad_id
         seg_info = PathSegmentInfo.from_values(ptype, src_isd, src_ad, dst_isd,
                                                dst_ad)
-        if not len(self.up_segments):
+        if not len(self.up_segments()):
             if ptype == PST.DOWN:
                 logging.info('Pending target added (%d, %d)', dst_isd, dst_ad)
                 self.waiting_targets.add((dst_isd, dst_ad, seg_info))
@@ -875,7 +875,7 @@ class LocalPathServer(PathServer):
         paths_to_send = []
         # Requester wants up-path.
         if seg_type in (PST.UP, PST.UP_DOWN):
-            if len(self.up_segments):
+            if len(self.up_segments()):
                 paths_to_send.extend(self.up_segments()[:self.MAX_SEG_NO])
             else:
                 if seg_type == PST.UP_DOWN:

--- a/lib/path_db.py
+++ b/lib/path_db.py
@@ -190,6 +190,8 @@ class PathSegmentDB(object):
             cur_rec.pcb = pcb
             if self._segment_ttl:
                 cur_rec.exp_time = now + self._segment_ttl
+            else:
+                cur_rec.exp_time = pcb.get_expiration_time()
             return DBResult.ENTRY_UPDATED
 
     def update_all(self, pcbs, first_isd, first_ad, last_isd, last_ad):

--- a/test/lib_path_db_test.py
+++ b/test/lib_path_db_test.py
@@ -208,9 +208,9 @@ class TestPathSegmentDBUpdate(object):
     def test_entry_update(self, db_rec):
         pcb = create_mock(["get_expiration_time"], class_=PathSegment)
         pcb.get_expiration_time.return_value = 1
-        record = create_mock(['id'])
+        record = create_mock(['id', 'exp_time'])
         record.id = "str"
-        cur_rec = create_mock(['pcb', 'id'])
+        cur_rec = create_mock(['pcb', 'id', 'exp_time'])
         cur_rec.pcb = create_mock(["get_expiration_time"])
         cur_rec.pcb.get_expiration_time.return_value = 0
         db_rec.return_value = record


### PR DESCRIPTION
Previous fix only applied to PathSegmentDB instances created with a
specified TTL value

Also, len(self.up_segments) includes expired entries, could cause problems.

I suspect this is involved in #434
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/543%23discussion_r46046132%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/543%23discussion_r46046557%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/543%23discussion_r46047325%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20f3a5790fc27182122f6de78413f9268994a1d20e%20endhost/sciond.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/543%23discussion_r46046132%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20this%20change%3F%20%60PathSegmentDB%60%20implements%20%60__len__%60%22%2C%20%22created_at%22%3A%20%222015-11-27T13%3A21%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28Turns%20out%20that%20doing%20len%28%29%20on%20a%20pathsegmentdb%20instance%20will%20return%20the%20number%20of%20_all_%20segments%20in%20the%20database%2C%20even%20expired%20ones%29%22%2C%20%22created_at%22%3A%20%222015-11-27T13%3A27%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-27T13%3A37%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/sciond.py%3AL340-354%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull f3a5790fc27182122f6de78413f9268994a1d20e endhost/sciond.py 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/543#discussion_r46046132'>File: endhost/sciond.py:L340-354</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Why this change? `PathSegmentDB` implements `__len__`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (Turns out that doing len() on a pathsegmentdb instance will return the number of _all_ segments in the database, even expired ones)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/543?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/543?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/543'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
