### PR TITLE
Drop local core PCBs that have come from another ISD.

### DIFF
--- a/infrastructure/beacon_server/core.py
+++ b/infrastructure/beacon_server/core.py
@@ -151,10 +151,14 @@ class CoreBeaconServer(BeaconServer):
                 except SCIONParseError as e:
                     logging.error("Unable to parse raw pcb: %s", e)
                     continue
+            local_isd = pcb.get_first_pcbm().isd_as[0] == self.addr.isd_as[0]
             # Before we append the PCB for further processing we need to check
-            # that it hasn't been received before.
+            # that it hasn't been received before. Also check that it didn't
+            # originate in this ISD and propagate through other ISDs on the way.
             for asm in pcb.ases:
-                if asm.pcbm.isd_as == self.topology.isd_as:
+                if ((asm.pcbm.isd_as == self.addr.isd_as) or
+                    ((asm.pcbm.isd_as[0] != self.addr.isd_as[0]) and
+                     local_isd)):
                     count += 1
                     break
             else:


### PR DESCRIPTION
Fixes #666
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/668%23discussion_r55974281%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/668%23discussion_r55974567%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/668%23issuecomment-196227817%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/668%23issuecomment-196227817%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-03-14T09%3A39%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208126ff6f1cbaaa2bd43bbb5e39b548574010a742%20infrastructure/beacon_server/core.py%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/668%23discussion_r55974281%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60local_isd%60%20sounds%20more%20accurate%20to%20me.%22%2C%20%22created_at%22%3A%20%222016-03-14T09%3A36%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Changed.%22%2C%20%22created_at%22%3A%20%222016-03-14T09%3A38%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/beacon_server/core.py%3AL151-165%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 8126ff6f1cbaaa2bd43bbb5e39b548574010a742 infrastructure/beacon_server/core.py 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/668#discussion_r55974281'>File: infrastructure/beacon_server/core.py:L151-165</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> `local_isd` sounds more accurate to me.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Changed.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/668#issuecomment-196227817'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/668?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/668?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/668'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
