### PR TITLE
Add SCION multi-path socket mode to SCION proxy.

### DIFF
--- a/endhost/scion_socket.py
+++ b/endhost/scion_socket.py
@@ -131,6 +131,18 @@ class ScionBaseSocket(object):
             return
         return self.libsock.SCIONSend(self.fd, msg, len(msg))
 
+    def sendall(self, msg):
+        """
+        For the SCION multi-path socket this call means only a wrapper for
+        send() as it already implements a sendall() style logic internally.
+        :param msg: The data to be sent on the socket.
+        :type msg: bytes
+        :returns: None to indicate success.
+        :rtype: NoneType
+        """
+        self.send(msg)
+        return None
+
     def recv(self, bufsize):
         """
         Receive data from the socket. The return value is a bytes object
@@ -176,6 +188,10 @@ class ScionBaseSocket(object):
         py_stats = ScionStats(raw_stats.contents)
         self.libsock.SCIONDestroyStats(raw_stats)
         return py_stats
+
+    def close(self):
+        # TODO(ercanucan) : call the deleteSCIONSocket() once it is tested.
+        pass
 
 
 class ScionServerSocket(ScionBaseSocket):

--- a/test/integration/ssp_cli_srv_test.py
+++ b/test/integration/ssp_cli_srv_test.py
@@ -43,12 +43,12 @@ import threading
 import time
 
 # SCION
+from endhost.scion_socket import ScionServerSocket, ScionClientSocket
 from lib.defines import L4_SSP
 from lib.log import init_logging
 from lib.main import main_wrapper
 from lib.thread import thread_safety_net
 from lib.util import handle_signals
-from endhost.scion_socket import ScionServerSocket, ScionClientSocket
 
 SERVER_PORT = 8080
 SERVER_LOG_BASE = 'logs/scion_test_app'


### PR DESCRIPTION
This change adds the capability to use SCION multi-path socket in
the proxy. It avoids the select.select() since the current version
of our socket does not support it. The select call will be used once
our socket library supports it.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/570%23issuecomment-165099397%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23discussion_r47787000%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23discussion_r47788014%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23discussion_r47788282%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23issuecomment-165139584%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23discussion_r47907091%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23discussion_r47907206%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23discussion_r47907810%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23discussion_r47907875%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23issuecomment-165460537%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23issuecomment-165470160%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23issuecomment-165474370%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23issuecomment-165475317%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23discussion_r47914197%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23issuecomment-165775090%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23issuecomment-165099397%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40aznair%20%40kormat%20%40pszalach%20would%20be%20glad%20to%20see%20what%20you%20think%20about%20this%20change.%20Cheers%21%22%2C%20%22created_at%22%3A%20%222015-12-16T13%3A08%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222015-12-16T15%3A22%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40pszalach%20python%20socket%20library%20has%20sendall%28%29%20%5Cr%5Cnhttps%3A//docs.python.org/3/library/socket.html%5Cr%5Cn%5Cr%5Cnit%20basically%20ensures%20that%20send%28%29%20is%20called%20%28repeatedly%20if%20necessary%29%20until%20all%20the%20data%20is%20sent.%20Stephen%20had%20suggested%20that%20I%20use%20this%20call%20in%20that%20particular%20section%20of%20the%20code.%22%2C%20%22created_at%22%3A%20%222015-12-17T14%3A04%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20I%20would%20not%20add%20this%20wrapper%20%28until%20it%20implements%20similar%20logic%20as%20standard%20%60sendall%28%29%60%20does%29%22%2C%20%22created_at%22%3A%20%222015-12-17T14%3A46%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40pszalach%20Scion-socket%27s%20send%20actually%20implements%20the%20sendall%28%29%20style%20logic%20internally%20%28%40aznair%20can%20confirm%29.%20So%20I%20added%20this%20wrapper%20as%20a%20convenience%20wrapper%20because%20we%20a%20have%20a%20%60target_sock.sendall%28%29%60%20call%20in%20the%20_proxy%28%29%20method.%20If%20you%20prefer%20not%20to%20have%20this%2C%20then%20I%20would%20basically%20need%20to%20detect%20the%20type%20of%20the%20socket%20%28unix%20or%20scion%20sock%29%20at%20run-time%20and%20then%20call%20send%28%29%20or%20sendall%28%29%20on%20it%20accordingly.%20%20%22%2C%20%22created_at%22%3A%20%222015-12-17T14%3A53%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20I%20see%2C%20then%20it%20makes%20sense%20to%20me%21%22%2C%20%22created_at%22%3A%20%222015-12-17T14%3A55%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Proceeding%20with%20merge%20as%20both%20%40pszalach%20and%20%40aznair%20gave%20lgtm%20%28%40kormat%20is%20out%20sick%29%22%2C%20%22created_at%22%3A%20%222015-12-18T13%3A18%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208816058b63271485ee6f58cd1d16efb56c00bf53%20endhost/scion_socket.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23discussion_r47788014%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22IMO%20the%20caller%20should%20handle%20that%22%2C%20%22created_at%22%3A%20%222015-12-16T15%3A20%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22btw.%20will%20this%20method%20be%20extended%3F%22%2C%20%22created_at%22%3A%20%222015-12-16T15%3A21%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22no%20plans%20to%20extend%20it%20so%20far.%20i%20tried%20to%20make%20it%20compatible%20with%20behaviour%20of%20sendall%20in%20unix%20sockets.%20%28it%20also%20returns%20none%20after%20success%29.%20did%20you%20have%20a%20suggestion%20here%3F%22%2C%20%22created_at%22%3A%20%222015-12-17T13%3A54%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22unix%20sockets%20have%20sendall%28%29%3F%5Cr%5CnFor%20me%20just%20send%28%29%20is%20fine.%22%2C%20%22created_at%22%3A%20%222015-12-17T14%3A01%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-17T14%3A56%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL131-150%22%7D%2C%20%22Pull%208816058b63271485ee6f58cd1d16efb56c00bf53%20endhost/scion_proxy.py%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/570%23discussion_r47787000%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60scion_mode%60%20is%20unused%20here%22%2C%20%22created_at%22%3A%20%222015-12-16T15%3A13%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22removed%22%2C%20%22created_at%22%3A%20%222015-12-17T13%3A53%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-17T14%3A00%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL109-116%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/570#issuecomment-165099397'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @aznair @kormat @pszalach would be glad to see what you think about this change. Cheers!
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @pszalach python socket library has sendall()
  https://docs.python.org/3/library/socket.html
  it basically ensures that send() is called (repeatedly if necessary) until all the data is sent. Stephen had suggested that I use this call in that particular section of the code.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> @ercanucan I would not add this wrapper (until it implements similar logic as standard `sendall()` does)
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @pszalach Scion-socket's send actually implements the sendall() style logic internally (@aznair can confirm). So I added this wrapper as a convenience wrapper because we a have a `target_sock.sendall()` call in the _proxy() method. If you prefer not to have this, then I would basically need to detect the type of the socket (unix or scion sock) at run-time and then call send() or sendall() on it accordingly.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> @ercanucan I see, then it makes sense to me!
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Proceeding with merge as both @pszalach and @aznair gave lgtm (@kormat is out sick)
- [x] <a href='#crh-comment-Pull 8816058b63271485ee6f58cd1d16efb56c00bf53 endhost/scion_proxy.py 28'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/570#discussion_r47787000'>File: endhost/scion_proxy.py:L109-116</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> `scion_mode` is unused here
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> removed
- [x] <a href='#crh-comment-Pull 8816058b63271485ee6f58cd1d16efb56c00bf53 endhost/scion_socket.py 13'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/570#discussion_r47788014'>File: endhost/scion_socket.py:L131-150</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> IMO the caller should handle that
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> btw. will this method be extended?
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> no plans to extend it so far. i tried to make it compatible with behaviour of sendall in unix sockets. (it also returns none after success). did you have a suggestion here?
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> unix sockets have sendall()?
  For me just send() is fine.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/570?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/570?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/570'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
