### PR TITLE
Initial version of the SCION-socket knowledge-base lookup service.

### DIFF
--- a/endhost/scion_proxy.py
+++ b/endhost/scion_proxy.py
@@ -485,8 +485,12 @@ def main():
     if args.scion:
         logging.info("SCION-socket mode is on.")
         if args.kbase:
-            logging.info("SCION-socket knowledge-base is enabled.")
-            kbase = SocketKnowledgeBase()
+            if args.forward:
+                logging.info("SCION-socket knowledge-base is enabled.")
+                kbase = SocketKnowledgeBase()
+            else:
+                logging.info("SCION-socket knowledge-base is supported "
+                             "only in forwarding mode.")
 
     if args.scion and not args.forward:
         logging.info("Starting the server with SCION multi-path socket.")

--- a/endhost/scion_socket.py
+++ b/endhost/scion_socket.py
@@ -76,35 +76,49 @@ class ScionStats(object):
         :type: C_SCIONStats
         """
         self.exists = list(stats.exists)
-        self.receivedPackets = list(stats.receivedPackets)
-        self.sentPackets = list(stats.sentPackets)
-        self.ackedPackets = list(stats.ackedPackets)
+        self.received_packets = list(stats.receivedPackets)
+        self.sent_packets = list(stats.sentPackets)
+        self.acked_packets = list(stats.ackedPackets)
         self.rtts = list(stats.rtts)
-        self.lossRates = list(stats.lossRates)
-        self.ifCounts = list(stats.ifCounts)
-        # TODO(ercanucan): Enable this stats later on as currently this
-        # piece of code occasionaly throws nil pointer exceptions.
-        # self.ifLists = []
-        # for i in range(MAX_PATHS):
-        #     iflist = []
-        #     if self.ifCounts[i]:
-        #         for j in range(self.ifCounts[i]):
-        #             iflist.append(copy.deepcopy(stats.ifLists[i][j]))
-        #     self.ifLists.append(iflist)
-        self.highestReceived = copy.deepcopy(stats.highestReceived)
-        self.highestAcked = copy.deepcopy(stats.highestAcked)
+        self.loss_rates = list(stats.lossRates)
+        self.if_counts = list(stats.ifCounts)
+        self.if_lists = []
+        for i in range(MAX_PATHS):
+            if_list = []
+            if self.if_counts[i]:
+                for j in range(self.if_counts[i]):
+                    if_list.append(copy.deepcopy(stats.ifLists[i][j]))
+            self.if_lists.append(if_list)
+        self.highest_received = copy.deepcopy(stats.highestReceived)
+        self.highest_acked = copy.deepcopy(stats.highestAcked)
 
     def __str__(self):
         """
         String representation of a ScionStats object.
+        :returns: The stats as a string.
+        :rtype: str
         """
         result = []
-        result.append("Sent Packets: " + str(self.sentPackets))
-        result.append("Received Packets: " + str(self.receivedPackets))
-        result.append("Acked Packets: " + str(self.ackedPackets))
+        result.append("Sent Packets: " + str(self.sent_packets))
+        result.append("Received Packets: " + str(self.received_packets))
+        result.append("Acked Packets: " + str(self.acked_packets))
         result.append("RTTs: " + str(self.rtts))
-        result.append("Loss-Rates: " + str(self.lossRates))
+        result.append("Loss-Rates: " + str(self.loss_rates))
         return "\n".join(result)
+
+    def to_dict(self):
+        """
+        Represents and returns the stats in the form of a dictionary.
+        :returns: The stats as a dictionary object.
+        :rtype: dict
+        """
+        result = {}
+        result["sent_packets"] = self.sent_packets
+        result["received_packets"] = self.received_packets
+        result["acked_packets"] = self.acked_packets
+        result["rtts"] = self.rtts
+        result["loss_rates"] = self.loss_rates
+        return result
 
 
 SHARED_LIB_LOCATION = os.path.join("endhost", "ssp")

--- a/test/integration/kbase_lookup_test.py
+++ b/test/integration/kbase_lookup_test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/python3
+# Copyright 2016 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+:mod:`kbase_lookup_test` --- A test-client to query SCION kbase.
+================================================================
+"""
+
+# Stdlib
+import json
+import logging
+import struct
+
+
+# SCION
+from lib.log import init_logging
+from lib.main import main_wrapper
+from lib.socket import UDPSocket
+from lib.types import AddrType
+from lib.util import handle_signals
+
+
+CLIENT_LOG_BASE = 'logs/scion_kbase_test_client'
+SERVER_ADDRESS = "127.0.0.1", 7777
+
+
+def main():
+    init_logging(CLIENT_LOG_BASE,
+                 file_level=logging.DEBUG, console_level=logging.DEBUG)
+    handle_signals()
+    run()
+
+
+def run():
+    """
+    Creates a sample request, sends it to the UDP server and
+    reads the response.
+    """
+    # Create a UDP socket
+    sock = UDPSocket(None, AddrType.IPV4)
+
+    req = {"version": "0.1",
+           "command": "CONNECT",
+           "res_name": "api.github.com:443"}
+
+    try:
+        req_json_bytes = json.dumps(req).encode('utf-8')
+        req_to_send = []
+        req_to_send.append(struct.pack("!I", len(req_json_bytes)))
+        req_to_send.append(req_json_bytes)
+
+        # Send the req length + request itself
+        logging.debug('Sending "%s"' % req_json_bytes)
+        sock.send(b''.join(req_to_send), SERVER_ADDRESS)
+
+        # Receive the response (length + response body)
+        logging.debug('Waiting to receive the response length')
+        data_raw, server = sock.recv()
+        logging.debug('Data = %s' % data_raw)
+        data_len = struct.unpack("!I", data_raw[0:4])[0]
+        logging.debug('Length of the response = %d' % data_len)
+
+        # Unpack the response itself
+        logging.debug('Response json')
+        logging.debug('Received "%s"' % data_raw[4:4+data_len])
+
+    finally:
+        logging.debug('Closing socket')
+        sock.close()
+
+if __name__ == "__main__":
+    main_wrapper(main)

--- a/test/integration/ssp_cli_srv_test.py
+++ b/test/integration/ssp_cli_srv_test.py
@@ -108,8 +108,8 @@ def client():
     stats = client_sock.getStats()
     if stats:
         logging.info("interfaces for path 0:")
-        for i in range(stats.ifCounts[0]):
-            ifinfo = stats.ifLists[0][i]
+        for i in range(stats.if_counts[0]):
+            ifinfo = stats.if_lists[0][i]
             logging.info("(%d, %d)%d", ifinfo.isd, ifinfo.ad, ifinfo.interface)
 
     logging.info("Client starts the receive protocol.")


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-176888426%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-178029423%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-178059283%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-178061138%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-178061908%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-178075884%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-178090908%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51532007%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51532151%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-178416151%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-178455669%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-178520006%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51561187%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51561331%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51561367%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51562360%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51562597%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51562706%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51562804%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-178596943%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51706368%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51708061%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-179338857%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-179358996%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-179423127%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-179520083%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51848944%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51849627%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-179839641%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-179876017%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51883176%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51883406%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51884101%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51884822%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51885251%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51885513%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51886573%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51887225%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51887744%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51888405%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-179911079%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51893522%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-179920790%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-179921345%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-176888426%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40mwfarb%20Here%20is%20the%20first%20version%20of%20Socket-knowledge%20base%20look-up%20service.%5Cr%5CnThere%20is%20still%20bits%20to%20clean-up%2C%20I%20will%20address%20them%20on%20Monday.%5Cr%5Cn%40aznair%20Also%2C%20feel%20free%20to%20have%20a%20look%20and%20let%20me%20know%20what%20you%20think%20of%20the%20general%20direction.%20Thanks%21%22%2C%20%22created_at%22%3A%20%222016-01-29T18%3A01%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mwfarb%20here%20is%20a%20slightly%20updated%20version.%20Modified%20the%20protocol%20so%20that%20it%20first%20sends%20the%20length%20of%20the%20JSON%20response%20and%20then%20sends%20the%20actual%20JSON%20object%20itself.%22%2C%20%22created_at%22%3A%20%222016-02-01T15%3A39%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22Trying%20some%20testing%20now.%20Is%20it%20sufficient%20to%20launch%20with%3A%20%60endhost/scion_proxy.py%20-k%60%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-02-01T16%3A35%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22you%20need%20to%20run%20two%20instances%20of%20the%20proxy%2C%20both%20with%20scion%20socket..%20one%20in%20bridge%20mode%20%28on%20port%208080%29%20with%20the%20following%20command%3A%5Cr%5Cnendhost/scion_proxy.py%20-f%20-s%20-k%5Cr%5Cnand%20the%20other%20one%20in%20normal%20mode%20and%20on%20a%20different%20port%3A%5Cr%5Cnendhost/scion_proxy.py%20-p%209090%20-s%20-k%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-02-01T16%3A40%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40pszalach%20could%20you%20also%20please%20have%20a%20look%20and%20possibly%20give%20me%20a%20feedback%20%28at%20least%20on%20the%20coding%20style%20etc.%29%3F%22%2C%20%22created_at%22%3A%20%222016-02-01T16%3A43%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22sure%2C%20tomorrow%20I%27ll%20review%20it.%5Cn%5CnOn%201%20February%202016%20at%2017%3A43%2C%20ercanucan%20%3Cnotifications%40github.com%3E%20wrote%3A%5Cn%5Cn%3E%20%40pszalach%20%3Chttps%3A//github.com/pszalach%3E%20could%20you%20also%20please%20have%20a%20look%5Cn%3E%20and%20possibly%20give%20me%20a%20feedback%20%28at%20least%20on%20the%20coding%20style%20etc.%29%3F%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-178061908%3E.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-02-01T17%3A16%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20Looks%20like%20I%20missed%20initializing%20something%20else%2C%20I%20received%20the%20same%20error%20on%20both%3A%20FileNotFoundError%3A%20%5BErrno%202%5D%20No%20such%20file%20or%20directory%3A%20%27/git/scion/logs/scion_proxy_forward.DEBUG%27%5Cr%5Cn%5Cr%5CnMaybe%20we%20can%20walk%20through%20it%20when%20we%20meet%20tomorrow.%22%2C%20%22created_at%22%3A%20%222016-02-01T17%3A43%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22otherwise%20lgtm%22%2C%20%22created_at%22%3A%20%222016-02-02T07%3A14%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mwfarb%20Looks%20like%20you%20need%20to%20either%20run%20./scion.sh%20topology%20or%20create%20the%20%5C%22logs%5C%22%20directory%20manually%5Cr%5Cn%40ercanucan%20The%20ideas%20seem%20fine%2C%20I%27ll%20leave%20syntax%20etc%20to%20other%20people%22%2C%20%22created_at%22%3A%20%222016-02-02T08%3A59%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40pszalach%20thanks%20for%20the%20review%2C%20addressed%20your%20comments..%20Also%20changed%20the%20coding%20style%20of%20some%20of%20the%20old%20code%20to%20python%20style%20%28except%20from%20the%20ones%20inside%20C_SCIONStats%20about%20which%20%40aznair%20said%20that%20they%20might%20need%20to%20be%20the%20same%20naming%20as%20the%20C%20version%29.%20%22%2C%20%22created_at%22%3A%20%222016-02-02T11%3A32%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aznair%20I%5Cu2019ll%20bet%20you%5Cu2019re%20right.%20I%20did%20a%20clean%20pull%20and%20forgot%20about%20the%20topology.%5Cn%5Cn%3E%20On%20Feb%202%2C%202016%2C%20at%203%3A59%20AM%2C%20Jason%20Lee%20%3Cnotifications%40github.com%3E%20wrote%3A%5Cn%3E%20%5Cn%3E%20%40mwfarb%20%3Chttps%3A//github.com/mwfarb%3E%20Looks%20like%20you%20need%20to%20either%20run%20./scion.sh%20topology%20or%20create%20the%20%5C%22logs%5C%22%20directory%20manually%5Cn%3E%20%40ercanucan%20%3Chttps%3A//github.com/ercanucan%3E%20The%20ideas%20seem%20fine%2C%20I%27ll%20leave%20syntax%20etc%20to%20other%20people%5Cn%3E%20%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-178455669%3E.%5Cn%3E%20%5Cn%5Cn%22%2C%20%22created_at%22%3A%20%222016-02-02T14%3A23%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20I%20tried%20to%20address%20all%20of%20your%20comments.%20I%27d%20be%20glad%20if%20you%20could%20have%20a%20look%20at%20it%20once%20more.%20Cheers%21%22%2C%20%22created_at%22%3A%20%222016-02-03T16%3A48%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20I%5Cu2019ll%20tray%20your%20latest.%20I%20was%20having%20trouble%20with%20the%20position%20of%20the%20server%20buffer%20reading%20differing%20between%20my%20test%20client%20and%20your%20test%20client%20yesterday%2C%20but%20this%20may%20fix%20it.%5Cn%5Cn%3E%20On%20Feb%203%2C%202016%2C%20at%2011%3A48%20AM%2C%20ercanucan%20%3Cnotifications%40github.com%3E%20wrote%3A%5Cn%3E%20%5Cn%3E%20%40kormat%20%3Chttps%3A//github.com/kormat%3E%20I%20tried%20to%20address%20all%20of%20your%20comments.%20I%27d%20be%20glad%20if%20you%20could%20have%20a%20look%20at%20it%20once%20more.%20Cheers%21%5Cn%3E%20%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-179338857%3E.%5Cn%3E%20%5Cn%5Cn%22%2C%20%22created_at%22%3A%20%222016-02-03T17%3A22%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20The%20difference%20is%20I%27m%20sending/receiving%20eash%20UDP%20request%20as%201%20datagram%20%20%28length%20%2B%20data%29%20and%20you%20are%20sending/receiving%20as%202%20separate%20datagrams%20%28length%2C%20data%29.%20What%20do%20you%20think%20of%20sending%201%20datagram%20per%20request%20so%20clients%20won%27t%20have%20to%20track%20race%20conditions%20for%20which%202%20datagrams%20should%20be%20paired%20toegther%3F%22%2C%20%22created_at%22%3A%20%222016-02-03T19%3A39%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mwfarb%20my%20last%20modification%20to%20the%20PR%20exactly%20does%20that%20%3A-%29%20Sending%201%20datagram%20for%20length%20%2B%20data.%22%2C%20%22created_at%22%3A%20%222016-02-03T23%3A02%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20could%20you%20please%20have%20a%20quick%20look%20now%3F%20i%20addressed%20your%20comment%20about%20improving%20exception%20handling.%22%2C%20%22created_at%22%3A%20%222016-02-04T13%3A33%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thank%20you%21%20I%20tested%20it%20yesterday%20soon%20after%20your%20commit.%20%3B-%29%5Cn%5Cn%3E%20On%20Feb%203%2C%202016%2C%20at%206%3A02%20PM%2C%20ercanucan%20%3Cnotifications%40github.com%3E%20wrote%3A%5Cn%3E%20%5Cn%3E%20%40mwfarb%20%3Chttps%3A//github.com/mwfarb%3E%20my%20last%20modification%20to%20the%20PR%20exactly%20does%20that%20%3A-%29%20Sending%201%20datagram%20for%20length%20%2B%20data.%5Cn%3E%20%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%20%3Chttps%3A//github.com/netsec-ethz/scion/pull/601%23issuecomment-179520083%3E.%5Cn%3E%20%5Cn%5Cn%22%2C%20%22created_at%22%3A%20%222016-02-04T14%3A42%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20addressed%20your%20comments..%20could%20you%20please%20do%20this%20%28hopefully%29%20one%20last%20iteration%3F%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-02-04T15%3A50%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%22%2C%20%22created_at%22%3A%20%222016-02-04T16%3A09%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thx%20%40kormat%20I%20will%20merge%20it%20when%20circleci%20finishes.%22%2C%20%22created_at%22%3A%20%222016-02-04T16%3A10%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20b9bb6353b8718d21ac8d47f135b13fe3fac8fc95%20endhost/kbase_lookup_service.py%20113%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51849627%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Having%20a%20large%20amount%20of%20code%20in%20a%20try/except%20block%20is%20really%20bad%20style%2C%20as%20is%20catching%20the%20generic%20Exception.%20try/except%20blocks%20should%20contain%20the%20minimum%20amount%20of%20code%2C%20and%20have%20the%20most%20specific%20exceptions%20possible.%5Cr%5CnIn%20this%20case%20you%20should%20have%20separate%20exception%20handling%20for%20receiving%20data%2C%20decoding%20it%2C%20encoding%20the%20resonse%2C%20and%20sending%20the%20response.%20This%20will%20add%20a%20fair%20bit%20of%20code%2C%20which%20is%20a%20good%20hint%20that%20you%20should%20break%20this%20up%20into%20smaller%20methods.%22%2C%20%22created_at%22%3A%20%222016-02-04T09%3A49%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/kbase_lookup_service.py%3AL1-115%22%7D%2C%20%22Pull%20ded13e61df98e0c2ee982fb22ff2a4fc4b24bee1%20endhost/scion_proxy.py%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51562360%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22No%20need%20for%20the%20%60%2B%60%22%2C%20%22created_at%22%3A%20%222016-02-02T12%3A37%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL485-497%22%7D%2C%20%22Pull%20b25866d5855400772b982d6be73507fefd34d4f4%20endhost/kbase_lookup_service.py%2083%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51885251%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20exception%20doesn%27t%20seem%20to%20match%20the%20contents%20of%20the%20try%20block.%20%5Cr%5Cn%5Cr%5Cnstruct.unpack%20won%27t%20raise%20an%20exception%20unless%20there%27s%20something%20wrong%20with%20the%20code%2C%20so%20i%20would%20move%20it%20outside%20the%20try%20block%20%28but%20if%20it%20did%20it%20wouldn%27t%20be%20a%20ValueError.%20It%20would%20either%20be%20a%20TypeError%20or%20https%3A//docs.python.org/3/library/struct.html%23struct.error%29.%5Cr%5Cn%5Cr%5Cnb%5C%22%5C%22.decode%20raises%20UnicodeDecodeError%5Cr%5Cn%5Cr%5Cnjson.loads%20raises%20JSONDecodeError%5Cr%5Cn%5Cr%5CnBoth%20of%20these%20last%20two%20are%20subclasses%20of%20ValueError%2C%20but%20it%27s%20much%20better%20to%20catch%20them%20explicitly%3A%5Cr%5Cn%60%60%60%5Cr%5Cnexcept%20%28UnicodeDecodeError%2C%20JSONDecodeError%29%20as%20e%3A%5Cr%5Cn%20%20%20logging.error%28%5C%22Error%20decoding%20request%3A%20%25s%5C%22%2C%20e%29%5Cr%5Cn%20%20%20return%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-02-04T15%3A12%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/kbase_lookup_service.py%3AL1-145%22%7D%2C%20%22Pull%20b25866d5855400772b982d6be73507fefd34d4f4%20endhost/kbase_lookup_service.py%2081%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51884822%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20UDP%20will%20deliver%20the%20entire%20request%20to%20you%20as%20a%20single%20block%2C%20the%20only%20reason%20for%20having%20a%20length%20is%20so%20you%20can%20confirm%20that%20it%20didn%27t%20get%20truncated.%20The%20best%20way%20to%20do%20that%20would%20be%3A%5Cr%5Cn%60%60%60%5Cr%5Cnif%20req_len%20%21%3D%20len%28req_raw%5B4%3A%5D%29%3A%20%5Cr%5Cn%20%20%20%23%20log%20an%20error%2C%20stop%20processing%20request%5Cr%5Cnreq_str%20%3D%20req_raw%28%5B4%3A%5D%29.decode%28%5C%22utf-8%5C%22%29%5Cr%5Cn%60%60%60%5Cr%5CnOtherwise%20you%20don%27t%20actually%20get%20any%20guarantees%20that%20you%20have%20all%20of%20the%20request.%20Using%20a%20slice%20that%27s%20longer%20than%20the%20array%20isn%27t%20an%20error.%22%2C%20%22created_at%22%3A%20%222016-02-04T15%3A10%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/kbase_lookup_service.py%3AL1-145%22%7D%2C%20%22Pull%206d226eb3c236928666d6e710a53a4c0f7306cce2%20endhost/scion_socket.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51532007%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20know%20this%20was%20merged%20before%2C%20but%20variable%20names%20are%20inconsistent...%20I%27d%20use%20%60if_lists%60%20etc...%22%2C%20%22created_at%22%3A%20%222016-02-02T07%3A10%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL82-103%22%7D%2C%20%22Pull%20b25866d5855400772b982d6be73507fefd34d4f4%20endhost/kbase_lookup_service.py%2080%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51883406%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22There%27s%20no%20need%20for%20the%200%2C%20%60%5B%3A4%5D%60%20is%20equivalent.%22%2C%20%22created_at%22%3A%20%222016-02-04T15%3A00%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/kbase_lookup_service.py%3AL1-145%22%7D%2C%20%22Pull%20051d861d6f121bef2778a105011277e7412576be%20endhost/kbase_lookup_service.py%20118%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51893522%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20would%20be%20good%20to%20log%20the%20actual%20exception%20here%2C%20so%20you%20can%20tell%20what%20happened.%22%2C%20%22created_at%22%3A%20%222016-02-04T16%3A04%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/kbase_lookup_service.py%3AL1-152%22%7D%2C%20%22Pull%20b25866d5855400772b982d6be73507fefd34d4f4%20endhost/kbase_lookup_service.py%2078%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51883176%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20there%20was%20a%20problem%20receiving%20data%2C%20then%20the%20socket%20is%20dead%2C%20so%20the%20loop%20in%20_run%28%29%20should%20exit.%20The%20simplest%20thing%20to%20do%20would%20be%20to%20raise%20an%20exception%20in%20_recv_data%28%29%2C%20and%20catch%20it%20in%20_run%28%29.%22%2C%20%22created_at%22%3A%20%222016-02-04T14%3A58%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Should%20we%20always%20assume%20that%20socket%20is%20totally%20dead%3F%20It%20may%20be%20an%20intermittent%20exception%20from%20socket%2C%20don%27t%20you%20think%20so%3F%22%2C%20%22created_at%22%3A%20%222016-02-04T15%3A04%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20you%20look%20at%20socket%282%29%2C%20the%20only%20errors%20that%20aren%27t%20fatal%20are%20EAGAIN/EWOULDBLOCK%2C%20which%20only%20applies%20if%20you%27re%20using%20non-blocking%20sockets%2C%20and%20EINTR%2C%20which%20should%20really%20be%20handled%20by%20UDPSocket.recv.%22%2C%20%22created_at%22%3A%20%222016-02-04T15%3A21%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ah%20okay.%20So%20I%20do%20this%20now%20inside%20%60_serve_query%60%5Cr%5Cn%20%20%20%20%20%20%20%20%60if%20req_raw%20is%20None%20or%20addr%20is%20None%3A%60%5Cr%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%60raise%20OSError%28%27Socket%20is%20dead%27%29%60%5Cr%5Cn%5Cr%5Cnand%20catch%20it%20up%20in%20_run%28%29..%20%5Cr%5Cnwhat%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222016-02-04T15%3A25%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22or%20you%20think%20its%20better%20practice%20to%20just%20raise%20the%20exception%20directly%20inside%20the%20_recv_data%28%29%20and%20catch%20it%20only%20in%20the%20_run%28%29%20method%3F%22%2C%20%22created_at%22%3A%20%222016-02-04T15%3A29%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20makes%20the%20most%20sense%20in%20this%20case.%20You%27re%20not%20doing%20anything%20with%20the%20information%20in%20_serve_query.%22%2C%20%22created_at%22%3A%20%222016-02-04T15%3A32%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/kbase_lookup_service.py%3AL1-145%22%7D%2C%20%22Pull%20b25866d5855400772b982d6be73507fefd34d4f4%20endhost/kbase_lookup_service.py%20144%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51885513%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20also%20terminate%20the%20_run%28%29%20loop%22%2C%20%22created_at%22%3A%20%222016-02-04T15%3A14%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/kbase_lookup_service.py%3AL1-145%22%7D%2C%20%22Pull%20ded13e61df98e0c2ee982fb22ff2a4fc4b24bee1%20endhost/scion_socket.py%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51562597%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22The%20string%20class%20in%20python%20is%20%60str%60.%22%2C%20%22created_at%22%3A%20%222016-02-02T12%3A39%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL76-126%22%7D%2C%20%22Pull%20ded13e61df98e0c2ee982fb22ff2a4fc4b24bee1%20endhost/socket_kbase.py%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51562706%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20mutating%20global%20variables%3F%22%2C%20%22created_at%22%3A%20%222016-02-02T12%3A41%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/socket_kbase.py%3AL24-36%22%7D%2C%20%22Pull%20ded13e61df98e0c2ee982fb22ff2a4fc4b24bee1%20endhost/kbase_lookup_service.py%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51562804%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20there%20a%20reason%20not%20to%20use%20%60lib.socket%60%20for%20socket%20handling%3F%22%2C%20%22created_at%22%3A%20%222016-02-02T12%3A42%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/kbase_lookup_service.py%3AL1-130%22%7D%2C%20%22Pull%20ded13e61df98e0c2ee982fb22ff2a4fc4b24bee1%20endhost/kbase_lookup_service.py%20122%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51561187%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20looks%20problematic.%20recvfrom%20may%20discard%20excess%20bytes%20if%20the%20packet%20is%20bigger%20than%20the%20requested%20length.%22%2C%20%22created_at%22%3A%20%222016-02-02T12%3A24%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22http%3A//stackoverflow.com/a/675821%22%2C%20%22created_at%22%3A%20%222016-02-02T12%3A25%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22DGRAM%20sockets%20require%20different%20semantics%20than%20STREAM%20sockets%22%2C%20%22created_at%22%3A%20%222016-02-02T12%3A25%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20for%20the%20review%20and%20pointing%20this%20out%20%40kormat%21%20It%20did%20not%20exhibit%20a%20problem%20so%20far%20while%20I%20was%20testing.%20However%20I%20will%20change%20it%20a%20bit%20and%20assume%20a%20max%20message%20size%20and%20read%20the%20data%20all%20at%20once.%20What%20do%20you%20think%3F%20%28This%20assumption%20should%20work%20for%20us%20at%20our%20current%20state%20of%20socket%20stats%20knowledge-base%29.%20%22%2C%20%22created_at%22%3A%20%222016-02-03T10%3A57%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20should%20always%20read%20a%20max-sized%20amount%20from%20a%20UDP%20socket%2C%20which%20is%2065535%20bytes%20%28technically%20the%20max%20size%20with%20UDP/IP%20is%20about%2060bytes%20smaller%2C%20but%20you%20can%20be%20guaranteed%20that%2065535%20will%20always%20be%20big%20enough%29.%20You%20can%20then%20parse%20the%20data%20at%20will.%22%2C%20%22created_at%22%3A%20%222016-02-03T11%3A16%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/kbase_lookup_service.py%3AL1-130%22%7D%2C%20%22Pull%206d226eb3c236928666d6e710a53a4c0f7306cce2%20endhost/kbase_lookup_service.py%2032%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51532151%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60SERVER_ADDRESS%20%3D%20%5C%22127.0.0.1%5C%22%2C%207777%60%20%3F%22%2C%20%22created_at%22%3A%20%222016-02-02T07%3A12%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/kbase_lookup_service.py%3AL1-132%22%7D%2C%20%22Pull%20b9bb6353b8718d21ac8d47f135b13fe3fac8fc95%20endhost/kbase_lookup_service.py%2051%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/601%23discussion_r51848944%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20can%20be%20simplified%20to%3A%5Cr%5Cn%60%60%60%5Cr%5Cnself.sock%20%3D%20UDPSocket%28SERVER_ADDRESS%2C%20AddrType.IPV4%29%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-02-04T09%3A44%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/kbase_lookup_service.py%3AL1-115%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#issuecomment-176888426'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @mwfarb Here is the first version of Socket-knowledge base look-up service.
  There is still bits to clean-up, I will address them on Monday.
  @aznair Also, feel free to have a look and let me know what you think of the general direction. Thanks!
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @mwfarb here is a slightly updated version. Modified the protocol so that it first sends the length of the JSON response and then sends the actual JSON object itself.
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> Trying some testing now. Is it sufficient to launch with: `endhost/scion_proxy.py -k`?
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> you need to run two instances of the proxy, both with scion socket.. one in bridge mode (on port 8080) with the following command:
  endhost/scion_proxy.py -f -s -k
  and the other one in normal mode and on a different port:
  endhost/scion_proxy.py -p 9090 -s -k
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @pszalach could you also please have a look and possibly give me a feedback (at least on the coding style etc.)?
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> sure, tomorrow I'll review it.
  On 1 February 2016 at 17:43, ercanucan notifications@github.com wrote:
  > @pszalach https://github.com/pszalach could you also please have a look
  > and possibly give me a feedback (at least on the coding style etc.)?
  >
  > —
  > Reply to this email directly or view it on GitHub
  > https://github.com/netsec-ethz/scion/pull/601#issuecomment-178061908.
  >
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @ercanucan Looks like I missed initializing something else, I received the same error on both: FileNotFoundError: [Errno 2] No such file or directory: '/git/scion/logs/scion_proxy_forward.DEBUG'
  Maybe we can walk through it when we meet tomorrow.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> otherwise lgtm
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> @mwfarb Looks like you need to either run ./scion.sh topology or create the "logs" directory manually
  @ercanucan The ideas seem fine, I'll leave syntax etc to other people
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @pszalach thanks for the review, addressed your comments.. Also changed the coding style of some of the old code to python style (except from the ones inside C_SCIONStats about which @aznair said that they might need to be the same naming as the C version).
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @aznair I’ll bet you’re right. I did a clean pull and forgot about the topology.
  > On Feb 2, 2016, at 3:59 AM, Jason Lee notifications@github.com wrote:
  >
  > @mwfarb https://github.com/mwfarb Looks like you need to either run ./scion.sh topology or create the "logs" directory manually
  > @ercanucan https://github.com/ercanucan The ideas seem fine, I'll leave syntax etc to other people
  >
  > —
  > Reply to this email directly or view it on GitHub https://github.com/netsec-ethz/scion/pull/601#issuecomment-178455669.
  >
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat I tried to address all of your comments. I'd be glad if you could have a look at it once more. Cheers!
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @ercanucan I’ll tray your latest. I was having trouble with the position of the server buffer reading differing between my test client and your test client yesterday, but this may fix it.
  > On Feb 3, 2016, at 11:48 AM, ercanucan notifications@github.com wrote:
  >
  > @kormat https://github.com/kormat I tried to address all of your comments. I'd be glad if you could have a look at it once more. Cheers!
  >
  > —
  > Reply to this email directly or view it on GitHub https://github.com/netsec-ethz/scion/pull/601#issuecomment-179338857.
  >
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @ercanucan The difference is I'm sending/receiving eash UDP request as 1 datagram  (length + data) and you are sending/receiving as 2 separate datagrams (length, data). What do you think of sending 1 datagram per request so clients won't have to track race conditions for which 2 datagrams should be paired toegther?
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @mwfarb my last modification to the PR exactly does that :-) Sending 1 datagram for length + data.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat could you please have a quick look now? i addressed your comment about improving exception handling.
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> Thank you! I tested it yesterday soon after your commit. ;-)
  > On Feb 3, 2016, at 6:02 PM, ercanucan notifications@github.com wrote:
  >
  > @mwfarb https://github.com/mwfarb my last modification to the PR exactly does that :-) Sending 1 datagram for length + data.
  >
  > —
  > Reply to this email directly or view it on GitHub https://github.com/netsec-ethz/scion/pull/601#issuecomment-179520083.
  >
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat addressed your comments.. could you please do this (hopefully) one last iteration? :)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Thx @kormat I will merge it when circleci finishes.
- [ ] <a href='#crh-comment-Pull 6d226eb3c236928666d6e710a53a4c0f7306cce2 endhost/scion_socket.py 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51532007'>File: endhost/scion_socket.py:L82-103</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> I know this was merged before, but variable names are inconsistent... I'd use `if_lists` etc...
- [ ] <a href='#crh-comment-Pull 6d226eb3c236928666d6e710a53a4c0f7306cce2 endhost/kbase_lookup_service.py 32'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51532151'>File: endhost/kbase_lookup_service.py:L1-132</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> `SERVER_ADDRESS = "127.0.0.1", 7777` ?
- [ ] <a href='#crh-comment-Pull ded13e61df98e0c2ee982fb22ff2a4fc4b24bee1 endhost/kbase_lookup_service.py 122'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51561187'>File: endhost/kbase_lookup_service.py:L1-130</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This looks problematic. recvfrom may discard excess bytes if the packet is bigger than the requested length.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> http://stackoverflow.com/a/675821
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> DGRAM sockets require different semantics than STREAM sockets
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Thanks for the review and pointing this out @kormat! It did not exhibit a problem so far while I was testing. However I will change it a bit and assume a max message size and read the data all at once. What do you think? (This assumption should work for us at our current state of socket stats knowledge-base).
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You should always read a max-sized amount from a UDP socket, which is 65535 bytes (technically the max size with UDP/IP is about 60bytes smaller, but you can be guaranteed that 65535 will always be big enough). You can then parse the data at will.
- [ ] <a href='#crh-comment-Pull ded13e61df98e0c2ee982fb22ff2a4fc4b24bee1 endhost/scion_proxy.py 10'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51562360'>File: endhost/scion_proxy.py:L485-497</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> No need for the `+`
- [ ] <a href='#crh-comment-Pull ded13e61df98e0c2ee982fb22ff2a4fc4b24bee1 endhost/scion_socket.py 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51562597'>File: endhost/scion_socket.py:L76-126</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The string class in python is `str`.
- [ ] <a href='#crh-comment-Pull ded13e61df98e0c2ee982fb22ff2a4fc4b24bee1 endhost/socket_kbase.py 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51562706'>File: endhost/socket_kbase.py:L24-36</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Why mutating global variables?
- [ ] <a href='#crh-comment-Pull ded13e61df98e0c2ee982fb22ff2a4fc4b24bee1 endhost/kbase_lookup_service.py 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51562804'>File: endhost/kbase_lookup_service.py:L1-130</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Is there a reason not to use `lib.socket` for socket handling?
- [ ] <a href='#crh-comment-Pull b9bb6353b8718d21ac8d47f135b13fe3fac8fc95 endhost/kbase_lookup_service.py 51'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51848944'>File: endhost/kbase_lookup_service.py:L1-115</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This can be simplified to:

```
self.sock = UDPSocket(SERVER_ADDRESS, AddrType.IPV4)
```
- [ ] <a href='#crh-comment-Pull b9bb6353b8718d21ac8d47f135b13fe3fac8fc95 endhost/kbase_lookup_service.py 113'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51849627'>File: endhost/kbase_lookup_service.py:L1-115</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Having a large amount of code in a try/except block is really bad style, as is catching the generic Exception. try/except blocks should contain the minimum amount of code, and have the most specific exceptions possible.
  In this case you should have separate exception handling for receiving data, decoding it, encoding the resonse, and sending the response. This will add a fair bit of code, which is a good hint that you should break this up into smaller methods.
- [ ] <a href='#crh-comment-Pull b25866d5855400772b982d6be73507fefd34d4f4 endhost/kbase_lookup_service.py 78'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51883176'>File: endhost/kbase_lookup_service.py:L1-145</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> If there was a problem receiving data, then the socket is dead, so the loop in _run() should exit. The simplest thing to do would be to raise an exception in _recv_data(), and catch it in _run().
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Should we always assume that socket is totally dead? It may be an intermittent exception from socket, don't you think so?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> If you look at socket(2), the only errors that aren't fatal are EAGAIN/EWOULDBLOCK, which only applies if you're using non-blocking sockets, and EINTR, which should really be handled by UDPSocket.recv.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Ah okay. So I do this now inside `_serve_query`
  `if req_raw is None or addr is None:`
  `raise OSError('Socket is dead')`
  and catch it up in _run()..
  what do you think?
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> or you think its better practice to just raise the exception directly inside the _recv_data() and catch it only in the _run() method?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> That makes the most sense in this case. You're not doing anything with the information in _serve_query.
- [ ] <a href='#crh-comment-Pull b25866d5855400772b982d6be73507fefd34d4f4 endhost/kbase_lookup_service.py 80'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51883406'>File: endhost/kbase_lookup_service.py:L1-145</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> There's no need for the 0, `[:4]` is equivalent.
- [ ] <a href='#crh-comment-Pull b25866d5855400772b982d6be73507fefd34d4f4 endhost/kbase_lookup_service.py 81'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51884822'>File: endhost/kbase_lookup_service.py:L1-145</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> As UDP will deliver the entire request to you as a single block, the only reason for having a length is so you can confirm that it didn't get truncated. The best way to do that would be:

```
if req_len != len(req_raw[4:]):
# log an error, stop processing request
req_str = req_raw([4:]).decode("utf-8")
```

Otherwise you don't actually get any guarantees that you have all of the request. Using a slice that's longer than the array isn't an error.
- [ ] <a href='#crh-comment-Pull b25866d5855400772b982d6be73507fefd34d4f4 endhost/kbase_lookup_service.py 83'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51885251'>File: endhost/kbase_lookup_service.py:L1-145</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This exception doesn't seem to match the contents of the try block.
  struct.unpack won't raise an exception unless there's something wrong with the code, so i would move it outside the try block (but if it did it wouldn't be a ValueError. It would either be a TypeError or https://docs.python.org/3/library/struct.html#struct.error).
  b"".decode raises UnicodeDecodeError
  json.loads raises JSONDecodeError
  Both of these last two are subclasses of ValueError, but it's much better to catch them explicitly:

```
except (UnicodeDecodeError, JSONDecodeError) as e:
logging.error("Error decoding request: %s", e)
return
```
- [ ] <a href='#crh-comment-Pull b25866d5855400772b982d6be73507fefd34d4f4 endhost/kbase_lookup_service.py 144'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51885513'>File: endhost/kbase_lookup_service.py:L1-145</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This should also terminate the _run() loop
- [ ] <a href='#crh-comment-Pull 051d861d6f121bef2778a105011277e7412576be endhost/kbase_lookup_service.py 118'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/601#discussion_r51893522'>File: endhost/kbase_lookup_service.py:L1-152</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It would be good to log the actual exception here, so you can tell what happened.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/601?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/601?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/601'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
