### PR TITLE
Include MTU in PathCombinator output

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -202,7 +202,7 @@ class SCIONDaemon(SCIONElement):
         Path request:
           | \x00 (1B) | ISD (12bits) |  AD (20bits)  |
         Reply:
-          |p1_len(1B)|p1((p1_len*8)B)|fh_IP(4B)|fh_port(2B)|
+          |p1_len(1B)|p1((p1_len*8)B)|fh_IP(4B)|fh_port(2B)|mtu(2B)|
            p1_if_count(1B)|p1_if_1(5B)|...|p1_if_n(5B)|
            p2_len(1B)|...
          or b"" when no path found. Only IPv4 supported currently.
@@ -222,12 +222,13 @@ class SCIONDaemon(SCIONElement):
             path_len = len(raw_path) // 8
             reply.append(struct.pack("B", path_len) + raw_path +
                          haddr.pack() + struct.pack("H", SCION_UDP_PORT) +
+                         struct.pack("H", path.mtu) +
                          struct.pack("B", len(path.interfaces)))
             for interface in path.interfaces:
                 (isd_ad, link) = interface
                 isd_ad_bits = (isd_ad.isd << 20) + (isd_ad.ad & 0xFFFFF)
                 reply.append(struct.pack("I", isd_ad_bits))
-                reply.append(struct.pack("B", link))
+                reply.append(struct.pack("H", link))
         self._api_sock.send(b"".join(reply), sender)
 
     def handle_revocation(self, pkt):

--- a/endhost/sdamp/ConnectionManager.cpp
+++ b/endhost/sdamp/ConnectionManager.cpp
@@ -107,9 +107,9 @@ void PathManager::getPaths()
                 int pathLen = *(buf + offset) * 8;
                 if (pathLen + offset > buflen)
                     break;
-                int interfaceOffset = offset + 1 + pathLen + SCION_HOST_ADDR_LEN + 2;
+                int interfaceOffset = offset + 1 + pathLen + SCION_HOST_ADDR_LEN + 2 + 2;
                 int interfaceCount = *(buf + interfaceOffset);
-                if (interfaceOffset + 1 + interfaceCount * 5 > buflen)
+                if (interfaceOffset + 1 + interfaceCount * SCION_IF_SIZE > buflen)
                     break;
                 for (size_t j = 0; j < mPaths.size(); j++) {
                     if (mPaths[j]->isSamePath(buf + offset + 1, pathLen)) {
@@ -127,7 +127,7 @@ void PathManager::getPaths()
                     Path *p = createPath(*i, buf + offset, 0);
                     candidates.push_back(p);
                 }
-                offset = interfaceOffset + 1 + interfaceCount * 5;
+                offset = interfaceOffset + 1 + interfaceCount * SCION_IF_SIZE;
             }
         }
         if (mPaths.size() - invalid + candidates.size() == MAX_TOTAL_PATHS)

--- a/endhost/sdamp/Path.h
+++ b/endhost/sdamp/Path.h
@@ -51,7 +51,7 @@ protected:
     HostAddr        mFirstHop;
     std::vector<SCIONInterface> mInterfaces;
 
-    int             mMTU;
+    uint16_t        mMTU;
     bool            mUp;
 
     bool            mUsed;

--- a/endhost/sdamp/SCIONDefines.h
+++ b/endhost/sdamp/SCIONDefines.h
@@ -52,10 +52,11 @@ typedef struct{
 #define ISD_AD(isd, ad) ((isd) << 20) | ((ad) & 0xfffff)
 
 typedef struct {
-    uint32_t isd;
+    uint16_t isd;
     uint32_t ad;
-    uint8_t interface;
+    uint16_t interface;
 } SCIONInterface;
+#define SCION_IF_SIZE 6
 
 #pragma pack(push)
 #pragma pack(1)

--- a/endhost/sdamp/SCIONProtocol.cpp
+++ b/endhost/sdamp/SCIONProtocol.cpp
@@ -310,7 +310,7 @@ int SDAMPProtocol::handlePacket(SCIONPacket *packet, uint8_t *buf)
     }
     if (sp->header.flags & SDAMP_NEW_PATH) {
         sp->interfaceCount = *ptr++;
-        int interfaceLen = 5 * sp->interfaceCount;
+        int interfaceLen = SCION_IF_SIZE * sp->interfaceCount;
         sp->interfaces = (uint8_t *)malloc(interfaceLen);
         memcpy(sp->interfaces, ptr, interfaceLen);
         ptr += interfaceLen;
@@ -669,7 +669,7 @@ int SSPProtocol::handlePacket(SCIONPacket *packet, uint8_t *buf)
     if (flags & SSP_NEW_PATH) {
         sip->interfaceCount = *ptr++;
         DEBUG("%d interfaces in new path\n", sip->interfaceCount);
-        int interfaceLen = 5 * sip->interfaceCount;
+        int interfaceLen = SCION_IF_SIZE * sip->interfaceCount;
         sip->interfaces = (uint8_t *)malloc(interfaceLen);
         memcpy(sip->interfaces, ptr, interfaceLen);
         ptr += interfaceLen;

--- a/lib/defines.py
+++ b/lib/defines.py
@@ -80,3 +80,5 @@ SERVICE_TYPES = (
 
 #: How often IFID packet is sent to neighboring router.
 IFID_PKT_TOUT = 1
+
+SCION_MIN_MTU = 1280  # IPv6 min value

--- a/test/lib_packet_path_test.py
+++ b/test/lib_packet_path_test.py
@@ -44,6 +44,7 @@ from lib.packet.path import (
     parse_path,
 )
 from lib.packet.opaque_field import OpaqueField
+from lib.packet.pcb_ext.mtu import MtuPcbExt
 from lib.types import OpaqueFieldType as OFT
 from test.testcommon import assert_these_calls, create_mock
 
@@ -1210,24 +1211,40 @@ class TestPathCombinatorBuildCorePath(PathCombinatorBase):
         up = create_mock(['ads'])
         core = create_mock(['ads'])
         down = create_mock(['ads'])
-        up.ads = [create_mock(['pcbm']) for i in range(6)]
+        up.ads = [create_mock(['pcbm', 'ext']) for i in range(6)]
+        mtus = [i * 100 for i in range(11)]
+        idx = 3  # MTUs: 300, 400, 500, 600, 700, 800
         for m in up.ads:
             m.pcbm = create_mock(['isd_id', 'ad_id', 'hof'])
             m.pcbm.hof = create_mock(['egress_if', 'ingress_if'])
-        core.ads = [create_mock(['pcbm']) for i in range(6)]
+            m.ext = create_mock(['EXT_TYPE', 'mtu'])
+            m.ext.EXT_TYPE = MtuPcbExt.EXT_TYPE
+            m.ext.mtu = mtus[idx]
+            idx += 1
+        core.ads = [create_mock(['pcbm', 'ext']) for i in range(6)]
+        idx = 5  # MTUs: 500, 400, 300, 200, 100, 0 (invalid)
         for m in core.ads:
             m.pcbm = create_mock(['isd_id', 'ad_id', 'hof'])
             m.pcbm.hof = create_mock(['egress_if', 'ingress_if'])
-        down.ads = [create_mock(['pcbm']) for i in range(6)]
+            m.ext = create_mock(['EXT_TYPE', 'mtu'])
+            m.ext.EXT_TYPE = MtuPcbExt.EXT_TYPE
+            m.ext.mtu = mtus[idx]
+            idx -= 1
+        down.ads = [create_mock(['pcbm', 'ext']) for i in range(6)]
+        idx = 2  # MTUs: 200, 300, 400, 500, 600, 700
         for m in down.ads:
             m.pcbm = create_mock(['isd_id', 'ad_id', 'hof'])
             m.pcbm.hof = create_mock(['egress_if', 'ingress_if'])
+            m.ext = create_mock(['EXT_TYPE', 'mtu'])
+            m.ext.EXT_TYPE = MtuPcbExt.EXT_TYPE
+            m.ext.mtu = mtus[idx]
+            idx += 1
 
         check_connected.return_value = True
         copy_seg.side_effect = [
-            ("up_iof", "up_hofs"),
-            ("core_iof", "core_hofs"),
-            ("down_iof", "down_hofs"),
+            ("up_iof", "up_hofs", 300),
+            ("core_iof", "core_hofs", 100),  # smallest valid MTU is 100
+            ("down_iof", "down_hofs", 200),
         ]
         # Call
         ntools.eq_(PathCombinator._build_core_path(up, core, down),
@@ -1246,7 +1263,8 @@ class TestPathCombinatorCopySegment(object):
     Unit tests for lib.packet.path.PathCombinator._copy_segment
     """
     def test_no_segment(self):
-        ntools.eq_(PathCombinator._copy_segment(None, "xovrs"), (None, None))
+        ntools.eq_(PathCombinator._copy_segment(None, "xovrs"),
+                   (None, None, None))
 
     @patch("lib.packet.path.PathCombinator._copy_hofs",
            new_callable=create_mock)
@@ -1260,9 +1278,9 @@ class TestPathCombinatorCopySegment(object):
             hof = create_mock(["info"])
             hof.info = OFT.NORMAL_OF
             hofs.append(hof)
-        copy_hofs.return_value = hofs
+        copy_hofs.return_value = hofs, None
         # Call
-        ntools.eq_(PathCombinator._copy_segment(seg, [0, 2]), (iof, hofs))
+        ntools.eq_(PathCombinator._copy_segment(seg, [0, 2]), (iof, hofs, None))
         # Tests
         deepcopy.assert_called_once_with(seg.iof)
         ntools.eq_(iof.up_flag, True)
@@ -1278,10 +1296,10 @@ class TestPathCombinatorCopySegment(object):
         seg = create_mock(["ads", "iof"])
         iof = create_mock(["up_flag"])
         deepcopy.return_value = iof
-        copy_hofs.return_value = "hofs"
+        copy_hofs.return_value = "hofs", None
         # Call
         ntools.eq_(PathCombinator._copy_segment(seg, [], up=False),
-                   (iof, "hofs"))
+                   (iof, "hofs", None))
         # Tests
         copy_hofs.assert_called_once_with(seg.ads, reverse=False)
 
@@ -1364,18 +1382,29 @@ class TestPathCombinatorJoinShortcuts(object):
         down_iof = create_mock(["info"])
         up_seg = create_mock(['ads'])
         down_seg = create_mock(['ads'])
-        up_seg.ads = [create_mock(['pcbm']) for i in range(6)]
+        up_seg.ads = [create_mock(['pcbm', 'ext']) for i in range(6)]
+        mtus = [i * 100 for i in range(11)]
+        idx = 1
         for m in up_seg.ads:
             m.pcbm = create_mock(['isd_id', 'ad_id', 'hof'])
             m.pcbm.hof = create_mock(['egress_if', 'ingress_if'])
-        down_seg.ads = [create_mock(['pcbm']) for i in range(6)]
+            m.ext = create_mock(['EXT_TYPE', 'mtu'])
+            m.ext.EXT_TYPE = MtuPcbExt.EXT_TYPE
+            m.ext.mtu = mtus[idx]
+            idx += 1
+        down_seg.ads = [create_mock(['pcbm', 'ext']) for i in range(6)]
+        idx = 10
         for m in down_seg.ads:
             m.pcbm = create_mock(['isd_id', 'ad_id', 'hof'])
             m.pcbm.hof = create_mock(['egress_if', 'ingress_if'])
+            m.ext = create_mock(['EXT_TYPE', 'mtu'])
+            m.ext.EXT_TYPE = MtuPcbExt.EXT_TYPE
+            m.ext.mtu = mtus[idx]
+            idx -= 1
 
         join_shortcuts.side_effect = [
-            (up_iof, "up_hofs", "up_upstream_hof"),
-            (down_iof, "down_hofs", "down_upstream_hof"),
+            (up_iof, "up_hofs", "up_upstream_hof", 100),
+            (down_iof, "down_hofs", "down_upstream_hof", 400),
         ]
         # Call
         ntools.eq_(
@@ -1412,8 +1441,8 @@ class TestPathCombinatorJoinShortcuts(object):
         up_iof = create_mock(["info"])
         down_iof = create_mock(["info"])
         join_shortcuts.side_effect = [
-            (up_iof, "up_hofs", "up_upstream_hof"),
-            (down_iof, "down_hofs", "down_upstream_hof"),
+            (up_iof, "up_hofs", "up_upstream_hof", None),
+            (down_iof, "down_hofs", "down_upstream_hof", None),
         ]
         up_peering_hof = create_mock(['ingress_if'])
         down_peering_hof = create_mock(['ingress_if'])
@@ -1493,23 +1522,25 @@ class TestPathCombinatorCopyHofs(object):
         deepcopy.side_effect = list(range(4))
         blocks = []
         for _ in range(4):
-            block = create_mock(["pcbm"])
+            block = create_mock(["pcbm", "ext"])
             block.pcbm = create_mock(["hof"])
+            block.ext = []
             blocks.append(block)
         # Call
-        ntools.eq_(PathCombinator._copy_hofs(blocks), [3, 2, 1, 0])
+        ntools.eq_(PathCombinator._copy_hofs(blocks), ([3, 2, 1, 0], None))
 
     @patch("lib.packet.path.copy.deepcopy", new_callable=create_mock)
     def test_no_reverse(self, deepcopy):
         deepcopy.side_effect = list(range(4))
         blocks = []
         for _ in range(4):
-            block = create_mock(["pcbm"])
+            block = create_mock(["pcbm", "ext"])
             block.pcbm = create_mock(["hof"])
+            block.ext = []
             blocks.append(block)
         # Call
         ntools.eq_(PathCombinator._copy_hofs(blocks, reverse=False),
-                   [0, 1, 2, 3])
+                   ([0, 1, 2, 3], None))
 
 
 class TestPathCombinatorCopySegmentShortcut(object):
@@ -1528,14 +1559,14 @@ class TestPathCombinatorCopySegmentShortcut(object):
         hofs = []
         for _ in range(6):
             hofs.append(create_mock(["info"]))
-        copy_hofs.return_value = hofs
+        copy_hofs.return_value = hofs, None
         upstream_hof = create_mock(["info"])
         deepcopy.side_effect = [iof, upstream_hof]
         return seg, iof, hofs, upstream_hof
 
         # Call
         ntools.eq_(PathCombinator._copy_segment_shortcut(seg, 4),
-                   (iof, hofs, upstream_hof))
+                   (iof, hofs, upstream_hof, None))
         # Tests
         assert_these_calls(deepcopy, [call(seg.iof), call(seg.ads[3].pcbm.hof)])
         ntools.eq_(iof.hops, 6)
@@ -1551,7 +1582,7 @@ class TestPathCombinatorCopySegmentShortcut(object):
         seg, iof, hofs, upstream_hof = self._setup(deepcopy, copy_hofs)
         # Call
         ntools.eq_(PathCombinator._copy_segment_shortcut(seg, 4),
-                   (iof, hofs, upstream_hof))
+                   (iof, hofs, upstream_hof, None))
         # Tests
         assert_these_calls(deepcopy, [call(seg.iof), call(seg.ads[3].pcbm.hof)])
         ntools.eq_(iof.hops, 6)
@@ -1567,7 +1598,7 @@ class TestPathCombinatorCopySegmentShortcut(object):
         seg, iof, hofs, upstream_hof = self._setup(deepcopy, copy_hofs)
         # Call
         ntools.eq_(PathCombinator._copy_segment_shortcut(seg, 7, up=False),
-                   (iof, hofs, upstream_hof))
+                   (iof, hofs, upstream_hof, None))
         # Tests
         ntools.assert_false(iof.up_flag)
         copy_hofs.assert_called_once_with(seg.ads[7:], reverse=False)


### PR DESCRIPTION
The MTU hints in PCBs were lost when paths were assembled.
This patch adds an "mtu" attribute to PathBase to preserve these values.
SCIOND and the socket code are also modified to use the path MTU values.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/547%23issuecomment-160689455%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23issuecomment-160911332%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46164703%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46165238%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46166589%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46250982%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46251126%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46255049%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46255069%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23issuecomment-160689455%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Addressed%20comments%20%2B%20included%20end2end%20patch%20to%20print%20%28ISD%2C%20AD%29%3AIFID%20information%5Cr%5Cn%5Cr%5Cne.g.%20%281%2C%2010%29%20-%3E%20%281%2C%2017%29%5Cr%5Cn...%20blah%20blah%20blah%20...%5Cr%5Cn%20%20%5BUDP%20hdr%20%288B%29%3A%20sport%3A%2059709%20dport%3A%2040838%20length%3A%2024B%20checksum%3A%200x24a%5D%5Cr%5Cn%20%20Payload%2816B%29%3A%2070696e6720312d31303c2d3e312d3137%5Cr%5CnFirst%20hop%3A%20127.0.0.52%3A30040%5Cr%5Cn2015-11-30%2016%3A51%3A27.567578%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20Interfaces%3A%5Cr%5Cn2015-11-30%2016%3A51%3A27.567748%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20%281%2C%2010%29%3A1%5Cr%5Cn2015-11-30%2016%3A51%3A27.567872%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20%281%2C%2019%29%3A2%5Cr%5Cn2015-11-30%2016%3A51%3A27.567993%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20%281%2C%2019%29%3A1%5Cr%5Cn2015-11-30%2016%3A51%3A27.568112%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20%281%2C%2016%29%3A3%5Cr%5Cn2015-11-30%2016%3A51%3A27.568231%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20%281%2C%2016%29%3A1%5Cr%5Cn2015-11-30%2016%3A51%3A27.568353%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20%281%2C%2013%29%3A3%5Cr%5Cn2015-11-30%2016%3A51%3A27.568472%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20%281%2C%2013%29%3A1%5Cr%5Cn2015-11-30%2016%3A51%3A27.568592%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20%281%2C%2011%29%3A2%5Cr%5Cn2015-11-30%2016%3A51%3A27.568711%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20%281%2C%2011%29%3A4%5Cr%5Cn2015-11-30%2016%3A51%3A27.568830%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20%281%2C%2014%29%3A1%5Cr%5Cn2015-11-30%2016%3A51%3A27.568946%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20%281%2C%2014%29%3A4%5Cr%5Cn2015-11-30%2016%3A51%3A27.569064%2B00%3A00%20%5BINFO%5D%20%28E2E.ping_app%29%20%281%2C%2017%29%3A1%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-11-30T16%3A58%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-12-01T09%3A41%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20e2d83a582e96f035e84d8c73be5402978959eff5%20lib/packet/path.py%2084%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46251126%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20%60ext.mtu%60%20is%200%2C%20then%20this%20becomes%200%22%2C%20%22created_at%22%3A%20%222015-12-01T08%3A34%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL1029-1044%22%7D%2C%20%22Pull%20d53f15303283084cb06b38ad5c908417e2f6deb8%20lib/packet/path.py%2033%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46164703%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20more%20style%20consistent%20to%20do%3A%5Cr%5Cn%60%60%60%5Cr%5Cncore_iof%2C%20core_hofs%2C%20core_mtu%20%3D%20cls._copy_segment%28%5Cr%5Cn%20%20%20%20core_segment%2C%20%5B-1%2C%200%5D%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-11-30T16%3A21%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Heh%2C%20except%20this%20actually%20fits%20in%2080%20chars%20%3B%29%22%2C%20%22created_at%22%3A%20%222015-11-30T16%3A25%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL827-844%22%7D%2C%20%22Pull%20403d8d02d5388926ebe1be021cbc78b6720b5aa0%20test/integration/end2end_test.py%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46255069%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Aren%27t%20IFIDs%202%20bytes%3F%22%2C%20%22created_at%22%3A%20%222015-12-01T09%3A18%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/integration/end2end_test.py%3AL90-108%22%7D%2C%20%22Pull%20403d8d02d5388926ebe1be021cbc78b6720b5aa0%20test/integration/end2end_test.py%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46255049%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Probably%20makes%20more%20sense%20to%20use%20%60ISD_AD.from_raw%28%29%60%22%2C%20%22created_at%22%3A%20%222015-12-01T09%3A18%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/integration/end2end_test.py%3AL90-108%22%7D%2C%20%22Pull%20e2d83a582e96f035e84d8c73be5402978959eff5%20endhost/sciond.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46250982%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20the%20%60None%60%20value%20is%20going%20to%20be%20represented%20as%200%20anyway%2C%20might%20as%20well%20just%20initialise%20path.mtu%20to%200.%22%2C%20%22created_at%22%3A%20%222015-12-01T08%3A31%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/sciond.py%3AL218-225%22%7D%2C%20%22Pull%20d53f15303283084cb06b38ad5c908417e2f6deb8%20lib/packet/path.py%2041%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/547%23discussion_r46166589%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Alternative%20suggestion%3A%5Cr%5Cn%60%60%60%5Cr%5Cntry%3A%5Cr%5Cn%20%20path.mtu%20%3D%20min%28filter%28bool%2C%20%28up_mtu%2C%20core_mtu%2C%20down_mtu%29%29%29%5Cr%5Cnexcept%20ValueError%3A%5Cr%5Cn%20%20path.mtu%20%3D%20None%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-11-30T16%3A34%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL827-844%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/kormat%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/kormat'><img src='https://avatars.githubusercontent.com/u/6919822?v=3' width=34 height=34></a>
- [ ] <a href='#crh-comment-Pull d53f15303283084cb06b38ad5c908417e2f6deb8 lib/packet/path.py 33'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/547#discussion_r46164703'>File: lib/packet/path.py:L827-844</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It's more style consistent to do:

```
core_iof, core_hofs, core_mtu = cls._copy_segment(
core_segment, [-1, 0])
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Heh, except this actually fits in 80 chars ;)
- [ ] <a href='#crh-comment-Pull d53f15303283084cb06b38ad5c908417e2f6deb8 lib/packet/path.py 41'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/547#discussion_r46166589'>File: lib/packet/path.py:L827-844</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Alternative suggestion:

```
try:
path.mtu = min(filter(bool, (up_mtu, core_mtu, down_mtu)))
except ValueError:
path.mtu = None
```
- [ ] <a href='#crh-comment-Pull e2d83a582e96f035e84d8c73be5402978959eff5 endhost/sciond.py 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/547#discussion_r46250982'>File: endhost/sciond.py:L218-225</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> If the `None` value is going to be represented as 0 anyway, might as well just initialise path.mtu to 0.
- [ ] <a href='#crh-comment-Pull e2d83a582e96f035e84d8c73be5402978959eff5 lib/packet/path.py 84'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/547#discussion_r46251126'>File: lib/packet/path.py:L1029-1044</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> If `ext.mtu` is 0, then this becomes 0
- [ ] <a href='#crh-comment-Pull 403d8d02d5388926ebe1be021cbc78b6720b5aa0 test/integration/end2end_test.py 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/547#discussion_r46255049'>File: test/integration/end2end_test.py:L90-108</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Probably makes more sense to use `ISD_AD.from_raw()`
- [ ] <a href='#crh-comment-Pull 403d8d02d5388926ebe1be021cbc78b6720b5aa0 test/integration/end2end_test.py 35'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/547#discussion_r46255069'>File: test/integration/end2end_test.py:L90-108</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Aren't IFIDs 2 bytes?
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/547#issuecomment-160689455'>General Comment</a></b>
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> Addressed comments + included end2end patch to print (ISD, AD):IFID information
  e.g. (1, 10) -> (1, 17)
  ... blah blah blah ...
  [UDP hdr (8B): sport: 59709 dport: 40838 length: 24B checksum: 0x24a]
  Payload(16B): 70696e6720312d31303c2d3e312d3137
  First hop: 127.0.0.52:30040
  2015-11-30 16:51:27.567578+00:00 [INFO](E2E.ping_app) Interfaces:
  2015-11-30 16:51:27.567748+00:00 [INFO](E2E.ping_app) (1, 10):1
  2015-11-30 16:51:27.567872+00:00 [INFO](E2E.ping_app) (1, 19):2
  2015-11-30 16:51:27.567993+00:00 [INFO](E2E.ping_app) (1, 19):1
  2015-11-30 16:51:27.568112+00:00 [INFO](E2E.ping_app) (1, 16):3
  2015-11-30 16:51:27.568231+00:00 [INFO](E2E.ping_app) (1, 16):1
  2015-11-30 16:51:27.568353+00:00 [INFO](E2E.ping_app) (1, 13):3
  2015-11-30 16:51:27.568472+00:00 [INFO](E2E.ping_app) (1, 13):1
  2015-11-30 16:51:27.568592+00:00 [INFO](E2E.ping_app) (1, 11):2
  2015-11-30 16:51:27.568711+00:00 [INFO](E2E.ping_app) (1, 11):4
  2015-11-30 16:51:27.568830+00:00 [INFO](E2E.ping_app) (1, 14):1
  2015-11-30 16:51:27.568946+00:00 [INFO](E2E.ping_app) (1, 14):4
  2015-11-30 16:51:27.569064+00:00 [INFO](E2E.ping_app) (1, 17):1

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/547?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/547?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/547?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/547'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
