### PR TITLE
Minor post-capnp cleanups.

### DIFF
--- a/infrastructure/sibra_server/steady.py
+++ b/infrastructure/sibra_server/steady.py
@@ -225,7 +225,7 @@ class SteadyPath(object):
         """
         dest = SCIONAddr.from_values(self.remote, SVCType.SB)
         cmn_hdr, addr_hdr = build_base_hdrs(self.addr, dest)
-        payload = SIBRAPayload()
+        payload = SIBRAPayload.from_values()
         udp_hdr = SCIONUDPHeader.from_values(
             self.addr, SCION_UDP_PORT, dest, SCION_UDP_PORT)
         return cmn_hdr, addr_hdr, udp_hdr, payload

--- a/lib/packet/packet_base.py
+++ b/lib/packet/packet_base.py
@@ -20,7 +20,6 @@ import struct
 from abc import ABCMeta, abstractmethod
 
 # SCION
-from lib.types import PayloadClass
 from lib.util import hex_str
 
 
@@ -202,7 +201,7 @@ class PayloadRaw(PayloadBase):  # pragma: no cover
         return s
 
 
-class SCIONPayloadBase(PayloadBase):  # pragma: no cover
+class SCIONPayloadBaseProto(Cerealizable):  # pragma: no cover
     """
     All child classes must define two attributes:
         PAYLOAD_CLASS: Global payload class, defined by PayloadClass.
@@ -212,23 +211,8 @@ class SCIONPayloadBase(PayloadBase):  # pragma: no cover
     # 1B each for payload class and type.
     METADATA_LEN = 2
 
-    def pack_meta(self):
-        return struct.pack("!BB", self.PAYLOAD_CLASS, self.PAYLOAD_TYPE)
-
-
-class SCIONPayloadBaseProto(Cerealizable):  # pragma: no cover
-    """
-    Equivelant to SCIONPayloadBase, but using capnp serialization.
-    """
-    METADATA_LEN = 2
-
     def pack_full(self):
         return self.pack_meta() + self.pack()
 
     def pack_meta(self):
         return struct.pack("!BB", self.PAYLOAD_CLASS, self.PAYLOAD_TYPE)
-
-
-class PathMgmtPayloadBase(SCIONPayloadBase):
-    PAYLOAD_CLASS = PayloadClass.PATH
-    PAYLOAD_TYPE = None

--- a/lib/sibra/payload.py
+++ b/lib/sibra/payload.py
@@ -15,37 +15,28 @@
 :mod:`payload` --- SIBRA payload
 ================================
 """
-# Stdlib
+# External
+import capnp  # noqa
 
 # SCION
+import proto.sibra_capnp as P
 from lib.errors import SCIONParseError
-from lib.packet.packet_base import SCIONPayloadBase
+from lib.packet.packet_base import SCIONPayloadBaseProto
 from lib.types import PayloadClass, SIBRAPayloadType
 
 
-class SIBRAPayload(SCIONPayloadBase):  # pragma: no cover
+class SIBRAPayload(SCIONPayloadBaseProto):  # pragma: no cover
     """
     An empty payload to allow for packet dispatching.
     """
     NAME = "SIBRAPayload"
+    P_CLS = P.SibraPayload
     PAYLOAD_CLASS = PayloadClass.SIBRA
     PAYLOAD_TYPE = SIBRAPayloadType.EMPTY
 
-    def _parse(self, raw):
-        pass
-
     @classmethod
     def from_values(cls):
-        return cls()
-
-    def pack(self):
-        return b""
-
-    def __len__(self):
-        return 0
-
-    def __str__(self):
-        return "<Empty SIBRA payload>"
+        return cls(cls.P_CLS.new_message())
 
 
 def parse_sibra_payload(type_, data):  # pragma: no cover
@@ -55,4 +46,4 @@ def parse_sibra_payload(type_, data):  # pragma: no cover
     if type_ not in type_map:
         raise SCIONParseError("Unsupported sibra payload type: %s", type_)
     handler = type_map[type_]
-    return handler(data.pop())
+    return handler.from_raw(data.pop())

--- a/proto/sibra.capnp
+++ b/proto/sibra.capnp
@@ -6,3 +6,6 @@ struct SibraPCBExt {
     up @2 :Bool;
     sofs @3 :List(Data);
 }
+
+struct SibraPayload {
+}


### PR DESCRIPTION
- Remove the unused SCIONPayloadBase and PathMgmtPayloadBase classes.
- Convert SIBRAPayload to SCIONPayloadBaseProto

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/767)

<!-- Reviewable:end -->
