### PR TITLE
Re-work the calculation of HopField MACs

### DIFF
--- a/lib/packet/opaque_field.py
+++ b/lib/packet/opaque_field.py
@@ -121,8 +121,9 @@ class HopOpaqueField(OpaqueField):
         raw += self.pack(mac=True)
         if prev_hof:
             raw += prev_hof.pack()[1:]  # Ignore flag byte
-        to_mac = bytes(raw.zfill(self.MAC_BLOCK_LEN))
-        return cbcmac(key, to_mac)[:self.MAC_LEN]
+        else:
+            raw += bytes(self.LEN-1)
+        return cbcmac(key, bytes(raw))[:self.MAC_LEN]
 
     def verify_mac(self, *args, **kwargs):  # pragma: no cover
         return self.mac == self.calc_mac(*args, **kwargs)


### PR DESCRIPTION
Changes:
- Re-order the input data, so that all the mandatory data is at the
  start, for easier computation.
- Ignore the flag field of the previous HopF, bringing the input data
  down to a single 16B AES block (instead of 17B of data and 15B of
  padding previously).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/846)

<!-- Reviewable:end -->
