### PR TITLE
SSP: client should not add paths from server

### DIFF
--- a/endhost/ssp/ConnectionManager.cpp
+++ b/endhost/ssp/ConnectionManager.cpp
@@ -503,7 +503,7 @@ int SSPConnectionManager::sendAlternatePath(SCIONPacket *packet, size_t exclude)
     return ret;
 }
 
-int SSPConnectionManager::handlePacket(SCIONPacket *packet)
+int SSPConnectionManager::handlePacket(SCIONPacket *packet, bool receiver)
 {
     bool found = false;
     int index;
@@ -531,6 +531,11 @@ int SSPConnectionManager::handlePacket(SCIONPacket *packet)
         }
     }
     if (!found) {
+        if (!receiver) {
+            DEBUG("sender should not add paths from remote end\n");
+            pthread_mutex_unlock(&mPathMutex);
+            return -1;
+        }
         SCIONAddr saddr;
         saddr.isd_as = ntohl(*(uint32_t *)(packet->header.srcAddr));
         // TODO: IPv6?

--- a/endhost/ssp/ConnectionManager.h
+++ b/endhost/ssp/ConnectionManager.h
@@ -77,7 +77,7 @@ public:
     void sendAck(SCIONPacket *packet);
     void sendProbes(uint32_t probeNum, uint64_t flowID);
 
-    int handlePacket(SCIONPacket *packet);
+    int handlePacket(SCIONPacket *packet, bool receiver);
     void handleAck(SCIONPacket *packet, size_t initCount, bool receiver);
     void handleProbeAck(SCIONPacket *packet);
     void handleTimeout();

--- a/endhost/ssp/SCIONProtocol.cpp
+++ b/endhost/ssp/SCIONProtocol.cpp
@@ -412,7 +412,7 @@ int SSPProtocol::handlePacket(SCIONPacket *packet, uint8_t *buf)
     }
 
     packet->payload = sp;
-    mConnectionManager->handlePacket(packet);
+    mConnectionManager->handlePacket(packet, mIsReceiver);
 
     if (sp->header.flags & SSP_ACK) {
         DEBUG("incoming packet is ACK\n");


### PR DESCRIPTION
Client: uses paths found by sciond only
Server: uses paths used by client only

This will be the policy for until we run into a need to change it.

@ercanucan
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/696%23issuecomment-207456411%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/696%23issuecomment-207456411%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22That%20fixed%20it%21%20LGTM%22%2C%20%22created_at%22%3A%20%222016-04-08T14%3A38%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/696#issuecomment-207456411'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> That fixed it! LGTM

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/696?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/696?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/696'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
