### PR TITLE
Various fixes

### DIFF
--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -54,7 +54,9 @@ log "Scion status:"
 
 sleep 5
 
-cat << EOF | parallel -n2 -j10 run
+# FIXME(kormat): to be reverted to -j0 or so once sciond's api is over a
+# reliable transport.
+cat << EOF | parallel -n2 -j1 run
 End2End
 test/integration/end2end_test.py
 C2S_extn

--- a/endhost/dispatcher.c
+++ b/endhost/dispatcher.c
@@ -150,6 +150,10 @@ int create_sockets()
         return -1;
     }
     int optval = 1;
+    /*
+     * FIXME(kormat): This should go away once the dispatcher and the router no
+     * longer try binding to the same socket.
+     */
     res = setsockopt(data_socket, SOL_SOCKET, SO_REUSEADDR,
             &optval, sizeof(optval));
     res |= setsockopt(data_socket, IPPROTO_IP, IP_PKTINFO, &optval, sizeof(optval));

--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -79,8 +79,9 @@ class SCIONDaemon(SCIONElement):
                                            max_res_no=self.MAX_SEG_NO)
         self.core_segments = PathSegmentDB(segment_ttl=self.SEGMENT_TTL,
                                            max_res_no=self.MAX_SEG_NO)
+        req_name = "SCIONDaemon Requests %s" % self.addr.isd_as
         self.requests = RequestHandler.start(
-            "SCIONDaemon Requests", self._check_segments, self._fetch_segments,
+            req_name, self._check_segments, self._fetch_segments,
             self._reply_segments, ttl=self.TIMEOUT, key_map=self._req_key_map,
         )
         self._api_socket = None
@@ -112,9 +113,9 @@ class SCIONDaemon(SCIONElement):
         paths = sd.get_paths(isd_as)
         """
         inst = cls(conf_dir, addr, api_addr, run_local_api, port, api_port)
+        name = "SCIONDaemon.run %s" % inst.addr.isd_as
         inst.daemon_thread = threading.Thread(
-            target=thread_safety_net, args=(inst.run,), name="SCIONDaemon.run",
-            daemon=True)
+            target=thread_safety_net, args=(inst.run,), name=name, daemon=True)
         inst.daemon_thread.start()
         return inst
 
@@ -186,7 +187,7 @@ class SCIONDaemon(SCIONElement):
             threading.Thread(
                 target=thread_safety_net,
                 args=(self._api_handle_path_request, packet, sender),
-                name="SCIONDaemon", daemon=True).start()
+                daemon=True).start()
         elif packet[0] == 1:  # address request
             self._api_sock.send(self.addr.pack(), sender)
         else:
@@ -205,8 +206,13 @@ class SCIONDaemon(SCIONElement):
         FIXME(kormat): make IP-version independent
         """
         dst_ia = ISD_AS(packet[1:ISD_AS.LEN + 1])
+        thread = threading.current_thread()
+        thread.name = "SCIONDaemon API id:%s %s -> %s" % (
+            thread.ident, self.addr.isd_as, dst_ia)
         paths = self.get_paths(dst_ia)
         reply = []
+        logging.debug("Replying to api request for %s with %d paths",
+                      dst_ia, len(paths))
         for path in paths:
             raw_path = path.pack()
             # assumed IPv4 addr
@@ -369,8 +375,7 @@ class SCIONDaemon(SCIONElement):
                 tuples.append((up_seg, None, down_seg))
                 for core_seg in core_segs:
                     tuples.append((up_seg, core_seg, down_seg))
-                full_paths.extend(
-                    PathCombinator.tuples_to_full_paths(tuples))
+        full_paths.extend(PathCombinator.tuples_to_full_paths(tuples))
         return full_paths
 
     def _resolve_not_core_not_core_sibra(self, dst_ia):

--- a/infrastructure/router/main.py
+++ b/infrastructure/router/main.py
@@ -161,9 +161,11 @@ class Router(SCIONElement):
         """
         Setup incoming socket
         """
+        # FIXME(kormat): reuse=True should to away once the dispatcher and the
+        # router no longer try binding to the same socket.
         self._local_sock = UDPSocket(
             bind=(str(self.addr.host), SCION_UDP_EH_DATA_PORT, self.id),
-            addr_type=self.addr.host.TYPE,
+            addr_type=self.addr.host.TYPE, reuse=True,
         )
         self._port = self._local_sock.port
         self._socks.add(self._local_sock)

--- a/lib/log.py
+++ b/lib/log.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 # errors.
 
 #: Bytes
-LOG_MAX_SIZE = 1 * 1024 * 1024
+LOG_MAX_SIZE = 10 * 1024 * 1024
 LOG_BACKUP_COUNT = 1
 
 # Logging handlers that will log logging exceptions, and then re-raise them. The


### PR DESCRIPTION
- Don't run integration tests in parallel until there's a reliable
  sciond api.
- Name sciond threads so it's clear which messages are from which
  sciond.
- Remove the misguided default SO_REUSEADDR for udp sockets. Fixes an
  issue where multiple processes could bind to the same address:port,
  and get the wrong responses.
- Temporary exception for the router/dispatcher on SO_REUSEADDR as right
  now they both bind to the same port. The dispatcher binds to a
  wildcard address, and the router to a specific IP, so the router wins
  for any packets to that IP, and the dispatcher otherwise gets all
  packets.
- Increase the max log size to 10MB, as even a single end2end test was
  generating more than 2MB of logs, and hence losing data.
- Check that socket sending actually sends all of the requested data.
- Increase the api query timeout for integration tests.
  <a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/718%23issuecomment-216516879%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/718%23issuecomment-216516904%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/718%23issuecomment-216518767%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/718%23issuecomment-216523298%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/718%23issuecomment-216516879%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222016-05-03T12%3A49%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aznair%20%22%2C%20%22created_at%22%3A%20%222016-05-03T12%3A49%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22while%20we%27re%20fixing%20things%20might%20as%20well%20pull%20out%20the%20tuples_to_full_paths%28%29%20call%20in%20sciond%3Aresolve_not_core_to_not_core%28%29%20to%20outside%20the%20for%20loops%5Cr%5Cn%5Cr%5Cnotherwise%20lgtm%22%2C%20%22created_at%22%3A%20%222016-05-03T12%3A57%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aznair%20-%20done.%22%2C%20%22created_at%22%3A%20%222016-05-03T13%3A14%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
  <a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/718#issuecomment-216516879'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @aznair
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> while we're fixing things might as well pull out the tuples_to_full_paths() call in sciond:resolve_not_core_to_not_core() to outside the for loops
  otherwise lgtm
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @aznair - done.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/718?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/718?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/718'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
