### PR TITLE
Make docker/integration_test even quieter.

### DIFF
--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -56,17 +56,17 @@ sleep 5
 
 cat << EOF | parallel -n2 -j0 run
 End2End
-test/integration/end2end_test.py
+test/integration/end2end_test.py -l ERROR
 C2S_extn
-test/integration/cli_srv_ext_test.py
+test/integration/cli_srv_ext_test.py -l ERROR
 SCMP error
-test/integration/scmp_error_test.py --runs 60
+test/integration/scmp_error_test.py -l ERROR --runs 60
 Cert/TRC request
-test/integration/cert_req_test.py
+test/integration/cert_req_test.py -l ERROR
 Sibra Ext
-test/integration/sibra_ext_test.py --wait 30 --runs 10
+test/integration/sibra_ext_test.py -l ERROR --wait 30 --runs 10
 SSP
-test/integration/ssp_test.py
+test/integration/ssp_test.py -l ERROR
 EOF
 result=$?
 

--- a/test/integration/base_cli_srv.py
+++ b/test/integration/base_cli_srv.py
@@ -275,6 +275,8 @@ class TestClientServerBase(object):
                 break
             src = SCIONAddr.from_values(src_ia, self.client_ip)
             dst = SCIONAddr.from_values(dst_ia, self.server_ip)
+            t = threading.current_thread()
+            t.name = "%s %s > %s main" % (self.NAME, src_ia, dst_ia)
             if not self._run_test(src, dst):
                 sys.exit(1)
 
@@ -289,7 +291,7 @@ class TestClientServerBase(object):
         data = self._create_data(src, dst)
         server = self._create_server(data, finished, dst)
         client = self._create_client(data, finished, src, dst, server.sock.port)
-        server_name = "Server %s" % dst.isd_as
+        server_name = "%s %s > %s server" % (self.NAME, src.isd_as, dst.isd_as)
         s_thread = threading.Thread(
             target=thread_safety_net, args=(server.run,), name=server_name,
             daemon=True)
@@ -367,6 +369,8 @@ def _parse_locs(as_str, as_list):
 def setup_main(name, parser=None):
     handle_signals()
     parser = parser or argparse.ArgumentParser()
+    parser.add_argument('-l', '--loglevel', default="INFO",
+                        help='Console logging level (Default: %(default)s)')
     parser.add_argument('-c', '--client', help='Client address')
     parser.add_argument('-s', '--server', help='Server address')
     parser.add_argument('-m', '--mininet', action='store_true',
@@ -378,7 +382,7 @@ def setup_main(name, parser=None):
     parser.add_argument('src_ia', nargs='?', help='Src isd-as')
     parser.add_argument('dst_ia', nargs='?', help='Dst isd-as')
     args = parser.parse_args()
-    init_logging("logs/%s" % name, console_level=logging.INFO)
+    init_logging("logs/%s" % name, console_level=args.loglevel)
 
     if not args.client:
         args.client = "169.254.0.2" if args.mininet else "127.0.0.2"


### PR DESCRIPTION
Looking at a failure on circleci's web interface is quite painful due to
the many hundres of lines that are output by the integration_test script
currently. This changes the console logging level to ERROR, and sets the
thread names to indicate the current test.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/765)

<!-- Reviewable:end -->
