### PR TITLE
New path resolution.

### DIFF
--- a/infrastructure/beacon_server.py
+++ b/infrastructure/beacon_server.py
@@ -1168,7 +1168,7 @@ class CoreBeaconServer(BeaconServer):
         :param pcb: verified path segment.
         :type pcb: PathSegment
         """
-        isd_id, ad_id = pcb.get_first_pcbm().get_isd_ad()
+        isd_id, ad_id = pcb.get_first_isd_ad()
         self.core_beacons[(isd_id, ad_id)].add_segment(pcb)
 
     def register_core_segments(self):

--- a/infrastructure/path_server.py
+++ b/infrastructure/path_server.py
@@ -17,7 +17,6 @@
 ========================================
 """
 # Stdlib
-import copy
 import logging
 import threading
 from _collections import defaultdict
@@ -34,7 +33,6 @@ from lib.errors import SCIONParseError
 from lib.log import log_exception
 from lib.main import main_default, main_wrapper
 from lib.packet.host_addr import haddr_parse
-from lib.packet.path import UP_IOF
 from lib.packet.path_mgmt import (
     PathRecordsReply,
     PathRecordsSync,
@@ -42,13 +40,13 @@ from lib.packet.path_mgmt import (
     RevocationInfo,
 )
 from lib.packet.scion import PacketType as PT, SCIONL4Packet
+from lib.packet.scion_addr import ISD_AD
 from lib.path_db import DBResult, PathSegmentDB
 from lib.thread import thread_safety_net
 from lib.types import PathMgmtType as PMT, PathSegmentType as PST, PayloadClass
 from lib.util import (
     SCIONTime,
     sleep_interval,
-    update_dict,
 )
 from lib.zookeeper import ZkNoConnection, ZkSharedCache, Zookeeper
 
@@ -75,9 +73,8 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         self.down_segments = PathSegmentDB(max_res_no=self.MAX_SEG_NO)
         # Core segments are in direction of the propagation.
         self.core_segments = PathSegmentDB(max_res_no=self.MAX_SEG_NO)
-        self.pending_down = {}  # Dict of pending DOWN _and_ UP_DOWN requests.
-        self.pending_core = {}
-        self.waiting_targets = set()  # Used when local PS doesn't have up-path.
+        self.pending_req = defaultdict(list)  # Dict of pending requests.
+        self.waiting_targets = set()  # Used when l/cPS doesn't have up/dw-path.
         self.revocations = ExpiringDict(1000, 300)
         self.iftoken2seg = defaultdict(set)
         # Must be set in child classes:
@@ -85,7 +82,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
 
         self.PLD_CLASS_MAP = {
             PayloadClass.PATH: {
-                PMT.REQUEST: self.handle_path_request,
+                PMT.REQUEST: self.path_resolution,
                 PMT.REPLY: self.dispatch_path_segment_record,
                 PMT.REG: self.dispatch_path_segment_record,
                 PMT.REVOCATION: self._handle_revocation,
@@ -231,54 +228,87 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         next_hop = self.ifid2addr[if_id]
         self.send(pkt, next_hop)
 
-    def send_path_segments(self, pkt, paths):
+    def _send_path_segments(self, pkt, up=None, core=None, down=None):
         """
-        Sends path-segments to requester (depending on Path Server's location)
+        Sends path-segments to requester (depending on Path Server's location).
         """
+        up = up or set()
+        core = core or set()
+        down = down or set()
+        if not (up | core | down):
+            logging.warning("No segments to send")
         rep_pkt = pkt.reversed_copy()
-        seg_info = rep_pkt.get_payload()
         rep_pkt.set_payload(PathRecordsReply.from_values(
-            {seg_info.seg_type: paths}))
+            {PST.UP: up, PST.CORE: core, PST.DOWN: down}))
+        rep_pkt.addrs.src_addr = self.addr.host_addr
         (next_hop, port) = self.get_first_hop(rep_pkt)
         if next_hop is None:
             logging.error("Next hop is None for Interface %d",
                           rep_pkt.path.get_fwd_if())
             return
         logging.info(
-            "Sending PATH_REPLY with %d path(s) for %s:%s-%s "
-            "to:(%s-%s, %s:%s):\n  %s", len(paths),
-            PST.to_str(seg_info.seg_type), seg_info.dst_isd,
-            seg_info.dst_ad, rep_pkt.addrs.dst_isd, rep_pkt.addrs.dst_ad,
+            "Sending PATH_REPLY with %d segment(s) to:(%s-%s, %s:%s):\n  %s",
+            len(up | core | down), rep_pkt.addrs.dst_isd, rep_pkt.addrs.dst_ad,
             rep_pkt.addrs.dst_addr, rep_pkt.l4_hdr.dst_port,
-            "\n  ".join([pcb.short_desc() for pcb in paths]),
+            "\n  ".join([pcb.short_desc() for pcb in (up | core | down)]),
         )
         self.send(rep_pkt, next_hop, port)
+
+    def _handle_pending_requests(self, added):
+        for dst_isd, dst_ad in added:
+            to_remove = []
+            # Serve pending requests.
+            for pkt in self.pending_req[(dst_isd, dst_ad)]:
+                if self.path_resolution(pkt, new_request=False):
+                    to_remove.append(pkt)
+            # Clean state.
+            for pkt in to_remove:
+                self.pending_req[(dst_isd, dst_ad)].remove(pkt)
+            if not self.pending_req[(dst_isd, dst_ad)]:
+                del self.pending_req[(dst_isd, dst_ad)]
 
     def dispatch_path_segment_record(self, pkt):
         """
         Dispatches path record packet.
         """
-        # FIXME(kormat): this needs to change once we start putting multiple
-        # types of segments into a PathSegmentRecords object.
-        handler = None
+        # FIXME(PSz): ugly for now
+        handlers = []
         payload = pkt.get_payload()
         if payload.pcbs[PST.UP]:
-            handler = self._handle_up_segment_record
-        elif payload.pcbs[PST.DOWN] or payload.pcbs[PST.UP_DOWN]:
-            handler = self._handle_down_segment_record
-        elif payload.pcbs[PST.CORE]:
-            handler = self._handle_core_segment_record
-        if handler is None:
+            handlers.append(self._handle_up_segment_record)
+        if payload.pcbs[PST.CORE]:
+            handlers.append(self._handle_core_segment_record)
+        if payload.pcbs[PST.DOWN]:
+            handlers.append(self._handle_down_segment_record)
+        if not handlers:
             logging.error("Unsupported path record type: %s", payload)
             return
-        handler(pkt)
+
+        added = set()
+        for handler in handlers:
+            added.update(handler(pkt))
+        # Handling pending request, basing on added segments.
+        self._handle_pending_requests(added)
 
     @abstractmethod
-    def handle_path_request(self, path_request):
+    def path_resolution(self, path_request):
         """
         Handles all types of path request.
         """
         raise NotImplementedError
+
+    def _handle_waiting_targets(self, path):
+        if not self.waiting_targets:
+            return
+        dst_isd, dst_ad = path.get_first_isd_ad()
+        path = path.get_path(reverse_direction=True)
+        while self.waiting_targets:
+            isd, ad, seg_info = self.waiting_targets.pop()
+            req_pkt = self._build_packet(
+                PT.PATH_MGMT, dst_isd=dst_isd, dst_ad=dst_ad,
+                path=path, payload=seg_info)
+            self._send_to_next_hop(req_pkt, path.get_fwd_if())
+            logging.info("PATH_REQ sent using (first) registered up-path")
 
     def _share_segments(self, pkt):
         """
@@ -325,14 +355,8 @@ class CorePathServer(PathServer):
         super().__init__(server_id, conf_dir, is_sim=is_sim)
         # Sanity check that we should indeed be a core path server.
         assert self.topology.is_core_ad, "This shouldn't be a core PS!"
-        self.core_ads = {}  # Mapping: ISD_ID -> list of core ASes.
-        self._init_core_ads()
         self._master_id = None  # Address of master core Path Server.
         self._cached_seg_handler = self._handle_core_segment_record
-
-    def _init_core_ads(self):
-        for trc in self.trust_store.get_trcs():
-            self.core_ads[trc.isd_id] = trc.get_core_ads()
 
     def _update_master(self):
         """
@@ -397,20 +421,21 @@ class CorePathServer(PathServer):
 
     def _handle_down_segment_record(self, pkt):
         """
-        Handle registration of a down path.
+        Handle registration of a down path. Return a set of added destinations.
         """
+        added = set()
         records = pkt.get_payload()
+        if not records.pcbs[PST.DOWN]:
+            return added
         from_master = (
             pkt.addrs.src_isd == self.addr.isd_id and
             pkt.addrs.src_ad == self.addr.ad_id and
             records.PAYLOAD_TYPE == PMT.REPLY)
-        if not records.pcbs[PST.DOWN] and not records.pcbs[PST.UP_DOWN]:
-            return
         paths_to_propagate = []
         paths_to_master = []
-        for pcb in records.pcbs[PST.DOWN] + records.pcbs[PST.UP_DOWN]:
-            src_isd, src_ad = pcb.get_first_pcbm().get_isd_ad()
-            dst_isd, dst_ad = pcb.get_last_pcbm().get_isd_ad()
+        for pcb in records.pcbs[PST.DOWN]:
+            src_isd, src_ad = pcb.get_first_isd_ad()
+            dst_isd, dst_ad = pcb.get_last_isd_ad()
             res = self.down_segments.update(pcb, src_isd, src_ad,
                                             dst_isd, dst_ad)
             if (dst_isd == pkt.addrs.src_isd and dst_ad == pkt.addrs.src_ad):
@@ -421,55 +446,52 @@ class CorePathServer(PathServer):
                 # Master replicates all seen down-paths from ISD.
                 paths_to_master.append(pcb)
             if res != DBResult.NONE:
-                logging.info("Down-Segment registered: %s", pcb.short_desc())
                 if res == DBResult.ENTRY_ADDED:
                     self._add_if_mappings(pcb)
+                    added.add((dst_isd, dst_ad))
+                    logging.info("Down-Seg registered: %s", pcb.short_desc())
             else:
                 logging.info("Down-Segment already known: %s", pcb.short_desc())
         # For now we let every CPS know about all the down-paths within an ISD.
         # Also send paths to local master.
-        # FIXME: putting all paths into single packet may be not a good decision
         if paths_to_propagate:
             recs = PathRecordsReply.from_values({PST.DOWN: paths_to_propagate})
             # Now propagate paths to other core ADs (in the ISD).
             logging.debug("Propagate among core ADs")
             self._propagate_to_core_ads(recs)
         # Send paths to local master.
-        if (paths_to_master and not from_master and self._master_id and not
-                self._is_master()):
+        if (paths_to_master and not from_master and not self._is_master()):
             rep_recs = PathRecordsReply.from_values(
                 {PST.DOWN: paths_to_master})
             pkt = self._build_packet(payload=rep_recs)
             self._send_to_master(pkt)
-        # Serve pending requests.
-        target = (dst_isd, dst_ad)
-        if target in self.pending_down:
-            segments_to_send = self.down_segments(last_isd=dst_isd,
-                                                  last_ad=dst_ad)
-            for pkt in self.pending_down[target]:
-                self.send_path_segments(pkt, segments_to_send)
-            del self.pending_down[target]
+        return added
 
     def _handle_core_segment_record(self, pkt, from_zk=False):
         """
-        Handle registration of a core path.
+        Handle registration of a core path. Return a set of added destinations.
         """
+        added = set()
         records = pkt.get_payload()
+        if not records.pcbs[PST.CORE]:
+            return added
         from_master = (
             pkt.addrs.src_isd == self.addr.isd_id and
             pkt.addrs.src_ad == self.addr.ad_id and
             records.PAYLOAD_TYPE == PMT.REPLY)
-        if not records.pcbs[PST.CORE]:
-            return
         pcb_from_local_isd = True
         for pcb in records.pcbs[PST.CORE]:
-            src_isd, src_ad = pcb.get_last_pcbm().get_isd_ad()
-            dst_isd, dst_ad = pcb.get_first_pcbm().get_isd_ad()
+            src_isd, src_ad = pcb.get_last_isd_ad()
+            dst_isd, dst_ad = pcb.get_first_isd_ad()
             res = self.core_segments.update(pcb, first_isd=dst_isd,
                                             first_ad=dst_ad, last_isd=src_isd,
                                             last_ad=src_ad)
             if res == DBResult.ENTRY_ADDED:
                 self._add_if_mappings(pcb)
+                added.add((dst_isd, dst_ad))
+                if dst_isd != self.addr.isd_id:
+                    # Mark that a segment to remote ISD was added.
+                    added.add((dst_isd, 0))
                 logging.info("Core-Path registered (from zk: %s): %s",
                              from_zk, pcb.short_desc())
             else:
@@ -486,37 +508,8 @@ class CorePathServer(PathServer):
                 self._send_to_master(pkt)
         # Send pending requests that couldn't be processed due to the lack of
         # a core path to the destination PS.
-        if self.waiting_targets:
-            pcb = records.pcbs[PST.CORE][0]
-            path = pcb.get_path(reverse_direction=True)
-            targets = copy.copy(self.waiting_targets)
-            if_id = pcb.get_last_pcbm().hof.ingress_if
-            for (target_isd, target_ad, seg_info) in targets:
-                if target_isd == dst_isd:
-                    req_pkt = self._build_packet(
-                        PT.PATH_MGMT, payload=seg_info, path=path,
-                        dst_isd=dst_isd, dst_ad=dst_ad)
-                    logging.debug("Sending path request %s on newly learned "
-                                  "path to (%d, %d)", seg_info, dst_isd, dst_ad)
-                    self._send_to_next_hop(req_pkt, if_id)
-                    self.waiting_targets.remove((target_isd, target_ad,
-                                                 seg_info))
-
-        # Serve pending core path requests.
-        for target in [((src_isd, src_ad), (dst_isd, dst_ad)),
-                       ((src_isd, src_ad), (dst_isd, 0))]:
-            if self.pending_core:
-                logging.debug("D01 Target: %s, pending_core: %s " %
-                              (target, self.pending_core))
-            if target in self.pending_core:
-                segments_to_send = self.core_segments(first_isd=dst_isd,
-                                                      first_ad=dst_ad or None,
-                                                      last_isd=src_isd,
-                                                      last_ad=src_ad)
-                for pkt in self.pending_core[target]:
-                    self.send_path_segments(pkt, segments_to_send)
-                del self.pending_core[target]
-                logging.debug("D02: %s removed from pending_core", target)
+        self._handle_waiting_targets(records.pcbs[PST.CORE][0])
+        return added
 
     def _send_to_master(self, pkt):
         """
@@ -538,6 +531,9 @@ class CorePathServer(PathServer):
         """
         Query master for a path.
         """
+        if self._is_master():
+            logging.debug("I'm master, query abandoned.")
+            return
         if src_isd is None:
             src_isd = self.topology.isd_id
         if src_ad is None:
@@ -557,7 +553,7 @@ class CorePathServer(PathServer):
         :param pkt: the packet to propagate (without path)
         :type pkt: lib.packet.packet_base.PacketBase
         """
-        for (isd, ad) in self.core_ads[self.topology.isd_id]:
+        for (isd, ad) in self._core_ads[self.topology.isd_id]:
             if (isd, ad) == self.addr.get_isd_ad():
                 continue
             cpaths = self.core_segments(first_isd=isd, first_ad=ad,
@@ -572,79 +568,125 @@ class CorePathServer(PathServer):
             else:
                 logging.warning("Path to AD (%d, %d) not found.", isd, ad)
 
-    def handle_path_request(self, pkt):
+    def path_resolution(self, pkt, new_request=True):
+        """
+        Handle generic type of a path request.
+        new_request informs whether a pkt is a new request (True), or is a
+        pending request (False).
+        Return True when resolution succeeded, False otherwise.
+        """
         seg_info = pkt.get_payload()
         seg_type = seg_info.seg_type
-        dst_isd = seg_info.dst_isd
-        dst_ad = seg_info.dst_ad
-        logging.info("PATH_REQ received: type: %s, addr: (%d, %d)",
-                     PST.to_str(seg_type), dst_isd, dst_ad)
-        segments_to_send = []
-        if seg_type == PST.UP:
-            logging.error("CPS received up-segment request! This should not "
-                          "happen")
-            return
-        if seg_type in [PST.DOWN, PST.UP_DOWN]:
-            paths = self.down_segments(last_isd=dst_isd, last_ad=dst_ad)
-            if paths:
-                # We already have paths matching the request
-                segments_to_send.extend(paths)
-            elif dst_isd == self.topology.isd_id:
-                update_dict(self.pending_down, (dst_isd, dst_ad), [pkt])
-                logging.info("No down-path segment for (%d, %d), "
-                             "request is pending.", dst_isd, dst_ad)
-                if not self._is_master():
-                    self._query_master(seg_type, dst_isd, dst_ad)
-            else:
-                # Destination is in a different ISD. Ask a CPS in a this ISD for
-                # a down-path using the first available core path.
-                update_dict(self.pending_down, (dst_isd, dst_ad), [pkt])
-                cpaths = self.core_segments(first_isd=dst_isd,
-                                            last_isd=self.topology.isd_id,
-                                            last_ad=self.topology.ad_id)
-                if cpaths:
-                    path = cpaths[0].get_path(reverse_direction=True)
-                    dst_isd, dst_ad = cpaths[0].get_first_pcbm().get_isd_ad()
-                    req_pkt = self._build_packet(
-                        PT.PATH_MGMT, dst_isd=dst_isd, dst_ad=dst_ad,
-                        path=path, payload=seg_info)
-                    logging.info("Down-Segment request for different ISD. "
-                                 "Forwarding request to CPS in (%d, %d).",
-                                 dst_isd, dst_ad)
-                    self._send_to_next_hop(req_pkt, path.get_fwd_if())
-                # If no core_path was available, add request to waiting targets.
-                else:
-                    logging.info("Waiting for core path to target ISD (%d, %d)",
-                                 dst_isd, dst_ad)
-                    self.waiting_targets.add((dst_isd, dst_ad, seg_info))
-                    if not self._is_master():
-                        # Ask for any path to dst_isd
-                        self._query_master(PST.CORE, dst_isd, 0)
-        elif seg_type == PST.CORE:
-            src_isd = seg_info.src_isd
-            src_ad = seg_info.src_ad
-            # Check if requester wants any path to ISD.
-            if not dst_ad and not self._is_master():
-                logging.warning("Request for ISD path and self is not master")
-            key = ((src_isd, src_ad), (dst_isd, dst_ad))
-            paths = self.core_segments(first_isd=dst_isd,
-                                       first_ad=dst_ad or None,
-                                       last_isd=src_isd,
-                                       last_ad=src_ad)
-            if paths:
-                segments_to_send.extend(paths)
-            else:
-                update_dict(self.pending_core, key, [pkt])
-                logging.info("No core-segment for (%d, %d) -> (%d, %d), "
-                             "request is pending.", src_isd, src_ad,
-                             dst_isd, dst_ad)
-                if not self._is_master():
-                    self._query_master(seg_type, dst_isd, dst_ad, src_isd,
-                                       src_ad)
+        dst = ISD_AD(seg_info.dst_isd, seg_info.dst_ad)
+        assert seg_type == PST.GENERIC
+        logging.info("PATH_REQ received, addr: %d,%d" % dst)
+        if dst == self.addr.get_isd_ad():
+            logging.warning("Dropping request: requested DST is local AD")
+            return False
+
+        dst_is_core = dst in self._core_ads[dst.isd] or not dst.ad
+        if dst_is_core:
+            core_seg = self._resolve_core(pkt, dst.isd, dst.ad, new_request)
+            down_seg = set()
         else:
-            logging.error("CPS received unsupported path request!.")
-        if segments_to_send:
-            self.send_path_segments(pkt, segments_to_send)
+            core_seg, down_seg = self._resolve_not_core(pkt, dst.isd, dst.ad,
+                                                        new_request)
+
+        if not (core_seg | down_seg):
+            if new_request:
+                logging.debug("Segs to %d,%d not found." % dst)
+            else:
+                # That could happend when a needed segment has expired.
+                logging.warning("Handling pending request and needed seg"
+                                "is missing. Shouldn't be here (too often).")
+            return False
+
+        logging.debug("Sending segments to %d,%d" % dst)
+        self._send_path_segments(pkt, None, core_seg, down_seg)
+        return True
+
+    def _resolve_core(self, pkt, dst_isd, dst_ad, new_request):
+        """
+        Dst is core AS.
+        """
+        my_isd, my_ad = self.addr.get_isd_ad()
+        core_seg = set(self.core_segments(first_isd=dst_isd,
+                                          first_ad=dst_ad or None,
+                                          last_isd=my_isd, last_ad=my_ad))
+        if not core_seg and new_request:
+            # Segments not found and it is a neq request.
+            self.pending_req[(dst_isd, dst_ad)].append(pkt)
+            # If dst is in remote ISD then a segment may be kept by master.
+            if dst_isd != self.addr.isd_id:
+                self._query_master(PST.GENERIC, dst_isd, dst_ad)
+        return core_seg
+
+    def _resolve_not_core(self, pkt, dst_isd, dst_ad, new_request):
+        """
+        Dst is regular AS.
+        """
+        core_seg = set()
+        down_seg = set()
+        my_isd, my_ad = self.addr.get_isd_ad()
+        # Check if there exists down-seg to dst.
+        tmp_down_seg = self.down_segments(last_isd=dst_isd, last_ad=dst_ad)
+        if not tmp_down_seg and new_request:
+            self._resolve_not_core_failed(pkt, dst_isd, dst_ad)
+
+        for dseg in tmp_down_seg:
+            isd, ad = dseg.get_first_isd_ad()
+            # Check whether it is a direct down segment.
+            if (isd, ad) == self.addr.get_isd_ad():
+                down_seg.add(dseg)
+                continue
+
+            # Now try core segments that connect to down segment.
+            tmp_core_seg = self.core_segments(first_isd=isd, first_ad=ad,
+                                              last_isd=my_isd, last_ad=my_ad)
+            if not tmp_core_seg and new_request:
+                # Core segment not found and it is a new request.
+                self.pending_req[(isd, ad)].append(pkt)
+                if dst_isd != self.addr.isd_id:  # Master may know a segment.
+                    self._query_master(PST.GENERIC, isd, ad)
+            elif tmp_core_seg:
+                down_seg.add(dseg)
+                core_seg.update(tmp_core_seg)
+        return core_seg, down_seg
+
+    def _resolve_not_core_failed(self, pkt, dst_isd, dst_ad):
+        """
+        Execute after _resolve_not_core() cannot resolve a new request, due to
+        lack of corresponding down segment(s).
+        This must not be executed for a pending request.
+        """
+        self.pending_req[(dst_isd, dst_ad)].append(pkt)
+        if dst_isd == self.addr.isd_id:
+            # Master may know down segment as dst is in local ISD.
+            self._query_master(PST.GENERIC, dst_isd, dst_ad)
+            return
+
+        # Dst is in a remote ISD, ask any AS from there.
+        csegs = self.core_segments(first_isd=dst_isd,
+                                   last_isd=self.topology.isd_id,
+                                   last_ad=self.topology.ad_id)
+        seg_info = pkt.get_payload()
+        if csegs:
+            path = csegs[0].get_path(reverse_direction=True)
+            dst_isd, dst_ad = csegs[0].get_first_isd_ad()
+            req_pkt = self._build_packet(
+                PT.PATH_MGMT, dst_isd=dst_isd, dst_ad=dst_ad,
+                path=path, payload=seg_info)
+            logging.info("Down-Segment request for different ISD."
+                         "Forwarding request to CPS in (%d, %d).",
+                         dst_isd, dst_ad)
+            self._send_to_next_hop(req_pkt, path.get_fwd_if())
+        # If no core_path was available, add request to waiting targets.
+        else:
+            logging.info("Waiting for core path to AS (%d, %d)",
+                         dst_isd, dst_ad)
+            self.waiting_targets.add((dst_isd, dst_ad, seg_info))
+            # Ask for any path to dst_isd
+            self._query_master(PST.GENERIC, dst_isd, 0)
 
 
 class LocalPathServer(PathServer):
@@ -663,7 +705,6 @@ class LocalPathServer(PathServer):
         assert not self.topology.is_core_ad, "This shouldn't be a local PS!"
         # Database of up-segments to the core.
         self.up_segments = PathSegmentDB(max_res_no=self.MAX_SEG_NO)
-        self.pending_up = []  # List of pending UP requests.
         self._cached_seg_handler = self._handle_up_segment_record
 
     def _update_master(self):
@@ -671,100 +712,74 @@ class LocalPathServer(PathServer):
 
     def _handle_up_segment_record(self, pkt, from_zk=False):
         """
-        Handle Up Path registration from local BS or ZK's cache.
+        Handle Up Path registration from local BS or ZK's cache. Return a set of
+        added destinations.
 
         :param pkt:
         :type pkt:
         """
+        added = set()
         records = pkt.get_payload()
         if not records.pcbs[PST.UP]:
-            return
+            return added
         for pcb in records.pcbs[PST.UP]:
-            res = self.up_segments.update(pcb, pcb.get_first_pcbm().isd_id,
-                                          pcb.get_first_pcbm().ad_id,
-                                          self.topology.isd_id,
-                                          self.topology.ad_id)
+            first_isd, first_ad = pcb.get_first_isd_ad()
+            res = self.up_segments.update(pcb, first_isd, first_ad,
+                                          self.addr.isd_id, self.addr.ad_id)
             if res == DBResult.ENTRY_ADDED:
                 self._add_if_mappings(pcb)
+                added.add((first_isd, first_ad))
                 logging.info("Up-Segment registered (from zk: %s): %s",
                              from_zk, pcb.short_desc())
         # Share Up Segment via ZK.
         if not from_zk:
             self._share_segments(pkt)
         # Sending pending targets to the core using first registered up-path.
-        if self.waiting_targets:
-            pcb = records.pcbs[PST.UP][0]
-            path = pcb.get_path(reverse_direction=True)
-            dst_isd = pcb.get_isd()
-            dst_ad = pcb.get_first_pcbm().ad_id
-            targets = copy.copy(self.waiting_targets)
-            for (isd, ad, seg_info) in targets:
-                req_pkt = self._build_packet(
-                    PT.PATH_MGMT, dst_isd=dst_isd, dst_ad=dst_ad,
-                    path=path, payload=seg_info)
-                self._send_to_next_hop(req_pkt, path.get_fwd_if())
-                logging.info("PATH_REQ sent using (first) registered up-path")
-                self.waiting_targets.remove((isd, ad, seg_info))
-        # Handling pending UP_PATH requests.
-        for path_request in self.pending_up:
-            self.send_path_segments(path_request, self.up_segments())
-        self.pending_up = []
+        self._handle_waiting_targets(records.pcbs[PST.UP][0])
+        return added
 
     def _handle_down_segment_record(self, pkt):
         """
-        :param pkt:
-        :type pkt:
+        Handle down segment record. Return a set of added destinations.
         """
+        added = set()
         records = pkt.get_payload()
-        if not records.pcbs[PST.DOWN] and not records.pcbs[PST.UP_DOWN]:
-            return
-        for pcb in records.pcbs[PST.DOWN] + records.pcbs[PST.UP_DOWN]:
-            src_isd, src_ad = pcb.get_first_pcbm().get_isd_ad()
-            dst_isd, dst_ad = pcb.get_last_pcbm().get_isd_ad()
+        if not records.pcbs[PST.DOWN]:
+            return added
+        for pcb in records.pcbs[PST.DOWN]:
+            src_isd, src_ad = pcb.get_first_isd_ad()
+            dst_isd, dst_ad = pcb.get_last_isd_ad()
             res = self.down_segments.update(pcb, src_isd, src_ad,
                                             dst_isd, dst_ad)
             if res == DBResult.ENTRY_ADDED:
                 self._add_if_mappings(pcb)
-
-        # serve pending requests
-        target = (dst_isd, dst_ad)
-        if target in self.pending_down:
-            segments_to_send = self.down_segments(last_isd=dst_isd,
-                                                  last_ad=dst_ad)
-            for path_request in self.pending_down[target]:
-                self.send_path_segments(path_request, segments_to_send)
-            del self.pending_down[target]
+                added.add((dst_isd, dst_ad))
+                logging.info("Down-Seg registered: %s", pcb.short_desc())
+        return added
 
     def _handle_core_segment_record(self, pkt):
         """
-        Handle registration of a core path.
+        Handle registration of a core path. Return a set of added destinations.
 
         :param pkt:
         :type pkt:
         """
+        added = set()
         records = pkt.get_payload()
         if not records.pcbs[PST.CORE]:
-            return
+            return added
         for pcb in records.pcbs[PST.CORE]:
             # Core segments have down-path direction.
-            src_isd, src_ad = pcb.get_last_pcbm().get_isd_ad()
-            dst_isd, dst_ad = pcb.get_first_pcbm().get_isd_ad()
+            src_isd, src_ad = pcb.get_last_isd_ad()
+            dst_isd, dst_ad = pcb.get_first_isd_ad()
             res = self.core_segments.update(pcb, first_isd=dst_isd,
                                             first_ad=dst_ad, last_isd=src_isd,
                                             last_ad=src_ad)
             if res == DBResult.ENTRY_ADDED:
                 self._add_if_mappings(pcb)
+                added.add((dst_isd, dst_ad))
                 logging.info("Core-Segment registered: %s", pcb.short_desc())
-        # Serve pending core path requests.
-        target = ((src_isd, src_ad), (dst_isd, dst_ad))
-        if target in self.pending_core:
-            segments_to_send = self.core_segments(first_isd=dst_isd,
-                                                  first_ad=dst_ad,
-                                                  last_isd=src_isd,
-                                                  last_ad=src_ad)
-            for path_request in self.pending_core[target]:
-                self.send_path_segments(path_request, segments_to_send)
-            del self.pending_core[target]
+        return added
 
     def _remove_revoked_segments(self, rev_info):
         """
@@ -787,8 +802,92 @@ class LocalPathServer(PathServer):
                 del self.iftoken2seg[rev_token]
             rev_token = SHA256.new(rev_token).digest()
 
-    def _request_paths_from_core(self, ptype, dst_isd, dst_ad,
-                                 src_isd=None, src_ad=None):
+    def path_resolution(self, pkt, new_request=True):
+        """
+        Handle generic type of a path request.
+        """
+        seg_info = pkt.get_payload()
+        seg_type = seg_info.seg_type
+        dst = ISD_AD(seg_info.dst_isd, seg_info.dst_ad)
+        assert seg_type == PST.GENERIC
+        logging.info("PATH_REQ received, addr: %d,%d" % dst)
+        if dst == self.addr.get_isd_ad():
+            logging.warning("Dropping request: requested DST is local AD")
+            return False
+
+        dst_is_core = dst in self._core_ads[dst.isd]
+        dst_in_local_isd = (dst.isd == self.addr.isd_id)
+        down_seg = set()
+        if dst_is_core:
+            up_seg, core_seg = self._resolve_core(dst.isd, dst.ad,
+                                                  dst_in_local_isd)
+        else:
+            up_seg, core_seg, down_seg = self._resolve_not_core(
+                dst.isd, dst.ad, dst_in_local_isd)
+
+        if not (up_seg | core_seg | down_seg):
+            if new_request:
+                logging.debug("Segs to %d,%d not found, querying core." % dst)
+                self._request_paths_from_core(dst.isd, dst.ad)
+                self.pending_req[dst].append(pkt)
+            else:
+                # That could happend when needed segment expired.
+                logging.warning("Handling pending request and needed seg"
+                                "is missing. Shouldn't be here (too often).")
+            return False
+
+        logging.debug("Sending segments to %d,%d" % dst)
+        self._send_path_segments(pkt, up_seg, core_seg, down_seg)
+        return True
+
+    def _resolve_core(self, dst_isd, dst_ad, dst_in_local_isd):
+        """
+        Dst is core AS.
+        """
+        up_seg = set()
+        core_seg = set()
+        if dst_in_local_isd:
+            # Dst in local ISD. First check whether DST is a (super)-parent.
+            up_seg.update(self.up_segments(first_isd=dst_isd, first_ad=dst_ad))
+        # Check whether dst is known core AS.
+        for cseg in self.core_segments(first_isd=dst_isd, first_ad=dst_ad):
+            # Check do we have an up-seg that is connected to core_seg.
+            isd, ad = cseg.get_last_isd_ad()
+            tmp_up_segs = self.up_segments(first_isd=isd, first_ad=ad)
+            if tmp_up_segs:
+                up_seg.update(tmp_up_segs)
+                core_seg.add(cseg)
+        return up_seg, core_seg
+
+    def _resolve_not_core(self, dst_isd, dst_ad, dst_in_local_isd):
+        """
+        Dst is regular AS.
+        """
+        up_seg = set()
+        core_seg = set()
+        down_seg = set()
+        # Check if there exists down-seg to DST.
+        for dseg in self.down_segments(last_isd=dst_isd, last_ad=dst_ad):
+            isd, ad = dseg.get_first_isd_ad()
+            if dst_in_local_isd:
+                # Dst in local ISD. First try to find direct up-seg.
+                tmp_up_seg = self.up_segments(first_isd=isd, first_ad=ad)
+                if tmp_up_seg:
+                    up_seg.update(tmp_up_seg)
+                    down_seg.add(dseg)
+            # Now try core segments that connect to down segment.
+            # PSz: it might make sense to start with up_segments instead.
+            for cseg in self.core_segments(first_isd=isd, first_ad=ad):
+                isd_, ad_ = cseg.get_last_isd_ad()
+                # And up segments that connect to core segment.
+                tmp_up_seg = self.up_segments(first_isd=isd_, first_ad=ad_)
+                if tmp_up_seg:
+                    up_seg.update(tmp_up_seg)
+                    down_seg.add(dseg)
+                    core_seg.add(cseg)
+        return up_seg, core_seg, down_seg
+
+    def _request_paths_from_core(self, dst_isd, dst_ad):
         """
         Try to request core PS for given target (isd, ad).
 
@@ -803,91 +902,22 @@ class LocalPathServer(PathServer):
         :param src_ad:
         :type src_ad:
         """
-        if src_isd is None:
-            src_isd = self.topology.isd_id
-        if src_ad is None:
-            src_ad = self.topology.ad_id
-        seg_info = PathSegmentInfo.from_values(ptype, src_isd, src_ad, dst_isd,
-                                               dst_ad)
+        src_isd, src_ad = self.addr.get_isd_ad()
+        seg_info = PathSegmentInfo.from_values(PST.GENERIC, src_isd, src_ad,
+                                               dst_isd, dst_ad)
         if not len(self.up_segments()):
-            if ptype == PST.DOWN:
-                logging.info('Pending target added (%d, %d)', dst_isd, dst_ad)
-                self.waiting_targets.add((dst_isd, dst_ad, seg_info))
-            return
-        logging.info('Requesting path from core: type: %s, addr: %d,%d',
-                     PST.to_str(ptype), dst_isd, dst_ad)
-        if ptype == PST.DOWN:
-            # Take any path towards core.
-            pcb = self.up_segments()[0]
-        elif ptype == PST.CORE:
-            # Request core AD that should have given core-path.
-            pcbs = self.up_segments(first_isd=src_isd, first_ad=src_ad)
-            if not pcbs:
-                logging.warning("Core path (%d, %d)->(%d, %d) requested, "
-                                "but up path to (%d, %d) not found." %
-                                (src_isd, src_ad, dst_isd, dst_ad,
-                                    src_isd, src_ad))
-                return
-            pcb = pcbs[0]
-        else:
-            logging.error("UP_PATH request to core.")
+            logging.info('Pending target added (%d, %d)', dst_isd, dst_ad)
+            self.waiting_targets.add((dst_isd, dst_ad, seg_info))
             return
 
+        logging.info('Requesting core for: %d,%d', dst_isd, dst_ad)
+        # PSz: for multipath it makes sense to query with multiple core ASes
+        pcb = self.up_segments()[0]
         path = pcb.get_path(reverse_direction=True)
-        up_seg_info = path.get_ofs_by_label(UP_IOF)[0]
-        up_seg_info.up_flag = True
-        req_pkt = self._build_packet(
-            PT.PATH_MGMT, payload=seg_info, path=path, dst_isd=pcb.get_isd(),
-            dst_ad=pcb.get_first_pcbm().ad_id)
+        req_pkt = self._build_packet(PT.PATH_MGMT, payload=seg_info, path=path,
+                                     dst_isd=pcb.get_isd(),
+                                     dst_ad=pcb.get_first_pcbm().ad_id)
         self._send_to_next_hop(req_pkt, path.get_fwd_if())
-
-    def handle_path_request(self, pkt):
-        """
-        Handle all types of path request.
-
-        :param pkt:
-        :type pkt:
-        """
-        seg_info = pkt.get_payload()
-        seg_type = seg_info.seg_type
-        dst_isd = seg_info.dst_isd
-        dst_ad = seg_info.dst_ad
-        logging.info("PATH_REQ received: type: %s, addr: %d,%d",
-                     PST.to_str(seg_type), dst_isd, dst_ad,)
-        paths_to_send = []
-        # Requester wants up-path.
-        if seg_type in (PST.UP, PST.UP_DOWN):
-            if len(self.up_segments()):
-                paths_to_send.extend(self.up_segments())
-            else:
-                if seg_type == PST.UP_DOWN:
-                    update_dict(self.pending_down, (dst_isd, dst_ad), [pkt])
-                    self.waiting_targets.add((dst_isd, dst_ad, seg_info))
-                self.pending_up.append(pkt)
-                return
-        # Requester wants down-path.
-        if seg_type in (PST.DOWN, PST.UP_DOWN):
-            paths = self.down_segments(last_isd=dst_isd, last_ad=dst_ad)
-            paths_to_send.extend(paths)
-            if not paths:
-                update_dict(self.pending_down, (dst_isd, dst_ad), [pkt])
-                self._request_paths_from_core(PST.DOWN, dst_isd, dst_ad)
-                logging.info("No downpath, request is pending.")
-        # Requester wants core-path.
-        if seg_type == PST.CORE:
-            src_isd = seg_info.src_isd
-            src_ad = seg_info.src_ad
-            paths = self.core_segments(last_isd=src_isd, last_ad=src_ad,
-                                       first_isd=dst_isd, first_ad=dst_ad)
-            paths_to_send.extend(paths)
-            if not paths:
-                update_dict(self.pending_core,
-                            ((src_isd, src_ad), (dst_isd, dst_ad)), [pkt])
-                self._request_paths_from_core(PST.CORE, dst_isd, dst_ad,
-                                              src_isd, src_ad)
-        if paths_to_send:
-            self.send_path_segments(pkt, paths_to_send)
-
 
 if __name__ == "__main__":
     main_wrapper(main_default, CorePathServer, LocalPathServer)

--- a/lib/packet/pcb.py
+++ b/lib/packet/pcb.py
@@ -444,6 +444,12 @@ class PathSegment(SCIONPayloadBase):
         else:
             return None
 
+    def get_first_isd_ad(self):  # pragma: no cover
+        return self.get_first_pcbm().get_isd_ad()
+
+    def get_last_isd_ad(self):  # pragma: no cover
+        return self.get_last_pcbm().get_isd_ad()
+
     def compare_hops(self, other):
         """
         Compares the (AD-level) hops of two half-paths. Returns true if all hops
@@ -578,6 +584,9 @@ class PathSegment(SCIONPayloadBase):
         for ad_marking in self.ads:
             s.append("  %s" % ad_marking)
         return "\n".join(s)
+
+    def __hash__(self):
+        return hash(self.get_hops_hash())  # FIMXE(PSz): should add timestamp?
 
 
 def parse_pcb_payload(type_, data):

--- a/lib/path_db.py
+++ b/lib/path_db.py
@@ -255,7 +255,7 @@ class PathSegmentDB(object):
         criterias specified.
 
         :param full: Return list of results not bounded by self._max_res_no.
-        :type segment_ids: bool
+        :type full: bool
         :param args:
         :type args:
         :param kwargs:

--- a/lib/types.py
+++ b/lib/types.py
@@ -99,7 +99,7 @@ class PathSegmentType(TypeBase):
     UP = 0  # Request/Reply for up-paths
     DOWN = 1  # Request/Reply for down-paths
     CORE = 2  # Request/Reply for core-paths
-    UP_DOWN = 3  # Request/Reply for up- and down-paths
+    GENERIC = 3  # FIXME(PSz): experimental for now.
 
 
 class PCBType(TypeBase):

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -259,7 +259,7 @@ class TestSCIONDaemon(unittest.TestCase):
 def _load_ad_list():
     ad_dict = load_yaml_file(os.path.join(GEN_PATH, AD_LIST_FILE))
     ad_list = []
-    for ad_str in ad_dict.get("Non-core", []):
+    for ad_str in ad_dict.get("Non-core", []) + ad_dict.get("Core", []):
         isd, ad = ad_str.split("-")
         ad_list.append((int(isd), int(ad)))
     return ad_list

--- a/test/lib_packet_path_test.py
+++ b/test/lib_packet_path_test.py
@@ -433,42 +433,6 @@ class TestPathBaseGetFirstIofIdx(object):
         ntools.eq_(inst._get_first_iof_idx(), None)
 
 
-class TestPathBaseGetFirstHofIdx(object):
-    """
-    Unit tests for lib.packet.path.PathBase._get_first_hof_idx
-    """
-    @patch("lib.packet.path.PathBase.__init__", autospec=True,
-           return_value=None)
-    def test_with_up_hofs(self, init):
-        inst = PathBaseTesting()
-        inst._ofs = create_mock(["get_by_label"])
-        # Call
-        ntools.eq_(inst._get_first_hof_idx(), 1)
-        # Tests
-        inst._ofs.get_by_label.assert_called_once_with(UP_HOFS)
-
-    @patch("lib.packet.path.PathBase.__init__", autospec=True,
-           return_value=None)
-    def test_with_down_hofs(self, init):
-        inst = PathBaseTesting()
-        inst._ofs = create_mock(["get_by_label"])
-        inst._ofs.get_by_label.side_effect = [False, True]
-        # Call
-        ntools.eq_(inst._get_first_hof_idx(), 1)
-        # Tests
-        assert_these_calls(inst._ofs.get_by_label,
-                           [call(UP_HOFS), call(DOWN_HOFS)])
-
-    @patch("lib.packet.path.PathBase.__init__", autospec=True,
-           return_value=None)
-    def test_without_hofs(self, init):
-        inst = PathBaseTesting()
-        inst._ofs = create_mock(["get_by_label"])
-        inst._ofs.get_by_label.return_value = False
-        # Call
-        ntools.assert_is_none(inst._get_first_hof_idx())
-
-
 class TestPathBaseGetOfsByLabel(object):
     """
     Unit tests for lib.packet.path.PathBase.get_ofs_by_label


### PR DESCRIPTION
- fixing #464 #531
- single packet for path request/reply
- endhost and PSes are aware of dst's position (remote/local ISD, core/noncore
  AS)
- end2end_test enhanced by core ASes as dst/src
- few minor fixes

Following PRs:
- cleaning
- changes in PathCombinator, SegInfo, marked parts of PS and sciond
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/553%23issuecomment-161999388%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23issuecomment-161999574%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46815671%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46815747%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46815947%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46816159%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46816271%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46816331%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46816920%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817069%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817079%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817089%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817158%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817429%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817628%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817647%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817757%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817814%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817872%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817918%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46818196%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46818586%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46818731%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46818998%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46819077%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46821436%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46821797%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46821988%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46834104%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46978601%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46978702%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23issuecomment-162941683%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47066646%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47066701%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47066769%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47066953%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47066962%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067058%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067133%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067188%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067252%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067277%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067320%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067376%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067466%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067499%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067540%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067570%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067598%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067655%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067684%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067763%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067808%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47069549%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47069599%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47069741%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47070657%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47070724%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47070740%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47070910%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47070953%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47074568%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47074884%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23issuecomment-163184470%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23issuecomment-163186852%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20endhost/sciond.py%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817069%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20really%20bad.%20Please%20move%20%60init_core_ads%60%20to%20somewhere%20saner.%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A51%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Perhaps%20%60scion_elem.py%60%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A51%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%27s%20a%20bit%20weird%20that%20SCIOND%20has%20a%20dependency%20on%20%60path_server.py%60%20now.%20Maybe%20move%20this%20function%20somewhere%20else%20and%20use%20it%20in%20%60path_server.py%60%20and%20%60sciond.py%60.%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A52%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A26%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/sciond.py%3AL81-89%22%7D%2C%20%22Pull%20c0934d6e41baba6ae1368d3fb1197d0e895d32fd%20lib/packet/path.py%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r47067133%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Needs%20unit%20tests.%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A25%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ll%20add%20with%20PathCombinator%27s%20PR.%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A51%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL852-883%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%2093%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817918%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%28%29%60%20aren%27t%20needed.%22%2C%20%22created_at%22%3A%20%222015-12-07T13%3A03%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A28%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL234-326%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%2089%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817872%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20debug%20for%20things%20like%20this%22%2C%20%22created_at%22%3A%20%222015-12-07T13%3A02%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A27%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL234-326%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20lib/packet/path.py%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46816331%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Needs%20unit%20testing%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A42%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22ping%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A24%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20going%20to%20do%20few%20changes%20to%20PathCombinator%20so%20I%27m%20going%20to%20postpone%20unit%20tests%20until%20it%20is%20ready.%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A49%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL1093-1146%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%20103%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46818196%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20almost%20certainly%20a%20race%20condition.%20Please%20use%20lib.request%20instead.%22%2C%20%22created_at%22%3A%20%222015-12-07T13%3A06%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20will%20do%20this%20in%20a%20following%20PR%20%28if%20it%20does%20not%20complicate%20things%20too%20much%29.%22%2C%20%22created_at%22%3A%20%222015-12-08T16%3A45%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Having%20looked%20closer%2C%20%60pending_req%60%20is%20only%20accessed%20by%20a%20single%20thread%2C%20and%20so%20is%20ok.%20%60waiting_targets%60%20on%20the%20other%20hand%20is%20accessed%20by%202%20threads%2C%20and%20so%20has%20a%20race%20condition.%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A59%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ll%20integrate%20it%20with%20lib.requests%20in%20a%20near%20future%20%28but%20if%20it%20looks%20too%20complicated%20I%27ll%20just%20go%20with%20a%20lock%29.%22%2C%20%22created_at%22%3A%20%222015-12-09T10%3A02%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL234-326%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%20151%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46818731%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20would%20be%20simpler%20to%20do%3A%5Cr%5Cn%60%60%60%5Cr%5Cnwhile%20self.waiting_targets%3A%5Cr%5Cn%20%20isd%2C%20ad%2C%20seg_info%20%3D%20self.waiting_targets.pop%28%29%5Cr%5Cn%20%20...%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-12-07T13%3A13%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A28%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL234-326%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20test/lib_packet_path_test.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46816920%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60_get_first_hof_idx%60%20is%20so%20simple%2C%20and%20these%20tests%20are%20bad%2C%20so%20i%20would%20say%20remove%20the%20tests%20and%20make%20it%20%60%23%20pragma%3A%20no%20cover%60.%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A49%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A25%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib_packet_path_test.py%3AL449-456%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20lib/packet/path.py%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46815747%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Needs%20a%20docstring%20to%20describe%20what%20it%20does.%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A33%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A20%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL1093-1146%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%20358%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46821797%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60down_seg%60%20is%20redefined%20if%20it%27s%20not%20a%20core%20AD%2C%20so%20maybe%20do%3A%5Cr%5Cn%60%60%60%5Cr%5Cnif%20dst_is_core%3A%5Cr%5Cn%20%20%20core_seg%20%3D%20...%5Cr%5Cn%20%20%20down_seg%20%3D%20set%28%29%5Cr%5Cnelse%3A%5Cr%5Cn%20%20core_seg%2C%20down_seg%20%3D%20...%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-12-07T13%3A50%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A30%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL573-691%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%20331%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46821436%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%28dst_isd%2C%20dst_ad%29%60%20is%20used%20repeatedly%2C%20maybe%20do%3A%5Cr%5Cn%60%60%60%5Cr%5Cndst%20%3D%20ISD_AD%28seg_info.dst_isd%2C%20seg_info.dst_ad%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-12-07T13%3A46%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22ping%3F%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A29%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20tried%20that%2C%20and%20IMO%20there%20are%20too%20many%20dsts%20then.%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A49%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20only%20need%20one%20%3AP%20%60dst.isd%60%2C%20%60dst.ad%60%20are%20both%20accessible%20via%20the%20ISD_AD%20object.%22%2C%20%22created_at%22%3A%20%222015-12-09T10%3A02%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22then%20it%20makes%20some%20sense%20%3B-%29%2C%20fixed%22%2C%20%22created_at%22%3A%20%222015-12-09T10%3A37%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T10%3A40%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL573-691%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%20190%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46818998%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Move%20this%20above%20%60from_master%60%2C%20as%20there%27s%20no%20need%20to%20calculate%20%60from_master%60%20if%20there%20are%20no%20down%20paths.%22%2C%20%22created_at%22%3A%20%222015-12-07T13%3A17%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Same%20for%20%60_handle_core_segment_record%60%22%2C%20%22created_at%22%3A%20%222015-12-07T13%3A17%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A29%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL433-452%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20lib/packet/path.py%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46816159%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20block%20is%20identical%20to%20the%20%60up_core%60%20block%2C%20except%20the%20interfaces%20are%20added%20in%20the%20opposite%20order.%20Maybe%20make%20a%20small%20method%20to%20replace%20the%20blocks%2C%20and%20pass%20it%20an%20ordering%20flag.%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A39%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A23%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL1093-1146%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23issuecomment-161999388%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20%22%2C%20%22created_at%22%3A%20%222015-12-04T15%3A41%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40shitz%20%2C%20%40aznair%20may%20be%20interested%20%28at%20least%20in%20some%20parts%29%20too.%22%2C%20%22created_at%22%3A%20%222015-12-04T15%3A42%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22thanks%20for%20feedback%2C%20ready%20for%20another%20pass%22%2C%20%22created_at%22%3A%20%222015-12-08T16%3A47%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%22%2C%20%22created_at%22%3A%20%222015-12-09T10%3A40%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Merging%20as%20Sam%20comments%20are%20also%20addressed.%22%2C%20%22created_at%22%3A%20%222015-12-09T10%3A49%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20lib/packet/pcb.py%2018%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46816271%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20hash%20a%20hash%3F%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A41%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60__hash__%60%20has%20to%20return%20an%20int%22%2C%20%22created_at%22%3A%20%222015-12-08T16%3A45%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A23%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/pcb.py%3AL585-594%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%2064%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817647%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%60%60%5Cr%5Cnup%20%3D%20up%20or%20set%28%29%5Cr%5Cncore%20%3D%20core%20or%20set%28%29%5Cr%5Cndown%20%3D%20down%20or%20set%28%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A59%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A26%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL234-326%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%2065%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817079%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Use%20%60or%60%20instead%20of%20%60%7C%60.%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A51%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nevermind.%20You%20use%20it%20below%20for%20set%20union.%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A59%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A26%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL234-326%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%20387%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46834104%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20this%20a%20FIXME/TODO%3F%22%2C%20%22created_at%22%3A%20%222015-12-07T15%3A37%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A31%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL573-691%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20endhost/sciond.py%2088%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817429%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Not%20super%20happy%20with%20the%20naming%20here.%20What%20about%20%60_resolve_core%60%2C%20%60_resolve_core_not_core%60%20and%20%60_resolve_not_core_not_core%60.%20The%20first%20core/not_core%20always%20applies%20to%20self%20and%20the%20second%20to%20the%20destination.%20%60ncore%60%20isn%27t%20that%20good%20because%20usually%20you%20prepend%20a%20%27n%27%20to%20name%20a%20variable%20that%20contains%20a%20count%2C%20e.g.%2C%20%60npaths%60.%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A56%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T10%3A00%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/sciond.py%3AL281-360%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20lib/packet/path.py%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46815671%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20would%20be%20simpler%3A%5Cr%5Cn%60%60%60%5Cr%5Cnfor%20l%20in%20UP_HOFS%2C%20CORE_HOFS%2C%20DOWN_HOFS%3A%5Cr%5Cn%20%20if%20self._ofs.get_by_label%28l%29%3A%5Cr%5Cn%20%20%20%20return%201%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A32%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A20%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL214-222%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%2083%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817814%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22s/path%28s%29/segment%28s%29/%20probably%22%2C%20%22created_at%22%3A%20%222015-12-07T13%3A01%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A27%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL234-326%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%20147%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46818586%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Having%20a%20method%20with%20a%20single%20if%20statement%20containing%20the%20rest%20of%20the%20code%20unnecessary.%5Cr%5Cn%60%60%60%5Cr%5Cnif%20not%20self.waiting_targets%3A%5Cr%5Cn%20%20return%5Cr%5Cn...%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-12-07T13%3A11%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A28%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL234-326%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20lib/packet/path.py%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46815947%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60up_core%20%2B%3D%20list%28reversed%28core_segment.ads%29%29%60%22%2C%20%22created_at%22%3A%20%222015-12-07T12%3A36%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A21%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL1093-1146%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%20323%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46821988%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20does%20%60handle_request%60%20do%3F%20Looking%20at%20the%20code%2C%20it%20seems%20it%20just%20logs%20differently%3F%22%2C%20%22created_at%22%3A%20%222015-12-07T13%3A52%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T09%3A30%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL573-691%22%7D%2C%20%22Pull%206745bf797fa371140dfc843237696a73ff4a2497%20infrastructure/path_server.py%20240%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/553%23discussion_r46817757%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20add%20to%20docstring%20what%20the%20function%20returns.%22%2C%20%22created_at%22%3A%20%222015-12-07T13%3A01%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T10%3A00%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server.py%3AL456-506%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#issuecomment-161999388'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> @kormat
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> @shitz , @aznair may be interested (at least in some parts) too.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> thanks for feedback, ready for another pass
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> Merging as Sam comments are also addressed.
- [ ] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 lib/packet/path.py 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46816331'>File: lib/packet/path.py:L1093-1146</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Needs unit testing
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> ping
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> I'm going to do few changes to PathCombinator so I'm going to postpone unit tests until it is ready.
- [ ] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 103'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46818196'>File: infrastructure/path_server.py:L234-326</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is almost certainly a race condition. Please use lib.request instead.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> I will do this in a following PR (if it does not complicate things too much).
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Having looked closer, `pending_req` is only accessed by a single thread, and so is ok. `waiting_targets` on the other hand is accessed by 2 threads, and so has a race condition.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> I'll integrate it with lib.requests in a near future (but if it looks too complicated I'll just go with a lock).
- [ ] <a href='#crh-comment-Pull c0934d6e41baba6ae1368d3fb1197d0e895d32fd lib/packet/path.py 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r47067133'>File: lib/packet/path.py:L852-883</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Needs unit tests.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> I'll add with PathCombinator's PR.
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 lib/packet/path.py 6'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46815671'>File: lib/packet/path.py:L214-222</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This would be simpler:

```
for l in UP_HOFS, CORE_HOFS, DOWN_HOFS:
if self._ofs.get_by_label(l):
return 1
```
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 lib/packet/path.py 15'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46815747'>File: lib/packet/path.py:L1093-1146</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Needs a docstring to describe what it does.
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 lib/packet/path.py 37'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46815947'>File: lib/packet/path.py:L1093-1146</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `up_core += list(reversed(core_segment.ads))`
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 lib/packet/path.py 50'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46816159'>File: lib/packet/path.py:L1093-1146</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This block is identical to the `up_core` block, except the interfaces are added in the opposite order. Maybe make a small method to replace the blocks, and pass it an ordering flag.
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 lib/packet/pcb.py 18'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46816271'>File: lib/packet/pcb.py:L585-594</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Why hash a hash?
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> `__hash__` has to return an int
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 test/lib_packet_path_test.py 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46816920'>File: test/lib_packet_path_test.py:L449-456</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `_get_first_hof_idx` is so simple, and these tests are bad, so i would say remove the tests and make it `# pragma: no cover`.
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 endhost/sciond.py 18'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46817069'>File: endhost/sciond.py:L81-89</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is really bad. Please move `init_core_ads` to somewhere saner.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Perhaps `scion_elem.py`
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> It's a bit weird that SCIOND has a dependency on `path_server.py` now. Maybe move this function somewhere else and use it in `path_server.py` and `sciond.py`.
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 65'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46817079'>File: infrastructure/path_server.py:L234-326</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Use `or` instead of `|`.
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Nevermind. You use it below for set union.
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 endhost/sciond.py 88'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46817429'>File: endhost/sciond.py:L281-360</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Not super happy with the naming here. What about `_resolve_core`, `_resolve_core_not_core` and `_resolve_not_core_not_core`. The first core/not_core always applies to self and the second to the destination. `ncore` isn't that good because usually you prepend a 'n' to name a variable that contains a count, e.g., `npaths`.
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 64'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46817647'>File: infrastructure/path_server.py:L234-326</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> 

```
up = up or set()
core = core or set()
down = down or set()
```
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 240'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46817757'>File: infrastructure/path_server.py:L456-506</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Should add to docstring what the function returns.
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 83'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46817814'>File: infrastructure/path_server.py:L234-326</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> s/path(s)/segment(s)/ probably
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 89'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46817872'>File: infrastructure/path_server.py:L234-326</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Use debug for things like this
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 93'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46817918'>File: infrastructure/path_server.py:L234-326</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `()` aren't needed.
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 147'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46818586'>File: infrastructure/path_server.py:L234-326</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Having a method with a single if statement containing the rest of the code unnecessary.

```
if not self.waiting_targets:
return
...
```
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 151'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46818731'>File: infrastructure/path_server.py:L234-326</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It would be simpler to do:

```
while self.waiting_targets:
isd, ad, seg_info = self.waiting_targets.pop()
...
```
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 190'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46818998'>File: infrastructure/path_server.py:L433-452</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Move this above `from_master`, as there's no need to calculate `from_master` if there are no down paths.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Same for `_handle_core_segment_record`
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 331'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46821436'>File: infrastructure/path_server.py:L573-691</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `(dst_isd, dst_ad)` is used repeatedly, maybe do:

```
dst = ISD_AD(seg_info.dst_isd, seg_info.dst_ad)
```
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> ping?
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> I tried that, and IMO there are too many dsts then.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You only need one :P `dst.isd`, `dst.ad` are both accessible via the ISD_AD object.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> then it makes some sense ;-), fixed
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 358'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46821797'>File: infrastructure/path_server.py:L573-691</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `down_seg` is redefined if it's not a core AD, so maybe do:

```
if dst_is_core:
core_seg = ...
down_seg = set()
else:
core_seg, down_seg = ...
```
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 323'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46821988'>File: infrastructure/path_server.py:L573-691</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> What does `handle_request` do? Looking at the code, it seems it just logs differently?
- [x] <a href='#crh-comment-Pull 6745bf797fa371140dfc843237696a73ff4a2497 infrastructure/path_server.py 387'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/553#discussion_r46834104'>File: infrastructure/path_server.py:L573-691</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Is this a FIXME/TODO?

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/553?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/553?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/553'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
