### PR TITLE
Add a CLEAR command to the knowledge-base.

### DIFF
--- a/endhost/kbase_lookup_service.py
+++ b/endhost/kbase_lookup_service.py
@@ -108,13 +108,16 @@ class KnowledgeBaseLookupService(object):
             resp = self.kbase.list()
         elif cmd == 'LOOKUP':
             try:
+                conn_id = request['conn_id']
                 req_type = request['req_type']
                 res_name = request['res_name']
             except KeyError as e:
                 logging.error('Key error while parsing LOOKUP req: %s' % e)
                 return
             assert(isinstance(req_type, str))
-            resp = self.kbase.lookup(req_type, res_name)
+            resp = self.kbase.lookup(conn_id, req_type, res_name)
+        elif cmd == 'CLEAR':
+            resp = self.kbase.clear()
         elif cmd == 'TOPO':
             resp = self._get_topology()
         elif cmd == 'LOCATIONS':

--- a/endhost/scion_proxy.py
+++ b/endhost/scion_proxy.py
@@ -395,7 +395,8 @@ class ForwardingProxyConnectionHandler(ConnectionHandler):
             soc.connect(self.scion_target_proxy, self.scion_target_port)
             if self.socket_kbase:
                 self._handle_socket_options(soc)
-                self.socket_kbase.add_socket(soc, self.method, self.path)
+                self.socket_kbase.add_socket(soc, self.conn_id,
+                                             self.method, self.path)
         else:
             soc = self._unix_client_socket()
         return soc

--- a/test/integration/kbase_lookup_test.py
+++ b/test/integration/kbase_lookup_test.py
@@ -40,13 +40,15 @@ def main():
     init_logging(CLIENT_LOG_BASE,
                  file_level=logging.DEBUG, console_level=logging.DEBUG)
     handle_signals()
-    test_list()
-    test_lookup()
+    res = test_list()
+    test_lookup(res)
     test_topology_lookup()
     test_locations_lookup()
     test_set_ISD_whitelist()
     test_clear_ISD_whitelist()
     test_ISD_endpoints_lookup()
+    test_clear_kbase()
+    test_list()
 
 
 def test_list():
@@ -61,23 +63,44 @@ def test_list():
     req = {"version": "0.1",
            "command": "LIST"}
 
-    send_req_and_read_resp(sock, req)
+    raw_resp = send_req_and_read_resp(sock, req)
+    return extract_from_json(raw_resp)
 
 
-def test_lookup():
+def test_lookup(res):
     """
     Creates a sample look-up request, sends it to the UDP server and
     reads the response.
     """
+    if res is None or len(res) == 0:
+        return
 
     logging.info('Starting the look-up test')
+    item = res[0]
     # Create a UDP socket
     sock = UDPSocket(None, AddrType.IPV4)
 
     req = {"version": "0.1",
            "command": "LOOKUP",
-           "req_type": "CONNECT",
-           "res_name": "api.github.com:443"}
+           "conn_id": item[0],
+           "req_type": item[1],
+           "res_name": item[2]}
+
+    logging.info('Sending LOOKUP request %s', req)
+    send_req_and_read_resp(sock, req)
+
+
+def test_clear_kbase():
+    """
+    Creates a sample clear knowledge-base request, sends it to the
+    UDP server and reads the response returned.
+    """
+    logging.info('Starting the clear test')
+    # Open up a UDP socket
+    sock = UDPSocket(None, AddrType.IPV4)
+
+    req = {"version": "0.1",
+           "command": "CLEAR"}
 
     send_req_and_read_resp(sock, req)
 


### PR DESCRIPTION
This PR adds a possibility to clear the socket knowledge-base so
that the stale information can be removed from the visualization.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-220339412%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23discussion_r64051647%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-220636301%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-220640510%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-220642136%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-220675551%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-220701671%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-220920897%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-220944878%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-220973308%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-221030818%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-221034848%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-221080702%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-221206118%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23discussion_r64355840%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-221241610%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-221271623%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-221272703%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23discussion_r64395301%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23discussion_r64395327%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-221306111%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23issuecomment-220339412%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40mwfarb%20Would%20be%20glad%20if%20you%20could%20have%20a%20look%20at%20this.%20%40kormat%20%40aznair%20Happy%20to%20hear%20if%20you%20guys%20have%20any%20advice%20regarding%20coding%20style.%20Cheers%21%22%2C%20%22created_at%22%3A%20%222016-05-19T14%3A22%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20addressed%20your%20comment%22%2C%20%22created_at%22%3A%20%222016-05-20T15%3A23%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%22%2C%20%22created_at%22%3A%20%222016-05-20T15%3A38%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20a%20lot%20%40kormat%21%20%5Cr%5Cn%40mwfarb%2C%20any%20comments%3F%20Does%20it%20look%20good%20to%20you%20as%20well%3F%22%2C%20%22created_at%22%3A%20%222016-05-20T15%3A44%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20The%20code%20looks%20good%20but%20getting%20some%20weird%20performance%20when%20testing%20with%20latest%20visualization%20https%3A//github.com/netsec-ethz/scion-viz/pull/11.%20Looks%20like%20everything%20got%20cleared%20out%20from%20calling%20ISD_WHITELIST%20then%20CLEAR%2C%20but%20subsequent%20calls%20to%20LOOKUP%20seemed%20to%20be%20still%20using%20old%20paths.%5Cr%5Cn%5Cr%5CnLet%20me%20try%20again%20tonight%20and%20I%27ll%20let%20you%20know%20if%20I%20still%20see%20it.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-05-20T17%3A57%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20Tried%20it%20again%20with%20same%20result.%20I%20send%20ISD_WHITELIST%20with%20%5B1%2C3%5D%2C%20and%20then%20send%20CLEAR.%20After%20response%20from%20CLEAR%2C%20the%20visualization%20calls%20LIST%20again%20getting%20an%20empty%20set%20the%20first%20time%20and%20%27live.github.com%27%20on%20the%20second%2C%20which%20seems%20appropriate%20as%20the%20browser%20pages%20self-refresh.%20I%20then%20send%20%27LOOKUP%27%20for%20it%2C%20and%20get%20a%20send%20of%20paths%20back%20that%20still%20include%20ISD%202.%20%5Cr%5Cn%5Cr%5CnCan%20you%20confirm%20seeing%20the%20same%20when%20running%20%23727%20with%20%20netsec-ethz/scion-viz%2311%3F%20Maybe%20I%20am%20calling%20something%20out%20of%20order%3F%20%5Cr%5Cn%5Cr%5Cn%21%5Bscreenshot%20from%202016-05-20%2015%2035%2045%5D%28https%3A//cloud.githubusercontent.com/assets/215994/15440014/1d4ffca8-1ea1-11e6-8aed-b0caae4c961c.png%29%22%2C%20%22created_at%22%3A%20%222016-05-20T19%3A47%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mwfarb%20I%20will%20look%20at%20this%20right%20now.%20Could%20it%20be%20that%20the%20browser%20cached%20the%20results%20of%20some%20requests%3F%20Maybe%20that%20needs%20clearing%20as%20well.%22%2C%20%22created_at%22%3A%20%222016-05-23T08%3A43%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mwfarb%20I%20had%20a%20more%20detailed%20look%20into%20this.%20This%20may%20be%20due%20to%20the%20fact%20that%20even%20when%20we%20clear%20the%20list%2C%20there%20are%20still%20some%20active%20sockets%20%28for%20instance%20some%20CONNECT%20requests%29%20in%20the%20system.%20The%20stats%20of%20each%20active%20socket%20periodically%20%28every%205%20seconds%29%20is%20entered%20into%20the%20kbase%20%28and%20also%20at%20the%20time%20of%20closing%29.%20Currently%20our%20sockets%20do%20not%20support%20enforcing%20socket%20options%20on%20the%20already%20active%20sockets.%20The%20new%20ISD%20white-list%20will%20be%20applied%20to%20all%20the%20newly%20opened%20sockets%20but%20not%20to%20the%20existing%20ones.%20I%20think%20I%20will%20adapt%20the%20clear%20call%20accordingly%20so%20that%20it%20does%20not%20remove%20the%20stats%20of%20already%20open%20connections%20%28otherwise%20it%27s%20a%20bit%20misleading%20as%20you%20say%29.%22%2C%20%22created_at%22%3A%20%222016-05-23T10%3A33%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20Is%20there%20anything%20the%20visualization%20can%20do%20to%20help%3F%22%2C%20%22created_at%22%3A%20%222016-05-23T13%3A00%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mwfarb%20I%20have%20now%20an%20update%20PR%20however%20it%20seems%20like%20github%20has%20issues%20to%20update%20my%20PR.%20I%20will%20email%20you%20the%20PR%20as%20a%20patch%20so%20that%20you%20can%20try%20it%20out.%22%2C%20%22created_at%22%3A%20%222016-05-23T16%3A57%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mwfarb%20It%20seems%20to%20have%20picked%20up%20the%20changes%20now.%20You%20can%20have%20a%20look%20at%20it%20now.%20%22%2C%20%22created_at%22%3A%20%222016-05-23T17%3A13%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20It%20looks%20good%20so%20far%20in%20testing.%20I%27ll%20send%20an%20updated%20visualization%20PR%20for%20you%20to%20show%20handling%20the%20new%20communication%20id.%20%22%2C%20%22created_at%22%3A%20%222016-05-23T20%3A07%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mwfarb%20Cool%2C%20that%20sounds%20good.%20I%20am%20looking%20forward%20to%20your%20modified%20PR.%20%40aznair%20or%20%40kormat%20I%20made%20some%20slight%20changes%20to%20this%20PR%20since%20last%20time.%20Happy%20to%20hear%20if%20you%20have%20coding%20style%20advice.%22%2C%20%22created_at%22%3A%20%222016-05-24T08%3A51%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40ercanucan%20I%20updated%20yesterday%20to%20handle%20the%20new%20communication%20id%2C%20the%20only%20delay%20is%20some%20unsatisfying%20results%20from%20testing%20UDP%20message%20synchronization.%20Once%20I%20get%20a%20grip%20on%20that%20I%27ll%20give%20the%20all%20clear.%20You%20could%20test%20with%20the%20current%20PR%20now%20to%20see%20if%20you%20like%20how%20the%20new%20ids%20look%20in%20the%20UI%20while%20I%20muck%20about%20chasing%20dropped%20packets.%22%2C%20%22created_at%22%3A%20%222016-05-24T11%3A30%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/215994%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwfarb%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40kormat%20yep%2C%20definitely%20agree%20with%20your%20comment.%20Addressed%20it.%22%2C%20%22created_at%22%3A%20%222016-05-24T13%3A38%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40mwfarb%20okay%2C%20I%20will%20give%20your%20PR-in-progress%20a%20try.%20Will%20probably%20merge%20this%20PR%20if%20you%20do%20not%20have%20further%20comments%20on%20it.%22%2C%20%22created_at%22%3A%20%222016-05-24T13%3A41%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%2C%20%7B%22body%22%3A%20%22Merging%20as%20I%20got%20the%20green%20light%20from%20%40mwfarb%20and%20%40kormat%20%22%2C%20%22created_at%22%3A%20%222016-05-24T15%3A21%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c08cd06bb4ccad0008259da7866d46dc663e5724%20endhost/socket_kbase.py%2046%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23discussion_r64355840%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Using%20this%20tuple%20literal%204%20times%20is%20kinda%20inelegant.%20I%27d%20suggest%20putting%20this%20before%20the%20%60with%60%3A%5Cr%5Cn%60%60%60%5Cr%5Cnkey%20%3D%20conn_id%2C%20method%2C%20path%5Cr%5Cn%60%60%60%5Cr%5Cnand%20just%20using%20that%20instead.%20%28For%20the%20logging%20message%2C%20use%20%60%2Akey%60%20to%20expand%20the%20tuple%29%22%2C%20%22created_at%22%3A%20%222016-05-24T09%3A18%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-05-24T13%3A59%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/socket_kbase.py%3AL69-143%22%7D%2C%20%22Pull%20f7fadce6a30709811687c903ecad298204b4893c%20endhost/socket_kbase.py%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/727%23discussion_r64051647%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Doing%20manual%20%60acquire%60/%60release%60%20calls%20is%20generally%20bad%20practise%2C%20as%20it%27s%20too%20hard%20to%20make%20sure%20it%27s%20done%20consistently%2C%20especially%20when%20errors%20may%20occur.%20A%20much%20better%20way%20is%20to%20use%20%60with%60%3A%5Cr%5Cn%60%60%60%5Cr%5Cnwith%20self.socket_list_lock%3A%5Cr%5Cn%20%20%20%3Cdo%20stuff%3E%5Cr%5Cn%3Clock%20automatically%20released%3E%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-05-20T14%3A39%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222016-05-24T13%3A59%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20endhost/socket_kbase.py%3AL69-93%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/727#issuecomment-220339412'>General Comment</a></b>
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @mwfarb Would be glad if you could have a look at this. @kormat @aznair Happy to hear if you guys have any advice regarding coding style. Cheers!
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat addressed your comment
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> LGTM
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Thanks a lot @kormat!
  @mwfarb, any comments? Does it look good to you as well?
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @ercanucan The code looks good but getting some weird performance when testing with latest visualization https://github.com/netsec-ethz/scion-viz/pull/11. Looks like everything got cleared out from calling ISD_WHITELIST then CLEAR, but subsequent calls to LOOKUP seemed to be still using old paths.
  Let me try again tonight and I'll let you know if I still see it.
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @ercanucan Tried it again with same result. I send ISD_WHITELIST with [1,3], and then send CLEAR. After response from CLEAR, the visualization calls LIST again getting an empty set the first time and 'live.github.com' on the second, which seems appropriate as the browser pages self-refresh. I then send 'LOOKUP' for it, and get a send of paths back that still include ISD 2.
  Can you confirm seeing the same when running #727 with  netsec-ethz/scion-viz#11? Maybe I am calling something out of order?
  ![screenshot from 2016-05-20 15 35 45](https://cloud.githubusercontent.com/assets/215994/15440014/1d4ffca8-1ea1-11e6-8aed-b0caae4c961c.png)
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @mwfarb I will look at this right now. Could it be that the browser cached the results of some requests? Maybe that needs clearing as well.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @mwfarb I had a more detailed look into this. This may be due to the fact that even when we clear the list, there are still some active sockets (for instance some CONNECT requests) in the system. The stats of each active socket periodically (every 5 seconds) is entered into the kbase (and also at the time of closing). Currently our sockets do not support enforcing socket options on the already active sockets. The new ISD white-list will be applied to all the newly opened sockets but not to the existing ones. I think I will adapt the clear call accordingly so that it does not remove the stats of already open connections (otherwise it's a bit misleading as you say).
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @ercanucan Is there anything the visualization can do to help?
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @mwfarb I have now an update PR however it seems like github has issues to update my PR. I will email you the PR as a patch so that you can try it out.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @mwfarb It seems to have picked up the changes now. You can have a look at it now.
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @ercanucan It looks good so far in testing. I'll send an updated visualization PR for you to show handling the new communication id.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @mwfarb Cool, that sounds good. I am looking forward to your modified PR. @aznair or @kormat I made some slight changes to this PR since last time. Happy to hear if you have coding style advice.
- <a href='https://github.com/mwfarb'><img border=0 src='https://avatars.githubusercontent.com/u/215994?v=3' height=16 width=16'></a> @ercanucan I updated yesterday to handle the new communication id, the only delay is some unsatisfying results from testing UDP message synchronization. Once I get a grip on that I'll give the all clear. You could test with the current PR now to see if you like how the new ids look in the UI while I muck about chasing dropped packets.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @kormat yep, definitely agree with your comment. Addressed it.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> @mwfarb okay, I will give your PR-in-progress a try. Will probably merge this PR if you do not have further comments on it.
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> Merging as I got the green light from @mwfarb and @kormat
- [x] <a href='#crh-comment-Pull f7fadce6a30709811687c903ecad298204b4893c endhost/socket_kbase.py 15'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/727#discussion_r64051647'>File: endhost/socket_kbase.py:L69-93</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Doing manual `acquire`/`release` calls is generally bad practise, as it's too hard to make sure it's done consistently, especially when errors may occur. A much better way is to use `with`:

```
with self.socket_list_lock:
<do stuff>
<lock automatically released>
```
- [x] <a href='#crh-comment-Pull c08cd06bb4ccad0008259da7866d46dc663e5724 endhost/socket_kbase.py 46'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/727#discussion_r64355840'>File: endhost/socket_kbase.py:L69-143</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Using this tuple literal 4 times is kinda inelegant. I'd suggest putting this before the `with`:

```
key = conn_id, method, path
```

and just using that instead. (For the logging message, use `*key` to expand the tuple)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/727?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/727?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/727'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
