### PR TITLE
Add basic extension handling to SCION Socket

### DIFF
--- a/endhost/dispatcher.c
+++ b/endhost/dispatcher.c
@@ -24,7 +24,7 @@
 #define DATA_BUFSIZE 2048
 #define NAME_MAX 32
 
-uint8_t L4PROTOCOLS[] = {1, 6, 17, SCION_PROTO_SUDP, SCION_PROTO_SSP};
+uint8_t L4PROTOCOLS[] = {1, 6, SCION_PROTO_UDP, SCION_PROTO_SSP};
 
 typedef struct Entry {
     struct sockaddr_in addr;
@@ -115,7 +115,7 @@ void * appHandler(void *arg)
                 case SCION_PROTO_SSP:
                     registerSSP(buf, len, &addr);
                     break;
-                case SCION_PROTO_SUDP:
+                case SCION_PROTO_UDP:
                     registerSUDP(buf, len, &addr);
                     break;
             }
@@ -144,7 +144,7 @@ uint8_t getL4Protocol(uint8_t **l4ptr)
         currentHeader = *ptr;
         uint8_t nextLen = *(ptr + 1);
         nextLen = (nextLen + 1) * 8;
-        ptr += 3 + nextLen;
+        ptr += nextLen;
     }
     *l4ptr = ptr;
     return currentHeader;
@@ -201,7 +201,7 @@ void * dataHandler(void *arg)
                 case SCION_PROTO_SSP:
                     deliverSSP(buf, l4ptr, len, &addr);
                     break;
-                case SCION_PROTO_SUDP:
+                case SCION_PROTO_UDP:
                     deliverSUDP(buf, l4ptr, len, &addr);
                     break;
             }

--- a/endhost/ssp/DataStructures.h
+++ b/endhost/ssp/DataStructures.h
@@ -129,7 +129,8 @@ typedef struct {
 typedef struct {
     uint16_t srcPort;
     uint16_t dstPort;
-    uint8_t flags;
+    uint16_t len;
+    uint16_t checksum;
 } SUDPHeader;
 
 #pragma pack(pop)

--- a/endhost/ssp/Extensions.cpp
+++ b/endhost/ssp/Extensions.cpp
@@ -1,0 +1,113 @@
+#include <arpa/inet.h>
+#include <stdio.h>
+
+#include "Extensions.h"
+#include "Utils.h"
+
+uint8_t * parseExtensions(SCIONHeader *sh, uint8_t *ptr)
+{
+    SCIONCommonHeader *sch = &sh->commonHeader;
+    uint8_t nextHeader = sch->nextHeader;
+    uint8_t currHeader = nextHeader;
+    uint8_t headerLen = sch->headerLen;
+    uint8_t type = 0;
+    while (!isL4(currHeader)) {
+        nextHeader = *ptr++;
+        headerLen = *ptr++;
+        type = *ptr++;
+        uint8_t realLen = (headerLen + 1) * SCION_EXT_LINE;
+        SCIONExtension *ext = (SCIONExtension *)malloc(sizeof(SCIONExtension));
+        memset(ext, 0, sizeof(SCIONExtension));
+        ext->nextHeader = nextHeader;
+        ext->headerLen = headerLen;
+        ext->type = type;
+        ext->extClass = currHeader;
+        ext->data = malloc(realLen - SCION_EXT_SUBHDR);
+        memcpy(ext->data, ptr, realLen - SCION_EXT_SUBHDR);
+        currHeader = nextHeader;
+        ptr += realLen - SCION_EXT_SUBHDR;
+
+        if (sh->extensions == NULL) {
+            sh->extensions = ext;
+        } else {
+            SCIONExtension *se = sh->extensions;
+            while (se->nextExt != NULL)
+                se = se->nextExt;
+            se->nextExt = ext;
+        }
+        sh->numExtensions++;
+    }
+    return ptr;
+}
+
+uint8_t * packExtensions(SCIONHeader *sh, uint8_t *ptr)
+{
+    SCIONExtension *ext = sh->extensions;
+    while (ext != NULL) {
+        if (ext->extClass == HOP_BY_HOP) {
+        } else {
+            switch (ext->type) {
+            case PATH_PROBE:
+                ptr = packProbeExtension(ext, ptr);
+                break;
+            default:
+                break;
+            }
+        }
+        ext = ext->nextExt;
+    }
+    return ptr;
+}
+
+uint8_t * packSubheader(SCIONExtension *ext, uint8_t *ptr)
+{
+    *ptr++ = ext->nextHeader;
+    *ptr++ = ext->headerLen;
+    *ptr++ = ext->type;
+    return ptr;
+}
+
+void addProbeExtension(SCIONHeader *sh, uint32_t probeNum, uint8_t ack)
+{
+    SCIONCommonHeader *sch = &sh->commonHeader;
+    SCIONExtension *ext = (SCIONExtension *)malloc(sizeof(SCIONExtension));
+    memset(ext, 0, sizeof(SCIONExtension));
+    ext->type = PATH_PROBE;
+    ext->extClass = END_TO_END;
+    ext->data = malloc(5);
+    *(uint8_t *)ext->data = ack;
+    setProbeNum(ext, probeNum);
+    SCIONExtension *se = sh->extensions;
+    if (se == NULL) {
+        sh->extensions = ext;
+        ext->nextHeader = sch->nextHeader;
+        sch->nextHeader = ext->extClass;
+    } else {
+        while (se->nextExt != NULL)
+            se = se->nextExt;
+        se->nextExt = ext;
+        ext->nextHeader = se->nextHeader;
+        se->nextHeader = ext->extClass;
+    }
+    sh->numExtensions++;
+}
+
+uint8_t * packProbeExtension(SCIONExtension *ext, uint8_t *ptr)
+{
+    ptr = packSubheader(ext, ptr);
+    *ptr++ = *(uint8_t *)ext->data;
+    *(uint32_t *)ptr = htonl(getProbeNum(ext));
+    ptr += 4;
+    return ptr;
+}
+
+SCIONExtension * findProbeExtension(SCIONHeader *sh)
+{
+    SCIONExtension *ext = sh->extensions;
+    while (ext != NULL) {
+        if (ext->type == PATH_PROBE && ext->extClass == END_TO_END)
+            return ext;
+        ext = ext->nextExt;
+    }
+    return NULL;
+}

--- a/endhost/ssp/Extensions.h
+++ b/endhost/ssp/Extensions.h
@@ -1,0 +1,30 @@
+#ifndef EXTENSIONS_H
+#define EXTENSIONS_H
+
+#include "SCIONDefines.h"
+
+// Extensions
+#define SCION_EXT_LINE 8
+#define SCION_EXT_SUBHDR 3
+
+#define HOP_BY_HOP 0
+#define END_TO_END 222
+
+#define TRACEROUTE 0
+#define SIBRA 1
+
+#define PATH_TRANSPORT 0
+#define PATH_PROBE 1
+
+uint8_t * parseExtensions(SCIONHeader *sh, uint8_t *ptr);
+uint8_t * packSubheader(SCIONExtension *ext, uint8_t *ptr);
+uint8_t * packExtensions(SCIONHeader *sh, uint8_t *ptr);
+void addProbeExtension(SCIONHeader *sh, uint32_t probeNum, uint8_t ack);
+uint8_t * packProbeExtension(SCIONExtension *ext, uint8_t *ptr);
+SCIONExtension * findProbeExtension(SCIONHeader *sh);
+
+#define getProbeNum(ext) (*(uint32_t *)((uint8_t *)ext->data + 1))
+#define setProbeNum(ext, num) (*(uint32_t *)((uint8_t *)ext->data + 1) = htonl(num))
+#define getHeaderLen(ext) ((ext->headerLen + 1) * SCION_EXT_LINE)
+
+#endif

--- a/endhost/ssp/Makefile
+++ b/endhost/ssp/Makefile
@@ -8,7 +8,7 @@ SCIOND_DEP=ConnectionManager.cpp Utils.cpp
 CLIENT_OBJS=$(SCIOND_DEP:.cpp=._client.o)
 SERVER_OBJS=$(SCIOND_DEP:.cpp=._server.o)
 COMMON=SCIONSocket.cpp SCIONProtocol.cpp Path.cpp PathState.cpp\
-	   OrderedList.cpp SCIONWrapper.cpp
+	   OrderedList.cpp SCIONWrapper.cpp Extensions.cpp
 COMMON_OBJS=$(COMMON:.cpp=.o)
 SOCKET_OBJS=$(COMMON_OBJS) $(CLIENT_OBJS) $(SERVER_OBJS)
 CLIENT_LIB=libclient.so

--- a/endhost/ssp/Path.h
+++ b/endhost/ssp/Path.h
@@ -36,7 +36,7 @@ public:
     bool usesSameInterfaces(uint8_t *interfaces, size_t count);
     bool isSamePath(uint8_t *path, size_t len);
 
-    void copySCIONHeader(uint8_t *bufptr, SCIONCommonHeader *ch);
+    void copySCIONHeader(uint8_t *bufptr, SCIONHeader *sh);
 
     virtual void getStats(SCIONStats *stats);
 

--- a/endhost/ssp/SCIONDefines.h
+++ b/endhost/ssp/SCIONDefines.h
@@ -15,8 +15,13 @@
 #define SCION_UDP_EH_DATA_PORT 30041
 
 #define SCION_ADDR_LEN 8 // ISD + AD = 4, ADDR = 4
-#define SCION_PROTO_SUDP 151
+
+#define SCION_PROTO_ICMP 1
+#define SCION_PROTO_TCP 6
+#define SCION_PROTO_UDP 17
 #define SCION_PROTO_SSP 152
+#define SCION_PROTO_NONE 254
+#define SCION_PROTO_RES 255
 
 #define SCION_ISD_AD_LEN 4
 #define SCION_HOST_ADDR_LEN 4
@@ -87,12 +92,23 @@ typedef struct {
     uint8_t headerLen;
 } SCIONCommonHeader;
 
+typedef struct SCIONExtension {
+    uint8_t nextHeader;
+    uint8_t headerLen;
+    uint8_t type;
+    uint8_t extClass;
+    void *data;
+    struct SCIONExtension *nextExt;
+} SCIONExtension;
+
 typedef struct {
     SCIONCommonHeader commonHeader;
     uint8_t srcAddr[SCION_ADDR_LEN];
     uint8_t dstAddr[SCION_ADDR_LEN];
     uint8_t *path;
     size_t pathLen;
+    SCIONExtension *extensions;
+    size_t numExtensions;
 } SCIONHeader;
 
 #pragma pack(pop)

--- a/endhost/ssp/SCIONProtocol.h
+++ b/endhost/ssp/SCIONProtocol.h
@@ -57,7 +57,7 @@ protected:
 
     // dead path probing
     uint32_t               mProbeInterval;
-    uint64_t               mProbeNum;
+    uint32_t               mProbeNum;
     struct timeval         mLastProbeTime;
 
     pthread_t              mTimerThread;
@@ -99,7 +99,7 @@ protected:
     void getWindowSize();
     int getDeadlineFromProfile(DataProfile profile);
 
-    void handleProbe(SSPPacket *packet, int pathIndex);
+    void handleProbe(SCIONPacket *packet);
     void handleData(SSPPacket *packet, int pathIndex);
     void sendAck(SSPPacket *sip, int pathIndex, bool full=false);
 

--- a/endhost/ssp/SCIONSocket.h
+++ b/endhost/ssp/SCIONSocket.h
@@ -30,6 +30,7 @@ public:
     bool isListener();
     bool isRunning();
     int getDispatcherSocket();
+    bool bypassDispatcher();
 
     // wait for dispatcher registration
     void waitForRegistration();

--- a/endhost/ssp/SocketConfigs.h
+++ b/endhost/ssp/SocketConfigs.h
@@ -4,7 +4,7 @@
 // Build config
 
 //#define SIMULATOR // uncomment for WANem testing
-#define BYPASS_ROUTERS // send packets directly to remote end
+//#define BYPASS_ROUTERS // send packets directly to remote end
 
 #define DEBUG_MODE 0
 #if DEBUG_MODE

--- a/endhost/ssp/Utils.h
+++ b/endhost/ssp/Utils.h
@@ -43,4 +43,7 @@ uint64_t createRandom(int bits);
 int registerFlow(int proto, void *data, int sock, uint8_t reg);
 void destroyStats(SCIONStats *stats);
 
+int isL4(uint8_t type);
+uint16_t checksum(SCIONPacket *packet);
+
 #endif

--- a/endhost/ssp/test/server.cpp
+++ b/endhost/ssp/test/server.cpp
@@ -1,51 +1,25 @@
-#include <unistd.h>
 #include <string.h>
 #include <stdio.h>
 #include "SCIONSocket.h"
 
-#define BUFSIZE 10240
-
-void *sender(void *arg)
-{
-    printf("started sender thread\n");
-    uint8_t buf[BUFSIZE];
-    memset(buf, 0, BUFSIZE);
-    SCIONSocket *sock = (SCIONSocket *)arg;
-    int count = 0;
-    while (1) {
-        count++;
-        sprintf((char *)buf, "This is message %d\n", count);
-        sock->send(buf, BUFSIZE);
-        printf("server sent message on sock %p\n", sock);
-        usleep(50000);
-    }
-    return NULL;
-}
-
-void *receiver(void *arg)
-{
-    printf("started receiver thread\n");
-    uint8_t buf[BUFSIZE];
-    SCIONSocket *sock = (SCIONSocket *)arg;
-    while (1) {
-        sock->recv(buf, BUFSIZE, NULL);
-        printf("server received message on sock %p\n", sock);
-    }
-    return NULL;
-}
+#define BUFSIZE 1024
 
 int main()
 {
-    SCIONSocket s(SCION_PROTO_SSP, NULL, 0, 8080, 0);
+    SCIONSocket s(SCION_PROTO_UDP, NULL, 0, 8080, 0);
+    //SCIONSocket &newSocket = s.accept();
+    char buf[BUFSIZE];
+    int size = 0;
+    struct timeval start, end;
+    gettimeofday(&start, NULL);
     while (1) {
-        SCIONSocket *newSocket = s.accept();
-        printf("accepted socket\n");
-
-        pthread_t sendthread;
-        pthread_t recvthread;
-        pthread_create(&sendthread, NULL, sender, newSocket);
-        pthread_create(&recvthread, NULL, receiver, newSocket);
+        memset(buf, 0, BUFSIZE);
+        int recvlen = s.recv((uint8_t *)buf, BUFSIZE, NULL);
+        printf("received message: %s", buf);
+        gettimeofday(&end, NULL);
+        size += recvlen;
+        long us = end.tv_usec - start.tv_usec + (end.tv_sec - start.tv_sec) * 1000000;
+        fprintf(stderr, "%d bytes: %f bps\n", size, (double)size / us * 1000000);
     }
-
     exit(0);
 }

--- a/lib/packet/ext/path_probe.py
+++ b/lib/packet/ext/path_probe.py
@@ -1,0 +1,95 @@
+# Copyright 2016 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`path_probe` --- path_probe extension header
+=========================================================
+"""
+# Stdlib
+import struct
+
+# SCION
+from lib.packet.ext_hdr import EndToEndExtension
+from lib.types import ExtEndToEndType
+from lib.util import Raw
+
+
+class PathProbeExt(EndToEndExtension):
+    """
+    Packets with this extension act as probe packets to determine whether a
+    path that has previously failed is back up.
+    An extension with the IS_ACK field set to 1 and PROBE_ID matching the
+    value in the original probe packet confirms the path is alive.
+    0B       1        2        3        4        5        6        7
+    +--------+--------+--------+--------+--------+--------+--------+--------+
+    | xxxxxxxxxxxxxxxxxxxxxxxx | IS_ACK |              PROBE_ID             |
+    +--------+--------+--------+--------+--------+--------+--------+--------+
+    """
+    NAME = "PathProbe"
+    EXT_TYPE = ExtEndToEndType.PATH_PROBE
+    LEN = 5
+
+    def __init__(self, raw=None):
+        """
+        Initialize an instance of the class PathProbe
+
+        :param raw: Raw data containing IS_ACK and PROBE_ID
+        :type raw: bytes
+        """
+        super().__init__()
+        self.is_ack = False
+        self.probe_id = 0
+        if raw is not None:
+            self._parse(raw)
+
+    def _parse(self, raw):
+        """
+        Parse payload to extract values
+
+        :param raw: Raw payload
+        :type raw: bytes
+        """
+        super()._parse(raw)
+        data = Raw(raw, self.NAME, self.LEN)
+        self.is_ack = bool(data.pop(1))
+        self.probe_id = struct.unpack("!I", data.pop(4))[0]
+
+    @classmethod
+    def from_values(cls, is_ack, probe_id):
+        """
+        Create an instance of the class PathProbe from the provided values
+
+        :param is_ack: True if this packet is an ACK of a previous probe
+        :type is_ack: bool
+        :param probe_id: ID value to use for this probe packet
+        :type probe_id: int
+        """
+        inst = cls()
+        inst.is_ack = is_ack
+        inst.probe_id = probe_id
+        return inst
+
+    def pack(self):
+        """
+        Pack into byte string
+        """
+        raw = struct.pack("!BI", self.is_ack, self.probe_id)
+        self._check_len(raw)
+        return raw
+
+    def __str__(self):
+        """
+        Return string representation
+        """
+        return "%s(%dB):  ACK: %s Probe ID: %d" % (self.NAME, len(self),
+                                                   self.is_ack, self.probe_id)

--- a/lib/packet/ext_util.py
+++ b/lib/packet/ext_util.py
@@ -24,6 +24,7 @@ from lib.defines import L4_PROTOS
 from lib.errors import SCIONParseError
 from lib.packet.ext_hdr import ExtensionHeader
 from lib.packet.ext.path_transport import PathTransportExt
+from lib.packet.ext.path_probe import PathProbeExt
 from lib.packet.ext.sibra import SibraExt
 from lib.packet.ext.traceroute import TracerouteExt
 from lib.types import ExtensionClass, ExtEndToEndType, ExtHopByHopType
@@ -34,6 +35,7 @@ EXTENSION_MAP = {
     (ExtensionClass.HOP_BY_HOP, ExtHopByHopType.TRACEROUTE): TracerouteExt,
     (ExtensionClass.END_TO_END, ExtEndToEndType.PATH_TRANSPORT):
         PathTransportExt,
+    (ExtensionClass.END_TO_END, ExtEndToEndType.PATH_PROBE): PathProbeExt,
 }
 
 

--- a/lib/types.py
+++ b/lib/types.py
@@ -54,6 +54,7 @@ class ExtHopByHopType(TypeBase):
 
 class ExtEndToEndType(TypeBase):
     PATH_TRANSPORT = 0
+    PATH_PROBE = 1
 
 
 class OpaqueFieldType(TypeBase):


### PR DESCRIPTION
- Parse extensions in incoming packets
  - So far only type handled is probe packets
- New extension class for path probe packets
- Unify SUDP with UDP used in infrastructure
  - i.e. regular UDP with SCION addr in checksum
    <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51244537%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51244709%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51244782%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51244870%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51244978%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51245088%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51245135%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51245218%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23issuecomment-178627046%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51582319%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51582363%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51582403%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51582422%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51582486%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51582517%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51582547%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23issuecomment-178633322%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23issuecomment-178627046%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40kormat%20%40pszalach%20would%20appreciate%20another%20review%20on%20this%20%28rebased%2C%20comments%20addressed%29%22%2C%20%22created_at%22%3A%20%222016-02-02T15%3A15%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20python%20code%20LGTM%22%2C%20%22created_at%22%3A%20%222016-02-02T15%3A26%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20089221f0379fdb6becbda9badcc5a3d22b0bef2a%20lib/packet/ext/path_probe.py%2069%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51244709%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20typical%20method%20order%20in%20the%20codebase%20is%3A%5Cr%5Cn-%20%60__init__%28%29%60%5Cr%5Cn-%20%60_parse%28%29%60%5Cr%5Cn-%20%60from_values%28%29%60%5Cr%5Cn-%20%60pack%28%29%60%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A16%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-02T15%3A23%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/ext/path_probe.py%3AL1-102%22%7D%2C%20%22Pull%20089221f0379fdb6becbda9badcc5a3d22b0bef2a%20lib/packet/ext/path_probe.py%2077%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51244870%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20go%20before%20the%20Raw%28%29%20call%2C%20%60ExtensionHeader._parse%60%20expects%20raw%20bytes%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A18%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-02T15%3A24%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/ext/path_probe.py%3AL1-102%22%7D%2C%20%22Pull%20089221f0379fdb6becbda9badcc5a3d22b0bef2a%20lib/packet/ext/path_probe.py%2078%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51244978%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60is_ack%60%20is%20initalized%20in%20%60__init__%60%20as%20a%20boolean%2C%20so%20it%27s%20probably%20good%20to%20add%20a%20%60bool%28%29%60%20around%20the%20%60data.pop%60%2C%20to%20keep%20the%20type%20consistent.%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A19%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-02T15%3A24%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/ext/path_probe.py%3AL1-102%22%7D%2C%20%22Pull%20089221f0379fdb6becbda9badcc5a3d22b0bef2a%20lib/packet/ext/path_probe.py%2076%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51244782%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20don%27t%20need%20to%20specify%20%60min_%3DFalse%60%2C%20as%20that%27s%20the%20default.%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A17%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-02T15%3A24%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/ext/path_probe.py%3AL1-102%22%7D%2C%20%22Pull%20089221f0379fdb6becbda9badcc5a3d22b0bef2a%20lib/packet/ext/path_probe.py%2087%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51245088%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20you%27re%20doing%20all%20the%20packing%20in%20a%20single%20step%2C%20you%20don%27t%20need%20to%20go%20via%20an%20array%20for%20this.%5Cr%5Cn%5Cr%5Cn%60raw%20%3D%20struct.pack%28...%29%60%20is%20sufficient.%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A20%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-02T15%3A24%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/ext/path_probe.py%3AL1-102%22%7D%2C%20%22Pull%20089221f0379fdb6becbda9badcc5a3d22b0bef2a%20lib/packet/ext/path_probe.py%20100%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51245135%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22if%20%60is_ack%60%20is%20a%20boolean%2C%20then%20you%20can%20just%20use%20%60self.is_ack%60%20here.%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A21%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22and%20actually%20the%20method%20could%20be%20a%20single%20line%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A22%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-02T15%3A24%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/ext/path_probe.py%3AL1-102%22%7D%2C%20%22Pull%20089221f0379fdb6becbda9badcc5a3d22b0bef2a%20lib/packet/ext/path_probe.py%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/599%23discussion_r51244537%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%222016%3F%22%2C%20%22created_at%22%3A%20%222016-01-29T10%3A14%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-02T15%3A23%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/ext/path_probe.py%3AL1-102%22%7D%7D%7D'></a>
    <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/599#issuecomment-178627046'>General Comment</a></b>
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> @kormat @pszalach would appreciate another review on this (rebased, comments addressed)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The python code LGTM
- [x] <a href='#crh-comment-Pull 089221f0379fdb6becbda9badcc5a3d22b0bef2a lib/packet/ext/path_probe.py 1'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/599#discussion_r51244537'>File: lib/packet/ext/path_probe.py:L1-102</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> 2016?
- [x] <a href='#crh-comment-Pull 089221f0379fdb6becbda9badcc5a3d22b0bef2a lib/packet/ext/path_probe.py 69'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/599#discussion_r51244709'>File: lib/packet/ext/path_probe.py:L1-102</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The typical method order in the codebase is:
- `__init__()`
- `_parse()`
- `from_values()`
- `pack()`
- [x] <a href='#crh-comment-Pull 089221f0379fdb6becbda9badcc5a3d22b0bef2a lib/packet/ext/path_probe.py 76'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/599#discussion_r51244782'>File: lib/packet/ext/path_probe.py:L1-102</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You don't need to specify `min_=False`, as that's the default.
- [x] <a href='#crh-comment-Pull 089221f0379fdb6becbda9badcc5a3d22b0bef2a lib/packet/ext/path_probe.py 77'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/599#discussion_r51244870'>File: lib/packet/ext/path_probe.py:L1-102</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This should go before the Raw() call, `ExtensionHeader._parse` expects raw bytes
- [x] <a href='#crh-comment-Pull 089221f0379fdb6becbda9badcc5a3d22b0bef2a lib/packet/ext/path_probe.py 78'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/599#discussion_r51244978'>File: lib/packet/ext/path_probe.py:L1-102</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `is_ack` is initalized in `__init__` as a boolean, so it's probably good to add a `bool()` around the `data.pop`, to keep the type consistent.
- [x] <a href='#crh-comment-Pull 089221f0379fdb6becbda9badcc5a3d22b0bef2a lib/packet/ext/path_probe.py 87'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/599#discussion_r51245088'>File: lib/packet/ext/path_probe.py:L1-102</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> As you're doing all the packing in a single step, you don't need to go via an array for this.
  `raw = struct.pack(...)` is sufficient.
- [x] <a href='#crh-comment-Pull 089221f0379fdb6becbda9badcc5a3d22b0bef2a lib/packet/ext/path_probe.py 100'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/599#discussion_r51245135'>File: lib/packet/ext/path_probe.py:L1-102</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> if `is_ack` is a boolean, then you can just use `self.is_ack` here.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> and actually the method could be a single line

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/599?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/599?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/599'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
