### PR TITLE
Libscion path handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: all clean dispatcher install
+
+CC=gcc
+CFLAGS +=-Wall -g
+LIB_DIR=lib/libscion
+LIBFILE=$(LIB_DIR)/libscion.a
+LIB_H_SRC=$(LIB_DIR)/*.c $(LIB_DIR)/*.h
+DISPATCHER_DIR=endhost
+DISPATCHER=$(DISPATCHER_DIR)/dispatcher
+SOCKET_DIR=endhost/ssp
+SOCKET=$(SOCKET_DIR)/libsocket.so
+
+all:
+	$(MAKE) -C $(LIB_DIR)
+	$(MAKE) -C $(DISPATCHER_DIR)
+	$(MAKE) -C $(SOCKET_DIR)
+
+dispatcher:
+	$(MAKE) -C $(DISPATCHER_DIR)
+
+install:
+	cp $(DISPATCHER) bin/
+
+clean:
+	$(MAKE) clean -C $(LIB_DIR)
+	$(MAKE) clean -C $(DISPATCHER_DIR)
+	$(MAKE) clean -C $(SOCKET_DIR)
+	rm -f bin/dispatcher

--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -32,6 +32,8 @@ shutdown() {
 
 export PYTHONPATH=.
 
+log "Building dispatcher"
+./scion.sh build
 log "Starting scion"
 ./scion.sh run | grep -v "RUNNING"
 log "Scion status:"

--- a/endhost/Makefile
+++ b/endhost/Makefile
@@ -1,19 +1,20 @@
 CC=gcc
 CFLAGS +=-Wall -g
 INC += -I./ssp -I../lib/libscion
-LIB=-L../lib/libscion
 LDFLAGS += -lpthread -lscion
-LIBFILE=../lib/libscion/libscion.a
+LIBDIR=../lib/libscion
+LIBFLAG=-L$(LIBDIR)
+LIBFILE=$(LIBDIR)/libscion.a
+LIBHSRC=$(LIBDIR)/*.c $(LIBDIR)/*.h
+SRCS=dispatcher.c
 
 HDRS=$(wildcard *.h)
 
 all: dispatcher
 
-dispatcher: dispatcher.c
-ifeq ($(wildcard $(LIBFILE)),)
-	cd ../lib/libscion && $(MAKE)
-endif
-	$(CC) $(CFLAGS) $(INC) $^ -o $@ $(LDFLAGS) $(LIB)
+dispatcher: dispatcher.c $(LIBHSRC)
+	$(MAKE) -C $(LIBDIR)
+	$(CC) $(CFLAGS) $(INC) $(SRCS) -o $@ $(LDFLAGS) $(LIBFLAG)
 
 install:
 	cp dispatcher ../bin

--- a/endhost/dispatcher.c
+++ b/endhost/dispatcher.c
@@ -44,8 +44,6 @@ Entry * parse_request(char *buf, int proto, sockaddr_in *addr);
 void reply(char code, sockaddr_in *addr);
 
 void handle_data();
-int is_known_proto(uint8_t type);
-uint8_t get_l4_proto(uint8_t **l4ptr);
 void deliver_ssp(uint8_t *buf, uint8_t *l4ptr, int len, sockaddr_in *addr);
 void deliver_udp(uint8_t *buf, int len, sockaddr_in *from, sockaddr_in *key);
 

--- a/endhost/ssp/Makefile
+++ b/endhost/ssp/Makefile
@@ -1,8 +1,10 @@
 CC=g++
 CFLAGS=-Wall -g -std=c++11 -fPIC
 LDFLAGS=-shared -lpthread -lscion
-INC=-I../../lib/libscion
-LIB=-L../../lib/libscion
+LIBDIR=../../lib/libscion
+INC=-I$(LIBDIR)
+LIBFLAG=-L$(LIBDIR)
+LIBHSRC=$(LIBDIR)/*.c $(LIBDIR)/*.h
 
 HDRS=$(wildcard *.h) ../../lib/libscion/libscion_api.h
 
@@ -27,11 +29,13 @@ all: $(CLIENT_LIB) $(SERVER_LIB)
 %.o: %.cpp $(HDRS)
 	$(CC) $(CFLAGS) $(INC) -c -o $@ $<
 
-$(CLIENT_LIB): $(COMMON_OBJS) $(CLIENT_OBJS) $(HDRS)
-	$(CC) -o $@ $(COMMON_OBJS) $(CLIENT_OBJS) $(LDFLAGS) $(LIB)
+$(CLIENT_LIB): $(COMMON_OBJS) $(CLIENT_OBJS) $(HDRS) $(LIBHSRC)
+	$(MAKE) -C $(LIBDIR)
+	$(CC) -o $@ $(COMMON_OBJS) $(CLIENT_OBJS) $(LDFLAGS) $(LIBFLAG)
 
-$(SERVER_LIB): $(COMMON_OBJS) $(SERVER_OBJS) $(HDRS)
-	$(CC) -o $@ $(COMMON_OBJS) $(SERVER_OBJS) $(LDFLAGS) $(LIB)
+$(SERVER_LIB): $(COMMON_OBJS) $(SERVER_OBJS) $(HDRS) $(LIBHSRC)
+	$(MAKE) -C $(LIBDIR)
+	$(CC) -o $@ $(COMMON_OBJS) $(SERVER_OBJS) $(LDFLAGS) $(LIBFLAG)
 
 clean:
 	-rm -f $(SOCKET_OBJS) $(CLIENT_LIB) $(SERVER_LIB)

--- a/endhost/ssp/SCIONSocket.cpp
+++ b/endhost/ssp/SCIONSocket.cpp
@@ -267,7 +267,7 @@ void SCIONSocket::handlePacket(uint8_t *buf, size_t len, struct sockaddr_in *add
 #ifdef SIMULATOR
     memcpy(sh.path, buf + sch.headerLen - sh.pathLen, sh.pathLen);
 #else
-    int res = reverse_path(buf + sch.headerLen - sh.pathLen, sh.path, sh.pathLen);
+    int res = reverse_path(buf, buf + sch.headerLen - sh.pathLen, sh.path, sh.pathLen);
     if (res < 0) {
         DEBUG("reverse_path failed\n");
         free(packet);

--- a/lib/libscion/libscion_api.h
+++ b/lib/libscion/libscion_api.h
@@ -5,12 +5,20 @@
 extern "C" {
 #endif
 
-int reverse_path(uint8_t *original, uint8_t *reverse, int len);
+int reverse_path(uint8_t *buf, uint8_t *original, uint8_t *reverse, int len);
+void reverse_packet(uint8_t *buf);
 
 uint8_t * get_src_addr(uint8_t *buf);
 uint8_t get_src_len(uint8_t *buf);
 void * get_dst_addr(uint8_t *buf);
 uint8_t get_dst_len(uint8_t *buf);
+
+void build_cmn_hdr(uint8_t *buf, int src_type, int dst_type, int next_hdr);
+void build_addr_hdr(uint8_t *buf, uint8_t *src, uint8_t *dst);
+void init_of_idx(uint8_t *buf);
+void inc_hof_idx(uint8_t *buf);
+int is_known_proto(uint8_t type);
+uint8_t get_l4_proto(uint8_t **l4ptr);
 
 #ifdef __cplusplus
 }

--- a/lib/libscion/opaque_field.h
+++ b/lib/libscion/opaque_field.h
@@ -1,14 +1,16 @@
 #ifndef _OPAQUE_FIELD_H_
 #define _OPAQUE_FIELD_H_
 
-// Types for HopOpaqueFields (7 MSB bits).
-#define    OFT_NORMAL_OF       0b0000000
-#define    OFT_XOVR_POINT      0b0010000  
-// Types for Info Opaque Fields (7 MSB bits).
-#define    OFT_CORE            0b1000000
-#define    OFT_SHORTCUT        0b1100000
-#define    OFT_INTRA_ISD_PEER  0b1111000
-#define    OFT_INTER_ISD_PEER  0b1111100
+#define SCION_OF_LEN 8
+
+#define IOF_FLAG_UPDOWN   0x01
+#define IOF_FLAG_SHORTCUT 0x02
+#define IOF_FLAG_PEER     0x04
+
+#define HOF_FLAG_XOVER        0x01
+#define HOF_FLAG_VERIFY_ONLY  0x02
+#define HOF_FLAG_FORWARD_ONLY 0x04
+#define HOF_FLAG_RECURSE      0x08
 
 #define PATH_TYPE_TDC 0
 #define PATH_TYPE_XOVR 1

--- a/lib/libscion/packet.c
+++ b/lib/libscion/packet.c
@@ -18,27 +18,64 @@ void build_cmn_hdr(uint8_t *buf, int src_type, int dst_type, int next_hdr)
     sch->versionSrcDst = htons(vsd);
     sch->nextHeader = next_hdr;
     sch->headerLen = sizeof(*sch);
-    sch->currentIOF = 0;
-    sch->currentOF = 0;
     sch->totalLen = htons(sch->headerLen);
 }
 
-void build_addr_hdr(uint8_t *buf, SCIONAddr *src, SCIONAddr *dst)
+void build_addr_hdr(uint8_t *buf, uint8_t *src, uint8_t *dst)
 {
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
     int src_len = get_src_len(buf);
     int dst_len = get_dst_len(buf);
     int pad = (SCION_ADDR_PAD - ((src_len + dst_len) % 8)) % 8;
     uint8_t *ptr = (uint8_t *)sch + sizeof(*sch);
-    *(uint32_t *)ptr = htonl(src->isd_ad);
+    SCIONAddr *src_addr = (SCIONAddr *)src;
+    SCIONAddr *dst_addr = (SCIONAddr *)dst;
+    *(uint32_t *)ptr = htonl(src_addr->isd_ad);
     ptr += 4;
-    memcpy(ptr, src->host_addr, src_len);
+    memcpy(ptr, src_addr->host_addr, src_len);
     ptr += src_len;
-    *(uint32_t *)ptr = htonl(dst->isd_ad);
+    *(uint32_t *)ptr = htonl(dst_addr->isd_ad);
     ptr += 4;
-    memcpy(ptr, dst->host_addr, dst_len);
+    memcpy(ptr, dst_addr->host_addr, dst_len);
     sch->headerLen += src_len + dst_len + 8 + pad;
     sch->totalLen = htons(sch->headerLen);
+}
+
+void init_of_idx(uint8_t *buf)
+{
+    SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
+    int addr_len = get_src_len(buf) + get_dst_len(buf) + 2 * SCION_ISD_AD_LEN;
+    addr_len = (addr_len + SCION_ADDR_PAD - 1) & ~(SCION_ADDR_PAD - 1);
+    sch->currentIOF = sizeof(SCIONCommonHeader) + addr_len;
+    sch->currentOF = sch->currentIOF;
+
+    uint8_t *iof = buf + sch->currentIOF;
+    uint8_t *hof = buf + sch->currentIOF + SCION_OF_LEN;
+    if ((*iof & IOF_FLAG_PEER) && (*hof & HOF_FLAG_XOVER))
+        sch->currentOF += SCION_OF_LEN;
+
+    inc_hof_idx(buf);
+}
+
+void inc_hof_idx(uint8_t *buf)
+{
+    SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
+    uint8_t *iof = buf + sch->currentIOF;
+    uint8_t *hof = buf + sch->currentOF;
+    int hops = *(iof + SCION_OF_LEN - 1);
+
+    while (1) {
+        sch->currentOF += SCION_OF_LEN;
+        if ((sch->currentOF - sch->currentIOF) / SCION_OF_LEN > hops) {
+            sch->currentIOF = sch->currentOF;
+            iof = buf + sch->currentIOF;
+            hops = *(iof + SCION_OF_LEN - 1);
+            continue;
+        }
+        hof = buf + sch->currentOF;
+        if (!(*hof & HOF_FLAG_VERIFY_ONLY))
+            break;
+    }
 }
 
 int is_known_proto(uint8_t type)
@@ -51,6 +88,11 @@ int is_known_proto(uint8_t type)
     return 0;
 }
 
+/*
+ * Function to get L4 protocol of packet and a pointer to the L4 header.
+ * (*l4ptr) should initially point to the start of the SCION packet. When the
+ * function returns it will point to the start of the L4 header.
+ */
 uint8_t get_l4_proto(uint8_t **l4ptr)
 {
     uint8_t *ptr = *l4ptr;
@@ -65,4 +107,41 @@ uint8_t get_l4_proto(uint8_t **l4ptr)
     }
     *l4ptr = ptr;
     return currentHeader;
+}
+
+/*
+ * Certain features require sending a resply packet back to the sender.
+ * One exmample is SCMP Echo.
+ * This function is a utility function to be used in those cases
+ */
+void reverse_packet(uint8_t *buf)
+{
+    SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
+    uint8_t *srcptr = buf + sizeof(SCIONCommonHeader);
+    int srclen = get_src_len(buf) + SCION_ISD_AD_LEN;
+    uint8_t *dstptr = srcptr + srclen;
+    int dstlen = get_dst_len(buf) + SCION_ISD_AD_LEN;
+    uint8_t *orig_src = (uint8_t *)malloc(srclen);
+    /* reverse src/dst addrs */
+    memcpy(orig_src, srcptr, srclen);
+    memcpy(srcptr, dstptr, dstlen);
+    memcpy(dstptr, orig_src, srclen);
+    int pathlen = sch->headerLen - srclen - dstlen - sizeof(SCIONCommonHeader);
+    int rem = (srclen + dstlen) % SCION_ADDR_PAD;
+    if (rem != 0)
+        pathlen -= SCION_ADDR_PAD - rem;
+    uint8_t *path = buf + sch->headerLen - pathlen;
+    uint8_t *reverse = (uint8_t *)malloc(pathlen);
+    reverse_path(buf, path, reverse, pathlen);
+    memcpy(path, reverse, pathlen);
+    uint8_t *ptr = buf;
+    uint8_t l4 = get_l4_proto(&ptr);
+    switch (l4) {
+        case L4_UDP:
+            reverse_udp_header(ptr);
+            break;
+        default:
+            /* other protocols may be added later as they become necessary */
+            break;
+    }
 }

--- a/lib/libscion/packet.h
+++ b/lib/libscion/packet.h
@@ -26,4 +26,11 @@ typedef struct {
 #define SRC_TYPE(sch) ((ntohs(sch->versionSrcDst) & 0xfc0) >> 6)
 #define DST_TYPE(sch) (ntohs(sch->versionSrcDst) & 0x3f)
 
+void build_cmn_hdr(uint8_t *buf, int src_type, int dst_type, int next_hdr);
+void build_addr_hdr(uint8_t *buf, uint8_t *src, uint8_t *dst);
+void init_of_idx(uint8_t *buf);
+void inc_hof_idx(uint8_t *buf);
+int is_known_proto(uint8_t type);
+uint8_t get_l4_proto(uint8_t **l4ptr);
+
 #endif

--- a/lib/libscion/path.h
+++ b/lib/libscion/path.h
@@ -43,4 +43,6 @@ typedef struct {
 #define INGRESS_IF(HOF) (ntohl((HOF)->ingress_egress_if) >> (12 + 8))
 #define EGRESS_IF(HOF) ((ntohl((HOF)->ingress_egress_if) >> 8) & 0x000fff)
 
+int reverse_path(uint8_t *buf, uint8_t *original, uint8_t *reverse, int len);
+
 #endif

--- a/lib/libscion/udp.c
+++ b/lib/libscion/udp.c
@@ -91,3 +91,11 @@ void update_scion_udp_checksum(uint8_t *buf)
     scion_udp_hdr->checksum = htons(scion_udp_checksum(buf));
     //printf("SCION UDP checksum=%x\n",scion_udp_hdr->dgram_cksum);
 }
+
+void reverse_udp_header(uint8_t *l4ptr)
+{
+    SCIONUDPHeader *udp = (SCIONUDPHeader *)l4ptr;
+    uint16_t src = udp->src_port;
+    udp->src_port = udp->dst_port;
+    udp->dst_port = src;
+}

--- a/lib/libscion/udp.h
+++ b/lib/libscion/udp.h
@@ -13,4 +13,11 @@ typedef struct {
 
 #pragma pack(pop)
 
+void build_scion_udp(uint8_t *buf, uint16_t payload_len);
+uint8_t get_payload_class(uint8_t *buf);
+uint8_t get_payload_type(uint8_t *buf);
+uint16_t scion_udp_checksum(uint8_t *buf);
+void update_scion_udp_checksum(uint8_t *buf);
+void reverse_udp_header(uint8_t *l4ptr);
+
 #endif

--- a/scion.sh
+++ b/scion.sh
@@ -18,14 +18,10 @@ cmd_topology() {
 }
 
 cmd_run() {
-    echo "Building dispatcher..."
-    make -C endhost
-    result=$?
-    if [ $result -ne 0 ]; then
-        echo "Dispatcher build failed"
-        exit $result
+    if ! [ -x bin/dispatcher ]; then
+        echo "Dispatcher not built - please run the \"build\" command first"
+        exit -1
     fi
-    make install -C endhost
     echo "Running the network..."
     supervisor/supervisor.sh reload
     # Supervisor reload causes the domain socket to briefly disappear, which
@@ -73,11 +69,13 @@ cmd_version() {
 	_EOF
 }
 
-cmd_sock_bld() {
-    make -C lib/libscion
-    make -C endhost
-    make -C endhost/ssp
-    make -C endhost/ssp/test
+cmd_build() {
+    make dispatcher
+    make install
+}
+
+cmd_clean() {
+    make clean
 }
 
 SOCKDIR=endhost/ssp
@@ -153,7 +151,7 @@ shift
 
 case "$COMMAND" in
     coverage|help|lint|run|stop|status|test|topology|version|\
-    sock_cli|sock_ser|sock_bld|run_cli|run_ser)
+    sock_cli|sock_ser|build|clean|run_cli|run_ser)
         "cmd_$COMMAND" "$@" ;;
     *)  cmd_help; exit 1 ;;
 esac


### PR DESCRIPTION
This is mainly to adopt the latest changes to Paths and OpaqueFields into the C library.

There is also now a top-level Makefile to build the C lib, dispatcher, and socket lib.
Attempting ./scion.sh run without building the dispatcher will fail and alert the user to build the dispatcher first using the command ./scion.sh build.
This will build the dispatcher and copy it into the bin/ directory.

None of the Python code is directly affected, but changes to the scion.sh and integration_test.sh scripts may be worth a review.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r55999399%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56000302%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56000853%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56001465%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56001711%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56001761%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56002356%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56008334%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56011691%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56012815%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56016317%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56016582%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56016631%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23issuecomment-196363812%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56016854%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23issuecomment-196376836%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23issuecomment-196363812%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22otherwise%20lgtm%22%2C%20%22created_at%22%3A%20%222016-03-14T15%3A17%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22will%20merge%20after%20circleci%20completes%22%2C%20%22created_at%22%3A%20%222016-03-14T15%3A47%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20129ef2cf061dab7234a9f8352f709a068017e303%20lib/libscion/packet.c%2099%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56012815%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20does%20not%20reverse%20the%20ports%20for%20UDP/SCION%22%2C%20%22created_at%22%3A%20%222016-03-14T14%3A54%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aznair%20%20so%20this%20function%20is%20used%20only%20for%20UDP/SCION%3F%22%2C%20%22created_at%22%3A%20%222016-03-14T15%3A16%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/libscion/packet.c%3AL103-128%22%7D%2C%20%22Pull%206f0e19a73276fc970a46790355bca1b84a68b84a%20lib/libscion/packet.c%2010%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56000302%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20change%20these%2C%20only%20to%20case%20them%20back%20a%20few%20lines%20below%3F%22%2C%20%22created_at%22%3A%20%222016-03-14T13%3A37%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Right%20now%20there%27s%20a%20problem%20where%20some%20of%20the%20structs%20and/or%20values%20defined%20in%20the%20headers%20here%20is%20also%20defined%20in%20headers%20in%20the%20socket%20lib%20directory.%5Cr%5Cn%5Cr%5CnOnce%20I%20get%20around%20to%20actually%20refactoring%20the%20socket%20lib%20so%20that%20it%20only%20uses%20headers%20here%20it%20won%27t%20be%20an%20issue%20but%20for%20now%20I%27m%20trying%20to%20define%20function%20prototypes%20using%20generic%20datatypes%20to%20avoid%20conflicts.%5Cr%5Cn%5Cr%5CnThis%20is%20also%20why%20some%20function%20declarations%20are%20in%20their%20own%20headers%20and%20also%20libscion_api.h%2C%20so%20the%20socket%20lib%20can%20include%20only%20libscion_api.h%20and%20not%20have%20any%20conflicts.%22%2C%20%22created_at%22%3A%20%222016-03-14T13%3A45%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/libscion/packet.c%3AL18-84%22%7D%2C%20%22Pull%20129ef2cf061dab7234a9f8352f709a068017e303%20lib/libscion/packet.c%2079%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56016317%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22what%20does%20it%20mean%3F%20Reversing%20packets%20in%20the%20python%20codebase%20is%20a%20hack%20%20%28due%20to%20lack%20of%20layers%29.%20I%27m%20not%20sure%20why%20you%20need%20that.%22%2C%20%22created_at%22%3A%20%222016-03-14T15%3A14%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20my%20case%20I%20needed%20this%20for%20SCMP%20Echo%20%28which%20is%20not%20included%20here%29%22%2C%20%22created_at%22%3A%20%222016-03-14T15%3A16%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20see%2C%20so%20maybe%20put%20a%20comment%20on%20that.%22%2C%20%22created_at%22%3A%20%222016-03-14T15%3A17%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/libscion/packet.c%3AL103-128%22%7D%2C%20%22Pull%206f0e19a73276fc970a46790355bca1b84a68b84a%20lib/libscion/packet.c%2045%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56000853%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20logic%20is%20different%20to%20that%20in%20%60SCIONPath._init_of_idxs%60%22%2C%20%22created_at%22%3A%20%222016-03-14T13%3A41%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20_iof/hof_idx%20properties%20in%20the%20Python%20class%20and%20the%20fields%20in%20the%20common%20header%20aren%27t%20the%20same%20thing%2C%20but%20the%20end%20result%20is%20the%20same%20isn%27t%20it%3F%22%2C%20%22created_at%22%3A%20%222016-03-14T13%3A51%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22ok%20fixed%20in%20latest%20push%22%2C%20%22created_at%22%3A%20%222016-03-14T14%3A29%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/libscion/packet.c%3AL18-84%22%7D%2C%20%22Pull%2084f601d47997c337bd9e676a3b60c715c40d35ac%20Makefile%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56011691%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60-f%60%20would%20be%20better%2C%20to%20prevent%20errors%20when%20it%20doesn%27t%20exist.%22%2C%20%22created_at%22%3A%20%222016-03-14T14%3A48%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Makefile%3AL1-29%22%7D%2C%20%22Pull%206f0e19a73276fc970a46790355bca1b84a68b84a%20Makefile%201%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r55999399%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20should%20also%20include%20%60all%60%2C%20%60install%60%2C%20%60clean%60%22%2C%20%22created_at%22%3A%20%222016-03-14T13%3A30%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20Makefile%3AL1-29%22%7D%2C%20%22Pull%206f0e19a73276fc970a46790355bca1b84a68b84a%20lib/libscion/packet.c%2091%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/669%23discussion_r56001711%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20seems%20to%20ignore%20address%20padding%22%2C%20%22created_at%22%3A%20%222016-03-14T13%3A47%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22But%20if%20i%20read%20even%20one%20more%20line..%20sign.%5Cr%5Cn%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-03-14T13%3A47%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/libscion/packet.c%3AL103-128%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 6f0e19a73276fc970a46790355bca1b84a68b84a Makefile 1'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/669#discussion_r55999399'>File: Makefile:L1-29</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This should also include `all`, `install`, `clean`
- [ ] <a href='#crh-comment-Pull 6f0e19a73276fc970a46790355bca1b84a68b84a lib/libscion/packet.c 10'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/669#discussion_r56000302'>File: lib/libscion/packet.c:L18-84</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Why change these, only to case them back a few lines below?
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> Right now there's a problem where some of the structs and/or values defined in the headers here is also defined in headers in the socket lib directory.
  Once I get around to actually refactoring the socket lib so that it only uses headers here it won't be an issue but for now I'm trying to define function prototypes using generic datatypes to avoid conflicts.
  This is also why some function declarations are in their own headers and also libscion_api.h, so the socket lib can include only libscion_api.h and not have any conflicts.
- [ ] <a href='#crh-comment-Pull 6f0e19a73276fc970a46790355bca1b84a68b84a lib/libscion/packet.c 45'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/669#discussion_r56000853'>File: lib/libscion/packet.c:L18-84</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This logic is different to that in `SCIONPath._init_of_idxs`
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> The _iof/hof_idx properties in the Python class and the fields in the common header aren't the same thing, but the end result is the same isn't it?
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> ok fixed in latest push
- [ ] <a href='#crh-comment-Pull 84f601d47997c337bd9e676a3b60c715c40d35ac Makefile 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/669#discussion_r56011691'>File: Makefile:L1-29</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `-f` would be better, to prevent errors when it doesn't exist.
- [ ] <a href='#crh-comment-Pull 129ef2cf061dab7234a9f8352f709a068017e303 lib/libscion/packet.c 99'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/669#discussion_r56012815'>File: lib/libscion/packet.c:L103-128</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This does not reverse the ports for UDP/SCION
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> @aznair  so this function is used only for UDP/SCION?
- [ ] <a href='#crh-comment-Pull 129ef2cf061dab7234a9f8352f709a068017e303 lib/libscion/packet.c 79'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/669#discussion_r56016317'>File: lib/libscion/packet.c:L103-128</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> what does it mean? Reversing packets in the python codebase is a hack  (due to lack of layers). I'm not sure why you need that.
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> In my case I needed this for SCMP Echo (which is not included here)
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> I see, so maybe put a comment on that.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/669#issuecomment-196363812'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> otherwise lgtm
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> will merge after circleci completes
- [x] <a href='#crh-comment-Pull 6f0e19a73276fc970a46790355bca1b84a68b84a lib/libscion/packet.c 91'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/669#discussion_r56001711'>File: lib/libscion/packet.c:L103-128</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This seems to ignore address padding
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> But if i read even one more line.. sign.
  :+1:

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/669?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/669?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/669'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
