### PR TITLE
Don't include core segs for remote queries

### DIFF
--- a/infrastructure/path_server/local.py
+++ b/infrastructure/path_server/local.py
@@ -106,10 +106,7 @@ class LocalPathServer(PathServer):
             self._resolve_core(seg_req, up_segs, core_segs)
         else:
             self._resolve_not_core(seg_req, up_segs, core_segs, down_segs)
-        all_segs = up_segs | core_segs | down_segs
-        if all_segs:
-            logging.debug("Replying with %s segments to %s",
-                          len(all_segs), seg_req.short_desc())
+        if (up_segs | core_segs | down_segs):
             self._send_path_segments(pkt, up_segs, core_segs, down_segs)
             return True
         if new_request:


### PR DESCRIPTION
Currently if a query to a remote cPS for a down-segment will get a reply
that includes core-segments within the remote ISD, which are useless for
the queryer.

Also removing a couple of less useful logging lines.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/645%23issuecomment-188256447%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/645%23issuecomment-188257737%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/645%23issuecomment-188256447%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222016-02-24T13%3A31%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-02-24T13%3A37%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/645#issuecomment-188256447'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/645?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/645?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/645'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
