### PR TITLE
Add ISD_AD.int() to return an integer representation.

### DIFF
--- a/lib/packet/scion_addr.py
+++ b/lib/packet/scion_addr.py
@@ -63,9 +63,15 @@ class ISD_AD(namedtuple('ISD_AD', 'isd ad')):
             (remaining 20 bits).
         :rtype: bytes
         """
+        return struct.pack("!I", self.int())
+
+    def int(self):
+        """
+        Return an integer representation of the isd/ad tuple.
+        """
         isd = self.isd << 20
         ad = self.ad & 0x000fffff
-        return struct.pack("!I", isd + ad)
+        return isd + ad
 
     def __len__(self):  # pragma: no cover
         return self.LEN

--- a/test/lib_packet_scion_addr_test.py
+++ b/test/lib_packet_scion_addr_test.py
@@ -51,9 +51,21 @@ class TestISDADPack(object):
     Unit tests for lib.packet.scion_addr.ISD_AD.pack
     """
     def test(self):
+        inst = ISD_AD(0, 0)
+        inst.int = create_mock()
+        inst.int.return_value = 0x12345678
+        # Call
+        ntools.eq_(inst.pack(), bytes.fromhex("12345678"))
+
+
+class TestISDADInt(object):
+    """
+    Unit tests for lib.packet.scion_addr.ISD_AD.int
+    """
+    def test(self):
         inst = ISD_AD(0x111, 0x22222)
         # Call
-        ntools.eq_(inst.pack(), bytes.fromhex("11122222"))
+        ntools.eq_(inst.int(), 0x11122222)
 
 
 class TestSCIONAddrInit(object):


### PR DESCRIPTION
The integer representation is needed when using the C interface to the
multipath socket.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/550?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/550'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
