### PR TITLE
Add GET_ISD_WHITELIST call to SCION knowledge-base.

### DIFF
--- a/endhost/kbase_lookup_service.py
+++ b/endhost/kbase_lookup_service.py
@@ -126,9 +126,11 @@ class KnowledgeBaseLookupService(object):
                 logging.error('Key error in parsing ISD_WHITELIST req: %s' % e)
                 return
             assert(isinstance(isds, list))
-            resp = self._handle_ISD_whitelist(isds)
+            resp = self._handle_set_ISD_whitelist(isds)
+        elif cmd == 'GET_ISD_WHITELIST':
+            resp = self._handle_get_ISD_whitelist()
         else:
-            logging.error('Unsupported command: %s')
+            logging.error('Unsupported command: %s', cmd)
             return
 
         assert((isinstance(resp, dict) or isinstance(resp, list)))
@@ -212,7 +214,7 @@ class KnowledgeBaseLookupService(object):
                 logging.error('Error while reading the locations YAML: %s' % e)
                 return {}
 
-    def _handle_ISD_whitelist(self, isds):
+    def _handle_set_ISD_whitelist(self, isds):
         """
         Lets the kbase know of which ISDs should be whitelisted.
         :param isds: List of ISDs (numbers)
@@ -221,3 +223,11 @@ class KnowledgeBaseLookupService(object):
         :rtype: dict
         """
         return self.kbase.set_ISD_whitelist(isds)
+
+    def _handle_get_ISD_whitelist(self):
+        """
+        Queries the kbase and return which ISDs are whitelisted.
+        :returns: A list (potentially empty) containing the whitelisted ISDs.
+        :rtype: list
+        """
+        return self.kbase.get_ISD_whitelist()

--- a/test/integration/kbase_lookup_test.py
+++ b/test/integration/kbase_lookup_test.py
@@ -127,6 +127,9 @@ def test_set_ISD_whitelist():
            "isds": [1, 3]}
 
     send_req_and_read_resp(sock, req)
+    raw_resp = get_ISD_whitelist()
+    res = extract_from_json(raw_resp)
+    assert(res == [1, 3])
 
 
 def test_clear_ISD_whitelist():
@@ -143,6 +146,41 @@ def test_clear_ISD_whitelist():
            "isds": []}
 
     send_req_and_read_resp(sock, req)
+    raw_resp = get_ISD_whitelist()
+    res = extract_from_json(raw_resp)
+    assert(res == [])
+
+
+def get_ISD_whitelist():
+    """
+    Creates an ISD whitelist request, sends it to the UDP server.
+    """
+
+    logging.info('Starting the Get ISD whitelist test')
+    # Create a UDP socket
+    sock = UDPSocket(None, AddrType.IPV4)
+
+    req = {"version": "0.1",
+           "command": "GET_ISD_WHITELIST"}
+
+    return send_req_and_read_resp(sock, req)
+
+
+def extract_from_json(req_raw):
+    """
+    Extract a Python object from a raw JSON and return it.
+    :param req_raw: Encoded JSON string
+    :type req_raw: bytes
+    :returns: A python object.
+    :rtype: object
+    """
+    try:
+        req_str = req_raw.decode("utf-8")
+        obj = json.loads(req_str)
+        return obj
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        logging.error('Error decoding request: %s' % e)
+        return None
 
 
 def send_req_and_read_resp(sock, req):
@@ -170,6 +208,8 @@ def send_req_and_read_resp(sock, req):
     finally:
         logging.debug('Closing socket')
         sock.close()
+
+    return data_raw[4:4+data_len]
 
 
 def send(sock, req):


### PR DESCRIPTION
@mwfarb would this be useful for your purpose?
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/689%23issuecomment-206373665%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/689%23issuecomment-206406263%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/689%23issuecomment-206434818%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/689%23issuecomment-206494667%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/689%23issuecomment-206373665%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22LGTM%21%20This%20is%20exactly%20what%20is%20needed.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-04-06T13%3A30%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-04-06T14%3A38%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20test_get_ISD_whitelist%28%29%20isn%27t%20called%20in%20the%20test.%20I%20tried%20it%20by%20modifying%20the%20test%20list%20to%20this...%5Cr%5Cn%5Cr%5Cn%20%20%20%20test_list%28%29%5Cr%5Cn%20%20%20%20test_lookup%28%29%5Cr%5Cn%20%20%20%20test_topology_lookup%28%29%5Cr%5Cn%20%20%20%20test_locations_lookup%28%29%5Cr%5Cn%20%20%20%20test_set_ISD_whitelist%28%29%5Cr%5Cn%20%20%20%20test_get_ISD_whitelist%28%29%5Cr%5Cn%20%20%20%20test_clear_ISD_whitelist%28%29%5Cr%5Cn%20%20%20%20test_get_ISD_whitelist%28%29%5Cr%5Cn%5Cr%5Cn...%20the%20the%20script%20exited%20after%20the%20first%20test_get_ISD_whitelist%28%29%20call%3A%5Cr%5Cn%60%60%60%5Cr%5Cn016-04-06%2015%3A33%3A26.447330%2B00%3A00%20%5BINFO%5D%20%28MainThread%29%20Starting%20the%20Get%20ISD%20whitelist%20test%5Cr%5Cn2016-04-06%2015%3A33%3A26.447540%2B00%3A00%20%5BDEBUG%5D%20%28MainThread%29%20Sending%20%5C%22b%27%7B%5C%22version%5C%22%3A%20%5C%220.1%5C%22%2C%20%5C%22command%5C%22%3A%20%5C%22GET_ISD_WHITELIST%5C%22%7D%27%5C%22%5Cr%5Cn2016-04-06%2015%3A33%3A26.447692%2B00%3A00%20%5BDEBUG%5D%20%28MainThread%29%20Waiting%20to%20receive%20the%20response%20length%5Cr%5Cn2016-04-06%2015%3A33%3A26.448186%2B00%3A00%20%5BDEBUG%5D%20%28MainThread%29%20Length%20of%20the%20response%20%3D%206%5Cr%5Cn2016-04-06%2015%3A33%3A26.448415%2B00%3A00%20%5BDEBUG%5D%20%28MainThread%29%20Response%20json%5Cr%5Cn2016-04-06%2015%3A33%3A26.448635%2B00%3A00%20%5BDEBUG%5D%20%28MainThread%29%20Received%20%5C%22b%27%5B1%2C%203%5D%27%5C%22%5Cr%5Cn2016-04-06%2015%3A33%3A26.448767%2B00%3A00%20%5BDEBUG%5D%20%28MainThread%29%20Closing%20socket%5Cr%5Cn2016-04-06%2015%3A33%3A26.448961%2B00%3A00%20%5BCRITICAL%5D%20%28MainThread%29%20Exception%20in%20main%20process%3A%5Cr%5Cn2016-04-06%2015%3A33%3A26.449809%2B00%3A00%20%5BCRITICAL%5D%20%28MainThread%29%20Traceback%20%28most%20recent%20call%20last%29%3A%5Cr%5Cn2016-04-06%2015%3A33%3A26.450153%2B00%3A00%20%5BCRITICAL%5D%20%28MainThread%29%20%20%20File%20%5C%22/git/scion/lib/main.py%5C%22%2C%20line%2037%2C%20in%20main_wrapper%5Cr%5Cn2016-04-06%2015%3A33%3A26.450503%2B00%3A00%20%5BCRITICAL%5D%20%28MainThread%29%20%20%20%20%20main%28%2Aargs%2C%20%2A%2Akwargs%29%5Cr%5Cn2016-04-06%2015%3A33%3A26.450824%2B00%3A00%20%5BCRITICAL%5D%20%28MainThread%29%20%20%20File%20%5C%22test/integration/kbase_lookup_test.py%5C%22%2C%20line%2048%2C%20in%20main%5Cr%5Cn2016-04-06%2015%3A33%3A26.451138%2B00%3A00%20%5BCRITICAL%5D%20%28MainThread%29%20%20%20%20%20test_get_ISD_whitelist%28%29%5Cr%5Cn2016-04-06%2015%3A33%3A26.451453%2B00%3A00%20%5BCRITICAL%5D%20%28MainThread%29%20NameError%3A%20name%20%27test_get_ISD_whitelist%27%20is%20not%20defined%5Cr%5Cn2016-04-06%2015%3A33%3A26.451941%2B00%3A00%20%5BCRITICAL%5D%20%28MainThread%29%20%5Cr%5Cn2016-04-06%2015%3A33%3A26.452283%2B00%3A00%20%5BCRITICAL%5D%20%28MainThread%29%20Exiting%5Cr%5Cn%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-04-06T15%3A41%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20I%27m%20wrong.%20%3A-%28%20I%20wasn%27t%20readying%20the%20code%20correctly%2C%20all%20is%20well.%22%2C%20%22created_at%22%3A%20%222016-04-06T18%3A06%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/689#issuecomment-206373665'>General Comment</a></b>
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> LGTM! This is exactly what is needed. :+1:
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @ercanucan test_get_ISD_whitelist() isn't called in the test. I tried it by modifying the test list to this...
  test_list()
  test_lookup()
  test_topology_lookup()
  test_locations_lookup()
  test_set_ISD_whitelist()
  test_get_ISD_whitelist()
  test_clear_ISD_whitelist()
  test_get_ISD_whitelist()
  ... the the script exited after the first test_get_ISD_whitelist() call:

```
016-04-06 15:33:26.447330+00:00 [INFO] (MainThread) Starting the Get ISD whitelist test
2016-04-06 15:33:26.447540+00:00 [DEBUG] (MainThread) Sending "b'{"version": "0.1", "command": "GET_ISD_WHITELIST"}'"
2016-04-06 15:33:26.447692+00:00 [DEBUG] (MainThread) Waiting to receive the response length
2016-04-06 15:33:26.448186+00:00 [DEBUG] (MainThread) Length of the response = 6
2016-04-06 15:33:26.448415+00:00 [DEBUG] (MainThread) Response json
2016-04-06 15:33:26.448635+00:00 [DEBUG] (MainThread) Received "b'[1, 3]'"
2016-04-06 15:33:26.448767+00:00 [DEBUG] (MainThread) Closing socket
2016-04-06 15:33:26.448961+00:00 [CRITICAL] (MainThread) Exception in main process:
2016-04-06 15:33:26.449809+00:00 [CRITICAL] (MainThread) Traceback (most recent call last):
2016-04-06 15:33:26.450153+00:00 [CRITICAL] (MainThread)   File "/git/scion/lib/main.py", line 37, in main_wrapper
2016-04-06 15:33:26.450503+00:00 [CRITICAL] (MainThread)     main(*args, **kwargs)
2016-04-06 15:33:26.450824+00:00 [CRITICAL] (MainThread)   File "test/integration/kbase_lookup_test.py", line 48, in main
2016-04-06 15:33:26.451138+00:00 [CRITICAL] (MainThread)     test_get_ISD_whitelist()
2016-04-06 15:33:26.451453+00:00 [CRITICAL] (MainThread) NameError: name 'test_get_ISD_whitelist' is not defined
2016-04-06 15:33:26.451941+00:00 [CRITICAL] (MainThread)
2016-04-06 15:33:26.452283+00:00 [CRITICAL] (MainThread) Exiting
```
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @ercanucan I'm wrong. :-( I wasn't readying the code correctly, all is well.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/689?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/689?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/689'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
