### PR TITLE
Make building c code via scion.sh quiet.

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -73,14 +73,14 @@ cmd_version() {
 
 cmd_build() {
     if [ "$1" == "bypass" ]; then
-        USER_OPTS=-DBYPASS_ROUTERS make all install
+        USER_OPTS=-DBYPASS_ROUTERS make -s all install
     else
-        make all install
+        make -s all install
     fi
 }
 
 cmd_clean() {
-    make clean
+    make -s clean
 }
 
 SOCKDIR=endhost/ssp


### PR DESCRIPTION
This removes 52 lines from the output of docker/integration_test.sh
If there are errors, you might not have enough context, in which case
running 'make all' by hand will give you the noisy output again.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/766)

<!-- Reviewable:end -->
