### PR TITLE
Refactoring integration tests

### DIFF
--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -48,7 +48,7 @@ else
 fi
 
 log "C2S_extn starting:"
-test/integration/cli_srv_ext_test.py
+test/integration/cli_srv_ext_test.py 1-19 2-26
 result=$?
 if [ $result -eq 0 ]; then
     log "C2S_extn: success"

--- a/scion.sh
+++ b/scion.sh
@@ -32,6 +32,7 @@ cmd_run() {
     # breaks the detection logic in supervisor.sh
     sleep 1
     bash gen/zk_datalog_dirs.sh || exit 1
+    supervisor/supervisor.sh quickstart dispatcher:dispatcher
     supervisor/supervisor.sh quickstart all
 }
 

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -1,0 +1,321 @@
+#!/usr/bin/python3
+# Copyright 2016 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`base_cli_srv` --- Base classes for single packet end2end testing
+======================================================================
+"""
+# Stdlib
+import argparse
+import copy
+import logging
+import os
+import random
+import struct
+import sys
+import threading
+import time
+
+# SCION
+from endhost.sciond import SCIOND_API_HOST, SCIOND_API_PORT, SCIONDaemon
+from lib.defines import AS_LIST_FILE, GEN_PATH
+from lib.log import init_logging
+from lib.main import main_wrapper
+from lib.packet.host_addr import (
+    haddr_get_type,
+    haddr_parse_interface,
+)
+from lib.packet.packet_base import PayloadRaw
+from lib.packet.path import EmptyPath, SCIONPath
+from lib.packet.scion import SCIONL4Packet, build_base_hdrs
+from lib.packet.scion_addr import ISD_AS, SCIONAddr
+from lib.packet.scion_udp import SCIONUDPHeader
+from lib.socket import UDPSocket
+from lib.thread import kill_self, thread_safety_net
+from lib.types import AddrType
+from lib.util import (
+    Raw,
+    handle_signals,
+    load_yaml_file,
+    reg_dispatcher,
+    trim_dispatcher_packet,
+)
+
+TOUT = 10  # How long wait for response.
+
+
+class TestClientBase(object):
+    """
+    Base client app
+    """
+    def __init__(self, src, dst, dport, data, api=False):
+        self.src = src
+        self.dst = dst
+        self.dport = dport
+        self.data = data
+        self.done = False
+        self.api = api
+        self.path = None
+        self.iflist = []
+        conf_dir = "%s/ISD%d/AS%d/endhost" % (
+            GEN_PATH, src.isd_as[0], src.isd_as[1])
+        # Local api on, random port:
+        self.sd = SCIONDaemon.start(
+            conf_dir, self.src.host, run_local_api=True, port=0)
+        if self.api:
+            self._get_path_via_api()
+        else:
+            self._get_path_direct()
+        self.sock = UDPSocket(bind=(str(self.src.host), 0, "Test Client App"),
+                              addr_type=AddrType.IPV4)
+        reg_dispatcher(self.sock, self.src.host, self.sock.port)
+
+    def _get_path_via_api(self):
+        """
+        Test local API.
+        """
+        data = self._try_sciond_api()
+        path_len = data.pop(1) * 8
+        if not path_len:
+            self.path = EmptyPath()
+            return
+        self.path = SCIONPath(data.pop(path_len))
+        haddr_type = haddr_get_type("IPV4")
+        data.pop(haddr_type.LEN)  # first hop, unused here
+        data.pop(2)  # port number, unused here
+        data.pop(2)  # MTU, unused here
+        ifcount = data.pop(1)
+        for i in range(ifcount):
+            isd_as = ISD_AS(data.pop(ISD_AS.LEN))
+            ifid = struct.unpack("!H", data.pop(2))[0]
+            self.iflist.append((isd_as, ifid))
+
+    def _try_sciond_api(self):
+        sock = UDPSocket(bind=("127.0.0.1", 0), addr_type=AddrType.IPV4)
+        msg = b'\x00' + self.dst.isd_as.pack()
+        for _ in range(5):
+            logging.info("Sending path request to local API.")
+            sock.send(msg, (SCIOND_API_HOST, SCIOND_API_PORT))
+            data = Raw(sock.recv()[0], "Path response")
+            if data:
+                return data
+            logging.warning("Empty response from local api.")
+        else:
+            logging.critical("Unable to get path from local api.")
+            kill_self()
+        sock.close()
+
+    def _get_path_direct(self):
+        logging.info("Sending PATH request for %s", self.dst)
+        # Get paths through local API.
+        paths = []
+        for _ in range(5):
+            paths = self.sd.get_paths(self.dst.isd_as)
+            if paths:
+                break
+        else:
+            logging.critical("Unable to get path directly from sciond")
+            kill_self()
+        self.path = paths[0]
+        self.iflist = self.path.interfaces
+
+    def run(self):
+        self._send()
+        self._recv()
+
+    def _send(self):
+        cmn_hdr, addr_hdr = build_base_hdrs(self.src, self.dst)
+        payload = self._create_payload()
+        l4_hdr = self._create_l4_hdr(payload)
+        extensions = self._create_extensions()
+        spkt = SCIONL4Packet.from_values(
+            cmn_hdr, addr_hdr, self.path, extensions, l4_hdr, payload)
+        next_hop, port = self.sd.get_first_hop(spkt)
+        assert next_hop is not None
+        logging.info("Sending packet via (%s:%s):\n%s", next_hop, port, spkt)
+        if self.iflist:
+            logging.info("Interfaces: %s", ", ".join(
+                ["%s:%s" % ifentry for ifentry in self.iflist]))
+        self.sd.send(spkt, next_hop, port)
+
+    def _create_payload(self):
+        return PayloadRaw(self.data)
+
+    def _create_l4_hdr(self, payload):
+        return SCIONUDPHeader.from_values(
+            self.src, self.sock.port, self.dst, self.dport, payload)
+
+    def _create_extensions(self):
+        return []
+
+    def _recv(self):
+        packet = self.sock.recv()[0]
+        packet = trim_dispatcher_packet(packet)
+        spkt = SCIONL4Packet(packet)
+        self._handle_response(spkt)
+        self.sock.close()
+        self.sd.stop()
+
+    def _handle_response(self, spkt):
+        pass
+
+
+class TestServerBase(object):
+    """
+    Base server app
+    """
+    def __init__(self, dst, data):
+        self.dst = dst
+        self.data = data
+        self.done = False
+        conf_dir = "%s/ISD%d/AS%d/endhost" % (
+            GEN_PATH, self.dst.isd_as[0], self.dst.isd_as[1])
+        # API off, standard port.
+        self.sd = SCIONDaemon.start(conf_dir, self.dst.host)
+        self.sock = UDPSocket(bind=(str(self.dst.host), 0, "Test Server App"),
+                              addr_type=AddrType.IPV4)
+        reg_dispatcher(self.sock, self.dst.host, self.sock.port)
+
+    def run(self):
+        packet = self.sock.recv()[0]
+        packet = trim_dispatcher_packet(packet)
+        spkt = SCIONL4Packet(packet)
+        payload = spkt.get_payload()
+        if self._verify_request(payload):
+            self._handle_request(spkt)
+            self.done = True
+        self.sock.close()
+        self.sd.stop()
+
+    def _verify_request(self, payload):
+        return True
+
+    def _handle_request(self, spkt):
+        pass
+
+
+class TestClientServerBase(object):
+    """
+    Test module to run client and server
+    """
+    def __init__(self, client, server, sources, destinations, local=True):
+        self.client_ip = haddr_parse_interface(client)
+        self.server_ip = haddr_parse_interface(server)
+        self.src_ias = sources
+        self.dst_ias = destinations
+        self.local = local
+        self.client_name = "Base Client"
+        self.server_name = "Base Server"
+        self.thread_name = "Base.MainThread"
+
+    def run(self):
+        """
+        Run a test for every pair of src and dst
+        """
+        thread = threading.current_thread()
+        thread.name = self.thread_name
+        for src_ia in self.src_ias:
+            for dst_ia in self.dst_ias:
+                if not self.local and src_ia == dst_ia:
+                    continue
+                self._run_test(src_ia, dst_ia)
+
+    def _run_test(self, src_ia, dst_ia):
+        """
+        Run client and server, wait for both to finish
+        """
+        logging.info("Testing: %s -> %s", src_ia, dst_ia)
+        src_addr = SCIONAddr.from_values(src_ia, self.client_ip)
+        dst_addr = SCIONAddr.from_values(dst_ia, self.server_ip)
+        data = self._create_data()
+        server = self._create_server(dst_addr, data)
+        threading.Thread(
+            target=thread_safety_net, args=(server.run,),
+            name=self.server_name, daemon=True).start()
+        client = self._create_client(src_addr, dst_addr, server.sock.port, data)
+        threading.Thread(
+            target=thread_safety_net, args=(client.run,),
+            name=self.client_name, daemon=True).start()
+        for _ in range(TOUT * 10):
+            time.sleep(0.1)
+            if server.done and client.done:
+                break
+        else:
+            logging.error("Test timed out")
+            sys.exit(1)
+
+    def _create_data(self):
+        """
+        Create raw payload data
+        """
+        return b""
+
+    def _create_server(self, addr, data):
+        """
+        Instantiate server app
+        """
+        return TestServerBase(addr, data)
+
+    def _create_client(self, src, dst, port, data):
+        """
+        Instantiate client app
+        """
+        return TestClientBase(src, dst, port, data)
+
+
+def _load_as_list():
+    as_dict = load_yaml_file(os.path.join(GEN_PATH, AS_LIST_FILE))
+    as_list = []
+    for as_str in as_dict.get("Non-core", []) + as_dict.get("Core", []):
+        as_list.append(ISD_AS(as_str))
+    return as_list
+
+
+def _parse_locs(as_str, as_list):
+    if as_str:
+        return [ISD_AS(as_str)]
+    copied = copy.copy(as_list)
+    random.shuffle(copied)
+    return copied
+
+
+def setup_main():
+    handle_signals()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--client', help='Client address')
+    parser.add_argument('-s', '--server', help='Server address')
+    parser.add_argument('-m', '--mininet', action='store_true',
+                        help="Running under mininet")
+    parser.add_argument('src_ia', nargs='?', help='Src isd-as')
+    parser.add_argument('dst_ia', nargs='?', help='Dst isd-as')
+    args = parser.parse_args()
+    init_logging("logs/end2end", console_level=logging.DEBUG)
+
+    if not args.client:
+        args.client = "169.254.0.2" if args.mininet else "127.0.0.2"
+    if not args.server:
+        args.server = "169.254.0.3" if args.mininet else "127.0.0.3"
+    as_list = _load_as_list()
+    srcs = _parse_locs(args.src_ia, as_list)
+    dsts = _parse_locs(args.dst_ia, as_list)
+    return args, srcs, dsts
+
+
+def main():
+    args, srcs, dsts = setup_main()
+    TestClientServerBase(args.client, args.server, srcs, dsts).run()
+
+
+if __name__ == "__main__":
+    main_wrapper(main)

--- a/test/integration/cli_srv_ext_test.py
+++ b/test/integration/cli_srv_ext_test.py
@@ -17,15 +17,9 @@
 ======================================================================
 """
 # Stdlib
-import argparse
 import logging
-import threading
-import time
 
 # SCION
-from endhost.sciond import SCIONDaemon
-from lib.defines import GEN_PATH
-from lib.log import init_logging
 from lib.main import main_wrapper
 from lib.packet.ext.traceroute import TracerouteExt
 from lib.packet.ext.path_transport import (
@@ -33,148 +27,97 @@ from lib.packet.ext.path_transport import (
     PathTransOFPath,
     PathTransType,
 )
-from lib.packet.host_addr import haddr_parse_interface
 from lib.packet.packet_base import PayloadRaw
-from lib.packet.scion import SCIONL4Packet, build_base_hdrs
-from lib.packet.scion_addr import ISD_AS, SCIONAddr
-from lib.packet.scion_udp import SCIONUDPHeader
-from lib.socket import UDPSocket
-from lib.thread import thread_safety_net
-from lib.util import handle_signals, reg_dispatcher, trim_dispatcher_packet
-
-TOUT = 10  # How long wait for response.
-SERVER_PORT = 30042  # default port number for server
+from test.integration.base_cli_srv import (
+    setup_main,
+    TestClientBase,
+    TestClientServerBase,
+    TestServerBase,
+)
 
 
-def client(c_addr, s_addr):
+class ExtClient(TestClientBase):
     """
-    Simple client
+    Extension test client app.
     """
-    conf_dir = "%s/ISD%d/AS%d/endhost" % (
-        GEN_PATH, c_addr.isd_as[0], c_addr.isd_as[1])
-    # Start SCIONDaemon
-    sd = SCIONDaemon.start(conf_dir, c_addr.host)
-    logging.info("CLI: Sending PATH request for %s", s_addr.isd_as)
-    # Open a socket for incomming DATA traffic
-    sock = UDPSocket(bind=(str(c_addr.host), 0, "Client"),
-                     addr_type=c_addr.host.TYPE)
-    reg_dispatcher(sock, c_addr.host, sock.port)
-    # Get paths to server through function call
-    paths = sd.get_paths(s_addr.isd_as)
-    assert paths
-    # Get a first path
-    path = paths[0]
-    # Determine number of border routers on path in single direction
-    routers_no = (path.get_as_hops() - 1) * 2
-    # Number of router for round-trip (return path is symmetric)
-    routers_no *= 2
+    def _create_extensions(self):
+        # Determine number of border routers on path in single direction
+        routers_no = (self.path.get_as_hops() - 1) * 2
+        # Number of router for round-trip (return path is symmetric)
+        routers_no *= 2
 
-    # Extensions
-    exts = []
-    # Create empty Traceroute extensions with allocated space
-    exts.append(TracerouteExt.from_values(routers_no))
-    # Create PathTransportExtension
-    # One with data-plane path.
-    of_path = PathTransOFPath.from_values(c_addr, s_addr, path)
-    exts.append(PathTransportExt.from_values(PathTransType.OF_PATH, of_path))
-    # And another PathTransportExtension with control-plane path.
-    if sd.up_segments() or sd.core_segments() or sd.down_segments():
-        seg = (sd.up_segments() + sd.core_segments() + sd.down_segments())[0]
-        exts.append(PathTransportExt.from_values(PathTransType.PCB_PATH, seg))
+        # Extensions
+        exts = []
+        # Create empty Traceroute extensions with allocated space
+        exts.append(TracerouteExt.from_values(routers_no))
+        # Create PathTransportExtension
+        # One with data-plane path.
+        of_path = PathTransOFPath.from_values(self.src, self.dst, self.path)
+        exts.append(PathTransportExt.from_values(
+            PathTransType.OF_PATH, of_path))
+        # And another PathTransportExtension with control-plane path.
+        if (self.sd.up_segments() or
+                self.sd.core_segments() or
+                self.sd.down_segments()):
+            seg = (self.sd.up_segments() +
+                   self.sd.core_segments() +
+                   self.sd.down_segments())[0]
+            exts.append(PathTransportExt.from_values(
+                PathTransType.PCB_PATH, seg))
+        return exts
 
-    # Set payload
-    payload = PayloadRaw(b"request to server")
-    # Create a SCION packet with the extensions
-    cmn_hdr, addr_hdr = build_base_hdrs(c_addr, s_addr)
-    udp_hdr = SCIONUDPHeader.from_values(
-        c_addr, sock.port, s_addr, SERVER_PORT, payload,
-    )
-    spkt = SCIONL4Packet.from_values(cmn_hdr, addr_hdr, path,
-                                     exts, udp_hdr, payload)
-    # Determine first hop (i.e., local address of border router)
-    next_hop, port = sd.get_first_hop(spkt)
-    assert next_hop is not None
-    logging.info("CLI: Sending packet:\n%s\nFirst hop: %s:%s",
-                 spkt, next_hop, port)
-    # Send packet to first hop (it is sent through SCIONDaemon)
-    sd.send(spkt, next_hop, port)
-    # Waiting for a response
-    raw, _ = sock.recv()
-    raw = trim_dispatcher_packet(raw)
-    logging.info('CLI: Received response:\n%s', SCIONL4Packet(raw))
-    logging.info("CLI: leaving.")
-    sock.close()
+    def _handle_response(self, spkt):
+        self.done = True
+        logging.info('CLI: Received response:\n%s', spkt)
+        logging.info("CLI: leaving.")
 
 
-def server(addr):
+class ExtServer(TestServerBase):
     """
-    Simple server.
+    Extension test server app.
     """
-    conf_dir = "%s/ISD%d/AS%d/endhost" % (
-        GEN_PATH, addr.isd_as[0], addr.isd_as[1])
-    # Start SCIONDaemon
-    sd = SCIONDaemon.start(conf_dir, addr.host)
-    # Open a socket for incomming DATA traffic
-    sock = UDPSocket(
-        bind=(str(addr.host), SERVER_PORT, "Server"),
-        addr_type=addr.host.TYPE
-    )
-    reg_dispatcher(sock, addr.host, sock.port)
-    # Waiting for a request
-    raw, _ = sock.recv()
-    raw = trim_dispatcher_packet(raw)
-    # Request received, instantiating SCION packet
-    spkt = SCIONL4Packet(raw)
-    logging.info('SRV: received: %s', spkt)
-    if spkt.get_payload() == PayloadRaw(b"request to server"):
+    def _verify_request(self, payload):
+        return payload == PayloadRaw(b"request to server")
+
+    def _handle_request(self, spkt):
         logging.info('SRV: request received, sending response.')
         # Reverse the packet
         spkt.reverse()
         # Setting payload
         spkt.set_payload(PayloadRaw(b"response"))
         # Determine first hop (i.e., local address of border router)
-        (next_hop, port) = sd.get_first_hop(spkt)
+        (next_hop, port) = self.sd.get_first_hop(spkt)
         assert next_hop is not None
         # Send packet to first hop (it is sent through SCIONDaemon)
-        sd.send(spkt, next_hop, port)
-    logging.info("SRV: Leaving server.")
-    sock.close()
+        self.sd.send(spkt, next_hop, port)
+        logging.info("SRV: Leaving server.")
+
+
+class TestClientServerExtension(TestClientServerBase):
+    """
+    End to end packet transmission test with extension.
+    For this test a infrastructure must be running.
+    """
+    def __init__(self, client, server, sources, destinations, local):
+        super().__init__(client, server, sources, destinations, local)
+        self.client_name = "Ext Client"
+        self.server_name = "Ext Server"
+        self.thread_name = "CliSrvExt.MainThread"
+
+    def _create_data(self):
+        return b"request to server"
+
+    def _create_server(self, addr, data):
+        return ExtServer(addr, data)
+
+    def _create_client(self, src, dst, port, data):
+        return ExtClient(src, dst, port, data)
 
 
 def main():
-    handle_signals()
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-c', '--client', help='Client address')
-    parser.add_argument('-s', '--server', help='Server address')
-    parser.add_argument('-m', '--mininet', action='store_true',
-                        help="Running under mininet")
-    parser.add_argument('cli_ia', nargs='?', help='Client isd-as',
-                        default="1-19")
-    parser.add_argument('srv_ia', nargs='?', help='Server isd-as',
-                        default="2-26")
-    args = parser.parse_args()
-    init_logging("logs/c2s_extn", console_level=logging.DEBUG)
+    args, srcs, dsts = setup_main()
+    TestClientServerExtension(args.client, args.server, srcs, dsts, False).run()
 
-    if not args.client:
-        args.client = "169.254.0.2" if args.mininet else "127.0.0.2"
-    if not args.server:
-        args.server = "169.254.0.3" if args.mininet else "127.0.0.3"
-
-    srv_ia = ISD_AS(args.srv_ia)
-    srv_addr = SCIONAddr.from_values(srv_ia, haddr_parse_interface(args.server))
-    threading.Thread(
-        target=thread_safety_net, args=(server, srv_addr),
-        name="C2S_extn.server", daemon=True).start()
-    time.sleep(0.5)
-
-    cli_ia = ISD_AS(args.cli_ia)
-    cli_addr = SCIONAddr.from_values(cli_ia, haddr_parse_interface(args.client))
-    t_client = threading.Thread(
-        target=thread_safety_net, args=(
-            client, cli_addr, srv_addr,
-        ), name="C2S_extn.client", daemon=True)
-    t_client.start()
-    t_client.join()
 
 if __name__ == "__main__":
     main_wrapper(main)

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -17,274 +17,85 @@
 ===========================================
 """
 # Stdlib
-import argparse
-import copy
 import logging
-import os
-import random
-import struct
-import sys
-import threading
-import time
 
 # SCION
-from endhost.sciond import SCIOND_API_HOST, SCIOND_API_PORT, SCIONDaemon
-from lib.defines import AS_LIST_FILE, GEN_PATH
-from lib.log import init_logging
 from lib.main import main_wrapper
-from lib.packet.host_addr import (
-    haddr_get_type,
-    haddr_parse,
-    haddr_parse_interface,
-)
 from lib.packet.packet_base import PayloadRaw
-from lib.packet.path import SCIONPath, EmptyPath
-from lib.packet.scion import SCIONL4Packet, build_base_hdrs
-from lib.packet.scion_addr import ISD_AS, SCIONAddr
-from lib.packet.scion_udp import SCIONUDPHeader
-from lib.socket import UDPSocket
-from lib.thread import kill_self, thread_safety_net
-from lib.types import AddrType
-from lib.util import (
-    Raw,
-    handle_signals,
-    load_yaml_file,
-    reg_dispatcher,
-    trim_dispatcher_packet,
+from lib.thread import kill_self
+from test.integration.base_cli_srv import (
+    setup_main,
+    TestClientBase,
+    TestClientServerBase,
+    TestServerBase,
 )
 
-TOUT = 10  # How long wait for response.
 
-
-def get_paths_via_api(addr):
-    """
-    Test local API.
-    """
-    sock = UDPSocket(bind=("127.0.0.1", 0), addr_type=AddrType.IPV4)
-    msg = b'\x00' + addr.isd_as.pack()
-
-    for _ in range(5):
-        logging.info("Sending path request to local API.")
-        sock.send(msg, (SCIOND_API_HOST, SCIOND_API_PORT))
-        data = Raw(sock.recv()[0], "Path response")
-        if data:
-            break
-        logging.warning("Empty response from local api.")
-    else:
-        logging.critical("Unable to get path from local api.")
-        kill_self()
-
-    paths_hops = []
-    iflists = []
-    while len(data) > 0:
-        path_len = data.pop(1) * 8
-        if not path_len:
-            return [(EmptyPath(), haddr_parse("IPV4", "0.0.0.0"))], [[]]
-        path = SCIONPath(data.pop(path_len))
-        haddr_type = haddr_get_type("IPV4")
-        hop = haddr_type(data.get(haddr_type.LEN))
-        data.pop(len(hop))
-        paths_hops.append((path, hop))
-        data.pop(2)  # port number, unused here
-        data.pop(2)  # MTU, unused here
-        ifcount = data.pop(1)
-        ifs = []
-        if ifcount:
-            for i in range(ifcount):
-                isd_as = ISD_AS(data.pop(ISD_AS.LEN))
-                ifid = struct.unpack("!H", data.pop(2))[0]
-                ifs.append((isd_as, ifid))
-        iflists.append(ifs)
-    sock.close()
-    return paths_hops, iflists
-
-
-class Ping(object):
+class E2EClient(TestClientBase):
     """
     Simple ping app.
     """
-    def __init__(self, src, dst, dport, token):
-        self.src = src
-        self.dst = dst
-        self.dport = dport
-        self.token = token
-        self.pong_received = False
-        conf_dir = "%s/ISD%d/AS%d/endhost" % (
-            GEN_PATH, src.isd_as[0], src.isd_as[1])
-        # Local api on, random port:
-        self.sd = SCIONDaemon.start(
-            conf_dir, self.src.host, run_local_api=True, port=0)
-        self.get_path()
-        self.sock = UDPSocket(bind=(str(self.src.host), 0, "Ping App"),
-                              addr_type=AddrType.IPV4)
-        reg_dispatcher(self.sock, self.src.host, self.sock.port)
+    def _create_payload(self):
+        return PayloadRaw(b"ping " + self.data)
 
-    def get_path(self):
-        logging.info("Sending PATH request for %s", self.dst)
-        # Get paths through local API.
-        paths_hops, iflists = get_paths_via_api(self.dst)
-        self.path, self.hop = paths_hops[0]
-        if isinstance(self.path, EmptyPath):
-            self.hop = self.dst.host
-        self.iflist = iflists[0]
-
-    def run(self):
-        self.send()
-        self.recv()
-
-    def send(self):
-        cmn_hdr, addr_hdr = build_base_hdrs(self.src, self.dst)
-        payload = PayloadRaw(b"ping " + self.token)
-        udp_hdr = SCIONUDPHeader.from_values(
-            self.src, self.sock.port, self.dst, self.dport, payload)
-        spkt = SCIONL4Packet.from_values(
-            cmn_hdr, addr_hdr, self.path, [], udp_hdr, payload)
-        next_hop, port = self.sd.get_first_hop(spkt)
-        assert next_hop is not None
-        assert next_hop == self.hop
-        logging.info("Sending packet via (%s:%s):\n%s", next_hop, port, spkt)
-        if self.iflist:
-            logging.info("Interfaces: %s", ", ".join(
-                ["%s:%s" % ifentry for ifentry in self.iflist]))
-        self.sd.send(spkt, next_hop, port)
-
-    def recv(self):
-        packet = self.sock.recv()[0]
-        packet = trim_dispatcher_packet(packet)
-        spkt = SCIONL4Packet(packet)
+    def _handle_response(self, spkt):
         payload = spkt.get_payload()
-        pong = PayloadRaw(b"pong " + self.token)
+        pong = PayloadRaw(b"pong " + self.data)
         if payload == pong:
             logging.info('%s:%d: pong received.', self.src.host, self.sock.port)
-            self.pong_received = True
+            self.done = True
         else:
             logging.error("Unexpected payload received: %s (expected: %s)",
                           payload, pong)
             kill_self()
-        self.sock.close()
-        self.sd.stop()
 
 
-class Pong(object):
+class E2EServer(TestServerBase):
     """
     Simple pong app.
     """
-    def __init__(self, dst, token):
-        self.dst = dst
-        self.token = token
-        self.ping_received = False
-        conf_dir = "%s/ISD%d/AS%d/endhost" % (
-            GEN_PATH, self.dst.isd_as[0], self.dst.isd_as[1])
-        # API off, standard port.
-        self.sd = SCIONDaemon.start(conf_dir, self.dst.host)
-        self.sock = UDPSocket(bind=(str(self.dst.host), 0, "Pong App"),
-                              addr_type=AddrType.IPV4)
-        reg_dispatcher(self.sock, self.dst.host, self.sock.port)
+    def _verify_request(self, payload):
+        return payload == PayloadRaw(b"ping " + self.data)
 
-    def run(self):
-        packet = self.sock.recv()[0]
-        packet = trim_dispatcher_packet(packet)
-        spkt = SCIONL4Packet(packet)
-        payload = spkt.get_payload()
-        ping = PayloadRaw(b"ping " + self.token)
-        if payload == ping:
-            # Reverse the packet and send "pong".
-            logging.info('%s:%d: ping received, sending pong.',
-                         self.dst.host, self.sock.port)
-            self.ping_received = True
-            spkt.reverse()
-            spkt.set_payload(PayloadRaw(b"pong " + self.token))
-            next_hop, port = self.sd.get_first_hop(spkt)
-            assert next_hop is not None
-            logging.info("Replying with (via %s:%s):\n%s", next_hop, port, spkt)
-            self.sd.send(spkt, next_hop, port)
-        self.sock.close()
-        self.sd.stop()
+    def _handle_request(self, spkt):
+        # Reverse the packet and send "pong".
+        logging.info('%s:%d: ping received, sending pong.',
+                     self.dst.host, self.sock.port)
+        self.ping_received = True
+        spkt.reverse()
+        spkt.set_payload(PayloadRaw(b"pong " + self.data))
+        next_hop, port = self.sd.get_first_hop(spkt)
+        assert next_hop is not None
+        logging.info("Replying with (via %s:%s):\n%s", next_hop, port, spkt)
+        self.sd.send(spkt, next_hop, port)
 
 
-class TestSCIONDaemon(object):
+class TestEnd2End(TestClientServerBase):
     """
-    Unit tests for sciond.py. For this test a infrastructure must be running.
+    End to end packet transmission test.
+    For this test a infrastructure must be running.
     """
-    def __init__(self, client, server, sources, destinations):
-        self.client_ip = haddr_parse_interface(client)
-        self.server_ip = haddr_parse_interface(server)
-        self.src_ias = sources
-        self.dst_ias = destinations
-        self.run()
+    def __init__(self, client, server, sources, destinations, local=True):
+        super().__init__(client, server, sources, destinations)
+        self.src = client
+        self.dst = server
+        self.client_name = "E2E Client"
+        self.server_name = "E2E Server"
+        self.thread_name = "E2E.MainThread"
 
-    def run(self):
-        """
-        Testing function. Creates an instance of SCIONDaemon, then verifies path
-        requesting, and finally sends packet through SCION. Sender is placed in
-        every AS from `sources`, and receiver is from every AS from
-        `destinations`.
-        """
-        thread = threading.current_thread()
-        thread.name = "E2E.MainThread"
-        for src_ia in self.src_ias:
-            for dst_ia in self.dst_ias:
-                self._run_test(src_ia, dst_ia)
+    def _create_data(self):
+        return ("%s<->%s" % (self.src, self.dst)).encode("UTF-8")
 
-    def _run_test(self, src_ia, dst_ia):
-        logging.info("Testing: %s -> %s", src_ia, dst_ia)
-        src_addr = SCIONAddr.from_values(src_ia, self.client_ip)
-        dst_addr = SCIONAddr.from_values(dst_ia, self.server_ip)
-        token = ("%s<->%s" % (src_addr, dst_addr)).encode("UTF-8")
-        pong_app = Pong(dst_addr, token)
-        threading.Thread(
-            target=thread_safety_net, args=(pong_app.run,),
-            name="E2E.pong_app", daemon=True).start()
-        ping_app = Ping(src_addr, dst_addr, pong_app.sock.port, token)
-        threading.Thread(
-            target=thread_safety_net, args=(ping_app.run,),
-            name="E2E.ping_app", daemon=True).start()
-        for _ in range(TOUT * 10):
-            time.sleep(0.1)
-            if pong_app.ping_received and ping_app.pong_received:
-                break
-        else:
-            logging.error("Test timed out")
-            sys.exit(1)
+    def _create_server(self, addr, data):
+        return E2EServer(addr, data)
 
-
-def _load_as_list():
-    as_dict = load_yaml_file(os.path.join(GEN_PATH, AS_LIST_FILE))
-    as_list = []
-    for as_str in as_dict.get("Non-core", []) + as_dict.get("Core", []):
-        as_list.append(ISD_AS(as_str))
-    return as_list
-
-
-def _parse_locs(as_str, as_list):
-    if as_str:
-        return [ISD_AS(as_str)]
-    copied = copy.copy(as_list)
-    random.shuffle(copied)
-    return copied
+    def _create_client(self, src, dst, port, data):
+        return E2EClient(src, dst, port, data, True)
 
 
 def main():
-    handle_signals()
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-c', '--client', help='Client address')
-    parser.add_argument('-s', '--server', help='Server address')
-    parser.add_argument('-m', '--mininet', action='store_true',
-                        help="Running under mininet")
-    parser.add_argument('src_ia', nargs='?', help='Src isd-as')
-    parser.add_argument('dst_ia', nargs='?', help='Dst isd-as')
-    args = parser.parse_args()
-    init_logging("logs/end2end", console_level=logging.DEBUG)
-
-    if not args.client:
-        args.client = "169.254.0.2" if args.mininet else "127.0.0.2"
-    if not args.server:
-        args.server = "169.254.0.3" if args.mininet else "127.0.0.3"
-    as_list = _load_as_list()
-    srcs = _parse_locs(args.src_ia, as_list)
-    dsts = _parse_locs(args.dst_ia, as_list)
-
-    TestSCIONDaemon(args.client, args.server, srcs, dsts)
+    args, srcs, dsts = setup_main()
+    TestEnd2End(args.client, args.server, srcs, dsts).run()
 
 
 if __name__ == "__main__":

--- a/topology/generator.py
+++ b/topology/generator.py
@@ -595,6 +595,8 @@ class SupervisorGenerator(object):
             'startsecs': 5,
             'command': " ".join(['"%s"' % arg for arg in cmd_args]),
         }
+        if name == "dispatcher":
+            entry['startsecs'] = 1
         if self.mininet:
             entry['autostart'] = 'true'
         return entry


### PR DESCRIPTION
This is a WIP PR for refactoring our integration tests.
Since we have several tests doing basically the same thing (get paths, send a packet, wait for a response) it would make sense to have this common functionality in one place.

Each individual test is now reduced to creating its payload data and optionally extensions.

Note: Since SIBRA is scary I have put it off until tomorrow, for now I have just fixed the SIBRA test to work with the dispatcher.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/663%23issuecomment-193836084%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23issuecomment-194346874%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55691299%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55691438%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55693731%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55693832%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23issuecomment-194900579%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23issuecomment-194925058%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55823844%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55823899%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55824203%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23issuecomment-195350145%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55824378%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55824391%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55824401%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55824412%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55824550%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55824753%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23issuecomment-193836084%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22SIBRA%20portion%20has%20been%20extracted%20into%20its%20own%20PR%22%2C%20%22created_at%22%3A%20%222016-03-08T15%3A54%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20%40pszalach%20feel%20free%20to%20review%20since%20the%20other%20tests%20we%20have%20now%20don%27t%20look%20like%20they%20will%20use%20this%20model%22%2C%20%22created_at%22%3A%20%222016-03-09T15%3A29%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20rest%20looks%20pretty%20cool%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-03-10T15%3A18%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22rebased%20and%20cleaned%20up%20a%20bit%22%2C%20%22created_at%22%3A%20%222016-03-10T16%3A02%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22Three%20very%20minor%20comments%20left%2C%20otherwise%20LGTM%22%2C%20%22created_at%22%3A%20%222016-03-11T12%3A38%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%203e536f4f46f6abf64ac15bb3dc32411702373545%20test/integration/base_cli_srv.py%20137%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55693832%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20probably%20makes%20sense%20to%20have%20a%20%60_get_path_api%60%2C%20and%20%60_get_path_direct%60%20or%20similar%22%2C%20%22created_at%22%3A%20%222016-03-10T15%3A18%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-03-11T12%3A39%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/integration/base_cli_srv.py%3AL1-348%22%7D%2C%20%22Pull%203e536f4f46f6abf64ac15bb3dc32411702373545%20test/integration/base_cli_srv.py%20139%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55691299%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22All%20instance%20variables%20should%20be%20declared%20in%20%60__init__%60%2C%20to%20make%20things%20easier%20to%20follow.%22%2C%20%22created_at%22%3A%20%222016-03-10T15%3A02%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-03-11T12%3A39%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/integration/base_cli_srv.py%3AL1-348%22%7D%2C%20%22Pull%2045b223dce1d89a92828002e97eae0cd7e42fb520%20test/integration/base_cli_srv.py%20223%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55824203%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22As%20these%20strings%20are%20only%20accessed%20in%20a%20single%20location%20each%2C%20it%27s%20probably%20slightly%20cleaner%20to%20just%20use%20the%20literals%20directly.%22%2C%20%22created_at%22%3A%20%222016-03-11T12%3A36%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Having%20them%20be%20instance%20variables%20is%20a%20way%20to%20allow%20tests%20to%20define%20their%20own%20thread%20names%2C%20since%20the%20actual%20thread%20creation%20is%20only%20done%20in%20the%20base%20class.%22%2C%20%22created_at%22%3A%20%222016-03-11T12%3A41%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oops%2C%20excellent%20point%20%3A%29%5Cr%5Cn%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-03-11T12%3A43%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/integration/base_cli_srv.py%3AL1-325%22%7D%2C%20%22Pull%203e536f4f46f6abf64ac15bb3dc32411702373545%20test/integration/base_cli_srv.py%20152%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55691438%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20does%20this%20not%20get%20set%20if%20using%20sciond%20directly%3F%22%2C%20%22created_at%22%3A%20%222016-03-10T15%3A03%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-03-11T12%3A39%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/integration/base_cli_srv.py%3AL1-348%22%7D%2C%20%22Pull%203e536f4f46f6abf64ac15bb3dc32411702373545%20test/integration/base_cli_srv.py%2060%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55693731%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20method%20is%20a%20monstrosity.%20It%20would%20be%20nice%20to%20break%20it%20into%20smaller%20pieces%22%2C%20%22created_at%22%3A%20%222016-03-10T15%3A17%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-03-11T12%3A39%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/integration/base_cli_srv.py%3AL1-348%22%7D%2C%20%22Pull%2045b223dce1d89a92828002e97eae0cd7e42fb520%20test/integration/base_cli_srv.py%2099%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55823899%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20could%20just%20use%20self.iflist%20directly%22%2C%20%22created_at%22%3A%20%222016-03-11T12%3A32%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/integration/base_cli_srv.py%3AL1-325%22%7D%2C%20%22Pull%2045b223dce1d89a92828002e97eae0cd7e42fb520%20test/integration/base_cli_srv.py%20100%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/663%23discussion_r55823844%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20%60if%60%20isn%27t%20needed%2C%20if%20%60ifcount%60%20is%20zero%2C%20then%20the%20for-loop%20won%27t%20run%20anyway.%22%2C%20%22created_at%22%3A%20%222016-03-11T12%3A31%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/integration/base_cli_srv.py%3AL1-325%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/663#issuecomment-193836084'>General Comment</a></b>
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> SIBRA portion has been extracted into its own PR
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> @kormat @pszalach feel free to review since the other tests we have now don't look like they will use this model
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The rest looks pretty cool :)
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> rebased and cleaned up a bit
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Three very minor comments left, otherwise LGTM
- [ ] <a href='#crh-comment-Pull 45b223dce1d89a92828002e97eae0cd7e42fb520 test/integration/base_cli_srv.py 100'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/663#discussion_r55823844'>File: test/integration/base_cli_srv.py:L1-325</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This `if` isn't needed, if `ifcount` is zero, then the for-loop won't run anyway.
- [ ] <a href='#crh-comment-Pull 45b223dce1d89a92828002e97eae0cd7e42fb520 test/integration/base_cli_srv.py 99'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/663#discussion_r55823899'>File: test/integration/base_cli_srv.py:L1-325</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This could just use self.iflist directly
- [x] <a href='#crh-comment-Pull 3e536f4f46f6abf64ac15bb3dc32411702373545 test/integration/base_cli_srv.py 139'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/663#discussion_r55691299'>File: test/integration/base_cli_srv.py:L1-348</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> All instance variables should be declared in `__init__`, to make things easier to follow.
- [x] <a href='#crh-comment-Pull 3e536f4f46f6abf64ac15bb3dc32411702373545 test/integration/base_cli_srv.py 152'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/663#discussion_r55691438'>File: test/integration/base_cli_srv.py:L1-348</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Why does this not get set if using sciond directly?
- [x] <a href='#crh-comment-Pull 3e536f4f46f6abf64ac15bb3dc32411702373545 test/integration/base_cli_srv.py 60'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/663#discussion_r55693731'>File: test/integration/base_cli_srv.py:L1-348</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This method is a monstrosity. It would be nice to break it into smaller pieces
- [x] <a href='#crh-comment-Pull 3e536f4f46f6abf64ac15bb3dc32411702373545 test/integration/base_cli_srv.py 137'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/663#discussion_r55693832'>File: test/integration/base_cli_srv.py:L1-348</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> It probably makes sense to have a `_get_path_api`, and `_get_path_direct` or similar
- [x] <a href='#crh-comment-Pull 45b223dce1d89a92828002e97eae0cd7e42fb520 test/integration/base_cli_srv.py 223'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/663#discussion_r55824203'>File: test/integration/base_cli_srv.py:L1-325</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> As these strings are only accessed in a single location each, it's probably slightly cleaner to just use the literals directly.
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> Having them be instance variables is a way to allow tests to define their own thread names, since the actual thread creation is only done in the base class.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Oops, excellent point :)
  :+1:

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/663?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/663?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/663'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
