### PR TITLE
Small improvements to dependency installer script

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-set -e
-
 cmd_all() {
     cmd_pkgs
     cmd_pip
-    cmd_misc
+    cmd_supervisor
 }
 
 cmd_pkgs() {
@@ -38,7 +36,7 @@ cmd_pip() {
 }
 
 
-cmd_misc() {
+cmd_supervisor() {
     echo "Installing supervisor packages from pip2"
     pip2 install --user supervisor==3.1.3
     pip2 install --user supervisor-quick
@@ -46,19 +44,19 @@ cmd_misc() {
 
 cmd_help() {
 	cat <<-_EOF
-	$PROGRAM [all|pkgs|pip|misc|help]
+	$PROGRAM [all|pkgs|pip|supervisor|help]
 	
 	Usage:
 	    $PROGRAM all
-	        Install all dependancies.
+	        Install all dependancies (recommended).
 	    $PROGRAM pkgs
-	        Install all system package dependancies (e.g. via apt-get).
-	        Uses sudo.
+	        Install only system package dependancies via apt-get (uses sudo).
 	    $PROGRAM pip
-	        Install all pip package dependancies (using --user, so no root
-	        access required)
-	    $PROGRAM misc
-	        Install any additional packages not from the first 2 sources.
+	        Install only pip package dependancies (using --user, root
+	        privileges not required).
+	    $PROGRAM supervisor
+	        Install only supervisor packages (using --user, root privileges
+	        not required).
 	    $PROGRAM help
 	        Show this text.
 	_EOF
@@ -70,7 +68,8 @@ COMMAND="$1"
 shift
 
 case "$COMMAND" in
-    all|pkgs|pip|misc)
-            "cmd_$COMMAND" "$@" ;;
-    help|*)  cmd_help ;;
+    all|pkgs|pip|supervisor|help)
+        "cmd_$COMMAND" "$@" ;;
+    *)
+        cmd_help ;;
 esac


### PR DESCRIPTION
By using the set -e directive, the script would exit mysteriously if any of the
invoked commands returns non-zero status. This happens, for example when apt
tries to restart zookeperd or ntp. By not having set -e the script will try to
go through all the steps in the script. This also now shows the help when
deps.sh is run without arguments.

Also modify the wording slightly to better reflect what each option does.
Previous helped appeared to give the user the option of installing packages with
or without root. Hopefully it is now clear that all packages need to be
installed, but only some require root privs to install. It was not clear what
misc meant, when it currently only installs supervisor packages. Renamed the
functions accordingly.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/586?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/586'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
