### PR TITLE
Small typo which causes HOF to have an additional field

### DIFF
--- a/lib/packet/opaque_field.py
+++ b/lib/packet/opaque_field.py
@@ -72,7 +72,7 @@ class HopOpaqueField(OpaqueField):
         self.xover = bool(flags & HopOFFlags.XOVER)
         self.verify_only = bool(flags & HopOFFlags.VERIFY_ONLY)
         self.forward_only = bool(flags & HopOFFlags.FORWARD_ONLY)
-        self.rescurse = bool(flags & HopOFFlags.RECURSE)
+        self.recurse = bool(flags & HopOFFlags.RECURSE)
 
     @classmethod
     def from_values(cls, exp_time, ingress_if=0, egress_if=0,


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/680?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/680'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
