### PR TITLE
Adds stay ISD feature.

### DIFF
--- a/endhost/kbase_lookup_service.py
+++ b/endhost/kbase_lookup_service.py
@@ -111,7 +111,7 @@ class KnowledgeBaseLookupService(object):
                 req_type = request['req_type']
                 res_name = request['res_name']
             except KeyError as e:
-                logging.error('Key error while parsing request: %s' % e)
+                logging.error('Key error while parsing LOOKUP req: %s' % e)
                 return
             assert(isinstance(req_type, str))
             resp = self.kbase.lookup(req_type, res_name)
@@ -119,6 +119,14 @@ class KnowledgeBaseLookupService(object):
             resp = self._get_topology()
         elif cmd == 'LOCATIONS':
             resp = self._get_locations()
+        elif cmd == 'STAY_ISD':
+            try:
+                isd = request['isd']
+            except KeyError as e:
+                logging.error('Key error while parsing STAY_ISD req: %s' % e)
+                return
+            assert(isinstance(isd, int))
+            resp = self._handle_stay_ISD(isd)
         else:
             logging.error('Unsupported command: %s')
             return
@@ -203,3 +211,13 @@ class KnowledgeBaseLookupService(object):
             except (yaml.YAMLError, KeyError) as e:
                 logging.error('Error while reading the locations YAML: %s' % e)
                 return {}
+
+    def _handle_stay_ISD(self, isd):
+        """
+        Lets the kbase know of which ISD should be enforced.
+        :param isd: ISD number
+        :type isd: int
+        :returns: A dictionary indicating the result.
+        :rtype: dict
+        """
+        return self.kbase.set_stay_ISD(isd)

--- a/endhost/socket_kbase.py
+++ b/endhost/socket_kbase.py
@@ -44,6 +44,7 @@ class SocketKnowledgeBase(object):
         """
         self.active_sockets = set()
         self.kbase = {}  # HTTP Req (method, path) to stats (ScionStats)
+        self.stay_ISD = 0  # ISD to enforce. 0 means do not enforce any.
         self.lock = threading.Lock()
         self.gatherer = threading.Thread(
             target=thread_safety_net,
@@ -106,6 +107,28 @@ class SocketKnowledgeBase(object):
         :rtype: list
         """
         return list(self.kbase.keys())
+
+    def set_stay_ISD(self, isd):
+        """
+        Setter function for stay_ISD class member.
+        :param isd: ISD number (positive integer)
+        :type isd: int
+        """
+        if isd < 0:
+            logging.error("Invalid value to set_stay_ISD. Ignoring: %d", isd)
+            return {'STATUS': 'INVALID_ISD'}
+        else:
+            self.stay_ISD = isd
+            logging.info("Stay ISD set: %d", self.stay_ISD)
+            return {'STATUS': 'OK'}
+
+    def get_stay_ISD(self):
+        """
+        Getter function for stay_ISD class member.
+        :returns ISD to enforce.
+        :type isd: int
+        """
+        return self.stay_ISD
 
     def update_single_stat(self, soc):
         """

--- a/test/integration/kbase_lookup_test.py
+++ b/test/integration/kbase_lookup_test.py
@@ -44,6 +44,7 @@ def main():
     test_lookup()
     test_topology_lookup()
     test_locations_lookup()
+    test_stay_ISD()
 
 
 def test_list():
@@ -107,6 +108,22 @@ def test_locations_lookup():
 
     req = {"version": "0.1",
            "command": "LOCATIONS"}
+
+    send_req_and_read_resp(sock, req)
+
+
+def test_stay_ISD():
+    """
+    Creates a stay ISD request, sends it to the UDP server.
+    """
+
+    logging.info('Starting the stay ISD request test')
+    # Create a UDP socket
+    sock = UDPSocket(None, AddrType.IPV4)
+
+    req = {"version": "0.1",
+           "command": "STAY_ISD",
+           "isd": 1}
 
     send_req_and_read_resp(sock, req)
 


### PR DESCRIPTION
This patch adds the ability to the SCION proxy and knowledge-base to enforce
the communication within a certain ISD. SCION visualization extension can
now talk to the SCION socket knowledge-base and enforce the communication
to stay in a given ISD.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/655%23issuecomment-190305779%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/655%23discussion_r54525328%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/655%23issuecomment-190800212%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/655%23issuecomment-190801658%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/655%23discussion_r54594671%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/655%23issuecomment-190813397%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/655%23issuecomment-190305779%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40mwfarb%20%40kormat%20%40aznair%20%22%2C%20%22created_at%22%3A%20%222016-02-29T17%3A43%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aznair%20done%20the%20change%20you%20mentioned.%20what%20do%20you%20think%3F%22%2C%20%22created_at%22%3A%20%222016-03-01T16%3A37%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-03-01T16%3A39%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22thx.%20merging%22%2C%20%22created_at%22%3A%20%222016-03-01T16%3A59%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%200a4ed62075716b6bc240dc401abc13935fd75cc1%20endhost/scion_proxy.py%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/655%23discussion_r54525328%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22setopt%20will%20return%20a%20POSIX%20errno%20value%20such%20as%20EINVAL%20or%20EPERM%20so%20we%20could%20probably%20use%20some%20errno%20module%20to%20print%20a%20string%20representation%20of%20the%20error%20value%2C%20which%20might%20help%20debugging%22%2C%20%22created_at%22%3A%20%222016-03-01T05%3A44%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-03-01T16%3A39%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/scion_proxy.py%3AL387-399%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/655#issuecomment-190305779'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @mwfarb @kormat @aznair
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @aznair done the change you mentioned. what do you think?
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> thx. merging
- [x] <a href='#crh-comment-Pull 0a4ed62075716b6bc240dc401abc13935fd75cc1 endhost/scion_proxy.py 28'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/655#discussion_r54525328'>File: endhost/scion_proxy.py:L387-399</a></b>
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> setopt will return a POSIX errno value such as EINVAL or EPERM so we could probably use some errno module to print a string representation of the error value, which might help debugging

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/655?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/655?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/655'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
