### PR TITLE
General preparation for fuller sibra support.

### DIFF
--- a/lib/packet/ext/path_transport.py
+++ b/lib/packet/ext/path_transport.py
@@ -21,12 +21,13 @@ import struct
 
 # SCION
 from lib.errors import SCIONParseError
-from lib.packet.ext_hdr import EndToEndExtension, EndToEndType
+from lib.packet.ext_hdr import EndToEndExtension
 from lib.packet.opaque_field import OpaqueField
 from lib.packet.packet_base import HeaderBase
 from lib.packet.path import parse_path
 from lib.packet.pcb import PathSegment
 from lib.packet.scion_addr import SCIONAddr
+from lib.types import ExtEndToEndType
 from lib.util import calc_padding, Raw
 
 
@@ -113,7 +114,7 @@ class PathTransportExt(EndToEndExtension):
     +--------+--------+--------+--------+--------+--------+--------+--------+
     """
     NAME = "PathTransportExt"
-    EXT_TYPE = EndToEndType.PATH_TRANSPORT
+    EXT_TYPE = ExtEndToEndType.PATH_TRANSPORT
 
     def __init__(self, raw=None):
         """

--- a/lib/packet/ext/sibra.py
+++ b/lib/packet/ext/sibra.py
@@ -23,7 +23,8 @@ from binascii import hexlify
 # SCION
 from lib.crypto.symcrypto import cbcmac
 from lib.errors import SCIONParseError
-from lib.packet.ext_hdr import HopByHopExtension, HopByHopType
+from lib.packet.ext_hdr import HopByHopExtension
+from lib.types import ExtHopByHopType
 from lib.util import Raw, calc_padding
 
 #: Number of seconds per sibra interval
@@ -49,7 +50,7 @@ class SibraExt(HopByHopExtension):
       - version (2b): SIBRA version, to be used as (SCION ver, SIBRA ver).
     """
     NAME = "SibraExt"
-    EXT_TYPE = HopByHopType.SIBRA
+    EXT_TYPE = ExtHopByHopType.SIBRA
     STEADY_ID_LEN = 8
     EPHEMERAL_ID_LEN = 8
     MIN_LEN = HopByHopExtension.SUBHDR_LEN

--- a/lib/packet/ext/traceroute.py
+++ b/lib/packet/ext/traceroute.py
@@ -19,9 +19,10 @@
 import struct
 
 # SCION
-from lib.packet.ext_hdr import HopByHopExtension, HopByHopType
+from lib.packet.ext_hdr import HopByHopExtension
 from lib.packet.scion_addr import ISD_AD
 from lib.util import Raw, SCIONTime
+from lib.types import ExtHopByHopType
 
 
 class TracerouteExt(HopByHopExtension):
@@ -34,7 +35,7 @@ class TracerouteExt(HopByHopExtension):
     |                     (padding)  or HOP info                           |
     """
     NAME = "TracerouteExt"
-    EXT_TYPE = HopByHopType.TRACEROUTE
+    EXT_TYPE = ExtHopByHopType.TRACEROUTE
     PADDING_LEN = 4
     MIN_LEN = 1 + PADDING_LEN
     HOP_LEN = HopByHopExtension.LINE_LEN  # Size of every hop information.

--- a/lib/packet/ext_hdr.py
+++ b/lib/packet/ext_hdr.py
@@ -19,17 +19,8 @@
 import binascii
 
 # SCION
-from lib.types import ExtensionClass, TypeBase
+from lib.types import ExtensionClass
 from lib.packet.packet_base import HeaderBase
-
-
-class HopByHopType(TypeBase):
-    TRACEROUTE = 0
-    SIBRA = 1
-
-
-class EndToEndType(TypeBase):
-    PATH_TRANSPORT = 0
 
 
 class ExtensionHeader(HeaderBase):
@@ -113,6 +104,12 @@ class ExtensionHeader(HeaderBase):
     @classmethod
     def hdr_len_to_bytes(cls, hdr_len):  # pragma: no cover
         return (hdr_len + 1) * cls.LINE_LEN
+
+    def reverse(self):  # pragma: no cover
+        pass
+
+    def get_first_ifid(self):  # pragma: no cover
+        pass
 
     def __str__(self):
         payload_hex = binascii.hexlify(self.pack())

--- a/lib/packet/ext_util.py
+++ b/lib/packet/ext_util.py
@@ -22,17 +22,18 @@ import struct
 # SCION
 from lib.defines import L4_PROTOS
 from lib.errors import SCIONParseError
-from lib.packet.ext_hdr import EndToEndType, ExtensionHeader, HopByHopType
+from lib.packet.ext_hdr import ExtensionHeader
 from lib.packet.ext.path_transport import PathTransportExt
 from lib.packet.ext.sibra import SibraExt
 from lib.packet.ext.traceroute import TracerouteExt
-from lib.types import ExtensionClass
+from lib.types import ExtensionClass, ExtEndToEndType, ExtHopByHopType
 
 # Dictionary of supported extensions
 EXTENSION_MAP = {
-    (ExtensionClass.HOP_BY_HOP, HopByHopType.SIBRA): SibraExt,
-    (ExtensionClass.HOP_BY_HOP, HopByHopType.TRACEROUTE): TracerouteExt,
-    (ExtensionClass.END_TO_END, EndToEndType.PATH_TRANSPORT): PathTransportExt,
+    (ExtensionClass.HOP_BY_HOP, ExtHopByHopType.SIBRA): SibraExt,
+    (ExtensionClass.HOP_BY_HOP, ExtHopByHopType.TRACEROUTE): TracerouteExt,
+    (ExtensionClass.END_TO_END, ExtEndToEndType.PATH_TRANSPORT):
+        PathTransportExt,
 }
 
 
@@ -59,3 +60,9 @@ def parse_extensions(data, next_hdr):
             ext_class(data.pop(hdr_len - ExtensionHeader.SUBHDR_LEN)))
         cur_hdr_type = next_hdr_type
     return ext_hdrs, cur_hdr_type
+
+
+def find_ext_hdr(spkt, class_, type_):
+    for hdr in spkt.ext_hdrs:
+        if (hdr.EXT_CLASS == class_ and hdr.EXT_TYPE == type_):
+            return hdr

--- a/lib/packet/packet_base.py
+++ b/lib/packet/packet_base.py
@@ -169,6 +169,10 @@ class PayloadBase(object, metaclass=ABCMeta):  # pragma: no cover
 
 
 class PayloadRaw(PayloadBase):  # pragma: no cover
+    def __init__(self, raw=None):
+        self._raw = b""
+        super().__init__(raw)
+
     def _parse(self, raw):
         self._raw = raw or b""
 

--- a/lib/packet/path.py
+++ b/lib/packet/path.py
@@ -707,6 +707,9 @@ class EmptyPath(PathBase):  # pragma: no cover
     def from_values(self, *args, **kwargs):
         raise NotImplementedError
 
+    def get_hof(self):
+        return None
+
     def _parse(self, raw):
         raise NotImplementedError
 

--- a/lib/socket.py
+++ b/lib/socket.py
@@ -116,6 +116,9 @@ class UDPSocket(object):
         """
         self.sock.close()
 
+    def settimeout(self, timeout):
+        self.sock.settimeout(timeout)
+
 
 class UDPSocketMgr(object):
     """

--- a/lib/types.py
+++ b/lib/types.py
@@ -47,6 +47,15 @@ class ExtensionClass(TypeBase):
     END_TO_END = 222  # (Expected:-) number for SCION end2end extensions.
 
 
+class ExtHopByHopType(TypeBase):
+    TRACEROUTE = 0
+    SIBRA = 1
+
+
+class ExtEndToEndType(TypeBase):
+    PATH_TRANSPORT = 0
+
+
 class OpaqueFieldType(TypeBase):
     """
     Constants for the types of the opaque field (first byte of every opaque

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -203,6 +203,7 @@ class Pong(object):
             self.ping_received = True
             spkt.reverse()
             spkt.set_payload(PayloadRaw(b"pong " + self.token))
+            logging.info("Replying with:\n%s", spkt)
             (next_hop, port) = self.sd.get_first_hop(spkt)
             assert next_hop is not None
             self.sd.send(spkt, next_hop, port)


### PR DESCRIPTION
Router changes:
- Read signing key on startup
- Pass from_local_ad flag to extension handling
- Allow deliver() to work if there's no scion path
- Extract egress forwarding into seperate function, so it can be called
  by _process_flags().

Elem:
- Update get_first_hop to allow extensions to provide the interface.
- Check that src/dst AD are different when there's no path (and an
  extension hasn't provided the interface).

Misc:
- Move extension types into lib.types
- Add support for reversing extensions, and getting interface IDs from
  extensions.
- Adding utility function to find an extension of a specific class/type.
- EmptyPath.get_hof() now returns None
- Enforce extension headers to be a multiple of LINE_LEN
- Allow setting of timeouts on sockets
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/590%23issuecomment-172473759%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/590%23discussion_r50235710%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/590%23discussion_r50235989%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/590%23issuecomment-173159244%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/590%23discussion_r51238116%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/590%23discussion_r51238144%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/590%23discussion_r51392630%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/590%23discussion_r51393022%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/590%23discussion_r51394366%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/590%23discussion_r51394692%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/590%23issuecomment-172473759%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222016-01-18T09%3A28%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%20%28but%20it%20makes%20sense%20to%20me%20to%20review%20bigger%20parts%29%22%2C%20%22created_at%22%3A%20%222016-01-20T10%3A16%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20bb1355104800c3adc42abf2221112b8f897562e7%20infrastructure/router/main.py%2027%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/590%23discussion_r50235710%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22what%20does%20router%20sign%3F%22%2C%20%22created_at%22%3A%20%222016-01-20T10%3A10%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sibra%20Opaque%20Fields.%22%2C%20%22created_at%22%3A%20%222016-01-29T09%3A00%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22it%20is%20created%20with%20symmetric%20key%2C%20so%20I%20suggest%20to%20just%20derive%20one%3A%5Cr%5Cn%60self.sibra_key%20%3D%20PBKDF2%28self.config.master_ad_key%2C%20b%5C%22Derive%20SIBRA%20Key%5C%22%29%60%22%2C%20%22created_at%22%3A%20%222016-02-01T09%3A00%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed.%22%2C%20%22created_at%22%3A%20%222016-02-01T09%3A20%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/router/main.py%3AL132-140%22%7D%2C%20%22Pull%20bb1355104800c3adc42abf2221112b8f897562e7%20infrastructure/router/main.py%2074%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/590%23discussion_r50235989%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22router%20should%20not%20accept%20packets%20with%20empty%20path.%20At%20some%20point%20we%20need%20to%20have%20%60_is_spkt_correct%28%29%60%20that%20would%20do%20sanity%20checks.%22%2C%20%22created_at%22%3A%20%222016-01-20T10%3A12%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20not%20true.%20The%20majority%20of%20sibra%20packets%20will%20have%20empty%20paths.%22%2C%20%22created_at%22%3A%20%222016-01-29T09%3A01%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20see%2C%20but%20then%20maybe%20router%20should%20check%20that%20%28i.e.%2C%20if%20path%20is%20empty%20then%20sibra%20ext%20has%20to%20exist%29%2C%20...%20at%20least%20please%20comment%20that.%22%2C%20%22created_at%22%3A%20%222016-02-01T09%3A05%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20a%20comment.%22%2C%20%22created_at%22%3A%20%222016-02-01T09%3A25%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/router/main.py%3AL425-433%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/590#issuecomment-172473759'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm (but it makes sense to me to review bigger parts)
- [ ] <a href='#crh-comment-Pull bb1355104800c3adc42abf2221112b8f897562e7 infrastructure/router/main.py 27'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/590#discussion_r50235710'>File: infrastructure/router/main.py:L132-140</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> what does router sign?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Sibra Opaque Fields.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> it is created with symmetric key, so I suggest to just derive one:
  `self.sibra_key = PBKDF2(self.config.master_ad_key, b"Derive SIBRA Key")`
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Fixed.
- [ ] <a href='#crh-comment-Pull bb1355104800c3adc42abf2221112b8f897562e7 infrastructure/router/main.py 74'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/590#discussion_r50235989'>File: infrastructure/router/main.py:L425-433</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> router should not accept packets with empty path. At some point we need to have `_is_spkt_correct()` that would do sanity checks.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is not true. The majority of sibra packets will have empty paths.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> I see, but then maybe router should check that (i.e., if path is empty then sibra ext has to exist), ... at least please comment that.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Added a comment.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/590?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/590?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/590'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
