### PR TITLE
Use network byte order while sharing data between socket and python 

### DIFF
--- a/endhost/scion_socket.py
+++ b/endhost/scion_socket.py
@@ -75,7 +75,7 @@ class SCIONInterface(object):
         """
         data = Raw(raw, self.NAME, self.LEN)
         self.isd_as = ISD_AS(data.pop(ISD_AS.LEN))
-        self.ifid = struct.unpack("H", data.pop())[0]
+        self.ifid = struct.unpack("!H", data.pop())[0]
 
     def __str__(self):
         """
@@ -143,6 +143,7 @@ class ScionStats(object):
         data = Raw(raw, "Serialized SCION stats", self.FIXED_DATA_LEN, True)
         while len(data):
             values = data.pop(self.FIXED_DATA_LEN)
+            # The stats are native byte order
             rp, sp, ap, rtt, lr, ifc = struct.unpack("IIIIdI", values)
             self.received_packets.append(rp)
             self.sent_packets.append(sp)
@@ -362,7 +363,7 @@ class ScionBaseSocket(object):
         if opttype in self.LONG_OPTIONS:
             return buf
         else:
-            return struct.pack("I", opt.val)
+            return struct.pack("!I", opt.val)
 
     def shutdown(self, how):
         """

--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -210,14 +210,14 @@ class SCIONDaemon(SCIONElement):
             # TODO(PSz): remove dummy "0.0.0.0" address when API is saner
             haddr = self.ifid2addr.get(fwd_if, haddr_parse("IPV4", "0.0.0.0"))
             path_len = len(raw_path) // 8
-            reply.append(struct.pack("B", path_len) + raw_path +
-                         haddr.pack() + struct.pack("H", SCION_UDP_PORT) +
-                         struct.pack("H", path.mtu) +
-                         struct.pack("B", len(path.interfaces)))
+            reply.append(struct.pack("!B", path_len) + raw_path +
+                         haddr.pack() + struct.pack("!H", SCION_UDP_PORT) +
+                         struct.pack("!H", path.mtu) +
+                         struct.pack("!B", len(path.interfaces)))
             for interface in path.interfaces:
                 isd_as, link = interface
                 reply.append(isd_as.pack())
-                reply.append(struct.pack("H", link))
+                reply.append(struct.pack("!H", link))
         self._api_sock.send(b"".join(reply), sender)
 
     def handle_revocation(self, pkt):

--- a/endhost/ssp/Path.cpp
+++ b/endhost/ssp/Path.cpp
@@ -35,14 +35,14 @@ Path::Path(PathManager *manager, SCIONAddr &localAddr, SCIONAddr &dstAddr, uint8
             mFirstHop.addrLen = SCION_HOST_ADDR_LEN;
             memcpy(mFirstHop.addr, ptr, SCION_HOST_ADDR_LEN);
             ptr += mFirstHop.addrLen;
-            mFirstHop.port = *(uint16_t *)ptr;
+            mFirstHop.port = ntohs(*(uint16_t *)ptr);
             ptr += 2;
 #ifdef BYPASS_ROUTERS
             mFirstHop.addrLen = dstAddr.host.addrLen;
             memcpy(mFirstHop.addr, dstAddr.host.addr, mFirstHop.addrLen);
             mFirstHop.port = SCION_UDP_EH_DATA_PORT;
 #endif
-            mMTU = *(uint16_t *)ptr;
+            mMTU = ntohs(*(uint16_t *)ptr);
             if (mMTU == 0)
                 mMTU = SCION_DEFAULT_MTU;
             ptr += 2;
@@ -50,11 +50,11 @@ Path::Path(PathManager *manager, SCIONAddr &localAddr, SCIONAddr &dstAddr, uint8
             ptr++;
             for (int i = 0; i < interfaces; i++) {
                 SCIONInterface sif;
-                uint32_t isd_ad = *(uint32_t *)ptr;
+                uint32_t isd_ad = ntohl(*(uint32_t *)ptr);
                 ptr += 4;
                 sif.isd = isd_ad >> 20;
                 sif.ad = isd_ad & 0xfffff;
-                sif.interface = *(uint16_t *)ptr;
+                sif.interface = ntohs(*(uint16_t *)ptr);
                 ptr += 2;
                 mInterfaces.push_back(sif);
             }

--- a/endhost/ssp/SCIONSocket.cpp
+++ b/endhost/ssp/SCIONSocket.cpp
@@ -379,7 +379,7 @@ void * SCIONSocket::getStats(void *buf, int len)
             /* Python ISD_AD class expects network byte order */
             *(uint32_t *)ptr = htonl(ISD_AD(sif.isd, sif.ad));
             ptr += 4;
-            *(uint16_t *)ptr = sif.interface;
+            *(uint16_t *)ptr = htons(sif.interface);
             ptr += 2;
         }
     }

--- a/lib/crypto/symcrypto.py
+++ b/lib/crypto/symcrypto.py
@@ -65,7 +65,7 @@ def gen_of_mac(key, hof, prev_hof, ts):
     else:
         # Constant length for CBC-MAC's security.
         prev_hof_raw = b"\x00" * (HopOpaqueField.LEN - 1)
-    ts_raw = struct.pack("I", ts)
+    ts_raw = struct.pack("!I", ts)
     to_mac = hof_raw + prev_hof_raw + ts_raw + b"\x00"  # With \x00 as padding.
     return cbcmac(key, to_mac)[:HopOpaqueField.MAC_LEN]
 

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -96,7 +96,7 @@ def get_paths_via_api(addr):
         if ifcount:
             for i in range(ifcount):
                 isd_as = ISD_AS(data.pop(ISD_AS.LEN))
-                ifid = struct.unpack("H", data.pop(2))[0]
+                ifid = struct.unpack("!H", data.pop(2))[0]
                 ifs.append((isd_as, ifid))
         iflists.append(ifs)
     sock.close()


### PR DESCRIPTION
Patch put together by Jason.
Fixes https://github.com/netsec-ethz/scion/issues/634
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/635%23issuecomment-185705348%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/635%23issuecomment-185710558%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/635%23issuecomment-185770018%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/635%23issuecomment-185795188%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/635%23discussion_r53337829%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/635%23discussion_r53340186%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/635%23discussion_r53341325%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/635%23issuecomment-185808228%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/635%23issuecomment-185810052%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/635%23issuecomment-185705348%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22a%20formality%20at%20this%20point%2C%20but%20%5C%22lgtm%5C%22%22%2C%20%22created_at%22%3A%20%222016-02-18T12%3A44%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22There%27s%20a%20few%20other%20places%20that%20also%20need%20fixing%3A%5Cr%5Cn-%20%60ScionStats._parse%60%5Cr%5Cn-%20%60ScionBaseSocket.getopt%60%5Cr%5Cn-%20%60SCIONDaemon._api_handle_path_request%60%5Cr%5Cn%5Cr%5CnAlso%20places%20unrelated%20to%20the%20socket%3A%5Cr%5Cn-%20%60symcrypto.gen_of_mac%60%5Cr%5Cn-%20%60end2end_test.get_paths_via_api%60%22%2C%20%22created_at%22%3A%20%222016-02-18T13%3A04%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20%22%2C%20%22created_at%22%3A%20%222016-02-18T15%3A18%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20updated%20with%20the%20latest%20path.cpp%20changes.%22%2C%20%22created_at%22%3A%20%222016-02-18T16%3A11%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%22%2C%20%22created_at%22%3A%20%222016-02-18T16%3A42%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22thx%20%40kormat%20%21%22%2C%20%22created_at%22%3A%20%222016-02-18T16%3A48%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%203e6a39e118d7ebc5e2c8029c439330283a935a86%20endhost/ssp/SCIONSocket.cpp%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/635%23discussion_r53337829%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22After%20some%20checking%2C%20it%20seems%20that%20python%20does%20actually%20reverse%20bytes%20in%20a%20double%20as%20necessary%20for%20network%20byte%20order%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%3E%3E%3E%20struct.pack%28%5C%22%21d%5C%22%2C%20math.pi%29%5Cr%5Cnb%27%40%5C%5Ct%21%5C%5CxfbTD-%5C%5Cx18%27%5Cr%5Cn%3E%3E%3E%20struct.pack%28%5C%22d%5C%22%2C%20math.pi%29%5Cr%5Cnb%27%5C%5Cx18-DT%5C%5Cxfb%21%5C%5Ct%40%27%5Cr%5Cn%60%60%60%5Cr%5CnThis%20means%20that%20the%20lossRates%20stat%20should%20probably%20be%20passed%20through%20%60htobe64%60.%22%2C%20%22created_at%22%3A%20%222016-02-18T16%3A19%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22getStats%20only%20passes%20data%20around%20on%20the%20local%20host%20so%20why%20do%20we%20care%20about%20endianness%3F%22%2C%20%22created_at%22%3A%20%222016-02-18T16%3A32%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%27ve%20just%20decided%20to%20leave%20the%20rest%20of%20the%20stats%20as%20native-byte%20order.%20If%20there%20are%20going%20to%20be%20transmitted%20over%20the%20network%2C%20the%20application%20is%20responsible%20for%20representing%20them%20in%20a%20proper%20fashion.%5Cr%5Cn%5Cr%5CnIt%20does%20seem%20weird%20that%20/some/%20of%20the%20data%20returned%20by%20the%20call%20is%20native-order%20and%20some%20is%20network-order%2C%20but%20so%20it%20goes.%22%2C%20%22created_at%22%3A%20%222016-02-18T16%3A38%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/ssp/SCIONSocket.cpp%3AL362-386%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/635#issuecomment-185705348'>General Comment</a></b>
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> a formality at this point, but "lgtm"
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> There's a few other places that also need fixing:
- `ScionStats._parse`
- `ScionBaseSocket.getopt`
- `SCIONDaemon._api_handle_path_request`
  Also places unrelated to the socket:
- `symcrypto.gen_of_mac`
- `end2end_test.get_paths_via_api`
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat updated with the latest path.cpp changes.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> thx @kormat !
- [ ] <a href='#crh-comment-Pull 3e6a39e118d7ebc5e2c8029c439330283a935a86 endhost/ssp/SCIONSocket.cpp 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/635#discussion_r53337829'>File: endhost/ssp/SCIONSocket.cpp:L362-386</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> After some checking, it seems that python does actually reverse bytes in a double as necessary for network byte order:

```
>>> struct.pack("!d", math.pi)
b'@\t!\xfbTD-\x18'
>>> struct.pack("d", math.pi)
b'\x18-DT\xfb!\t@'
```

This means that the lossRates stat should probably be passed through `htobe64`.
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> getStats only passes data around on the local host so why do we care about endianness?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> We've just decided to leave the rest of the stats as native-byte order. If there are going to be transmitted over the network, the application is responsible for representing them in a proper fashion.
  It does seem weird that /some/ of the data returned by the call is native-order and some is network-order, but so it goes.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/635?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/635?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/635'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
