### PR TITLE
Try to protect against a race-condition in kazoo

### DIFF
--- a/lib/zk/zk.py
+++ b/lib/zk/zk.py
@@ -189,8 +189,12 @@ class Zookeeper(object):
     def _state_connected(self):
         """Handles the Kazoo 'connected' event."""
         # Might be first connection, or reconnecting after a problem.
+        clid = self.kazoo.client_id
+        if clid is None:
+            # Protect against a race-condition.
+            return
         logging.debug("Connection to Zookeeper succeeded (Session: %s)",
-                      hex(self.kazoo.client_id[0]))
+                      hex(clid[0]))
         try:
             self.ensure_path(self.prefix, abs=True)
             # Use a copy of the dictionary values, as the dictioary is changed

--- a/test/lib/zk/zk_test.py
+++ b/test/lib/zk/zk_test.py
@@ -299,6 +299,15 @@ class TestZookeeperStateConnected(BaseZookeeper):
         # Tests
         inst._on_connect.assert_called_once_with()
 
+    @patch("lib.zk.zk.Zookeeper.__init__", autospec=True, return_value=None)
+    def test_conn_flap(self, init):
+        inst = self._setup()
+        inst.kazoo.client_id = None
+        # Call
+        inst._state_connected()
+        # Tests
+        ntools.assert_false(inst.ensure_path.called)
+
 
 class TestZookeeperStateDisconnected(BaseZookeeper):
     """


### PR DESCRIPTION
If the connection to zookeeper is very flakey, it seems like it's
possible for kazoo to report a state change to CONNECTED, but then lose
the connection before the handler actually runs, causing the code to
crash with "TypeError: 'NoneType' object is not subscriptable" when
trying to print the session id.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/811)

<!-- Reviewable:end -->
