### PR TITLE
Documentation

### DIFF
--- a/lib/packet/packet_base.py
+++ b/lib/packet/packet_base.py
@@ -106,12 +106,29 @@ class PacketBase(object, metaclass=ABCMeta):  # pragma: no cover
     def get_payload(self):
         """
         Returns the packet payload.
+
+        .. warning::
+
+            This is a public accessor method for a non-public attribute. Both
+            the method and attribute should be public, or neither should be.
+
         """
         return self._payload
 
     def set_payload(self, new_payload):
         """
-        Set the packet payload.  Expects bytes or a Packet subclass.
+        Set the packet payload.
+
+        Expects bytes or a Packet subclass.
+
+        Args:
+            new_payload (:class:`PayloadBase`): the new payload to set.
+
+        .. warning::
+
+            This is a public accessor method for a non-public attribute. Both
+            the method and attribute should be public, or neither should be.
+
         """
         assert isinstance(new_payload, PayloadBase)
         self._payload = new_payload

--- a/lib/packet/scion.py
+++ b/lib/packet/scion.py
@@ -62,26 +62,60 @@ class PacketType(object):
 class SCIONCommonHdr(HeaderBase):
     """
     Encapsulates the common header for SCION packets.
+
+    The SCION common header is structured as follows::
+
+                            1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |  Ver  |  Src Type |  Dst Type |          Total Len            |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |    Curr IOF   |    Curr HOF   |    Next Hdr   |    Hdr Len    |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+    .. warning::
+
+       It is possible that the above format is outdated due to changing code.
+
+    Attributes:
+        LEN (int): length of the common header in bytes.
+        version (int): the SCION packet version.
+        src_addr_type (int): the source address type. The possible values for
+            address types are defined in the :class:`lib.types.AddrType` class.
+        dst_addr_type (int): the destination address type. The possible values
+            for address types are defined in the :class:`lib.types.AddrType`
+            class.
+        addrs_len (int): the length of the address block in bytes.
+        total_len (int): the total packet length in bytes.
+        next_hdr (int): the type of the next header field.
+        hdr_len (int): the length of the header in bytes.
+
     """
     LEN = 8
 
     def __init__(self, raw=None):
         """
-        Initialize an instance of the class SCIONCommonHdr.
+        Initialize a :class:`SCIONCommonHdr` instance.
 
-        :param raw:
-        :type raw:
+        Args:
+            raw (bytes): a raw bytestring representing the common header.
+
+        Returns:
+            An :class:`SCIONCommonHdr` instance with the fields populated
+            appropriately if a nonempty value of `raw` is supplied, otherwise a
+            :class:`SCIONCommonHdr` instance with all values initialized to 0
+            or `None`.
         """
         super().__init__()
-        self.version = 0  # Version of SCION packet.
-        self.src_addr_type = None  # Type of the src address.
-        self.dst_addr_type = None  # Length of the dst address.
-        self.addrs_len = None  # Length of the address block
-        self.total_len = None  # Total length of the packet.
+        self.version = 0
+        self.src_addr_type = None
+        self.dst_addr_type = None
+        self.addrs_len = None
+        self.total_len = None
         self._iof_idx = None  # Index of the current Info Opaque Field
         self._hof_idx = None  # Index of the current Hop Opaque Field
-        self.next_hdr = None  # Type of the next hdr field (IP protocol numbers)
-        self.hdr_len = None  # Header length including the path.
+        self.next_hdr = None
+        self.hdr_len = None
 
         if raw is not None:
             self._parse(raw)
@@ -107,11 +141,21 @@ class SCIONCommonHdr(HeaderBase):
     @classmethod
     def from_values(cls, src_type, dst_type, next_hdr=L4_NONE):
         """
-        Returns a SCIONCommonHdr object with the values specified.
+        Create a :class:`SCIONCommonHdr` object from specified attribute
+        values.
 
-        :param int src: Source address type.
-        :param int dst: Destination address type.
-        :param int next_hdr: Next header type.
+        Args:
+            src_addr_type (int): the source address type. The possible values
+                for address types are defined in the `lib.types.AddrType`
+                class.
+            dst_addr_type (int): the destination address type. The possible
+                values for address types are defined in the
+                `lib.types.AddrType` class.
+            next_hdr (int): the protocol number of the `next_hdr` field.
+
+        Returns:
+            A :class:`SCIONCommonHdr` instance whose attributes' values match
+            those of the passed arguments.
         """
         inst = cls()
         inst.src_addr_type = src_type
@@ -123,6 +167,13 @@ class SCIONCommonHdr(HeaderBase):
         return inst
 
     def pack(self):
+        """
+        Return the bytestring form of the :class:`SCIONCommonHdr` instance.
+
+        Returns:
+            A `bytes` instance representing the raw form of the
+            `SCIONCommonHdr` instance.
+        """
         packed = []
         types = ((self.version << 12) | (self.src_addr_type << 6) |
                  self.dst_addr_type)
@@ -139,9 +190,29 @@ class SCIONCommonHdr(HeaderBase):
         return raw
 
     def get_of_idxs(self):
+        """
+        Return the indices of the info and hop opaque fields.
+
+        .. warning::
+
+           This is an accessor method for non-public attributes. Either the
+           function should be made non-public, or the attributes should be made
+           public.
+
+        """
         return self._iof_idx, self._hof_idx
 
     def set_of_idxs(self, iof_idx, hof_idx):
+        """
+        Set the indices of the info and hop opaque fields.
+
+        .. warning::
+
+           This is a setter method for non-public attributes. Either the
+           function should be made non-public, or the attributes should be made
+           public.
+
+        """
         self._iof_idx = iof_idx
         self._hof_idx = hof_idx
 
@@ -166,13 +237,31 @@ class SCIONCommonHdr(HeaderBase):
 class SCIONAddrHdr(HeaderBase):
     """
     SCION Address header.
+
+    Attributes:
+        BLK_SIZE (int): the block size in bytes. All :class:`SCIONAddrHdr`
+            instances are padded to a multiple of the block size.
+        src_isd (int): the ISD identifier of the source address.
+        src_ad (int): the AS identifier of the source address.
+        src_addr (:any:`HostAddrBase`): the host address of the source.
+        dst_isd (int): the ISD identifier of the destination address.
+        dst_ad (int): the AS identifier of the destination address.
+        dst_addr (:any:`HostAddrBase`): the host address of the destination.
     """
+
     BLK_SIZE = 8
 
     def __init__(self, raw_values=()):
         """
-        :param tuple raw:
-            Tuple of src addr type, dst addr type, and raw addr bytes.
+        Create a new :class:`SCIONAddrHdr` instance.
+
+        Given the source and destination address types (subtypes of
+        :any:`HostAddrBase`) and a raw bytestring representing the source and
+        destination addresses, create a new :class:`SCIONAddrHdr` instance.
+
+        Args:
+            raw_values (tuple): a 3-tuple of the source address type,
+                destination address type, and the raw address header bytes.
         """
         super().__init__()
         self.src_isd = None
@@ -200,7 +289,17 @@ class SCIONAddrHdr(HeaderBase):
     @classmethod
     def from_values(cls, src, dst):
         """
-        src_addr/dst_addr must be a :any:`SCIONAddr`
+        Create and return a :class:`SCIONAddrHdr` instance from a source and
+        destination address.
+
+        Args:
+            src_addr (:any:`SCIONAddr`): the full source address.
+            dst_addr (:any:`SCIONAddr`): the full destination address.
+
+        Returns:
+            A :class:`SCIONAddrHdr` instance representing the specified source
+            and destination addresses.
+
         """
         inst = cls()
         inst.src_isd = src.isd_id
@@ -213,6 +312,13 @@ class SCIONAddrHdr(HeaderBase):
         return inst
 
     def pack(self):
+        """
+        Pack the address header into a raw bytestring.
+
+        Returns:
+            A `bytes` instance with length a multiple of `BLK_SIZE`
+            representing the address header.
+        """
         self.update()
         packed = []
         packed.append(ISD_AD(self.src_isd, self.src_ad).pack())
@@ -226,11 +332,29 @@ class SCIONAddrHdr(HeaderBase):
         return raw
 
     def update(self):
+        """
+        Update the length and number of padding bytes based on the source and
+        destination address types.
+        """
         self._total_len, self._pad_len = self.calc_len(
             self.src_addr.TYPE, self.dst_addr.TYPE, both=True)
 
     @classmethod
     def calc_len(cls, src_type, dst_type, both=False):
+        """
+        Return the length (and possibly the padding length) of the address
+        header.
+
+        Args:
+            src_type (:any:`AddrType`): the type of the source address.
+            dst_type (:any:`AddrType`): the type of the destination address.
+            both (bool): whether to return both the total and padding lengths
+                or just the total length.
+
+        Returns:
+            The total length of the address header, along with the number of
+            padding bytes if `both` is `True`.
+        """
         src_class = haddr_get_type(src_type)
         dst_class = haddr_get_type(dst_type)
         data_len = ISD_AD.LEN * 2 + src_class.LEN + dst_class.LEN
@@ -243,6 +367,14 @@ class SCIONAddrHdr(HeaderBase):
             return total_len
 
     def reverse(self):
+        """
+        Reverse the source and destination addresses in the header.
+
+        Reverse the address header by swapping the source ID identifiers, AS
+        identifiers, and host addresses. The function also updates the relevant
+        information in the address header (e.g., the source and destination
+        address types) for consistency.
+        """
         self.src_isd, self.dst_isd = self.dst_isd, self.src_isd
         self.src_ad, self.dst_ad = self.dst_ad, self.src_ad
         self.src_addr, self.dst_addr = self.dst_addr, self.src_addr
@@ -270,9 +402,23 @@ class SCIONAddrHdr(HeaderBase):
 
 class SCIONBasePacket(PacketBase):
     """
-    Encasulates the basic headers (common header, address header, and path
+    Encapsulates the basic headers (common header, address header, and path
     header). Everything else is stored as payload.
+
+    Attributes:
+        MIN_LEN (int): the minimum length of a :class:`SCIONBasePacket`
+        NAME (str): the class name for use in printing descriptive labels.
+        cmn_hdr (:class:`SCIONCommonHdr`): the SCION common header of the
+            packet.
+        addrs (:class:`SCIONAddrHdr`): the source/destination address header of
+            the packet.
+        path (:class:`PathBase`): the path header of the packet.
+        _l4_proto (int): the layer 4 protocol number indicated in the common
+            header.
+        _payload (bytes): the packet payload, which consists of the packet
+            without the common header, address header, and path header.
     """
+
     MIN_LEN = SCIONCommonHdr.LEN
     NAME = "SCIONBasePacket"
 
@@ -320,6 +466,19 @@ class SCIONBasePacket(PacketBase):
 
     @classmethod
     def from_values(cls, cmn_hdr, addr_hdr, path_hdr, payload=b""):
+        """
+        Create a :class:`SCIONBasePacket` instance from existing header class
+        instances and a payload string.
+
+        Args:
+            cmn_hdr (:class:`SCIONCommonHdr`): the common header of the new
+                packet.
+            addr_hdr (:class:`SCIONAddrHdr`): the address header of the new
+                packet.
+            path_hdr (:class:`PathBase`): the path header of the new packet.
+                The header may be an instance of any of the path types (i.e.,
+                :class:`CrossOverPath`, :class:`PeerPath`, etc.)
+        """
         inst = cls()
         inst._inner_from_values(cmn_hdr, addr_hdr, path_hdr)
         inst.set_payload(PayloadRaw(payload))
@@ -335,6 +494,18 @@ class SCIONBasePacket(PacketBase):
         self.path = path_hdr
 
     def pack(self):
+        """
+        Create a raw bytestring representation of the packet.
+
+        .. note::
+
+            For some reason this function is calling `update` before packing.
+            Shouldn't the update happen at the end of functions that modify the
+            address and common headers instead?
+
+        Returns:
+            A `bytes` instance representing the "wire format" of the packet.
+        """
         self.update()
         packed = []
         packed.append(self.cmn_hdr.pack())
@@ -353,6 +524,19 @@ class SCIONBasePacket(PacketBase):
         return self._payload.pack()
 
     def update(self):
+        """
+        Update the address and common headers.
+
+        Update the address and common headers after updating a field in one or
+        both of these headers. This function ensures that the information
+        relevant to the updated fields is also modified accordingly.
+        For example, the common header contains the types of the source and
+        destination addresses. If the source and destination addresses have
+        different types and are updated due to an operation such as reversing
+        the address header, the common header should also be updated to ensure
+        that the address types match the those of the new source and
+        destination addresses.
+        """
         self.addrs.update()
         self._update_cmn_hdr()
 
@@ -373,10 +557,28 @@ class SCIONBasePacket(PacketBase):
         return self._l4_proto
 
     def reverse(self):
+        """
+        Reverse the packet's address and path headers.
+
+        In preparation for sending the packet back along the path it traversed,
+        reverse the address header (containing the source and destination
+        addresses) and the path header (which contains the sequence of ASes,
+        interface identifiers, opaque fields, etc.).
+        """
         self.addrs.reverse()
         self.path.reverse()
 
     def reversed_copy(self):  # pragma: no cover
+        """
+        Create and return a reversed copy of the packet.
+
+        Create a deep copy of the packet, then reverse the copy for
+        transmission back along the path on which it arrived.
+
+        Returns:
+            A :class:`SCIONBasePacket` instance that is a reversed copy of the
+            calling :class:`SCIONBasePacket` instance.
+        """
         inst = copy.deepcopy(self)
         inst.reverse()
         return inst
@@ -403,7 +605,13 @@ class SCIONBasePacket(PacketBase):
 class SCIONExtPacket(SCIONBasePacket):
     """
     Extends :any:`SCIONBasePacket` to handle extension headers.
+
+    Attributes:
+        NAME (str): the class name for use in printing and descriptive labels.
+        ext_hdrs (list): a list of extension headers.
+
     """
+
     NAME = "SCIONExtPacket"
 
     def __init__(self, raw=None):
@@ -420,6 +628,26 @@ class SCIONExtPacket(SCIONBasePacket):
 
     @classmethod
     def from_values(cls, cmn_hdr, addr_hdr, path_hdr, ext_hdrs, payload=b""):
+        """
+        Create and return :any:`SCIONExtPacket` instance from headers and a
+        payload.
+
+        Args:
+            cmn_hdr (:any:`SCIONCommonHdr`): the common header of the new
+                packet.
+            addr_hdr (:any:`SCIONAddrHdr`): the address header of the new
+                packet.
+            path_hdr (:any:`PathBase`): the path header of the new packet.  The
+                header may be an instance of any of the path types (i.e.,
+                :any:`CrossOverPath`, :any:`PeerPath`, etc.)
+            ext_hdrs (list): a list of :any:`ExtensionHeader` instances
+                representing the extension headers of the new packet.
+            payload (bytes): the payload of the packet.
+
+        Returns:
+            A :any:`SCIONExtPacket` instance representing an extension packet
+            with the given header values and payload.
+        """
         inst = cls()
         inst._inner_from_values(cmn_hdr, addr_hdr, path_hdr, ext_hdrs)
         inst.set_payload(payload)
@@ -466,6 +694,11 @@ class SCIONExtPacket(SCIONBasePacket):
 class SCIONL4Packet(SCIONExtPacket):
     """
     Extends :any:`SCIONExtPacket` to handle L4 headers.
+
+    Attributes:
+        NAME (str): class name used for printing and descriptive labels.
+        l4_hdr (:class:`L4HeaderBase`): the layer 4 header of the packet.
+
     """
     NAME = "SCIONL4Packet"
 

--- a/lib/types.py
+++ b/lib/types.py
@@ -20,6 +20,8 @@ For all type classes that are used in multiple parts of the infrastructure.
 
 
 class TypeBase(object):  # pragma: no cover
+    """
+    """
     @classmethod
     def to_str(cls, type_):
         for attr in dir(cls):
@@ -32,6 +34,8 @@ class TypeBase(object):  # pragma: no cover
 # Basic types
 ############################
 class AddrType(TypeBase):
+    """
+    """
     NONE = 0
     IPV4 = 1
     IPV6 = 2
@@ -66,6 +70,8 @@ class OpaqueFieldType(TypeBase):
 # Payload class/types
 ############################
 class PayloadClass(TypeBase):
+    """
+    """
     PCB = 0
     IFID = 1
     CERT = 2
@@ -73,6 +79,8 @@ class PayloadClass(TypeBase):
 
 
 class CertMgmtType(TypeBase):
+    """
+    """
     CERT_CHAIN_REQ = 0
     CERT_CHAIN_REPLY = 1
     TRC_REQ = 2
@@ -103,10 +111,14 @@ class PathSegmentType(TypeBase):
 
 
 class PCBType(TypeBase):
+    """
+    """
     SEGMENT = 0
 
 
 class IFIDType(object):
+    """
+    """
     PAYLOAD = 0
 
 
@@ -114,6 +126,8 @@ class IFIDType(object):
 # Router types
 ############################
 class RouterFlag(TypeBase):
+    """
+    """
     ERROR = 0
     NO_PROCESS = 1
     FORWARD = 2

--- a/lib/util.py
+++ b/lib/util.py
@@ -340,9 +340,27 @@ class SCIONTime(object):
 
 class Raw(object):
     """
-    A class to wrap raw bytes objects
+    Wrapper class to handle raw bytes.
+
+    Wraps raw bytes for easier use in processing of raw bytes. Intuitively,
+    this class is a raw byte string like the `bytes` type, but with several
+    additional features. The `Raw` class adds a description attribute that also
+    serves as a label for the data bytes. The class also can simulate bytes
+    being "consumed" during process using an internal offset pointer that can
+    be advanced as the raw data is read.
     """
+
     def __init__(self, data, desc="", len_=None, min_=False):
+        """
+        Create a `Raw` instance that wraps a `bytes` instance.
+
+        Args:
+            data (`bytes`): the raw data to be wrapped.
+            desc (str): a description of what the raw data represents.
+            len_ (int): the minimum or exact data length requirement for
+                `data`.
+            min_ (bool): whether `len_` represents a minimum data length.
+        """
         self._data = data
         self._desc = desc
         self._len = len_

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx
+Sphinx>=1.3
 coverage
 dnslib
 dnspython3

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -35,7 +35,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.pngmath',
     'sphinx.ext.inheritance_diagram',
-    'sphinxcontrib.napoleon',
+    'sphinx.ext.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/sphinx-doc/lib/types.rst
+++ b/sphinx-doc/lib/types.rst
@@ -1,0 +1,4 @@
+
+.. automodule:: lib.types
+   :special-members: __init__
+   :members:


### PR DESCRIPTION
Documentation for many poorly-documented or undocumented functions that I came across while writing the end to end test.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/594%23issuecomment-174996345%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r50840965%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r50845890%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r51243107%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r51243264%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r51243915%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r51243966%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r51243998%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r51244007%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r51244191%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23issuecomment-176679799%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23issuecomment-176683959%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23issuecomment-199170548%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23issuecomment-174996345%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40syclops%20please%20squash%20them%20into%20one%20single%20commit.%22%2C%20%22created_at%22%3A%20%222016-01-26T12%3A46%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20have%20concerns%20about%20this%20approach.%20It%27s%20very%20verbose%2C%20which%20makes%20it%20much%20harder%20to%20have%20the%20relevant%20/code/%20on%20your%20screen.%20We%20have%20many%20many%20small%20and%20%5C%22obvious%5C%22%20methods%20in%20the%20codebase%2C%20where%20adding%20a%20docstring%20is%20a%20net-negative%20in%20my%20opinion.%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A13%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22IMO%20it%27s%20an%20issue%20that%20we%20should%20spend%20time%20discussing.%20The%20definition%20of%20%5C%22obvious%5C%22%20will%20vary%20among%20members%20of%20the%20group%2C%20and%20will%20vary%20even%20more%20so%20once%20external%20developers%20start%20building%20off%20of%20our%20code.%20Since%20many%20parts%20of%20the%20code%20base%20are%20not%20as%20familiar%20to%20me%20as%20they%20are%20to%20those%20who%20spend%20a%20lot%20more%20time%20with%20the%20code%2C%20I%20tried%20to%20add%20documentation%20to%20things%20that%20may%20not%20be%20as%20obvious%20at%20first%20%28though%20constructors%2C%20as%20you%20pointed%20out%2C%20should%20count%20as%20obvious%20enough%29.%5Cr%5Cn%5Cr%5CnThe%20other%20thing%20is%20how%20people%20prefer%20to%20read%20documentation.%20The%20general%20opinion%20seems%20to%20be%20that%20people%20prefer%20to%20read%20documentation%20within%20the%20code%2C%20but%20excessive%20verbosity%20is%20only%20helpful%20to%20those%20who%20don%27t%20have%20as%20good%20of%20a%20grasp%20on%20the%20code%20base.%20We%20can%20always%20make%20a%20separate%20%60.rst%60%20file%20for%20the%20externally-aimed%20documentation%20and%20document%20the%20code%20itself%20to%20a%20level%20that%20a%20developer%20well-versed%20in%20the%20code%20would%20need%2C%20but%20in%20this%20case%20it%27s%20important%20to%20maintain%20both%20external%20and%20internal%20documentation%20in%20sync.%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A30%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1296929%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/syclops%22%7D%7D%2C%20%7B%22body%22%3A%20%22Although%20some%20parts%20are%20nice%20I%20don%27t%20believe%20we%20are%20going%20to%20merge%20it.%5Cr%5CnAlso%20comments%20show%20that%20first%20we%20should%20decide%20on%20docstrings%20format%20etc...%22%2C%20%22created_at%22%3A%20%222016-03-21T08%3A29%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201d0d1cdba18383c44b76d3ef10b9b59f8bdb4908%20lib/packet/packet_base.py%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r51243107%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22..%20what%3F%22%2C%20%22created_at%22%3A%20%222016-01-29T09%3A57%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20whole%20point%20of%20an%20accessor%20method%20is%20that%20it%27s%20public%2C%20otherwise%20it%20can%27t%20be%20used%20to%20access%20anything.%20The%20point%20of%20having%20the%20attribute%20as%20non-public%20is%20to%20discourage%20direct%20public%20access.%20In%20this%20case%2C%20so%20that%20some%20checks%20can%20be%20done%20when%20changing%20the%20attribute%27s%20value.%22%2C%20%22created_at%22%3A%20%222016-01-29T09%3A58%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Why%20not%20do%20this%20using%20a%20property%3F%20%28Though%20I%20seem%20to%20remember%20that%20the%20question%20of%20using%20properties%20came%20up%20previously...%29%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A07%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1296929%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/syclops%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20had%20properties%2C%20i%20removed%20them%3A%20https%3A//github.com/netsec-ethz/scion/pull/350%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A10%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/packet_base.py%3AL106-135%22%7D%2C%20%22Pull%201d0d1cdba18383c44b76d3ef10b9b59f8bdb4908%20lib/packet/scion.py%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r51243915%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20needs%20to%20be%20more%20carefully%20specified.%20I%20believe%20it%20includes%3A%5Cr%5Cn-%20common%20header%5Cr%5Cn-%20address%20header%2C%20if%20any%5Cr%5Cn-%20path%20header%2C%20if%20any%5Cr%5Cn%5Cr%5Cnbut%20not%20any%20extension%20headers.%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A06%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/scion.py%3AL62-122%22%7D%2C%20%22Pull%201d0d1cdba18383c44b76d3ef10b9b59f8bdb4908%20lib/packet/scion.py%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r50840965%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40syclops%20It%20looks%20like%20the%20documentation%20on%20these%20lines%20got%20lost%20while%20squashing/rebasing%2C%20right%3F%20Could%20you%20please%20put%20them%20back%20in%3F%22%2C%20%22created_at%22%3A%20%222016-01-26T14%3A31%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20Nope%2C%20that%27s%20correct.%20They%20are%20now%20explained%20under%20%60Attributes%60%20in%20the%20top-level%20class%20docstring%2C%20so%20I%20removed%20them%20from%20the%20lines%20in%20the%20constructor.%22%2C%20%22created_at%22%3A%20%222016-01-26T15%3A06%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1296929%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/syclops%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/scion.py%3AL62-122%22%7D%2C%20%22Pull%201d0d1cdba18383c44b76d3ef10b9b59f8bdb4908%20lib/packet/scion.py%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r51243966%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20really%20don%27t%20need%20to%20describe%20that%20an%20%60__init__%28%29%60%20method%20makes%20an%20instance%20of%20a%20class..%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A07%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/scion.py%3AL62-122%22%7D%2C%20%22Pull%201d0d1cdba18383c44b76d3ef10b9b59f8bdb4908%20lib/packet/scion.py%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/594%23discussion_r51243998%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60__init__%28%29%60%20methods%20return%20%60None%60.%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A07%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/scion.py%3AL62-122%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/594#issuecomment-174996345'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @syclops please squash them into one single commit.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I have concerns about this approach. It's very verbose, which makes it much harder to have the relevant /code/ on your screen. We have many many small and "obvious" methods in the codebase, where adding a docstring is a net-negative in my opinion.
- <a href='https://github.com/syclops'><img border=0 src='https://avatars.githubusercontent.com/u/1296929?v=3' height=16 width=16'></a> IMO it's an issue that we should spend time discussing. The definition of "obvious" will vary among members of the group, and will vary even more so once external developers start building off of our code. Since many parts of the code base are not as familiar to me as they are to those who spend a lot more time with the code, I tried to add documentation to things that may not be as obvious at first (though constructors, as you pointed out, should count as obvious enough).
  The other thing is how people prefer to read documentation. The general opinion seems to be that people prefer to read documentation within the code, but excessive verbosity is only helpful to those who don't have as good of a grasp on the code base. We can always make a separate `.rst` file for the externally-aimed documentation and document the code itself to a level that a developer well-versed in the code would need, but in this case it's important to maintain both external and internal documentation in sync.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> Although some parts are nice I don't believe we are going to merge it.
  Also comments show that first we should decide on docstrings format etc...
- [x] <a href='#crh-comment-Pull 1d0d1cdba18383c44b76d3ef10b9b59f8bdb4908 lib/packet/scion.py 52'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/594#discussion_r50840965'>File: lib/packet/scion.py:L62-122</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @syclops It looks like the documentation on these lines got lost while squashing/rebasing, right? Could you please put them back in?
- <a href='https://github.com/syclops'><img border=0 src='https://avatars.githubusercontent.com/u/1296929?v=3' height=16 width=16'></a> @ercanucan Nope, that's correct. They are now explained under `Attributes` in the top-level class docstring, so I removed them from the lines in the constructor.
- [ ] <a href='#crh-comment-Pull 1d0d1cdba18383c44b76d3ef10b9b59f8bdb4908 lib/packet/packet_base.py 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/594#discussion_r51243107'>File: lib/packet/packet_base.py:L106-135</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> .. what?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The whole point of an accessor method is that it's public, otherwise it can't be used to access anything. The point of having the attribute as non-public is to discourage direct public access. In this case, so that some checks can be done when changing the attribute's value.
- <a href='https://github.com/syclops'><img border=0 src='https://avatars.githubusercontent.com/u/1296929?v=3' height=16 width=16'></a> Why not do this using a property? (Though I seem to remember that the question of using properties came up previously...)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> We had properties, i removed them: https://github.com/netsec-ethz/scion/pull/350
- [ ] <a href='#crh-comment-Pull 1d0d1cdba18383c44b76d3ef10b9b59f8bdb4908 lib/packet/scion.py 30'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/594#discussion_r51243915'>File: lib/packet/scion.py:L62-122</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This needs to be more carefully specified. I believe it includes:
- common header
- address header, if any
- path header, if any
  but not any extension headers.
- [ ] <a href='#crh-comment-Pull 1d0d1cdba18383c44b76d3ef10b9b59f8bdb4908 lib/packet/scion.py 38'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/594#discussion_r51243966'>File: lib/packet/scion.py:L62-122</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> We really don't need to describe that an `__init__()` method makes an instance of a class..
- [ ] <a href='#crh-comment-Pull 1d0d1cdba18383c44b76d3ef10b9b59f8bdb4908 lib/packet/scion.py 45'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/594#discussion_r51243998'>File: lib/packet/scion.py:L62-122</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `__init__()` methods return `None`.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/594?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/594?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/594'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
