### PR TITLE
Change repository URL to git-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Necessary steps in order to run SCION:
    ```
    mkdir -p "$GOPATH/src/github.com/netsec-ethz"
    cd "$GOPATH/src/github.com/netsec-ethz"
-   git clone --recursive https://github.com/netsec-ethz/scion
+   git clone --recursive git@github.com:netsec-ethz/scion
    cd scion
    ```
 


### PR DESCRIPTION
Since our submodules need to be checked out by CircleCI, which in turn
can't handle https://-referenced submodules (and you can't mix access
methods in git), we need to specify the git-scheme for our own
repository, too.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/857)

<!-- Reviewable:end -->
