### PR TITLE
Stop supervisor hogging a cpu.

### DIFF
--- a/topology/generator.py
+++ b/topology/generator.py
@@ -626,19 +626,22 @@ class SupervisorGenerator(object):
         entry = {
             'autostart': 'false' if self.mininet else 'false',
             'autorestart': 'false',
-            'redirect_stderr': 'true',
             'environment': 'PYTHONPATH=.,ZLOG_CFG="%s"' % zlog,
-            'stdout_logfile_maxbytes': 0,
-            'stdout_logfile': "logs/%s.OUT" % name,
+            'stdout_logfile': "NONE",
+            'stderr_logfile': "NONE",
             'startretries': 0,
             'startsecs': 5,
-            'command': " ".join(['"%s"' % arg for arg in cmd_args]),
+            'command': self._mk_cmd(name, cmd_args),
         }
         if name == "dispatcher":
             entry['startsecs'] = 1
         if self.mininet:
             entry['autostart'] = 'true'
         return entry
+
+    def _mk_cmd(self, name, cmd_args):
+        return "bash -c 'exec %s &>logs/%s.OUT'" % (
+            " ".join(['"%s"' % arg for arg in cmd_args]), name)
 
 
 class ZKConfGenerator(object):


### PR DESCRIPTION
Supervisor spends 100% of its time constantly polling the hundreds of
FDs it has open, including checking if random log FDs are writeable.
Despite not having anything to write, supervisor does this in
effectively an infinite loop. By moving the stdout/err redirection to
the command itself, we can avoid using that code at all.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion/892)

<!-- Reviewable:end -->
