### PR TITLE
Cleanup PCB string formatting.

### DIFF
--- a/lib/packet/pcb.py
+++ b/lib/packet/pcb.py
@@ -135,7 +135,7 @@ class PCBMarking(MarkingBase):
     def __str__(self):
         s = []
         s.append("%s(%dB): ISD-AS %s:" % (self.NAME, len(self), self.isd_as))
-        s.append("  ig_rev_token: %s" % self.ig_rev_token)
+        s.append("  ig_rev_token: %s" % hex_str(self.ig_rev_token))
         s.append("  %s" % self.hof)
         return "\n".join(s)
 
@@ -275,12 +275,18 @@ class ASMarking(MarkingBase):
         s.append("  cert_ver: %s, ext_len %s, sig_len: %s, block_len: %s" %
                  (self.cert_ver, len(self._pack_ext()),
                   len(self.sig), self.block_len))
-        s.append("  %s" % self.pcbm)
-        for peer_marking in self.pms:
-            s.append("  %s" % peer_marking)
+        for line in str(self.pcbm).splitlines():
+            s.append("  %s" % line)
+        if self.pms:
+            s.append("  Peer markings:")
+        for pm in self.pms:
+            for line in str(pm).splitlines():
+                s.append("    %s" % line)
+        if self.ext:
+            s.append("  PCB Extensions:")
         for ext in self.ext:
-            s.append("  %s" % str(ext))
-        s.append("  eg_rev_token: %s" % self.eg_rev_token)
+            s.append("    %s" % str(ext))
+        s.append("  eg_rev_token: %s" % hex_str(self.eg_rev_token))
         s.append("  Signature: %s" % hex_str(self.sig))
         return "\n".join(s)
 
@@ -555,10 +561,11 @@ class PathSegment(SCIONPayloadBase):
         s = []
         s.append("%s(%dB):" % (self.NAME, len(self)))
         s.append("  %s" % self.iof)
-        s.append("  trc_ver: %d, if_id: %d" % (self.trc_ver, self.if_id))
-        s.append(" Flags: %s" % PSF.to_str(self.flags))
+        s.append("  trc_ver: %d, if_id: %d, Flags: %s" % (
+            self.trc_ver, self.if_id, PSF.to_str(self.flags)))
         for asm in self.ases:
-            s.append("  %s" % asm)
+            for line in str(asm).splitlines():
+                s.append("  %s" % line)
         return "\n".join(s)
 
     def __hash__(self):  # pragma: no cover


### PR DESCRIPTION
Makes it much easier to read.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/656%23issuecomment-190653025%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/656%23issuecomment-190653136%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/656%23issuecomment-190653896%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/656%23issuecomment-190653025%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%40shitz%20%22%2C%20%22created_at%22%3A%20%222016-03-01T10%3A29%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Example%20of%20the%20new%2C%20properly-indented%2C%20output%3A%5Cr%5Cn%60%60%60%5Cr%5CnPathSegment%28405B%29%3A%5Cr%5Cn%20%20%5BInfo%20OF%20info%288B%29%3A%20CORE%2C%20up%3A%20False%2C%20TS%3A%202016-03-01%2010%3A28%3A01%2B00%3A00%2C%20ISD%3A%201%2C%20hops%3A%203%5D%5Cr%5Cn%20%20trc_ver%3A%200%2C%20if_id%3A%201%2C%20Flags%3A%20None%5Cr%5Cn%20%20ASMarking%2894B%29%3A%5Cr%5Cn%20%20%20%20cert_ver%3A%200%2C%20ext_len%2010%2C%20sig_len%3A%200%2C%20block_len%3A%2044%5Cr%5Cn%20%20%20%20PCBMarking%2844B%29%3A%20ISD-AS%201-13%3A%5Cr%5Cn%20%20%20%20%20%20ig_rev_token%3A%200000000000000000000000000000000000000000000000000000000000000000%5Cr%5Cn%20%20%20%20%20%20Hop%20OF%20info%288B%29%3A%20XOVR_POINT%2C%20exp_time%3A%2063%2C%20ingress%20if%3A%200%2C%20egress%20if%3A%203%2C%20mac%3A%204eddf4%5Cr%5Cn%20%20%20%20MTU%20Ext%282B%29%3A%20MTU%20is%201500B%5Cr%5Cn%20%20%20%20B/W%20available%20%28kbps%29%3A%20steady%3A%201%20ephemeral%3A%202%5Cr%5Cn%20%20%20%20eg_rev_token%3A%20f03ad65d2acf6bfd9b53b8c7c4ea5b9a5dc306fa98494b8081d3cdfc321c6a56%5Cr%5Cn%20%20%20%20Signature%3A%5Cr%5Cn%20%20ASMarking%28138B%29%3A%5Cr%5Cn%20%20%20%20cert_ver%3A%200%2C%20ext_len%2010%2C%20sig_len%3A%200%2C%20block_len%3A%2088%5Cr%5Cn%20%20%20%20PCBMarking%2844B%29%3A%20ISD-AS%201-16%3A%5Cr%5Cn%20%20%20%20%20%20ig_rev_token%3A%20d7a923d6b3aaa64571753b97250f3219426bd0c27a1768be0cb7dc56877a4bc6%5Cr%5Cn%20%20%20%20%20%20Hop%20OF%20info%288B%29%3A%20NORMAL_OF%2C%20exp_time%3A%2063%2C%20ingress%20if%3A%201%2C%20egress%20if%3A%203%2C%20mac%3A%20c51f08%5Cr%5Cn%20%20%20%20Peer%20markings%3A%5Cr%5Cn%20%20%20%20%20%20PCBMarking%2844B%29%3A%20ISD-AS%201-15%3A%5Cr%5Cn%20%20%20%20%20%20%20%20ig_rev_token%3A%2010e10291cd24db64a91e83809682c596a91fb0465adf945a740f04fd19f6eeaf%5Cr%5Cn%20%20%20%20%20%20%20%20Hop%20OF%20info%288B%29%3A%20XOVR_POINT%2C%20exp_time%3A%2063%2C%20ingress%20if%3A%202%2C%20egress%20if%3A%203%2C%20mac%3A%20f13ca9%5Cr%5Cn%20%20%20%20MTU%20Ext%282B%29%3A%20MTU%20is%201500B%5Cr%5Cn%20%20%20%20B/W%20available%20%28kbps%29%3A%20steady%3A%201%20ephemeral%3A%202%5Cr%5Cn%20%20%20%20eg_rev_token%3A%20bd0ad83022513cd8f75fd71f386994ac24103a6be8319131251586074bc344c8%5Cr%5Cn%20%20%20%20Signature%3A%5Cr%5Cn%20%20ASMarking%28158B%29%3A%5Cr%5Cn%20%20%20%20cert_ver%3A%200%2C%20ext_len%2010%2C%20sig_len%3A%2064%2C%20block_len%3A%2044%5Cr%5Cn%20%20%20%20PCBMarking%2844B%29%3A%20ISD-AS%201-19%3A%5Cr%5Cn%20%20%20%20%20%20ig_rev_token%3A%20d43ae348c5f6bf733e0873347ce45a13356af16acfc0d50761c63290424d5ea9%5Cr%5Cn%20%20%20%20%20%20Hop%20OF%20info%288B%29%3A%20NORMAL_OF%2C%20exp_time%3A%2063%2C%20ingress%20if%3A%201%2C%20egress%20if%3A%200%2C%20mac%3A%20e1a95f%5Cr%5Cn%20%20%20%20MTU%20Ext%282B%29%3A%20MTU%20is%201500B%5Cr%5Cn%20%20%20%20B/W%20available%20%28kbps%29%3A%20steady%3A%201%20ephemeral%3A%202%5Cr%5Cn%20%20%20%20eg_rev_token%3A%200000000000000000000000000000000000000000000000000000000000000000%5Cr%5Cn%20%20%20%20Signature%3A%207fcbb588c7f30652be4191b0fc5f58b501f03553e9607607fb2cc5e1562237fe2666010034d79039c72cfe69cea379376fcfb4a88e36a5224d4adf68cf7b2a0e%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-03-01T10%3A30%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-03-01T10%3A31%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/656#issuecomment-190653025'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach @shitz
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Example of the new, properly-indented, output:

```
PathSegment(405B):
[Info OF info(8B): CORE, up: False, TS: 2016-03-01 10:28:01+00:00, ISD: 1, hops: 3]
trc_ver: 0, if_id: 1, Flags: None
ASMarking(94B):
cert_ver: 0, ext_len 10, sig_len: 0, block_len: 44
PCBMarking(44B): ISD-AS 1-13:
ig_rev_token: 0000000000000000000000000000000000000000000000000000000000000000
Hop OF info(8B): XOVR_POINT, exp_time: 63, ingress if: 0, egress if: 3, mac: 4eddf4
MTU Ext(2B): MTU is 1500B
B/W available (kbps): steady: 1 ephemeral: 2
eg_rev_token: f03ad65d2acf6bfd9b53b8c7c4ea5b9a5dc306fa98494b8081d3cdfc321c6a56
Signature:
ASMarking(138B):
cert_ver: 0, ext_len 10, sig_len: 0, block_len: 88
PCBMarking(44B): ISD-AS 1-16:
ig_rev_token: d7a923d6b3aaa64571753b97250f3219426bd0c27a1768be0cb7dc56877a4bc6
Hop OF info(8B): NORMAL_OF, exp_time: 63, ingress if: 1, egress if: 3, mac: c51f08
Peer markings:
PCBMarking(44B): ISD-AS 1-15:
ig_rev_token: 10e10291cd24db64a91e83809682c596a91fb0465adf945a740f04fd19f6eeaf
Hop OF info(8B): XOVR_POINT, exp_time: 63, ingress if: 2, egress if: 3, mac: f13ca9
MTU Ext(2B): MTU is 1500B
B/W available (kbps): steady: 1 ephemeral: 2
eg_rev_token: bd0ad83022513cd8f75fd71f386994ac24103a6be8319131251586074bc344c8
Signature:
ASMarking(158B):
cert_ver: 0, ext_len 10, sig_len: 64, block_len: 44
PCBMarking(44B): ISD-AS 1-19:
ig_rev_token: d43ae348c5f6bf733e0873347ce45a13356af16acfc0d50761c63290424d5ea9
Hop OF info(8B): NORMAL_OF, exp_time: 63, ingress if: 1, egress if: 0, mac: e1a95f
MTU Ext(2B): MTU is 1500B
B/W available (kbps): steady: 1 ephemeral: 2
eg_rev_token: 0000000000000000000000000000000000000000000000000000000000000000
Signature: 7fcbb588c7f30652be4191b0fc5f58b501f03553e9607607fb2cc5e1562237fe2666010034d79039c72cfe69cea379376fcfb4a88e36a5224d4adf68cf7b2a0e
```
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/656?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/656?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/656'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
