### PR TITLE
Bug fixes in socket

### DIFF
--- a/endhost/sdamp/DataStructures.h
+++ b/endhost/sdamp/DataStructures.h
@@ -125,7 +125,6 @@ typedef struct {
 } SSPData;
 
 typedef struct {
-    uint32_t offset;
     uint8_t *data;
     uint32_t len;
     int skipCount;

--- a/endhost/sdamp/Path.cpp
+++ b/endhost/sdamp/Path.cpp
@@ -555,7 +555,7 @@ int SSPPath::send(SCIONPacket *packet, int sock)
             current.tv_sec = t.tv_sec;
             current.tv_usec = t.tv_nsec / 1000;
             if (elapsedTime(&mLastSendTime, &current) > mState->getRTO()) {
-                DEBUG("path %d: loss occurred, abort send\n", mIndex);
+                DEBUG("path %d: loss occurred, abort send packet %u\n", mIndex, ntohl(sh.offset));
                 pthread_mutex_unlock(&mWindowMutex);
                 mManager->abortSend(packet);
                 if (sendInterfaces) {
@@ -648,6 +648,12 @@ int SSPPath::send(SCIONPacket *packet, int sock)
     if (wasValid && !mValid)
         return 1;
     return 0;
+}
+
+int SSPPath::getPayloadLen(bool ack)
+{
+    int hlen = ack ? sizeof(SSPHeader) + sizeof(SSPAck) : sizeof(SSPHeader);
+    return mMTU - (28 + sizeof(SCIONCommonHeader) + 2 * SCION_ADDR_LEN + mPathLen + hlen);
 }
 
 void SSPPath::start()

--- a/endhost/sdamp/Path.h
+++ b/endhost/sdamp/Path.h
@@ -77,7 +77,7 @@ public:
 
     bool didTimeout(struct timeval *current);
     
-    int getPayloadLen(bool ack);
+    virtual int getPayloadLen(bool ack);
     int getETA(SCIONPacket *packet);
     int getRTT();
     int getRTO();
@@ -113,6 +113,7 @@ public:
     ~SSPPath();
 
     int send(SCIONPacket *packet, int sock);
+    int getPayloadLen(bool ack);
     void start();
     int handleAck(SCIONPacket *packet, bool rttSample);
     static void * workerHelper(void *arg);

--- a/endhost/sdamp/SCIONProtocol.cpp
+++ b/endhost/sdamp/SCIONProtocol.cpp
@@ -752,7 +752,7 @@ void SSPProtocol::handleData(SSPInPacket *packet, int pathIndex)
         DEBUG("in-order packet\n");
         pthread_mutex_lock(&mReadMutex);
         if (len + mTotalReceived > mLocalReceiveWindow) {
-            DEBUG("Receive window too full: %lu/%lu\n",
+            DEBUG("in-order: Receive window too full: %lu/%lu\n",
                     mTotalReceived, mLocalReceiveWindow);
             packet->data = NULL;
             destroySSPInPacket(packet);
@@ -791,7 +791,7 @@ void SSPProtocol::handleData(SSPInPacket *packet, int pathIndex)
         int packetSize = len + sizeof(SSPInPacket);
         pthread_mutex_lock(&mReadMutex);
         if (packetSize + mTotalReceived > mLocalReceiveWindow - maxPayload) {
-            DEBUG("Receive window too full: %lu/%lu\n",
+            DEBUG("out-of-order: Receive window too full: %lu/%lu\n",
                     mTotalReceived, mLocalReceiveWindow);
             packet->data = NULL;
             destroySSPInPacket(packet);
@@ -885,7 +885,6 @@ SCIONPacket * SSPProtocol::createPacket(uint8_t *buf, size_t len)
     }
     sp->data = buf;
     sp->len = len;
-    sp->offset = mNextOffset;
     mNextOffset += len;
 
     return packet;

--- a/endhost/sdamp/SCIONSocket.cpp
+++ b/endhost/sdamp/SCIONSocket.cpp
@@ -259,7 +259,7 @@ void SCIONSocket::handlePacket(uint8_t *buf, size_t len, struct sockaddr_in *add
         addrs[0] = srcAddr;
         DEBUG("create new socket to handle incoming flow\n");
         SCIONSocket *s = new SCIONSocket(mProtocolID, (SCIONAddr *)addrs, 1, -1, mDstPort);
-        s->mProtocol->createManager(mDstAddrs);
+        s->mProtocol->createManager(s->mDstAddrs);
         s->mProtocol->start(packet, buf + sch.headerLen, s->mDispatcherSocket);
         s->mRegistered = true;
         pthread_cond_signal(&s->mRegisterCond);

--- a/endhost/sdamp/Utils.cpp
+++ b/endhost/sdamp/Utils.cpp
@@ -35,7 +35,7 @@ bool compareOffset(void *p1, void *p2)
     SCIONPacket *s2 = (SCIONPacket *)p2;
     SSPOutPacket *sp1 = (SSPOutPacket *)(s1->payload);
     SSPOutPacket *sp2 = (SSPOutPacket *)(s2->payload);
-    return ntohl(sp1->offset) > ntohl(sp2->offset);
+    return ntohl(sp1->header.offset) > ntohl(sp2->header.offset);
 }
 
 int reversePath(uint8_t *original, uint8_t *reverse, int len)


### PR DESCRIPTION
- Few obscure deadlock conditions
- Incorrect arguments to accept()ed socket caused path discovery failure
  in certain cases
  <a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
  <a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/544?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/544'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
  <a href='#crh-end'></a>
