### PR TITLE
Add a direction flag to sibra reservation info blocks

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -411,11 +411,14 @@ class SCIONDaemon(SCIONElement):
 
     def _sibra_strip_pcb(self, pcb):
         last_asm = pcb.ases[-1]
-        info = last_asm.find_ext(BeaconExtType.SIBRA_SEG_INFO)
-        resv = ResvBlockSteady.from_values(info, pcb.get_n_hops())
-        for asm in reversed(pcb.ases):
-            resv.sofs.append(asm.find_ext(BeaconExtType.SIBRA_SEG_SOF))
-        return resv
+        info_ext = last_asm.find_ext(BeaconExtType.SIBRA_SEG_INFO)
+        resv_info = info_ext.info
+        resv = ResvBlockSteady.from_values(resv_info, pcb.get_n_hops())
+        asms = reversed(pcb.ases) if resv_info.fwd_dir else pcb.ases
+        for asm in asms:
+            sof_ext = asm.find_ext(BeaconExtType.SIBRA_SEG_SOF)
+            resv.sofs.append(sof_ext.sof)
+        return info_ext.id, resv
 
     def _wait_for_events(self, events, deadline):
         """

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -169,6 +169,8 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
             self._add_if_mappings(pcb)
             logging.info("%s-Segment registered: %s", name, pcb.short_desc())
             return True
+        elif res == DBResult.ENTRY_UPDATED:
+            logging.debug("%s-Segment updated: %s", name, pcb.short_desc())
         return False
 
     def _handle_revocation(self, pkt):

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -189,7 +189,7 @@ class SCIONElement(object):
 
     def _ext_first_hop(self, spkt):
         for hdr in spkt.ext_hdrs:
-            if_id = hdr.get_first_ifid()
+            if_id = hdr.get_next_ifid()
             if if_id is not None:
                 return if_id
 

--- a/infrastructure/sibra_server/main.py
+++ b/infrastructure/sibra_server/main.py
@@ -122,7 +122,6 @@ class SibraServerBase(SCIONElement):
                               spkt)
                 continue
             spkt.addrs.src.host = self.addr.host
-            logging.debug("Sending packet via %s:%s\n%s", dst, port, spkt)
             self.send(spkt, dst, port)
 
     def _find_dest(self, spkt):

--- a/infrastructure/sibra_server/steady.py
+++ b/infrastructure/sibra_server/steady.py
@@ -230,39 +230,26 @@ class SteadyPath(object):
             cmn_hdr, addr_hdr, EmptyPath(), [ext], udp_hdr, payload)
 
     def _register_path(self):
-        pcb = self._create_reg_pcb()
-        pkt = self._create_reg_pkt(pcb)
         logging.debug("Registering path with local path server")
+        pkt = self._create_reg_pkt()
         self.sendq.put(pkt)
-        pkt = self._create_reg_pkt(pcb, core=True)
         logging.debug("Registering path with core path server in %s",
                       self.remote)
+        pkt = self._create_reg_pkt(core=True)
         self.sendq.put(pkt)
 
-    def _create_reg_pcb(self):
-        pcb = copy.deepcopy(self.seg)
-        # TODO(kormat): It might make sense to remove peer markings also, but
-        # they might also be needed for sibra steady paths that traverse peer
-        # links in the future.
-        pcb.remove_signatures()
-        latest = self.blocks[-1]
-        for asm, sof in zip(reversed(pcb.ases), latest.sofs):
-            asm.add_ext(SibraSegSOF.from_values(sof))
-        last_asm = pcb.ases[-1]
-        last_asm.add_ext(SibraSegInfo.from_values(self.id, latest.info))
-        last_asm.sig = sign(pcb.pack(), self.signing_key)
-        pcb.flags |= PSF.SIBRA
-        return pcb
-
-    def _create_reg_pkt(self, pcb, core=False):
+    def _create_reg_pkt(self, core=False):
         if core:
             dst_ia = self.remote
             path = self.seg.get_path(True)
             type_ = PST.DOWN
+            fwd_dir = False
         else:
             dst_ia = self.addr.isd_as
             path = EmptyPath()
             type_ = PST.UP
+            fwd_dir = True
+        pcb = self._create_reg_pcb(fwd_dir=fwd_dir)
         pld = PathRecordsReg.from_values({type_: [pcb]})
         dest = SCIONAddr.from_values(dst_ia, PT.PATH_MGMT)
         cmn_hdr, addr_hdr = build_base_hdrs(self.addr, dest)
@@ -270,6 +257,23 @@ class SteadyPath(object):
             self.addr, SCION_UDP_PORT, dest, SCION_UDP_PORT, pld)
         return SCIONL4Packet.from_values(
             cmn_hdr, addr_hdr, path, [], udp_hdr, pld)
+
+    def _create_reg_pcb(self, fwd_dir):
+        pcb = copy.deepcopy(self.seg)
+        # TODO(kormat): It might make sense to remove peer markings also, but
+        # they might also be needed for sibra steady paths that traverse peer
+        # links in the future.
+        pcb.remove_signatures()
+        pcb.flags |= PSF.SIBRA
+        latest = self.blocks[-1]
+        info = copy.deepcopy(latest.info)
+        info.fwd_dir = fwd_dir
+        for asm, sof in zip(reversed(pcb.ases), latest.sofs):
+            asm.add_ext(SibraSegSOF.from_values(sof))
+        last_asm = pcb.ases[-1]
+        last_asm.add_ext(SibraSegInfo.from_values(self.id, info))
+        last_asm.sig = sign(pcb.pack(), self.signing_key)
+        return pcb
 
     def __str__(self):
         with self._lock:

--- a/lib/packet/ext_hdr.py
+++ b/lib/packet/ext_hdr.py
@@ -79,7 +79,7 @@ class ExtensionHeader(HeaderBase):
     def reverse(self):  # pragma: no cover
         pass
 
-    def get_first_ifid(self):  # pragma: no cover
+    def get_next_ifid(self):  # pragma: no cover
         pass
 
     def __str__(self):

--- a/lib/sibra/ext/sof.py
+++ b/lib/sibra/ext/sof.py
@@ -84,8 +84,7 @@ class SibraOpaqueField(object):
         """
         raw = []
         raw.append(struct.pack("!HH", self.ingress, self.egress))
-        # Don't include the last byte of the ResvInfo object
-        raw.append(info.pack()[:info.LEN-1] + bytes(1))
+        raw.append(info.pack(mac=True))
         ids_len = 0
         for id_ in path_ids:
             ids_len += len(id_)

--- a/lib/sibra/pcb_ext/sof.py
+++ b/lib/sibra/pcb_ext/sof.py
@@ -30,7 +30,7 @@ class SibraSegSOF(BeaconExtension):  # pragma: no cover
     LEN = SibraOpaqueField.LEN
 
     def __init__(self, raw=None):
-        self.info = None
+        self.sof = None
         super().__init__(raw)
 
     def _parse(self, raw):

--- a/test/lib/sibra/ext/info_test.py
+++ b/test/lib/sibra/ext/info_test.py
@@ -61,8 +61,9 @@ class TestResvInfoBasePack(object):
         inst.bw.ceil.return_value = bw
         inst.exp_tick = 0x00010203
         inst.index = 8
+        inst.fwd_dir = True
         inst.fail_hop = 7
-        expected = b"".join([bytes(range(4)), bytes.fromhex("05088007")])
+        expected = b"".join([bytes(range(4)), bytes.fromhex("05088807")])
         # Call
         ntools.eq_(inst.pack(), expected)
 

--- a/test/lib/sibra/ext/sof_test.py
+++ b/test/lib/sibra/ext/sof_test.py
@@ -76,7 +76,7 @@ class TestSibraOpaqueFieldCalcMac(object):
         ntools.eq_(inst.calc_mac(info, "key", [b"path id0"]), "cbcm")
         # Tests
         cbcmac.assert_called_once_with("key", b"".join([
-            bytes.fromhex("1111 FFFF"), b"packinf", bytes(1), b"path id0",
+            bytes.fromhex("1111 FFFF"), b"packinfo", b"path id0",
             bytes(inst.MAX_PATH_IDS_LEN - 8), bytes(8),
             bytes(inst.MAC_BLOCK_PADDING),
         ]))
@@ -96,7 +96,7 @@ class TestSibraOpaqueFieldCalcMac(object):
         ntools.eq_(inst.calc_mac(info, "key", path_ids, prev_raw), "cbcm")
         # Tests
         cbcmac.assert_called_once_with("key", b"".join([
-            bytes.fromhex("1111 FFFF"), b"packinf", bytes(1),
+            bytes.fromhex("1111 FFFF"), b"packinfo",
             b"steadyid", b"ephemeralpath id",
             prev_raw, bytes(inst.MAC_BLOCK_PADDING),
         ]))


### PR DESCRIPTION
When a leaf AS registers a sibra steady path with a core AS, it needs to
set a flag to say that the opaque-fields should be verified in reverse
order.

Also update sibra_ext_test.py to look up steady paths between two
specified ASes, and test that it works.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/646%23issuecomment-188351482%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/646%23issuecomment-188638345%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/646%23issuecomment-188695156%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/646%23issuecomment-188351482%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%5Cr%5Cn%40perrig%20%40reischuk%20%5Cr%5Cn%5Cr%5CnUnit%20tests%20still%20need%20updating.%22%2C%20%22created_at%22%3A%20%222016-02-24T16%3A55%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-02-25T06%3A44%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Unittests%20updated%2C%20merging.%22%2C%20%22created_at%22%3A%20%222016-02-25T09%3A45%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/646#issuecomment-188351482'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
  @perrig @reischuk
  Unit tests still need updating.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Unittests updated, merging.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/646?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/646?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/646'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
