### PR TITLE
Socket option for ISD whitelist

### DIFF
--- a/endhost/ssp/ConnectionManager.h
+++ b/endhost/ssp/ConnectionManager.h
@@ -30,6 +30,7 @@ public:
     virtual void getStats(SCIONStats *stats);
 
     int setStayISD(uint16_t isd);
+    int setISDWhitelist(void *data, size_t len);
 
 protected:
     int checkPath(uint8_t *ptr, int len, int addr, std::vector<Path *> &candidates);

--- a/endhost/ssp/PathPolicy.h
+++ b/endhost/ssp/PathPolicy.h
@@ -1,6 +1,7 @@
 #ifndef PATH_POLICY_H
 #define PATH_POLICY_H
 
+#include <set>
 #include <vector>
 
 #include "SCIONDefines.h"
@@ -13,13 +14,16 @@ public:
     ~PathPolicy();
 
     void setStayISD(uint16_t isd);
+    void setISDWhitelist(std::vector<uint16_t> &isds);
 
     bool validate(Path *p);
 
 protected:
-    bool checkStayISD(Path *p);
+    bool isInISD(Path *p);
+    bool isWhitelisted(Path *p);
 
     uint16_t mStayISD;
+    std::set<uint16_t> mWhitelist;
     std::vector<uint16_t> mAvoidISDs;
     std::vector<uint32_t> mAvoidADs;
 };

--- a/endhost/ssp/SCIONDefines.h
+++ b/endhost/ssp/SCIONDefines.h
@@ -38,6 +38,8 @@
 #define SCION_HOST_OFFSET 4
 #define MAX_HOST_ADDR_LEN 16
 
+#define MAX_OPTION_LEN 20
+
 #define NORMAL_OF    0x0
 #define LAST_OF      0x10
 #define PEER_XOVR    0x8
@@ -131,6 +133,7 @@ typedef struct {
 typedef enum {
     SCION_OPTION_BLOCKING = 0,
     SCION_OPTION_STAY_ISD,
+    SCION_OPTION_ISD_WLIST,
     SCION_OPTION_AVOID_ISD,
     SCION_OPTION_AVOID_AD,
 } SCIONOptionType;
@@ -138,7 +141,7 @@ typedef enum {
 typedef struct {
     SCIONOptionType type;
     int val;
-    void *data; // if int is not enough
+    char data[MAX_OPTION_LEN]; // if int is not enough
     size_t len; // len of data
 } SCIONOption;
 

--- a/endhost/ssp/SCIONProtocol.h
+++ b/endhost/ssp/SCIONProtocol.h
@@ -43,6 +43,7 @@ public:
     virtual void deregisterSelect(int index);
 
     int setStayISD(uint16_t isd);
+    int setISDWhitelist(void *data, size_t len);
 
     virtual int shutdown();
     virtual void removeDispatcher(int sock);
@@ -61,6 +62,7 @@ protected:
     pthread_cond_t         mReadCond;
     SCIONState             mState;
     std::vector<SCIONAddr> &mDstAddrs;
+    uint64_t               mNextSendByte;
 
     // dead path probing
     uint32_t               mProbeInterval;
@@ -134,7 +136,6 @@ protected:
     int                    mAckVectorOffset;
 
     // sending packets
-    uint64_t               mNextSendByte;
     PacketList             mSentPackets;
 
     // recv'ing packets

--- a/endhost/ssp/SCIONSocket.cpp
+++ b/endhost/ssp/SCIONSocket.cpp
@@ -176,17 +176,17 @@ int SCIONSocket::setSocketOption(SCIONOption *option)
 {
     if (!option)
         return -EINVAL;
+    if (!mProtocol)
+        return -EPERM;
 
     switch (option->type) {
     case SCION_OPTION_BLOCKING:
-        if (!mProtocol)
-            return -EPERM;
         mProtocol->setBlocking(option->val);
         return 0;
     case SCION_OPTION_STAY_ISD:
-        if (!mProtocol)
-            return -EPERM;
         return mProtocol->setStayISD(option->val);
+    case SCION_OPTION_ISD_WLIST:
+        return mProtocol->setISDWhitelist(option->data, option->len);
     default:
         break;
     }

--- a/endhost/ssp/test/client.cpp
+++ b/endhost/ssp/test/client.cpp
@@ -27,13 +27,16 @@ int main(int argc, char **argv)
     memcpy(saddr.host.addr, &in, 4);
     addrs[0] = saddr;
     SCIONSocket s(SCION_PROTO_SSP, addrs, 1, 0, 8080);
-    /*
+
     SCIONOption option;
     memset(&option, 0, sizeof(option));
-    option.type = SCION_OPTION_STAY_ISD;
-    option.val = 1;
+    option.type = SCION_OPTION_ISD_WLIST;
+    option.val = 0;
+    option.len = 4;
+    *(uint16_t *)(option.data) = 1;
+    *(uint16_t *)(option.data + 2) = 3;
     s.setSocketOption(&option);
-    */
+
     int count = 0;
     char buf[BUFSIZE];
     memset(buf, 0, BUFSIZE);

--- a/topology/Wide.topo
+++ b/topology/Wide.topo
@@ -28,6 +28,7 @@ links:
   - {a: 1-1, b: 1-2, ltype: ROUTING}
   - {a: 1-1, b: 2-1, ltype: ROUTING}
   - {a: 1-1, b: 2-2, ltype: ROUTING}
+  - {a: 1-1, b: 3-1, ltype: ROUTING}
   - {a: 1-1, b: 1-3, ltype: PARENT}
   - {a: 1-2, b: 2-1, ltype: ROUTING}
   - {a: 1-2, b: 1-4, ltype: PARENT}


### PR DESCRIPTION
This is a first draft attempt at adding an "ISD whitelist" option.

@ercanucan Actually testing this will require quite a bit of work but take a look at the code and see if it makes sense and/or looks usable.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/674%23discussion_r56818207%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-199275011%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-199361882%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-199549518%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-199681869%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-200259876%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-200262390%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-200268727%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-200270742%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-200340801%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-200410987%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-200412040%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-200489172%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-200495113%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23issuecomment-199275011%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40aznair%20The%20code%20looks%20good%20to%20me.%20Would%20be%20nice%20to%20have%20a%20test%20case%20for%20this%20in%20which%20we%20can%20see%20it%20in%20action%20%3A-%29%22%2C%20%22created_at%22%3A%20%222016-03-21T13%3A24%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22STAY_ISD%20option%20will%20be%20removed%20when%20the%20proxy%20is%20ready%20to%20switch%20over%20to%20ISD_WLIST%20to%20avoid%20import%20errors%20etc.%22%2C%20%22created_at%22%3A%20%222016-03-21T16%3A16%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aznair%20Sounds%20good.%20A%20whitelist%20could%20cover%20single%20and%20multiple%20ISDs%20of%20various%20configurations%2C%20negating%20the%20need%20for%20STAY_ISD.%20Is%20that%20the%20idea%3F%22%2C%20%22created_at%22%3A%20%222016-03-22T00%3A06%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mwfarb%20There%20have%20been%20some%20fixes%20in%20the%20infrastructure%20code%20recently%20that%20render%20the%20STAY_ISD%20option%20moot%20%28i.e.%20the%20STAY%20behavior%20has%20become%20default%29.%20Once%20we%20setup%20a%20topology%20that%20provides%20the%20right%20paths%20to%20test%20the%20whitelist%20option%20we%20will%20remove%20the%20STAY%20option.%22%2C%20%22created_at%22%3A%20%222016-03-22T07%3A45%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20%40mwfarb%20With%20the%20latest%20push%20you%20guys%20can%20try%20going%20from%201-4%20to%203-3%20on%20Wide.topo%20to%20test%20the%20ISD%20whitelist%20option.%20Without%20setting%20any%20options%20you%20will%20see%20paths%20that%20mostly%20go%20through%20ISD%202%2C%20but%20with%20the%20option%20you%20should%20only%20see%201%20path%20going%20directly%20from%20ISD%201%20to%203.%5Cr%5Cn%5Cr%5CnSee%20endhost/ssp/test/client.cpp%20for%20an%20example%20of%20setting%20the%20option%20in%20C%2B%2B%22%2C%20%22created_at%22%3A%20%222016-03-23T09%3A05%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22ok%20I%20may%20need%20to%20change%20the%20Python%20wrapper%20a%20bit%20to%20make%20this%20useful.%5Cr%5CnI%27ll%20push%20again%20soon%28ish%29%20with%20those%20changes%22%2C%20%22created_at%22%3A%20%222016-03-23T09%3A13%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22test/integration/ssp_cli_srv_test.py%20now%20contains%20an%20example%20of%20setting%20the%20whitelist%20option%22%2C%20%22created_at%22%3A%20%222016-03-23T09%3A33%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aznair%20Needs%20a%20%20rebase%3F%22%2C%20%22created_at%22%3A%20%222016-03-23T09%3A41%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aznair%20I%20tested%20with%20your%20latest%20commit%20once%20more%20and%20ssp_cli_serv%20test%20worked%20fine.%22%2C%20%22created_at%22%3A%20%222016-03-23T13%3A18%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM.%5Cr%5Cnssp_cli_srv_test%20needs%20to%20get%20some%20attention%2C%20but%20it%27s%20ok%20for%20now.%22%2C%20%22created_at%22%3A%20%222016-03-23T15%3A59%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%20as%20well%22%2C%20%22created_at%22%3A%20%222016-03-23T16%3A02%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aznair%20Just%20checking%20that%20I%20have%20everything%3A%5Cr%5Cn%5Cr%5Cn1.%20Be%20sure%20SCION%20is%20built%20for%20speed%3A%20%60./scion.sh%20build%20bypassrouters%60%5Cr%5Cn1.%20Be%20sure%20the%20socket%20library%20is%20built%3A%20%60./scion.sh%20sock_bld%60%5Cr%5Cn1.%20For%20wide%20topology%2C%20update%20it%20if%20desired%3A%20%60./scion.sh%20topology%20zkclean%20-c%20topology/Wide.topo%60%5Cr%5Cn1.%20Run%20SCION%3A%20%60./scion.sh%20run%60%5Cr%5Cn1.%20Start%204%20processes%20in%20separate%20terminals%3A%5Cr%5Cn1.%20%60./scion.sh%20sock_ser%201%204%60%5Cr%5Cn1.%20%60./scion.sh%20sock_cli%203%203%60%5Cr%5Cn1.%20%60endhost/scion_proxy.py%20-f%20-s%20-k%60%5Cr%5Cn1.%20%60endhost/scion_proxy.py%20-p%209090%20-s%20-k%60%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-03-23T18%3A41%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mwfarb%20%5Cr%5Cn1.%20should%20be%20./scion.sh%20build%20bypass%5Cr%5Cn2.%20no%20longer%20used%20%28replaced%20by%20build%20command%29%5Cr%5Cn%5Cr%5Cnrest%20looks%20ok%5Cr%5CnI%27ve%20only%20tested%20with%20client%20at%201-4%20and%20server%20at%203-3%20but%20I%20don%27t%20think%20it%20should%20matter%22%2C%20%22created_at%22%3A%20%222016-03-23T18%3A56%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201781d743f1bad29accc2ab903dbced648e65a5d5%20endhost/ssp/PathPolicy.cpp%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/674%23discussion_r56818207%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Since%20it%20returns%20a%20boolean%20value%2C%20I%20would%20name%20this%20function%20something%20like%20%60isWhitelisted%28%29%60%22%2C%20%22created_at%22%3A%20%222016-03-21T13%3A07%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/ssp/PathPolicy.cpp%3AL48-62%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull 1781d743f1bad29accc2ab903dbced648e65a5d5 endhost/ssp/PathPolicy.cpp 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/674#discussion_r56818207'>File: endhost/ssp/PathPolicy.cpp:L48-62</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Since it returns a boolean value, I would name this function something like `isWhitelisted()`
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/674#issuecomment-199275011'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @aznair The code looks good to me. Would be nice to have a test case for this in which we can see it in action :-)
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> STAY_ISD option will be removed when the proxy is ready to switch over to ISD_WLIST to avoid import errors etc.
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @aznair Sounds good. A whitelist could cover single and multiple ISDs of various configurations, negating the need for STAY_ISD. Is that the idea?
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> @mwfarb There have been some fixes in the infrastructure code recently that render the STAY_ISD option moot (i.e. the STAY behavior has become default). Once we setup a topology that provides the right paths to test the whitelist option we will remove the STAY option.
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> @ercanucan @mwfarb With the latest push you guys can try going from 1-4 to 3-3 on Wide.topo to test the ISD whitelist option. Without setting any options you will see paths that mostly go through ISD 2, but with the option you should only see 1 path going directly from ISD 1 to 3.
  See endhost/ssp/test/client.cpp for an example of setting the option in C++
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> ok I may need to change the Python wrapper a bit to make this useful.
  I'll push again soon(ish) with those changes
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> test/integration/ssp_cli_srv_test.py now contains an example of setting the whitelist option
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @aznair Needs a  rebase?
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @aznair I tested with your latest commit once more and ssp_cli_serv test worked fine.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM.
  ssp_cli_srv_test needs to get some attention, but it's ok for now.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> lgtm as well
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @aznair Just checking that I have everything:
- Be sure SCION is built for speed: `./scion.sh build bypassrouters`
- Be sure the socket library is built: `./scion.sh sock_bld`
- For wide topology, update it if desired: `./scion.sh topology zkclean -c topology/Wide.topo`
- Run SCION: `./scion.sh run`
- Start 4 processes in separate terminals:
- `./scion.sh sock_ser 1 4`
- `./scion.sh sock_cli 3 3`
- `endhost/scion_proxy.py -f -s -k`
- `endhost/scion_proxy.py -p 9090 -s -k`
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> @mwfarb
- should be ./scion.sh build bypass
- no longer used (replaced by build command)
  rest looks ok
  I've only tested with client at 1-4 and server at 3-3 but I don't think it should matter

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/674?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/674?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/674'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
