### PR TITLE
Don't cleanup sockets in .stop()

### DIFF
--- a/infrastructure/scion_elem.py
+++ b/infrastructure/scion_elem.py
@@ -476,7 +476,6 @@ class SCIONElement(object):
         """
         # Signal that the thread should stop
         self.run_flag.clear()
-        self._socks.close()
         # Wait for the thread to finish
         self.stopped_flag.wait(5)
 


### PR DESCRIPTION
The cleanup is already handled by .run()

Fixes the reason for this failure: https://circleci.com/gh/netsec-ethz/scion/2852
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/749?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/749'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/749)

<!-- Reviewable:end -->
