### PR TITLE
Fix for getStats

### DIFF
--- a/endhost/scion_socket.py
+++ b/endhost/scion_socket.py
@@ -18,18 +18,18 @@
 """
 
 # Stdlib
-import copy
 import ipaddress
 import logging
 import os
-from ctypes import (byref, CDLL, c_double, c_int, c_short, c_ubyte,
-                    c_uint, c_ulong, c_ushort, POINTER, Structure)
+import struct
+from ctypes import (byref, CDLL, c_int, c_short, c_ubyte, c_uint, Structure)
 
 # SCION
 from lib.packet.scion_addr import ISD_AD
+from lib.util import Raw
 
 ByteArray16 = c_ubyte * 16
-MAX_PATHS = 10
+MAX_PATHS = 20
 
 
 class C_HostAddr(Structure):
@@ -43,54 +43,91 @@ class C_SCIONAddr(Structure):
                 ("host", C_HostAddr)]
 
 
-class C_SCIONInterface(Structure):
-    _fields_ = [("ad", c_uint),
-                ("isd", c_ushort),
-                ("interface", c_ushort)]
+class SCIONInterface(object):
+    """
+    Class representing interface info, i.e. ISD_AD + IFID
 
+    :ivar int isd: ISD identifier
+    :ivar int ad: AD identifier
+    :ivar int ifid: Interface identifier
+    """
+    def __init__(self, raw=None):
+        """
+        Initialize an instance of the class SCIONInterface
 
-class C_SCIONStats(Structure):
-    _fields_ = [("exists", c_int * MAX_PATHS),
-                ("receivedPackets", c_int * MAX_PATHS),
-                ("sentPackets", c_int * MAX_PATHS),
-                ("ackedPackets", c_int * MAX_PATHS),
-                ("rtts", c_int * MAX_PATHS),
-                ("lossRates", c_double * MAX_PATHS),
-                ("ifCounts", c_int * MAX_PATHS),
-                ("ifLists", POINTER(C_SCIONInterface) * MAX_PATHS),
-                ("highestReceived", c_ulong),
-                ("highestAcked", c_ulong)]
+        :param raw: Byte string representing interface info
+        :type raw: bytes object
+        """
+        self.isd = None
+        self.ad = None
+        self.ifid = None
+        if raw:
+            self._parse(raw)
+
+    def _parse(self, raw):
+        """
+        Parse byte string representation
+
+        :param raw: Byte string representing interface info
+        :type raw: bytes object
+        """
+        data = Raw(raw, "Serialized SCION Interface", ISD_AD.LEN + 2)
+        isd_ad = ISD_AD.from_raw(data.pop(ISD_AD.LEN))
+        self.isd, self.ad = isd_ad.isd, isd_ad.ad
+        self.ifid = struct.unpack("H", data.pop())[0]
 
 
 class ScionStats(object):
     """
-    Python class containing SCION socket traffic data
+    Python class containing SCION socket traffic data.
+    This class should ONLY be instantiated by the getStats call in
+    ScionBaseSocket.
     """
 
-    def __init__(self, stats):
+    FIXED_DATA_LEN = 28
+
+    def __init__(self, raw=None):
         """
-        Python representation of SCION traffic info struct obtained from
+        Python representation of SCION traffic data obtained from
         getStats() call. Allows Python wrapper user to not worry about
         dereferencing pointers or freeing memory.
+
         :param stats: Struct returned by ScionBaseSocket.getStats()
         :type: C_SCIONStats
         """
-        self.exists = list(stats.exists)
-        self.received_packets = list(stats.receivedPackets)
-        self.sent_packets = list(stats.sentPackets)
-        self.acked_packets = list(stats.ackedPackets)
-        self.rtts = list(stats.rtts)
-        self.loss_rates = list(stats.lossRates)
-        self.if_counts = list(stats.ifCounts)
+        self.received_packets = []
+        self.sent_packets = []
+        self.acked_packets = []
+        self.rtts = []
+        self.loss_rates = []
+        self.if_counts = []
         self.if_lists = []
-        for i in range(MAX_PATHS):
-            if_list = []
-            if self.if_counts[i]:
-                for j in range(self.if_counts[i]):
-                    if_list.append(copy.deepcopy(stats.ifLists[i][j]))
-            self.if_lists.append(if_list)
-        self.highest_received = copy.deepcopy(stats.highestReceived)
-        self.highest_acked = copy.deepcopy(stats.highestAcked)
+        if raw:
+            self._parse(raw)
+
+    def _parse(self, raw):
+        """
+        Parse serialized stats data
+
+        :param raw: Serialized stats data
+        :type raw: bytes object
+        """
+        data = Raw(raw, "Serialized SCION stats", self.FIXED_DATA_LEN, True)
+        while len(data):
+            values = data.pop(self.FIXED_DATA_LEN)
+            rp, sp, ap, rtt, lr, ifc = struct.unpack("IIIIdI", values)
+            self.received_packets.append(rp)
+            self.sent_packets.append(sp)
+            self.acked_packets.append(ap)
+            self.rtts.append(rtt)
+            self.loss_rates.append(lr)
+            self.if_counts.append(ifc)
+            if ifc:
+                if_list = []
+                for j in range(ifc):
+                    saddr = SCIONInterface(data.pop(ISD_AD.LEN + 2))
+                    if_list.append(saddr)
+                self.if_lists.append(if_list)
 
     def __str__(self):
         """
@@ -124,6 +161,9 @@ class ScionStats(object):
 SHARED_LIB_LOCATION = os.path.join("endhost", "ssp")
 SHARED_LIB_SERVER = "libserver.so"
 SHARED_LIB_CLIENT = "libclient.so"
+
+# Slightly more than enough for 20 paths with 20 IFs each
+MAX_STATS_BUFFER = 3072
 
 
 class ScionBaseSocket(object):
@@ -215,12 +255,12 @@ class ScionBaseSocket(object):
         :returns: Python class containing socket traffic data
         :rtype: ScionStats
         """
-        self.libsock.SCIONGetStats.restype = POINTER(C_SCIONStats)
-        raw_stats = self.libsock.SCIONGetStats(self.fd)
-        if not raw_stats:
+        self.libsock.SCIONGetStats.restype = c_int
+        buf = bytes(MAX_STATS_BUFFER)
+        stats_len = self.libsock.SCIONGetStats(self.fd, buf, MAX_STATS_BUFFER)
+        if not stats_len:
             return None
-        py_stats = ScionStats(raw_stats.contents)
-        self.libsock.SCIONDestroyStats(raw_stats)
+        py_stats = ScionStats(buf[:stats_len])
         return py_stats
 
     def shutdown(self, how):

--- a/endhost/ssp/ConnectionManager.cpp
+++ b/endhost/ssp/ConnectionManager.cpp
@@ -856,7 +856,7 @@ void SSPConnectionManager::handleTimeout()
 
 void SSPConnectionManager::getStats(SCIONStats *stats)
 {
-    for (size_t i = 0; i < mPaths.size(); i++) {
+    for (size_t i = 0; i < mPaths.size() && i < MAX_TOTAL_PATHS; i++) {
         if (mPaths[i])
             mPaths[i]->getStats(stats);
     }

--- a/endhost/ssp/SCIONDefines.h
+++ b/endhost/ssp/SCIONDefines.h
@@ -22,6 +22,7 @@
 #define SCION_PROTO_NONE 254
 #define SCION_PROTO_RES 255
 
+#define SCION_IFID_LEN 2
 #define SCION_ISD_AD_LEN 4
 #define SCION_HOST_ADDR_LEN 4
 #define SCION_HOST_OFFSET 4
@@ -61,7 +62,7 @@ typedef struct {
 } SCIONInterface;
 #define SCION_IF_SIZE 6
 
-#define MAX_TOTAL_PATHS 10
+#define MAX_TOTAL_PATHS 20
 
 typedef struct {
     int exists[MAX_TOTAL_PATHS];
@@ -72,9 +73,9 @@ typedef struct {
     double lossRates[MAX_TOTAL_PATHS];
     int ifCounts[MAX_TOTAL_PATHS];
     SCIONInterface *ifLists[MAX_TOTAL_PATHS];
-    uint64_t highestReceived;
-    uint64_t highestAcked;
 } SCIONStats;
+
+#define SERIAL_INT_FIELDS 5
 
 #pragma pack(push)
 #pragma pack(1)

--- a/endhost/ssp/SCIONSocket.h
+++ b/endhost/ssp/SCIONSocket.h
@@ -43,7 +43,7 @@ public:
     int registerSelect(Notification *n, int mode);
     void deregisterSelect(int index);
 
-    SCIONStats * getStats();
+    void * getStats(void *buf, int len);
 
     int shutdown();
     void removeChild(SCIONSocket *child);

--- a/endhost/ssp/SCIONWrapper.cpp
+++ b/endhost/ssp/SCIONWrapper.cpp
@@ -97,12 +97,12 @@ int SCIONRecv(int sock, uint8_t *buf, size_t len,
     return e->sock->recv(buf, len, srcAddr);
 }
 
-SCIONStats * SCIONGetStats(int sock)
+void * SCIONGetStats(int sock, void *buf, int len)
 {
     SocketEntry *e = findSocket(sock);
     if (!e)
         return NULL;
-    return e->sock->getStats();
+    return e->sock->getStats(buf, len);
 }
 
 void SCIONDestroyStats(void *stats)

--- a/endhost/ssp/SCIONWrapper.h
+++ b/endhost/ssp/SCIONWrapper.h
@@ -23,7 +23,7 @@ int SCIONSelect(int numfds, fd_set *readfds, fd_set *writefds,
                 struct timeval *timeout);
 int SCIONShutdown(int fd);
 
-SCIONStats * SCIONGetStats(int sock);
+void * SCIONGetStats(int sock, void *buf, int len);
 void SCIONDestroyStats(void *stats);
 
 #ifdef __cplusplus

--- a/endhost/ssp/SocketConfigs.h
+++ b/endhost/ssp/SocketConfigs.h
@@ -4,7 +4,7 @@
 // Build config
 
 //#define SIMULATOR // uncomment for WANem testing
-//#define BYPASS_ROUTERS // send packets directly to remote end
+#define BYPASS_ROUTERS // send packets directly to remote end
 
 #define DEBUG_MODE 0
 #if DEBUG_MODE

--- a/endhost/ssp/test/web_client.cpp
+++ b/endhost/ssp/test/web_client.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
         if (us > 1000000) {
             count++;
             start = end;
-            stats = s.getStats();
+            stats = (SCIONStats *)s.getStats(NULL, 0);
             sprintf(curldata, "{\
                     \"packets\":{\
                     \"red\":[{\"time\":%d,\"value\":%.1f}],\

--- a/endhost/ssp/test/web_server.cpp
+++ b/endhost/ssp/test/web_server.cpp
@@ -64,7 +64,7 @@ int main()
         if (us > 1000000) {
             count++;
             SCIONStats *stats;
-            stats = newSocket->getStats();
+            stats = (SCIONStats *)newSocket->getStats(NULL, 0);
             printf("%d bytes: %f Mbps\n", size, (double)size / us * 1000000 / 1024 / 1024 * 8);
             sprintf(curldata, "{\
                     \"throughput\":{\"black\": [{\"time\":%d,\"value\":%.2f}]}\

--- a/test/integration/ssp_cli_srv_test.py
+++ b/test/integration/ssp_cli_srv_test.py
@@ -110,7 +110,7 @@ def client():
         logging.info("interfaces for path 0:")
         for i in range(stats.if_counts[0]):
             ifinfo = stats.if_lists[0][i]
-            logging.info("(%d, %d)%d", ifinfo.isd, ifinfo.ad, ifinfo.interface)
+            logging.info("(%d, %d)%d", ifinfo.isd, ifinfo.ad, ifinfo.ifid)
 
     logging.info("Client starts the receive protocol.")
     # secondly, act as a receiver


### PR DESCRIPTION
Added a serialize version of getStats to fix memory problems we've been having in the proxy/kbase.

See commit info for details.

@ercanucan
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/617%23discussion_r52158171%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23discussion_r52158370%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23discussion_r52158401%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23discussion_r52158627%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23discussion_r52158828%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23discussion_r52158924%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23discussion_r52158977%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23issuecomment-181387445%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23issuecomment-181388207%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23issuecomment-181387445%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40aznair%20maybe%20squash%20them%20into%20one%20single%20commit%3F%22%2C%20%22created_at%22%3A%20%222016-02-08T14%3A11%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22yeah%20I%20generally%20squash%20after%20I%20get%20the%20green%20light%20to%20merge%20%28although%20I%20did%20forget%20once%20so%20reminders%20are%20welcome%29%22%2C%20%22created_at%22%3A%20%222016-02-08T14%3A13%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2053220430b81568685ca4176729bae9b169c28bc3%20endhost/ssp/SCIONDefines.h%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23discussion_r52158401%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22are%20these%20not%20relevant%20anymore%3F%22%2C%20%22created_at%22%3A%20%222016-02-08T11%3A32%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22they%20weren%27t%20getting%20populated%20anyway%20so%20unless%20we%20run%20in%20to%20need%20for%20such%20values%20%28or%20other%20ones%20I%20haven%27t%20thought%20of%20yet%29%20I%20figured%20I%20might%20as%20well%20remove%20them%22%2C%20%22created_at%22%3A%20%222016-02-08T11%3A35%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/ssp/SCIONDefines.h%3AL72-78%22%7D%2C%20%22Pull%2053220430b81568685ca4176729bae9b169c28bc3%20endhost/scion_socket.py%20122%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23discussion_r52158171%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Can%20pop%2828%29%20go%20wrong%3F%20If%20so%2C%20maybe%20worth%20doing%20a%20bit%20more%20error%20handling%3F%20Also%2C%20maybe%20it%20makes%20sense%20to%20make%2028%20a%20constant%3F%20It%20would%20make%20the%20code%20more%20readable.%22%2C%20%22created_at%22%3A%20%222016-02-08T11%3A29%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20will%20be%20fine%20as%20long%20as%20this%20class%20is%20only%20instantiated%20from%20the%20result%20of%20a%20getStats%20call.%20Maybe%20I%27ll%20put%20in%20some%20comments%20saying%20it%20should%20only%20be%20used%20in%20that%20way.%5Cr%5Cn%5Cr%5CnAs%20for%20making%20it%20a%20constant%2C%20yeah%20that%20might%20be%20nice.%22%2C%20%22created_at%22%3A%20%222016-02-08T11%3A38%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL82-130%22%7D%2C%20%22Pull%2053220430b81568685ca4176729bae9b169c28bc3%20endhost/ssp/SCIONSocket.cpp%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23discussion_r52158924%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%225%20here%2C%20again%20looks%20like%20a%20magic%20number%20to%20me.%20not%20very%20readable%22%2C%20%22created_at%22%3A%20%222016-02-08T11%3A39%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/ssp/SCIONSocket.cpp%3AL308-357%22%7D%2C%20%22Pull%2053220430b81568685ca4176729bae9b169c28bc3%20endhost/ssp/SCIONSocket.cpp%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23discussion_r52158977%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ditto.%20I%20think%20I%20don%27t%20like%20hard-coded%20numbers%20inside%20the%20code%20in%20general%20%3A-%29%22%2C%20%22created_at%22%3A%20%222016-02-08T11%3A40%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/ssp/SCIONSocket.cpp%3AL308-357%22%7D%2C%20%22Pull%2053220430b81568685ca4176729bae9b169c28bc3%20endhost/scion_socket.py%2066%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/617%23discussion_r52158370%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20the%20length%20seems%20to%20be%20fixed%2C%20it%20would%20be%20good%20to%20pass%20a%20name%20and%20a%20length%20to%20%60Raw%60%20so%20it%20can%20perform%20a%20check.%22%2C%20%22created_at%22%3A%20%222016-02-08T11%3A32%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_socket.py%3AL43-81%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 53220430b81568685ca4176729bae9b169c28bc3 endhost/scion_socket.py 122'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/617#discussion_r52158171'>File: endhost/scion_socket.py:L82-130</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Can pop(28) go wrong? If so, maybe worth doing a bit more error handling? Also, maybe it makes sense to make 28 a constant? It would make the code more readable.
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> This will be fine as long as this class is only instantiated from the result of a getStats call. Maybe I'll put in some comments saying it should only be used in that way.
  As for making it a constant, yeah that might be nice.
- [ ] <a href='#crh-comment-Pull 53220430b81568685ca4176729bae9b169c28bc3 endhost/scion_socket.py 66'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/617#discussion_r52158370'>File: endhost/scion_socket.py:L43-81</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> As the length seems to be fixed, it would be good to pass a name and a length to `Raw` so it can perform a check.
- [ ] <a href='#crh-comment-Pull 53220430b81568685ca4176729bae9b169c28bc3 endhost/ssp/SCIONDefines.h 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/617#discussion_r52158401'>File: endhost/ssp/SCIONDefines.h:L72-78</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> are these not relevant anymore?
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> they weren't getting populated anyway so unless we run in to need for such values (or other ones I haven't thought of yet) I figured I might as well remove them
- [ ] <a href='#crh-comment-Pull 53220430b81568685ca4176729bae9b169c28bc3 endhost/ssp/SCIONSocket.cpp 22'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/617#discussion_r52158924'>File: endhost/ssp/SCIONSocket.cpp:L308-357</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> 5 here, again looks like a magic number to me. not very readable
- [ ] <a href='#crh-comment-Pull 53220430b81568685ca4176729bae9b169c28bc3 endhost/ssp/SCIONSocket.cpp 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/617#discussion_r52158977'>File: endhost/ssp/SCIONSocket.cpp:L308-357</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> ditto. I think I don't like hard-coded numbers inside the code in general :-)
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/617#issuecomment-181387445'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @aznair maybe squash them into one single commit?
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> yeah I generally squash after I get the green light to merge (although I did forget once so reminders are welcome)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/617?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/617?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/617'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
