### PR TITLE
Deregister from dispatcher when socket is destroyed

### DIFF
--- a/endhost/ssp/ConnectionManager.cpp
+++ b/endhost/ssp/ConnectionManager.cpp
@@ -994,7 +994,9 @@ void SSPConnectionManager::didSend(SCIONPacket *packet)
                 pthread_mutex_unlock(&mSentMutex);
                 return;
             }
-            printf("duplicate packet in sent list: %lu|%lu, path %d|%d (%p)\n", be64toh(s->header.offset), be64toh(sp->header.offset), packet->pathIndex, p->pathIndex, packet);
+            printf("duplicate packet in sent list: %lu|%lu, path %d|%d (%p)\n",
+                    be64toh(s->header.offset), be64toh(sp->header.offset),
+                    packet->pathIndex, p->pathIndex, packet);
             exit(0);
         }
     }

--- a/endhost/ssp/SCIONProtocol.cpp
+++ b/endhost/ssp/SCIONProtocol.cpp
@@ -129,6 +129,10 @@ int SCIONProtocol::shutdown()
     return 0;
 }
 
+void SCIONProtocol::removeDispatcher(int sock)
+{
+}
+
 // SSP
 
 SSPProtocol::SSPProtocol(std::vector<SCIONAddr> &dstAddrs, short srcPort, short dstPort)
@@ -296,7 +300,7 @@ void SSPProtocol::start(SCIONPacket *packet, uint8_t *buf, int sock)
     SSPEntry se;
     se.flowID = mFlowID;
     se.port = 0;
-    registerFlow(SCION_PROTO_SSP, &se, sock);
+    registerFlow(SCION_PROTO_SSP, &se, sock, 1);
     DEBUG("start protocol for flow %lu\n", mFlowID);
     if (packet && buf)
         handlePacket(packet, buf);
@@ -720,6 +724,14 @@ void SSPProtocol::notifyFinAck()
     mReadyToRead = true;
     pthread_cond_broadcast(&mReadCond);
     pthread_mutex_unlock(&mReadMutex);
+}
+
+void SSPProtocol::removeDispatcher(int sock)
+{
+    SSPEntry se;
+    se.flowID = mFlowID;
+    se.port = 0;
+    registerFlow(SCION_PROTO_SSP, &se, sock, 0);
 }
 
 // SUDP

--- a/endhost/ssp/SCIONProtocol.h
+++ b/endhost/ssp/SCIONProtocol.h
@@ -41,6 +41,7 @@ public:
     virtual void deregisterSelect(int index);
 
     virtual int shutdown();
+    virtual void removeDispatcher(int sock);
 
 protected:
     int                    mSocket;
@@ -91,6 +92,7 @@ public:
 
     int shutdown();
     void notifyFinAck();
+    void removeDispatcher(int sock);
 
     uint64_t               mFlowID;
 protected:

--- a/endhost/ssp/Utils.cpp
+++ b/endhost/ssp/Utils.cpp
@@ -205,7 +205,7 @@ uint64_t createRandom(int bits)
     return r & ((1 << bits) - 1);
 }
 
-int registerFlow(int proto, void *data, int sock)
+int registerFlow(int proto, void *data, int sock, uint8_t reg)
 {
     DEBUG("register flow via socket %d\n", sock);
 
@@ -217,19 +217,20 @@ int registerFlow(int proto, void *data, int sock)
 
     int len;
     char buf[32];
-    buf[0] = proto;
+    buf[0] = reg;
+    buf[1] = proto;
     switch (proto) {
         case SCION_PROTO_SSP: {
             SSPEntry *se = (SSPEntry *)data;
-            memcpy(buf + 1, &se->flowID, sizeof(se->flowID));
-            memcpy(buf + 9, &se->port, sizeof(se->port));
-            len = 11;
+            memcpy(buf + 2, &se->flowID, sizeof(se->flowID));
+            memcpy(buf + 10, &se->port, sizeof(se->port));
+            len = 12;
             break;
         }
         case SCION_PROTO_SUDP: {
             SUDPEntry *se = (SUDPEntry *)data;
-            memcpy(buf + 1, &se->port, sizeof(se->port));
-            len = 3;
+            memcpy(buf + 2, &se->port, sizeof(se->port));
+            len = 4;
             break;
         }
         default:

--- a/endhost/ssp/Utils.h
+++ b/endhost/ssp/Utils.h
@@ -40,7 +40,7 @@ void destroySUDPPacket(void *p);
 
 int reversePath(uint8_t *original, uint8_t *reverse, int len);
 uint64_t createRandom(int bits);
-int registerFlow(int proto, void *data, int sock);
+int registerFlow(int proto, void *data, int sock, uint8_t reg);
 void destroyStats(SCIONStats *stats);
 
 #endif

--- a/endhost/ssp/test/hash_client.cpp
+++ b/endhost/ssp/test/hash_client.cpp
@@ -83,5 +83,5 @@ int main(int argc, char **argv)
         printf("success\n");
     }
 
-    exit(0);
+    return 0;
 }

--- a/endhost/ssp/test/hash_server.cpp
+++ b/endhost/ssp/test/hash_server.cpp
@@ -40,5 +40,5 @@ int main()
     while (newSocket->recv((uint8_t *)fbuf, BUFSIZE, NULL) > 0);
     delete newSocket;
     fclose(fp);
-    exit(0);
+    return 0;
 }


### PR DESCRIPTION
Sockets register with the dispatcher upon startup to receive packets, so they should deregister when they are destroyed.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/593%23issuecomment-172851793%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/593%23issuecomment-172851793%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22No%20consequences%20outside%20of%20socket%20code%20so%20moving%20ahead%20with%20merge%22%2C%20%22created_at%22%3A%20%222016-01-19T13%3A24%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/593#issuecomment-172851793'>General Comment</a></b>
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> No consequences outside of socket code so moving ahead with merge

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/593?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/593?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/593'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
