### PR TITLE
Fix zkcleanslate not wiping all zk state

### DIFF
--- a/tools/zkcleanslate
+++ b/tools/zkcleanslate
@@ -7,5 +7,6 @@
 
 sudo service zookeeper stop
 find /run/shm/*-zk/ -type f | sudo xargs -r rm -v
+rm -v gen/ISD*/AD*/zk*/data/version-2/*
 sudo rm -v /var/lib/zookeeper/version-2/*
 sudo service zookeeper start


### PR DESCRIPTION
SCION-managed zookeeper instances (like in AD 1-12 in Default.topo)
store their main database inside the gen/ directory, and zkcleanslate
wasn't wiping these, leading to stale data hanging around.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/621%23issuecomment-182789332%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/621%23issuecomment-182789332%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-02-11T10%3A04%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/621#issuecomment-182789332'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/621?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/621?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/621'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
