### PR TITLE
Start switching payload serilization to capnproto.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN sudo apt-get update && APTARGS=-y ./deps.sh pkgs
 # Copy over requirements.txt. If it has changed, then re-run the remaining steps.
 COPY requirements.txt $BASE/
 RUN sudo chown -R scion: $HOME
+RUN ./deps.sh capnp
 RUN ./deps.sh zlog
 RUN ./deps.sh misc
 RUN ./deps.sh pip

--- a/circle.yml
+++ b/circle.yml
@@ -17,10 +17,10 @@ test:
     override:
         - ./docker.sh run -c "./scion.sh coverage -v"
         - ./docker.sh run -c "./scion.sh lint"
-        - ./docker.sh run -c "make -C sphinx-doc clean html"
+        - ./docker.sh run -c "make -f sphinx-doc/Makefile clean html"
         - ./docker.sh run -c "docker/integration_test.sh"
     post:
         - cp -a htmlcov "$CIRCLE_ARTIFACTS"/coverage
-        - cp -a sphinx-doc/_build/html "$CIRCLE_ARTIFACTS"/docs
+        - cp -a sphinx-doc/_build/html/sphinx-doc/ "$CIRCLE_ARTIFACTS"/docs
         - cp -a logs "$CIRCLE_ARTIFACTS"/logs
         - LOGS="logs.pr${CIRCLE_PR_NUMBER}.build${CIRCLE_BUILD_NUM}"; mv logs/ "$LOGS"; tar czf "${CIRCLE_ARTIFACTS}/$LOGS.tar.gz" "$LOGS"

--- a/deps.sh
+++ b/deps.sh
@@ -51,6 +51,22 @@ cmd_zlog() {
     fi
 }
 
+cmd_capnp() {
+    if type -P capnp &>/dev/null; then
+        return
+    fi
+    CP_DIR=~/.local/capnproto
+    if [ ! -d $CP_DIR ]; then
+        echo "No capnproto directory, download and extract"
+        mkdir -p $CP_DIR
+        curl -L https://capnproto.org/capnproto-c++-0.5.3.tar.gz | tar xzf - --strip-components=1 -C $CP_DIR
+    fi
+    cd "$CP_DIR"
+    ./configure
+    make -j6 check
+    sudo make install
+}
+
 
 cmd_misc() {
     echo "Installing supervisor packages from pip2"
@@ -60,7 +76,7 @@ cmd_misc() {
 
 cmd_help() {
 	cat <<-_EOF
-	$PROGRAM [all|pkgs|pip|zlog|misc|help]
+	$PROGRAM CMD
 	
 	Usage:
 	    $PROGRAM all
@@ -73,6 +89,8 @@ cmd_help() {
 	        access required)
 	    $PROGRAM zlog
 	        Install libzlog
+	    $PROGRAM capnp
+	        Install capnproto
 	    $PROGRAM misc
 	        Install any additional packages not from the first 2 sources.
 	    $PROGRAM help
@@ -86,7 +104,7 @@ COMMAND="$1"
 shift || { cmd_help; exit; }
 
 case "$COMMAND" in
-    all|pkgs|pip|zlog|misc)
+    all|pkgs|pip|capnp|zlog|misc)
             "cmd_$COMMAND" "$@" ;;
     help|*)  cmd_help ;;
 esac

--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -381,7 +381,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         :type ipkt: IFIDPayload
         """
         payload = pkt.get_payload()
-        ifid = payload.reply_id
+        ifid = payload.p.relayIF
         if ifid not in self.ifid_state:
             raise SCIONKeyError("Invalid IF %d in IFIDPayload" % ifid)
         prev_state = self.ifid_state[ifid].update()

--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -372,7 +372,7 @@ class SCIONElement(object):
         dst_addr = SCIONAddr.from_values(dst_ia, dst_host)
         cmn_hdr, addr_hdr = build_base_hdrs(self.addr, dst_addr)
         udp_hdr = SCIONUDPHeader.from_values(
-            self.addr, self._port, dst_addr, dst_port, payload)
+            self.addr, self._port, dst_addr, dst_port)
         return SCIONL4Packet.from_values(
             cmn_hdr, addr_hdr, path, ext_hdrs, udp_hdr, payload)
 

--- a/infrastructure/sibra_server/steady.py
+++ b/infrastructure/sibra_server/steady.py
@@ -211,7 +211,7 @@ class SteadyPath(object):
         cmn_hdr, addr_hdr = build_base_hdrs(self.addr, dest)
         payload = SIBRAPayload()
         udp_hdr = SCIONUDPHeader.from_values(
-            self.addr, SCION_UDP_PORT, dest, SCION_UDP_PORT, payload)
+            self.addr, SCION_UDP_PORT, dest, SCION_UDP_PORT)
         return cmn_hdr, addr_hdr, udp_hdr, payload
 
     def _create_scion_pkt(self, ext):
@@ -257,7 +257,7 @@ class SteadyPath(object):
         dest = SCIONAddr.from_values(dst_ia, SVCType.PS)
         cmn_hdr, addr_hdr = build_base_hdrs(self.addr, dest)
         udp_hdr = SCIONUDPHeader.from_values(
-            self.addr, SCION_UDP_PORT, dest, SCION_UDP_PORT, pld)
+            self.addr, SCION_UDP_PORT, dest, SCION_UDP_PORT)
         return SCIONL4Packet.from_values(
             cmn_hdr, addr_hdr, path, [], udp_hdr, pld)
 

--- a/lib/packet/ifid.py
+++ b/lib/packet/ifid.py
@@ -1,0 +1,49 @@
+# Copyright 2016 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`ifid` --- Interface ID payload
+====================================
+"""
+# External
+import capnp
+
+# SCION
+from lib.errors import SCIONParseError
+from lib.packet.packet_base import SCIONPayloadBaseProto
+from lib.types import IFIDType, PayloadClass
+
+
+class IFIDPayload(SCIONPayloadBaseProto):  # pragma: no cover
+    """
+    IFID packet.
+    """
+    PAYLOAD_CLASS = PayloadClass.IFID
+    PAYLOAD_TYPE = IFIDType.PAYLOAD
+    NAME = "IFIDPayload"
+    P = capnp.load("proto/ifid.capnp")
+    P_CLS = P.IFID
+
+    @classmethod
+    def from_values(cls, orig_if):  # pragma: no cover
+        return cls(cls.P_CLS.new_message(origIF=orig_if))
+
+
+def parse_ifid_payload(type_, data):
+    type_map = {
+        IFIDType.PAYLOAD: IFIDPayload.from_raw,
+    }
+    if type_ not in type_map:
+        raise SCIONParseError("Unsupported IFID type: %s", type_)
+    handler = type_map[type_]
+    return handler(data.pop())

--- a/lib/packet/scmp/payload.py
+++ b/lib/packet/scmp/payload.py
@@ -103,7 +103,7 @@ class SCMPPayload(PayloadBase):
         if SCMPIncParts.EXTS in inc_list:
             inst._exts = pkt.pack_exts()
         if SCMPIncParts.L4 in inc_list:
-            inst._l4_hdr = pkt.l4_hdr.pack()
+            inst._l4_hdr = pkt.l4_hdr.pack(b"")
             inst.l4_proto = pkt.l4_hdr.TYPE
         else:
             inst.l4_proto = L4Proto.NONE

--- a/proto/ifid.capnp
+++ b/proto/ifid.capnp
@@ -1,0 +1,6 @@
+@0x9cb1ca08a160c787;
+
+struct IFID {
+   origIF @0 :UInt16;
+   relayIF @1 :UInt16;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Sphinx
+pycapnp
 coverage
 dnslib
 dnspython3

--- a/sphinx-doc/Makefile
+++ b/sphinx-doc/Makefile
@@ -5,7 +5,8 @@
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
-BUILDDIR      = _build
+SPHINXDIR     = sphinx-doc
+BUILDDIR      = $(SPHINXDIR)/_build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -15,7 +16,7 @@ endif
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -W -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = -c $(SPHINXDIR) -W -v $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 

--- a/sphinx-doc/conf.py
+++ b/sphinx-doc/conf.py
@@ -18,7 +18,7 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('..'))
+#sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
 
@@ -48,7 +48,7 @@ source_suffix = '.rst'
 #source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = 'sphinx-doc/index'
 
 # General information about the project.
 project = u'SCION'
@@ -75,7 +75,7 @@ release = '1.0'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['*/_build']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/test/integration/end2end_test.py
+++ b/test/integration/end2end_test.py
@@ -37,7 +37,7 @@ class E2EClient(TestClientBase):
     """
     def _create_payload(self, spkt):
         data = b"ping " + self.data
-        pld_len = self.path.mtu - len(spkt)
+        pld_len = self.path.mtu - spkt.cmn_hdr.hdr_len - len(spkt.l4_hdr)
         return self._gen_max_pld(data, pld_len)
 
     def _gen_max_pld(self, data, pld_len):

--- a/test/integration/scmp_error_test.py
+++ b/test/integration/scmp_error_test.py
@@ -20,7 +20,6 @@
 import copy
 import logging
 import random
-import socket
 import sys
 
 # SCION
@@ -28,8 +27,8 @@ from lib.defines import MAX_HOPBYHOP_EXT
 from lib.main import main_wrapper
 from lib.packet.ext.traceroute import TracerouteExt
 from lib.packet.host_addr import HostAddrSVC
+from lib.packet.ifid import IFIDPayload
 from lib.packet.path import SCIONPath
-from lib.packet.scion import IFIDPayload
 from lib.packet.scion_addr import ISD_AS, SCIONAddr
 from lib.packet.scmp.ext import SCMPExt
 from lib.packet.scmp.types import (
@@ -59,9 +58,8 @@ class ErrorGenBase(TestClientBase):
         if self.CLASS is None:
             # Allow testing of errors which don't send SCMP responses.
             return True
-        try:
-            pkt = self._recv()
-        except socket.timeout:
+        pkt = self._recv()
+        if not pkt:
             logging.error("Test timed out")
             return False
         ret = self._handle_response(pkt)

--- a/test/lib/packet/scmp/hdr_test.py
+++ b/test/lib/packet/scmp/hdr_test.py
@@ -50,30 +50,9 @@ class TestSCMPHeaderParse(object):
         ntools.eq_(inst._dst, "dst")
         ntools.eq_(inst.class_, 0x1111)
         ntools.eq_(inst.type, 0x2222)
-        ntools.eq_(inst._length, 0x000F)
+        ntools.eq_(inst.total_len, 0x000F)
         ntools.eq_(inst._checksum, bytes.fromhex("9999"))
         ntools.eq_(inst.timestamp, 0x2323232323232323)
-
-
-class TestSCMPHeaderUpdate(object):
-    """
-    Unit tests for lib.packet.scmp.hdr.SCMPHeader.update
-    """
-    def test_full(self):
-        inst = SCMPHeader()
-        inst._calc_checksum = create_mock()
-        inst._calc_checksum.return_value = 0x9999
-        # Call
-        inst.update(src="src addr", dst="dst addr", class_="class",
-                    type_="type", payload="payload")
-        # Tests
-        ntools.eq_(inst._src, "src addr")
-        ntools.eq_(inst._dst, "dst addr")
-        ntools.eq_(inst.class_, "class")
-        ntools.eq_(inst.type, "type")
-        ntools.eq_(inst._length, inst.LEN + 7)
-        inst._calc_checksum.assert_called_once_with("payload")
-        ntools.eq_(inst._checksum, 0x9999)
 
 
 class TestSCMPHeaderValidate(object):
@@ -83,14 +62,14 @@ class TestSCMPHeaderValidate(object):
     @patch("lib.packet.scmp.hdr.Raw", autospec=True)
     def test_bad_length(self, raw):
         inst = SCMPHeader()
-        inst._length = 10
+        inst.total_len = 10
         # Call
         ntools.assert_raises(SCMPBadPktLen, inst.validate, range(9))
 
     @patch("lib.packet.scmp.hdr.Raw", autospec=True)
     def test_bad_checksum(self, raw):
         inst = SCMPHeader()
-        inst._length = 10 + inst.LEN
+        inst.total_len = 10 + inst.LEN
         inst._calc_checksum = create_mock()
         inst._calc_checksum.return_value = bytes.fromhex("8888")
         inst._checksum = bytes.fromhex("9999")
@@ -111,11 +90,10 @@ class TestSCMPHeaderCalcChecksum(object):
         inst._dst.pack.return_value = b"destination address"
         inst.pack = create_mock()
         inst.pack.return_value = b"packed with null checksum"
-        payload = create_mock(["pack"])
-        payload.pack.return_value = b"payload"
+        payload = b"payload"
         expected_call = b"".join([
             b"source address", b"destination address", bytes([L4Proto.SCMP]),
-            b"packed with null checksum", b"payload",
+            b"packed with null checksum", payload,
         ])
         scapy_checksum.return_value = 0x3412
         # Call


### PR DESCRIPTION
Most of the changes are related to the fact that a capnp object should
not be packed multiple times (as this can cause memory leakage, or
wasted data bytes). Currently we pack() everything multiple times to
calculate lengths. This change stops that (and has an assertion to make
sure it won't happen in future). One caveat is that packets that have
been assembled (as opposed to created) won't display meaningful lengths.
E.g:
- the total_len field in the common header isn't populated during packet
  assembly, and is instead filled in during packet packing.
- UDP and SCMP checksums aren't calculated before packet packing.

This does not apply to parsed packets.

Details:
- Install pycapnp from pip to provide capnproto python support.
- Install the current capnp library/tools release.
- Created SCIONPayloadBaseProto to be the new base class for any capnp
  payload classes.
- IFIDPayload is now a capnp message.
- Change sphinx building around so that it builds in the root directory,
  otherwise the .capnp schema loading will fail.
#528, #730

<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/726%23issuecomment-220617257%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64179533%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64179701%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64180504%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64180523%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64180548%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64180576%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64180797%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23issuecomment-220910563%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64181525%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64181532%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64195636%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64196964%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64197791%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23issuecomment-220617257%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%5Cr%5Cn%23528%20%22%2C%20%22created_at%22%3A%20%222016-05-20T14%3A14%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%20otherwise%22%2C%20%22created_at%22%3A%20%222016-05-23T07%3A52%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20ced9910728414adde0b27a346b8930ef2d777a53%20proto/ifid.capnp%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64195636%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20don%27t%20we%20adhere%20to%20our%20Python%20naming%20conventions%20and%20call%20them%20%60orig_if%60%20and%20%60relay_if%60%3F%20It%20would%20fit%20in%20better%20when%20you%20access%20them%20from%20Python%20code.%22%2C%20%22created_at%22%3A%20%222016-05-23T09%3A50%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20capnproto%20schema%20language%20doesn%27t%20allow%20%60_%60%20%28or%20fields%20to%20start%20with%20capital%20letters%29.%22%2C%20%22created_at%22%3A%20%222016-05-23T10%3A01%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22gotcha%22%2C%20%22created_at%22%3A%20%222016-05-23T10%3A07%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3840858%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/shitz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20proto/ifid.capnp%3AL1-7%22%7D%2C%20%22Pull%2021f3f66b010c38ece47f7070f910335f99fb3d43%20infrastructure/router/main.py%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64179701%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20copy%28%29%20is%20needed%3F%22%2C%20%22created_at%22%3A%20%222016-05-23T07%3A41%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Because%20a%20capnproto%20object%20can%20only%20be%20packed%20/once/.%20See%20%60SCIONPayloadBaseProto%60%20enforces%20this.%22%2C%20%22created_at%22%3A%20%222016-05-23T07%3A50%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20the%20warning%20that%20you%20get%3A%5Cr%5Cn%3E%20%5C%22This%20message%20has%20already%20been%20written%20once.%20Be%20very%20careful%20that%20you%27re%20not%20setting%20Text/Struct/List%20fields%20more%20than%20once%2C%20since%20that%20will%20cause%20memory%20leaks%20%28both%20in%20memory%20and%20in%20the%20serialized%20data%29.%20You%20can%20disable%20this%20warning%20by%20setting%20the%20%60_is_written%60%20field%20of%20this%20object%20to%20False%20after%20every%20write.%5C%22%22%2C%20%22created_at%22%3A%20%222016-05-23T07%3A52%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20infrastructure/router/main.py%3AL298-315%22%7D%2C%20%22Pull%2021f3f66b010c38ece47f7070f910335f99fb3d43%20test/lib/packet/scion_test.py%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64180548%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ditto%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-05-23T07%3A49%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed.%22%2C%20%22created_at%22%3A%20%222016-05-23T08%3A00%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/lib/packet/scion_test.py%3AL27-41%22%7D%2C%20%22Pull%2021f3f66b010c38ece47f7070f910335f99fb3d43%20test/integration/scmp_error_test.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64180523%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22order%22%2C%20%22created_at%22%3A%20%222016-05-23T07%3A49%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Fixed.%22%2C%20%22created_at%22%3A%20%222016-05-23T08%3A00%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/integration/scmp_error_test.py%3AL28-35%22%7D%2C%20%22Pull%2021f3f66b010c38ece47f7070f910335f99fb3d43%20deps.sh%2012%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/726%23discussion_r64179533%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20possible%20I%20would%20prefer%20to%20use%20.deb%22%2C%20%22created_at%22%3A%20%222016-05-23T07%3A39%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22Me%20too%2C%20but%20the%20version%20in%20ubuntu%2014.04%20has%20a%20known%20security%20vulnerability%3A%20https%3A//capnproto.org/news/2015-03-05-another-cpu-amplification.html%5Cr%5CnWhen%20we%20switch%20to%20ubuntu%2016.04%20in%20a%20couple%20of%20months%2C%20we%20can%20use%20the%20version%20from%20apt%20again.%22%2C%20%22created_at%22%3A%20%222016-05-23T07%3A49%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20deps.sh%3AL51-73%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/726#issuecomment-220617257'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
  #528
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm otherwise
- [ ] <a href='#crh-comment-Pull 21f3f66b010c38ece47f7070f910335f99fb3d43 deps.sh 12'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/726#discussion_r64179533'>File: deps.sh:L51-73</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> If possible I would prefer to use .deb
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Me too, but the version in ubuntu 14.04 has a known security vulnerability: https://capnproto.org/news/2015-03-05-another-cpu-amplification.html
  When we switch to ubuntu 16.04 in a couple of months, we can use the version from apt again.
- [ ] <a href='#crh-comment-Pull 21f3f66b010c38ece47f7070f910335f99fb3d43 infrastructure/router/main.py 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/726#discussion_r64179701'>File: infrastructure/router/main.py:L298-315</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> why copy() is needed?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Because a capnproto object can only be packed /once/. See `SCIONPayloadBaseProto` enforces this.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> This is the warning that you get:
  > "This message has already been written once. Be very careful that you're not setting Text/Struct/List fields more than once, since that will cause memory leaks (both in memory and in the serialized data). You can disable this warning by setting the `_is_written` field of this object to False after every write."
- [ ] <a href='#crh-comment-Pull 21f3f66b010c38ece47f7070f910335f99fb3d43 test/integration/scmp_error_test.py 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/726#discussion_r64180523'>File: test/integration/scmp_error_test.py:L28-35</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> order
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Fixed.
- [ ] <a href='#crh-comment-Pull 21f3f66b010c38ece47f7070f910335f99fb3d43 test/lib/packet/scion_test.py 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/726#discussion_r64180548'>File: test/lib/packet/scion_test.py:L27-41</a></b>
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> ditto
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Fixed.
- [ ] <a href='#crh-comment-Pull ced9910728414adde0b27a346b8930ef2d777a53 proto/ifid.capnp 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/726#discussion_r64195636'>File: proto/ifid.capnp:L1-7</a></b>
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> Why don't we adhere to our Python naming conventions and call them `orig_if` and `relay_if`? It would fit in better when you access them from Python code.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> The capnproto schema language doesn't allow `_` (or fields to start with capital letters).
- <a href='https://github.com/shitz'><img border=0 src='https://avatars.githubusercontent.com/u/3840858?v=3' height=16 width=16'></a> gotcha

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/726?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/726?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/726'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
