### PR TITLE
Initial implementation of the SCION Multi-Path Socket Python Wrapper.

### DIFF
--- a/endhost/scion_socket.py
+++ b/endhost/scion_socket.py
@@ -1,0 +1,182 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+:mod:`scion_socket` --- Python wrapper for the SCION Multi-Path Socket
+======================================================================
+"""
+
+# Stdlib
+import ipaddress
+import logging
+import os
+from ctypes import byref, CDLL, c_int, c_short, c_ubyte, c_uint, Structure
+
+# SCION
+from lib.packet.scion_addr import ISD_AD
+
+ByteArray16 = c_ubyte * 16
+
+
+class C_HostAddr(Structure):
+    _fields_ = [("addrLen", c_int),
+                ("addr", ByteArray16),
+                ("port", c_short)]
+
+
+class C_SCIONAddr(Structure):
+    _fields_ = [("isd_ad", c_uint),
+                ("host", C_HostAddr)]
+
+
+SHARED_LIB_LOCATION = os.path.join("endhost", "sdamp")
+SHARED_LIB_SERVER = "libserver.so"
+SHARED_LIB_CLIENT = "libclient.so"
+
+
+class ScionBaseSocket(object):
+    """
+    Base class of the SCION Multi-Path Socket Python Wrapper.
+    """
+
+    def __init__(self, fd, libsock):
+        """
+        This class can be used if the fd and libsock are known in
+        advance. See accept() in ScionServerSocket for an example
+        usage.
+        :param fd: Underlying file descriptor of the socket.
+        :type fd: int
+        :param libsock: The relevant SCION Multi-Path Socket library.
+        :type: Dynamically loaded shared library (.so).
+        """
+        self.fd = fd
+        self.libsock = libsock
+
+    def send(self, msg):
+        """
+        Send data to the socket. Returns the number of bytes sent. Applications
+        are responsible for checking that all data has been sent; if only some
+        of the data was transmitted, the application needs to attempt delivery
+        of the remaining data.
+        :param msg: The data to be sent on the socket.
+        :type msg: bytes
+        :returns: The number of bytes sent.
+        :rtype: int
+        """
+        if msg is None or len(msg) == 0:
+            return
+        return self.libsock.SCIONSend(self.fd, msg, len(msg))
+
+    def recv(self, bufsize):
+        """
+        Receive data from the socket. The return value is a bytes object
+        representing the data received. The maximum amount of data to be
+        received at once is specified by bufsize.
+        :param bufsize: The maximum amount of data to be received at once.
+        :type bufsize: int
+        :returns: A bytes object representing the data received.
+        :rtype: bytes object
+        """
+        buf = (c_ubyte * bufsize)()
+        num_bytes_rcvd = self.libsock.SCIONRecv(self.fd, byref(buf),
+                                                bufsize, None)
+        if num_bytes_rcvd < 0:
+            logging.error("Error during recv.")
+            return None
+        elif num_bytes_rcvd == 0:
+            logging.warning("Received 0 bytes on fd %d. Is the socket closed?"
+                            % self.fd)
+
+        return bytes(buf[:num_bytes_rcvd])
+
+    def fileno(self):
+        """
+        Returns the underlying socket’s file descriptor. This is useful with
+        select.select().
+        :returns: The socket's file descriptor.
+        :rtype: int
+        """
+        return self.fd
+
+
+class ScionServerSocket(ScionBaseSocket):
+    """
+    Server side wrapper of the SCION Multi-Path Socket.
+    """
+
+    def __init__(self, proto, server_port, fd=None):
+        """
+        :param proto: The type of SCION socket protocol to be used
+        (see lib/defines).
+        :type proto: int
+        :param server_port: The port number that the server will listen on.
+        :type server_port: int
+        """
+        self.proto = proto
+        self.server_port = server_port
+        self.libsock = CDLL(os.path.join(SHARED_LIB_LOCATION,
+                                         SHARED_LIB_SERVER))
+        if fd is None:
+            self.fd = self.libsock.newSCIONSocket(proto, None,
+                                                  1, server_port, 0)
+        else:
+            self.fd = fd
+
+        logging.info("ScionServerSocket fd = %d" % self.fd)
+
+    def accept(self):
+        """
+        Accepts a connection. The return value is a pair (conn, address) where
+        conn is a new ScionBaseSocket object usable to send and receive data on
+        the connection, and address is the address bound to the socket on the
+        other end of the connection. Currently returning the address is not
+        supported (i.e. it will always return None).
+        :returns: A new SCION socket object usable to send/receive data on the
+        connection.
+        :rtype: Address tuple (ScionBaseSocket, Address)
+        """
+        newfd = self.libsock.SCIONAccept(self.fd)
+        logging.info("Accepted socket %d" % newfd)
+        return ScionBaseSocket(newfd, self.libsock), None
+
+
+class ScionClientSocket(ScionBaseSocket):
+    """
+    Client side wrapper of the SCION Multi-Path Socket.
+    """
+
+    def __init__(self, proto, isd_ad, target_address):
+        """
+        :param proto: The type of SCION socket protocol to be used
+        (see lib/defines).
+        :type proto: int
+        :param isd_ad: ISD and AD tuple
+        :type isd_ad: int tuple
+        :param target_address: The address of the server to connect to.
+        :type target_address: (string, int) tuple
+        """
+        self.proto = proto
+        self.isd, self.ad = isd_ad
+        self.target_IP, self.target_port = target_address
+        self.libsock = CDLL(os.path.join(SHARED_LIB_LOCATION,
+                                         SHARED_LIB_CLIENT))
+        sa = C_SCIONAddr()
+        sa.isd_ad = c_uint(ISD_AD(self.isd, self.ad).int())
+        ip_bytes = ipaddress.ip_interface(self.target_IP).ip.packed
+        sa.host.addrLen = len(ip_bytes)
+        sa.host.addr = ByteArray16(*ip_bytes)
+        self.fd = self.libsock.newSCIONSocket(proto, byref(sa), 1,
+                                              0, self.target_port)
+
+        logging.info("ScionClientSocket fd = %d" % self.fd)

--- a/test/integration/sdamp_cli_srv_test.py
+++ b/test/integration/sdamp_cli_srv_test.py
@@ -1,0 +1,184 @@
+#!/usr/bin/python3
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+:mod:`sdamp_cli_srv_test` --- A client-server test using SCION Sockets
+======================================================================
+
+Running this test has the following requirements:
+
+1) SCION infrastructure should already be running:
+From the SCION root directory, run:
+./scion.sh run
+
+2) SCION socket library must be built:
+From the SCION root directory, run:
+./scion.sh sock_bld
+
+3) SCION socket dispatchers for both client and server should be running:
+From the SCION root directory in two separate terminals, run:
+./scion.sh sock_ser
+and
+./scion.sh sock_cli
+"""
+
+# Stdlib
+import hashlib
+import logging
+import os
+import struct
+import threading
+import time
+
+# SCION
+from lib.defines import L4_SSP
+from lib.log import init_logging
+from lib.main import main_wrapper
+from lib.thread import thread_safety_net
+from lib.util import handle_signals
+from endhost.scion_socket import ScionServerSocket, ScionClientSocket
+
+SERVER_PORT = 8080
+SERVER_LOG_BASE = 'logs/scion_test_app'
+SERVER_IP = "127.2.26.254"
+# TODO(ercanucan): Increase this value as the library matures.
+DATA_SIZE = 200 * 1024
+DIGEST_LEN = 16
+TIMEOUT = 60  # How long to wait for hanging threads.
+
+
+def main():
+    init_logging(SERVER_LOG_BASE,
+                 file_level=logging.DEBUG, console_level=logging.DEBUG)
+    handle_signals()
+    server_thread = threading.Thread(target=thread_safety_net, args=(server,),
+                                     name="server", daemon=True)
+    client_thread = threading.Thread(target=thread_safety_net, args=(client,),
+                                     name="client", daemon=True)
+    server_thread.start()
+    client_thread.start()
+
+    for _ in range(TIMEOUT * 10):
+        time.sleep(0.1)
+        if not server_thread.is_alive() and not client_thread.is_alive():
+            break
+    else:
+        logging.error("Test timed out.")
+
+
+def server():
+    logging.info("Starting SCION test server application.")
+    sock = ScionServerSocket(L4_SSP, SERVER_PORT)
+
+    (server_sock, _) = sock.accept()
+
+    logging.info("Server starts the receive protocol.")
+    # firstly, act as a receiver
+    _run_receive_protocol(server_sock)
+
+    logging.info("Server starts the send protocol.")
+    # secondly, act as a sender
+    _run_send_protocol(server_sock)
+
+
+def client():
+    logging.info("Starting SCION test client application.")
+
+    isd_ad = 2, 26
+    target_addr = SERVER_IP, SERVER_PORT
+    client_sock = ScionClientSocket(L4_SSP, isd_ad, target_addr)
+
+    logging.info("Client starts the send protocol.")
+    # firstly, act as a sender
+    _run_send_protocol(client_sock)
+
+    logging.info("Client starts the receive protocol.")
+    # secondly, act as a receiver
+    _run_receive_protocol(client_sock)
+
+
+def _run_send_protocol(sock):
+    # generate the data
+    msg = _generate_message(DATA_SIZE)
+    # send the data length
+    _send_data(sock, struct.pack("!I", DATA_SIZE))
+    # send the data itself
+    _send_data(sock, msg)
+    # compute and send the digest
+    m = hashlib.md5()
+    m.update(msg)
+    digest = m.digest()
+    logging.info("Digest = %s" % digest)
+    _send_data(sock, digest)
+
+    # wait for the ack to finish transfer
+    ack = sock.recv(1)
+    logging.debug("Ack received = %s" % ack.decode('ascii'))
+    logging.info("Finished send protocol successfully.")
+
+
+def _run_receive_protocol(sock):
+    # read the length of the data (assume 4B int)
+    data_len = struct.unpack("!I", _receive_data(sock, 4))[0]
+    logging.info("Data length is %d" % data_len)
+
+    # read the data
+    rcvd_data = _receive_data(sock, data_len)
+    logging.info("Received all the data.")
+
+    # read the digest (assume DIGEST_LEN)
+    rcvd_digest = _receive_data(sock, DIGEST_LEN)
+    logging.info("Received the digest.")
+
+    logging.info("Marking the receive protocol, sending ACK.")
+    sock.send(bytes("F", 'ascii'))
+
+    _verify_test_data(rcvd_data, rcvd_digest)
+
+    logging.info("Finished receive protocol successfully.")
+
+
+def _generate_message(size):
+    return os.urandom(size)
+
+
+def _send_data(sock, msg):
+    logging.debug("Sending Data.")
+    num_bytes_sent = sock.send(msg)
+    if num_bytes_sent < 0:
+        logging.error("Error during send on client socket")
+        raise Exception("ScionSocket cannot send data.")
+
+
+def _receive_data(sock, size):
+    data_lst = []
+    num_bytes_rcvd = 0
+    while num_bytes_rcvd < size:
+        data = sock.recv(size - num_bytes_rcvd)
+        assert(data is not None)
+        num_bytes_rcvd += len(data)
+        data_lst.append(data)
+
+    return b"".join(data_lst)
+
+
+def _verify_test_data(data, rcvd_digest):
+    m = hashlib.md5()
+    m.update(data)
+    assert(m.digest() == rcvd_digest)
+
+
+if __name__ == "__main__":
+    main_wrapper(main)


### PR DESCRIPTION
- Implements a Python Wrapper socket class with a similar API to Unix
  sockets.
- Adds a test client and a test server to verify the functionality.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/548%23issuecomment-161050231%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23issuecomment-161692987%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46391002%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46394000%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46394037%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46395430%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46395615%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46395729%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46396098%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46396111%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46396477%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46396595%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46396927%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46396938%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46397100%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46397212%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46397351%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46397363%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46397887%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46397942%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46397981%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46398190%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46398762%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46401350%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46401490%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46659740%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46659832%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46659870%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46659947%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46660145%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46660224%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46660460%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46660741%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46660779%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46661740%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46662330%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46662531%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46663596%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46664773%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46664947%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46665072%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46665226%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46665401%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46665448%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46666491%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46670449%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46670460%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46670479%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46670493%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46670522%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46670529%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46670809%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46670995%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671318%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671392%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671493%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671520%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671540%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671611%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671642%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671656%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671676%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671682%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671704%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671752%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671821%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671844%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671878%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671884%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671893%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46671903%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23issuecomment-161940682%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23issuecomment-161942482%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_socket.py%2074%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46394037%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20unused%22%2C%20%22created_at%22%3A%20%222015-12-02T09%3A47%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T10%3A58%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL1-160%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_socket.py%2072%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46394000%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20if/else%20here%20contain%20quite%20a%20lot%20of%20code%2C%20especially%20for%20an%20%60__init__%60%20method.%20It%20would%20be%20better%20to%20move%20these%20blocks%20into%20separate%20methods.%22%2C%20%22created_at%22%3A%20%222015-12-02T09%3A47%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Actually%2C%20given%20that%20half%20the%20code%20in%20%60__init__%60%20is%20server-specific%2C%20and%20%60accept%28%29%60%20is%20server-specific%2C%20it%20probably%20makes%20most%20sense%20to%20have%20separate%20classes%20for%20client%20and%20server.%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A03%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20we%20talked%20about%20this%20but%20then%20I%20thought%20that%20in%20that%20case%20one%20would%20have%20to%20instantiate%20the%20classes%20differently%20like%20ScionServerSocket%28%29%20and%20ScionClientSocket%28%29.%20I%20thought%20it%20could%20be%20better%20to%20encapsulate%20this%20info%20inside%20one%20class.%20The%20the%20users%20of%20the%20socket%20class%20can%20just%20instantiate%20as%20ScionSocket.%20What%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A28%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22Having%20%60ScionServerSocket%60%20and%20%60ScionClientSocket%60%2C%20where%20each%20only%20accept/require%20the%20relevant%20arguments%2C%20is%20much%20better%20than%20having%20a%20combined%20class%20where%20half%20the%20arguments%20and%201/3rd%20of%20the%20code%20don%27t%20apply%20to%20half%20of%20the%20use%20cases.%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A33%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T10%3A58%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL1-160%22%7D%2C%20%22Pull%20be8666497956fa33f59f656edae6ebf19dfd83a2%20endhost/scion_socket.py%2048%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46659740%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22By%20convention%2C%20all%20base%20objects%20inherit%20from%20%60object%60.%20%28This%20is%20no%20longer%20necessary%20in%20py3%2C%20but%20the%20rest%20of%20the%20code%20does%20this%29%22%2C%20%22created_at%22%3A%20%222015-12-04T08%3A42%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%27s%20probably%20a%20good%20idea%20to%20mark%20this%20as%20an%20abstract%20base%20class.%5Cr%5Cn%60%60%60%5Cr%5Cnfrom%20abc%20import%20ABCMeta%2C%20abstractmethod%5Cr%5Cn...%5Cr%5Cnclass%20ScionSocket%28object%2C%20metaclass%3DABCMeta%29%5Cr%5Cn...%5Cr%5Cn%20%20%40abstractmethod%5Cr%5Cn%20%20def%20__init__%28self%29%3A%5Cr%5Cn%20%20%20%20self.fd%20%3D%20None%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-12-04T08%3A44%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60ScionBaseSocket%60%20would%20be%20a%20better%20name%22%2C%20%22created_at%22%3A%20%222015-12-04T08%3A58%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A13%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL1-168%22%7D%2C%20%22Pull%20be8666497956fa33f59f656edae6ebf19dfd83a2%20endhost/scion_socket.py%2067%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46659870%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20can%20be%20simplified%20slightly%20to%3A%5Cr%5Cn%60%60%60%5Cr%5Cnreturn%20self.libsock.SCIONSend%28self.fd%2C%20msg%2C%20len%28msg%29%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-12-04T08%3A45%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A14%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL1-168%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_test_client.py%2040%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46396938%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Ditto%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A15%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A11%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_client.py%3AL1-62%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_socket.py%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46396098%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%222015%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A07%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T10%3A59%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL1-160%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_test_server.py%2053%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46397351%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20probably%20better%20to%20keep%20reading%20until%20the%20connection%20is%20closed.%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A20%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Uh%2C%20disregard%20that%2C%20otherwise%20you%20can%27t%20send%20an%20ack.%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A25%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A12%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_server.py%3AL1-73%22%7D%2C%20%22Pull%20be8666497956fa33f59f656edae6ebf19dfd83a2%20endhost/scion_test_client_server.py%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46661740%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20suggest%20moving%20this%20into%20test/integration%20with%20the%20rest%20of%20the%20integration%20tests%2C%20and%20probably%20renaming%20it%20to%20something%20like%20%5C%22sdamp_cli_srv_test.py%5C%22%22%2C%20%22created_at%22%3A%20%222015-12-04T09%3A12%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A15%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_client_server.py%3AL1-163%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_test_client.py%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46396111%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%222015%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A07%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T10%3A59%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_client.py%3AL1-62%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_test_server.py%2058%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46397363%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Same%20issue%20here%20re%3A%20string%20building%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A20%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A12%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_server.py%3AL1-73%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23issuecomment-161050231%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40aznair%20%40kormat%20%40pszalach%20Here%20is%20the%20initial%20implementation%20of%20Python%20Wrapper%20for%20the%20SCION%20multi-path%20socket.%20It%20also%20adds%20a%20test%20client%20and%20a%20server%20application%20to%20test%20the%20functionality.%20I%20would%20be%20happy%20to%20receive%20your%20feedback%20on%20this.%20Cheers%21%22%2C%20%22created_at%22%3A%20%222015-12-01T18%3A07%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20%40pszalach%20I%20have%20re-written%20the%20PR%20significantly%20to%20reflect%20your%20suggestions.%20I%27d%20be%20glad%20if%20you%20could%20take%20a%20look%20and%20let%20me%20know%20what%20you%20think.%20Thanks%21%22%2C%20%22created_at%22%3A%20%222015-12-03T16%3A10%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%5Cr%5CnOnce%20the%20integration%20test%20can%20deal%20with%20starting%20the%20required%20dispatchers%20and%20sciond%27s%2C%20we%20can%20add%20it%20to%20the%20regular%20%60docker/integration_test.sh%60%20script%2C%20which%20will%20then%20run%20it%20on%20circleci.%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A17%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20thanks%21%20yes%2C%20that%27s%20the%20plan.%20I%20will%20do%20the%20integration%20with%20circleci%20as%20a%20separate%20PR.%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A24%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20be8666497956fa33f59f656edae6ebf19dfd83a2%20endhost/scion_socket.py%20162%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46660460%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20don%27t%20need%20to%20hard-code%20the%20address%20length%3A%5Cr%5Cn%60%60%60%5Cr%5Cnip_bytes%20%3D%20ipaddress.ip_interface%28self.target_IP%29.ip.packed%5Cr%5Cnsa.host.addrLen%20%3D%20len%28ip_bytes%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-12-04T08%3A53%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A15%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL1-168%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_test_server.py%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46396595%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%222015%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A12%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A09%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_server.py%3AL1-73%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_socket.py%2087%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46395430%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20concerns%20me%20a%20bit.%20The%20encoding%20of%20isd/ad%20should%20preferably%20only%20be%20done%20in%20one%20place%20%28%60scion_addr.ISD_AD%60%29.%20I%27m%20putting%20a%20quick%20PR%20together%20to%20add%20a%20method%20to%20ISD_AD%20to%20return%20an%20integer.%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A00%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/550%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A01%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T10%3A59%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL1-160%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_test_client.py%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46397100%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%27s%20probably%20better%20to%20be%20using%20large%20messages%2C%20bigger%20than%20the%20MTU%20size.%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A17%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22One%20thing%20you%20could%20do%20is%20read%20a%20chunk%20of%20data%20from%20%60/dev/urandom%60%2C%20start%20the%20message%20with%20the%20length%20and%20md5sum%20of%20the%20data%2C%20then%20send%20the%20data.%20The%20server%20can%20then%20verify%20the%20data%20is%20all%20there%2C%20and%20is%20correct.%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A25%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A11%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_client.py%3AL1-62%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_socket.py%2089%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46391002%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20you%20use%20%60ipaddress.ip_interface%28%29%60%20instead%2C%20you%20no%20longer%20need%20to%20hard-code%20the%20assumption%20of%20ipv4.%22%2C%20%22created_at%22%3A%20%222015-12-02T09%3A13%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T10%3A58%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL1-160%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_test_client.py%2051%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46396477%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22A%20more%20pythonic%20way%20is%3A%5Cr%5Cn%60%60%60%5Cr%5Cnfor%20count%20in%20range%2810%29%3A%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A11%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A03%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_client.py%3AL1-62%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_test_client.py%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46396927%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%28%29%60%20is%20unnecessary%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A15%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A11%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_client.py%3AL1-62%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_test_server.py%2067%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46397212%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20quite%20an%20expensive%20way%20to%20build%20a%20string.%20Much%20better%20to%20use%20a%20list%2C%20then%20%60%5C%22%5C%22.join%28list%29%60%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A18%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A12%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_server.py%3AL1-73%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_test_server.py%2066%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46401490%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22just%20%60range%2810%29%60%22%2C%20%22created_at%22%3A%20%222015-12-02T11%3A02%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A13%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_server.py%3AL1-73%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_test_server.py%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46397981%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Bi-directional%20data%20transfer%20would%20probably%20be%20a%20better%20test%22%2C%20%22created_at%22%3A%20%222015-12-02T10%3A26%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A12%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_server.py%3AL1-73%22%7D%2C%20%22Pull%20be8666497956fa33f59f656edae6ebf19dfd83a2%20endhost/scion_socket.py%2082%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46659947%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20are%20the%20semantics%20when%20calling%20recv%20on%20a%20closed%20socket%3F%20In%20plain%20python%20it%20can%20return%200%20bytes%20on%20every%20attempt.%22%2C%20%22created_at%22%3A%20%222015-12-04T08%3A46%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Do%20you%20mean%20empty%20bytes%20object%3F%20The%20return%20value%20of%20recv%20in%20Python%20socket%20library%20is%20bytes%20object%20not%20an%20int.%22%2C%20%22created_at%22%3A%20%222015-12-04T10%3A11%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22added%20the%20warning%20as%20we%20discussed%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A05%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A09%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL1-168%22%7D%2C%20%22Pull%20be8666497956fa33f59f656edae6ebf19dfd83a2%20endhost/scion_socket.py%20136%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46660145%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%60%60%5Cr%5Cnreturn%20ScionServerSocket%28self.proto%2C%20self.server_port%2C%20newfd%29%2C%20None%5Cr%5Cn%60%60%60%5Cr%5Cnworks%20fine%22%2C%20%22created_at%22%3A%20%222015-12-04T08%3A49%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Actually%2C%20i%27m%20not%20convinced%20by%20returning%20a%20server%20socket%20here.%20It%27s%20not%20something%20you%20can%20call%20accept%20on.%22%2C%20%22created_at%22%3A%20%222015-12-04T08%3A50%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20maybe%20the%20base%20class%20shouldn%27t%20be%20abstract%20after%20all%2C%20and%20just%20return%20an%20instance%20of%20it%20here.%22%2C%20%22created_at%22%3A%20%222015-12-04T08%3A58%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20basically%20you%20suggest%20returning%20a%20ScionSocket%20object%20initialized%20with%20the%20proper%20fd%2C%20right%3F%20%22%2C%20%22created_at%22%3A%20%222015-12-04T09%3A50%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yep%22%2C%20%22created_at%22%3A%20%222015-12-04T09%3A52%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20okay%2C%20makes%20sense.%20In%20this%20case%20maybe%20it%20makes%20sense%20to%20keep%20the%20name%20as%20ScionSocket%3F%20or%20should%20we%20still%20name%20it%20as%20ScionBaseSocket%3F%22%2C%20%22created_at%22%3A%20%222015-12-04T09%3A53%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22To%20me%2C%20%60ScionSocket%60%20implies%20%5C%22This%20is%20the%20main%20class%2C%20use%20this%20by%20default%20unless%20you%20know%20otherwise%5C%22.%20%60ScionBaseSocket%60%20has%20the%20hint%20that%20maybe%20you%20shouldn%27t%20be%20using%20this%20directly.%22%2C%20%22created_at%22%3A%20%222015-12-04T09%3A55%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sure%2C%20I%20agree.%20I%20will%20name%20it%20as%20ScionBaseSocket%22%2C%20%22created_at%22%3A%20%222015-12-04T09%3A58%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A14%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL1-168%22%7D%2C%20%22Pull%2059fd477200dc66a7a294433f57f8adf47447b0b3%20endhost/scion_socket.py%20150%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46401350%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22just%20%60%5B%3Anum_bytes_rcvd%5D%60%22%2C%20%22created_at%22%3A%20%222015-12-02T11%3A00%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A12%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL1-160%22%7D%2C%20%22Pull%20be8666497956fa33f59f656edae6ebf19dfd83a2%20endhost/scion_test_client_server.py%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/548%23discussion_r46662330%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%2210KB%20isn%27t%20big%20enough.%20Something%20like%2010MB%20would%20be%20better.%20I%20changed%20it%20to%201MB%20locally%2C%20but%20the%20test%20now%20times%20out.%22%2C%20%22created_at%22%3A%20%222015-12-04T09%3A19%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%602%2A%2A19%60%20bytes%20works%20fine.%20%602%2A%2A20%60%20bytes%20doesn%27t.%22%2C%20%22created_at%22%3A%20%222015-12-04T09%3A21%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20not%20so%20sure%20about%20the%20current%20limits%20of%20the%20underlying%20socket.%20%40aznair%20can%20clarify%20probably.%20I%20tried%20with%201MB%20before%20%28with%20a%20larger%20timeout%20value%29%20and%20I%20saw%20it%20working%20fine.%20%40aznair%20told%20me%20to%20not%20to%20try%20with%20very%20very%20large%20values%20than%20that%20yet%20%3A-%29%22%2C%20%22created_at%22%3A%20%222015-12-04T09%3A35%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20there%27s%20some%20potential%20problems%20in%20the%20current%20implementation%20regarding%20the%20send%20buffer.%20I%27m%20refactoring/rewriting%20a%20lot%20of%20this%20stuff%20and%20when%20that%27s%20done%20those%20problems%20will%20be%20fixed.%20For%20now%20it%20would%20be%20nice%20to%20keep%20the%20send%20calls%20small%20%28maybe%20several%20hundred%20KB%20at%20a%20time%29.%22%2C%20%22created_at%22%3A%20%222015-12-04T09%3A58%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20left%20it%20at%20200KB%20for%20now.%20We%20will%20increase%20the%20data%20size%20as%20the%20library%20matures.%20%28put%20a%20TODO%20item%20in%20the%20code%29%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A15%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22200KB%20is%20fine%20for%20now%20then.%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-04T11%3A15%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_test_client_server.py%3AL1-163%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#issuecomment-161050231'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @aznair @kormat @pszalach Here is the initial implementation of Python Wrapper for the SCION multi-path socket. It also adds a test client and a server application to test the functionality. I would be happy to receive your feedback on this. Cheers!
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat @pszalach I have re-written the PR significantly to reflect your suggestions. I'd be glad if you could take a look and let me know what you think. Thanks!
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM
  Once the integration test can deal with starting the required dispatchers and sciond's, we can add it to the regular `docker/integration_test.sh` script, which will then run it on circleci.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat thanks! yes, that's the plan. I will do the integration with circleci as a separate PR.
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_socket.py 89'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46391002'>File: endhost/scion_socket.py:L1-160</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> If you use `ipaddress.ip_interface()` instead, you no longer need to hard-code the assumption of ipv4.
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_socket.py 72'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46394000'>File: endhost/scion_socket.py:L1-160</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The if/else here contain quite a lot of code, especially for an `__init__` method. It would be better to move these blocks into separate methods.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Actually, given that half the code in `__init__` is server-specific, and `accept()` is server-specific, it probably makes most sense to have separate classes for client and server.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Yes we talked about this but then I thought that in that case one would have to instantiate the classes differently like ScionServerSocket() and ScionClientSocket(). I thought it could be better to encapsulate this info inside one class. The the users of the socket class can just instantiate as ScionSocket. What do you think?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Having `ScionServerSocket` and `ScionClientSocket`, where each only accept/require the relevant arguments, is much better than having a combined class where half the arguments and 1/3rd of the code don't apply to half of the use cases.
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_socket.py 74'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46394037'>File: endhost/scion_socket.py:L1-160</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is unused
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_socket.py 87'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46395430'>File: endhost/scion_socket.py:L1-160</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This concerns me a bit. The encoding of isd/ad should preferably only be done in one place (`scion_addr.ISD_AD`). I'm putting a quick PR together to add a method to ISD_AD to return an integer.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> https://github.com/netsec-ethz/scion/pull/550
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_socket.py 1'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46396098'>File: endhost/scion_socket.py:L1-160</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> 2015
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_test_client.py 2'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46396111'>File: endhost/scion_test_client.py:L1-62</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> 2015
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_test_client.py 51'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46396477'>File: endhost/scion_test_client.py:L1-62</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> A more pythonic way is:

```
for count in range(10):
```
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_test_server.py 2'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46396595'>File: endhost/scion_test_server.py:L1-73</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> 2015
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_test_client.py 39'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46396927'>File: endhost/scion_test_client.py:L1-62</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `()` is unnecessary
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_test_client.py 40'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46396938'>File: endhost/scion_test_client.py:L1-62</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ditto
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_test_client.py 30'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46397100'>File: endhost/scion_test_client.py:L1-62</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It's probably better to be using large messages, bigger than the MTU size.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> One thing you could do is read a chunk of data from `/dev/urandom`, start the message with the length and md5sum of the data, then send the data. The server can then verify the data is all there, and is correct.
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_test_server.py 67'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46397212'>File: endhost/scion_test_server.py:L1-73</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is quite an expensive way to build a string. Much better to use a list, then `"".join(list)`
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_test_server.py 53'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46397351'>File: endhost/scion_test_server.py:L1-73</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It's probably better to keep reading until the connection is closed.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Uh, disregard that, otherwise you can't send an ack.
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_test_server.py 58'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46397363'>File: endhost/scion_test_server.py:L1-73</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same issue here re: string building
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_test_server.py 45'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46397981'>File: endhost/scion_test_server.py:L1-73</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Bi-directional data transfer would probably be a better test
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_socket.py 150'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46401350'>File: endhost/scion_socket.py:L1-160</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> just `[:num_bytes_rcvd]`
- [x] <a href='#crh-comment-Pull 59fd477200dc66a7a294433f57f8adf47447b0b3 endhost/scion_test_server.py 66'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46401490'>File: endhost/scion_test_server.py:L1-73</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> just `range(10)`
- [x] <a href='#crh-comment-Pull be8666497956fa33f59f656edae6ebf19dfd83a2 endhost/scion_socket.py 48'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46659740'>File: endhost/scion_socket.py:L1-168</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> By convention, all base objects inherit from `object`. (This is no longer necessary in py3, but the rest of the code does this)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It's probably a good idea to mark this as an abstract base class.

```
from abc import ABCMeta, abstractmethod
...
class ScionSocket(object, metaclass=ABCMeta)
...
@abstractmethod
def __init__(self):
self.fd = None
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `ScionBaseSocket` would be a better name
- [x] <a href='#crh-comment-Pull be8666497956fa33f59f656edae6ebf19dfd83a2 endhost/scion_socket.py 67'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46659870'>File: endhost/scion_socket.py:L1-168</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This can be simplified slightly to:

```
return self.libsock.SCIONSend(self.fd, msg, len(msg))
```
- [x] <a href='#crh-comment-Pull be8666497956fa33f59f656edae6ebf19dfd83a2 endhost/scion_socket.py 82'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46659947'>File: endhost/scion_socket.py:L1-168</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> What are the semantics when calling recv on a closed socket? In plain python it can return 0 bytes on every attempt.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Do you mean empty bytes object? The return value of recv in Python socket library is bytes object not an int.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> added the warning as we discussed
- [x] <a href='#crh-comment-Pull be8666497956fa33f59f656edae6ebf19dfd83a2 endhost/scion_socket.py 136'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46660145'>File: endhost/scion_socket.py:L1-168</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> 

```
return ScionServerSocket(self.proto, self.server_port, newfd), None
```

works fine
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Actually, i'm not convinced by returning a server socket here. It's not something you can call accept on.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> So maybe the base class shouldn't be abstract after all, and just return an instance of it here.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> So basically you suggest returning a ScionSocket object initialized with the proper fd, right?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Yep
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Yeah okay, makes sense. In this case maybe it makes sense to keep the name as ScionSocket? or should we still name it as ScionBaseSocket?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> To me, `ScionSocket` implies "This is the main class, use this by default unless you know otherwise". `ScionBaseSocket` has the hint that maybe you shouldn't be using this directly.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Sure, I agree. I will name it as ScionBaseSocket
- [x] <a href='#crh-comment-Pull be8666497956fa33f59f656edae6ebf19dfd83a2 endhost/scion_socket.py 162'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46660460'>File: endhost/scion_socket.py:L1-168</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You don't need to hard-code the address length:

```
ip_bytes = ipaddress.ip_interface(self.target_IP).ip.packed
sa.host.addrLen = len(ip_bytes)
```
- [x] <a href='#crh-comment-Pull be8666497956fa33f59f656edae6ebf19dfd83a2 endhost/scion_test_client_server.py 1'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46661740'>File: endhost/scion_test_client_server.py:L1-163</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I suggest moving this into test/integration with the rest of the integration tests, and probably renaming it to something like "sdamp_cli_srv_test.py"
- [x] <a href='#crh-comment-Pull be8666497956fa33f59f656edae6ebf19dfd83a2 endhost/scion_test_client_server.py 35'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/548#discussion_r46662330'>File: endhost/scion_test_client_server.py:L1-163</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> 10KB isn't big enough. Something like 10MB would be better. I changed it to 1MB locally, but the test now times out.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `2**19` bytes works fine. `2**20` bytes doesn't.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> I am not so sure about the current limits of the underlying socket. @aznair can clarify probably. I tried with 1MB before (with a larger timeout value) and I saw it working fine. @aznair told me to not to try with very very large values than that yet :-)
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> So there's some potential problems in the current implementation regarding the send buffer. I'm refactoring/rewriting a lot of this stuff and when that's done those problems will be fixed. For now it would be nice to keep the send calls small (maybe several hundred KB at a time).
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> I left it at 200KB for now. We will increase the data size as the library matures. (put a TODO item in the code)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> 200KB is fine for now then.
  :+1:

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/548?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/548?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/548'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
