### PR TITLE
Execute zk_datalog_dirs.sh only if it exists.

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -30,7 +30,9 @@ cmd_run() {
         cmd_build || exit 1
     fi
     echo "Running the network..."
-    bash gen/zk_datalog_dirs.sh || exit 1
+    if [ -e gen/zk_datalog_dirs.sh ]; then
+        bash gen/zk_datalog_dirs.sh || exit 1
+    fi
     supervisor/supervisor.sh quickstart all
 }
 


### PR DESCRIPTION
zk_datalog_dirs.sh is not needed in SCION deployments.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/783)

<!-- Reviewable:end -->
