### PR TITLE
Path transport ext utest

### DIFF
--- a/lib/packet/ext/path_transport.py
+++ b/lib/packet/ext/path_transport.py
@@ -38,7 +38,7 @@ class PathTransOFPath(HeaderBase):
     NAME = "PathTransOFPath"
     MIN_LEN = 2
 
-    def __init__(self, raw=None):
+    def __init__(self, raw=None):  # pragma: no cover
         """
         Initialize an instance of the class PathTransOFPath.
 
@@ -70,7 +70,7 @@ class PathTransOFPath(HeaderBase):
         inst.path = path
         return inst
 
-    def pack(self):
+    def pack(self):  # pragma: no cover
         packed = []
         packed.append(struct.pack("!B", self.src.host.TYPE))
         packed.append(struct.pack("!B", self.dst.host.TYPE))
@@ -79,7 +79,7 @@ class PathTransOFPath(HeaderBase):
         packed.append(self.path.pack())
         return b"".join(packed)
 
-    def __len__(self):
+    def __len__(self):  # pragma: no cover
         return len(self.pack())
 
     def __str__(self):

--- a/test/lib/packet/ext/path_transport_test.py
+++ b/test/lib/packet/ext/path_transport_test.py
@@ -1,0 +1,163 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+mod:`path_transport_test` --- lib.packet.ext.path_transport unit tests
+======================================================================
+"""
+# Stdlib
+from unittest.mock import patch, call
+
+# External packages
+import nose
+import nose.tools as ntools
+
+# SCION
+from lib.errors import SCIONParseError
+from lib.packet.ext.path_transport import (
+    PathTransportExt,
+    PathTransOFPath,
+    PathTransType,
+)
+from lib.packet.opaque_field import OpaqueField
+from test.testcommon import (
+    assert_these_calls,
+    create_mock,
+)
+
+
+class TestPathTransOFPathParse(object):
+    """
+    Unit tests for lib.packet.ext.path_transport.PathTransOFPath._parse
+    """
+    @patch("lib.packet.ext.path_transport.parse_path", autospec=True)
+    @patch("lib.packet.ext.path_transport.SCIONAddr", autospec=True)
+    @patch("lib.packet.ext.path_transport.Raw", autospec=True)
+    def test(self, raw, scion_addr, parse_path):
+        inst = PathTransOFPath()
+        data = create_mock(["pop", "get", "__len__"])
+        data.pop.side_effect = "src_type", "dst_type", None, None, "path"
+        data.get.side_effect = "src_addr", "dst_addr"
+        data.__len__.return_value = 22
+        raw.return_value = data
+        scion_addr.side_effect = "scion_src_addr", "scion_dst_addr"
+        # Call
+        inst._parse("data")
+        # Tests
+        raw.assert_called_once_with("data", inst.NAME, inst.MIN_LEN, min_=True)
+        ntools.eq_(inst.src, "scion_src_addr")
+        ntools.eq_(inst.dst, "scion_dst_addr")
+        assert_these_calls(scion_addr, [call(("src_type", "src_addr")),
+                                        call(("dst_type", "dst_addr"))])
+        parse_path.assert_called_once_with("path")
+        data.pop.assert_called_with(22 - (22 % OpaqueField.LEN))
+
+
+class TestPathTransportExtFromValues(object):
+    """
+    Unit tests for lib.packet.ext.path_transport.PathTransportExt.from_values
+    """
+    @patch("lib.packet.ext.path_transport.PathTransportExt._init_size",
+           autospec=True)
+    def _check(self, plen, expected, init_size):
+        path = create_mock(["pack"])
+        path.pack.return_value = bytes(range(plen))
+        # Call
+        inst = PathTransportExt.from_values("path_type", path)
+        # Tests
+        ntools.eq_(inst.path_type, "path_type")
+        ntools.eq_(inst.path, path)
+        init_size.assert_called_once_with(inst, expected)
+
+    def test(self):
+        for plen, expected in (
+            (0, 0), (1, 0), (3, 0), (4, 0), (5, 1), (11, 1), (12, 1), (13, 2),
+        ):
+            yield self._check, plen, expected
+
+
+class TestPathTransportExtParse(object):
+    """
+    Unit tests for lib.packet.ext.path_transport.PathTransportExt._parse
+    """
+    @patch("lib.packet.ext.path_transport.PathTransOFPath", autospec=True)
+    @patch("lib.packet.ext.path_transport.EndToEndExtension._parse",
+           autospec=True)
+    @patch("lib.packet.ext.path_transport.Raw", autospec=True)
+    def test_of_type(self, raw, super_parse, of_path):
+        data = create_mock(["pop", "__len__"])
+        data.pop.side_effect = PathTransType.OF_PATH, b"of_path"
+        data.__len__.return_value = 8
+        raw.return_value = data
+        inst = PathTransportExt()
+        of_path.return_value = "parsed_of_path"
+        # Call
+        inst._parse("data")
+        # Tests
+        raw.assert_called_once_with("data", inst.NAME, inst.MIN_LEN, min_=True)
+        super_parse.assert_called_once_with(inst, data)
+        ntools.eq_(inst.path_type, PathTransType.OF_PATH)
+        ntools.eq_(inst.path, of_path.return_value)
+        of_path.assert_called_once_with(b"of_path")
+
+    @patch("lib.packet.ext_hdr.EndToEndExtension._parse", autospec=True)
+    @patch("lib.packet.ext.path_transport.PathSegment", autospec=True)
+    @patch("lib.packet.ext.path_transport.Raw", autospec=True)
+    def test_pcb_type(self, raw, pcb_path, super_parse):
+        data = create_mock(["pop", "__len__"])
+        data.pop.side_effect = PathTransType.PCB_PATH, b"pcb_path"
+        data.__len__.return_value = 9
+        raw.return_value = data
+        inst = PathTransportExt()
+        pcb_path.return_value = "parsed_pcb_path"
+        # Call
+        inst._parse("data")
+        # Tests
+        ntools.eq_(inst.path, "parsed_pcb_path")
+        pcb_path.assert_called_once_with(b"pcb_path")
+
+    @patch("lib.packet.ext_hdr.EndToEndExtension._parse", autospec=True)
+    @patch("lib.packet.ext.path_transport.Raw", autospec=True)
+    def test_wrong_type(self, raw, super_parse):
+        data = create_mock(["pop", "__len__"])
+        data.pop.return_value = 3456
+        data.__len__.return_value = 1
+        raw.return_value = data
+        inst = PathTransportExt()
+        # Call
+        ntools.assert_raises(SCIONParseError, inst._parse, "data")
+
+
+class TestPathTransportExtPack(object):
+    """
+    Unit tests for lib.packet.ext.path_transport.PathTransportExt.pack
+    """
+    @patch("lib.packet.ext_hdr.ExtensionHeader._check_len", autospec=True)
+    @patch("lib.packet.ext.path_transport.calc_padding", autospec=True)
+    def test(self, calc_padding, check_len):
+        inst = PathTransportExt()
+        inst._hdr_len = 1
+        inst.path_type = 1
+        inst.path = create_mock(["pack"])
+        inst.path.pack.return_value = b"packed_path"
+        calc_padding.return_value = 1
+        expected = b"\x01packed_path\x00"
+        # Call
+        inst.pack()
+        # Tests
+        calc_padding.assert_called_once_with(11 - 4, inst.LINE_LEN)
+        check_len.assert_called_once_with(inst, expected)
+
+
+if __name__ == "__main__":
+    nose.run(defaultTest=__name__)


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/571%23issuecomment-165131985%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48822742%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48822988%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48823279%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48823583%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48823851%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824050%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824171%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824303%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824388%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824452%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824462%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824563%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23issuecomment-176651163%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23issuecomment-177849091%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52473852%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52473893%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52473968%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52474055%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52474097%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52474232%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52474280%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52474364%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52474502%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52474598%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52474660%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52480197%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23issuecomment-185635521%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23issuecomment-165131985%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20%22%2C%20%22created_at%22%3A%20%222015-12-16T14%3A52%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ping%3F%22%2C%20%22created_at%22%3A%20%222016-01-29T09%3A00%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22pong%21%20%28forgot%20about%20that%3B-%29%22%2C%20%22created_at%22%3A%20%222016-02-01T08%3A36%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22remaining%20issues%20fixed%2C%20merging.%22%2C%20%22created_at%22%3A%20%222016-02-18T10%3A02%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20d8261b30fbc85a68511b778f508ff4bffdf35ae7%20test/lib/packet/ext/path_transport_test.py%20119%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r52480197%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5E%20%23%20Tests%22%2C%20%22created_at%22%3A%20%222016-02-10T16%3A14%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/ext/path_transport_test.py%3AL1-157%22%7D%2C%20%22Pull%20da9de2f47b055a3e76fadad6c905364642da61d9%20test/lib/packet/ext/path_transport_test.py%2062%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48823583%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20a%20little%20uncomfortable%20that%20%60padding_len%60%20isn%27t%20checked%20anywhere.%20One%20solution%20is%20to%20add%3A%5Cr%5Cn%60%60%60%5Cr%5Cndata.pop.assert_called_with%2822%20-%20%2822%20%25%20OpaqueField.LEN%29%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-01-05T08%3A56%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-10T15%3A40%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/ext/path_transport_test.py%3AL1-143%22%7D%2C%20%22Pull%20da9de2f47b055a3e76fadad6c905364642da61d9%20test/lib/packet/ext/path_transport_test.py%2078%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824050%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22After%20the..%20robust%20discussions%20about%20the%20%60init_size%60%20call%2C%20it%20probably%20is%20a%20good%20idea%20to%20use%20a%20test%20generator%20to%20make%20sure%20the%20correct%20calculation%20is%20done%20for%200%20%3C%3D%20plen%20%3C%3D%2016.%22%2C%20%22created_at%22%3A%20%222016-01-05T09%3A01%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ping%3F%22%2C%20%22created_at%22%3A%20%222016-02-10T15%3A41%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/ext/path_transport_test.py%3AL1-143%22%7D%2C%20%22Pull%20da9de2f47b055a3e76fadad6c905364642da61d9%20test/lib/packet/ext/path_transport_test.py%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48822988%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Don%27t%20need%20%28%29%27s%20on%20the%20above%202%20lines.%22%2C%20%22created_at%22%3A%20%222016-01-05T08%3A49%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-10T15%3A39%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/ext/path_transport_test.py%3AL1-143%22%7D%2C%20%22Pull%20da9de2f47b055a3e76fadad6c905364642da61d9%20test/lib/packet/ext/path_transport_test.py%2088%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824563%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20can%20just%20be%20moved%20down%201%20line%2C%20and%20assigned%20directly%20to%20%60inst._raw%60%22%2C%20%22created_at%22%3A%20%222016-01-05T09%3A09%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/ext/path_transport_test.py%3AL1-143%22%7D%2C%20%22Pull%20da9de2f47b055a3e76fadad6c905364642da61d9%20test/lib/packet/ext/path_transport_test.py%2074%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48823851%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Adding%20a%20%60%23%20Call%60%20comment%20above%20helps%20readability.%22%2C%20%22created_at%22%3A%20%222016-01-05T08%3A59%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-10T15%3A40%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/ext/path_transport_test.py%3AL1-143%22%7D%2C%20%22Pull%20da9de2f47b055a3e76fadad6c905364642da61d9%20test/lib/packet/ext/path_transport_test.py%2086%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824388%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%202%20patches%20should%20be%20reordered%2C%20as%20%60_parse%60%20is%20called%20before%20%60PathTransOFPath%60%22%2C%20%22created_at%22%3A%20%222016-01-05T09%3A06%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-10T15%3A42%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/ext/path_transport_test.py%3AL1-143%22%7D%2C%20%22Pull%20da9de2f47b055a3e76fadad6c905364642da61d9%20test/lib/packet/ext/path_transport_test.py%2085%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824171%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20actually%20be%20%60%5C%22lib.packet.ext.path_transport.EndToEndExtension._parse%5C%22%60%2C%20as%20that%27s%20the%20reference%20to%20the%20object%20that%20you%20want%20to%20patch.%22%2C%20%22created_at%22%3A%20%222016-01-05T09%3A03%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-10T15%3A41%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/ext/path_transport_test.py%3AL1-143%22%7D%2C%20%22Pull%20da9de2f47b055a3e76fadad6c905364642da61d9%20test/lib/packet/ext/path_transport_test.py%2059%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48823279%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20assertion%20should%20be%20before%20the%20%60src_addr%60%2C%20%60dst_addr%60%20checks.%20It%20also%20shouldn%27t%20hardcode%20%602%60.%22%2C%20%22created_at%22%3A%20%222016-01-05T08%3A52%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-02-10T15%3A40%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-10T15%3A43%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/ext/path_transport_test.py%3AL1-143%22%7D%2C%20%22Pull%20da9de2f47b055a3e76fadad6c905364642da61d9%20test/lib/packet/ext/path_transport_test.py%2094%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824303%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60%23%20Tests%60%22%2C%20%22created_at%22%3A%20%222016-01-05T09%3A05%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-10T15%3A42%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/ext/path_transport_test.py%3AL1-143%22%7D%2C%20%22Pull%20da9de2f47b055a3e76fadad6c905364642da61d9%20test/lib/packet/ext/path_transport_test.py%2096%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48824452%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20can%20simplify%20this%20to%20just%3A%20%60ntools.eq_%28inst.path%2C%20of_path.return_value%29%60%22%2C%20%22created_at%22%3A%20%222016-01-05T09%3A07%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28and%20remove%20%60of_path.return_value%20%3D%20%5C%22parsed_of_path%5C%22%60%29%22%2C%20%22created_at%22%3A%20%222016-01-05T09%3A07%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ping%20re%3A%20second%20part%22%2C%20%22created_at%22%3A%20%222016-02-10T15%3A43%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/ext/path_transport_test.py%3AL1-143%22%7D%2C%20%22Pull%20da9de2f47b055a3e76fadad6c905364642da61d9%20test/lib/packet/ext/path_transport_test.py%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/571%23discussion_r48822742%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22With%20the%20reorganising%20of%20the%20test%20direction%2C%20it%20probably%20is%20better%20to%20just%20do%3A%5Cr%5Cn%60%60%60%5Cr%5Cnmod%3A%60path_transport_test%60%20---%20lib.packet.ext.path_transport%20unit%20tests%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-01-05T08%3A46%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-10T15%3A39%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/ext/path_transport_test.py%3AL1-143%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#issuecomment-165131985'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> @kormat
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ping?
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> pong! (forgot about that;-)
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> remaining issues fixed, merging.
- [ ] <a href='#crh-comment-Pull da9de2f47b055a3e76fadad6c905364642da61d9 test/lib/packet/ext/path_transport_test.py 78'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#discussion_r48824050'>File: test/lib/packet/ext/path_transport_test.py:L1-143</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> After the.. robust discussions about the `init_size` call, it probably is a good idea to use a test generator to make sure the correct calculation is done for 0 <= plen <= 16.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ping?
- [ ] <a href='#crh-comment-Pull da9de2f47b055a3e76fadad6c905364642da61d9 test/lib/packet/ext/path_transport_test.py 96'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#discussion_r48824452'>File: test/lib/packet/ext/path_transport_test.py:L1-143</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You can simplify this to just: `ntools.eq_(inst.path, of_path.return_value)`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (and remove `of_path.return_value = "parsed_of_path"`)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ping re: second part
- [ ] <a href='#crh-comment-Pull da9de2f47b055a3e76fadad6c905364642da61d9 test/lib/packet/ext/path_transport_test.py 88'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#discussion_r48824563'>File: test/lib/packet/ext/path_transport_test.py:L1-143</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This can just be moved down 1 line, and assigned directly to `inst._raw`
- [ ] <a href='#crh-comment-Pull d8261b30fbc85a68511b778f508ff4bffdf35ae7 test/lib/packet/ext/path_transport_test.py 119'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#discussion_r52480197'>File: test/lib/packet/ext/path_transport_test.py:L1-157</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> ^ # Tests
- [x] <a href='#crh-comment-Pull da9de2f47b055a3e76fadad6c905364642da61d9 test/lib/packet/ext/path_transport_test.py 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#discussion_r48822742'>File: test/lib/packet/ext/path_transport_test.py:L1-143</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> With the reorganising of the test direction, it probably is better to just do:

```
mod:`path_transport_test` --- lib.packet.ext.path_transport unit tests
```
- [x] <a href='#crh-comment-Pull da9de2f47b055a3e76fadad6c905364642da61d9 test/lib/packet/ext/path_transport_test.py 50'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#discussion_r48822988'>File: test/lib/packet/ext/path_transport_test.py:L1-143</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Don't need ()'s on the above 2 lines.
- [x] <a href='#crh-comment-Pull da9de2f47b055a3e76fadad6c905364642da61d9 test/lib/packet/ext/path_transport_test.py 59'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#discussion_r48823279'>File: test/lib/packet/ext/path_transport_test.py:L1-143</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This assertion should be before the `src_addr`, `dst_addr` checks. It also shouldn't hardcode `2`.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> :
- [x] <a href='#crh-comment-Pull da9de2f47b055a3e76fadad6c905364642da61d9 test/lib/packet/ext/path_transport_test.py 62'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#discussion_r48823583'>File: test/lib/packet/ext/path_transport_test.py:L1-143</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I'm a little uncomfortable that `padding_len` isn't checked anywhere. One solution is to add:

```
data.pop.assert_called_with(22 - (22 % OpaqueField.LEN))
```
- [x] <a href='#crh-comment-Pull da9de2f47b055a3e76fadad6c905364642da61d9 test/lib/packet/ext/path_transport_test.py 74'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#discussion_r48823851'>File: test/lib/packet/ext/path_transport_test.py:L1-143</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Adding a `# Call` comment above helps readability.
- [x] <a href='#crh-comment-Pull da9de2f47b055a3e76fadad6c905364642da61d9 test/lib/packet/ext/path_transport_test.py 85'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#discussion_r48824171'>File: test/lib/packet/ext/path_transport_test.py:L1-143</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This should actually be `"lib.packet.ext.path_transport.EndToEndExtension._parse"`, as that's the reference to the object that you want to patch.
- [x] <a href='#crh-comment-Pull da9de2f47b055a3e76fadad6c905364642da61d9 test/lib/packet/ext/path_transport_test.py 94'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#discussion_r48824303'>File: test/lib/packet/ext/path_transport_test.py:L1-143</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `# Tests`
- [x] <a href='#crh-comment-Pull da9de2f47b055a3e76fadad6c905364642da61d9 test/lib/packet/ext/path_transport_test.py 86'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/571#discussion_r48824388'>File: test/lib/packet/ext/path_transport_test.py:L1-143</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> These 2 patches should be reordered, as `_parse` is called before `PathTransOFPath`

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/571?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/571?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/571'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
