### PR TITLE
Fix master detection in cPSes.

### DIFF
--- a/docker/integration_test.sh
+++ b/docker/integration_test.sh
@@ -27,7 +27,6 @@ shutdown() {
     log "Stopping scion"
     ./scion.sh stop | grep -v "STOPPED"
     log "Scion stopped"
-    exit $result
 }
 
 run() {
@@ -72,4 +71,9 @@ result=$?
 
 shutdown
 
-return $result
+if [ $result -eq 0 ]; then
+    log "All tests successful"
+else
+    log "$result tests failed"
+fi
+exit $result

--- a/infrastructure/path_server/core.py
+++ b/infrastructure/path_server/core.py
@@ -52,28 +52,30 @@ class CorePathServer(PathServer):
         Read master's address from shared lock, and if new master is elected
         sync it with segments.
         """
+        if self.zk.have_lock():
+            self._segs_to_master.clear()
+            return
         try:
             curr_master = self.zk.get_lock_holder()
         except ZkNoConnection:
             logging.warning("_update_master(): ZkNoConnection.")
             return
+        if curr_master and curr_master == self._master_id:
+            return
+        self._master_id = curr_master
         if not curr_master:
             logging.warning("_update_master(): current master is None.")
             return
-        if not self._master_id or curr_master != self._master_id:
-            self._master_id = curr_master
-            logging.debug("New master is: %s", self._master_id)
-            self._sync_master()
+        logging.debug("New master is: %s", self._master_id)
+        self._sync_master()
 
     def _sync_master(self):
         """
         Feed newly-elected master with segments.
         """
+        assert not self.zk.have_lock()
+        assert self._master_id
         # TODO(PSz): consider mechanism for avoiding a registration storm.
-        master = self._master_id
-        if (not master or self._is_master()) and not self._quiet_startup():
-            logging.warning('Sync abandoned: master not set or I am a master')
-            return
         core_segs = []
         # Find all core segments from remote ISDs
         for pcb in self.core_segments(full=True):
@@ -81,7 +83,7 @@ class CorePathServer(PathServer):
                 core_segs.append(pcb)
         # Find down-segments from local ISD.
         down_segs = self.down_segments(full=True, last_isd=self.addr.isd_as[0])
-        logging.debug("Syncing with %s", master)
+        logging.debug("Syncing with %s", self._master_id)
         seen_ases = set()
         for seg_type, segs in [(PST.CORE, core_segs), (PST.DOWN, down_segs)]:
             for pcb in segs:
@@ -91,9 +93,6 @@ class CorePathServer(PathServer):
                     continue
                 seen_ases.add(key)
                 self._segs_to_master.append((seg_type, pcb))
-
-    def _is_master(self):
-        return self._master_id == self._zkid
 
     def _handle_up_segment_record(self, pcb, **kwargs):
         logging.error("Core Path Server received up-segment record!")
@@ -128,7 +127,7 @@ class CorePathServer(PathServer):
             if first_ia[0] == self.addr.isd_as[0]:
                 # Local core segment, share via ZK
                 self._segs_to_zk.append((PST.CORE, pcb))
-            elif self._master_id:
+            else:
                 # Remote core segment, send to master
                 self._segs_to_master.append((PST.CORE, pcb))
         if not added:
@@ -152,10 +151,13 @@ class CorePathServer(PathServer):
 
     def _propagate_and_sync(self):
         super()._propagate_and_sync()
-        self._prop_to_core()
-        self._prop_to_master()
+        if self.zk.have_lock():
+            self._prop_to_core()
+        else:
+            self._prop_to_master()
 
     def _prop_to_core(self):
+        assert self.zk.have_lock()
         if not self._segs_to_prop:
             return
         logging.info("Propagating %d segment(s) to other core ASes",
@@ -164,13 +166,14 @@ class CorePathServer(PathServer):
             self._propagate_to_core_ases(PathRecordsReply.from_values(pcbs))
 
     def _prop_to_master(self):
-        if self._is_master():
+        assert not self.zk.have_lock()
+        if not self._master_id:
             self._segs_to_master.clear()
             return
         if not self._segs_to_master:
             return
-        logging.info("Propagating %d segment(s) to master PS",
-                     len(self._segs_to_master))
+        logging.info("Propagating %d segment(s) to master PS: %s",
+                     len(self._segs_to_master), self._master_id)
         for pcbs in self._gen_prop_recs(self._segs_to_master):
             self._send_to_master(PathRecordsReply.from_values(pcbs))
 
@@ -178,12 +181,18 @@ class CorePathServer(PathServer):
         """
         Send the payload to the master PS.
         """
-        if self._is_master():
+        # XXX(kormat): Both of these should be very rare, as they are guarded
+        # against in the two methods that call this one (_prop_to_master() and
+        # _query_master(), but a race-condition could cause this to happen when
+        # called from _query_master().
+        if self.zk.have_lock():
+            logging.warning("send_to_master: abandoning as we are master")
             return
-        if not self._master_id:
-            logging.warning("_send_to_master(): _master_id not set.")
+        master = self._master_id
+        if not master:
+            logging.warning("send_to_master: abandoning as there is no master")
             return
-        addr, port = self._master_id.addr(0)
+        addr, port = master.addr(0)
         pkt = self._build_packet(addr, dst_port=port, payload=pld.copy())
         self.send(pkt, addr, SCION_UDP_EH_DATA_PORT)
 
@@ -191,11 +200,9 @@ class CorePathServer(PathServer):
         """
         Query master for a segment.
         """
-        if self._is_master():
-            logging.debug("I'm master, query abandoned.")
+        if self.zk.have_lock() or not self._master_id:
             return
-        if src_ia is None:
-            src_ia = self.addr.isd_as
+        src_ia = src_ia or self.addr.isd_as
         req = PathSegmentReq.from_values(src_ia, dst_ia, flags=flags)
         logging.debug("Asking master for segment: %s" % req.short_desc())
         self._send_to_master(req)

--- a/lib/zk/id.py
+++ b/lib/zk/id.py
@@ -51,6 +51,11 @@ class ZkID(Cerealizable):  # pragma: no cover
         for i in range(start, len(self.p.addrs)):
             yield self.addr(i)
 
+    def __eq__(self, other):
+        # XXX(kormat): comparing capnp objects always fails if they contain
+        # lists, even if the list contents are the same :(
+        return str(self) == str(other)
+
     def __str__(self):
         s = []
         for a, p in self.iter_addrs():


### PR DESCRIPTION
- The default ZkID comparison method fails on the list of addresses,
  even if the contents are identical, so for now switch to comparing
  string representations which are consistent.
- Use the zookeeper lock to determine if a cPS is already master.
- Make it clearer that only the master cPS propagates to other core
  ASes.
- Add assertions to make clear the expected state in various methods,
  and improved logging.
- Add handling for a possible but rare race-condition in _send_to_master

Also:
- explicitly print success/failure at the end of
  docker/integration_test.sh

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/809)

<!-- Reviewable:end -->
