### PR TITLE
Fix integration test return values

### DIFF
--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -24,6 +24,7 @@ import os
 import random
 import socket
 import struct
+import sys
 import threading
 import time
 from abc import ABCMeta, abstractmethod
@@ -253,7 +254,7 @@ class TestClientServerBase(object):
                 if not self.local and src_ia == dst_ia:
                     continue
                 if not self._run_test(src_ia, dst_ia):
-                    break
+                    sys.exit(1)
 
     def _run_test(self, src_ia, dst_ia):
         """
@@ -283,7 +284,7 @@ class TestClientServerBase(object):
             return False
         if client.success and server.success:
             logging.debug("Success")
-            return
+            return True
         logging.error("Client success? %s Server success? %s",
                       client.success, server.success)
         return False


### PR DESCRIPTION
Success case was returning nothing, so was being considered failure.
However, this only made the test break from inner loop, so tests ran
from all sources to only one destination and reported success.

@pszalach @kormat
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/734%23discussion_r64354730%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/734%23issuecomment-221211343%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/734%23discussion_r64355000%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/734%23discussion_r64355433%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/734%23issuecomment-221211343%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Good%20catch%20%3A%29%22%2C%20%22created_at%22%3A%20%222016-05-24T09%3A13%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2075ccb64bf2235977cd48037149ff010438e77860%20test/integration/base_cli_srv.py%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/734%23discussion_r64354730%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22A%20%60return%60%20is%20sufficient.%22%2C%20%22created_at%22%3A%20%222016-05-24T09%3A13%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22Wouldn%27t%20that%20make%20the%20integration%20test%20script%20think%20it%20succeeded%3F%22%2C%20%22created_at%22%3A%20%222016-05-24T09%3A14%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/801826%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aznair%22%7D%7D%2C%20%7B%22body%22%3A%20%22Oh.%20Argh%2C%20yes.%20Ok%2C%20i%20tested%20that%20the%20%60finally%60%20clause%20will%20still%20run%2C%20so%20yeah%2C%20%60exit%60%20should%20be%20fine.%22%2C%20%22created_at%22%3A%20%222016-05-24T09%3A16%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/integration/base_cli_srv.py%3AL254-261%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 75ccb64bf2235977cd48037149ff010438e77860 test/integration/base_cli_srv.py 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/734#discussion_r64354730'>File: test/integration/base_cli_srv.py:L254-261</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> A `return` is sufficient.
- <a href='https://github.com/aznair'><img border=0 src='https://avatars.githubusercontent.com/u/801826?v=3' height=16 width=16'></a> Wouldn't that make the integration test script think it succeeded?
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Oh. Argh, yes. Ok, i tested that the `finally` clause will still run, so yeah, `exit` should be fine.
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/734#issuecomment-221211343'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> Good catch :)

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/734?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/734?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/734'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
