### PR TITLE
Small memory leak fix in dispatcher

### DIFF
--- a/endhost/dispatcher.c
+++ b/endhost/dispatcher.c
@@ -64,6 +64,7 @@ void registerSSP(char *buf, int len, struct sockaddr_in *addr)
         if (reg)
             HASH_ADD(hh, SSPWildcards, port, 2, e);
     }
+    free(e);
     printf("registration success\n");
     reply(1, addr);
 }
@@ -82,6 +83,7 @@ void registerUDP(char *buf, int len, struct sockaddr_in *addr)
     e->addr = *addr;
     e->port = port;
     HASH_REPLACE(hh, UDPPorts, port, 2, e, old);
+    free(e);
     printf("registration success\n");
     reply(1, addr);
 }
@@ -200,7 +202,7 @@ void * dataHandler(void *arg)
 int main(int argc, char **argv)
 {
     if (argc != 2) {
-        fprintf(stderr, "usage: %s host_addresss\n", argv[0]);
+        fprintf(stderr, "usage: %s host_address\n", argv[0]);
         return 1;
     }
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/640%23discussion_r53617370%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/640%23discussion_r53744636%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/640%23discussion_r53745472%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/640%23discussion_r53745533%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/640%23issuecomment-187587478%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/640%23issuecomment-190215301%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20e2c7fd7837836349be2b570d8874c64477ddef7c%20endhost/dispatcher.c%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/640%23discussion_r53745533%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Again%2C%20should%20be%20free%28old%29%20but%20this%20also%20needs%20to%20look%20like%20the%20registerSSP%20part%20to%20allow%20for%20de-registration.%22%2C%20%22created_at%22%3A%20%222016-02-23T07%3A46%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/dispatcher.c%3AL83-90%22%7D%2C%20%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/640%23issuecomment-187587478%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20starting%20to%20look%20like%20it%20should%20be%20part%20of%20the%20dispatcher%20PR%20I%27m%20currently%20working%20on%20in%20connection%20with%20SCMP.%20Let%27s%20keep%20this%20up%20here%20so%20I%20don%27t%20forget%2C%20but%20I%27ll%20include%20the%20contents%20in%20the%20next%20dispatcher%20PR%20I%20put%20in.%22%2C%20%22created_at%22%3A%20%222016-02-23T07%3A48%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20changes%20discussed%20here%20have%20been%20included%20in%20%23651%20%22%2C%20%22created_at%22%3A%20%222016-02-29T13%3A38%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20e2c7fd7837836349be2b570d8874c64477ddef7c%20endhost/dispatcher.c%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/640%23discussion_r53617370%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Should%20be%20free%28old%29%20shouldn%27t%20it%3F%22%2C%20%22created_at%22%3A%20%222016-02-22T12%3A20%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22isn%27t%20%5C%22old%5C%22%20located%20in%20the%20stack%20memory%3F%20while%20%5C%22e%5C%22%20is%20allocated%20on%20the%20heap.%20I%20will%20come%20by%20your%20office%20for%20a%20quick%20chat%20if%20this%20is%20ok%20for%20you.%20%22%2C%20%22created_at%22%3A%20%222016-02-23T07%3A34%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12380145%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brothen%22%7D%7D%2C%20%7B%22body%22%3A%20%22My%20office%20at%20the%20moment%20is%20in%20Korea%20so%20probably%20not%20%3A%29%5Cr%5CnAfter%20looking%20through%20the%20file%20again%2C%20this%20part%20should%20be%20a%20%5C%22free%28old%29%5C%22%20inside%20the%20%5C%22if%20%28old%29%5C%22%20blocks.%5Cr%5CnAfter%20the%20HASH_FIND%20macro%2C%20old%20points%20to%20the%20previously%20allocated%20block%20%28if%20any%29%20in%20the%20list%20and%20e%20is%20the%20new%20element%20added%20to%20the%20list%2C%20so%20old%20is%20the%20one%20that%20should%20be%20freed.%22%2C%20%22created_at%22%3A%20%222016-02-23T07%3A45%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/dispatcher.c%3AL64-71%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull e2c7fd7837836349be2b570d8874c64477ddef7c endhost/dispatcher.c 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/640#discussion_r53617370'>File: endhost/dispatcher.c:L64-71</a></b>
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> Should be free(old) shouldn't it?
- <a href='https://github.com/brothen'><img border=0 src='https://avatars.githubusercontent.com/u/12380145?v=3' height=16 width=16'></a> isn't "old" located in the stack memory? while "e" is allocated on the heap. I will come by your office for a quick chat if this is ok for you.
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> My office at the moment is in Korea so probably not :)
  After looking through the file again, this part should be a "free(old)" inside the "if (old)" blocks.
  After the HASH_FIND macro, old points to the previously allocated block (if any) in the list and e is the new element added to the list, so old is the one that should be freed.
- [ ] <a href='#crh-comment-Pull e2c7fd7837836349be2b570d8874c64477ddef7c endhost/dispatcher.c 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/640#discussion_r53745533'>File: endhost/dispatcher.c:L83-90</a></b>
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> Again, should be free(old) but this also needs to look like the registerSSP part to allow for de-registration.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/640#issuecomment-187587478'>General Comment</a></b>
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> This is starting to look like it should be part of the dispatcher PR I'm currently working on in connection with SCMP. Let's keep this up here so I don't forget, but I'll include the contents in the next dispatcher PR I put in.
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> The changes discussed here have been included in #651

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/640?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/640?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/640'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
