### PR TITLE
Rewrite handling of info byte in Opaque Fields.

### DIFF
--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -35,7 +35,6 @@ from infrastructure.beacon_server.rev_obj import RevocationObject
 from lib.crypto.asymcrypto import sign
 from lib.crypto.certificate import CertificateChain, verify_sig_chain_trc
 from lib.crypto.hash_chain import HashChain, HashChainExhausted
-from lib.crypto.symcrypto import gen_of_mac
 from lib.defines import (
     BEACON_SERVICE,
     CERTIFICATE_SERVICE,
@@ -72,7 +71,6 @@ from lib.thread import thread_safety_net
 from lib.types import (
     CertMgmtType,
     IFIDType,
-    OpaqueFieldType as OFT,
     PCBType,
     PathMgmtType as PMT,
     PayloadClass,
@@ -324,8 +322,8 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         hof = HopOpaqueField.from_values(self.HOF_EXP_TIME,
                                          ingress_if, egress_if)
         if prev_hof is None:
-            hof.info = OFT.XOVR_POINT
-        hof.mac = gen_of_mac(self.of_gen_key, hof, prev_hof, ts)
+            hof.xover = True
+        hof.set_mac(self.of_gen_key, ts, prev_hof)
         pcbm = PCBMarking.from_values(
             self.addr.isd_as, hof, self._get_if_rev_token(ingress_if))
         peer_markings = []
@@ -336,8 +334,8 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
                 continue
             peer_hof = HopOpaqueField.from_values(self.HOF_EXP_TIME,
                                                   if_id, egress_if)
-            peer_hof.info = OFT.XOVR_POINT
-            peer_hof.mac = gen_of_mac(self.of_gen_key, peer_hof, hof, ts)
+            peer_hof.xover = True
+            peer_hof.set_mac(self.of_gen_key, ts, hof)
             peer_marking = \
                 PCBMarking.from_values(router_peer.interface.isd_as,
                                        peer_hof, self._get_if_rev_token(if_id))

--- a/infrastructure/beacon_server/core.py
+++ b/infrastructure/beacon_server/core.py
@@ -29,7 +29,7 @@ from lib.packet.path_mgmt import PathRecordsReg
 from lib.packet.pcb import PathSegment
 from lib.packet.scion import PacketType as PT
 from lib.path_store import PathStore
-from lib.types import OpaqueFieldType as OFT, PathSegmentType as PST
+from lib.types import PathSegmentType as PST
 from lib.util import SCIONTime
 
 
@@ -99,13 +99,11 @@ class CoreBeaconServer(BeaconServer):
         """
         timestamp = int(SCIONTime.get_time())
         # Create beacon for downstream ASes.
-        down_iof = InfoOpaqueField.from_values(
-            OFT.CORE, False, timestamp, self.topology.isd_as[0])
+        down_iof = InfoOpaqueField.from_values(timestamp, self.addr.isd_as[0])
         downstream_pcb = PathSegment.from_values(down_iof)
         self.propagate_downstream_pcb(downstream_pcb)
         # Create beacon for core ASes.
-        core_iof = InfoOpaqueField.from_values(
-            OFT.CORE, False, timestamp, self.topology.isd_as[0])
+        core_iof = InfoOpaqueField.from_values(timestamp, self.addr.isd_as[0])
         core_pcb = PathSegment.from_values(core_iof)
         core_count = self.propagate_core_pcb(core_pcb)
         # Propagate received beacons. A core beacon server can only receive

--- a/lib/crypto/symcrypto.py
+++ b/lib/crypto/symcrypto.py
@@ -15,14 +15,8 @@
 :mod:`symcrypto` --- SCION symmetric crypto functions
 =====================================================
 """
-# Stdlib
-import struct
-
 # External packages
 from Crypto.Cipher import AES
-
-# SCION
-from lib.packet.opaque_field import HopOpaqueField
 
 
 def cbcmac(key, msg):
@@ -50,28 +44,3 @@ def cbcmac(key, msg):
         iv = b"\x00" * 16
         cipher = AES.new(key, AES.MODE_CBC, iv)
         return cipher.encrypt(msg)[-16:]  # Return the last block of ciphertext.
-
-
-def gen_of_mac(key, hof, prev_hof, ts):
-    """
-    Generates MAC for newly created OF.
-    Takes newly created OF (except MAC field), previous HOF, and timestamp.
-    """
-    # TODO: this is stronly SCION-related, maybe move to other file?
-    # Drop info field (as it changes) and MAC field (empty).
-    hof_raw = hof.pack()[1:-HopOpaqueField.MAC_LEN]
-    if prev_hof:
-        prev_hof_raw = prev_hof.pack()[1:]  # Drop info field.
-    else:
-        # Constant length for CBC-MAC's security.
-        prev_hof_raw = b"\x00" * (HopOpaqueField.LEN - 1)
-    ts_raw = struct.pack("!I", ts)
-    to_mac = hof_raw + prev_hof_raw + ts_raw + b"\x00"  # With \x00 as padding.
-    return cbcmac(key, to_mac)[:HopOpaqueField.MAC_LEN]
-
-
-def verify_of_mac(key, hof, prev_hof, ts):
-    """
-    Verifies MAC of OF.
-    """
-    return hof.mac == gen_of_mac(key, hof, prev_hof, ts)

--- a/lib/defines.py
+++ b/lib/defines.py
@@ -90,8 +90,10 @@ DISPATCHER_TIMEOUT = 60
 
 #: How often IFID packet is sent to neighboring router.
 IFID_PKT_TOUT = 1
-
-SCION_MIN_MTU = 1280  # IPv6 min value
+#: IPv6 min value
+SCION_MIN_MTU = 1280
+#: Length of opaque fields
+OPAQUE_FIELD_LEN = 8
 
 #: Number of seconds per sibra tick
 SIBRA_TICK = 4

--- a/lib/flagtypes.py
+++ b/lib/flagtypes.py
@@ -31,11 +31,27 @@ class FlagBase(object):  # pragma: no cover
         for val in sorted(self._rev):
             if flags & val:
                 ret.append(self._rev[val])
-        if not ret:
-            return "None"
-        return "|".join(ret)
+        return "|".join(ret) or "None"
 
 
 PathSegFlags = FlagBase((
     ("SIBRA", 1),
+))
+
+InfoOFFlags = FlagBase((
+    ("UP", 1),
+    ("SHORTCUT", 2),
+    ("PEER_SHORTCUT", 4),
+))
+
+HopOFFlags = FlagBase((
+    # Used to signal that this HOF is at a cross-over point between segments,
+    # and needs special provcessing. Set by the endhost.
+    ("XOVER", 1),
+    # Used by an AS to disallow local delivery of packets (AKA a forward-only
+    # AS).
+    ("FORWARD_ONLY", 2),
+    # Flag used with an SVC address to redirect a packet to the local service at
+    # a given hop. Set by the endhost.
+    ("RECURSE", 4),
 ))

--- a/lib/types.py
+++ b/lib/types.py
@@ -57,21 +57,6 @@ class ExtEndToEndType(TypeBase):
     PATH_PROBE = 1
 
 
-class OpaqueFieldType(TypeBase):
-    """
-    Constants for the types of the opaque field (first byte of every opaque
-    field).
-    """
-    # Types for HopOpaqueFields (7 MSB bits).
-    NORMAL_OF = 0b0000000
-    XOVR_POINT = 0b0010000  # Indicates a crossover point.
-    # Types for Info Opaque Fields (7 MSB bits).
-    CORE = 0b1000000
-    SHORTCUT = 0b1100000
-    INTRA_ISD_PEER = 0b1111000
-    INTER_ISD_PEER = 0b1111100
-
-
 ############################
 # Payload class/types
 ############################


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/659%23issuecomment-191761854%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55510085%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55510380%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55510710%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55515610%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55516503%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55520390%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55520984%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55521204%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55523854%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55524274%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55536993%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23issuecomment-194352179%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55661614%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55662111%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23issuecomment-191761854%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%5Cr%5CnEnd2end%20test%20works%2C%20updating%20unit%20tests%20now.%22%2C%20%22created_at%22%3A%20%222016-03-03T13%3A30%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%22%2C%20%22created_at%22%3A%20%222016-03-09T15%3A42%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a974794bd0a08c62488467839c0afb46328be251%20infrastructure/router/main.py%2071%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55510085%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60...%20and%20not%20curr_iof.peer%60%20%3F%22%2C%20%22created_at%22%3A%20%222016-03-09T12%3A16%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22if%20%60.shortcut%60%20is%20unset%2C%20then%20%60.peer%60%20is%20unset.%22%2C%20%22created_at%22%3A%20%222016-03-09T13%3A16%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/router/main.py%3AL545-552%22%7D%2C%20%22Pull%20a974794bd0a08c62488467839c0afb46328be251%20lib/packet/opaque_field.py%2089%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55510710%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22at%20this%20point%20it%20is%20fine%2C%20but%20we%20should%20not%20hardcode%20that.%20Opaque%20fields%20can%20have%20different%20sizes%2C%20so%20maybe%20put%20a%20comment.%22%2C%20%22created_at%22%3A%20%222016-03-09T12%3A23%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/opaque_field.py%3AL17-148%22%7D%2C%20%22Pull%20672f9cff7c1b9668a9e7aa8d66fa975f6427159a%20lib/packet/opaque_field.py%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55520390%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20leave%20interface%20in%20base%20class.%22%2C%20%22created_at%22%3A%20%222016-03-09T13%3A56%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Inherited%20from%20%60HeaderBase%60%22%2C%20%22created_at%22%3A%20%222016-03-09T14%3A01%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20not%20how%20type-hierarchies%20work.%20Opaquefields%20aren%27t%20HeaderBases%2C%20so%20please%20copy%20the%20abstract%20methods%20that%20you%20removed%20back%20to%20the%20base%20class.%22%2C%20%22created_at%22%3A%20%222016-03-09T14%3A02%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20real%20solution%20is%20to%20rename%20%60HeaderBase%60%20to%20something%20slightly%20more%20generic%2C%20and%20inherit%20from%20that%20instead.%20I%27m%20open%20to%20suggestions%20on%20naming%2C%20but%20it%27s%20not%20something%20that%20belongs%20in%20this%20PR.%22%2C%20%22created_at%22%3A%20%222016-03-10T10%3A42%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22And%20that%27s%20how%20bullshit%20like%20this%20gets%20carried%20around%20and%20never%20gets%20fixed.%20It%20does%20belong%20to%20this%20PR%2C%20since%20you%20replace%20something%20that%20was%20in%20place%20with%20something%20that%20is%20wrong.%20So%20either%20you%20copy%20it%20back%20or%20make%20the%20solution%20part%20of%20the%20PR...%22%2C%20%22created_at%22%3A%20%222016-03-10T10%3A47%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/opaque_field.py%3AL17-148%22%7D%2C%20%22Pull%2053769db44cca3484778fe8149bef0540ee20dfd2%20lib/packet/opaque_field.py%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55524274%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22maybe%20it%20makes%20sense%20to%20leave%20it.%20We%20should%20have%20a%20reserved%20bit%20for%20this.%22%2C%20%22created_at%22%3A%20%222016-03-09T14%3A22%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/opaque_field.py%3AL17-149%22%7D%2C%20%22Pull%2053769db44cca3484778fe8149bef0540ee20dfd2%20lib/flagtypes.py%2029%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55523854%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20we%20need%20a%20dedicated%20flag%20for%20this%3F%20Isn%27t%20%60FORWARD_ONLY%60%20in%20combination%20with%20SVC%20address%20enough%3F%22%2C%20%22created_at%22%3A%20%222016-03-09T14%3A20%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222016-03-09T15%3A42%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/flagtypes.py%3AL31-58%22%7D%2C%20%22Pull%20a974794bd0a08c62488467839c0afb46328be251%20lib/flagtypes.py%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/659%23discussion_r55510380%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22forward%20only%3F%20recurse%3F%20Please%20clarify%20what%20these%20denote.%22%2C%20%22created_at%22%3A%20%222016-03-09T12%3A19%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Updated%22%2C%20%22created_at%22%3A%20%222016-03-09T13%3A24%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/flagtypes.py%3AL31-52%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/659#issuecomment-191761854'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
  End2end test works, updating unit tests now.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> LGTM
- [ ] <a href='#crh-comment-Pull a974794bd0a08c62488467839c0afb46328be251 infrastructure/router/main.py 71'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/659#discussion_r55510085'>File: infrastructure/router/main.py:L545-552</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> `... and not curr_iof.peer` ?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> if `.shortcut` is unset, then `.peer` is unset.
- [ ] <a href='#crh-comment-Pull a974794bd0a08c62488467839c0afb46328be251 lib/flagtypes.py 23'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/659#discussion_r55510380'>File: lib/flagtypes.py:L31-52</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> forward only? recurse? Please clarify what these denote.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Updated
- [ ] <a href='#crh-comment-Pull a974794bd0a08c62488467839c0afb46328be251 lib/packet/opaque_field.py 89'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/659#discussion_r55510710'>File: lib/packet/opaque_field.py:L17-148</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> at this point it is fine, but we should not hardcode that. Opaque fields can have different sizes, so maybe put a comment.
- [ ] <a href='#crh-comment-Pull 672f9cff7c1b9668a9e7aa8d66fa975f6427159a lib/packet/opaque_field.py 29'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/659#discussion_r55520390'>File: lib/packet/opaque_field.py:L17-148</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Please leave interface in base class.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Inherited from `HeaderBase`
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> This is not how type-hierarchies work. Opaquefields aren't HeaderBases, so please copy the abstract methods that you removed back to the base class.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The real solution is to rename `HeaderBase` to something slightly more generic, and inherit from that instead. I'm open to suggestions on naming, but it's not something that belongs in this PR.
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> And that's how bullshit like this gets carried around and never gets fixed. It does belong to this PR, since you replace something that was in place with something that is wrong. So either you copy it back or make the solution part of the PR...
- [ ] <a href='#crh-comment-Pull 53769db44cca3484778fe8149bef0540ee20dfd2 lib/packet/opaque_field.py 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/659#discussion_r55524274'>File: lib/packet/opaque_field.py:L17-149</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> maybe it makes sense to leave it. We should have a reserved bit for this.
- [x] <a href='#crh-comment-Pull 53769db44cca3484778fe8149bef0540ee20dfd2 lib/flagtypes.py 29'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/659#discussion_r55523854'>File: lib/flagtypes.py:L31-58</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> why we need a dedicated flag for this? Isn't `FORWARD_ONLY` in combination with SVC address enough?

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/659?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/659?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/659'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
