### PR TITLE
Replace sock_ser and sock_cli with run_sciond and parameterize.

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -126,9 +126,9 @@ cmd_help() {
 	        other arguments or options are passed to topology/generator.py
 	    $PROGRAM run
 	        Run network.
-        $PROGRAM sciond ISD AS [ADDR]
-            Start sciond with provided ISD and AS parameters. A third optional
-            parameter is the address to bind when not running on localhost.
+	    $PROGRAM sciond ISD AS [ADDR]
+	        Start sciond with provided ISD and AS parameters. A third optional
+	        parameter is the address to bind when not running on localhost.
 	    $PROGRAM stop
 	        Terminate this run of the SCION infrastructure.
 	    $PROGRAM status


### PR DESCRIPTION
This was we can easily start sciond on deployment machines, by simply
providing command line arguments.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/794)

<!-- Reviewable:end -->
