### PR TITLE
Use base class _get_paths for MPUDP test

### DIFF
--- a/test/integration/mpudp_test.py
+++ b/test/integration/mpudp_test.py
@@ -50,10 +50,6 @@ class MPUDPClient(TestClientBase):
         sock.settimeout(self._timeout)
         return sock
 
-    def _get_path(self, api):
-        # Libssock takes care of this internally
-        pass
-
     def _recv(self):
         return self.sock.recvfrom(DATA_LEN)[0]
 


### PR DESCRIPTION
To avoid test failure due to path query timeout in case of slow startup

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/821)

<!-- Reviewable:end -->
