### PR TITLE
Addition of a testbed topology.

### DIFF
--- a/topology/Testbed.topo
+++ b/topology/Testbed.topo
@@ -1,0 +1,20 @@
+---
+defaults:
+  zookeepers:
+    1:
+      manage: false
+      addr: 127.0.0.1
+ADs:
+  1-1: {core: true}       # CMU
+  1-2: {cert_issuer: 1-1} # UIUC
+  2-1: {core: true}       # ETH
+  2-2: {core: true}       # AWS (Ireland)
+  2-3: {cert_issuer: 2-1} # AWS (Frankfurt)
+  3-1: {core: true}       # KDDI
+links:
+  - {a: 1-1, b: 1-2, ltype: PARENT}
+  - {a: 1-1, b: 2-1, ltype: ROUTING}
+  - {a: 1-2, b: 2-1, ltype: ROUTING}
+  - {a: 2-1, b: 2-2, ltype: ROUTING}
+  - {a: 2-1, b: 3-1, ltype: ROUTING}
+  - {a: 2-1, b: 2-3, ltype: PARENT}


### PR DESCRIPTION
This topology contains 3 ISD, 6 ADs.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/572%23issuecomment-166307072%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/572%23issuecomment-166319918%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/572%23issuecomment-168967538%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/572%23issuecomment-172503082%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/572%23issuecomment-166307072%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20What%20do%20you%20think%20of%20such%20a%20testbed%20topology%3F%20Would%20be%20glad%20to%20hear%20your%20feedback.%20Cheers%21%22%2C%20%22created_at%22%3A%20%222015-12-21T13%3A34%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%20%28Althought%20I%27m%20not%20sure%20whether%20git%20repo%20is%20a%20good%20place%20for%20it%29.%22%2C%20%22created_at%22%3A%20%222015-12-21T14%3A41%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20agree%20with%20%40pszalach.%20It%20might%20make%20sense%20to%20have%20a%20git%20repo%20for%20the%20testbed%20configuration%2C%20and%20put%20it%20there.%22%2C%20%22created_at%22%3A%20%222016-01-05T10%3A37%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Closing%20this%20for%20now%2C%20we%20will%20add%20it%20to%20a%20separate%20%27testbed%27%20repo%20.%22%2C%20%22created_at%22%3A%20%222016-01-18T11%3A28%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/572#issuecomment-166307072'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @pszalach What do you think of such a testbed topology? Would be glad to hear your feedback. Cheers!
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm (Althought I'm not sure whether git repo is a good place for it).
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I agree with @pszalach. It might make sense to have a git repo for the testbed configuration, and put it there.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Closing this for now, we will add it to a separate 'testbed' repo .

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/572?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/572?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/572'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
