### PR TITLE
Rename if2addr and make it more general.

### DIFF
--- a/endhost/sciond.py
+++ b/endhost/sciond.py
@@ -220,7 +220,10 @@ class SCIONDaemon(SCIONElement):
             fwd_if = path.get_fwd_if()
             # Set dummy host addr if path is empty.
             # TODO(PSz): remove dummy "0.0.0.0" address when API is saner
-            haddr = self.ifid2addr.get(fwd_if, haddr_parse("IPV4", "0.0.0.0"))
+            if fwd_if == 0:
+                haddr = haddr_parse("IPV4", "0.0.0.0")
+            else:
+                haddr = self.ifid2er[fwd_if].addr
             path_len = len(raw_path) // 8
             reply.append(struct.pack("!B", path_len) + raw_path +
                          haddr.pack() +

--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -130,7 +130,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         self.revs_to_downstream = ExpiringDict(max_len=1000, max_age_seconds=60)
 
         self.ifid_state = {}
-        for ifid in self.ifid2addr:
+        for ifid in self.ifid2er:
             self.ifid_state[ifid] = InterfaceState()
 
         self.CTRL_PLD_CLASS_MAP = {

--- a/infrastructure/beacon_server/local.py
+++ b/infrastructure/beacon_server/local.py
@@ -92,11 +92,11 @@ class LocalBeaconServer(BeaconServer):
         pkt = self._build_packet(SVCType.PS, dst_ia=dst_ia, path=core_path,
                                  payload=records)
         fwd_if = core_path.get_fwd_if()
-        if fwd_if not in self.ifid2addr:
+        if fwd_if not in self.ifid2er:
             raise SCIONKeyError(
                 "Invalid IF %d in CorePath" % fwd_if)
 
-        next_hop = self.ifid2addr[fwd_if]
+        next_hop = self.ifid2er[fwd_if].addr
         self.send(pkt, next_hop)
 
     def register_segments(self):

--- a/infrastructure/path_server/base.py
+++ b/infrastructure/path_server/base.py
@@ -214,10 +214,10 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         :param if_id: The interface ID of the corresponding interface.
         :type if_id: int.
         """
-        if if_id not in self.ifid2addr:
-            logging.error("Interface ID %d not found in ifid2addr.", if_id)
+        if if_id not in self.ifid2er:
+            logging.error("Unknown Interface ID: %d", if_id)
             return
-        next_hop = self.ifid2addr[if_id]
+        next_hop = self.ifid2er[if_id].addr
         self.send(pkt, next_hop)
 
     def _send_path_segments(self, pkt, up=None, core=None, down=None):

--- a/infrastructure/router/main.py
+++ b/infrastructure/router/main.py
@@ -94,15 +94,6 @@ class Router(SCIONElement):
     """
     The SCION Router.
 
-    :ivar addr: the router address.
-    :type addr: :class:`SCIONAddr`
-    :ivar topology: the AS topology as seen by the router.
-    :type topology: :class:`Topology`
-    :ivar config: the configuration of the router.
-    :type config: :class:`Config`
-    :ivar dict ifid2addr:
-        a map from interface identifiers to the corresponding border router
-        addresses in the server's AS.
     :ivar interface: the router's inter-AS interface, if any.
     :type interface: :class:`lib.topology.InterfaceElement`
     """
@@ -571,7 +562,7 @@ class Router(SCIONElement):
             fwd_if = path.get_fwd_if()
             path_incd = False
         try:
-            if_addr = self.ifid2addr[fwd_if]
+            if_addr = self.ifid2er[fwd_if].addr
         except KeyError:
             # So that the error message will show the current state of the
             # packet.
@@ -653,7 +644,7 @@ class Router(SCIONElement):
             logging.error("Extension asked to forward this to interface 0:\n%s",
                           pkt)
             return
-        next_hop = self.ifid2addr[ifid]
+        next_hop = self.ifid2er[ifid].addr
         logging.debug("Packet forwarded by extension via %s", next_hop)
         self.send(pkt, next_hop)
 


### PR DESCRIPTION
Currently self.if2addr is a map of interface ID to router address. This
patch renames it to self.id_er, makes it instead a map from interface ID
to RouterElement. This allows much easier access to router attributes.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/752%23issuecomment-222647081%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/752%23issuecomment-222664023%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/752%23issuecomment-222647081%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222016-05-31T10%3A10%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%2C%20although%20IMO%20the%20previous%20one%20is%20more%20verbose%20and%20clear%22%2C%20%22created_at%22%3A%20%222016-05-31T11%3A39%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/752#issuecomment-222647081'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm, although IMO the previous one is more verbose and clear

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/752?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/752?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/752'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/752)

<!-- Reviewable:end -->

---

---
