### PR TITLE
Allow clients to query for paths to any core AS

### DIFF
--- a/test/lib/requests_test.py
+++ b/test/lib/requests_test.py
@@ -40,11 +40,14 @@ class TestRequestHandlerRun(object):
         inst = RequestHandler(q, "check", "fetch", "reply")
         inst._add_req = create_mock()
         inst._answer_reqs = create_mock()
+        inst._key_map = create_mock()
+        inst._key_map.side_effect = ("key0map0", "key0map1"), ("key1map0",)
         # Call
         ntools.assert_raises(StopIteration, inst.run)
         # Tests
         inst._add_req.assert_called_once_with("key0", "req0")
-        assert_these_calls(inst._answer_reqs, [call("key0"), call("key1")])
+        assert_these_calls(inst._answer_reqs, [
+            call("key0map0"), call("key0map1"), call("key1map0")])
 
 
 class TestRequestHandlerAddReq(object):
@@ -111,13 +114,6 @@ class TestRequestHandlerAnswerReqs(object):
         inst._answer_reqs("key")
         # Tests
         ntools.eq_(inst._req_map["key"], ["req0"])
-        ntools.assert_false(inst._expire_reqs.called)
-
-    def test_no_reqs(self):
-        inst = self._setup()
-        # Call
-        inst._answer_reqs("key")
-        # Tests
         ntools.assert_false(inst._expire_reqs.called)
 
     def test_reqs(self):


### PR DESCRIPTION
By specifying AS 0, a client can ask for a path to any core AS. If the
specified ISD is the local ISD, this will return up segments only. If
it's a remote ISD, then it will get both up and core segments.

This required expanding lib.requests slightly, so that programs that use
it can specify what answers satisfy which requests. This allows sciond
to tell lib.requests that ISD,0 requests can be fulfilled by any ISD,X
response.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/575%23issuecomment-168733753%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/575%23issuecomment-168966997%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/575%23issuecomment-168968129%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/575%23discussion_r48837946%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/575%23issuecomment-168982450%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/575%23discussion_r48839918%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/575%23issuecomment-168987190%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/575%23issuecomment-168988753%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/575%23issuecomment-168991339%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/575%23issuecomment-168733753%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222016-01-04T16%3A58%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Why%20we%20need%20to%20query%20for%20any%20%20path%20to%20remote%20ISD%20%3F%22%2C%20%22created_at%22%3A%20%222016-01-05T10%3A34%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40pszalach%20-%20if%20a%20client%20wants%20to%20talk%20to%20a%20remote%20core%20AS%20for%20any%20reason%2C%20but%20doesn%27t%20care%20about%20/which/%20core%20AS.%20%22%2C%20%22created_at%22%3A%20%222016-01-05T10%3A40%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-01-05T12%3A04%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20I%20don%27t%20see%20any%20use%20case%20for%20that.%22%2C%20%22created_at%22%3A%20%222016-01-05T12%3A32%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40pszalach%20-%20https%3A//github.com/netsec-ethz/scion/blob/master/infrastructure/path_server/core.py%23L381%22%2C%20%22created_at%22%3A%20%222016-01-05T12%3A38%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20this%20query%20is%20IMO%20needed%20only%20in%20two%20cases%3A%201%29%20non-core%20PS%20needs%20an%20up-path%20to%20conduct%20a%20resolution%2C%202%29%20core%20PS%20needs%20a%20core-path%20for%20the%20same%20reason%20%28you%20gave%20a%20ref%20for%20this%20case%29.%20%5Cr%5CnI%20don%27t%20see%20why%20non-core%20PS/endhost%20would%20need%20a%20path%20to%20any%20core%20AS%20in%20a%20remote%20ISD.%22%2C%20%22created_at%22%3A%20%222016-01-05T12%3A55%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2062f97ea24ccaed00d140ac2e96196905317eb078%20endhost/sciond.py%2021%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/575%23discussion_r48837946%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22isn%27t%20%60and%20not%20dst_ad%60%20%28instead%20of%20%60dst_ad%20%3D%3D%200%60%29%20suggested%3F%22%2C%20%22created_at%22%3A%20%222016-01-05T11%3A59%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Changed%22%2C%20%22created_at%22%3A%20%222016-01-05T12%3A27%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/sciond.py%3AL281-290%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/575#issuecomment-168733753'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> Why we need to query for any  path to remote ISD ?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach - if a client wants to talk to a remote core AS for any reason, but doesn't care about /which/ core AS.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> @kormat I don't see any use case for that.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach - https://github.com/netsec-ethz/scion/blob/master/infrastructure/path_server/core.py#L381
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> @kormat this query is IMO needed only in two cases: 1) non-core PS needs an up-path to conduct a resolution, 2) core PS needs a core-path for the same reason (you gave a ref for this case).
  I don't see why non-core PS/endhost would need a path to any core AS in a remote ISD.
- [ ] <a href='#crh-comment-Pull 62f97ea24ccaed00d140ac2e96196905317eb078 endhost/sciond.py 21'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/575#discussion_r48837946'>File: endhost/sciond.py:L281-290</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> isn't `and not dst_ad` (instead of `dst_ad == 0`) suggested?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Changed

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/575?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/575?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/575'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
