### PR TITLE
Fix an issue with docker caching on circleci

### DIFF
--- a/docker/cache.sh
+++ b/docker/cache.sh
@@ -9,7 +9,7 @@ BUILDDIR=docker/_build
 
 cmd_save() {
     echo "====> Docker image: saving"
-    time docker save scion:latest | gzip -1 > "$DOCKERCACHE"
+    time docker save scion:latest ubuntu:14.04 | gzip -1 > "$DOCKERCACHE"
     echo "====> Docker image: saved ($(get_size "$DOCKERCACHE"))"
 }
 


### PR DESCRIPTION
A docker image is actually a stack of layered COW file-systems. Each
depends on the layer below. Our Dockerfile specifies the ubuntu:14.04
image as our base. However, when docker/cache.sh saved the latest image,
it stripped the ubuntu label from that image. When docker/cache.sh
restored the image for the next build, docker would then decide that it
didn't already have ubuntu, download it fresh, and blow away the cached
layers, causing a full (and very slow) rebuild.
