### PR TITLE
SIBRA steady path registration

### DIFF
--- a/infrastructure/sibra_server/link.py
+++ b/infrastructure/sibra_server/link.py
@@ -33,17 +33,19 @@ class Link(object):
     """
     The Link class handles steady path management on a single interface.
     """
-    def __init__(self, addr, sendq, iface):
+    def __init__(self, addr, sendq, signing_key, iface):
         """
         :param ScionAddr addr: the address of this sibra server
         :param queue.Queue sendq:
             packets written to this queue will be sent by the sibra server
             thread.
+        :param bytes signing_key: AS signing key.
         :param topology.InterfaceElement iface: the interface to manage.
         """
         self.addr = addr
         self.sendq = sendq
         self.iface = iface
+        self.signing_key = signing_key
         self.neigh = iface.isd_ad()
         self.id = iface.if_id
         self.state = SibraState(iface.bandwidth, self.addr.get_isd_ad())
@@ -83,7 +85,8 @@ class Link(object):
         # FIXME(kormat): un-hardcode these bandwidths
         bwsnap = BWSnapshot(25 * 1024, 15 * 1024)
         with self.lock:
-            steady = SteadyPath(self.addr, self.sendq, self._pick_seg(), bwsnap)
+            steady = SteadyPath(self.addr, self.sendq, self.signing_key,
+                                self._pick_seg(), bwsnap)
             self.steadies[steady.id] = steady
             steady.setup()
 

--- a/lib/sibra/seg_db.py
+++ b/lib/sibra/seg_db.py
@@ -1,0 +1,134 @@
+# Copyright 2016 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`seg_db` --- SIBRA steady path segment database
+====================================================
+"""
+# Stdlib
+import logging
+import threading
+
+# External packages
+from pydblite.pydblite import Base
+
+# SCION
+from lib.sibra.segment import SibraSegment
+from lib.path_db import DBResult
+from lib.util import SCIONTime
+
+
+class SibraDBRecord(object):
+    """
+    Sibra steady path segment that gets stored in the SibraSegmentDB.
+    """
+    def __init__(self, seg):
+        assert isinstance(seg, SibraSegment)
+        self.seg = seg
+        self.id = self.seg.id
+        self._update_attrs()
+
+    def update(self, seg):
+        assert isinstance(seg, SibraSegment)
+        assert self.id == seg.id
+        if seg.expiry() < self.exp_time:
+            return DBResult.NONE
+        self.seg = seg
+        self._update_attrs()
+        return DBResult.ENTRY_UPDATED
+
+    def _update_attrs(self):
+        # Fidelity can be used to configure the desirability of a path. For now
+        # we just use path length.
+        self.fidelity = self.seg.num_hops()
+        self.exp_time = self.seg.expiry()
+
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __hash__(self):
+        return self.id
+
+
+class SibraSegmentDB(object):
+    """
+    Simple database for segments using PyDBLite.
+    """
+    def __init__(self, segment_ttl=None, max_res_no=None):
+        self._db = Base("", save_to_file=False)
+        self._db.create('record', 'id', 'first_isd', 'first_ad', 'last_isd',
+                        'last_ad', mode='override')
+        self._db.create_index('id')
+        self._db.create_index('last_isd')
+        self._db.create_index('last_ad')
+        self._lock = threading.Lock()
+
+    def __getitem__(self, seg_id):
+        with self._lock:
+            recs = self._db(id=seg_id)
+        assert len(recs) <= 1
+        if recs:
+            return recs[0]['record'].seg
+        return None
+
+    def __contains__(self, seg_id):
+        return bool(self[seg_id])
+
+    def update(self, seg):
+        assert isinstance(seg, SibraSegment)
+        with self._lock:
+            recs = self._db(id=seg.id)
+            assert len(recs) <= 1
+            if not recs:
+                rec = SibraDBRecord(seg)
+                self._db.insert(rec, seg.id, seg.src.isd, seg.src.ad,
+                                seg.dst.isd, seg.dst.ad)
+                return DBResult.ENTRY_ADDED
+            cur_rec = recs[0]['record']
+            return cur_rec.update(seg)
+
+    def delete(self, seg_id):
+        with self._lock:
+            recs = self._db(id=seg_id)
+            if not recs:
+                return DBResult.NONE
+            self._db.delete(recs)
+        return DBResult.ENTRY_DELETED
+
+    def __call__(self, *args, **kwargs):
+        """
+        Selection by field values.
+
+        Returns a sorted (path fidelity) list of paths according to the
+        criterias specified.
+        """
+        now = int(SCIONTime.get_time())
+        expired_recs = []
+        valid_recs = []
+        with self._lock:
+            recs = self._db(*args, **kwargs)
+            # Remove expired path from the cache.
+            for r in recs:
+                if r['record'].exp_time < now:
+                    expired_recs.append(r)
+                    logging.debug("Expired: %s", r['record'].seg)
+                else:
+                    valid_recs.append(r)
+            self._db.delete(expired_recs)
+        records = sorted([r['record'] for r in valid_recs],
+                         key=lambda x: x.fidelity)
+        return [r.seg for r in records]
+
+    def __len__(self):
+        with self._lock:
+            return len(self._db)

--- a/lib/sibra/segment.py
+++ b/lib/sibra/segment.py
@@ -1,0 +1,124 @@
+# Copyright 2016 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`segment` --- SIBRA steady path segment
+============================================
+"""
+# Stdlib
+import struct
+
+# SCION
+from lib.crypto.asymcrypto import sign
+from lib.defines import SIBRA_STEADY_ID_LEN
+from lib.packet.scion_addr import ISD_AD
+from lib.sibra.ext.info import ResvInfoSteady
+from lib.sibra.ext.sof import SibraOpaqueField
+from lib.util import Raw, SCIONTime, hex_str, iso_timestamp
+
+
+class SibraSegment(object):
+    """
+    Contains a SIBRA steady path segment.
+    """
+    NAME = "SibraSegment"
+    TS_LEN = 4
+    SIG_LEN = 64
+    MIN_LEN = (SIBRA_STEADY_ID_LEN + TS_LEN + ResvInfoSteady.LEN + ISD_AD.LEN +
+               1 + SIG_LEN)
+
+    def __init__(self, raw=None):
+        self.id = None
+        self.timestamp = None
+        self.info = None
+        self.src = None
+        self.dst = None
+        self._sofs = []
+        self.sig = bytes(self.SIG_LEN)
+        if raw is not None:
+            self._parse(raw)
+
+    def _parse(self, raw):
+        data = Raw(raw, self.NAME, self.MIN_LEN, min_=True)
+        self.id = data.pop(SIBRA_STEADY_ID_LEN)
+        self.timestamp = struct.unpack("!I", data.pop(self.TS_LEN))[0]
+        self.info = ResvInfoSteady(data.pop(ResvInfoSteady.LEN))
+        self._set_src()
+        self.dst = ISD_AD.from_raw(data.pop(ISD_AD.LEN))
+        num_hops = data.pop(1)
+        for _ in range(num_hops):
+            sof = SibraOpaqueField(data.pop(SibraOpaqueField.LEN))
+            self._sofs.append(sof)
+        self.sig = data.pop(self.SIG_LEN)
+
+    @classmethod
+    def from_values(cls, id_, info, dst, sofs, ts=None):
+        inst = cls()
+        assert len(id_) == SIBRA_STEADY_ID_LEN
+        assert isinstance(dst, ISD_AD)
+        assert len(sofs) > 0
+        inst.id = id_
+        inst.timestamp = ts or int(SCIONTime.get_time())
+        inst.info = info
+        inst._set_src()
+        inst.dst = dst
+        inst._sofs = sofs
+        return inst
+
+    def pack(self):
+        packed = []
+        packed.append(self.id)
+        packed.append(struct.pack("!I", self.timestamp))
+        packed.append(self.info.pack())
+        packed.append(self.dst.pack())
+        packed.append(struct.pack("!B", len(self._sofs)))
+        for sof in self._sofs:
+            packed.append(sof.pack())
+        packed.append(self.sig)
+        return b"".join(packed)
+
+    def _pack_sig(self, key):
+        # Exclude the existing key (if any) from the input for the new
+        # signature.
+        data = self.pack()[:-self.SIG_LEN]
+        return sign(data, key)
+
+    def sign(self, key):
+        self.sig = self._pack_sig(key)
+
+    def verify(self, key):
+        return self.sig == self._pack_sig()
+
+    def num_hops(self):
+        return len(self._sofs)
+
+    def expiry(self):
+        return self.info.exp_ts()
+
+    def _set_src(self):
+        self.src = ISD_AD.from_raw(self.id[:ISD_AD.LEN])
+
+    def __len__(self):
+        return self.MIN_LEN + len(self._sofs) * SibraOpaqueField.LEN
+
+    def __str__(self):
+        s = [self.short_desc()]
+        s.append("  %s" % self.info)
+        return "\n".join(s)
+
+    def short_desc(self):
+        return ("%s(%dB): %s->%s hops:%s id:%s ts:%s sig:%s..." % (
+            self.NAME, len(self), self.src, self.dst, len(self._sofs),
+            hex_str(self.id), iso_timestamp(self.timestamp),
+            hex_str(self.sig)[:8],
+        ))

--- a/lib/types.py
+++ b/lib/types.py
@@ -111,6 +111,7 @@ class PathSegmentType(TypeBase):
     DOWN = 1  # Request/Reply for down-paths
     CORE = 2  # Request/Reply for core-paths
     GENERIC = 3  # FIXME(PSz): experimental for now.
+    SIBRA = 4  # Request/Reply for sibra steady paths
 
 
 class PCBType(TypeBase):

--- a/test/lib/packet/path_mgmt_test.py
+++ b/test/lib/packet/path_mgmt_test.py
@@ -124,22 +124,32 @@ class TestPathSegmentRecordsParse(object):
     """
     Unit tests for lib.packet.path_mgmt.PathSegmentRecords._parse
     """
-    @patch("lib.packet.path_mgmt.PathSegment", new_callable=create_mock)
+    @patch("lib.packet.path_mgmt.SibraSegment", autospec=True)
+    @patch("lib.packet.path_mgmt.PathSegment", autospec=True)
     @patch("lib.packet.path_mgmt.Raw", autospec=True)
-    def test(self, raw, path_seg):
+    def test(self, raw, path_seg, sib_seg):
         inst = PathSegmentRecords()
         inst.NAME = "PathSegmentRecords"
-        data = create_mock(["pop", "get", "__bool__"])
-        data.pop.side_effect = "raw type", "raw pcbs"
-        data.get.side_effect = ("raw pcb",)
-        data.__bool__.side_effect = True, False
+        data = create_mock(["__len__", "pop", "get"])
+        data.__len__.return_value = 0
+        data.pop.side_effect = (
+            3, 2, 1, None, 1, None, 2, None, None, None,
+        )
+        data.get.side_effect = (
+            "pcb1_0", "pcb1_1", "pcb2_0", "sib0", "sib1"
+        )
         raw.return_value = data
+        path_seg.side_effect = lambda x: x
+        sib_seg.side_effect = lambda x: x
         # Call
         inst._parse("data")
         # Tests
         raw.assert_called_once_with("data", inst.NAME, inst.MIN_LEN, min_=True)
-        ntools.eq_(inst.pcbs, {"raw type": [path_seg.return_value]})
-        path_seg.assert_called_once_with("raw pcb")
+        assert_these_calls(path_seg, [
+            call("pcb1_0"), call("pcb1_1"), call("pcb2_0")])
+        assert_these_calls(sib_seg, [call("sib0"), call("sib1")])
+        ntools.eq_(dict(inst.pcbs), {1: ["pcb1_0", "pcb1_1"], 2: ["pcb2_0"]})
+        ntools.eq_(inst.sibra_segs, ["sib0", "sib1"])
 
 
 class TestPathSegmentRecordsFromValues(object):
@@ -157,17 +167,29 @@ class TestPathSegmentRecordsPack(object):
     """
     Unit tests for lib.packet.path_mgmt.PathSegmentRecords.pack
     """
+    def _mk_seg(self, val):
+        seg = create_mock(['__len__', 'pack'])
+        seg.__len__.return_value = len(val)
+        seg.pack.return_value = val
+        return seg
+
     def test(self):
         inst = PathSegmentRecords()
-        pcbs = []
-        for x in b"abc":
-            pcb = create_mock(['pack'])
-            pcb.pack.return_value = bytes([x])
-            pcbs.append(pcb)
-        inst.pcbs = {1: pcbs, 2: reversed(pcbs)}
-        expected = b"\x01a\x01b\x01c\x02c\x02b\x02a"
+        inst.pcbs = {
+            1: [self._mk_seg(b"pcb1_0"), self._mk_seg(b"pcb1_1")],
+            2: [self._mk_seg(b"pcb2_0")],
+        }
+        inst.sibra_segs = [self._mk_seg(b"sib0"), self._mk_seg(b"sib1")]
+        expected = [
+            b"\x01pcb1_0", b"\x01pcb1_1", b"\x02pcb2_0", b"sib0", b"sib1"
+        ]
         # Call
-        ntools.eq_(inst.pack(), expected)
+        ret = inst.pack()
+        # Tests
+        ntools.eq_(ret[:2], bytes([3, 2]))
+        ntools.eq_(len(ret), len(b"".join(expected)) + 2)
+        for b in expected:
+            ntools.assert_in(b, ret)
 
 
 class TestPathSegmentRecordsLen(object):
@@ -177,8 +199,9 @@ class TestPathSegmentRecordsLen(object):
     def test(self):
         inst = PathSegmentRecords()
         inst.pcbs = {1: ['1', '22', '333', '4444'], 2: ['55555'], 3: ['666666']}
+        inst.sibra_segs = ['7777777']
         # Call
-        ntools.eq_(len(inst), 2 + 3 + 4 + 5 + 6 + 7)
+        ntools.eq_(len(inst), 2 + 2 + 3 + 4 + 5 + 6 + 7 + 7)
 
 
 class TestIFStateInfoParse(object):


### PR DESCRIPTION
Includes some path server refactoring. As SIBRA segments are not PCBs,
they need to be handled seperately.
- Handle all core PS propagation in a single place,
  _propagate_and_sync()
- Pack multiple segments into a propagation message if available.
- Have sibra server register steady paths with both the local and remote
  path servers.
- Extend PathSegmentRecords to handle sibra segments.
- Add a path_db equivelent for sibra (lib.sibra.seg_db).

Note: this change does not include querying for sibra paths, which will
be added in a later PR, and will involve more changes to the path
server.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/623%23issuecomment-182899916%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52992016%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52992281%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52992283%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52992365%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52992431%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52994650%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52995841%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52996062%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52996272%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r53002030%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r53002176%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23issuecomment-184659463%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r53024631%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r53025087%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r53025920%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r53040909%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23issuecomment-182899916%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%40shitz%20%5Cr%5Cn%40perrig%20%40reischuk%20%22%2C%20%22created_at%22%3A%20%222016-02-11T15%3A03%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%5Cr%5CnThere%20are%20many%20nice%20changes%21%20%5Cr%5Cn...%20but%20IMO%20it%27d%20be%20easier%20and%20cleaner%20to%20store%20sibra%20segments%20within%20PathSegments%20%22%2C%20%22created_at%22%3A%20%222016-02-16T12%3A11%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20bcec129485b777c462add765b4779bb63aa60484%20lib/sibra/segment.py%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r53002030%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22SibraSegments%20should%20be%20signed%20and%20timestamped.%22%2C%20%22created_at%22%3A%20%222016-02-16T12%3A06%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Good%20point%20-%20i%20had%20been%20relying%20on%20the%20ResvInfo%20object%27s%20expiry%20timestamp%2C%20but%20that%27s%20not%20great%20because%20it%20only%20has%20a%204s%20resolution.%20Working%20on%20that%20and%20adding%20a%20signature%20now.%22%2C%20%22created_at%22%3A%20%222016-02-16T15%3A31%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ve%20added%20both%2C%20but%20as%20discussed%20i%27ll%20look%20at%20using%20PathSegment%20instead%20soon.%22%2C%20%22created_at%22%3A%20%222016-02-16T16%3A58%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/sibra/segment.py%3AL1-99%22%7D%2C%20%22Pull%20bcec129485b777c462add765b4779bb63aa60484%20infrastructure/path_server/base.py%2081%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52992016%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20don%27t%20you%20unify%20that%20and%20use%20smth%20like%20%60PST.SIBRA%3A%20sibra%60%20%3F%22%2C%20%22created_at%22%3A%20%222016-02-16T10%3A22%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Because%20all%20the%20code%20that%20interacts%20with%20that%20object%20expects%20the%20contents%20of%20the%20dict%20to%20be%20PCBs%2C%20which%20the%20sibra%20segment%20is%20not.%22%2C%20%22created_at%22%3A%20%222016-02-16T10%3A25%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22yeah%2C%20and%20that%27s%20first%20mistake%20%3B-%29%22%2C%20%22created_at%22%3A%20%222016-02-16T10%3A26%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server/base.py%3AL240-262%22%7D%2C%20%22Pull%20bcec129485b777c462add765b4779bb63aa60484%20infrastructure/path_server/core.py%20151%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52994650%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Maybe%20put%20a%20comment%20or%20rename%20this%20variable%20to%20%60all_pcbs_from_local_isd%60.%5Cr%5CnThe%20issue%20is%20that%20via%20ZK%20we%20share%20packets%2C%20not%20pcbs%20%28on%20the%20other%20hand%20it%20is%20convenient%20to%20handle%20packets...%29.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-02-16T10%3A47%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20should%20definitely%20switch%20to%20sharing%20segments%2C%20probably%20combined%20with%20a%20src%20address.%20I%27ve%20added%20some%20comments%2C%20and%20a%20FIXME%20for%20now.%22%2C%20%22created_at%22%3A%20%222016-02-16T15%3A23%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server/core.py%3AL153-268%22%7D%2C%20%22Pull%20bcec129485b777c462add765b4779bb63aa60484%20lib/packet/path_mgmt.py%2032%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52995841%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60if%20data%60%20%3F%22%2C%20%22created_at%22%3A%20%222016-02-16T10%3A58%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Wasn%27t%20100%25%20sure%20if%20the%20semantics%20of%20Raw%20handled%20this%20correctly%2C%20but%20they%20do.%20Changed.%22%2C%20%22created_at%22%3A%20%222016-02-16T15%3A26%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path_mgmt.py%3AL125-186%22%7D%2C%20%22Pull%20bcec129485b777c462add765b4779bb63aa60484%20infrastructure/path_server/core.py%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52992281%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22what%27s%20that%3F%22%2C%20%22created_at%22%3A%20%222016-02-16T10%3A24%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Rather%20than%20sending%20a%20packet%20for%20every%20record%20that%20needs%20to%20be%20propagate%2C%20i%27ve%20added%20logic%20so%20that%20multiple%20records%20can%20be%20put%20in%20a%20single%20packet%2C%20currently%20limited%20to%205%20per%20packet.%22%2C%20%22created_at%22%3A%20%222016-02-16T10%3A25%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20see%2C%20before%20we%20thought%20that%20maybe%20it%20makes%20sense%20to%20register%20a%20segment%20using%20its%20path%20%28to%20additionally%20ensure%20that%20path%20works%29%2C%20but%20with%20revocation%20system%20working%20it%20may%20be%20unnecessary.%22%2C%20%22created_at%22%3A%20%222016-02-16T12%3A08%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/path_server/core.py%3AL39-47%22%7D%2C%20%22Pull%20bcec129485b777c462add765b4779bb63aa60484%20lib/packet/path_mgmt.py%2067%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/623%23discussion_r52996062%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20you%20add%20these%20two%20bytes%20here%3F%22%2C%20%22created_at%22%3A%20%222016-02-16T11%3A00%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Because%20there%27s%20now%20two%20sets%20of%20information%20in%20the%20raw%20packet%2C%20which%20have%20to%20be%20parsed%20differently%2C%20so%20i%27ve%20added%20a%20byte%20for%20each%20to%20specify%20how%20many%20of%20each%20to%20read.%22%2C%20%22created_at%22%3A%20%222016-02-16T11%3A02%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path_mgmt.py%3AL125-186%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/623#issuecomment-182899916'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach @shitz
  @perrig @reischuk
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
  There are many nice changes!
  ... but IMO it'd be easier and cleaner to store sibra segments within PathSegments
- [ ] <a href='#crh-comment-Pull bcec129485b777c462add765b4779bb63aa60484 infrastructure/path_server/base.py 81'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/623#discussion_r52992016'>File: infrastructure/path_server/base.py:L240-262</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> why don't you unify that and use smth like `PST.SIBRA: sibra` ?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Because all the code that interacts with that object expects the contents of the dict to be PCBs, which the sibra segment is not.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> yeah, and that's first mistake ;-)
- [ ] <a href='#crh-comment-Pull bcec129485b777c462add765b4779bb63aa60484 infrastructure/path_server/core.py 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/623#discussion_r52992281'>File: infrastructure/path_server/core.py:L39-47</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> what's that?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Rather than sending a packet for every record that needs to be propagate, i've added logic so that multiple records can be put in a single packet, currently limited to 5 per packet.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> I see, before we thought that maybe it makes sense to register a segment using its path (to additionally ensure that path works), but with revocation system working it may be unnecessary.
- [ ] <a href='#crh-comment-Pull bcec129485b777c462add765b4779bb63aa60484 infrastructure/path_server/core.py 151'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/623#discussion_r52994650'>File: infrastructure/path_server/core.py:L153-268</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> Maybe put a comment or rename this variable to `all_pcbs_from_local_isd`.
  The issue is that via ZK we share packets, not pcbs (on the other hand it is convenient to handle packets...).
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> We should definitely switch to sharing segments, probably combined with a src address. I've added some comments, and a FIXME for now.
- [ ] <a href='#crh-comment-Pull bcec129485b777c462add765b4779bb63aa60484 lib/packet/path_mgmt.py 32'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/623#discussion_r52995841'>File: lib/packet/path_mgmt.py:L125-186</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> `if data` ?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Wasn't 100% sure if the semantics of Raw handled this correctly, but they do. Changed.
- [ ] <a href='#crh-comment-Pull bcec129485b777c462add765b4779bb63aa60484 lib/packet/path_mgmt.py 67'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/623#discussion_r52996062'>File: lib/packet/path_mgmt.py:L125-186</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> why you add these two bytes here?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Because there's now two sets of information in the raw packet, which have to be parsed differently, so i've added a byte for each to specify how many of each to read.
- [ ] <a href='#crh-comment-Pull bcec129485b777c462add765b4779bb63aa60484 lib/sibra/segment.py 29'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/623#discussion_r53002030'>File: lib/sibra/segment.py:L1-99</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> SibraSegments should be signed and timestamped.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Good point - i had been relying on the ResvInfo object's expiry timestamp, but that's not great because it only has a 4s resolution. Working on that and adding a signature now.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I've added both, but as discussed i'll look at using PathSegment instead soon.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/623?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/623?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/623'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
