### PR TITLE
Various generator/logging fixes

### DIFF
--- a/endhost/dispatcher.c
+++ b/endhost/dispatcher.c
@@ -157,8 +157,11 @@ int main(int argc, char **argv)
 
     setenv("TZ", "UTC", 1);
 
-    if (zlog_init("endhost/dispatcher.conf") < 0) {
-        fprintf(stderr, "failed to init zlog\n");
+    char *zlog_cfg = getenv("ZLOG_CFG");
+    if (!zlog_cfg)
+        zlog_cfg = "endhost/dispatcher.conf";
+    if (zlog_init(zlog_cfg) < 0) {
+        fprintf(stderr, "failed to init zlog (cfg: %s)\n", zlog_cfg);
         return -1;
     }
     zc = zlog_get_category("dispatcher");

--- a/topology/mininet/topology.py
+++ b/topology/mininet/topology.py
@@ -95,13 +95,8 @@ class ScionTopo(Topo):
         key = tuple(self.sorted([node1, node2]))
         # Map the supplied params to the node1 interface, even if sorting turns
         # it into the second interface.
-        opts = {"port1": port1, "port2": port2}
-        if key[0] == node1:
-            opts.update(params1=params, intfName1=intfName,
-                        node1=node1, node2=node2)
-        else:
-            opts.update(params2=params, intfName2=intfName,
-                        node1=node2, node2=node1)
+        opts = {"port1": port1, "port2": port2, "params1": params,
+                "intfName1": intfName, "node1": node1, "node2": node2}
         self.g.add_edge(node1, node2, key, opts)
         return key
 

--- a/topology/zlog.tmpl
+++ b/topology/zlog.tmpl
@@ -1,0 +1,11 @@
+[global]
+default format = "%d(%F %T).%us%d(%z) [%V] (%p:%c:%F:%L) %m%n"
+file perms = 644
+
+[rules]
+default.* >stdout
+${name}.DEBUG "logs/${elem}.zlog.DEBUG", 10MB*2
+${name}.INFO "logs/${elem}.zlog.INFO", 10MB*2
+${name}.WARN "logs/${elem}.zlog.WARNING", 10MB*2
+${name}.ERROR "logs/${elem}.zlog.ERROR", 10MB*2
+${name}.FATAL "logs/${elem}.zlog.CRITICAL", 10MB*2


### PR DESCRIPTION
- Output plain IPs (rather than IP/Netmask) as addresses in topology.
- Generate zlog configs for every element, including dispatchers run as
  part of mininet.
- Fix mininet on the full topo on 16.04.
- Export DISPATCHER_ID appropriately for mininet.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/886)

<!-- Reviewable:end -->
