### PR TITLE
Adding SIBRA extension to SCION.

### DIFF
--- a/lib/packet/ext/sibra.py
+++ b/lib/packet/ext/sibra.py
@@ -1,0 +1,408 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`sibra` --- SIBRA extension for SCION
+==========================================
+"""
+# Stdlib
+import os
+import struct
+from binascii import hexlify
+
+# SCION
+from lib.crypto.symcrypto import cbcmac
+from lib.errors import SCIONParseError
+from lib.packet.ext_hdr import HopByHopExtension, HopByHopType
+from lib.util import Raw, calc_padding
+
+#: Number of seconds per sibra interval
+SIBRA_INTERVAL = 4
+LINE_LEN = HopByHopExtension.LINE_LEN
+
+
+class SibraExt(HopByHopExtension):
+    """
+    The first byte contains the flag field. Its bits are allocated as follows:
+      - (MSB) path setup flag:
+          Set if packet is setting up a new SIBRA path.
+      - request flag:
+          Set if packet is requesting a reservation, i.e. setup or renewal.
+      - accepted flag:
+          Set if the reservation request has been accepted so far.
+      - error flag:
+          Set if an error has occurred.
+      - steady flag:
+          Set if this is a steady path, unset if this is an ephemeral path.
+      - forward flag:
+          Set if packet is travelling src->dest.
+      - version (2b): SIBRA version, to be used as (SCION ver, SIBRA ver).
+    """
+    NAME = "SibraExt"
+    EXT_TYPE = HopByHopType.SIBRA
+    STEADY_ID_LEN = 8
+    EPHEMERAL_ID_LEN = 8
+    MIN_LEN = HopByHopExtension.SUBHDR_LEN
+    SIBRA_VERSION = 0
+    FLAG_PATH_SETUP = 0b10000000
+    FLAG_REQ = 0b01000000
+    FLAG_ACCEPT = 0b00100000
+    FLAG_ERROR = 0b00010000
+    FLAG_STEADY = 0b00001000
+    FLAG_FWD = 0b00000100
+    FLAG_VERSION = 0b00000011
+
+    def __init__(self, raw=None):  # pragma: no cover
+        super().__init__()
+        # Flags:
+        self.setup = None
+        self.req = None
+        self.accepted = True
+        self.error = False
+        self.steady = True
+        self.fwd = True
+        self.version = self.SIBRA_VERSION
+        # Rest of extension:
+        self.curr_hop = 0
+        self.path_ids = []
+        self.active_blocks = []
+        self.req_block = None
+        # Metadata
+        self.total_hops = 0
+
+        if raw:
+            self._parse(raw)
+
+    def _parse(self, raw):
+        data = Raw(raw, "SibraExt", self.MIN_LEN, min_=True)
+        self._parse_flags(data.pop(1))
+        self.curr_hop = data.pop(1)
+        path_lens = struct.unpack("!BBB", data.pop(3))
+        self.total_hops = sum(path_lens)
+        self.path_ids.append(self._parse_path_id(data, self.steady))
+        if not self.steady:
+            # Ephemeral packets contain 1-3 steady path IDs before the active
+            # reservation block(s)
+            for plen in path_lens:
+                if not plen:
+                    break
+                self.path_ids.append(self._parse_path_id(data, steady=True))
+        if not (self.setup and self.steady):
+            # All non-steady-setup packets have an 1+ active reservation blocks
+            for plen in path_lens:
+                if not plen:
+                    break
+                self.active_blocks.append(self._parse_block(data, plen))
+        if self.req:
+            if self.accepted:
+                self.req_block = self._parse_block(data, self.total_hops)
+            else:
+                self.req_block = self._parse_offers_block(data)
+        if len(data):
+            raise SCIONParseError("%s bytes left when parsing SibraExt: %s" % (
+                len(data), hexlify(data.get())))
+
+    def _parse_flags(self, flags):
+        self.setup = bool(flags & self.FLAG_PATH_SETUP)
+        self.req = bool(flags & self.FLAG_REQ)
+        self.accepted = bool(flags & self.FLAG_ACCEPT)
+        self.error = bool(flags & self.FLAG_ERROR)
+        self.steady = bool(flags & self.FLAG_STEADY)
+        self.fwd = bool(flags & self.FLAG_FWD)
+        self.version = flags & self.FLAG_VERSION
+        if self.setup:
+            assert self.req
+        assert self.version == self.SIBRA_VERSION
+
+    def _parse_path_id(self, data, steady=False):  # pragma: no cover
+        if steady:
+            return data.pop(self.STEADY_ID_LEN)
+        return data.pop(self.EPHEMERAL_ID_LEN)
+
+    def _parse_block(self, data, num_hops):
+        block_len = (1 + num_hops) * LINE_LEN
+        return ResvBlock(data.pop(block_len))
+
+    def _parse_offers_block(self, data):  # pragma: no cover
+        block = OfferBlock(data.get())
+        data.pop(len(block))
+        return block
+
+    @classmethod
+    def from_values(cls):
+        raise NotImplementedError
+
+    @classmethod
+    def steady_from_values(cls, isd_ad, req_info, total_hops):
+        inst = cls()
+        inst.setup = True
+        inst.req = True
+        inst.path_ids.append(isd_ad.pack() + os.urandom(inst.STEADY_ID_LEN))
+        inst.req_block = ResvBlock.from_values(req_info, num_hops=total_hops)
+        return inst
+
+    @classmethod
+    def ephemeral_from_values(cls, isd_ad, req_info, steady_ids, steady_blocks):
+        assert len(steady_ids) == len(steady_blocks)
+        inst = cls()
+        inst.setup = True
+        inst.req = True
+        inst.steady = False
+        inst.path_ids.append(isd_ad.pack() + os.urandom(inst.EPHEMERAL_ID_LEN))
+        inst.path_ids.extend(steady_ids)
+        inst.active_blocks = steady_blocks
+        total_hops = sum([b.num_hops for b in steady_blocks])
+        inst.req_block = ResvBlock.from_values(req_info, num_hops=total_hops)
+        return inst
+
+    def pack(self):
+        raw = []
+        raw.append(self._pack_flags())
+        raw.append(struct.pack("!B", self.curr_hop))
+        path_lens = [0, 0, 0]
+        if self.active_blocks:
+            for i, active in enumerate(self.active_blocks):
+                path_lens[i] = active.num_hops
+        else:
+            path_lens[0] = self.total_hops
+        raw.append(struct.pack("!BBB", *path_lens))
+        raw.extend(self.path_ids)
+        for block in self.active_blocks:
+            raw.append(block.pack())
+        if self.req_block:
+            raw.append(self.req_block.pack())
+        result = b"".join(raw)
+        assert (len(result) + 3) % LINE_LEN == 0
+        return result
+
+    def _pack_flags(self):
+        flags = 0
+        if self.setup:
+            flags |= self.FLAG_PATH_SETUP
+        if self.req:
+            flags |= self.FLAG_REQ
+        if self.accepted:
+            flags |= self.FLAG_ACCEPT
+        if self.error:
+            flags |= self.FLAG_ERROR
+        if self.steady:
+            flags |= self.FLAG_STEADY
+        if self.fwd:
+            flags |= self.FLAG_FWD
+        flags |= self.version
+        return flags
+
+    def _pack_ephemeral_setup(self):
+        raw = []
+        for id_, block in zip(self.path_ids[1:], self.active_blocks):
+            raw.append(id_)
+            raw.append(block.pack())
+        return b"".join(raw)
+
+    def process(self, spkt):
+        pass
+
+
+class ResvInfo(object):
+    LEN = LINE_LEN
+
+    def __init__(self, raw=None):  # pragma: no cover
+        self.exp = None
+        self.bw_fwd = None
+        self.bw_rev = None
+        self.index = None
+        self.fail_hop = None
+        if raw:
+            self._parse(raw)
+
+    def _parse(self, raw):
+        data = Raw(raw, "ResvInfo", self.LEN)
+        self.exp = struct.unpack("!I", data.pop(4))[0] * SIBRA_INTERVAL
+        self.bw_fwd = data.pop(1)
+        self.bw_rev = data.pop(1)
+        self.index = data.pop(1) >> 4
+        self.fail_hop = data.pop(1)
+
+    @classmethod
+    def from_values(cls, exp, bw_fwd=0, bw_rev=0, index=0,
+                    fail_hop=0):  # pragma: no cover
+        inst = cls()
+        inst.exp = int(exp / SIBRA_INTERVAL)
+        inst.bw_fwd = bw_fwd
+        inst.bw_rev = bw_rev
+        inst.index = index
+        inst.fail_hop = fail_hop
+        return inst
+
+    def pack(self):
+        raw = []
+        raw.append(struct.pack("!I", int(self.exp / SIBRA_INTERVAL)))
+        raw.append(struct.pack("!BB", self.bw_fwd, self.bw_rev))
+        raw.append(struct.pack("!BB", self.index << 4, self.fail_hop))
+        return b"".join(raw)
+
+    def __len__(self):  # pragma: no cover
+        return self.LEN
+
+
+class ResvBlock(object):
+    MIN_LEN = ResvInfo.LEN
+
+    def __init__(self, raw=None):  # pragma: no cover
+        self.info = None
+        self.sofs = []
+        self.num_hops = 0
+        if raw:
+            self._parse(raw)
+
+    def _parse(self, raw):
+        data = Raw(raw, "ResvBlock", self.MIN_LEN, min_=True)
+        self.info = ResvInfo(data.pop(ResvInfo.LEN))
+        self.num_hops = len(data) // SibraOpaqueField.LEN
+        while data:
+            raw_sof = data.pop(SibraOpaqueField.LEN)
+            if raw_sof == bytes(SibraOpaqueField.LEN):
+                break
+            self.sofs.append(SibraOpaqueField(raw_sof))
+
+    @classmethod
+    def from_values(cls, info, sofs=None, num_hops=None):  # pragma: no cover
+        inst = cls()
+        inst.info = info
+        inst.sofs = sofs or []
+        inst.num_hops = num_hops or len(inst.sofs)
+        assert num_hops >= len(inst.sofs)
+
+    def pack(self, path_ids):
+        raw = []
+        raw.append(self.info.pack())
+        for i, sof in enumerate(self.sofs):
+            prev_sof = None
+            if i > 0:
+                prev_sof = self.sofs[i-1]
+            raw.append(sof.pack(self.info, path_ids, prev_sof))
+        for i in range(len(self.sofs), self.num_hops):
+            raw.append(bytes(SibraOpaqueField.LEN))
+        return b"".join(raw)
+
+    def __len__(self):  # pragma: no cover
+        return (1 + self.num_hops) * LINE_LEN
+
+
+class OfferBlock(object):
+    MIN_LEN = ResvInfo.LEN
+    OFFER_LEN = 2
+    OFFERS_PER_LINE = LINE_LEN // OFFER_LEN
+
+    def __init__(self, raw=None):  # pragma: no cover
+        self.info = None
+        self.offers = []
+        self.offer_hops = None
+        if raw:
+            self._parse(raw)
+
+    def _parse(self, raw):
+        data = Raw(raw, "OfferBlock", self.MIN_LEN, min_=True)
+        self.info = ResvInfo(data.pop(ResvInfo.LEN))
+        self.offer_hops = len(data) // self.OFFER_LEN
+        while data:
+            offer = struct.unpack("!BB", data.pop(2))
+            if offer == (0, 0):
+                break
+            self.offers.append(offer)
+
+    @classmethod
+    def from_values(cls, info, offer_hops, bw_fwd=0, bw_rev=0):
+        inst = cls()
+        inst.info = info
+        inst.offers.append((bw_fwd, bw_rev))
+        inst.offer_hops = offer_hops
+        # Pad number of offer hops to a full line
+        inst.offer_hops += calc_padding(offer_hops, cls.OFFERS_PER_LINE)
+        return inst
+
+    def pack(self):
+        raw = []
+        raw.append(self.info.pack())
+        for offer in self.offers:
+            raw.append(struct.pack("!BB", *offer))
+        for i in range(len(self.offers), self.offer_hops):
+            raw.append(bytes(self.OFFER_LEN))
+        result = b"".join(raw)
+        assert len(result) % LINE_LEN == 0
+        assert len(result) == len(self)
+        return result
+
+    def __len__(self):  # pragma: no cover
+        return ResvInfo.LEN + self.offer_hops * self.OFFER_LEN
+
+
+class SibraOpaqueField(object):
+    MAC_LEN = 4
+    IF_LEN = 2
+    LEN = IF_LEN * 2 + MAC_LEN
+    # Steady + ephemeral path:
+    MAX_PATH_IDS_LEN = SibraExt.STEADY_ID_LEN + SibraExt.EPHEMERAL_ID_LEN
+
+    def __init__(self, raw=None):  # pragma: no cover
+        self.ingress = None
+        self.egress = None
+        self.mac = None
+        if raw:
+            self._parse(raw)
+
+    def _parse(self, raw):
+        data = Raw(raw, "SibraOpaqueField", self.LEN)
+        self.ingress, self.egress = struct.unpack(
+            "!HH", data.pop(self.IF_LEN * 2))
+        self.mac = struct.unpack("!I", data.pop(self.MAC_LEN))[0]
+
+    @classmethod
+    def from_values(cls, ingress=0, egress=0, mac=None):  # pragma: no cover
+        inst = cls()
+        inst.ingress = ingress
+        inst.egress = egress
+        inst.mac = mac or bytes(cls.MAC_LEN)
+        return inst
+
+    def pack(self):
+        raw = []
+        raw.append(struct.pack("!HH", self.ingress, self.egress))
+        raw.append(struct.pack("!I", self.mac))
+        return b"".join(raw)
+
+    def calc_mac(self, key, info, path_ids, prev_raw=None):
+        raw = []
+        raw.append(struct.pack("!HH", self.ingress, self.egress))
+        # Don't include the last byte of the ResvInfo object
+        raw.append(info.pack()[:info.LEN-1] + bytes(1))
+        ids_len = 0
+        for id_ in path_ids:
+            ids_len += len(id_)
+            raw.append(id_)
+        # Pad path IDs with 0's to give constant length
+        raw.append(bytes(self.MAX_PATH_IDS_LEN - ids_len))
+        raw.append(prev_raw or bytes(self.LEN))
+        to_mac = b"".join(raw)
+        assert len(to_mac) == (self.IF_LEN * 2 + ResvInfo.LEN +
+                               self.MAX_PATH_IDS_LEN + self.LEN)
+        return cbcmac(key, b"".join(raw))[:self.MAC_LEN]
+
+    def __len__(self):  # pragma: no cover
+        return self.LEN
+
+
+def sibra_ext_handler(**kwargs):
+    ext = kwargs["ext"]
+    spkt = kwargs["spkt"]
+    ext.process(spkt)

--- a/lib/packet/ext_hdr.py
+++ b/lib/packet/ext_hdr.py
@@ -26,6 +26,7 @@ from lib.util import Raw
 
 class HopByHopType(TypeBase):
     TRACEROUTE = 0
+    SIBRA = 1
 
 
 class ExtensionHeader(HeaderBase):

--- a/lib/packet/ext_util.py
+++ b/lib/packet/ext_util.py
@@ -23,11 +23,13 @@ import struct
 from lib.defines import L4_PROTOS
 from lib.errors import SCIONParseError
 from lib.packet.ext_hdr import ExtensionHeader, HopByHopType
+from lib.packet.ext.sibra import SibraExt
 from lib.packet.ext.traceroute import TracerouteExt
 from lib.types import ExtensionClass
 
 # Dictionary of supported extensions
 EXTENSION_MAP = {
+    (ExtensionClass.HOP_BY_HOP, HopByHopType.SIBRA): SibraExt,
     (ExtensionClass.HOP_BY_HOP, HopByHopType.TRACEROUTE): TracerouteExt,
 }
 

--- a/test/lib_packet_ext_sibra_test.py
+++ b/test/lib_packet_ext_sibra_test.py
@@ -1,0 +1,489 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`lib_packet_ext_sibra_test` --- lib.packet.ext.sibra unit tests
+====================================================================
+"""
+# Stdlib
+from unittest.mock import call, patch
+
+# External packages
+import nose
+import nose.tools as ntools
+
+# SCION
+from lib.packet.ext.sibra import (
+    OfferBlock,
+    ResvBlock,
+    ResvInfo,
+    SIBRA_INTERVAL,
+    SibraExt,
+    SibraOpaqueField,
+)
+from test.testcommon import assert_these_calls, create_mock
+
+FLAG_MAP = (
+    # Steady setup accepted fwd
+    (0b11101100, (True, True, True, False, True, True, 0)),
+    # Ephemeral setup denied rev
+    (0b11000000, (True, True, False, False, False, False, 0)),
+    # Steady use error fwd
+    (0b00111100, (False, False, True, True, True, True, 0)),
+)
+
+
+class TestSibraExtParse(object):
+    """
+    Unit tests for lib.packet.ext.sibra.SibraExt._parse
+    """
+    def _setup(self, setup=True, req=True, accepted=True, steady=True):
+        inst = SibraExt()
+        inst._parse_flags = create_mock()
+        inst._parse_path_id = create_mock()
+        inst.setup = setup
+        inst.req = req
+        inst.steady = steady
+        inst.accepted = accepted
+        data = create_mock(["__len__", "pop"])
+        data.__len__.return_value = 0
+        data.pop.side_effect = 12, 5, bytes([4, 5, 0])
+        return inst, data
+
+    @patch("lib.packet.ext.sibra.Raw", autospec=True)
+    def test_ephemeral_setup_accepted(self, raw):
+        inst, data = self._setup(steady=False)
+        inst._parse_block = create_mock()
+        raw.return_value = data
+        # Call
+        inst._parse("data")
+        # Tests
+        raw.assert_called_once_with("data", "SibraExt", inst.MIN_LEN, min_=True)
+        inst._parse_flags.assert_called_once_with(12)
+        ntools.eq_(inst.curr_hop, 5)
+        ntools.eq_(inst.total_hops, 2+3+4)
+        assert_these_calls(inst._parse_path_id, [
+            call(data, False), call(data, steady=True), call(data, steady=True),
+        ])
+        ntools.eq_(inst.path_ids, [inst._parse_path_id.return_value] * 3)
+        assert_these_calls(inst._parse_block, [
+            call(data, 4), call(data, 5), call(data, 4+5),
+        ])
+        ntools.eq_(inst.active_blocks, [inst._parse_block.return_value] * 2)
+        ntools.eq_(inst.req_block, inst._parse_block.return_value)
+
+    @patch("lib.packet.ext.sibra.Raw", autospec=True)
+    def test_steady_setup_denied(self, raw):
+        inst, data = self._setup(accepted=False)
+        inst._parse_offers_block = create_mock()
+        raw.return_value = data
+        # Call
+        inst._parse("data")
+        # Tests
+        inst._parse_offers_block.assert_called_once_with(data)
+        ntools.eq_(inst.req_block, inst._parse_offers_block.return_value)
+
+
+class TestSibraExtParseFlags(object):
+    """
+    Unit tests for lib.packet.ext.sibra.SibraExt._parse_flags
+    """
+    def _check(self, flags, values):
+        inst = SibraExt()
+        # Call
+        inst._parse_flags(flags)
+        # Tests
+        ntools.eq_(inst.setup, values.pop(0))
+        ntools.eq_(inst.req, values.pop(0))
+        ntools.eq_(inst.accepted, values.pop(0))
+        ntools.eq_(inst.error, values.pop(0))
+        ntools.eq_(inst.steady, values.pop(0))
+        ntools.eq_(inst.fwd, values.pop(0))
+        ntools.eq_(inst.version, values.pop(0))
+
+    def test(self):
+        for flags, values in FLAG_MAP:
+            yield self._check, flags, list(values)
+
+
+class TestSibraExtParseBlock(object):
+    """
+    Unit tests for lib.packet.ext.sibra.SibraExt._parse_block
+    """
+    @patch("lib.packet.ext.sibra.ResvBlock", autospec=True)
+    def test(self, resvb):
+        inst = SibraExt()
+        data = create_mock(["pop"])
+        # Call
+        ntools.eq_(inst._parse_block(data, 5), resvb.return_value)
+        # Tests
+        data.pop.assert_called_once_with(6 * inst.LINE_LEN)
+        resvb.assert_called_once_with(data.pop.return_value)
+
+
+class TestSibraExtSteadyFromValues(object):
+    """
+    Unit tests for lib.packet.ext.sibra.SibraExt.steady_from_values
+    """
+    @patch("lib.packet.ext.sibra.os.urandom", autospec=True)
+    @patch("lib.packet.ext.sibra.ResvBlock.from_values",
+           new_callable=create_mock)
+    def test(self, resvb_fv, urandom):
+        isd_ad = create_mock(["pack"])
+        isd_ad.pack.return_value = b"isd ad"
+        urandom.return_value = b"random"
+        # Call
+        inst = SibraExt.steady_from_values(isd_ad, "req info", 40)
+        # Tests
+        ntools.assert_is_instance(inst, SibraExt)
+        ntools.eq_(inst.setup, True)
+        ntools.eq_(inst.req, True)
+        urandom.assert_called_once_with(inst.STEADY_ID_LEN)
+        ntools.eq_(inst.path_ids, [b"isd ad" b"random"])
+        resvb_fv.assert_called_once_with("req info", num_hops=40)
+        ntools.eq_(inst.req_block, resvb_fv.return_value)
+
+
+class TestSibraExtEphemeralFromValues(object):
+    """
+    Unit tests for lib.packet.ext.sibra.SibraExt.ephemeral_from_values
+    """
+    @patch("lib.packet.ext.sibra.os.urandom", autospec=True)
+    @patch("lib.packet.ext.sibra.ResvBlock.from_values",
+           new_callable=create_mock)
+    def test(self, resvb_fv, urandom):
+        isd_ad = create_mock(["pack"])
+        isd_ad.pack.return_value = b"isd ad"
+        urandom.return_value = b"random"
+        steady_ids = ["steady0", "steady1", "steady2"]
+        steady_blocks = []
+        for i in 2, 3, 4:
+            block = create_mock(["num_hops"])
+            block.num_hops = i
+            steady_blocks.append(block)
+        # Call
+        inst = SibraExt.ephemeral_from_values(isd_ad, "req info", steady_ids,
+                                              steady_blocks)
+        # Tests
+        ntools.assert_is_instance(inst, SibraExt)
+        ntools.eq_(inst.setup, True)
+        ntools.eq_(inst.req, True)
+        ntools.eq_(inst.steady, False)
+        urandom.assert_called_once_with(inst.EPHEMERAL_ID_LEN)
+        ntools.eq_(inst.path_ids, [b"isd ad" b"random"] + steady_ids)
+        ntools.eq_(inst.active_blocks, steady_blocks)
+        resvb_fv.assert_called_once_with("req info", num_hops=(2+3+4))
+        ntools.eq_(inst.req_block, resvb_fv.return_value)
+
+
+class TestSibraExtPack(object):
+    """
+    Unit tests for lib.packet.ext.sibra.SibraExt.pack
+    """
+    def _setup(self, path_lens=(), req=True):
+        inst = SibraExt()
+        inst._pack_flags = create_mock()
+        inst._pack_flags.return_value = b"F"
+        inst.curr_hop = 7
+        if path_lens:
+            inst.total_hops = sum(path_lens)
+        inst.path_ids.append(b"path id0")
+        for i, plen in enumerate(path_lens):
+            block = create_mock(["num_hops", "pack"])
+            block.num_hops = plen
+            block.pack.return_value = ("block %2d" % i).encode("ascii")
+            inst.active_blocks.append(block)
+            if i:
+                inst.path_ids.append(("path id%d" % i).encode("ascii"))
+        if req:
+            block = create_mock(["pack"])
+            block.pack.return_value = b"req pack"
+            inst.req_block = block
+        return inst
+
+    def test_active_req(self):
+        inst = self._setup(path_lens=[10])
+        expected = b"".join([
+            b"F", bytes([7, 10, 0, 0]), b"path id0", b"block  0", b"req pack",
+        ])
+        # Call
+        ntools.eq_(inst.pack(), expected)
+
+    def test_active_multi(self):
+        inst = self._setup(path_lens=[2, 4, 6], req=False)
+        expected = b"".join([
+            b"F", bytes([7, 2, 4, 6]), b"path id0", b"path id1", b"path id2",
+            b"block  0", b"block  1", b"block  2",
+        ])
+        # Call
+        ntools.eq_(inst.pack(), expected)
+
+    def test_req_only(self):
+        inst = self._setup()
+        inst.total_hops = 10
+        expected = b"".join([
+            b"F", bytes([7, 10, 0, 0]), b"path id0", b"req pack"])
+        # Call
+        ntools.eq_(inst.pack(), expected)
+
+
+class TestSibraExtPackFlags(object):
+    """
+    Unit tests for lib.packet.ext.sibra.SibraExt._pack_flags
+    """
+    def _check(self, expected, flags):
+        inst = SibraExt()
+        inst.setup = flags.pop(0)
+        inst.req = flags.pop(0)
+        inst.accepted = flags.pop(0)
+        inst.error = flags.pop(0)
+        inst.steady = flags.pop(0)
+        inst.fwd = flags.pop(0)
+        inst.version = flags.pop(0)
+        # Call
+        ntools.eq_(inst._pack_flags(), expected)
+
+    def test(self):
+        for flags, values in FLAG_MAP:
+            yield self._check, flags, list(values)
+
+
+class TestSibraExtPackEphemeralSetup(object):
+    """
+    Unit tests for lib.packet.ext.sibra.SibraExt._pack_ephemeral_setup
+    """
+    def test(self):
+        inst = SibraExt()
+        inst.path_ids = [b"eph id", b"active id0", b"active id1"]
+        for i in range(2):
+            block = create_mock(["pack"])
+            block.pack.return_value = ("block pack %d" % i).encode("ascii")
+            inst.active_blocks.append(block)
+        expected = b"".join([
+            b"active id0", b"block pack 0", b"active id1", b"block pack 1"])
+        # Call
+        ntools.eq_(inst._pack_ephemeral_setup(), expected)
+
+
+class TestResvInfoParse(object):
+    """
+    Unit tests for lib.packet.ext.sibra.ResvInfo._parse
+    """
+    @patch("lib.packet.ext.sibra.Raw", autospec=True)
+    def test(self, raw):
+        inst = ResvInfo()
+        data = create_mock(["pop"])
+        data.pop.side_effect = bytes.fromhex("01234567"), 2, 4, 0b10101111, 7
+        raw.return_value = data
+        # Call
+        inst._parse("data")
+        # Tests
+        raw.assert_called_once_with("data", "ResvInfo", inst.LEN)
+        ntools.eq_(inst.exp, 0x01234567 * SIBRA_INTERVAL)
+        ntools.eq_(inst.bw_fwd, 2)
+        ntools.eq_(inst.bw_rev, 4)
+        ntools.eq_(inst.index, 0b1010)
+        ntools.eq_(inst.fail_hop, 7)
+
+
+class TestResvInfoPack(object):
+    """
+    Unit tests for lib.packet.ext.sibra.ResvInfo.pack
+    """
+    def test(self):
+        inst = ResvInfo()
+        inst.exp = 0x01234567 * SIBRA_INTERVAL
+        inst.bw_fwd = 2
+        inst.bw_rev = 4
+        inst.index = 0b1010
+        inst.fail_hop = 7
+        expected = b"".join([bytes.fromhex("01234567"),
+                             bytes([2, 4, 0b10100000, 7])])
+        # Call
+        ntools.eq_(inst.pack(), expected)
+
+
+class TestResvBlockParse(object):
+    """
+    Unit tests for lib.packet.ext.sibra.ResvBlock._parse
+    """
+    @patch("lib.packet.ext.sibra.SibraOpaqueField", autospec=True)
+    @patch("lib.packet.ext.sibra.ResvInfo", autospec=True)
+    @patch("lib.packet.ext.sibra.Raw", autospec=True)
+    def test(self, raw, resvinfo, sof):
+        inst = ResvBlock()
+        sof.LEN = SibraOpaqueField.LEN
+        data = create_mock(["__bool__", "__len__", "pop"])
+        data.__bool__.side_effect = True, True, True
+        data.__len__.return_value = sof.LEN * 2
+        data.pop.side_effect = "resvinfo", bytes(range(sof.LEN)), bytes(sof.LEN)
+        raw.return_value = data
+        # Call
+        inst._parse("data")
+        # Tests
+        raw.assert_called_once_with("data", "ResvBlock", inst.MIN_LEN,
+                                    min_=True)
+        resvinfo.assert_called_once_with("resvinfo")
+        ntools.eq_(inst.info, resvinfo.return_value)
+        ntools.eq_(inst.num_hops, 2)
+        sof.assert_called_once_with(bytes(range(sof.LEN)))
+        ntools.eq_(inst.sofs, [sof.return_value])
+
+
+class TestResvBlockPack(object):
+    """
+    Unit tests for lib.packet.ext.sibra.ResvBlock.pack
+    """
+    def test(self):
+        inst = ResvBlock()
+        inst.info = create_mock(["pack"])
+        inst.info.pack.return_value = b"info"
+        inst.num_hops = 5
+        for i in range(3):
+            sof = create_mock(["pack"])
+            sof.pack.return_value = ("sof %d" % i).encode("ascii")
+            inst.sofs.append(sof)
+        expected = b"".join([
+            b"info", b"sof 0", b"sof 1", b"sof 2", bytes(SibraOpaqueField.LEN),
+            bytes(SibraOpaqueField.LEN)
+        ])
+        # Call
+        ntools.eq_(inst.pack("path ids"), expected)
+        # Tests
+        inst.sofs[0].pack.assert_called_once_with(inst.info, "path ids", None)
+        inst.sofs[1].pack.assert_called_once_with(inst.info, "path ids",
+                                                  inst.sofs[0])
+        inst.sofs[2].pack.assert_called_once_with(inst.info, "path ids",
+                                                  inst.sofs[1])
+
+
+class TestOfferBlockParse(object):
+    """
+    Unit tests for lib.packet.ext.sibra.OfferBlock._parse
+    """
+    @patch("lib.packet.ext.sibra.ResvInfo", autospec=True)
+    @patch("lib.packet.ext.sibra.Raw", autospec=True)
+    def test(self, raw, resvinfo):
+        inst = OfferBlock()
+        data = create_mock(["__bool__", "__len__", "pop"])
+        data.__bool__.side_effect = True, True, True
+        data.__len__.return_value = inst.OFFER_LEN * 7
+        data.pop.side_effect = ("resvinfo", bytes([3, 4]), bytes([5, 6]),
+                                bytes(2))
+        raw.return_value = data
+        # Call
+        inst._parse("data")
+        # Tests
+        raw.assert_called_once_with("data", "OfferBlock", inst.MIN_LEN,
+                                    min_=True)
+        resvinfo.assert_called_once_with("resvinfo")
+        ntools.eq_(inst.offer_hops, 7)
+        ntools.eq_(inst.offers, [(3, 4), (5, 6)])
+
+
+class TestOfferBlockFromValues(object):
+    """
+    Unit tests for lib.packet.ext.sibra.OfferBlock.from_values
+    """
+    def _check(self, hops):
+        # Call
+        inst = OfferBlock.from_values("info", hops, 1, 3)
+        # Tests
+        ntools.assert_is_instance(inst, OfferBlock)
+        ntools.eq_(inst.info, "info")
+        ntools.eq_(inst.offers, [(1, 3)])
+        ntools.assert_greater_equal(inst.offer_hops, hops)
+        ntools.eq_(inst.offer_hops % inst.OFFERS_PER_LINE, 0)
+
+    def test(self):
+        for hops in range(8):
+            yield self._check, hops
+
+
+class TestOfferBlockPack(object):
+    """
+    Unit tests for lib.packet.ext.sibra.OfferBlock.pack
+    """
+    def test(self):
+        inst = OfferBlock()
+        inst.info = create_mock(["pack"])
+        inst.info.pack.return_value = b"infopack"
+        inst.offer_hops = 8
+        for i in range(5):
+            inst.offers.append((i, i+10))
+        expected = b"".join([
+            b"infopack",
+            bytes([0, 10, 1, 11, 2, 12, 3, 13, 4, 14, 0, 0, 0, 0, 0, 0]),
+        ])
+        # Call
+        ntools.eq_(inst.pack(), expected)
+
+
+class TestSibraOpaqueFieldParse(object):
+    """
+    Unit tests for lib.packet.ext.sibra.SibraOpaqueField._parse
+    """
+    @patch("lib.packet.ext.sibra.Raw", autospec=True)
+    def test(self, raw):
+        inst = SibraOpaqueField()
+        data = create_mock(["pop"])
+        data.pop.side_effect = (bytes.fromhex("00AA 99FF"),
+                                bytes.fromhex("01234567"))
+        raw.return_value = data
+        # Call
+        inst._parse("data")
+        # Tests
+        ntools.eq_(inst.ingress, 0x00AA)
+        ntools.eq_(inst.egress, 0x99FF)
+        ntools.eq_(inst.mac, 0x01234567)
+
+
+class TestSibraOpaqueFieldPack(object):
+    """
+    Unit tests for lib.packet.ext.sibra.SibraOpaqueField.pack
+    """
+    def test(self):
+        inst = SibraOpaqueField()
+        inst.ingress = 0x00AA
+        inst.egress = 0x99FF
+        inst.mac = 0x01234567
+        expected = bytes.fromhex("00AA 99FF 01234567")
+        # Call
+        ntools.eq_(inst.pack(), expected)
+
+
+class TestSibraOpaqueFieldCalcMac(object):
+    """
+    Unit tests for lib.packet.ext.sibra.SibraOpaqueField.calc_mac
+    """
+    @patch("lib.packet.ext.sibra.cbcmac", autospec=True)
+    def test(self, cbcmac):
+        inst = SibraOpaqueField()
+        inst.ingress = 0x00AA
+        inst.egress = 0x99FF
+        info = create_mock(["LEN", "pack"])
+        info.LEN = ResvInfo.LEN
+        info.pack.return_value = b"infopack"
+        path_ids = (b"key0", b"key1")
+        cbcmac.return_value = bytes(range(inst.MAC_LEN * 2))
+        # Call
+        ntools.eq_(inst.calc_mac("key", info, path_ids, b"prev_raw"),
+                   bytes(range(inst.MAC_LEN)))
+        # Tests
+        cbcmac.assert_called_once_with("key", b"".join([
+            bytes.fromhex("00AA 99FF"), b"infopac\x00", b"key0", b"key1",
+            bytes(inst.MAX_PATH_IDS_LEN - 8), b"prev_raw",
+        ]))
+
+if __name__ == "__main__":
+    nose.run(defaultTest=__name__)


### PR DESCRIPTION
This adds the code required to parse and pack the SIBRA extension
(including the SIBRA Lite modification), but doesn't include any code to
actually process the extension yet.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/558%23issuecomment-163319295%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23issuecomment-163320361%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23issuecomment-163632080%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23discussion_r47334357%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23discussion_r47334515%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23discussion_r47334940%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23discussion_r47335024%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23issuecomment-163886924%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23discussion_r47474335%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23discussion_r47474483%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23discussion_r47474780%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23issuecomment-164388101%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23issuecomment-163319295%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222015-12-09T16%3A43%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40reischuk%20%22%2C%20%22created_at%22%3A%20%222015-12-09T16%3A47%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ready%20for%20review%20now.%22%2C%20%22created_at%22%3A%20%222015-12-10T14%3A17%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22the%20rest%20lgtm%22%2C%20%22created_at%22%3A%20%222015-12-11T09%3A35%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22PR%20updated.%22%2C%20%22created_at%22%3A%20%222015-12-14T09%3A28%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20aba8ff163866ec86db5bc129068de5a9136dd944%20infrastructure/router.py%2026%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23discussion_r47334357%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22for%20every%20hop-by-hop%20extension%20we%20stop%20router%27s%20regular%20processing%3F%5Cr%5CnDoes%20it%20work%20with%20TracerouteExt%20now%3F%22%2C%20%22created_at%22%3A%20%222015-12-11T09%3A17%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22also%20do%20we%20have%20a%20rule%20that%20sibra%20ext%20is%20first%20%3F%22%2C%20%22created_at%22%3A%20%222015-12-11T09%3A19%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%2C%20for%20every%20hop-by-hop%20extension%20that%20signals%20we%20should%20stop%20regular%20processing%2C%20we%20stop%20regular%20processing.%20Note%20that%20the%20code%20checks%20the%20return%20value%20of%20the%20handler.%5Cr%5Cn%5Cr%5CnWe%27ll%20need%20to%20make%20this%20more%20granular%20in%20future%2C%20but%20this%20works%20for%20now.%22%2C%20%22created_at%22%3A%20%222015-12-14T09%3A17%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/router.py%3AL252-262%22%7D%2C%20%22Pull%20aba8ff163866ec86db5bc129068de5a9136dd944%20lib/packet/ext/sibra.py%20109%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23discussion_r47334940%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22still%20policy%20with%20assertions%20and%20exceptions%20in%20unclear%20to%20me%2C%20so%20why%20here%20assert%20%3F%22%2C%20%22created_at%22%3A%20%222015-12-11T09%3A25%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Good%20catch%2C%20this%20should%20be%20an%20exception.%20Fixing.%22%2C%20%22created_at%22%3A%20%222015-12-14T09%3A19%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/ext/sibra.py%3AL1-405%22%7D%2C%20%22Pull%20aba8ff163866ec86db5bc129068de5a9136dd944%20lib/packet/ext/sibra.py%2055%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/558%23discussion_r47335024%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22somehow%20I%20prefer%20binary%20representation%20for%20flags...%22%2C%20%22created_at%22%3A%20%222015-12-11T09%3A26%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20can%20do%20that%2C%20sure%2C%20It%27s%20just%20tricky%20counting%20the%200%27s.%20Changing.%22%2C%20%22created_at%22%3A%20%222015-12-14T09%3A22%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/ext/sibra.py%3AL1-405%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/558#issuecomment-163319295'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @reischuk
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ready for review now.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> the rest lgtm
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> PR updated.
- [ ] <a href='#crh-comment-Pull aba8ff163866ec86db5bc129068de5a9136dd944 infrastructure/router.py 26'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/558#discussion_r47334357'>File: infrastructure/router.py:L252-262</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> for every hop-by-hop extension we stop router's regular processing?
  Does it work with TracerouteExt now?
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> also do we have a rule that sibra ext is first ?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> No, for every hop-by-hop extension that signals we should stop regular processing, we stop regular processing. Note that the code checks the return value of the handler.
  We'll need to make this more granular in future, but this works for now.
- [ ] <a href='#crh-comment-Pull aba8ff163866ec86db5bc129068de5a9136dd944 lib/packet/ext/sibra.py 109'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/558#discussion_r47334940'>File: lib/packet/ext/sibra.py:L1-405</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> still policy with assertions and exceptions in unclear to me, so why here assert ?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Good catch, this should be an exception. Fixing.
- [ ] <a href='#crh-comment-Pull aba8ff163866ec86db5bc129068de5a9136dd944 lib/packet/ext/sibra.py 55'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/558#discussion_r47335024'>File: lib/packet/ext/sibra.py:L1-405</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> somehow I prefer binary representation for flags...
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> We can do that, sure, It's just tricky counting the 0's. Changing.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/558?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/558?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/558'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
