### PR TITLE
Go add 'Core' to topology

### DIFF
--- a/go/lib/topology/doc.go
+++ b/go/lib/topology/doc.go
@@ -29,6 +29,7 @@ type Topo struct {
     ISD_AS         *addr.ISD_AS
     Overlay        overlay.Type
     MTU            int
+    Core           bool
 
     BR             map[string]BRInfo
     BRNames        []string

--- a/go/lib/topology/raw.go
+++ b/go/lib/topology/raw.go
@@ -43,6 +43,7 @@ type RawTopo struct {
 	ISD_AS             string
 	Overlay            string
 	MTU                int
+	Core               bool
 	BorderRouters      map[string]RawBRInfo   `json:",omitempty"`
 	ZookeeperService   map[int]RawAddrPort    `json:",omitempty"`
 	BeaconService      map[string]RawAddrInfo `json:",omitempty"`

--- a/go/lib/topology/testdata/basic.json
+++ b/go/lib/topology/testdata/basic.json
@@ -4,6 +4,7 @@
     "ISD_AS": "1-11",
     "MTU": 1472,
     "Overlay": "IPv4+6",
+    "Core": false,
     "BorderRouters": {
         "br1-11-1": {
             "InternalAddrs": [

--- a/go/lib/topology/testdata/core.json
+++ b/go/lib/topology/testdata/core.json
@@ -3,6 +3,7 @@
     "TimestampHuman": "May  6 00:00:00 CET 1975",
     "ISD_AS": "6-22",
     "MTU": 1472,
+    "Core": true,
     "Overlay": "IPv4+6",
     "BorderRouters": {
         "borderrouter6-22-1": {

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -35,6 +35,7 @@ type Topo struct {
 	ISD_AS         *addr.ISD_AS
 	Overlay        overlay.Type
 	MTU            int
+	Core           bool
 
 	BR      map[string]BRInfo
 	BRNames []string
@@ -107,6 +108,7 @@ func (t *Topo) populateMeta(raw *RawTopo) error {
 		return err
 	}
 	t.MTU = raw.MTU
+	t.Core = raw.Core
 	return nil
 }
 

--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -77,6 +77,8 @@ func Test_Meta(t *testing.T) {
 		SoMsg("Checking field 'ISD_AS'", c.ISD_AS, ShouldResemble, &addr.ISD_AS{I: 1, A: 11})
 		SoMsg("Checking field 'Overlay'", c.Overlay, ShouldEqual, overlay.IPv46)
 		SoMsg("Checking field 'MTU'", c.MTU, ShouldEqual, 1472)
+		SoMsg("Checking field 'Core'", c.Core, ShouldBeFalse)
+
 	})
 }
 


### PR DESCRIPTION
add field "Core" to topology in go implementation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1345)
<!-- Reviewable:end -->
