### PR TITLE
AS marking uses internal side of interface.

### DIFF
--- a/infrastructure/beacon_server/base.py
+++ b/infrastructure/beacon_server/base.py
@@ -220,7 +220,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
             return d
         er = self.ifid2er[if_id]
         d["remote_ia"] = er.interface.isd_as
-        d["remote_if"] = er.interface.to_if_id
+        d["remote_if"] = er.interface.if_id
         d["mtu"] = er.interface.mtu
         return d
 


### PR DESCRIPTION
_mk_if_info was using the remote side of the interface. It showed in incorrect interface lists being constructed for the path.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/782)

<!-- Reviewable:end -->
