### PR TITLE
Consolidate path handling into simpler class.

### DIFF
--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -321,8 +321,6 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         """
         hof = HopOpaqueField.from_values(self.HOF_EXP_TIME,
                                          ingress_if, egress_if)
-        if prev_hof is None:
-            hof.xover = True
         hof.set_mac(self.of_gen_key, ts, prev_hof)
         pcbm = PCBMarking.from_values(
             self.addr.isd_as, hof, self._get_if_rev_token(ingress_if))

--- a/lib/flagtypes.py
+++ b/lib/flagtypes.py
@@ -20,38 +20,43 @@ For all flags types that are used in multiple parts of the infrastructure.
 
 
 class FlagBase(object):  # pragma: no cover
-    def __init__(self, name_vals):
+    def __init__(self, val_names):
         self._rev = {}
-        for name, val in name_vals:
-            setattr(self, name, val)
-            self._rev[val] = name
+        for val, *names in val_names:
+            setattr(self, names[0], val)
+            self._rev[val] = names
 
     def to_str(self, flags):
         ret = []
         for val in sorted(self._rev):
+            true, false = self._rev[val]
             if flags & val:
-                ret.append(self._rev[val])
+                ret.append(true)
+            elif false:
+                ret.append(false)
         return "|".join(ret) or "None"
 
 
 PathSegFlags = FlagBase((
-    ("SIBRA", 1),
+    (1, "SIBRA", "SCION"),
 ))
 
 InfoOFFlags = FlagBase((
-    ("UP", 1),
-    ("SHORTCUT", 2),
-    ("PEER_SHORTCUT", 4),
+    (1, "UP", "DOWN"),
+    (2, "SHORTCUT", ""),
+    (4, "PEER_SHORTCUT", ""),
 ))
 
 HopOFFlags = FlagBase((
     # Used to signal that this HOF is at a cross-over point between segments,
     # and needs special provcessing. Set by the endhost.
-    ("XOVER", 1),
+    (1, "XOVER", ""),
+    # Marks HOFs that aren't used for routing, just for mac verification.
+    (2, "VERIFY_ONLY", ""),
     # Used by an AS to disallow local delivery of packets (AKA a forward-only
     # AS).
-    ("FORWARD_ONLY", 2),
+    (4, "FORWARD_ONLY", ""),
     # Flag used with an SVC address to redirect a packet to the local service at
     # a given hop. Set by the endhost.
-    ("RECURSE", 4),
+    (8, "RECURSE", ""),
 ))

--- a/lib/packet/opaque_field.py
+++ b/lib/packet/opaque_field.py
@@ -49,6 +49,7 @@ class HopOpaqueField(OpaqueField):
 
     def __init__(self, raw=None):  # pragma: no cover
         self.xover = False
+        self.verify_only = False
         self.forward_only = False
         self.recurse = False
         self.exp_time = 0
@@ -69,15 +70,17 @@ class HopOpaqueField(OpaqueField):
 
     def _parse_flags(self, flags):  # pragma: no cover
         self.xover = bool(flags & HopOFFlags.XOVER)
+        self.verify_only = bool(flags & HopOFFlags.VERIFY_ONLY)
         self.forward_only = bool(flags & HopOFFlags.FORWARD_ONLY)
         self.rescurse = bool(flags & HopOFFlags.RECURSE)
 
     @classmethod
     def from_values(cls, exp_time, ingress_if=0, egress_if=0,
-                    mac=None, xover=False, forward_only=False,
-                    recurse=False):  # pragma: no cover
+                    mac=None, xover=False, verify_only=False,
+                    forward_only=False, recurse=False):  # pragma: no cover
         inst = cls()
         inst.xover = xover
+        inst.verify_only = verify_only
         inst.forward_only = forward_only
         inst.recurse = recurse
         inst.exp_time = exp_time
@@ -104,6 +107,8 @@ class HopOpaqueField(OpaqueField):
         flags = 0
         if self.xover:
             flags |= HopOFFlags.XOVER
+        if self.verify_only:
+            flags |= HopOFFlags.VERIFY_ONLY
         if self.forward_only:
             flags |= HopOFFlags.FORWARD_ONLY
         if self.recurse:

--- a/lib/packet/pcb.py
+++ b/lib/packet/pcb.py
@@ -30,7 +30,7 @@ from lib.errors import SCIONParseError
 from lib.flagtypes import PathSegFlags as PSF
 from lib.packet.opaque_field import HopOpaqueField, InfoOpaqueField
 from lib.packet.packet_base import SCIONPayloadBase
-from lib.packet.path import CorePath
+from lib.packet.path import SCIONPath
 from lib.packet.pcb_ext.mtu import MtuPcbExt
 from lib.packet.pcb_ext.rev import RevPcbExt
 from lib.packet.pcb_ext.sibra import SibraPcbExt
@@ -385,8 +385,7 @@ class PathSegment(SCIONPayloadBase):
             iof.up_flag = self.iof.up_flag ^ True
         for asm in ases:
             hofs.append(asm.pcbm.hof)
-        core_path = CorePath.from_values(iof, hofs)
-        return core_path
+        return SCIONPath.from_values(iof, hofs)
 
     def get_isd(self):  # pragma: no cover
         """

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -37,9 +37,8 @@ from lib.packet.host_addr import (
     haddr_parse,
     haddr_parse_interface,
 )
-from lib.packet.opaque_field import InfoOpaqueField
 from lib.packet.packet_base import PayloadRaw
-from lib.packet.path import CorePath, CrossOverPath, EmptyPath, PeerPath
+from lib.packet.path import SCIONPath, EmptyPath
 from lib.packet.scion import SCIONL4Packet, build_base_hdrs
 from lib.packet.scion_addr import ISD_AS, SCIONAddr
 from lib.packet.scion_udp import SCIONUDPHeader
@@ -81,14 +80,7 @@ def get_paths_via_api(addr):
         path_len = data.pop(1) * 8
         if not path_len:
             return [(EmptyPath(), haddr_parse("IPV4", "0.0.0.0"))], [[]]
-        iof = InfoOpaqueField(data.get(InfoOpaqueField.LEN))
-        if not iof.shortcut:
-            path = CorePath(data.pop(path_len))
-        else:
-            if not iof.peer:
-                path = CrossOverPath(data.pop(path_len))
-            else:
-                path = PeerPath(data.pop(path_len))
+        path = SCIONPath(data.pop(path_len))
         haddr_type = haddr_get_type("IPV4")
         hop = haddr_type(data.get(haddr_type.LEN))
         data.pop(len(hop))

--- a/test/lib/packet/opaque_field_test.py
+++ b/test/lib/packet/opaque_field_test.py
@@ -74,7 +74,7 @@ class TestHopOpaqueFieldPack(object):
         inst.ingress_if = 0x0a0
         inst.egress_if = 0xb0c
         inst.mac = bytes.fromhex('012345')
-        expected = bytes.fromhex('02 2a 0a0b0c')
+        expected = bytes.fromhex('04 2a 0a0b0c')
         # Call
         ntools.eq_(inst.pack(mac=True), expected)
 

--- a/tools/zkcleanslate
+++ b/tools/zkcleanslate
@@ -5,6 +5,7 @@
 # regenerated. Please do not run this routinely, as it will hide errors that we
 # should be handling properly.
 
+sudo /bin/true || exit 1  # Handle ctrl-c at sudo prompt
 sudo service zookeeper stop
 find /run/shm/*-zk/ -type f | sudo xargs -r rm -v
 rm -v gen/ISD*/AS*/zk*/data/version-2/*


### PR DESCRIPTION
- Greatly simplify router data packet handling.
- Add a VERIFY_ONLY flag for HopOpaqueField's, to simplify processing logic.
- Removed all concept of 'up', 'down' and 'core' segments from the path class.

Also:
- Extend flagtypes.FlagBase to print different strings for set/not set.
- Change tools/zkcleanslate so that hitting ctrl-c at the sudo prompt
  would cancel the operation cleanly.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/662%23issuecomment-193305317%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23issuecomment-193305425%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23issuecomment-193814565%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55521490%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55521764%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55523577%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55523659%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55525581%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55655596%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55655650%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55662356%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55662504%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55663232%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55663416%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55663493%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55663573%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55663763%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55665419%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55670738%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55670772%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55670892%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55670929%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23issuecomment-194817363%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23issuecomment-194817838%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55671305%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55671369%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55671579%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55671760%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23issuecomment-194819626%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55671827%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55671958%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55672012%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55672037%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23issuecomment-194834939%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23issuecomment-194839009%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23issuecomment-193305317%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Status%3A%5Cr%5Cn-%20infrastructure%20works%2C%20end2end%20works%5Cr%5Cn-%20need%20to%20update%20unit%20tests%5Cr%5Cn-%20need%20to%20add%20some%20flags%20to%20the%20HOF%20MAC%20input%22%2C%20%22created_at%22%3A%20%222016-03-07T15%3A44%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28Depends%20on%20%23659%29%22%2C%20%22created_at%22%3A%20%222016-03-07T15%3A44%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Unit%20tests%20updated%2C%20HOF%20flag%20verification%20moved%20to%20%23659.%22%2C%20%22created_at%22%3A%20%222016-03-08T14%3A59%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20it%20makes%20a%20lot%20of%20sense%2C%20but%20I%27d%20like%20to%20discuss%20it%20before%20merging.%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A20%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22...%20and%20some%20detailed%20description%20for%20logic%20in%20%60reverse%28%29%2C%20get_hof_ver%28%29%2C%20inc_hof_idx%28%29%60%20is%20IMO%20necessary%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A22%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Agree%20with%20detailed%20explanation%20for%20these%20functions.%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A29%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Comments%20for%20%60reverse%28%29%60%20look%20good%20%28maybe%20just%20use%20indices%20instead%20of%20indexs%29.%20If%20you%20add%20comments%20in%20this%20style%20for%20%60get_hof_ver%28%29%60%20and%20%60inc_hof_idx%28%29%60%20then%20this%20is%20LGTM.%22%2C%20%22created_at%22%3A%20%222016-03-10T13%3A10%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%22%2C%20%22created_at%22%3A%20%222016-03-10T13%3A29%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%209bc0181e3ac593ab36596f9fa11ecdb7e77d17f5%20infrastructure/router/main.py%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55521490%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Add%20docstring%20explaining%20the%20use%20of%20%28the%29%20%60force%60.%22%2C%20%22created_at%22%3A%20%222016-03-09T14%3A05%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Done.%22%2C%20%22created_at%22%3A%20%222016-03-10T10%3A49%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A17%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/router/main.py%3AL422-429%22%7D%2C%20%22Pull%209bc0181e3ac593ab36596f9fa11ecdb7e77d17f5%20infrastructure/router/main.py%20311%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55655596%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20update%20here%3F%22%2C%20%22created_at%22%3A%20%222016-03-10T09%3A50%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Because%20otherwise%20the%20error%20will%20print%20the%20old%20state%20of%20the%20packet.%20I%27ll%20add%20a%20comment%22%2C%20%22created_at%22%3A%20%222016-03-10T11%3A00%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22but%20the%20old%20state%20caused%20the%20problem%2C%20right%3F%20So%20IMO%20we%20should%20print%20it.%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A18%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22No%2C%20the%20new%20state%20caused%20the%20problem.%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A26%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/router/main.py%3AL496-527%22%7D%2C%20%22Pull%209bc0181e3ac593ab36596f9fa11ecdb7e77d17f5%20lib/packet/path.py%20858%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55665419%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22do%20we%20need%20EmptyPath%20class%20at%20all%3F%20If%20A%2C%20B%2C%20and%20C%20are%20empty/None%20then%20it%20is%20an%20empty%20path.%22%2C%20%22created_at%22%3A%20%222016-03-10T11%3A17%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%27s%20probably%20possible%20to%20extend%20SCIONPath%20to%20cover%20that%20case%2C%20but%20it%20would%20need%20some%20close%20examination.%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A30%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL293-329%22%7D%2C%20%22Pull%209bc0181e3ac593ab36596f9fa11ecdb7e77d17f5%20lib/defines.py%209%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55655650%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20don%27t%20use%20%60OpaqueField.LEN%60%20%3F%22%2C%20%22created_at%22%3A%20%222016-03-10T09%3A50%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22OpaqueField.LEN%20is%20set%20from%20this%20constant.%22%2C%20%22created_at%22%3A%20%222016-03-10T11%3A02%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/defines.py%3AL90-100%22%7D%2C%20%22Pull%209bc0181e3ac593ab36596f9fa11ecdb7e77d17f5%20lib/packet/path.py%2089%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55523659%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20do%20we%20want%20A%2C%20B%2C%20C%2C%20instead%20of%20UP%2C%20CORE%2C%20DOWN%3F%22%2C%20%22created_at%22%3A%20%222016-03-09T14%3A18%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Because%20all%20%60SCIONPath%60%20knows%20is%20that%20it%20might%20have%201%2C%202%2C%20or%203%20segments.%20It%20doesn%27t%20identify%20them%20as%20up/core/down%2C%20and%20doesn%27t%20care.%22%2C%20%22created_at%22%3A%20%222016-03-10T10%3A59%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Aha%2C%20so%20if%20a%20path%20consists%20only%20of%202%20segments%2C%20then%20A%20and%20B%20contain%20these%20segments%3F%20Or%20A%20and%20C%3F%20If%20the%20former%20is%20the%20case%2C%20then%20I%20agree%20with%20the%20naming.%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A19%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Correct.%20The%20possibilities%20are%3A%5Cr%5Cn-%20A%5Cr%5Cn-%20A%2C%20B%5Cr%5Cn-%20A%2C%20B%2C%20C%5Cr%5CnNo%20other%20possibility%20is%20allowed.%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A24%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A31%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL28-91%22%7D%2C%20%22Pull%209bc0181e3ac593ab36596f9fa11ecdb7e77d17f5%20infrastructure/router/main.py%20277%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55521764%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Might%20as%20well%20name%20the%20parameter%20%60ingress%60.%22%2C%20%22created_at%22%3A%20%222016-03-09T14%3A07%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Do%20you%20mean%20%60egress%60%3F%22%2C%20%22created_at%22%3A%20%222016-03-10T10%3A50%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20I%20guess%20that%20would%20make%20more%20sense.%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A17%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20could%20do%20that%2C%20and%20then%20invert%20it%20to%20get%20ingress%2C%20but%20%60from_local_as%60%20is%20used%2037%20times%20in%20the%20existing%20codebase%2C%20so%20i%20kept%20it%20for%20consistency.%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A23%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A31%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/router/main.py%3AL457-488%22%7D%2C%20%22Pull%209bc0181e3ac593ab36596f9fa11ecdb7e77d17f5%20lib/packet/path.py%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55525581%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Probably%2C%20we%20need%20another%20Interface%20class%20that%20isn%27t%20called%20%60HeaderBase%60%20that%20define%20the%20%60pack%60%2C%20%60parse%60%20etc.%20function%20signatures%2C%20because%20%60PathBase%60%20really%20isn%27t%20a%20%60HeaderBase%60.%20I%27ll%20let%20you%20come%20up%20with%20a%20suitable%20name.%22%2C%20%22created_at%22%3A%20%222016-03-09T14%3A31%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20disagree%20re%3A%20PathBase%20not%20being%20a%20HeaderBase.%20This%20is%20the%20path%20header.%22%2C%20%22created_at%22%3A%20%222016-03-10T10%3A59%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20guess%20that%27s%20a%20fair%20point%2C%20since%20the%20path%20is%20part%20of%20the%20header.%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A28%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20also%20working%20on%20a%20PR%20to%20rename%20%60HeaderBase%60%22%2C%20%22created_at%22%3A%20%222016-03-10T12%3A29%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL28-91%22%7D%2C%20%22Pull%209bc0181e3ac593ab36596f9fa11ecdb7e77d17f5%20lib/packet/path.py%20229%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/662%23discussion_r55523577%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20the%20comments%20where%20helpful%20for%20people%20not%20familiar%20with%20the%20logic%20here.%20Just%20change%20to%20A%2C%20B%2C%20C%20instead%20of%20UP%2C%20CORE%2C%20DOWN.%22%2C%20%22created_at%22%3A%20%222016-03-09T14%3A18%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20comments%20don%27t%20really%20apply%20any%20more%2C%20so%20i%27ve%20written%20a%20new%20description%20now%22%2C%20%22created_at%22%3A%20%222016-03-10T10%3A57%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/path.py%3AL110-289%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/662#issuecomment-193305317'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Status:
- infrastructure works, end2end works
- need to update unit tests
- need to add some flags to the HOF MAC input
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (Depends on #659)
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Unit tests updated, HOF flag verification moved to #659.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> I think it makes a lot of sense, but I'd like to discuss it before merging.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> ... and some detailed description for logic in `reverse(), get_hof_ver(), inc_hof_idx()` is IMO necessary
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Agree with detailed explanation for these functions.
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Comments for `reverse()` look good (maybe just use indices instead of indexs). If you add comments in this style for `get_hof_ver()` and `inc_hof_idx()` then this is LGTM.
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> LGTM
- [ ] <a href='#crh-comment-Pull 9bc0181e3ac593ab36596f9fa11ecdb7e77d17f5 lib/packet/path.py 229'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/662#discussion_r55523577'>File: lib/packet/path.py:L110-289</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> I think the comments where helpful for people not familiar with the logic here. Just change to A, B, C instead of UP, CORE, DOWN.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The comments don't really apply any more, so i've written a new description now
- [ ] <a href='#crh-comment-Pull 9bc0181e3ac593ab36596f9fa11ecdb7e77d17f5 lib/packet/path.py 46'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/662#discussion_r55525581'>File: lib/packet/path.py:L28-91</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Probably, we need another Interface class that isn't called `HeaderBase` that define the `pack`, `parse` etc. function signatures, because `PathBase` really isn't a `HeaderBase`. I'll let you come up with a suitable name.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I disagree re: PathBase not being a HeaderBase. This is the path header.
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> I guess that's a fair point, since the path is part of the header.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I'm also working on a PR to rename `HeaderBase`
- [ ] <a href='#crh-comment-Pull 9bc0181e3ac593ab36596f9fa11ecdb7e77d17f5 infrastructure/router/main.py 311'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/662#discussion_r55655596'>File: infrastructure/router/main.py:L496-527</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> why update here?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Because otherwise the error will print the old state of the packet. I'll add a comment
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> but the old state caused the problem, right? So IMO we should print it.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> No, the new state caused the problem.
- [ ] <a href='#crh-comment-Pull 9bc0181e3ac593ab36596f9fa11ecdb7e77d17f5 lib/defines.py 9'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/662#discussion_r55655650'>File: lib/defines.py:L90-100</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> why don't use `OpaqueField.LEN` ?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> OpaqueField.LEN is set from this constant.
- [ ] <a href='#crh-comment-Pull 9bc0181e3ac593ab36596f9fa11ecdb7e77d17f5 lib/packet/path.py 858'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/662#discussion_r55665419'>File: lib/packet/path.py:L293-329</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> do we need EmptyPath class at all? If A, B, and C are empty/None then it is an empty path.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It's probably possible to extend SCIONPath to cover that case, but it would need some close examination.
- [x] <a href='#crh-comment-Pull 9bc0181e3ac593ab36596f9fa11ecdb7e77d17f5 infrastructure/router/main.py 39'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/662#discussion_r55521490'>File: infrastructure/router/main.py:L422-429</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Add docstring explaining the use of (the) `force`.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Done.
- [x] <a href='#crh-comment-Pull 9bc0181e3ac593ab36596f9fa11ecdb7e77d17f5 infrastructure/router/main.py 277'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/662#discussion_r55521764'>File: infrastructure/router/main.py:L457-488</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Might as well name the parameter `ingress`.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Do you mean `egress`?
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Yes, I guess that would make more sense.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> I could do that, and then invert it to get ingress, but `from_local_as` is used 37 times in the existing codebase, so i kept it for consistency.
- [x] <a href='#crh-comment-Pull 9bc0181e3ac593ab36596f9fa11ecdb7e77d17f5 lib/packet/path.py 89'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/662#discussion_r55523659'>File: lib/packet/path.py:L28-91</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Why do we want A, B, C, instead of UP, CORE, DOWN?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Because all `SCIONPath` knows is that it might have 1, 2, or 3 segments. It doesn't identify them as up/core/down, and doesn't care.
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Aha, so if a path consists only of 2 segments, then A and B contain these segments? Or A and C? If the former is the case, then I agree with the naming.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Correct. The possibilities are:
- A
- A, B
- A, B, C
  No other possibility is allowed.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/662?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/662?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/662'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
