### PR TITLE
Add --wait flag to sibra_ext_test

### DIFF
--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -64,7 +64,7 @@ test/integration/scmp_error_test.py
 Cert/TRC request
 test/integration/cert_req_test.py
 Sibra Ext
-test/integration/sibra_ext_test.py
+test/integration/sibra_ext_test.py --wait 30
 EOF
 result=$?
 

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -348,9 +348,9 @@ def _parse_locs(as_str, as_list):
     return copied
 
 
-def setup_main(name):
+def setup_main(name, parser=None):
     handle_signals()
-    parser = argparse.ArgumentParser()
+    parser = parser or argparse.ArgumentParser()
     parser.add_argument('-c', '--client', help='Client address')
     parser.add_argument('-s', '--server', help='Server address')
     parser.add_argument('-m', '--mininet', action='store_true',

--- a/test/integration/sibra_ext_test.py
+++ b/test/integration/sibra_ext_test.py
@@ -16,6 +16,7 @@
 ======================================================================
 """
 # Stdlib
+import argparse
 import logging
 import random
 import sys
@@ -196,8 +197,18 @@ class SIBRATest(TestClientServerBase):
                            port)
 
 
+def setup(name):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-w", "--wait", type=float, default=0.0,
+                        help="Time in seconds to wait before running")
+    return setup_main(name, parser=parser)
+
+
 def main():
-    args, srcs, dsts = setup_main("sibra_ext_test")
+    args, srcs, dsts = setup("sibra_ext_test")
+    if args.wait:
+        logging.info("Waiting %ss", args.wait)
+        time.sleep(args.wait)
     SIBRATest(args.client, args.server, srcs, dsts).run()
 
 


### PR DESCRIPTION
The sibra service (SB) waits 30s after startup before creating steady
paths, to ensure it has a selection of paths to choose from. The sibra
integration test however times out after 15s of looking for a path. This
change adds a --wait flag to sibra_ext_test, which is used by
docker/integration.sh, as in that context the infrastructure has only
just been started.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/736%23issuecomment-221511252%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/736%23issuecomment-221514356%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/736%23issuecomment-221511252%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222016-05-25T08%3A47%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-05-25T09%3A00%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/736#issuecomment-221511252'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/736?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/736?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/736'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
