### PR TITLE
Add socket options API

### DIFF
--- a/endhost/ssp/ConnectionManager.h
+++ b/endhost/ssp/ConnectionManager.h
@@ -5,6 +5,7 @@
 
 #include "DataStructures.h"
 #include "OrderedList.h"
+#include "PathPolicy.h"
 #include "SCIONDefines.h"
 
 class SSPProtocol;
@@ -26,6 +27,8 @@ public:
     virtual void handleTimeout();
     virtual void getStats(SCIONStats *stats);
 
+    int setStayISD(uint16_t isd);
+
 protected:
     void getLocalAddress();
     int checkPath(uint8_t *ptr, int len, int addr, std::vector<Path *> &candidates);
@@ -39,7 +42,9 @@ protected:
     std::vector<SCIONAddr>      &mDstAddrs;
 
     std::vector<Path *>          mPaths;
+    pthread_mutex_t              mPathMutex;
     int                          mInvalid;
+    PathPolicy                   mPolicy;
 };
 
 // SUDP
@@ -72,6 +77,7 @@ public:
 
     void setRemoteWindow(uint32_t window);
     bool bufferFull(int window);
+    int totalQueuedSize();
     void waitForSendBuffer(int len, int windowSize);
 
     void queuePacket(SCIONPacket *packet);
@@ -105,7 +111,6 @@ protected:
     bool handleDupAck(SCIONPacket *packet);
     void addRetries(std::vector<SCIONPacket *> &retries);
     int handleAckOnPath(SCIONPacket *packet, bool rttSample);
-    int totalQueuedSize();
 
     int                          mReceiveWindow;
     int                          mInitSends;

--- a/endhost/ssp/Makefile
+++ b/endhost/ssp/Makefile
@@ -8,7 +8,7 @@ SCIOND_DEP=ConnectionManager.cpp Utils.cpp
 CLIENT_OBJS=$(SCIOND_DEP:.cpp=._client.o)
 SERVER_OBJS=$(SCIOND_DEP:.cpp=._server.o)
 COMMON=SCIONSocket.cpp SCIONProtocol.cpp Path.cpp PathState.cpp\
-	   OrderedList.cpp SCIONWrapper.cpp Extensions.cpp
+	   OrderedList.cpp SCIONWrapper.cpp Extensions.cpp PathPolicy.cpp
 COMMON_OBJS=$(COMMON:.cpp=.o)
 SOCKET_OBJS=$(COMMON_OBJS) $(CLIENT_OBJS) $(SERVER_OBJS)
 CLIENT_LIB=libclient.so

--- a/endhost/ssp/Path.cpp
+++ b/endhost/ssp/Path.cpp
@@ -161,6 +161,11 @@ void Path::setInterfaces(uint8_t *interfaces, size_t count)
     }
 }
 
+std::vector<SCIONInterface> & Path::getInterfaces()
+{
+    return mInterfaces;
+}
+
 bool Path::isUp()
 {
     bool ret;

--- a/endhost/ssp/Path.h
+++ b/endhost/ssp/Path.h
@@ -30,6 +30,7 @@ public:
     virtual void setIndex(int index);
     void setRawPath(uint8_t *path, int len);
     void setInterfaces(uint8_t *interfaces, size_t count);
+    std::vector<SCIONInterface> & getInterfaces();
     bool isUp();
     void setUp();
     bool isUsed();

--- a/endhost/ssp/PathPolicy.cpp
+++ b/endhost/ssp/PathPolicy.cpp
@@ -1,0 +1,38 @@
+#include "Path.h"
+#include "PathPolicy.h"
+
+PathPolicy::PathPolicy()
+    : mStayISD(0)
+{
+}
+
+PathPolicy::~PathPolicy()
+{
+}
+
+void PathPolicy::setStayISD(uint16_t isd)
+{
+    mStayISD = isd;
+}
+
+bool PathPolicy::validate(Path *p)
+{
+    if (!mStayISD)
+        return true;
+
+    bool valid = true;
+    valid = checkStayISD(p);
+    DEBUG("path %d valid? %d\n", p->getIndex(), valid);
+    return valid;
+}
+
+bool PathPolicy::checkStayISD(Path *p)
+{
+    std::vector<SCIONInterface> &ifs = p->getInterfaces();
+    for (size_t i = 0; i < ifs.size(); i++) {
+        SCIONInterface sif = ifs[i];
+        if (sif.isd != mStayISD)
+            return false;
+    }
+    return true;
+}

--- a/endhost/ssp/PathPolicy.h
+++ b/endhost/ssp/PathPolicy.h
@@ -1,0 +1,27 @@
+#ifndef PATH_POLICY_H
+#define PATH_POLICY_H
+
+#include <vector>
+
+#include "SCIONDefines.h"
+
+class Path;
+
+class PathPolicy {
+public:
+    PathPolicy();
+    ~PathPolicy();
+
+    void setStayISD(uint16_t isd);
+
+    bool validate(Path *p);
+
+protected:
+    bool checkStayISD(Path *p);
+
+    uint16_t mStayISD;
+    std::vector<uint16_t> mAvoidISDs;
+    std::vector<uint32_t> mAvoidADs;
+};
+
+#endif

--- a/endhost/ssp/SCIONDefines.h
+++ b/endhost/ssp/SCIONDefines.h
@@ -2,6 +2,7 @@
 #define SCION_DEFINES_H
 
 #include <stdint.h>
+#include <stdlib.h>
 
 // Shared defines
 
@@ -54,6 +55,8 @@ typedef struct{
 } SCIONAddr;
 
 #define ISD_AD(isd, ad) ((isd) << 20) | ((ad) & 0xfffff)
+#define GET_ISD(isd_ad) ((isd_ad) >> 20)
+#define GET_AD(isd_ad) ((isd_ad) & 0xfffff)
 
 typedef struct {
     uint32_t ad;
@@ -112,5 +115,19 @@ typedef struct {
 } SCIONHeader;
 
 #pragma pack(pop)
+
+typedef enum {
+    SCION_OPTION_BLOCKING = 0,
+    SCION_OPTION_STAY_ISD,
+    SCION_OPTION_AVOID_ISD,
+    SCION_OPTION_AVOID_AD,
+} SCIONOptionType;
+
+typedef struct {
+    SCIONOptionType type;
+    int val;
+    void *data; // if int is not enough
+    size_t len; // len of data
+} SCIONOption;
 
 #endif // SCION_DEFINES_H

--- a/endhost/ssp/SCIONProtocol.h
+++ b/endhost/ssp/SCIONProtocol.h
@@ -26,6 +26,8 @@ public:
 
     bool isReceiver();
     void setReceiver(bool receiver);
+    void setBlocking(bool blocking);
+    bool isBlocking();
 
     virtual bool claimPacket(SCIONPacket *packet, uint8_t *buf);
     virtual void createManager(std::vector<SCIONAddr> &dstAddrs);
@@ -40,16 +42,21 @@ public:
     virtual int registerSelect(Notification *n, int mode);
     virtual void deregisterSelect(int index);
 
+    int setStayISD(uint16_t isd);
+
     virtual int shutdown();
     virtual void removeDispatcher(int sock);
 
 protected:
+    PathManager            *mPathManager;
+
     int                    mSocket;
     uint16_t               mSrcPort;
     uint16_t               mDstPort;
     int                    mProtocolID;
     bool                   mIsReceiver;
     bool                   mReadyToRead;
+    bool                   mBlocking;
     pthread_mutex_t        mReadMutex;
     pthread_cond_t         mReadCond;
     SCIONState             mState;

--- a/endhost/ssp/SCIONSocket.cpp
+++ b/endhost/ssp/SCIONSocket.cpp
@@ -165,6 +165,44 @@ int SCIONSocket::recv(uint8_t *buf, size_t len, SCIONAddr *srcAddr)
     return mProtocol->recv(buf, len, srcAddr);
 }
 
+int SCIONSocket::setSocketOption(SCIONOption *option)
+{
+    if (!option)
+        return -EINVAL;
+
+    switch (option->type) {
+    case SCION_OPTION_BLOCKING:
+        if (!mProtocol)
+            return -EPERM;
+        mProtocol->setBlocking(option->val);
+        return 0;
+    case SCION_OPTION_STAY_ISD:
+        if (!mProtocol)
+            return -EPERM;
+        return mProtocol->setStayISD(option->val);
+    default:
+        break;
+    }
+    return 0;
+}
+
+int SCIONSocket::getSocketOption(SCIONOption *option)
+{
+    if (!option)
+        return -1;
+
+    switch (option->type) {
+    case SCION_OPTION_BLOCKING:
+        if (!mProtocol)
+            return -1;
+        option->val = mProtocol->isBlocking();
+        return 0;
+    default:
+        break;
+    }
+    return 0;
+}
+
 bool SCIONSocket::checkChildren(SCIONPacket *packet, uint8_t *ptr)
 {
     bool claimed = false;

--- a/endhost/ssp/SCIONSocket.h
+++ b/endhost/ssp/SCIONSocket.h
@@ -21,6 +21,8 @@ public:
     int send(uint8_t *buf, size_t len);
     int send(uint8_t *buf, size_t len, DataProfile profile);
     int recv(uint8_t *buf, size_t len, SCIONAddr *srcAddr);
+    int setSocketOption(SCIONOption *option);
+    int getSocketOption(SCIONOption *option);
 
     // construct SCION packet from incoming data
     void handlePacket(uint8_t *buf, size_t len, struct sockaddr_in *addr);

--- a/endhost/ssp/SCIONWrapper.cpp
+++ b/endhost/ssp/SCIONWrapper.cpp
@@ -111,6 +111,22 @@ void SCIONDestroyStats(void *stats)
     destroyStats(s);
 }
 
+int SCIONSetOption(int fd, SCIONOption *option)
+{
+    SocketEntry *e = findSocket(fd);
+    if (!e)
+        return -1;
+    return e->sock->setSocketOption(option);
+}
+
+int SCIONGetOption(int fd, SCIONOption *option)
+{
+    SocketEntry *e = findSocket(fd);
+    if (!e)
+        return -1;
+    return e->sock->getSocketOption(option);
+}
+
 int checkReadWrite(fd_set *fdset, int mode, int fd, Notification *n)
 {
     SocketEntry *e = findSocket(fd);

--- a/endhost/ssp/SCIONWrapper.h
+++ b/endhost/ssp/SCIONWrapper.h
@@ -26,6 +26,9 @@ int SCIONShutdown(int fd);
 void * SCIONGetStats(int sock, void *buf, int len);
 void SCIONDestroyStats(void *stats);
 
+int SCIONSetOption(int fd, SCIONOption *option);
+int SCIONGetOption(int fd, SCIONOption *option);
+
 #ifdef __cplusplus
 }
 #endif

--- a/endhost/ssp/test/client.cpp
+++ b/endhost/ssp/test/client.cpp
@@ -9,7 +9,8 @@ int main(int argc, char **argv)
 {
     SCIONAddr addrs[1];
     SCIONAddr saddr;
-    int isd, ad;
+    uint16_t isd;
+    uint32_t ad;
     char str[20];
     if (argc == 3) {
         isd = atoi(argv[1]);
@@ -26,6 +27,13 @@ int main(int argc, char **argv)
     memcpy(saddr.host.addr, &in, 4);
     addrs[0] = saddr;
     SCIONSocket s(SCION_PROTO_SSP, addrs, 1, 0, 8080);
+    /*
+    SCIONOption option;
+    memset(&option, 0, sizeof(option));
+    option.type = SCION_OPTION_STAY_ISD;
+    option.val = 1;
+    s.setSocketOption(&option);
+    */
     int count = 0;
     char buf[BUFSIZE];
     memset(buf, 0, BUFSIZE);


### PR DESCRIPTION
Only supports get/set blocking mode for now
Later this will be used for path policy, extensions, etc.

@ercanucan and @kormat might want to check scion_socket.py
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/614%23issuecomment-181260106%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52148337%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52148426%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52148586%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52150152%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52150187%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52150860%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52179384%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52185102%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52280907%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52285361%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52285429%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52285437%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23issuecomment-181785528%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23issuecomment-181260106%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Added%20path%20policy%20as%20socket%20option%20%28currently%20only%20supports%20%5C%22stay%20in%20ISD%20x%5C%22%29%22%2C%20%22created_at%22%3A%20%222016-02-08T08%3A58%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%2C%20pending%20squashes%22%2C%20%22created_at%22%3A%20%222016-02-09T09%3A45%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20617029eac545fe03c6d3f9a2df7c36559049c43f%20endhost/scion_socket.py%2058%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52148337%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20might%20make%20sense%20to%20convert%20the%20C%20return%20values%20to%20pythonic%20return%20values%20of%20True/False%22%2C%20%22created_at%22%3A%20%222016-02-08T09%3A47%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20was%20thinking%20I%20might%20eventually%20make%20it%20return%20different%20error%20codes%20depending%20on%20the%20option%20type%20and%20what%20went%20wrong%22%2C%20%22created_at%22%3A%20%222016-02-08T10%3A05%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok%2C%20in%20that%20case%20it%20might%20make%20sense%20to%20define%20constants%20for%20the%20various%20return%20values%2C%20and%20only%20use%20those.%22%2C%20%22created_at%22%3A%20%222016-02-08T10%3A12%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20would%20be%20the%20best%20way%20to%20define%20these%3F%20I%20see%20Python%203.4%20has%20enums%20which%20could%20work%20well%20-%20are%20we%20assuming%203.4%20or%20should%20stuff%20be%20backward%20compatible%3F%22%2C%20%22created_at%22%3A%20%222016-02-08T15%3A07%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20already%20depend%20on%20python%203.4%2B%2C%20so%20that%27s%20fine.%22%2C%20%22created_at%22%3A%20%222016-02-08T15%3A49%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20wrote%20up%20some%20enum%20values%20then%20decided%20to%20just%20use%20the%20standard%20errno%20values%20instead.%20Whatever%20code%20that%20uses%20the%20wrapper%20will%20check%20return%20values%20using%20the%20errno%20module.%22%2C%20%22created_at%22%3A%20%222016-02-09T08%3A58%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-09T09%3A44%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL223-278%22%7D%2C%20%22Pull%20617029eac545fe03c6d3f9a2df7c36559049c43f%20endhost/scion_socket.py%2088%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52148586%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22so%20%60LONG_OPTIONS%60%20is%20a%20map%20from%20opt%20type%20to%20the%20length%20of%20the%20data%3F%22%2C%20%22created_at%22%3A%20%222016-02-08T09%3A50%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes.%20Still%20not%20sure%20what%20options%20might%20need%20this%20yet%2C%20but%20if%20we%20get%20into%20path%20policies%20and%20such%204%20bytes%20might%20not%20be%20enough%20to%20express%20what%20you%20want.%22%2C%20%22created_at%22%3A%20%222016-02-08T10%3A05%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-09T09%3A45%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL223-278%22%7D%2C%20%22Pull%20617029eac545fe03c6d3f9a2df7c36559049c43f%20endhost/scion_socket.py%2069%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/614%23discussion_r52148426%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20this%20is%20a%20local%20programming%20error%2C%20an%20assertion%20probably%20makes%20more%20sense%5Cr%5Cn%60%60%60assert%20opttype%20not%20in%20self.LONG_OPTIONS%60%60%60%22%2C%20%22created_at%22%3A%20%222016-02-08T09%3A48%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-02-09T09%3A45%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL223-278%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/614#issuecomment-181260106'>General Comment</a></b>
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> Added path policy as socket option (currently only supports "stay in ISD x")
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM, pending squashes
- [x] <a href='#crh-comment-Pull 617029eac545fe03c6d3f9a2df7c36559049c43f endhost/scion_socket.py 58'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/614#discussion_r52148337'>File: endhost/scion_socket.py:L223-278</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It might make sense to convert the C return values to pythonic return values of True/False
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> I was thinking I might eventually make it return different error codes depending on the option type and what went wrong
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Ok, in that case it might make sense to define constants for the various return values, and only use those.
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> What would be the best way to define these? I see Python 3.4 has enums which could work well - are we assuming 3.4 or should stuff be backward compatible?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> We already depend on python 3.4+, so that's fine.
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> I wrote up some enum values then decided to just use the standard errno values instead. Whatever code that uses the wrapper will check return values using the errno module.
- [x] <a href='#crh-comment-Pull 617029eac545fe03c6d3f9a2df7c36559049c43f endhost/scion_socket.py 69'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/614#discussion_r52148426'>File: endhost/scion_socket.py:L223-278</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> As this is a local programming error, an assertion probably makes more sense
  `assert opttype not in self.LONG_OPTIONS`
- [x] <a href='#crh-comment-Pull 617029eac545fe03c6d3f9a2df7c36559049c43f endhost/scion_socket.py 88'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/614#discussion_r52148586'>File: endhost/scion_socket.py:L223-278</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> so `LONG_OPTIONS` is a map from opt type to the length of the data?
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> Yes. Still not sure what options might need this yet, but if we get into path policies and such 4 bytes might not be enough to express what you want.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/614?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/614?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/614'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
