### PR TITLE
Add `iso_timestamp` to format timestamps in UTC ISO format.

### DIFF
--- a/lib/log.py
+++ b/lib/log.py
@@ -56,8 +56,9 @@ class _ConsoleErrorHandler(logging.StreamHandler):
 
 class _Rfc3339Formatter(logging.Formatter):
     def formatTime(self, record, _):
-        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
-        return dt.isoformat(' ')
+        # Not using lib.util.iso_timestamp here, to avoid potential import
+        # loops.
+        return str(datetime.fromtimestamp(record.created, tz=timezone.utc))
 
 
 def init_logging(log_base=None, file_level=logging.DEBUG,

--- a/lib/packet/opaque_field.py
+++ b/lib/packet/opaque_field.py
@@ -17,14 +17,13 @@
 """
 # Stdlib
 import struct
-from datetime import datetime, timezone
 from abc import ABCMeta, abstractmethod
 from binascii import hexlify
 
 # SCION
 from lib.types import OpaqueFieldType as OFT
 from lib.errors import SCIONIndexError, SCIONKeyError
-from lib.util import Raw
+from lib.util import Raw, iso_timestamp
 
 
 class OpaqueField(object, metaclass=ABCMeta):
@@ -251,10 +250,9 @@ class InfoOpaqueField(OpaqueField):
             return False
 
     def __str__(self):
-        dt = datetime.fromtimestamp(self.timestamp, tz=timezone.utc)
         return ("[Info OF info(%dB): %s, up: %r, TS: %s, ISD ID: %d, hops: %d]"
                 % (len(self), OFT.to_str(self.info), self.up_flag,
-                   dt.isoformat(' '), self.isd_id, self.hops))
+                   iso_timestamp(self.timestamp), self.isd_id, self.hops))
 
 
 class OpaqueFieldList(object):

--- a/lib/packet/pcb.py
+++ b/lib/packet/pcb.py
@@ -21,7 +21,6 @@ import logging
 import struct
 from abc import ABCMeta, abstractmethod
 from binascii import hexlify
-from datetime import datetime, timezone
 
 # External packages
 from Crypto.Hash import SHA256
@@ -37,7 +36,7 @@ from lib.packet.pcb_ext.rev import RevPcbExt
 from lib.packet.pcb_ext.sibra import SibraPcbExt
 from lib.packet.scion_addr import ISD_AD
 from lib.types import PayloadClass, PCBType
-from lib.util import Raw
+from lib.util import Raw, iso_timestamp
 
 #: Default value for length (in bytes) of a revocation token.
 REV_TOKEN_LEN = 32
@@ -557,10 +556,9 @@ class PathSegment(SCIONPayloadBase):
         truncated hash, the IOF timestamp, and the list of hops.
         """
         desc = []
-        dt = datetime.fromtimestamp(self.get_timestamp(), tz=timezone.utc)
         desc.append("%s, %s, " % (
             self.get_hops_hash(hex=True)[:12],
-            dt.isoformat(' '),
+            iso_timestamp(self.get_timestamp()),
         ))
         hops = []
         for adm in self.ads:

--- a/lib/util.py
+++ b/lib/util.py
@@ -25,6 +25,7 @@ import shutil
 import signal
 import sys
 import time
+from datetime import datetime, timezone
 from functools import wraps
 
 # External packages
@@ -299,6 +300,16 @@ def _signal_handler(signum, _):
     else:
         logging.error(text)
         sys.exit(1)
+
+
+def iso_timestamp(ts):
+    """
+    Format a unix timestamp as a UTC ISO 8601 format string
+    (YYYY-MM-DD HH:MM:SS.mmmmmm+00:00)
+
+    :param float ts: Seconds since the UNIX epoch.
+    """
+    return str(datetime.fromtimestamp(ts, tz=timezone.utc))
 
 
 class SCIONTime(object):


### PR DESCRIPTION
This is used a lot by the SIBRA work i'm doing.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/shitz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/585%23issuecomment-170621212%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-01-11T17%3A09%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/585%23issuecomment-170621212%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/shitz'><img src='https://avatars.githubusercontent.com/u/3840858?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/585?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/585?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/585'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
