### PR TITLE
Rewrite zkcleanslate to not require root

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -5,6 +5,7 @@ export PYTHONPATH=.
 # BEGIN subcommand functions
 
 cmd_topology() {
+    local zkclean
     if type -p supervisorctl &>/dev/null; then
         echo "Shutting down supervisord: $(supervisor/supervisor.sh shutdown)"
     fi
@@ -12,11 +13,15 @@ cmd_topology() {
     [ -e gen ] && rm -r gen
     if [ "$1" = "zkclean" ]; then
         shift
-        echo "Deleting all Zookeeper state"
-        tools/zkcleanslate
+        zkclean="y"
     fi
     echo "Create topology, configuration, and execution files."
     topology/generator.py "$@"
+    if [ -n "$zkclean" ]; then
+        echo "Deleting all Zookeeper state"
+        rm -rf /run/shm/scion-zk
+        tools/zkcleanslate --zk 127.0.0.1:2181
+    fi
 }
 
 cmd_run() {

--- a/tools/zkcleanslate
+++ b/tools/zkcleanslate
@@ -1,13 +1,57 @@
-#!/bin/bash
+#!/usr/bin/python3
 
-# This script deletes the various Zookeeper datastores. This is a nuclear
-# option, and should generally only be used when the topology has been
-# regenerated. Please do not run this routinely, as it will hide errors that we
-# should be handling properly.
+# Stdlib
+import argparse
+import glob
+import os
+import sys
 
-sudo /bin/true || exit 1  # Handle ctrl-c at sudo prompt
-sudo service zookeeper stop
-find /run/shm/*-zk/ -type f | sudo xargs -r rm -v
-rm -v gen/ISD*/AS*/zk*/data/version-2/*
-sudo rm -v /var/lib/zookeeper/version-2/*
-sudo service zookeeper start
+# External
+from kazoo.client import KazooClient
+from kazoo.exceptions import KazooException
+from kazoo.handlers.threading import KazooTimeoutError
+
+# SCION
+from lib.topology import Topology
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--zk", help="Zookeeper service to connect to (E.g. 127.0.0.1:2181)")
+    parser.add_argument('root', default="/", nargs="?",
+                        help="Zookeeper dir to clean. (Default: %(default)s)")
+    args = parser.parse_args()
+    if not args.zk and os.system("./supervisor/supervisor.sh quickstart *:zk*"):
+        sys.exit(1)
+    servers = [args.zk] if args.zk else set(find_servers())
+    for server in servers:
+        clean_zk(server, args.root)
+    if not args.zk:
+        sys.exit(os.system("./supervisor/supervisor.sh quickstop *:zk*"))
+
+
+def find_servers():
+    for as_dir in glob.glob("gen/ISD*/AS*"):
+        t = Topology.from_file(os.path.join(as_dir, "endhost", "topology.yml"))
+        for zk_host in t.zookeepers:
+            yield zk_host
+
+
+def clean_zk(server, root):
+    print("=====> Cleaning: %s:%s" % (server, root))
+    zk = KazooClient(hosts=server)
+    try:
+        zk.start(timeout=1)
+    except (KazooException, KazooTimeoutError):
+        return
+    for entries in zk.get_children(root):
+        path = os.path.join(root, entries)
+        if path.startswith("/zookeeper"):
+            continue
+        zk.delete(path, recursive=True)
+    zk.stop()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
It will also clean any remote configured ZK services.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/netsec-ethz/scion/pull/755%23issuecomment-223251802%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/755%23issuecomment-223339779%22%2C%20%22https%3A//github.com/netsec-ethz/scion/pull/755%23issuecomment-223512513%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/netsec-ethz/scion/pull/755%23issuecomment-223251802%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40pszalach%20%22%2C%20%22created_at%22%3A%20%222016-06-02T10%3A16%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%2C%20%7B%22body%22%3A%20%22lgtm%2C%20though%20don%27t%20understand%20why%20it%20is%20so%20complicated.%20Last%20time%20I%20had%20to%20clean%20ZK%20cache%20it%20was%20something%20like%20%60rm%20-rf%20/run/shm/%2A-zk/%2A%60.%22%2C%20%22created_at%22%3A%20%222016-06-02T16%3A06%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8159928%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pszalach%22%7D%7D%2C%20%7B%22body%22%3A%20%22You%20can%20see%20the%20old%20version%20of%20the%20file%20to%20see%20how%20it%20used%20to%20work.%20It%20requires%20root%20access%2C%20restarting%20any%20system%20zookeeper%2C%20and%20it%20won%27t%20work%20for%20any%20zookeepers%20that%20aren%27t%20on%20the%20local%20machine.%22%2C%20%22created_at%22%3A%20%222016-06-03T07%3A42%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6919822%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kormat%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/netsec-ethz/scion/pull/755#issuecomment-223251802'>General Comment</a></b>
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> @pszalach
- <a href='https://github.com/pszalach'><img border=0 src='https://avatars.githubusercontent.com/u/8159928?v=3' height=16 width=16'></a> lgtm, though don't understand why it is so complicated. Last time I had to clean ZK cache it was something like `rm -rf /run/shm/*-zk/*`.
- <a href='https://github.com/kormat'><img border=0 src='https://avatars.githubusercontent.com/u/6919822?v=3' height=16 width=16'></a> You can see the old version of the file to see how it used to work. It requires root access, restarting any system zookeeper, and it won't work for any zookeepers that aren't on the local machine.

<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/755?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/netsec-ethz/scion/pull/755?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/netsec-ethz/scion/pull/755'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/755)

<!-- Reviewable:end -->

---

---

---
