### PR TITLE
Rename PacketType to SVCType

### DIFF
--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -65,7 +65,7 @@ from lib.packet.pcb_ext import BeaconExtType
 from lib.packet.pcb_ext.mtu import MtuPcbExt
 from lib.packet.pcb_ext.rev import RevPcbExt
 from lib.packet.pcb_ext.sibra import SibraPcbExt
-from lib.packet.scion import PacketType as PT
+from lib.packet.scion import SVCType
 from lib.path_store import PathPolicy
 from lib.thread import thread_safety_net
 from lib.types import (
@@ -220,7 +220,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
             new_pcb.add_as(as_marking)
             self._sign_beacon(new_pcb)
             beacon = self._build_packet(
-                PT.BEACON, dst_ia=router_child.interface.isd_as,
+                SVCType.BS, dst_ia=router_child.interface.isd_as,
                 payload=new_pcb)
             self.send(beacon, router_child.addr)
             logging.info("Downstream PCB propagated!")

--- a/infrastructure/beacon_server/core.py
+++ b/infrastructure/beacon_server/core.py
@@ -27,7 +27,7 @@ from lib.errors import SCIONParseError, SCIONServiceLookupError
 from lib.packet.opaque_field import InfoOpaqueField
 from lib.packet.path_mgmt import PathRecordsReg
 from lib.packet.pcb import PathSegment
-from lib.packet.scion import PacketType as PT
+from lib.packet.scion import SVCType
 from lib.path_store import PathStore
 from lib.types import PathSegmentType as PST
 from lib.util import SCIONTime
@@ -89,7 +89,8 @@ class CoreBeaconServer(BeaconServer):
             new_pcb.add_as(as_marking)
             self._sign_beacon(new_pcb)
             beacon = self._build_packet(
-                PT.BEACON, dst_ia=core_router.interface.isd_as, payload=new_pcb)
+                SVCType.BS, dst_ia=core_router.interface.isd_as,
+                payload=new_pcb)
             self.send(beacon, core_router.addr)
             count += 1
         return count

--- a/infrastructure/beacon_server/local.py
+++ b/infrastructure/beacon_server/local.py
@@ -25,7 +25,7 @@ from lib.errors import SCIONKeyError, SCIONParseError, SCIONServiceLookupError
 from lib.packet.cert_mgmt import CertChainRequest
 from lib.packet.path_mgmt import PathRecordsReg
 from lib.packet.pcb import PathSegment
-from lib.packet.scion import PacketType as PT
+from lib.packet.scion import SVCType
 from lib.path_store import PathStore
 from lib.types import PathSegmentType as PST
 from lib.util import SCIONTime
@@ -117,7 +117,7 @@ class LocalBeaconServer(BeaconServer):
         core_path = pcb.get_path(reverse_direction=True)
         records = PathRecordsReg.from_values({PST.DOWN: [pcb]})
         dst_ia = pcb.get_first_pcbm().isd_as
-        pkt = self._build_packet(PT.PATH_MGMT, dst_ia=dst_ia, path=core_path,
+        pkt = self._build_packet(SVCType.PS, dst_ia=dst_ia, path=core_path,
                                  payload=records)
         fwd_if = core_path.get_fwd_if()
         if fwd_if not in self.ifid2addr:

--- a/infrastructure/cert_server/main.py
+++ b/infrastructure/cert_server/main.py
@@ -35,7 +35,7 @@ from lib.packet.cert_mgmt import (
     TRCReply,
     TRCRequest,
 )
-from lib.packet.scion import PacketType as PT, SCIONL4Packet
+from lib.packet.scion import SCIONL4Packet, SVCType
 from lib.packet.scion_addr import ISD_AS
 from lib.requests import RequestHandler
 from lib.thread import thread_safety_net
@@ -167,7 +167,7 @@ class CertServer(SCIONElement):
         else:
             # Remote request
             next_hop = self._get_next_hop(src.isd_as, False, True, True)
-            dst_addr = PT.CERT_MGMT
+            dst_addr = SVCType.CS
         if next_hop:
             rep_pkt = self._build_packet(
                 dst_addr, dst_ia=src.isd_as, payload=payload, dst_port=src_port)
@@ -222,7 +222,7 @@ class CertServer(SCIONElement):
         isd_as, ver = key
         cc_req = CertChainRequest.from_values(isd_as, ver)
         dst_addr = self._get_next_hop(isd_as, True)
-        req_pkt = self._build_packet(PT.CERT_MGMT, dst_ia=isd_as,
+        req_pkt = self._build_packet(SVCType.CS, dst_ia=isd_as,
                                      payload=cc_req)
         if dst_addr:
             self.send(req_pkt, dst_addr)
@@ -289,7 +289,7 @@ class CertServer(SCIONElement):
         isd, ver = key
         isd_as = ISD_AS.from_values(isd, info[2])
         trc_req = TRCRequest.from_values(isd_as, ver)
-        req_pkt = self._build_packet(PT.CERT_MGMT, payload=trc_req)
+        req_pkt = self._build_packet(SVCType.CS, payload=trc_req)
         next_hop = self._get_next_hop(isd_as, True, False, True)
         if next_hop:
             self.send(req_pkt, next_hop)

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -35,7 +35,7 @@ from lib.packet.path_mgmt import (
     RevocationInfo,
 )
 from lib.packet.pcb import PathSegment
-from lib.packet.scion import PacketType as PT
+from lib.packet.scion import SVCType
 from lib.path_db import DBResult, PathSegmentDB
 from lib.thread import thread_safety_net
 from lib.types import PathMgmtType as PMT, PathSegmentType as PST, PayloadClass
@@ -329,7 +329,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         while targets:
             seg_req = targets.pop(0)
             req_pkt = self._build_packet(
-                PT.PATH_MGMT, dst_ia=src_ia, path=path, payload=seg_req)
+                SVCType.PS, dst_ia=src_ia, path=path, payload=seg_req)
             self._send_to_next_hop(req_pkt, path.get_fwd_if())
             logging.info("Waiting request (%s) sent via %s",
                          seg_req.short_desc(), pcb.short_desc())

--- a/infrastructure/path_server/core.py
+++ b/infrastructure/path_server/core.py
@@ -27,7 +27,7 @@ from lib.packet.path_mgmt import (
     PathRecordsReply,
     PathSegmentReq,
 )
-from lib.packet.scion import PacketType as PT
+from lib.packet.scion import SVCType
 from lib.types import PathMgmtType as PMT, PathSegmentType as PST
 from lib.zookeeper import ZkNoConnection
 
@@ -212,7 +212,7 @@ class CorePathServer(PathServer):
                 logging.warning("Segment to AS %s not found.", isd_as)
                 continue
             cseg = csegs[0].get_path(reverse_direction=True)
-            pkt = self._build_packet(PT.PATH_MGMT, dst_ia=isd_as, path=cseg,
+            pkt = self._build_packet(SVCType.PS, dst_ia=isd_as, path=cseg,
                                      payload=rep_recs)
             self._send_to_next_hop(pkt, cseg.get_fwd_if())
 
@@ -327,7 +327,7 @@ class CorePathServer(PathServer):
             cseg = csegs[0]
             path = cseg.get_path(reverse_direction=True)
             dst_ia = cseg.get_first_pcbm().isd_as
-            req_pkt = self._build_packet(PT.PATH_MGMT, dst_ia=dst_ia,
+            req_pkt = self._build_packet(SVCType.PS, dst_ia=dst_ia,
                                          path=path, payload=seg_req)
             logging.info("Down-Segment request for different ISD, "
                          "forwarding request to CPS in %s via %s",

--- a/infrastructure/path_server/local.py
+++ b/infrastructure/path_server/local.py
@@ -24,7 +24,7 @@ from Crypto.Hash import SHA256
 # SCION
 from infrastructure.path_server.base import PathServer
 from lib.flagtypes import PathSegFlags as PSF
-from lib.packet.scion import PacketType as PT
+from lib.packet.scion import SVCType
 from lib.path_db import PathSegmentDB
 from lib.types import PathSegmentType as PST
 
@@ -180,6 +180,6 @@ class LocalPathServer(PathServer):
         logging.info('Send request to core (%s) via %s',
                      seg_req.short_desc(), pcb.short_desc())
         path = pcb.get_path(reverse_direction=True)
-        req_pkt = self._build_packet(PT.PATH_MGMT, payload=seg_req, path=path,
+        req_pkt = self._build_packet(SVCType.PS, payload=seg_req, path=path,
                                      dst_ia=pcb.get_first_pcbm().isd_as)
         self._send_to_next_hop(req_pkt, path.get_fwd_if())

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -47,9 +47,9 @@ from lib.packet.packet_base import PayloadRaw
 from lib.packet.path import EmptyPath
 from lib.packet.scion import (
     build_base_hdrs,
-    PacketType,
     SCIONBasePacket,
     SCIONL4Packet,
+    SVCType
 )
 from lib.packet.scion_addr import SCIONAddr
 from lib.packet.scion_udp import SCIONUDPHeader
@@ -63,10 +63,10 @@ from lib.util import reg_dispatcher, trim_dispatcher_packet
 
 MAX_QUEUE = 30
 SVC_TYPE_MAP = {
-    BEACON_SERVICE: PacketType.BEACON,
-    CERTIFICATE_SERVICE: PacketType.CERT_MGMT,
-    PATH_SERVICE: PacketType.PATH_MGMT,
-    SIBRA_SERVICE: PacketType.SB_PKT
+    BEACON_SERVICE: SVCType.BS,
+    CERTIFICATE_SERVICE: SVCType.CS,
+    PATH_SERVICE: SVCType.PS,
+    SIBRA_SERVICE: SVCType.SB
 }
 
 

--- a/infrastructure/sibra_server/main.py
+++ b/infrastructure/sibra_server/main.py
@@ -28,7 +28,7 @@ from infrastructure.sibra_server.util import find_last_ifid
 from lib.defines import PATH_SERVICE, SCION_UDP_PORT, SIBRA_SERVICE
 from lib.errors import SCIONServiceLookupError
 from lib.packet.ext_util import find_ext_hdr
-from lib.packet.scion import PacketType as PT
+from lib.packet.scion import SVCType
 from lib.sibra.ext.steady import SibraExtSteady
 from lib.thread import thread_safety_net
 from lib.types import (
@@ -136,7 +136,7 @@ class SibraServerBase(SCIONElement):
         return self.get_first_hop(spkt)
 
     def _svc_lookup(self, addr):
-        if addr.host == PT.PATH_MGMT:
+        if addr.host == SVCType.PS:
             return self.dns_query_topo(PATH_SERVICE)[0]
 
     def handle_path_reg(self, pkt):

--- a/infrastructure/sibra_server/steady.py
+++ b/infrastructure/sibra_server/steady.py
@@ -33,7 +33,7 @@ from lib.errors import SCIONBaseError
 from lib.flagtypes import PathSegFlags as PSF
 from lib.packet.path import EmptyPath
 from lib.packet.path_mgmt import PathRecordsReg
-from lib.packet.scion import PacketType as PT
+from lib.packet.scion import SVCType
 from lib.packet.scion import SCIONL4Packet, build_base_hdrs
 from lib.packet.scion_addr import SCIONAddr
 from lib.packet.scion_udp import SCIONUDPHeader
@@ -207,7 +207,7 @@ class SteadyPath(object):
         """
         Create headers for a SCION packet
         """
-        dest = SCIONAddr.from_values(self.remote, PT.SB_PKT)
+        dest = SCIONAddr.from_values(self.remote, SVCType.SB)
         cmn_hdr, addr_hdr = build_base_hdrs(self.addr, dest)
         payload = SIBRAPayload()
         udp_hdr = SCIONUDPHeader.from_values(
@@ -254,7 +254,7 @@ class SteadyPath(object):
             fwd_dir = True
         pcb = self._create_reg_pcb(fwd_dir=fwd_dir)
         pld = PathRecordsReg.from_values({type_: [pcb]})
-        dest = SCIONAddr.from_values(dst_ia, PT.PATH_MGMT)
+        dest = SCIONAddr.from_values(dst_ia, SVCType.PS)
         cmn_hdr, addr_hdr = build_base_hdrs(self.addr, dest)
         udp_hdr = SCIONUDPHeader.from_values(
             self.addr, SCION_UDP_PORT, dest, SCION_UDP_PORT, pld)

--- a/lib/packet/scion.py
+++ b/lib/packet/scion.py
@@ -44,18 +44,18 @@ from lib.types import PayloadClass, IFIDType
 from lib.util import Raw, calc_padding
 
 
-class PacketType(object):
+class SVCType(object):
     """
-    Defines constants for the SCION packet types.
+    Defines the recognised SVC addresses.
     """
-    # Path Construction Beacon
-    BEACON = HostAddrSVC(0, raw=False)
-    # Path management packet from/to PS
-    PATH_MGMT = HostAddrSVC(1, raw=False)
-    # TRC file request to parent AS
-    CERT_MGMT = HostAddrSVC(2, raw=False)
+    # Beacon service
+    BS = HostAddrSVC(0, raw=False)
+    # Path service
+    PS = HostAddrSVC(1, raw=False)
+    # Certificate service
+    CS = HostAddrSVC(2, raw=False)
     # SIBRA service
-    SB_PKT = HostAddrSVC(3, raw=False)
+    SB = HostAddrSVC(3, raw=False)
 
 
 class SCIONCommonHdr(Serializable):


### PR DESCRIPTION
"PacketType" has been a misnomer since SVC addresses were introduced. An
SVC address specifies which service the packet is addressed to, it
doesn't imply anything about the packet's payload.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/671%23issuecomment-197925485%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/671%23issuecomment-197925485%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-03-17T15%3A09%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/671#issuecomment-197925485'>General Comment</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/671?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/671?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/671'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
