### PR TITLE
Fix hard-coded 64bit assumption in middleware.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 SRC_DIRS = lib/libscion lib/libfilter endhost/ssp sub/lwip-contrib lib/tcp endhost
 
-all: go clibs dispatcher
+all: clibs dispatcher go
 
 clean:
 	$(foreach var,$(SRC_DIRS),$(MAKE) -C $(var) clean || exit 1;)

--- a/lib/tcp/middleware.c
+++ b/lib/tcp/middleware.c
@@ -424,12 +424,12 @@ void tcpmw_send(struct conn_args *args, char *buf, int len){
         lwip_err = netconn_write_partly(args->conn, buf + sent, len - sent, NETCONN_COPY, &tmp_sent);
         if (lwip_err != ERR_OK){
             zlog_error(zc_tcp, "tcpmw_send(): netconn_write(): %s", lwip_strerr(lwip_err));
-            zlog_debug(zc_tcp, "netconn_write(): total_sent/tmp_sent/total_len: %lu/%lu/%d",
+            zlog_debug(zc_tcp, "netconn_write(): total_sent/tmp_sent/total_len: %zu/%zu/%d",
                        sent, tmp_sent, len);
             goto exit;
         }
         sent += tmp_sent;
-        zlog_debug(zc_tcp, "netconn_write(): total_sent/tmp_sent/total_len: %lu/%lu/%d",
+        zlog_debug(zc_tcp, "netconn_write(): total_sent/tmp_sent/total_len: %zu/%zu/%d",
                    sent, tmp_sent, len);
     }
 


### PR DESCRIPTION
Also move the go target after clibs in the top-level makefile, as go
code can link against the c libraries.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/834)

<!-- Reviewable:end -->
