### PR TITLE
Propagate all local down seg registrations via ZK

### DIFF
--- a/infrastructure/path_server/core.py
+++ b/infrastructure/path_server/core.py
@@ -102,7 +102,8 @@ class CorePathServer(PathServer):
         logging.error("Core Path Server received up-segment record!")
         return set()
 
-    def _handle_down_segment_record(self, pcb, from_master=False):
+    def _handle_down_segment_record(self, pcb, from_master=False,
+                                    from_zk=False):
         added = self._add_segment(pcb, self.down_segments, "Down")
         first_ia = pcb.get_first_pcbm().isd_as
         last_ia = pcb.get_last_pcbm().isd_as
@@ -110,10 +111,9 @@ class CorePathServer(PathServer):
             # Segment is to us, so propagate to all other core ASes within the
             # local ISD.
             self._segs_to_prop.append((PST.DOWN, pcb))
-        if (first_ia[0] == last_ia[0] == self.addr.isd_as[0] and not
-                from_master):
-            # Master gets a copy of all local segments.
-            self._segs_to_master.append((PST.DOWN, pcb))
+        if (first_ia[0] == last_ia[0] == self.addr.isd_as[0] and not from_zk):
+            # Sync all local down segs via zk
+            self._segs_to_zk.append((PST.DOWN, pcb))
         if added:
             return set([(last_ia, pcb.is_sibra())])
         return set()


### PR DESCRIPTION
This fixes an issue where if the master is the only one with the
registration, and it dies, then the registration is lost.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/737%23issuecomment-221528500%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/737%23issuecomment-221536168%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/737%23issuecomment-221542812%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/737%23issuecomment-221528500%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%5Cr%5Cn%40ercanucan%20-%20this%20should%20fix%20the%20problem%20seen%20in%20https%3A//circleci.com/gh/netsec-ethz/scion/2807%23artifacts%22%2C%20%22created_at%22%3A%20%222016-05-25T10%3A01%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%22%2C%20%22created_at%22%3A%20%222016-05-25T10%3A37%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22looks%20good%20to%20me%20too.%22%2C%20%22created_at%22%3A%20%222016-05-25T11%3A12%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7704593%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ercanucan%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/737#issuecomment-221528500'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
  @ercanucan - this should fix the problem seen in https://circleci.com/gh/netsec-ethz/scion/2807#artifacts
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm
- <a href='https://github.com/ercanucan'><img border=0 src='https://avatars.githubusercontent.com/u/7704593?v=3' height=16 width=16'></a> looks good to me too.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/737?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/737?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/737'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
