### PR TITLE
Socket fixes for proxy

### DIFF
--- a/endhost/ssp/ConnectionManager.h
+++ b/endhost/ssp/ConnectionManager.h
@@ -99,9 +99,12 @@ protected:
     int totalQueuedSize();
 
     int                          mReceiveWindow;
+    int                          mInitSends;
 
-    bool                         mInitPacketQueued;
     bool                         mRunning;
+    bool                         mFinAcked;
+    int                          mFinAttempts;
+    bool                         mResendInit;
 
     PacketList                   mSentPackets;
     OrderedList<SCIONPacket *>   *mRetryPackets;

--- a/endhost/ssp/DataStructures.h
+++ b/endhost/ssp/DataStructures.h
@@ -37,6 +37,7 @@ public:
     L4Packet()
         : data(NULL),
         len(0),
+        dataOffset(0),
         windowSize(0),
         skipCount(0),
         retryAttempts(0),
@@ -46,6 +47,8 @@ public:
 
     virtual ~L4Packet()
     {
+        if (interfaces)
+            free(interfaces);
         if (data)
             free(data);
     }
@@ -54,6 +57,7 @@ public:
 
     uint8_t *data;
     size_t len;
+    size_t dataOffset;
     size_t windowSize;
     uint32_t skipCount;
     uint8_t retryAttempts;
@@ -90,8 +94,6 @@ typedef struct {
     int32_t H;
     int32_t O;
     uint32_t V;
-    uint8_t mark;
-    bool full;
 } SSPAck;
 
 #pragma pack(pop)

--- a/endhost/ssp/OrderedList.cpp
+++ b/endhost/ssp/OrderedList.cpp
@@ -86,3 +86,4 @@ void OrderedList<T>::clean()
 
 template class OrderedList<SCIONPacket *>;
 template class OrderedList<L4Packet *>;
+template class OrderedList<SSPPacket *>;

--- a/endhost/ssp/Path.h
+++ b/endhost/ssp/Path.h
@@ -59,6 +59,8 @@ protected:
     bool            mValid;
     int             mProbeAttempts;
     struct timeval  mLastSendTime;
+
+    pthread_mutex_t mMutex;
 };
 
 class SSPPath : public Path {

--- a/endhost/ssp/ProtocolConfigs.h
+++ b/endhost/ssp/ProtocolConfigs.h
@@ -12,13 +12,20 @@
 #define SSP_FR_THRESHOLD 3
 #define SSP_MAX_LOSS_BURST 100
 
-// SSP Protocol
-
 #define SSP_ACK 0x1
 #define SSP_NEW_PATH 0x2
 #define SSP_PROBE 0x4
 #define SSP_WINDOW 0x8
 #define SSP_FULL 0x10
+#define SSP_FIN 0x80
+
+typedef enum {
+    SCION_CLOSED = 0,
+    SCION_SHUTDOWN,
+    SCION_FIN_RCVD,
+    SCION_FIN_READ,
+    SCION_RUNNING
+} SCIONState;
 
 // SUDP protocol
 

--- a/endhost/ssp/SCIONSocket.h
+++ b/endhost/ssp/SCIONSocket.h
@@ -15,7 +15,7 @@ public:
     ~SCIONSocket();
 
     // traditional socket functionality
-    SCIONSocket & accept();
+    SCIONSocket * accept();
     int send(uint8_t *buf, size_t len);
     int send(uint8_t *buf, size_t len, DataProfile profile);
     int recv(uint8_t *buf, size_t len, SCIONAddr *srcAddr);
@@ -42,16 +42,19 @@ public:
 
     SCIONStats * getStats();
 
-private:
+    int shutdown();
+    void removeChild(SCIONSocket *child);
 
+private:
     uint16_t                   mSrcPort;
     uint16_t                   mDstPort;
     int                        mProtocolID;
     int                        mDispatcherSocket;
     bool                       mRegistered;
-    bool                       mRunning;
+    SCIONState                 mState;
     int                        mLastAccept;
 
+    SCIONSocket               *mParent;
     SCIONProtocol             *mProtocol;
     std::vector<SCIONAddr>     mDstAddrs;
     std::vector<SCIONSocket *> mAcceptedSockets;

--- a/endhost/ssp/SCIONWrapper.h
+++ b/endhost/ssp/SCIONWrapper.h
@@ -21,6 +21,7 @@ int SCIONRecv(int sock, uint8_t *buf, size_t len,
               SCIONAddr *srcAddr);
 int SCIONSelect(int numfds, fd_set *readfds, fd_set *writefds,
                 struct timeval *timeout);
+int SCIONShutdown(int fd);
 
 SCIONStats * SCIONGetStats(int sock);
 void SCIONDestroyStats(void *stats);

--- a/endhost/ssp/SocketConfigs.h
+++ b/endhost/ssp/SocketConfigs.h
@@ -4,6 +4,7 @@
 // Build config
 
 //#define SIMULATOR // uncomment for WANem testing
+#define BYPASS_ROUTERS // send packets directly to remote end
 
 #define DEBUG_MODE 0
 #if DEBUG_MODE

--- a/endhost/ssp/Utils.cpp
+++ b/endhost/ssp/Utils.cpp
@@ -6,6 +6,8 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 #include "Utils.h"
 
@@ -195,13 +197,9 @@ int reversePath(uint8_t *original, uint8_t *reverse, int len)
 uint64_t createRandom(int bits)
 {
     // Eventually use better randomness
+    int fd = open("/dev/urandom", O_RDONLY);
     uint64_t r;
-    srand(time(NULL));
-    r = random();
-    if (bits == 32)
-        return r;
-    r = r << 32;
-    r |= random();
+    read(fd, &r, 8);
     if (bits == 64)
         return r;
     return r & ((1 << bits) - 1);

--- a/endhost/ssp/test/Makefile
+++ b/endhost/ssp/test/Makefile
@@ -12,10 +12,10 @@ WRAPPED = wrapper_client wrapper_server
 all: $(BINARIES)
 
 client: client.cpp $(HDRS)
-	$(PP) -o client $(INC) $(LIB) $(CFLAGS) client.cpp -lclient
+	$(PP) -o client $(INC) $(LIB) $(CFLAGS) client.cpp -lclient -lpthread
 
 server: server.cpp $(HDRS)
-	$(PP) -o server $(INC) $(LIB) $(CFLAGS) server.cpp -lserver
+	$(PP) -o server $(INC) $(LIB) $(CFLAGS) server.cpp -lserver -lpthread
 
 hash_client: hash_client.cpp $(HDRS)
 	$(PP) -o hash_client $(INC) $(LIB) $(CFLAGS) hash_client.cpp SHA1.cpp -lclient

--- a/endhost/ssp/test/client.cpp
+++ b/endhost/ssp/test/client.cpp
@@ -1,10 +1,41 @@
+#include <pthread.h>
 #include <stdlib.h>
 #include <arpa/inet.h>
 #include <string.h>
 #include <stdio.h>
 #include "SCIONSocket.h"
+#include <unistd.h>
 
-#define BUFSIZE 1024
+#define BUFSIZE 10240
+
+void *sender(void *arg)
+{
+    printf("start sender thread\n");
+    uint8_t buf[BUFSIZE];
+    memset(buf, 0, BUFSIZE);
+    SCIONSocket *sock = (SCIONSocket *)arg;
+    int count = 0;
+    while (1) {
+        count++;
+        sprintf((char *)buf, "This is message %d\n", count);
+        sock->send(buf, BUFSIZE);
+        printf("client sent message on sock %p\n", sock);
+        usleep(50000);
+    }
+    return NULL;
+}
+
+void *receiver(void *arg)
+{
+    printf("start receiver thread\n");
+    uint8_t buf[BUFSIZE];
+    SCIONSocket *sock = (SCIONSocket *)arg;
+    while (1) {
+        sock->recv(buf, BUFSIZE, NULL);
+        printf("client received message on sock %p\n", sock);
+    }
+    return NULL;
+}
 
 int main(int argc, char **argv)
 {
@@ -26,15 +57,17 @@ int main(int argc, char **argv)
     in_addr_t in = inet_addr(str);
     memcpy(saddr.host.addr, &in, 4);
     addrs[0] = saddr;
-    SCIONSocket s(SCION_PROTO_SSP, addrs, 1, 0, 8080);
-    int count = 0;
-    char buf[BUFSIZE];
-    memset(buf, 0, BUFSIZE);
-    while (1) {
-        count++;
-        sprintf(buf, "This is message %d\n", count);
-        s.send((uint8_t *)buf, BUFSIZE);
-        //usleep(50000);
+    pthread_t sendthread;
+    pthread_t recvthread;
+    SCIONSocket *s;
+    for (int i = 0; i < 10; i++) {
+        printf("client will create new socket\n");
+        s = new SCIONSocket(SCION_PROTO_SSP, addrs, 1, 0, 8080);
+
+        pthread_create(&sendthread, NULL, sender, s);
+        pthread_create(&recvthread, NULL, receiver, s);
     }
+    pthread_join(sendthread, NULL);
+    pthread_join(recvthread, NULL);
     exit(0);
 }

--- a/endhost/ssp/test/hash_client.cpp
+++ b/endhost/ssp/test/hash_client.cpp
@@ -9,14 +9,6 @@
 
 int main(int argc, char **argv)
 {
-    system("dd if=/dev/urandom of=randomfile bs=1024 count=1024");
-
-    uint8_t hash[20];
-    CSHA1 sha;
-    sha.HashFile("randomfile");
-    sha.Final();
-    sha.GetHash(hash);
-
     SCIONAddr addrs[1];
     SCIONAddr saddr;
     int isd, ad;
@@ -36,19 +28,60 @@ int main(int argc, char **argv)
     memcpy(saddr.host.addr, &in, 4);
     addrs[0] = saddr;
     SCIONSocket s(SCION_PROTO_SSP, addrs, 1, 0, 8080);
-    s.send((uint8_t *)hash, 20);
-    printf("hash sent: ");
+
+
+    char buf[BUFSIZE];
+    memset(buf, 0, BUFSIZE);
+    s.send((uint8_t *)buf, 1);
+    printf("sent 1 byte\n");
+
+    uint8_t recvdhash[20];
+    memset(recvdhash, 0, 20);
+    int ret = s.recv((uint8_t *)recvdhash, 20, NULL);
+    printf("recvd %d bytes\n", ret);
+    FILE *fp = fopen("recvdfile", "wb");
+    int size = 0;
+    struct timeval start, end;
+    gettimeofday(&start, NULL);
+    int recvlen;
+    while ((recvlen = s.recv((uint8_t *)buf, BUFSIZE, NULL)) > 0) {
+        gettimeofday(&end, NULL);
+        fwrite(buf, 1, recvlen, fp);
+        size += recvlen;
+        long us = end.tv_usec - start.tv_usec + (end.tv_sec - start.tv_sec) * 1000000;
+        printf("%d bytes: %f bps\n", size, (double)size / us * 1000000);
+    }
+    printf("received total %d bytes\n", size);
+    s.shutdown();
+    while (s.recv((uint8_t *)buf, BUFSIZE, NULL) > 0);
+    //s.send((uint8_t *)buf, 1);
+    fclose(fp);
+
+    CSHA1 sha;
+    sha.HashFile("recvdfile");
+    sha.Final();
+    uint8_t hash[20];
+    sha.GetHash(hash);
+    printf("received hash: ");
+    for (int i = 0; i < 20; i++)
+        printf("%x", recvdhash[i]);
+    printf("\n");
+    printf("computed hash: ");
     for (int i = 0; i < 20; i++)
         printf("%x", hash[i]);
     printf("\n");
-    FILE *fp = fopen("randomfile", "rb");
-    char fbuf[BUFSIZE];
-    memset(fbuf, 0, BUFSIZE);
-    int len = 0;
-    while ((len = fread(fbuf, 1, BUFSIZE, fp)) > 0)
-        s.send((uint8_t *)fbuf, len);
-    printf("done sending file\n");
-    s.recv((uint8_t *)fbuf, BUFSIZE, NULL);
-    fclose(fp);
+
+    bool success = true;
+    for (int i = 0; i < 20; i++) {
+        if (hash[i] != recvdhash[i]) {
+            printf("failed\n");
+            success = false;
+            break;
+        }
+    }
+    if (success) {
+        printf("success\n");
+    }
+
     exit(0);
 }

--- a/endhost/ssp/test/hash_server.cpp
+++ b/endhost/ssp/test/hash_server.cpp
@@ -7,56 +7,38 @@
 
 int main()
 {
-    SCIONSocket s(SCION_PROTO_SSP, NULL, 0, 8080, 0);
-    SCIONSocket &newSocket = s.accept();
-    printf("got new socket\n");
-    char buf[BUFSIZE];
-    uint8_t recvdhash[20];
-    memset(recvdhash, 0, 20);
-    int ret = newSocket.recv((uint8_t *)recvdhash, 20, NULL);
-    printf("recvd %d bytes\n", ret);
-    FILE *fp = fopen("recvdfile", "wb");
-    int size = 0;
-    struct timeval start, end;
-    gettimeofday(&start, NULL);
-    while (size < 1 * 1024 * 1024) {
-        memset(buf, 0, BUFSIZE);
-        int recvlen = newSocket.recv((uint8_t *)buf, BUFSIZE, NULL);
-        gettimeofday(&end, NULL);
-        fwrite(buf, 1, recvlen, fp);
-        size += recvlen;
-        long us = end.tv_usec - start.tv_usec + (end.tv_sec - start.tv_sec) * 1000000;
-        printf("%d bytes: %f bps\n", size, (double)size / us * 1000000);
-    }
-    printf("received total %d bytes\n", size);
-    newSocket.send((uint8_t *)buf, 1);
-    fclose(fp);
+    system("dd if=/dev/urandom of=randomfile bs=1024 count=1024");
 
-    CSHA1 sha;
-    sha.HashFile("recvdfile");
-    sha.Final();
     uint8_t hash[20];
+    CSHA1 sha;
+    sha.HashFile("randomfile");
+    sha.Final();
     sha.GetHash(hash);
-    printf("received hash: ");
-    for (int i = 0; i < 20; i++)
-        printf("%x", recvdhash[i]);
-    printf("\n");
-    printf("computed hash: ");
+
+    printf("random data + hash ready\n");
+    SCIONSocket s(SCION_PROTO_SSP, NULL, 0, 8080, 0);
+    SCIONSocket *newSocket = s.accept();
+    printf("got new socket\n");
+    uint8_t buf[10];
+    memset(buf, 0, 10);
+    newSocket->recv(buf, 1, NULL);
+    printf("read 1 byte\n");
+
+    newSocket->send((uint8_t *)hash, 20);
+    printf("hash sent: ");
     for (int i = 0; i < 20; i++)
         printf("%x", hash[i]);
     printf("\n");
-
-    bool success = true;
-    for (int i = 0; i < 20; i++) {
-        if (hash[i] != recvdhash[i]) {
-            printf("failed\n");
-            success = false;
-            break;
-        }
-    }
-    if (success) {
-        printf("success\n");
-    }
-
+    FILE *fp = fopen("randomfile", "rb");
+    char fbuf[BUFSIZE];
+    memset(fbuf, 0, BUFSIZE);
+    int len = 0;
+    while ((len = fread(fbuf, 1, BUFSIZE, fp)) > 0)
+        newSocket->send((uint8_t *)fbuf, len);
+    printf("done sending file\n");
+    newSocket->shutdown();
+    while (newSocket->recv((uint8_t *)fbuf, BUFSIZE, NULL) > 0);
+    delete newSocket;
+    fclose(fp);
     exit(0);
 }

--- a/endhost/ssp/test/server.cpp
+++ b/endhost/ssp/test/server.cpp
@@ -1,24 +1,51 @@
+#include <unistd.h>
 #include <string.h>
 #include <stdio.h>
 #include "SCIONSocket.h"
 
-#define BUFSIZE 1024
+#define BUFSIZE 10240
+
+void *sender(void *arg)
+{
+    printf("started sender thread\n");
+    uint8_t buf[BUFSIZE];
+    memset(buf, 0, BUFSIZE);
+    SCIONSocket *sock = (SCIONSocket *)arg;
+    int count = 0;
+    while (1) {
+        count++;
+        sprintf((char *)buf, "This is message %d\n", count);
+        sock->send(buf, BUFSIZE);
+        printf("server sent message on sock %p\n", sock);
+        usleep(50000);
+    }
+    return NULL;
+}
+
+void *receiver(void *arg)
+{
+    printf("started receiver thread\n");
+    uint8_t buf[BUFSIZE];
+    SCIONSocket *sock = (SCIONSocket *)arg;
+    while (1) {
+        sock->recv(buf, BUFSIZE, NULL);
+        printf("server received message on sock %p\n", sock);
+    }
+    return NULL;
+}
 
 int main()
 {
     SCIONSocket s(SCION_PROTO_SSP, NULL, 0, 8080, 0);
-    SCIONSocket &newSocket = s.accept();
-    char buf[BUFSIZE];
-    int size = 0;
-    struct timeval start, end;
-    gettimeofday(&start, NULL);
     while (1) {
-        memset(buf, 0, BUFSIZE);
-        int recvlen = newSocket.recv((uint8_t *)buf, BUFSIZE, NULL);
-        gettimeofday(&end, NULL);
-        size += recvlen;
-        long us = end.tv_usec - start.tv_usec + (end.tv_sec - start.tv_sec) * 1000000;
-        fprintf(stderr, "%d bytes: %f bps\n", size, (double)size / us * 1000000);
+        SCIONSocket *newSocket = s.accept();
+        printf("accepted socket\n");
+
+        pthread_t sendthread;
+        pthread_t recvthread;
+        pthread_create(&sendthread, NULL, sender, newSocket);
+        pthread_create(&recvthread, NULL, receiver, newSocket);
     }
+
     exit(0);
 }

--- a/endhost/ssp/test/web_server.cpp
+++ b/endhost/ssp/test/web_server.cpp
@@ -15,7 +15,7 @@ size_t dummy(void *buffer, size_t size, size_t nmemb, void *userp)
 int main()
 {
     SCIONSocket s(SCION_PROTO_SSP, NULL, 0, 8080, 0);
-    SCIONSocket &newSocket = s.accept();
+    SCIONSocket *newSocket = s.accept();
     char buf[BUFSIZE];
     char curldata[1024];
     int size = 0;
@@ -59,14 +59,14 @@ int main()
     curl_easy_perform(curl);
     while (1) {
         memset(buf, 0, BUFSIZE);
-        int recvlen = newSocket.recv((uint8_t *)buf, BUFSIZE, NULL);
+        int recvlen = newSocket->recv((uint8_t *)buf, BUFSIZE, NULL);
         gettimeofday(&end, NULL);
         size += recvlen;
         long us = end.tv_usec - period.tv_usec + (end.tv_sec - period.tv_sec) * 1000000;
         if (us > 1000000) {
             count++;
             SCIONStats *stats;
-            stats = newSocket.getStats();
+            stats = newSocket->getStats();
             printf("%d bytes: %f Mbps\n", size, (double)size / us * 1000000 / 1024 / 1024 * 8);
             sprintf(curldata, "{\
                     \"throughput\":{\"black\": [{\"time\":%d,\"value\":%.2f}]}\


### PR DESCRIPTION
Mainly fixing shutdown & destroy sequence, other minor bug fixes thrown in.
Proxy seems to work well(ish) with Chrome, not so much with Firefox.

@ercanucan please take a look at changes to proxy and python wrapper
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/582%23discussion_r49174380%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23discussion_r49174413%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23discussion_r49175347%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23discussion_r49175392%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23discussion_r49175500%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23discussion_r49175586%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23issuecomment-169958701%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23issuecomment-170469687%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23issuecomment-169958701%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22proxy%20related%20bits%20lgtm%22%2C%20%22created_at%22%3A%20%222016-01-08T10%3A37%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28Please%20remember%20to%20squash%20commits%20before%20merging%29%22%2C%20%22created_at%22%3A%20%222016-01-11T08%3A51%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f611f3319c90c2fa046568e664a629fe315f2f0f%20endhost/scion_socket.py%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23discussion_r49175500%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22we%20can%20now%20remove%20this%20TODO%20now%20that%20we%20are%20calling%20deleteSCIONSocket%28%29%22%2C%20%22created_at%22%3A%20%222016-01-08T10%3A30%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL195-217%22%7D%2C%20%22Pull%20f611f3319c90c2fa046568e664a629fe315f2f0f%20endhost/scion_socket.py%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23discussion_r49175347%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22let%27s%20return%200%20here%3F%22%2C%20%22created_at%22%3A%20%222016-01-08T10%3A28%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL127-136%22%7D%2C%20%22Pull%20f611f3319c90c2fa046568e664a629fe315f2f0f%20endhost/scion_proxy.py%2050%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23discussion_r49174380%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%27m%20not%20sure%20this%20is%20necessary%20-%20the%20%60finally%3A%20cleanup%28%29%60%20calls%20will%20already%20take%20care%20of%20this.%22%2C%20%22created_at%22%3A%20%222016-01-08T10%3A15%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL278-333%22%7D%2C%20%22Pull%20f611f3319c90c2fa046568e664a629fe315f2f0f%20endhost/scion_proxy.py%2063%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23discussion_r49174413%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Not%20strictly%20necessary%2C%20as%20it%27s%20already%20implied%22%2C%20%22created_at%22%3A%20%222016-01-08T10%3A16%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20I%20just%20like%20it%20better%20when%20things%20are%20explicit%2C%20but%20agree%20it%27s%20not%20necessary%22%2C%20%22created_at%22%3A%20%222016-01-08T10%3A31%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL278-333%22%7D%2C%20%22Pull%20f611f3319c90c2fa046568e664a629fe315f2f0f%20endhost/scion_socket.py%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/582%23discussion_r49175392%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22..and%20here%20as%20well%20%28return%200%29%22%2C%20%22created_at%22%3A%20%222016-01-08T10%3A28%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL127-136%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull f611f3319c90c2fa046568e664a629fe315f2f0f endhost/scion_proxy.py 50'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/582#discussion_r49174380'>File: endhost/scion_proxy.py:L278-333</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I'm not sure this is necessary - the `finally: cleanup()` calls will already take care of this.
- [ ] <a href='#crh-comment-Pull f611f3319c90c2fa046568e664a629fe315f2f0f endhost/scion_proxy.py 63'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/582#discussion_r49174413'>File: endhost/scion_proxy.py:L278-333</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Not strictly necessary, as it's already implied
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> Yeah I just like it better when things are explicit, but agree it's not necessary
- [ ] <a href='#crh-comment-Pull f611f3319c90c2fa046568e664a629fe315f2f0f endhost/scion_socket.py 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/582#discussion_r49175347'>File: endhost/scion_socket.py:L127-136</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> let's return 0 here?
- [ ] <a href='#crh-comment-Pull f611f3319c90c2fa046568e664a629fe315f2f0f endhost/scion_socket.py 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/582#discussion_r49175392'>File: endhost/scion_socket.py:L127-136</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> ..and here as well (return 0)
- [ ] <a href='#crh-comment-Pull f611f3319c90c2fa046568e664a629fe315f2f0f endhost/scion_socket.py 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/582#discussion_r49175500'>File: endhost/scion_socket.py:L195-217</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> we can now remove this TODO now that we are calling deleteSCIONSocket()
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/582#issuecomment-169958701'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> proxy related bits lgtm
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (Please remember to squash commits before merging)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/582?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/582?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/582'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
