### PR TITLE
Fix a bug in libscion's checksum

### DIFF
--- a/endhost/dispatcher.c
+++ b/endhost/dispatcher.c
@@ -445,8 +445,8 @@ void deliver_udp(uint8_t *buf, int len, sockaddr_in *from, sockaddr_in *dst)
 
     uint16_t checksum = scion_udp_checksum(buf);
     if (checksum != udp->checksum) {
-        zlog_error(zc, "Bad UDP checksum. Expected:%04x Got:%#04x",
-                udp->checksum, checksum);
+        zlog_error(zc, "Bad UDP checksum in packet to %s. Expected:%04x Got:%04x",
+                inet_ntoa(dst->sin_addr), ntohs(udp->checksum), ntohs(checksum));
         return;
     }
 

--- a/lib/libscion/checksum.c
+++ b/lib/libscion/checksum.c
@@ -26,6 +26,9 @@ uint16_t checksum(chk_input *in) {
         int j = 0;
         int len = in->len[i];
         uint8_t *ptr = in->ptr[i];
+        if (len == 0) {
+            continue;
+        }
         // Handle a carry byte from the previous chunk.
         if (carry) {
             _add_sum(&sum, *carry << 8 | ptr[0]);


### PR DESCRIPTION
If a 0-length chunk is encountered (e.g. a UDP packet with no payload),
the main checksum loop wouldn't notice, and end up adding a random 2
bytes to the sum. By explicitly checking for len 0, this change fixes
that.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/708%23issuecomment-214716914%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/708%23issuecomment-214717282%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/708%23issuecomment-214716914%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22For%20%40aznair%2C%20with%20apologies.%22%2C%20%22created_at%22%3A%20%222016-04-26T11%3A58%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-04-26T12%3A00%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/708#issuecomment-214716914'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> For @aznair, with apologies.
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/708?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/708?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/708'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
