### PR TITLE
Handling SVC addresses in dispatcher

### DIFF
--- a/endhost/dispatcher.c
+++ b/endhost/dispatcher.c
@@ -1,36 +1,66 @@
 #include <arpa/inet.h>
 #include <errno.h>
+#include <netinet/in.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <sys/select.h>
+#include <sys/socket.h>
 #include <sys/types.h>
+#include <sys/uio.h>
 #include <unistd.h>
 
 #include "libscion_api.h"
 #include "SCIONDefines.h"
 #include "uthash.h"
 
-#define APP_BUFSIZE 16
+#define APP_BUFSIZE 32
 #define DATA_BUFSIZE 65535
+
+#define MAX_SVCS_PER_ADDR 10
+
+#define DSTADDR_DATASIZE (CMSG_SPACE(sizeof(struct in_pktinfo)))
+#define DSTADDR(x) (((struct in_pktinfo *)(CMSG_DATA(x)))->ipi_addr)
 
 typedef struct sockaddr_in sockaddr_in;
 
 typedef struct {
     uint16_t port;
-    uint32_t host;
+    uint32_t isd_as;
     uint64_t flow_id;
+    uint8_t host[MAX_HOST_ADDR_LEN];
 } SSPKey;
 
-typedef struct Entry {
+typedef struct {
+    uint16_t port;
+    uint32_t isd_as;
+    uint8_t host[MAX_HOST_ADDR_LEN];
+} UDPKey;
+
+typedef struct {
+    uint16_t addr;
+    uint32_t isd_as;
+    uint8_t host[MAX_HOST_ADDR_LEN];
+} SVCKey;
+
+typedef struct {
     sockaddr_in addr;
-    sockaddr_in udp_key;
+    UDPKey udp_key;
     SSPKey ssp_key;
     UT_hash_handle hh;
 } Entry;
 
+typedef struct {
+    SVCKey key;
+    sockaddr_in addrs[MAX_SVCS_PER_ADDR];
+    int count;
+    UT_hash_handle hh;
+} SVCEntry;
+
 Entry *SSPFlows = NULL;
 Entry *SSPWildcards = NULL;
 Entry *UDPPorts = NULL;
+
+SVCEntry *SVCEntries = NULL;
 
 static int data_socket;
 static int app_socket;
@@ -38,14 +68,14 @@ static int app_socket;
 int create_sockets();
 
 void handle_app();
-void register_ssp(char *buf, int len, sockaddr_in *addr);
-void register_udp(char *buf, int len, sockaddr_in *addr);
-Entry * parse_request(char *buf, int proto, sockaddr_in *addr);
+void register_ssp(uint8_t *buf, int len, sockaddr_in *addr);
+void register_udp(uint8_t *buf, int len, sockaddr_in *addr);
+Entry * parse_request(uint8_t *buf, int len, int proto, sockaddr_in *addr);
 void reply(char code, sockaddr_in *addr);
 
 void handle_data();
 void deliver_ssp(uint8_t *buf, uint8_t *l4ptr, int len, sockaddr_in *addr);
-void deliver_udp(uint8_t *buf, int len, sockaddr_in *from, sockaddr_in *key);
+void deliver_udp(uint8_t *buf, int len, sockaddr_in *from, sockaddr_in *dst);
 
 int main(int argc, char **argv)
 {
@@ -93,10 +123,12 @@ int create_sockets()
     int optval = 1;
     res = setsockopt(data_socket, SOL_SOCKET, SO_REUSEADDR,
             &optval, sizeof(optval));
-    res |= setsockopt(app_socket, SOL_SOCKET, SO_REUSEADDR,
-            &optval, sizeof(optval));
+    res |= setsockopt(data_socket, IPPROTO_IP, IP_PKTINFO, &optval, sizeof(optval));
+    res |= setsockopt(app_socket, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+    optval = 1 << 20;
+    res |= setsockopt(data_socket, SOL_SOCKET, SO_RCVBUF, &optval, sizeof(optval));
     if (res < 0) {
-        fprintf(stderr, "failed to set addr resuse option\n");
+        fprintf(stderr, "failed to set socket options\n");
         return -1;
     }
     /* Bind data socket to SCION_UDP_EH_DATA_PORT */
@@ -111,8 +143,6 @@ int create_sockets()
                 inet_ntoa(sa.sin_addr), ntohs(sa.sin_port));
         return -1;
     }
-    optval = 1 << 20;
-    setsockopt(data_socket, SOL_SOCKET, SO_RCVBUF, &optval, sizeof(optval));
     fprintf(stderr, "data socket bound to %s:%d\n", inet_ntoa(sa.sin_addr), SCION_UDP_EH_DATA_PORT);
 
     /* Bind app socket to SCION_DISPATCHER_PORT */
@@ -132,12 +162,12 @@ void handle_app()
 {
     sockaddr_in addr;
     socklen_t addrLen = sizeof(addr);
-    char buf[APP_BUFSIZE];
+    uint8_t buf[APP_BUFSIZE];
     int len = recvfrom(app_socket, buf, APP_BUFSIZE, 0,
             (struct sockaddr *)&addr, &addrLen);
     if (len > 2) { /* command (1B) | proto (1B) | id */
         unsigned char protocol = buf[1];
-        fprintf(stderr, "received registration for proto: %d\n", protocol);
+        fprintf(stderr, "received registration for proto: %d (%d bytes)\n", protocol, len);
         switch (protocol) {
             case SCION_PROTO_SSP:
                 register_ssp(buf, len, &addr);
@@ -149,17 +179,11 @@ void handle_app()
     }
 }
 
-void register_ssp(char *buf, int len, sockaddr_in *addr)
+void register_ssp(uint8_t *buf, int len, sockaddr_in *addr)
 {
-    if (len != 16) {
-        fprintf(stderr, "invalid SSP registration\n");
-        reply(0, addr);
-        return;
-    }
     fprintf(stderr, "SSP registration request\n");
-    /* command (1B) | proto (1B) | flow_ID (8B) | port (2B) | addr (4B) */
     uint8_t reg = *buf; /* 0 = unregister, 1 = register */
-    Entry *e = parse_request(buf, SCION_PROTO_SSP, addr);
+    Entry *e = parse_request(buf, len, SCION_PROTO_SSP, addr);
     if (!e)
         return;
     Entry *old = NULL;
@@ -175,7 +199,7 @@ void register_ssp(char *buf, int len, sockaddr_in *addr)
         /* If command is "register", add new entry */
         if (reg) {
             HASH_ADD(hh, SSPFlows, ssp_key, sizeof(SSPKey), e);
-            fprintf(stderr, "flow registration success: %p\n", SSPFlows);
+            fprintf(stderr, "flow registration success: %lu\n", e->ssp_key.flow_id);
         }
     } else {
         /* Find registered wildcard port */
@@ -189,28 +213,22 @@ void register_ssp(char *buf, int len, sockaddr_in *addr)
         /* If command is "register", add new entry */
         if (reg) {
             HASH_ADD(hh, SSPWildcards, ssp_key, sizeof(SSPKey), e);
-            fprintf(stderr, "wildcard registration success: %p\n", SSPWildcards);
+            fprintf(stderr, "wildcard registration success: %d\n", e->ssp_key.port);
         }
     }
     reply(1, addr);
 }
 
-void register_udp(char *buf, int len, sockaddr_in *addr)
+void register_udp(uint8_t *buf, int len, sockaddr_in *addr)
 {
-    if (len != 8) {
-        fprintf(stderr, "invalid UDP registration\n");
-        reply(0, addr);
-        return;
-    }
     fprintf(stderr, "UDP registration request\n");
 
-    /* command (1B) | proto (1B) | port (2B) | addr (4B) */
     uint8_t reg = *buf; /* 0 = unregister, 1 = register */
-    Entry *e = parse_request(buf, SCION_PROTO_UDP, addr);
+    Entry *e = parse_request(buf, len, SCION_PROTO_UDP, addr);
     if (!e)
         return;
     Entry *old = NULL;
-    HASH_FIND(hh, UDPPorts, &e->udp_key, sizeof(sockaddr_in), old);
+    HASH_FIND(hh, UDPPorts, &e->udp_key, sizeof(UDPKey), old);
     if (old) {
         /* Delete obsolete entry - this also serves as unregister */
         HASH_DELETE(hh, UDPPorts, old);
@@ -218,38 +236,82 @@ void register_udp(char *buf, int len, sockaddr_in *addr)
     }
     /* If command is "register", add new entry */
     if (reg)
-        HASH_ADD(hh, UDPPorts, udp_key, sizeof(sockaddr_in), e);
-    fprintf(stderr, "registered for (%s:%d)\n",
-            inet_ntoa(e->udp_key.sin_addr), e->udp_key.sin_port);
+        HASH_ADD(hh, UDPPorts, udp_key, sizeof(UDPKey), e);
     reply(1, addr);
 }
 
-Entry * parse_request(char *buf, int proto, sockaddr_in *addr)
+Entry * parse_request(uint8_t *buf, int len, int proto, sockaddr_in *addr)
 {
-    uint16_t port = *(uint16_t *)(buf + 2);
-    uint64_t flow_id;
-    uint32_t host;
-    if (proto == SCION_PROTO_SSP) {
-        flow_id = *(uint64_t *)(buf + 4);
-        host = *(uint32_t *)(buf + 12);
-    } else if (proto == SCION_PROTO_UDP) {
-        host = *(uint32_t *)(buf + 4);
-    }
+    uint32_t isd_as = ntohl(*(uint32_t *)(buf + 2));
+    uint16_t port = ntohs(*(uint16_t *)(buf + 6));
+    int common = 9; // start of (protocol/addrtype)-dependent data
+
+    fprintf(stderr, "registration for isd_as %x(%d,%d)\n", isd_as, GET_ISD(isd_as), GET_AD(isd_as));
 
     Entry *e = (Entry *)malloc(sizeof(Entry));
-    if (!e)
-        return NULL;
+    if (!e) {
+        fprintf(stderr, "malloc failed, abandon ship\n");
+        exit(1);
+    }
     memset(e, 0, sizeof(Entry));
     e->addr = *addr;
-    if (proto == SCION_PROTO_SSP) {
-        e->ssp_key.flow_id = flow_id;
-        e->ssp_key.port = port;
-        e->ssp_key.host = host;
-    } else if (proto == SCION_PROTO_UDP) {
-        e->udp_key.sin_family = AF_INET;
-        e->udp_key.sin_addr.s_addr = host;
-        e->udp_key.sin_port = port;
+
+    uint8_t type = *(uint8_t *)(buf + 8);
+    if (type < ADDR_TYPE_IPV4 || type > ADDR_TYPE_IPV6) {
+        fprintf(stderr, "Invalid address type: %d\n", type);
+        return NULL;
     }
+
+    SVCKey svc_key;
+    memset(&svc_key, 0, sizeof(SVCKey));
+
+    int ADDR_LENS[] = {4, 16, 2};
+    int addr_len = ADDR_LENS[type - 1];
+    int end;
+
+    if (proto == SCION_PROTO_SSP) {
+    /* command (1B) | proto (1B) | isd_as (4B) | port (2B) | addr type (1B) | flow ID (8B) | addr (?B) | SVC (2B, optional) */
+        e->ssp_key.flow_id = *(uint64_t *)(buf + common);
+        e->ssp_key.port = port;
+        e->ssp_key.isd_as = isd_as;
+        memcpy(e->ssp_key.host, buf + common + 8, addr_len);
+        end = addr_len + common + 8;
+    } else if (proto == SCION_PROTO_UDP) {
+    /* command (1B) | proto (1B) | isd_as (4B) | port (2B) | addr type (1B) | addr (?B) | SVC (2B, optional) */
+        e->udp_key.port = port;
+        e->udp_key.isd_as = isd_as;
+        memcpy(e->udp_key.host, buf + common, addr_len);
+        end = addr_len + common;
+        sockaddr_in reg_addr;
+        memcpy(&reg_addr.sin_addr, e->udp_key.host, addr_len);
+        fprintf(stderr, "registration for %s:%d\n", inet_ntoa(reg_addr.sin_addr), e->udp_key.port);
+    }
+
+    if (len > end) {
+        memcpy(svc_key.host, buf + end - addr_len, addr_len);
+        svc_key.addr = ntohs(*(uint16_t *)(buf + end));
+        svc_key.isd_as = isd_as;
+        fprintf(stderr, "SVC (%d) registration included\n", svc_key.addr);
+        SVCEntry *se;
+        HASH_FIND(hh, SVCEntries, &svc_key, sizeof(svc_key), se);
+        if (se) {
+            if (se->count < MAX_SVCS_PER_ADDR)
+                se->addrs[se->count++] = *addr;
+            else
+                fprintf(stderr, "Reached maximum SVC entries for this host\n");
+        } else {
+            se = (SVCEntry *)malloc(sizeof(SVCEntry));
+            if (!se) {
+                fprintf(stderr, "malloc failed, abandon ship\n");
+                exit(1);
+            }
+            memset(se, 0, sizeof(SVCEntry));
+            se->key = svc_key;
+            se->addrs[se->count++] = *addr;
+            HASH_ADD(hh, SVCEntries, key, sizeof(SVCKey), se);
+        }
+    }
+
     return e;
 }
 
@@ -261,53 +323,73 @@ void reply(char code, sockaddr_in *addr)
 void handle_data()
 {
     sockaddr_in from;
-    socklen_t addrLen = sizeof(from);
+    sockaddr_in dst;
     uint8_t buf[DATA_BUFSIZE];
-    int len = recvfrom(data_socket, buf, DATA_BUFSIZE, 0,
-            (struct sockaddr *)&from, &addrLen);
+
+    struct msghdr msg;
+    char control_buf[DSTADDR_DATASIZE];
+    struct cmsghdr *cmsgptr;
+    struct iovec iov[1];
+
+    iov[0].iov_base = buf;
+    iov[0].iov_len = sizeof(buf);
+
+    memset(&msg, 0, sizeof(msg));
+    msg.msg_name = &from;
+    msg.msg_namelen = sizeof(from);
+    msg.msg_iov = iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = control_buf;;
+    msg.msg_controllen = sizeof(control_buf);
+
+    int len = recvmsg(data_socket, &msg, 0);
     if (len < 0) {
         fprintf(stderr, "error on recvfrom: %s\n", strerror(errno));
         return;
     }
+
+    for (cmsgptr = CMSG_FIRSTHDR(&msg); cmsgptr != NULL; cmsgptr = CMSG_NXTHDR(&msg, cmsgptr)) {
+        if (cmsgptr->cmsg_level == IPPROTO_IP && cmsgptr->cmsg_type == IP_PKTINFO) {
+            dst.sin_addr = DSTADDR(cmsgptr);
+        }
+    }
+
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    if (sch->headerLen > DATA_BUFSIZE ||
-            ntohs(sch->totalLen) > DATA_BUFSIZE) {
+    if (sch->headerLen > len || ntohs(sch->totalLen) > len) {
         fprintf(stderr, "invalid SCION packet\n");
         return;
     }
-    uint8_t *l4ptr = (uint8_t *)buf;
+    uint8_t *l4ptr = buf;
     uint8_t l4 = get_l4_proto(&l4ptr);
-    sockaddr_in key;
     switch (l4) {
         case SCION_PROTO_SSP:
             deliver_ssp(buf, l4ptr, len, &from);
             break;
         case SCION_PROTO_UDP:
-            memset(&key, 0, sizeof(key));
-            key.sin_family = AF_INET;
-            /* Find dst info in packet */
-            key.sin_port = htons(*(uint16_t *)(l4ptr + 2));
-            key.sin_addr.s_addr = *(uint32_t *)(get_dst_addr(buf));
-            deliver_udp(buf, len, &from, &key);
+            deliver_udp(buf, len, &from, &dst);
             break;
     }
 }
 
 void deliver_ssp(uint8_t *buf, uint8_t *l4ptr, int len, sockaddr_in *addr)
 {
+    uint8_t *dst_ptr = get_dst_addr(buf);
+    int dst_len = get_dst_len(buf);
     Entry *e;
     SSPKey key;
     memset(&key, 0, sizeof(key));
     key.flow_id = be64toh(*(uint64_t *)l4ptr);
     key.port = 0;
-    key.host = *(uint32_t *)get_dst_addr(buf);
+    key.isd_as = ntohl(*(uint32_t *)(get_dst_addr(buf) - SCION_ISD_AD_LEN));
+    memcpy(key.host, dst_ptr, dst_len);
     HASH_FIND(hh, SSPFlows, &key, sizeof(key), e);
     if (!e) {
+        fprintf(stderr, "no flow entry found for %lu\n", key.flow_id);
         key.flow_id = 0;
         key.port = ntohs(*(uint16_t *)(l4ptr + 8));
         HASH_FIND(hh, SSPWildcards, &key, sizeof(key), e);
         if (!e) {
-            fprintf(stderr, "no entry found\n");
+            fprintf(stderr, "no wildcard entry found for %d\n", key.port);
             return;
         }
     }
@@ -318,15 +400,46 @@ void deliver_ssp(uint8_t *buf, uint8_t *l4ptr, int len, sockaddr_in *addr)
             (struct sockaddr *)&e->addr, addrLen);
 }
 
-void deliver_udp(uint8_t *buf, int len, sockaddr_in *from, sockaddr_in *key)
+void deliver_udp(uint8_t *buf, int len, sockaddr_in *from, sockaddr_in *dst)
 {
-    Entry *e;
-    HASH_FIND(hh, UDPPorts, key, sizeof(*key), e);
-    if (!e)
-        return;
+    sockaddr_in addr;
+    SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
+    if (DST_TYPE(sch) == ADDR_TYPE_SVC) {
+        SVCKey svc_key;
+        memset(&svc_key, 0, sizeof(SVCKey));
+        svc_key.addr = ntohs(*(uint16_t *)get_dst_addr(buf));
+        svc_key.isd_as = ntohl(*(uint32_t *)(get_dst_addr(buf) - SCION_ISD_AD_LEN));
+        /* TODO: IPv6? */
+        memcpy(svc_key.host, &dst->sin_addr.s_addr, 4);
+        SVCEntry *se;
+        HASH_FIND(hh, SVCEntries, &svc_key, sizeof(SVCKey), se);
+        if (!se) {
+            fprintf(stderr, "SVC entry not found\n");
+            return;
+        }
+        addr = se->addrs[random() % se->count];
+    } else {
+        uint8_t *l4ptr = buf;
+        get_l4_proto(&l4ptr);
+
+        UDPKey key;
+        memset(&key, 0, sizeof(key));
+        /* Find dst info in packet */
+        key.port = ntohs(*(uint16_t *)(l4ptr + 2));
+        key.isd_as = ntohl(*(uint32_t *)(get_dst_addr(buf) - SCION_ISD_AD_LEN));
+        memcpy(key.host, get_dst_addr(buf), get_dst_len(buf));
+
+        Entry *e;
+        HASH_FIND(hh, UDPPorts, &key, sizeof(key), e);
+        if (!e) {
+            fprintf(stderr, "entry not found\n");
+            return;
+        }
+        addr = e->addr;
+    }
     socklen_t addrLen = sizeof(sockaddr_in);
     /* Append real first hop sender addr to end of message (needed by socket) */
     memcpy(buf + len, from, addrLen);
     sendto(app_socket, buf, len + addrLen, 0,
-            (struct sockaddr *)&e->addr, addrLen);
+            (struct sockaddr *)&addr, addrLen);
 }

--- a/endhost/ssp/DataStructures.h
+++ b/endhost/ssp/DataStructures.h
@@ -79,12 +79,6 @@ public:
     uint8_t *interfaces;
 };
 
-typedef struct {
-    uint16_t port;
-    uint32_t addr;
-    uint64_t flowID;
-} SSPEntry;
-
 typedef enum {
     SSP_METRIC_BANDWIDTH,
     SSP_METRIC_LATENCY,
@@ -164,9 +158,12 @@ typedef struct {
 } SUDPPacket;
 
 typedef struct {
+    uint32_t isd_as;
     uint16_t port;
-    uint32_t addr;
-} SUDPEntry;
+    uint8_t addr_type;
+    uint64_t flow_id;
+    uint8_t addr[MAX_HOST_ADDR_LEN];
+} DispatcherEntry;
 
 typedef struct {
     pthread_cond_t *cond;

--- a/endhost/ssp/ProtocolConfigs.h
+++ b/endhost/ssp/ProtocolConfigs.h
@@ -12,6 +12,7 @@
 #define SSP_FR_THRESHOLD 3
 #define SSP_MAX_LOSS_BURST 100
 #define SSP_HIGH_LOSS 0.3
+#define SSP_FID_LEN 8
 
 #define SSP_ACK 0x1
 #define SSP_NEW_PATH 0x2

--- a/endhost/ssp/SCIONDefines.h
+++ b/endhost/ssp/SCIONDefines.h
@@ -17,6 +17,14 @@
 
 #define SCION_ADDR_LEN 8 // ISD + AD = 4, ADDR = 4
 
+#define ADDR_TYPE_IPV4 1
+#define ADDR_TYPE_IPV6 2
+#define ADDR_TYPE_SVC  3
+
+#define ADDR_LEN_IPV4 4
+#define ADDR_LEN_IPV6 16
+#define ADDR_LEN_SVC  2
+
 #define SCION_PROTO_ICMP 1
 #define SCION_PROTO_TCP 6
 #define SCION_PROTO_UDP 17
@@ -28,7 +36,7 @@
 #define SCION_ISD_AD_LEN 4
 #define SCION_HOST_ADDR_LEN 4
 #define SCION_HOST_OFFSET 4
-#define MAX_HOST_ADDR_LEN 8
+#define MAX_HOST_ADDR_LEN 16
 
 #define NORMAL_OF    0x0
 #define LAST_OF      0x10
@@ -95,6 +103,9 @@ typedef struct {
     uint8_t nextHeader;
     uint8_t headerLen;
 } SCIONCommonHeader;
+
+#define SRC_TYPE(sch) ((ntohs(sch->versionAddrs) & 0xfc0) >> 6)
+#define DST_TYPE(sch) (ntohs(sch->versionAddrs) & 0x3f)
 
 typedef struct SCIONExtension {
     uint8_t nextHeader;

--- a/endhost/ssp/SCIONSocket.cpp
+++ b/endhost/ssp/SCIONSocket.cpp
@@ -76,11 +76,12 @@ SCIONSocket::SCIONSocket(int protocol, SCIONAddr *dstAddrs, int numAddrs,
                 }
             } else {
                 mProtocol = NULL;
-                SSPEntry se;
-                se.flowID = 0;
+                DispatcherEntry se;
+                se.flow_id = 0;
                 se.port = mSrcPort;
                 // FIXME: stopgap measure until big refactoring
-                se.addr = getLocalHostAddr();
+                se.isd_as = getLocalHostAddr(se.addr);
+                se.addr_type = ADDR_TYPE_IPV4;
                 registerFlow(SCION_PROTO_SSP, &se, mDispatcherSocket, 1);
                 mRegistered = true;
             }
@@ -122,14 +123,18 @@ SCIONSocket::~SCIONSocket()
         delete mProtocol;
         mProtocol = NULL;
     } else if (mProtocolID == SCION_PROTO_SSP) {
-        SSPEntry se;
-        se.flowID = 0;
+        DispatcherEntry se;
+        se.flow_id = 0;
         se.port = mSrcPort;
+        se.isd_as = getLocalHostAddr(se.addr);
+        se.addr_type = ADDR_TYPE_IPV4;
         registerFlow(SCION_PROTO_SSP, &se, mDispatcherSocket, 0);
     }
     if (mProtocolID == SCION_PROTO_UDP) {
-        SUDPEntry se;
+        DispatcherEntry se;
         se.port = mSrcPort;
+        se.addr_type = ADDR_TYPE_IPV4;
+        se.isd_as = getLocalHostAddr(se.addr);
         registerFlow(SCION_PROTO_UDP, &se, mDispatcherSocket, 0);
     }
     close(mDispatcherSocket);

--- a/endhost/ssp/SocketConfigs.h
+++ b/endhost/ssp/SocketConfigs.h
@@ -4,7 +4,7 @@
 // Build config
 
 //#define SIMULATOR // uncomment for WANem testing
-#define BYPASS_ROUTERS // send packets directly to remote end
+//#define BYPASS_ROUTERS // send packets directly to remote end
 
 #define DEBUG_MODE 0
 #if DEBUG_MODE

--- a/endhost/ssp/Utils.h
+++ b/endhost/ssp/Utils.h
@@ -45,8 +45,8 @@ void destroySUDPPacket(void *p);
 
 int reversePath(uint8_t *original, uint8_t *reverse, int len);
 uint64_t createRandom(int bits);
-uint32_t getLocalHostAddr();
-int registerFlow(int proto, void *data, int sock, uint8_t reg);
+uint32_t getLocalHostAddr(uint8_t *addr);
+int registerFlow(int proto, DispatcherEntry *e, int sock, uint8_t reg);
 void destroyStats(SCIONStats *stats);
 
 int isL4(uint8_t type);

--- a/infrastructure/beacon_server/core.py
+++ b/infrastructure/beacon_server/core.py
@@ -88,7 +88,8 @@ class CoreBeaconServer(BeaconServer):
 
             new_pcb.add_as(as_marking)
             self._sign_beacon(new_pcb)
-            beacon = self._build_packet(PT.BEACON, payload=new_pcb)
+            beacon = self._build_packet(
+                PT.BEACON, dst_ia=core_router.interface.isd_as, payload=new_pcb)
             self.send(beacon, core_router.addr)
             count += 1
         return count

--- a/infrastructure/cert_server/main.py
+++ b/infrastructure/cert_server/main.py
@@ -221,8 +221,9 @@ class CertServer(SCIONElement):
     def _fetch_cc(self, key, _):
         isd_as, ver = key
         cc_req = CertChainRequest.from_values(isd_as, ver)
-        req_pkt = self._build_packet(PT.CERT_MGMT, payload=cc_req)
         dst_addr = self._get_next_hop(isd_as, True)
+        req_pkt = self._build_packet(PT.CERT_MGMT, dst_ia=isd_as,
+                                     payload=cc_req)
         if dst_addr:
             self.send(req_pkt, dst_addr)
             logging.info("Cert chain request sent for %s", cc_req.short_desc())

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -45,7 +45,12 @@ from lib.log import log_exception
 from lib.packet.host_addr import HostAddrNone
 from lib.packet.packet_base import PayloadRaw
 from lib.packet.path import EmptyPath
-from lib.packet.scion import SCIONBasePacket, SCIONL4Packet, build_base_hdrs
+from lib.packet.scion import (
+    build_base_hdrs,
+    PacketType,
+    SCIONBasePacket,
+    SCIONL4Packet,
+)
 from lib.packet.scion_addr import SCIONAddr
 from lib.packet.scion_udp import SCIONUDPHeader
 from lib.socket import UDPSocket, UDPSocketMgr
@@ -57,6 +62,12 @@ from lib.util import reg_dispatcher, trim_dispatcher_packet
 
 
 MAX_QUEUE = 30
+SVC_TYPE_MAP = {
+    BEACON_SERVICE: PacketType.BEACON,
+    CERTIFICATE_SERVICE: PacketType.CERT_MGMT,
+    PATH_SERVICE: PacketType.PATH_MGMT,
+    SIBRA_SERVICE: PacketType.SB_PKT
+}
 
 
 class SCIONElement(object):
@@ -125,7 +136,8 @@ class SCIONElement(object):
             addr_type=self.addr.host.TYPE,
         )
         self._port = self._local_sock.port
-        reg_dispatcher(self._local_sock, self.addr.host, self._port)
+        svc = SVC_TYPE_MAP.get(self.SERVICE_TYPE)
+        reg_dispatcher(self._local_sock, self.addr, self._port, svc)
         self._socks.add(self._local_sock)
 
     def construct_ifid2addr_map(self):

--- a/lib/packet/host_addr.py
+++ b/lib/packet/host_addr.py
@@ -79,6 +79,8 @@ class HostAddrBase(Serializable):
         return self.LEN
 
     def __eq__(self, other):  # pragma: no cover
+        if other is None:
+            return False
         return (self.TYPE == other.TYPE) and (self.addr == other.addr)
 
     def __lt__(self, other):  # pragma: no cover

--- a/lib/packet/scion.py
+++ b/lib/packet/scion.py
@@ -48,18 +48,14 @@ class PacketType(object):
     """
     Defines constants for the SCION packet types.
     """
-    # Data packet
-    DATA = HostAddrSVC(0, raw=False)
     # Path Construction Beacon
-    BEACON = HostAddrSVC(1, raw=False)
+    BEACON = HostAddrSVC(0, raw=False)
     # Path management packet from/to PS
-    PATH_MGMT = HostAddrSVC(2, raw=False)
+    PATH_MGMT = HostAddrSVC(1, raw=False)
     # TRC file request to parent AS
-    CERT_MGMT = HostAddrSVC(3, raw=False)
-    # IF ID packet to the peer router
-    IFID_PKT = HostAddrSVC(4, raw=False)
+    CERT_MGMT = HostAddrSVC(2, raw=False)
     # SIBRA service
-    SB_PKT = HostAddrSVC(5, raw=False)
+    SB_PKT = HostAddrSVC(3, raw=False)
 
 
 class SCIONCommonHdr(Serializable):

--- a/lib/util.py
+++ b/lib/util.py
@@ -277,12 +277,19 @@ def hex_str(raw):
     return hexlify(raw).decode("ascii")
 
 
-def reg_dispatcher(sock, addr, port):
+def reg_dispatcher(sock, addr, port, svc=None):
     """
     Helper function for registering app with dispatcher
     """
     sock.settimeout(1.0)
-    buf = b"".join([struct.pack("BBH", 1, L4_UDP, port), addr.pack()])
+    data = [
+        struct.pack("!BBIHB", 1, L4_UDP, addr.isd_as.int(), port,
+                    addr.host.TYPE),
+        addr.host.pack()
+    ]
+    if svc is not None:
+        data.append(svc.pack())
+    buf = b"".join(data)
     for i in range(DISPATCHER_TIMEOUT):
         sock.send(buf, (SCION_DISPATCHER_ADDR, SCION_DISPATCHER_PORT))
         try:

--- a/scion.sh
+++ b/scion.sh
@@ -70,7 +70,7 @@ cmd_version() {
 }
 
 cmd_build() {
-    make dispatcher
+    make
     make install
 }
 

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -79,7 +79,7 @@ class TestClientBase(object):
             self._get_path_direct()
         self.sock = UDPSocket(bind=(str(self.src.host), 0, "Test Client App"),
                               addr_type=AddrType.IPV4)
-        reg_dispatcher(self.sock, self.src.host, self.sock.port)
+        reg_dispatcher(self.sock, self.src, self.sock.port)
 
     def _get_path_via_api(self):
         """
@@ -185,7 +185,7 @@ class TestServerBase(object):
         self.sd = SCIONDaemon.start(conf_dir, self.dst.host)
         self.sock = UDPSocket(bind=(str(self.dst.host), 0, "Test Server App"),
                               addr_type=AddrType.IPV4)
-        reg_dispatcher(self.sock, self.dst.host, self.sock.port)
+        reg_dispatcher(self.sock, self.dst, self.sock.port)
 
     def run(self):
         packet = self.sock.recv()[0]

--- a/test/integration/sibra_ext_test.py
+++ b/test/integration/sibra_ext_test.py
@@ -79,7 +79,7 @@ class _Base(object):
             bind=(str(self.addr.host), 0, self.NAME),
             addr_type=self.addr.host.TYPE)
         self.sock.settimeout(5)
-        reg_dispatcher(self.sock, addr.host, self.sock.port)
+        reg_dispatcher(self.sock, addr, self.sock.port)
 
     def listen(self):
         try:


### PR DESCRIPTION
Previously, we had the router replace the dst addr field in packets whose dst addr was an SVC address so that the dispatcher could tell where the packet was supposed to go.

This has been changed to a scheme where servers register with both their host addr and optionally an SVC addr that they wish to listen for. For incoming packets with SVC addrs, the dispatcher will extract the dst IP addr from the incoming packet, match both this IP and SVC addr to a registered entity, and deliver the packet.

This PR also adds ssp_cli_srv_test to the integration test script. This will be reverted later if it turns into a situation where people keep breaking this test and I have to figure out why because nobody knows what the C code does.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/670%23issuecomment-196961205%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23issuecomment-197325406%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56334138%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56366539%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56367243%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23issuecomment-197891352%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56511577%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56512100%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56513684%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56513846%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56514150%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56514207%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56514393%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56514983%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23issuecomment-197909698%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56515327%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23issuecomment-197912772%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23issuecomment-196961205%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ok%20CircleCI%20is%20such%20a%20terrible%20environment%20for%20ssp_cli_srv_test%20I%27m%20going%20to%20remove%20it%20again.%22%2C%20%22created_at%22%3A%20%222016-03-15T18%3A25%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-03-16T13%3A21%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20isd_as%20to%20registration%20info%20and%20fixed%20some%20broken%20stuff%20where%20BS%20and%20CS%20were%20sending%20%27malformed%27%20packets%22%2C%20%22created_at%22%3A%20%222016-03-17T14%3A01%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%22%2C%20%22created_at%22%3A%20%222016-03-17T14%3A44%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Squashed%20and%20addressed%20comments%20re%3A%20malloc%20failure%20and%20dictionary%20query%20simplification.%20Renaming%20stuff%20will%20be%20saved%20for%20a%20future%20PR.%5Cr%5Cn%5Cr%5CnWill%20merge%20when%20CircleCI%20completes.%22%2C%20%22created_at%22%3A%20%222016-03-17T14%3A49%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20444424a0bf4159355d984c9023f2cf494bb0aba9%20endhost/dispatcher.c%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56334138%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22From%20a%20quick%20look%2C%20%60IP_RECVDSTADDR%60%20is%20a%20BSD-specific%20option%2C%20so%20i%20don%27t%20think%20you%20need%20to%20include%20that%20here.%20%60IP_PKTINFO%60%20is%20the%20correct%20option%20for%20linux.%22%2C%20%22created_at%22%3A%20%222016-03-16T13%3A42%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/dispatcher.c%3AL1-95%22%7D%2C%20%22Pull%20444424a0bf4159355d984c9023f2cf494bb0aba9%20endhost/dispatcher.c%20114%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56366539%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20needs%20updating%2C%20as%20there%20are%20now%20other%20possible%20failures.%22%2C%20%22created_at%22%3A%20%222016-03-16T16%3A31%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/dispatcher.c%3AL136-146%22%7D%2C%20%22Pull%20516dd29591eddb89fb0242dfedf3ec1b98fd138a%20infrastructure/scion_elem.py%2035%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56513846%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22These%20lines%20can%20be%20simplified%20to%3A%5Cr%5Cn%60svc%20%3D%20SVC_TYPE_MAP.get%28self.SERVICE_TYPE%29%60%5Cr%5Cnwhich%20will%20return%20%60None%60%20if%20the%20value%20isn%27t%20in%20the%20dict.%22%2C%20%22created_at%22%3A%20%222016-03-17T14%3A36%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/scion_elem.py%3AL136-147%22%7D%2C%20%22Pull%20516dd29591eddb89fb0242dfedf3ec1b98fd138a%20endhost/dispatcher.c%20223%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56511577%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Shouldn%27t%20this%20be%20a%20fatal%20error%3F%22%2C%20%22created_at%22%3A%20%222016-03-17T14%3A24%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20really%20sure%20what%20exactly%20leads%20to%20malloc%20failing%2C%20but%20if%20this%20happened%20the%20application%20would%20fail%20to%20register%20at%20which%20point%20it%20%28the%20application%29%20would%20raise%20a%20fatal%20error.%5Cr%5Cn%5Cr%5CnWhether%20we%20should%20kill%20the%20dispatcher%20for%20failing%20to%20malloc%2C%20I%27m%20not%20sure.%22%2C%20%22created_at%22%3A%20%222016-03-17T14%3A27%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22Linux%20over-commits%20on%20memory%2C%20so%20if%20it%20actually%20says%20%5C%22no%5C%22%2C%20something%20is%20gone%20very%20wrong%2C%20so%20exiting%20is%20the%20only%20real%20response.%22%2C%20%22created_at%22%3A%20%222016-03-17T14%3A35%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22So%20if%20this%20does%20happen%2C%20what%20do%20we%20do%3F%20Killing%20the%20dispatcher%20will%20cripple%20everything%20else%20on%20top%20of%20it.%20Do%20we%20make%20a%20%5C%22I%27m%20restarting%2C%20re-register%20in%20a%20few%20seconds%5C%22%20message%20to%20tell%20applications%3F%22%2C%20%22created_at%22%3A%20%222016-03-17T14%3A38%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22When%20it%20gets%20that%20bad%2C%20you%27re%20mostly%20hoping%20the%20OS%20itself%20survives.%20If%20it%20does%2C%20monitoring%20will%20notice%20that%20things%20broke%2C%20and%20automation%20will%20fix%20it.%20Applications%20being%20crippled%20is%20expected%2C%20the%20rest%20of%20the%20system%20setup%20has%20to%20care%20about%20that.%22%2C%20%22created_at%22%3A%20%222016-03-17T14%3A43%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%28More%20realistically%2C%20you%27d%20probably%20end%20up%20rebooting%20the%20machine/vm%29%22%2C%20%22created_at%22%3A%20%222016-03-17T14%3A45%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/dispatcher.c%3AL236-312%22%7D%2C%20%22Pull%20516dd29591eddb89fb0242dfedf3ec1b98fd138a%20lib/packet/scion.py%202%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56514150%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%60PacketType%60%20has%20been%20a%20misnomer%20for%20a%20long%20time%2C%20now%20might%20be%20a%20good%20time%20to%20finally%20fix%20that.%20%60SVCType%60%20might%20make%20more%20sense.%22%2C%20%22created_at%22%3A%20%222016-03-17T14%3A38%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/scion.py%3AL48-62%22%7D%2C%20%22Pull%20444424a0bf4159355d984c9023f2cf494bb0aba9%20infrastructure/router/main.py%2062%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56367243%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20change%20is%20a%20no-op%22%2C%20%22created_at%22%3A%20%222016-03-16T16%3A35%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/router/main.py%3AL438-445%22%7D%2C%20%22Pull%20516dd29591eddb89fb0242dfedf3ec1b98fd138a%20lib/packet/scion.py%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/670%23discussion_r56514393%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22On%20a%20similar%20note%2C%20renaming%20the%20entries%20to%20be%20closer%20to%20the%20specific%20service%20would%20be%20good.%20%60SVCType.BS%60%2C%20%60SVCType.PS%60%20would%20actually%20work%20well.%22%2C%20%22created_at%22%3A%20%222016-03-17T14%3A40%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20lib/packet/scion.py%3AL48-62%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/670#issuecomment-196961205'>General Comment</a></b>
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> ok CircleCI is such a terrible environment for ssp_cli_srv_test I'm going to remove it again.
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> Added isd_as to registration info and fixed some broken stuff where BS and CS were sending 'malformed' packets
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> Squashed and addressed comments re: malloc failure and dictionary query simplification. Renaming stuff will be saved for a future PR.
  Will merge when CircleCI completes.
- [ ] <a href='#crh-comment-Pull 444424a0bf4159355d984c9023f2cf494bb0aba9 endhost/dispatcher.c 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/670#discussion_r56334138'>File: endhost/dispatcher.c:L1-95</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> From a quick look, `IP_RECVDSTADDR` is a BSD-specific option, so i don't think you need to include that here. `IP_PKTINFO` is the correct option for linux.
- [ ] <a href='#crh-comment-Pull 444424a0bf4159355d984c9023f2cf494bb0aba9 endhost/dispatcher.c 114'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/670#discussion_r56366539'>File: endhost/dispatcher.c:L136-146</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This needs updating, as there are now other possible failures.
- [ ] <a href='#crh-comment-Pull 444424a0bf4159355d984c9023f2cf494bb0aba9 infrastructure/router/main.py 62'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/670#discussion_r56367243'>File: infrastructure/router/main.py:L438-445</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This change is a no-op
- [ ] <a href='#crh-comment-Pull 516dd29591eddb89fb0242dfedf3ec1b98fd138a endhost/dispatcher.c 223'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/670#discussion_r56511577'>File: endhost/dispatcher.c:L236-312</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Shouldn't this be a fatal error?
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> I'm not really sure what exactly leads to malloc failing, but if this happened the application would fail to register at which point it (the application) would raise a fatal error.
  Whether we should kill the dispatcher for failing to malloc, I'm not sure.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Linux over-commits on memory, so if it actually says "no", something is gone very wrong, so exiting is the only real response.
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> So if this does happen, what do we do? Killing the dispatcher will cripple everything else on top of it. Do we make a "I'm restarting, re-register in a few seconds" message to tell applications?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> When it gets that bad, you're mostly hoping the OS itself survives. If it does, monitoring will notice that things broke, and automation will fix it. Applications being crippled is expected, the rest of the system setup has to care about that.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> (More realistically, you'd probably end up rebooting the machine/vm)
- [ ] <a href='#crh-comment-Pull 516dd29591eddb89fb0242dfedf3ec1b98fd138a infrastructure/scion_elem.py 35'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/670#discussion_r56513846'>File: infrastructure/scion_elem.py:L136-147</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> These lines can be simplified to:
  `svc = SVC_TYPE_MAP.get(self.SERVICE_TYPE)`
  which will return `None` if the value isn't in the dict.
- [ ] <a href='#crh-comment-Pull 516dd29591eddb89fb0242dfedf3ec1b98fd138a lib/packet/scion.py 2'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/670#discussion_r56514150'>File: lib/packet/scion.py:L48-62</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> `PacketType` has been a misnomer for a long time, now might be a good time to finally fix that. `SVCType` might make more sense.
- [ ] <a href='#crh-comment-Pull 516dd29591eddb89fb0242dfedf3ec1b98fd138a lib/packet/scion.py 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/670#discussion_r56514393'>File: lib/packet/scion.py:L48-62</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> On a similar note, renaming the entries to be closer to the specific service would be good. `SVCType.BS`, `SVCType.PS` would actually work well.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/670?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/670?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/670'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
