### PR TITLE
Handle payload length more consistently.

### DIFF
--- a/lib/packet/scion.py
+++ b/lib/packet/scion.py
@@ -350,7 +350,7 @@ class SCIONBasePacket(PacketBase):
         return b""
 
     def _pack_payload(self):  # pragma: no cover
-        return self._payload.pack()
+        return self._payload.pack_full()
 
     def update(self):
         self.addrs.update()
@@ -367,7 +367,7 @@ class SCIONBasePacket(PacketBase):
         hdr.next_hdr = self._get_next_hdr()
 
     def _get_offset_len(self):  # pragma: no cover
-        return len(self._payload)
+        return self._payload.total_len()
 
     def _get_next_hdr(self):  # pragma: no cover
         return self._l4_proto
@@ -516,9 +516,6 @@ class SCIONL4Packet(SCIONExtPacket):
             packed.append(self.l4_hdr.pack())
         return b"".join(packed)
 
-    def _pack_payload(self):  # pragma: no cover
-        return self._payload.pack_full()
-
     def update(self):
         if self.l4_hdr:
             self.l4_hdr.update(
@@ -552,7 +549,6 @@ class SCIONL4Packet(SCIONExtPacket):
         l = super()._get_offset_len()
         if self.l4_hdr:
             l += len(self.l4_hdr)
-            l += self._payload.METADATA_LEN
         return l
 
     def _inner_str(self):  # pragma: no cover

--- a/test/lib/packet/scion_test.py
+++ b/test/lib/packet/scion_test.py
@@ -630,8 +630,8 @@ class TestSCIONBasePacketPack(object):
         inst.path.pack.return_value = b"path"
         inst._inner_pack = create_mock()
         inst._inner_pack.return_value = b"inner pack"
-        inst._payload = create_mock(["pack"])
-        inst._payload.pack.return_value = b"payload"
+        inst._payload = create_mock(["pack_full"])
+        inst._payload.pack_full.return_value = b"payload"
         expected = b"cmn hdr" b"addrs" b"path" b"inner pack" b"payload"
         inst.cmn_hdr.total_len = len(expected)
         # Call
@@ -1065,11 +1065,9 @@ class TestSCIONL4PacketGetOffsetLen(object):
         inst = SCIONL4Packet()
         inst.l4_hdr = create_mock(["__len__"])
         inst.l4_hdr.__len__.return_value = 12
-        inst._payload = create_mock(["METADATA_LEN"])
-        inst._payload.METADATA_LEN = 2
         super_offset.return_value = 42
         # Call
-        ntools.eq_(inst._get_offset_len(), 56)
+        ntools.eq_(inst._get_offset_len(), 54)
 
 
 class TestIFIDPayloadInit(object):


### PR DESCRIPTION
payload.pack() and len(payload) both ignore the leading metadata (2
bytes in the case of scion control packets). payload.pack_full() and
payload.total_len() take the metadata into account. This change makes
usage consistent.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/605?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/605'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
