### PR TITLE
Allow extension handlers to direct packet processing

### DIFF
--- a/infrastructure/path_server/core.py
+++ b/infrastructure/path_server/core.py
@@ -290,7 +290,7 @@ class CorePathServer(PathServer):
                 logging.debug("Segs to %d,%d not found." % dst)
             else:
                 # That could happend when a needed segment has expired.
-                logging.warning("Handling pending request and needed seg"
+                logging.warning("Handling pending request and needed segment "
                                 "is missing. Shouldn't be here (too often).")
             return False
 

--- a/lib/types.py
+++ b/lib/types.py
@@ -108,3 +108,12 @@ class PCBType(TypeBase):
 
 class IFIDType(object):
     PAYLOAD = 0
+
+
+############################
+# Router types
+############################
+class RouterFlag(TypeBase):
+    ERROR = 0
+    NO_PROCESS = 1
+    FORWARD = 2


### PR DESCRIPTION
Extension handlers can return a list RouterFlags (with arguments,
depending on the flag), that the router can then process to see what
needs to happen to the packet.

An example use is most SIBRA packets won't use the normal path
processing in the router, and will instead be forwarded directly
instead.

Also:
- Fix minor log formatting in path server
- Identify whether it's a pre- or post- handler that's missing
- Print out a hexdump of a packet if payload parsing failed, otherwise
  this can trigger further exceptions.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/589%23issuecomment-171941393%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/589%23discussion_r49846686%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/589%23issuecomment-171943980%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/589%23discussion_r49972857%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/589%23issuecomment-172467883%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/589%23issuecomment-171941393%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222016-01-15T11%3A45%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22otherwise%20lgtm%22%2C%20%22created_at%22%3A%20%222016-01-15T12%3A00%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-01-18T08%3A59%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%204926327f8fb4d47cab4f46bfffe6218755a1f69c%20infrastructure/router/main.py%2069%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/589%23discussion_r49846686%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22as%20discussed%2C%20should%20be%20processed%20only%20if%20all%20flags%20are%20%60FORWARD%60%22%2C%20%22created_at%22%3A%20%222016-01-15T12%3A00%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed%2C%20please%20take%20another%20look.%22%2C%20%22created_at%22%3A%20%222016-01-18T08%3A51%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/router/main.py%3AL684-719%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/589#issuecomment-171941393'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> otherwise lgtm
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- [ ] <a href='#crh-comment-Pull 4926327f8fb4d47cab4f46bfffe6218755a1f69c infrastructure/router/main.py 69'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/589#discussion_r49846686'>File: infrastructure/router/main.py:L684-719</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> as discussed, should be processed only if all flags are `FORWARD`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Fixed, please take another look.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/589?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/589?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/589'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
