### PR TITLE
Increase how long tests wait for server thread.

### DIFF
--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -293,7 +293,7 @@ class TestClientServerBase(object):
         client.run()
         # If client is finished, server should finish within ~1s (due to recv
         # timeout). If it hasn't, then there was a problem.
-        s_thread.join(2.0)
+        s_thread.join(5.0)
         if s_thread.is_alive():
             logging.error("Timeout waiting for server thread to terminate")
             return False


### PR DESCRIPTION
Occasionally on circleci it takes longer than 1s to notice a thread has
exited, and with the existing socket timeout of 1s, it's possible for
this combined to exceed the current 2s join time. Increasing this to 5s
should cover all reasonable cases.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/746%23issuecomment-221907536%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/746%23issuecomment-221907536%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222016-05-26T15%3A35%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/746#issuecomment-221907536'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/746?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/746?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/746'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/746)

<!-- Reviewable:end -->
