### PR TITLE
Handle syscall interruption in recvfrom

### DIFF
--- a/lib/socket.py
+++ b/lib/socket.py
@@ -108,7 +108,11 @@ class UDPSocket(object):
         flags = 0
         if not block:
             flags = MSG_DONTWAIT
-        return self.sock.recvfrom(SCION_BUFLEN, flags)
+        while True:
+            try:
+                return self.sock.recvfrom(SCION_BUFLEN, flags)
+            except InterruptedError:
+                pass
 
     def close(self):
         """

--- a/test/lib/socket_test.py
+++ b/test/lib/socket_test.py
@@ -133,7 +133,7 @@ class TestUDPSocketRecv(object):
         inst = UDPSocket()
         inst.sock = create_mock(["recvfrom"])
         # Call
-        inst.recv()
+        ntools.eq_(inst.recv(), inst.sock.recvfrom.return_value)
         # Tests
         inst.sock.recvfrom.assert_called_once_with(SCION_BUFLEN, 0)
 
@@ -146,6 +146,17 @@ class TestUDPSocketRecv(object):
         # Tests
         inst.sock.recvfrom.assert_called_once_with(SCION_BUFLEN,
                                                    socket.MSG_DONTWAIT)
+
+    @patch("lib.socket.UDPSocket.__init__", autopatch=True, return_value=None)
+    def test_intr(self, init):
+        inst = UDPSocket()
+        inst.sock = create_mock(["recvfrom"])
+        inst.sock.recvfrom.side_effect = (
+            InterruptedError, InterruptedError, "data")
+        # Call
+        ntools.eq_(inst.recv(), "data")
+        # Tests
+        ntools.eq_(inst.sock.recvfrom.call_count, 3)
 
 
 class TestUDPSocketClose(object):


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/609%23issuecomment-179903910%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/609%23issuecomment-182336028%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/609%23discussion_r52439746%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/609%23discussion_r52441192%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/609%23discussion_r52448368%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/609%23issuecomment-179903910%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40shitz%20%3B%29%22%2C%20%22created_at%22%3A%20%222016-02-04T15%3A36%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222016-02-10T12%3A02%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206ee1d14afada6c33cd0752f77493e723fd88e487%20lib/socket.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/609%23discussion_r52439746%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22http%3A//stackoverflow.com/a/13438650%20suggests%20that%20we%20could%20just%20pass%20%60SA_RESTART%60%20to%20%60recvfrom%60%20and%20get%20this%20functionality%20for%20free%20without%20using%20this%20ugly%20loop.%22%2C%20%22created_at%22%3A%20%222016-02-10T10%3A30%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%27s%20not%20quite%20what%20it%20says%2C%20it%20says%20the%20flag%20has%20to%20be%20set%20when%20setting%20up%20the%20signal%20handler.%20Python%20doesn%27t%20support%20this.%20See%20https%3A//www.python.org/dev/peps/pep-0475/%23rationale%20for%20details%2C%20and%20https%3A//www.python.org/dev/peps/pep-0475/%23status-in-python-3-4%20in%20particular%20for%20the%20way%20this%20is%20handled%20in%20python%203.4%20%28which%20is%20identical%20to%20the%20code%20here%29.%22%2C%20%22created_at%22%3A%20%222016-02-10T10%3A43%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20see.%20So%20switching%20to%20Python%203.5%20would%20solve%20the%20problem%20%3B%29%20In%20that%20case%20LGTM%22%2C%20%22created_at%22%3A%20%222016-02-10T12%3A02%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/socket.py%3AL108-119%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/shitz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/shitz'><img src='https://avatars.githubusercontent.com/u/3840858?v=3' width=34 height=34></a>
- [ ] <a href='#crh-comment-Pull 6ee1d14afada6c33cd0752f77493e723fd88e487 lib/socket.py 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/609#discussion_r52439746'>File: lib/socket.py:L108-119</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> http://stackoverflow.com/a/13438650 suggests that we could just pass `SA_RESTART` to `recvfrom` and get this functionality for free without using this ugly loop.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> That's not quite what it says, it says the flag has to be set when setting up the signal handler. Python doesn't support this. See https://www.python.org/dev/peps/pep-0475/#rationale for details, and https://www.python.org/dev/peps/pep-0475/#status-in-python-3-4 in particular for the way this is handled in python 3.4 (which is identical to the code here).
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> I see. So switching to Python 3.5 would solve the problem ;) In that case LGTM
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/609#issuecomment-179903910'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @shitz ;)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/609?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/609?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/609?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/609'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
