### PR TITLE
PathState (congestion control) type configurable upon path creation

### DIFF
--- a/endhost/ssp/ConnectionManager.cpp
+++ b/endhost/ssp/ConnectionManager.cpp
@@ -256,7 +256,12 @@ int PathManager::insertOnePath(Path *p)
 
 Path * PathManager::createPath(SCIONAddr &dstAddr, uint8_t *rawPath, int pathLen)
 {
-    return new Path(this, mLocalAddr, dstAddr, rawPath, pathLen);
+    PathParams params;
+    params.localAddr = &mLocalAddr;
+    params.dstAddr = &dstAddr;
+    params.rawPath = rawPath;
+    params.pathLen = pathLen;
+    return new Path(this, &params);
 }
 
 void PathManager::handleTimeout()
@@ -543,7 +548,7 @@ int SSPConnectionManager::handlePacket(SCIONPacket *packet, bool receiver)
         saddr.host.addr_len = ADDR_IPV4_LEN;
         memcpy(&(saddr.host.addr), packet->header.srcAddr + ISD_AS_LEN, ADDR_IPV4_LEN);
 
-        SSPPath *p = new SSPPath(this, mLocalAddr, saddr, packet->header.path, packet->header.pathLen);
+        SSPPath *p = (SSPPath *)createPath(saddr, packet->header.path, packet->header.pathLen);
         p->setFirstHop(ADDR_IPV4_LEN, (uint8_t *)&(packet->firstHop));
         p->setInterfaces(sp->interfaces, sp->interfaceCount);
         if (mPolicy.validate(p)) {
@@ -866,7 +871,13 @@ void SSPConnectionManager::getStats(SCIONStats *stats)
 
 Path * SSPConnectionManager::createPath(SCIONAddr &dstAddr, uint8_t *rawPath, int pathLen)
 {
-    return new SSPPath(this, mLocalAddr, dstAddr, rawPath, pathLen);
+    PathParams params;
+    params.localAddr = &mLocalAddr;
+    params.dstAddr = &dstAddr;
+    params.rawPath = rawPath;
+    params.pathLen = pathLen;
+    params.type = CC_CUBIC;
+    return new SSPPath(this, &params);
 }
 
 void SSPConnectionManager::startScheduler()
@@ -1135,7 +1146,7 @@ void SUDPConnectionManager::handlePacket(SCIONPacket *packet)
         saddr.host.addr_len = ADDR_IPV4_LEN;
         memcpy(&(saddr.host.addr), packet->header.srcAddr + ISD_AS_LEN, ADDR_IPV4_LEN);
 
-        SUDPPath *p = new SUDPPath(this, mLocalAddr, saddr, packet->header.path, packet->header.pathLen);
+        SUDPPath *p = (SUDPPath *)createPath(saddr, packet->header.path, packet->header.pathLen);
         p->setFirstHop(ADDR_IPV4_LEN, (uint8_t *)&(packet->firstHop));
         index = insertOnePath(p);
         mLastProbeAcked.resize(mPaths.size());
@@ -1167,5 +1178,10 @@ void SUDPConnectionManager::setRemoteAddress(SCIONAddr addr)
 
 Path * SUDPConnectionManager::createPath(SCIONAddr &dstAddr, uint8_t *rawPath, int pathLen)
 {
-    return new SUDPPath(this, mLocalAddr, dstAddr, rawPath, pathLen);
+    PathParams params;
+    params.localAddr = &mLocalAddr;
+    params.dstAddr = &dstAddr;
+    params.rawPath = rawPath;
+    params.pathLen = pathLen;
+    return new SUDPPath(this, &params);
 }

--- a/endhost/ssp/Path.cpp
+++ b/endhost/ssp/Path.cpp
@@ -5,26 +5,26 @@
 #include "Path.h"
 #include "Utils.h"
 
-Path::Path(PathManager *manager, SCIONAddr &localAddr, SCIONAddr &dstAddr, uint8_t *rawPath, size_t pathLen)
+Path::Path(PathManager *manager, PathParams *params)
     : mIndex(-1),
-    mLocalAddr(localAddr),
-    mDstAddr(dstAddr),
+    mLocalAddr(*(params->localAddr)),
+    mDstAddr(*(params->dstAddr)),
     mUp(false),
     mUsed(false),
     mValid(true),
     mProbeAttempts(0)
 {
     mSocket = manager->getSocket();
-    if (pathLen == 0) {
+    if (params->pathLen == 0) {
         // raw data is in daemon reply format
-        uint8_t *ptr = rawPath;
-        mPathLen = *rawPath * 8;
+        uint8_t *ptr = params->rawPath;
+        mPathLen = *ptr * 8;
         ptr++;
         if (mPathLen == 0) {
             // empty path
             mPath = NULL;
-            mFirstHop.addr_len = dstAddr.host.addr_len;
-            memcpy(mFirstHop.addr, dstAddr.host.addr, mFirstHop.addr_len);
+            mFirstHop.addr_len = mDstAddr.host.addr_len;
+            memcpy(mFirstHop.addr, mDstAddr.host.addr, mFirstHop.addr_len);
             mFirstHop.port = SCION_UDP_EH_DATA_PORT;
             mMTU = SCION_DEFAULT_MTU;
         } else {
@@ -38,8 +38,8 @@ Path::Path(PathManager *manager, SCIONAddr &localAddr, SCIONAddr &dstAddr, uint8
             mFirstHop.port = ntohs(*(uint16_t *)ptr);
             ptr += 2;
 #ifdef BYPASS_ROUTERS
-            mFirstHop.addr_len = dstAddr.host.addr_len;
-            memcpy(mFirstHop.addr, dstAddr.host.addr, mFirstHop.addr_len);
+            mFirstHop.addr_len = mDstAddr.host.addr_len;
+            memcpy(mFirstHop.addr, mDstAddr.host.addr, mFirstHop.addr_len);
             mFirstHop.port = SCION_UDP_EH_DATA_PORT;
 #endif
             mMTU = ntohs(*(uint16_t *)ptr);
@@ -61,13 +61,29 @@ Path::Path(PathManager *manager, SCIONAddr &localAddr, SCIONAddr &dstAddr, uint8
         }
     } else {
         // raw data contains path only
-        mPathLen = pathLen;
+        mPathLen = params->pathLen;
         mPath = (uint8_t *)malloc(mPathLen);
-        memcpy(mPath, rawPath, mPathLen);
+        memcpy(mPath, params->rawPath, mPathLen);
         mMTU = SCION_DEFAULT_MTU;
     }
     gettimeofday(&mLastSendTime, NULL);
     pthread_mutex_init(&mMutex, NULL);
+
+    switch (params->type) {
+        case CC_CBR:
+            mState = new CBRPathState(SCION_DEFAULT_RTT, mMTU);
+            break;
+        case CC_PCC:
+            mState = new PCCPathState(SCION_DEFAULT_RTT, mMTU);
+            break;
+        case CC_RENO:
+            mState = new RenoPathState(SCION_DEFAULT_RTT, mMTU);
+            break;
+        case CC_CUBIC:
+        default:
+            mState = new CUBICPathState(SCION_DEFAULT_RTT, mMTU);
+            break;
+    }
 }
 
 Path::~Path()
@@ -290,16 +306,14 @@ void Path::copySCIONHeader(uint8_t *bufptr, SCIONHeader *sh)
 
 // SSP
 
-SSPPath::SSPPath(SSPConnectionManager *manager, SCIONAddr &localAddr, SCIONAddr &dstAddr, uint8_t *rawPath, size_t pathLen)
-    : Path(manager, localAddr, dstAddr, rawPath, pathLen),
+SSPPath::SSPPath(SSPConnectionManager *manager, PathParams *params)
+    : Path(manager, params),
     mManager(manager),
     mTotalReceived(0),
     mTotalSent(0),
     mTotalAcked(0),
     mTimeoutCount(0)
 {
-    mState = new CUBICPathState(SCION_DEFAULT_RTT, mMTU);
-
     gettimeofday(&mLastLossTime, NULL);
 
     pthread_mutex_init(&mTimeMutex, NULL);
@@ -568,8 +582,8 @@ void SSPPath::getStats(SCIONStats *stats)
 
 // SUDP
 
-SUDPPath::SUDPPath(SUDPConnectionManager *manager, SCIONAddr &localAddr, SCIONAddr &dstAddr, uint8_t *rawPath, size_t pathLen)
-    : Path(manager, localAddr, dstAddr, rawPath, pathLen)
+SUDPPath::SUDPPath(SUDPConnectionManager *manager, PathParams *params)
+    : Path(manager, params)
 {
 }
 

--- a/endhost/ssp/Path.h
+++ b/endhost/ssp/Path.h
@@ -9,9 +9,24 @@
 #include "PathState.h"
 #include "SCIONDefines.h"
 
+enum CCType {
+    CC_CBR,
+    CC_PCC,
+    CC_RENO,
+    CC_CUBIC,
+};
+
+struct PathParams {
+    SCIONAddr *localAddr;
+    SCIONAddr *dstAddr;
+    uint8_t *rawPath;
+    size_t pathLen;
+    CCType type;
+};
+
 class Path {
 public:
-    Path(PathManager *manager, SCIONAddr &localAddr, SCIONAddr &dstAddr, uint8_t *rawPath, size_t pathLen);
+    Path(PathManager *manager, PathParams *params);
     virtual ~Path();
 
     virtual int sendPacket(SCIONPacket *packet, int sock);
@@ -73,7 +88,7 @@ protected:
 
 class SSPPath : public Path {
 public:
-    SSPPath(SSPConnectionManager *manager, SCIONAddr &localAddr, SCIONAddr &dstAddr, uint8_t *rawPath, size_t pathLen);
+    SSPPath(SSPConnectionManager *manager, PathParams *params);
     ~SSPPath();
 
     virtual int sendPacket(SCIONPacket *packet, int sock);
@@ -115,7 +130,7 @@ protected:
 
 class SUDPPath : public Path {
 public:
-    SUDPPath(SUDPConnectionManager *manager, SCIONAddr &localAddr, SCIONAddr &dstAddr, uint8_t *rawPath, size_t pathLen);
+    SUDPPath(SUDPConnectionManager *manager, PathParams *params);
     ~SUDPPath();
 
     int sendPacket(SCIONPacket *packet, int sock);


### PR DESCRIPTION
Preparation for when SIBRA becomes a congestion control option for SSP socket
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/723?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/723'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/723)

<!-- Reviewable:end -->
