### PR TITLE
Bug fix in get_path_len

### DIFF
--- a/lib/libscion/packet.c
+++ b/lib/libscion/packet.c
@@ -100,7 +100,7 @@ uint8_t * get_path(uint8_t *buf)
 int get_path_len(uint8_t *buf)
 {
     SCIONCommonHeader *sch = (SCIONCommonHeader *)buf;
-    return ntohs(sch->header_len) - sizeof(SCIONCommonHeader) - padded_addr_len(buf);
+    return sch->header_len - sizeof(SCIONCommonHeader) - padded_addr_len(buf);
 }
 
 /*


### PR DESCRIPTION
header_len is 1 byte, shouldn't be ntohs()ing it

@pszalach
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/720?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/720'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
