### PR TITLE
Remove the _raw member variable from extension headers.

### DIFF
--- a/lib/packet/ext/path_transport.py
+++ b/lib/packet/ext/path_transport.py
@@ -145,12 +145,13 @@ class PathTransportExt(EndToEndExtension):
         """
         Parse payload to extract path.
         """
-        super()._parse(raw)
-        self.path_type = self._raw[0]
+        data = Raw(raw, self.NAME, self.MIN_LEN, min_=True)
+        super()._parse(data)
+        self.path_type = data.pop(1)
         if self.path_type == PathTransType.OF_PATH:
-            self.path = PathTransOFPath(self._raw[1:])
+            self.path = PathTransOFPath(data.pop())
         elif self.path_type == PathTransType.PCB_PATH:
-            self.path = PathSegment(self._raw[1:])
+            self.path = PathSegment(data.pop())
         else:
             raise SCIONParseError("Unsupported path type: %s", self.path_type)
 
@@ -161,8 +162,9 @@ class PathTransportExt(EndToEndExtension):
         packed.append(path_packed)
         # Add possible padding.
         packed.append(bytes(calc_padding(len(path_packed) - 4, self.LINE_LEN)))
-        self._set_payload(b"".join(packed))
-        return self._raw
+        raw = b"".join(packed)
+        self._check_len(raw)
+        return raw
 
     def __str__(self):  # pragma: no cover
         tmp = ["%s(%dB):" % (self.NAME, len(self))]

--- a/lib/packet/ext/sibra.py
+++ b/lib/packet/ext/sibra.py
@@ -85,6 +85,7 @@ class SibraExt(HopByHopExtension):
 
     def _parse(self, raw):
         data = Raw(raw, "SibraExt", self.MIN_LEN, min_=True)
+        super()._parse(data)
         self._parse_flags(data.pop(1))
         self.curr_hop = data.pop(1)
         path_lens = struct.unpack("!BBB", data.pop(3))
@@ -182,7 +183,7 @@ class SibraExt(HopByHopExtension):
         if self.req_block:
             raw.append(self.req_block.pack())
         result = b"".join(raw)
-        assert (len(result) + 3) % LINE_LEN == 0
+        self._check_len(result)
         return result
 
     def _pack_flags(self):

--- a/lib/packet/ext/traceroute.py
+++ b/lib/packet/ext/traceroute.py
@@ -36,6 +36,7 @@ class TracerouteExt(HopByHopExtension):
     NAME = "TracerouteExt"
     EXT_TYPE = HopByHopType.TRACEROUTE
     PADDING_LEN = 4
+    MIN_LEN = 1 + PADDING_LEN
     HOP_LEN = HopByHopExtension.LINE_LEN  # Size of every hop information.
 
     def __init__(self, raw=None):
@@ -57,30 +58,25 @@ class TracerouteExt(HopByHopExtension):
         """
         inst = TracerouteExt()
         inst._init_size(max_hops_no)
-        inst.update()
         return inst
 
     def _parse(self, raw):
         """
         Parse payload to extract hop informations.
         """
-        super()._parse(raw)
-        hops_no = self._raw[0]
-        data = Raw(self._raw, self.NAME,
-                   self.PADDING_LEN + hops_no * self.HOP_LEN, min_=True)
-        # Drop hops count and padding from the first row.
-        data.pop(1 + self.PADDING_LEN)
+        hops_no = raw[0]
+        data = Raw(raw, self.NAME, self.MIN_LEN + hops_no * self.HOP_LEN,
+                   min_=True)
+        super()._parse(data)
+        # Drop hops no and padding from the first row.
+        data.pop(self.MIN_LEN)
         for _ in range(hops_no):
             isd, ad = ISD_AD.from_raw(data.pop(ISD_AD.LEN))  # 4 bytes
-            if_id, timestamp = struct.unpack("!HH", data.pop(self.HOP_LEN -
-                                                             ISD_AD.LEN))
+            if_id, timestamp = struct.unpack(
+                "!HH", data.pop(self.HOP_LEN - ISD_AD.LEN))
             self.append_hop(isd, ad, if_id, timestamp)
 
-    def pack(self):  # pragma: no cover
-        self.update()
-        return self._raw
-
-    def update(self):
+    def pack(self):
         packed = []
         packed.append(struct.pack("!B", len(self.hops)))
         packed.append(bytes(self.PADDING_LEN))
@@ -90,7 +86,9 @@ class TracerouteExt(HopByHopExtension):
         # Compute and set padding for the rest of the payload.
         pad_hops = self._hdr_len - len(self.hops)
         packed.append(bytes(pad_hops * self.HOP_LEN))
-        self._set_payload(b"".join(packed))
+        raw = b"".join(packed)
+        self._check_len(raw)
+        return raw
 
     def append_hop(self, isd, ad, if_id, timestamp=None):
         """
@@ -102,7 +100,6 @@ class TracerouteExt(HopByHopExtension):
             # Truncate milliseconds to 2B
             timestamp = int(SCIONTime.get_time() * 1000) % 2**16
         self.hops.append((isd, ad, if_id, timestamp))
-        self.update()
 
     def __str__(self):
         """

--- a/lib/packet/ext_hdr.py
+++ b/lib/packet/ext_hdr.py
@@ -21,7 +21,6 @@ import binascii
 # SCION
 from lib.types import ExtensionClass, TypeBase
 from lib.packet.packet_base import HeaderBase
-from lib.util import Raw
 
 
 class HopByHopType(TypeBase):
@@ -55,7 +54,7 @@ class ExtensionHeader(HeaderBase):
     SUBHDR_LEN = 3
     MIN_PAYLOAD_LEN = MIN_LEN - SUBHDR_LEN
 
-    def __init__(self, raw=None):
+    def __init__(self, raw=None):  # pragma: no cover
         """
         Initialize an instance of the class ExtensionHeader.
 
@@ -73,37 +72,30 @@ class ExtensionHeader(HeaderBase):
         if raw is not None:
             self._parse(raw)
 
-    def _parse(self, raw):
+    def _parse(self, raw):  # pragma: no cover
         """
         Initialize an instance of the class ExtensionHeader.
 
         :param raw:
         :type raw:
         """
-        data = Raw(raw, self.NAME, self.MIN_LEN, min_=True)
-        self._hdr_len = self.bytes_to_hdr_len(len(data))
-        self._set_payload(data.pop())
+        self._hdr_len = self.bytes_to_hdr_len(len(raw))
 
-    def _init_size(self, additional_lines):
+    def _init_size(self, additional_lines):  # pragma: no cover
         """
         Initialize `additional_lines` of payload.
         All extensions have to have constant size.
         """
         self._hdr_len = additional_lines
-        # Allocate additional lines.
-        self._set_payload(bytes(self.MIN_PAYLOAD_LEN + self.LINE_LEN *
-                                additional_lines))
 
-    def _set_payload(self, payload):
+    def _check_len(self, payload):  # pragma: no cover
         """
-        Set payload. Payload length must be equal to allocated space for the
-        extensions.
+        Check whether payload length is equal to the allocated space for the
+        extension.
         """
-        # Check whether payload length is correct.
         assert self._hdr_len == self.bytes_to_hdr_len(len(payload))
-        self._raw = payload
 
-    def __len__(self):
+    def __len__(self):  # pragma: no cover
         """
         Return length of extenion header in bytes.
         """
@@ -123,7 +115,7 @@ class ExtensionHeader(HeaderBase):
         return (hdr_len + 1) * cls.LINE_LEN
 
     def __str__(self):
-        payload_hex = binascii.hexlify(self._raw)
+        payload_hex = binascii.hexlify(self.pack())
         return "[%s(%dB): class: %s payload: %s]" % (
             self.NAME, len(self), ExtensionClass.to_str(self.EXT_CLASS),
             payload_hex)


### PR DESCRIPTION
_raw and the corresponding _set_payload methods were effectively no-ops.
Instead _set_payload has become a simple check that the length of the
packed extension data is legal.

ExtenionHeader has now become so simple most of it doesn't need unit
tests, but this PR also adds unit tests for bytes_to_hdr_len.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/576%23issuecomment-168967053%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/576%23discussion_r48838765%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/576%23issuecomment-168983869%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/576%23discussion_r48840121%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/576%23issuecomment-168967053%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222016-01-05T10%3A34%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22otherwise%20lgtm%22%2C%20%22created_at%22%3A%20%222016-01-05T12%3A11%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%202e1e30d0860e0ae85e658f7e10e7965a7706aaef%20lib/packet/ext/traceroute.py%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/576%23discussion_r48838765%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Isn%27t%20%60Raw%28%29%60%20expected%20to%20do%20exactly%20such%20checks%3F%20Why%20don%27t%20call%20%60Raw%28%29%60%20with%20%60exp_len%60%20%28instead%20%60self.MIN_LEN%60%29%20%3F%20%22%2C%20%22created_at%22%3A%20%222016-01-05T12%3A10%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Good%20point%2C%20that%20could%20be%20cleaner.%20Fixing.%22%2C%20%22created_at%22%3A%20%222016-01-05T12%3A31%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/ext/traceroute.py%3AL59-89%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/576#issuecomment-168967053'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> otherwise lgtm
- [ ] <a href='#crh-comment-Pull 2e1e30d0860e0ae85e658f7e10e7965a7706aaef lib/packet/ext/traceroute.py 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/576#discussion_r48838765'>File: lib/packet/ext/traceroute.py:L59-89</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> Isn't `Raw()` expected to do exactly such checks? Why don't call `Raw()` with `exp_len` (instead `self.MIN_LEN`) ?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Good point, that could be cleaner. Fixing.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/576?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/576?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/576'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
