### PR TITLE
Different type segments in a single PathSegmentRecords

### DIFF
--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -1108,7 +1108,7 @@ class CoreBeaconServer(BeaconServer):
         except SCIONServiceLookupError:
             # If there are no local path servers, stop here.
             return
-        records = PathRecordsReg.from_values(info, [pcb])
+        records = PathRecordsReg.from_values({info.seg_type: [pcb]})
         pkt = self._build_packet(ps_addr, payload=records)
         self.send(pkt, ps_addr)
 
@@ -1276,11 +1276,8 @@ class LocalBeaconServer(BeaconServer):
         :raises:
             SCIONServiceLookupError: path server lookup failure
         """
-        info = PathSegmentInfo.from_values(
-            PST.UP, self.topology.isd_id, pcb.get_first_pcbm().ad_id,
-            self.topology.isd_id, self.topology.ad_id)
         ps_host = self.dns_query_topo(PATH_SERVICE)[0]
-        records = PathRecordsReg.from_values(info, [pcb])
+        records = PathRecordsReg.from_values({PST.UP: [pcb]})
         pkt = self._build_packet(ps_host, payload=records)
         self.send(pkt, ps_host)
 
@@ -1288,11 +1285,8 @@ class LocalBeaconServer(BeaconServer):
         """
         Send down-segment to Core Path Server
         """
-        info = PathSegmentInfo.from_values(
-            PST.DOWN, self.topology.isd_id, pcb.get_first_pcbm().ad_id,
-            self.topology.isd_id, self.topology.ad_id)
         core_path = pcb.get_path(reverse_direction=True)
-        records = PathRecordsReg.from_values(info, [pcb])
+        records = PathRecordsReg.from_values({PST.DOWN: [pcb]})
         pkt = self._build_packet(
             PT.PATH_MGMT, dst_isd=pcb.get_isd(),
             dst_ad=pcb.get_first_pcbm().ad_id, path=core_path, payload=records)

--- a/lib/packet/path_mgmt.py
+++ b/lib/packet/path_mgmt.py
@@ -19,9 +19,10 @@ Contains all the packet formats used for path management.
 """
 # Stdlib
 import struct
+from collections import defaultdict
 
 # SCION
-from lib.types import PathMgmtType as PMT, PathSegmentType
+from lib.types import PathMgmtType as PMT, PathSegmentType as PST
 from lib.errors import SCIONParseError
 from lib.packet.packet_base import PathMgmtPayloadBase
 from lib.packet.pcb import PathSegment
@@ -92,7 +93,7 @@ class PathSegmentInfo(PathMgmtPayloadBase):
 
     def short_desc(self):
         return "%s %s-%s -> %s-%s" % (
-            PathSegmentType.to_str(self.seg_type), self.src_isd, self.src_ad,
+            PST.to_str(self.seg_type), self.src_isd, self.src_ad,
             self.dst_isd, self.dst_ad,
         )
 
@@ -101,7 +102,7 @@ class PathSegmentInfo(PathMgmtPayloadBase):
 
     def __str__(self):
         return "[%s(%dB): seg type:%s src isd/ad: %s/%s dst isd/ad: %s/%s]" % (
-            self.NAME, len(self), PathSegmentType.to_str(self.seg_type),
+            self.NAME, len(self), PST.to_str(self.seg_type),
             self.src_isd, self.src_ad, self.dst_isd, self.dst_ad,
         )
 
@@ -112,7 +113,7 @@ class PathSegmentRecords(PathMgmtPayloadBase):
     represented as objects of the PathSegment class. Type of a path is
     determined through info field (object of PathSegmentInfo).
     """
-    MIN_LEN = PathSegmentInfo.LEN + PathSegment.MIN_LEN
+    MIN_LEN = 1 + PathSegment.MIN_LEN
 
     def __init__(self, raw=None):  # pragma: no cover
         """
@@ -122,50 +123,52 @@ class PathSegmentRecords(PathMgmtPayloadBase):
         :type raw:
         """
         super().__init__()
-        self.info = None
-        self.pcbs = None
+        self.pcbs = defaultdict(list)
         if raw is not None:
             self._parse(raw)
 
     def _parse(self, raw):
         data = Raw(raw, self.NAME, self.MIN_LEN, min_=True)
-        self.info = PathSegmentInfo(data.pop(PathSegmentInfo.LEN))
-        self.pcbs = PathSegment.deserialize(data.pop())
+        while data:
+            seg_type = data.pop(1)
+            pcb = PathSegment(data.get())
+            data.pop(len(pcb))
+            self.pcbs[seg_type].append(pcb)
 
     @classmethod
-    def from_values(cls, info, pcbs):
+    def from_values(cls, pcb_dict):
         """
         Returns a Path Record with the values specified.
 
-        :param info: type of the path segment records
-        :type info: PathSegmentInfo
-        :param pcbs: list of path segments
-        :type pcbs: list
+        :param pcb_dict: dict of {seg_type: pcbs}
         """
-        assert isinstance(info, PathSegmentInfo)
         inst = cls()
-        inst.info = info
-        inst.pcbs = pcbs
+        inst.pcbs = pcb_dict
         return inst
 
     def pack(self):
         packed = []
-        packed.append(self.info.pack())
-        packed.append(PathSegment.serialize(self.pcbs))
+        for seg_type, pcbs in self.pcbs.items():
+            for pcb in pcbs:
+                packed.append(struct.pack("!B", seg_type))
+                packed.append(pcb.pack())
         return b"".join(packed)
 
     def __len__(self):
-        l = len(self.info)
-        for pcb in self.pcbs:
-            l += len(pcb)
+        l = 0
+        for pcbs in self.pcbs.values():
+            for pcb in pcbs:
+                l += len(pcb) + 1  # segment type byte
         return l
 
     def __str__(self):
         s = []
         s.append("%s(%dB):" % (self.NAME, len(self)))
-        s.append("  %s" % self.info)
-        for pcb in self.pcbs:
-            s.append("  %s" % pcb)
+        for type_ in [PST.UP, PST.DOWN, PST.CORE]:
+            if self.pcbs[type_]:
+                s.append("  %s:" % PST.to_str(type_))
+                for pcb in self.pcbs[type_]:
+                    s.append("    %s" % pcb.short_desc())
         return "\n".join(s)
 
 

--- a/lib/packet/pcb.py
+++ b/lib/packet/pcb.py
@@ -118,6 +118,9 @@ class PCBMarking(MarkingBase):
         inst.ig_rev_token = ig_rev_token or bytes(REV_TOKEN_LEN)
         return inst
 
+    def get_isd_ad(self):  # pragma: no cover
+        return ISD_AD(self.isd_id, self.ad_id)
+
     def pack(self):
         packed = []
         packed.append(ISD_AD(self.isd_id, self.ad_id).pack())


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/545%23issuecomment-160564657%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23issuecomment-160589745%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46122359%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46122477%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46122525%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46124722%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46124888%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46124895%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46125084%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46126247%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46126255%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23issuecomment-160564657%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20%22%2C%20%22created_at%22%3A%20%222015-11-30T09%3A11%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-11-30T10%3A28%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2016aaf1a20a8296180490454a33c3f123d1c825b4%20lib/packet/pcb.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46125084%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%23%20pragma%3A%20no%20cover%60%22%2C%20%22created_at%22%3A%20%222015-11-30T10%3A05%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222015-11-30T10%3A18%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/pcb.py%3AL118-127%22%7D%2C%20%22Pull%20fd6717a214333e4fae7d5a6d03e4234312002d4f%20lib/packet/path_mgmt.py%20107%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46122359%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Also%20need%20to%20cover%20PST.DOWN%20and%20PST.CORE%22%2C%20%22created_at%22%3A%20%222015-11-30T09%3A38%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22and%20PST.UP_DOWN%2C%20until%20we%20get%20rid%20of%20that.%22%2C%20%22created_at%22%3A%20%222015-11-30T09%3A40%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-30T10%3A03%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path_mgmt.py%3AL123-174%22%7D%2C%20%22Pull%20fd6717a214333e4fae7d5a6d03e4234312002d4f%20test/lib_packet_path_mgmt_test.py%2088%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46124722%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ok%2C%20this%20is%20completely%20baffling.%20I%27ve%20no%20idea%20where%20those%20numbers%20come%20from%2C%20but%20they%20do%20add%20up%20to%20the%20correct%20amount.%20A%20clearer%20way%20%28at%20least%20for%20me%29%20is%3A%20%602%2B3%2B4%2B5%2B6%2B7%60%22%2C%20%22created_at%22%3A%20%222015-11-30T10%3A01%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22done%22%2C%20%22created_at%22%3A%20%222015-11-30T10%3A17%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_mgmt_test.py%3AL176-185%22%7D%2C%20%22Pull%20fd6717a214333e4fae7d5a6d03e4234312002d4f%20endhost/sciond.py%2025%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/545%23discussion_r46122477%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Slightly%20cleaner%20to%20do%3A%5Cr%5Cn%60%60%60%5Cr%5Cnfor%20seg_type%2C%20pcbs%20in%20path_reply.pcbs.items%28%29%3A%5Cr%5Cn%20%20for%20pcb%20in%20pcbs%3A%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-11-30T09%3A39%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-11-30T10%3A03%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/sciond.py%3AL131-164%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/kormat%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/kormat'><img src='https://avatars.githubusercontent.com/u/6919822?v=3' width=34 height=34></a>
- [ ] <a href='#crh-comment-Pull fd6717a214333e4fae7d5a6d03e4234312002d4f test/lib_packet_path_mgmt_test.py 88'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/545#discussion_r46124722'>File: test/lib_packet_path_mgmt_test.py:L176-185</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok, this is completely baffling. I've no idea where those numbers come from, but they do add up to the correct amount. A clearer way (at least for me) is: `2+3+4+5+6+7`
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> done
- [ ] <a href='#crh-comment-Pull 16aaf1a20a8296180490454a33c3f123d1c825b4 lib/packet/pcb.py 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/545#discussion_r46125084'>File: lib/packet/pcb.py:L118-127</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `# pragma: no cover`
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> done
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/545#issuecomment-160564657'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> @kormat
- [x] <a href='#crh-comment-Pull fd6717a214333e4fae7d5a6d03e4234312002d4f lib/packet/path_mgmt.py 107'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/545#discussion_r46122359'>File: lib/packet/path_mgmt.py:L123-174</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Also need to cover PST.DOWN and PST.CORE
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> and PST.UP_DOWN, until we get rid of that.
- [x] <a href='#crh-comment-Pull fd6717a214333e4fae7d5a6d03e4234312002d4f endhost/sciond.py 25'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/545#discussion_r46122477'>File: endhost/sciond.py:L131-164</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Slightly cleaner to do:

```
for seg_type, pcbs in path_reply.pcbs.items():
for pcb in pcbs:
```

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/545?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/545?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/545?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/545'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
