### PR TITLE
First draft of the SCION Socket Knowledge-base.

### DIFF
--- a/endhost/scion_socket.py
+++ b/endhost/scion_socket.py
@@ -82,15 +82,29 @@ class ScionStats(object):
         self.rtts = list(stats.rtts)
         self.lossRates = list(stats.lossRates)
         self.ifCounts = list(stats.ifCounts)
-        self.ifLists = []
-        for i in range(MAX_PATHS):
-            iflist = []
-            if self.ifCounts[i]:
-                for j in range(self.ifCounts[i]):
-                    iflist.append(copy.deepcopy(stats.ifLists[i][j]))
-            self.ifLists.append(iflist)
+        # TODO(ercanucan): Enable this stats later on as currently this
+        # piece of code occasionaly throws nil pointer exceptions.
+        # self.ifLists = []
+        # for i in range(MAX_PATHS):
+        #     iflist = []
+        #     if self.ifCounts[i]:
+        #         for j in range(self.ifCounts[i]):
+        #             iflist.append(copy.deepcopy(stats.ifLists[i][j]))
+        #     self.ifLists.append(iflist)
         self.highestReceived = copy.deepcopy(stats.highestReceived)
         self.highestAcked = copy.deepcopy(stats.highestAcked)
+
+    def __str__(self):
+        """
+        String representation of a ScionStats object.
+        """
+        result = []
+        result.append("Sent Packets: " + str(self.sentPackets))
+        result.append("Received Packets: " + str(self.receivedPackets))
+        result.append("Acked Packets: " + str(self.ackedPackets))
+        result.append("RTTs: " + str(self.rtts))
+        result.append("Loss-Rates: " + str(self.lossRates))
+        return "\n".join(result)
 
 
 SHARED_LIB_LOCATION = os.path.join("endhost", "ssp")
@@ -216,6 +230,12 @@ class ScionBaseSocket(object):
         self.libsock.deleteSCIONSocket(self.fd)
         self.fd = -1
 
+    def is_alive(self):
+        """
+        Returns a boolean whether this socket is still active or not.
+        """
+        return self.fd != -1
+
 
 class ScionServerSocket(ScionBaseSocket):
     """
@@ -285,5 +305,4 @@ class ScionClientSocket(ScionBaseSocket):
         sa.host.addr = ByteArray16(*ip_bytes)
         self.fd = self.libsock.newSCIONSocket(proto, byref(sa), 1,
                                               0, self.target_port)
-
         logging.info("ScionClientSocket fd = %d" % self.fd)

--- a/endhost/socket_kbase.py
+++ b/endhost/socket_kbase.py
@@ -1,0 +1,111 @@
+# Copyright 2015 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+:mod:`scion_socket_knowledge_base` --- Stats for SCION Multi-Path Socket
+========================================================================
+"""
+
+# Stdlib
+import logging
+import time
+import threading
+
+# SCION
+from lib.thread import thread_safety_net
+
+
+STATS_PERIOD = 5  # seconds
+SOC2REQ = {}  # Map socket objects to HTTP requests (method, path)
+KBASE = {}  # Map HTTP Requests (method, path) to their stats
+
+
+class SocketKnowledgeBase(object):
+    """
+    This class keeps statistics about connections on SCION Multi-path sockets.
+    It internally keeps a HashSet of the sockets and queries them periodically,
+    recording the stats in a dictionary.
+    """
+
+    def __init__(self):
+        """
+        Creates an instance of the knowledge base class.
+        """
+        self.active_sockets = set()
+        self.lock = threading.Lock()
+        self.gatherer = threading.Thread(
+            target=thread_safety_net,
+            args=(self._collect_stats,),
+            name="stats",
+            daemon=True)
+        self.gatherer.start()
+
+    def add_socket(self, soc, method, path):
+        """
+        Adds a socket to the knowledge-base to query for stats.
+        :param soc: The socket for which the stats gathering should be done.
+        :type soc: SCION-socket
+        :param method: HTTP method that soc is performing.
+        :type method: String
+        :param path: Path section of the HTTP Request that soc is performing.
+        :type path: String
+        """
+        logging.debug("Adding a socket to knowledge-base")
+        self.lock.acquire()
+        SOC2REQ[soc] = (method, path)
+        self.active_sockets.add(soc)
+        self.lock.release()
+
+    def remove_socket(self, soc):
+        """
+        Removes a socket from the knowledge-base.
+        :param soc: The socket to be removed from stats gathering.
+        :type soc: SCION-socket
+        """
+        self.lock.acquire()
+        if soc in self.active_sockets:
+            logging.debug("Removing a socket from knowledge-base")
+            self.update_single_stat(soc)
+            self.active_sockets.remove(soc)
+            del SOC2REQ[soc]
+        self.lock.release()
+
+    def update_single_stat(self, soc):
+        """
+        Updates the stats of a single socket.
+        :param soc: The socket for which the stats should be updated.
+        :type soc: SCION-socket
+        """
+        if soc.is_alive():
+            new_stats = soc.getStats()
+            if new_stats is not None:
+                method, path = SOC2REQ[soc]
+                KBASE[(method, path)] = new_stats
+
+    def _collect_stats(self):
+        """
+        Iterate through the list of all currently active sockets and call
+        getStats() on them.
+        """
+        while True:
+            logging.debug("Socket stats:")
+            self.lock.acquire()
+            for s in self.active_sockets:
+                self.update_single_stat(s)
+            self.lock.release()
+
+            for (req, stats) in KBASE.items():
+                logging.debug(str(req) + "\n" + str(stats)),
+
+            time.sleep(STATS_PERIOD)

--- a/endhost/ssp/ConnectionManager.cpp
+++ b/endhost/ssp/ConnectionManager.cpp
@@ -163,6 +163,8 @@ void PathManager::insertPaths(std::vector<Path *> &candidates)
         mPaths[i] = p;
         p->setIndex(i);
         mInvalid--;
+        if (candidates.empty())
+            break;
     }
     for (size_t i = 0; i < candidates.size(); i++) {
         Path *p = candidates[i];
@@ -712,7 +714,7 @@ void SSPConnectionManager::handleProbeAck(SCIONPacket *packet)
                 pthread_cond_broadcast(&mPathCond);
                 int used = 0;
                 for (size_t j = 0; j < mPaths.size(); j++) {
-                    if (mPaths[j]->isUsed())
+                    if (mPaths[j] && mPaths[j]->isUsed())
                         used++;
                 }
                 if (used < MAX_USED_PATHS) {
@@ -828,7 +830,7 @@ void SSPConnectionManager::handleTimeout()
                 DEBUG("path %lu is down: disable\n", j);
                 mPaths[j]->setUsed(false);
                 for (size_t k = 0; k < mPaths.size(); k++) {
-                    if (!mPaths[k]->isUsed() && mPaths[k]->isUp()) {
+                    if (mPaths[k] && !mPaths[k]->isUsed() && mPaths[k]->isUp()) {
                         DEBUG("use backup path %lu\n", k);
                         mPaths[k]->setUsed(true);
                         break;


### PR DESCRIPTION
Adds statistics gathering capabilities to the SCION-Sockets
for every HTTP request served.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/596%23issuecomment-174007251%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/596%23issuecomment-174439375%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/596%23issuecomment-174515154%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/596%23issuecomment-174543329%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/596%23issuecomment-174559710%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/596%23issuecomment-174994285%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/596%23issuecomment-174007251%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40aznair%20%40kormat%20I%20created%20this%20PR%20to%20ask%20you%20for%20feedback%20on%20the%20direction%20of%20the%20Scion%20Socket%20Knowledge%20Base%20module.%20I%20still%20need%20to%20extend%20it%20to%20serve%20the%20gathered%20data%20to%20the%20browser%20extension%20as%20a%20JSON%20file.%20I%27d%20be%20glad%20to%20hear%20your%20initial%20feedback%20on%20the%20direction.%20Cheers%21%22%2C%20%22created_at%22%3A%20%222016-01-22T18%3A47%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sure%20about%20the%20socket%20holding%20a%20reference%20to%20the%20knowledge%20base%20%28not%20really%20sure%20about%20this%20name%20either%20actually%20now%20that%20I%27m%20seeing%20it%20in%20code%29.%20Since%20it%27s%20really%20just%20some%20outside%20entity%20calling%20the%20getStats%20function%20on%20a%20socket%2C%20it%20doesn%27t%20seem%20like%20the%20kbase%20should%20be%20a%20part%20of%20the%20socket%20itself.%22%2C%20%22created_at%22%3A%20%222016-01-25T08%3A48%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aznair%20modified%20the%20PR%20so%20that%20the%20socket%20wrapper%20does%20not%20need%20to%20know%20about%20the%20socket%20kbase%20at%20all.%20I%20will%20keep%20the%20name%20as%20it%20is%20since%20we%20do%20not%20have%20a%20better%20idea%20than%20this%20at%20the%20moment%20%3B%29%22%2C%20%22created_at%22%3A%20%222016-01-25T13%3A53%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aznair%20updated%20the%20PR%20to%20include%20the%20locking%20as%20well.%22%2C%20%22created_at%22%3A%20%222016-01-25T15%3A27%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aznair%20Included%20your%20null%20pointer%20checks%20here%20as%20well%20which%20seems%20to%20reduce%20the%20seg-faults%20but%20still%20did%20not%20remove%20them%20entirely.%22%2C%20%22created_at%22%3A%20%222016-01-25T16%3A16%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22Proceeding%20with%20merge.%22%2C%20%22created_at%22%3A%20%222016-01-26T12%3A42%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/596#issuecomment-174007251'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @aznair @kormat I created this PR to ask you for feedback on the direction of the Scion Socket Knowledge Base module. I still need to extend it to serve the gathered data to the browser extension as a JSON file. I'd be glad to hear your initial feedback on the direction. Cheers!
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> I'm not sure about the socket holding a reference to the knowledge base (not really sure about this name either actually now that I'm seeing it in code). Since it's really just some outside entity calling the getStats function on a socket, it doesn't seem like the kbase should be a part of the socket itself.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @aznair modified the PR so that the socket wrapper does not need to know about the socket kbase at all. I will keep the name as it is since we do not have a better idea than this at the moment ;)
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @aznair updated the PR to include the locking as well.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @aznair Included your null pointer checks here as well which seems to reduce the seg-faults but still did not remove them entirely.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Proceeding with merge.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/596?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/596?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/596'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
