### PR TITLE
Fix an issue where docker wouldn't work on a fresh install.

### DIFF
--- a/pkgs_debian.txt
+++ b/pkgs_debian.txt
@@ -1,4 +1,5 @@
 dnsutils
+cgroup-bin
 gcc
 g++
 libcurl4-openssl-dev


### PR DESCRIPTION
Without the cgroups-bin package installed, docker can't mount cgroups,
and then dies.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/591?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/591'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
