### PR TITLE
Add support for ReadBatch/WriteBatch socket operations.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
     build:
         docker:
-            - image: scionproto/scion_base@sha256:3d444b514bee38462a794996a1e8336c9ce69258af7e7ea8a3e2e1de7d8dd9df
+            - image: scionproto/scion_base@sha256:78c53b6a8554fdb5f4df048aa3df32741099b53a8ee3cc14ce76ce35bb59ebfe
         <<: *job
         steps:
             - checkout

--- a/go/border/io.go
+++ b/go/border/io.go
@@ -22,25 +22,34 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gavv/monotime"
 	log "github.com/inconshreveable/log15"
 
 	"github.com/scionproto/scion/go/border/metrics"
 	"github.com/scionproto/scion/go/border/rctx"
 	"github.com/scionproto/scion/go/border/rpkt"
+	"github.com/scionproto/scion/go/lib/assert"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/overlay/conn"
 	"github.com/scionproto/scion/go/lib/ringbuf"
+)
+
+const (
+	inputBufCnt       = 32
+	inputBatchCnt     = 1 // Must be <= inputBufCnt
+	defInputLowBufCnt = 4
+	outputBufCnt      = 32
+	outputBatchCnt    = 32 // Must be <= outputBufCnt
 )
 
 func (r *Router) posixInput(s *rctx.Sock, stop, stopped chan struct{}) {
 	defer liblog.LogPanicAndExit()
 	defer close(stopped)
 	dst := s.Conn.LocalAddr()
-	log.Debug("posixInput starting", "addr", dst)
-	pkts := make(ringbuf.EntryList, 32)
-	var length int
-	var cmeta *conn.ReadMeta
+	log.Info("posixInput starting", "addr", dst)
+	defer log.Info("posixInput stopping", "addr", dst)
+	pkts := make(ringbuf.EntryList, 0, inputBufCnt)
+	msgs := conn.NewReadMessages(inputBatchCnt)
+	readMetas := make([]conn.ReadMeta, inputBatchCnt)
 	var err error
 	var sock = s.Labels["sock"]
 
@@ -56,7 +65,7 @@ func (r *Router) posixInput(s *rctx.Sock, stop, stopped chan struct{}) {
 
 	// Called when the packet's reference count hits 0.
 	free := func(rp *rpkt.RtrPkt) {
-		procPktTime.Add(monotime.Since(rp.TimeIn).Seconds())
+		procPktTime.Add(time.Since(rp.TimeIn).Seconds())
 		rp.Reset()
 		r.freePkts.Write(ringbuf.EntryList{rp}, true)
 	}
@@ -65,72 +74,112 @@ Top:
 	for {
 		select {
 		case <-stop:
-			log.Debug("posixInput stopping", "addr", dst)
-			return
+			break Top
 		default:
 		}
-		n, _ := r.freePkts.Read(pkts, true)
-		for i := 0; i < n; i++ {
+		if len(pkts) < defInputLowBufCnt {
+			before := len(pkts)
+			pkts = pkts[:cap(pkts)]
+			// fetch fresh buffers to the end of pkts
+			n, _ := r.freePkts.Read(pkts[before:], true)
+			if n < 0 {
+				pkts = pkts[:before]
+				break
+			}
+			pkts = pkts[:before+n]
+		}
+		// setup msg references
+		for i := range pkts {
+			if i == inputBatchCnt {
+				break
+			}
 			rp := pkts[i].(*rpkt.RtrPkt)
-			rp.Ctx = rctx.Get() // Get current router context for this packet.
+			msgs[i].Buffers[0] = rp.Raw
+		}
+		inputReads.Inc()
+		toRead := len(pkts)
+		if toRead > inputBatchCnt {
+			toRead = inputBatchCnt
+		}
+		var pktsRead int
+		// Loop until a read succeeds, or a non-trivial error occurs
+		for {
+			pktsRead, _, err = s.Conn.ReadBatch(msgs[:toRead], readMetas[:toRead])
+			if err == nil {
+				break
+			}
+			if isConnRefused(err) {
+				// As we are using a connected UDP socket for interface
+				// sockets, any ECONNREFUSED errors that happen while
+				// sending to the neighbouring BR show up as read errors on
+				// the socket. As these do not indicate a problem with this BR,
+				// these errors should not be counted, and should not
+				// increment the read counter.
+				// TODO(kormat): consider having a conn refused error count
+				// for external interfaces.
+				continue
+			}
+			inputReadErrs.Inc()
+			log.Error("Error reading from socket", "socket", dst, "err", err)
+			// The most likely reason for errors is that the socket has
+			// been closed, so jump back to the top to see if the stop
+			// signal has been sent.
+			continue Top
+		}
+		inputPkts.Add(float64(pktsRead))
+		// Grab current router context to attach to this batch of packets.
+		ctx := rctx.Get()
+		if assert.On {
+			assert.Must(pktsRead > 0, "Pktsread must be non-zero")
+		}
+		// Loop over all read packets and set their metadata
+		for i := 0; i < pktsRead; i++ {
+			rp := pkts[i].(*rpkt.RtrPkt)
+			msg := msgs[i]
+			meta := readMetas[i]
+			rp.Ctx = ctx
 			rp.DirFrom = s.Dir
 			rp.Free = free // Set free callback.
-			inputReads.Inc()
-			for {
-				length, cmeta, err = s.Conn.Read(rp.Raw)
-				if err == nil {
-					break // No error, process packet.
-				}
-				if isConnRefused(err) {
-					// As we are using a connected UDP socket for interface
-					// sockets, any ECONNREFUSED errors that happen while
-					// sending to the neighbouring BR show up as read errors on
-					// the socket. As these do not indicate a problem with this BR,
-					// these errors should not be counted, and should not
-					// increment the read counter.
-					// TODO(kormat): consider having a conn refused error count
-					// for external interfaces.
-					continue
-				}
-				inputReadErrs.Inc()
-				log.Error("Error reading from socket", "socket", dst, "err", err)
-				// Release all unwritten buffers, including the current one:
-				for j := i; j < n; j++ {
-					rp := pkts[j].(*rpkt.RtrPkt)
-					free(rp)
-				}
-				// The most likely reason for errors is that the socket has
-				// been closed, so jump back to the top to see if the stop
-				// signal has been sent.
-				continue Top
+			if i == pktsRead-1 {
+				// Only bother setting the Guage once per ReadBatch. Use
+				// the last read as internally the kernel calls recvmsg
+				// multiple times, so it will have the latest value.
+				inputRcvOvfl.Set(float64(meta.RcvOvfl))
 			}
-			inputRcvOvfl.Set(float64(cmeta.RcvOvfl))
-			inputLatency.Add((cmeta.Read - cmeta.Recvd).Seconds())
-			rp.TimeIn = cmeta.Recvd
-			rp.Raw = rp.Raw[:length] // Set the length of the slice
+			inputLatency.Add(meta.ReadDelay.Seconds())
+			rp.TimeIn = meta.Recvd
+			rp.Raw = rp.Raw[:msg.N] // Set the length of the slice
 			rp.Ingress.Dst = dst
-			// Make a copy, as cmeta.Src will be overwritten by the next packet.
-			src := *cmeta.Src
+			// Make a copy, as meta.Src will be overwritten.
+			src := meta.Src
 			rp.Ingress.Src = &src
 			rp.Ingress.IfIDs = s.Ifids
 			rp.Ingress.LocIdx = s.LocIdx
 			rp.Ingress.Sock = sock
-			inputPkts.Inc()
-			inputBytes.Add(float64(length))
-			inputPktSize.Observe(float64(length))
-			s.Ring.Write(ringbuf.EntryList{pkts[i]}, true)
-			// Clear RtrPkt reference
-			pkts[i] = nil
+			inputBytes.Add(float64(msg.N))
+			inputPktSize.Observe(float64(msg.N))
 		}
+		for written := 0; written < pktsRead; {
+			wn, _ := s.Ring.Write(pkts[written:pktsRead], true)
+			written += wn
+		}
+		// Move unused pkts to the start.
+		copied := copy(pkts, pkts[pktsRead:])
+		pkts = pkts[:copied]
 	}
+	// Return any unused buffers.
+	r.freePkts.Write(pkts, true)
 }
 
 func (r *Router) posixOutput(s *rctx.Sock, _, stopped chan struct{}) {
 	defer liblog.LogPanicAndExit()
 	defer close(stopped)
 	src := s.Conn.LocalAddr()
+	dst := s.Conn.RemoteAddr()
 	log.Info("posixOutput starting", "addr", src)
-	epkts := make(ringbuf.EntryList, 32)
+	defer log.Info("posixOutput stopping", "addr", src)
+	epkts := make(ringbuf.EntryList, 0, outputBufCnt)
+	msgs := conn.NewWriteMessages(outputBatchCnt)
 
 	// Pre-calculate metrics
 	outputPkts := metrics.OutputPkts.With(s.Labels)
@@ -140,39 +189,70 @@ func (r *Router) posixOutput(s *rctx.Sock, _, stopped chan struct{}) {
 	outputWriteErrs := metrics.OutputWriteErrors.With(s.Labels)
 	outputWriteLatency := metrics.OutputWriteLatency.With(s.Labels)
 
-	var count int
 	var err error
-	var start time.Duration
+	var pktsWritten int
+	var bytes int
 	var t float64
 	for {
-		n, _ := s.Ring.Read(epkts, true)
-		if n < 0 {
-			log.Debug("posixOutput stopping", "addr", src)
-			return
+		if len(epkts) == 0 {
+			epkts = epkts[:cap(epkts)]
+			n, _ := s.Ring.Read(epkts, true)
+			if n < 0 {
+				break
+			}
+			epkts = epkts[:n]
 		}
-		for i := 0; i < n; i++ {
+		// setup msgs
+		for i := range epkts {
+			if i == outputBatchCnt {
+				break
+			}
 			erp := epkts[i].(*rpkt.EgressRtrPkt)
 			rp := erp.Rp
-			// This becomes meaningful when we can write multiple packets at once:
-			outputWrites.Add(1)
-			start = monotime.Now()
-			if count, err = s.Conn.WriteTo(rp.Raw, erp.Dst); err != nil {
-				outputWriteErrs.Inc()
-				rp.Error("Error sending packet", "err", err, "dst", erp.Dst)
-				goto End
+			msgs[i].Buffers[0] = rp.Raw
+			if dst == nil {
+				// Unconnected socket, use supplied address
+				uaddr := msgs[i].Addr.(*net.UDPAddr)
+				uaddr.IP = erp.Dst.IP
+				uaddr.Port = erp.Dst.OverlayPort
 			}
-			if count != len(rp.Raw) {
-				rp.Error("Unable to write full packet", "len", len(rp.Raw), "written", count)
+		}
+		toWrite := len(epkts)
+		if toWrite > outputBatchCnt {
+			toWrite = outputBatchCnt
+		}
+		start := time.Now()
+		if pktsWritten, err = s.Conn.WriteBatch(msgs[:toWrite]); err != nil {
+			outputWriteErrs.Inc()
+			log.Error("Error sending packet(s)", "src", src, "err", err)
+			goto End
+		}
+		t = time.Since(start).Seconds()
+		bytes = 0
+		for i := 0; i < pktsWritten; i++ {
+			rp := epkts[i].(*rpkt.EgressRtrPkt).Rp
+			msg := &msgs[i]
+			if msg.N != len(rp.Raw) {
+				rp.Error("Unable to write full packet", "len", len(rp.Raw), "written", msg.N)
 			}
-			t = monotime.Since(start).Seconds()
-			outputWriteLatency.Add(t)
-			outputPkts.Inc()
-			outputBytes.Add(float64(count))
-			outputPktSize.Observe(float64(count))
-		End:
+			bytes += msg.N
+			outputPktSize.Observe(float64(msg.N))
 			rp.Release()   // Release inner RtrPkt entry
 			epkts[i] = nil // Clear EgressRtrPkt reference
 		}
+		outputWriteLatency.Add(t)
+		outputPkts.Add(float64(pktsWritten))
+		outputBytes.Add(float64(bytes))
+		outputWrites.Inc()
+	End:
+		// Move unsent packets to the start.
+		copied := copy(epkts, epkts[pktsWritten:])
+		epkts = epkts[:copied]
+	}
+	// Release any unsent pkts.
+	for i := range epkts {
+		rp := epkts[i].(*rpkt.EgressRtrPkt).Rp
+		rp.Release()
 	}
 }
 

--- a/go/border/router.go
+++ b/go/border/router.go
@@ -35,6 +35,8 @@ import (
 	"github.com/scionproto/scion/go/lib/ringbuf"
 )
 
+const processBufCnt = 128
+
 var sighup chan os.Signal
 
 func init() {
@@ -102,7 +104,7 @@ func (r *Router) confSig() {
 func (r *Router) handleSock(s *rctx.Sock, stop, stopped chan struct{}) {
 	defer liblog.LogPanicAndExit()
 	defer close(stopped)
-	pkts := make(ringbuf.EntryList, 32)
+	pkts := make(ringbuf.EntryList, processBufCnt)
 	log.Debug("handleSock starting", "sock", *s)
 	for {
 		n, _ := s.Ring.Read(pkts, true)
@@ -125,7 +127,6 @@ func (r *Router) processPacket(rp *rpkt.RtrPkt) {
 	if assert.On {
 		assert.Must(len(rp.Raw) > 0, "Raw must not be empty")
 		assert.Must(rp.DirFrom != rcmn.DirUnset, "DirFrom must be set")
-		assert.Must(rp.TimeIn != 0, "TimeIn must be set")
 		assert.Must(rp.Ingress.Dst != nil, "Ingress.Dst must be set")
 		assert.Must(rp.Ingress.Src != nil, "Ingress.Src must be set")
 		assert.Must(len(rp.Ingress.IfIDs) > 0, "Ingress.IfIDs must not be empty")

--- a/go/border/rpkt/create.go
+++ b/go/border/rpkt/create.go
@@ -17,7 +17,8 @@
 package rpkt
 
 import (
-	"github.com/gavv/monotime"
+	"time"
+
 	log "github.com/inconshreveable/log15"
 	logext "github.com/inconshreveable/log15/ext"
 
@@ -35,7 +36,7 @@ func RtrPktFromScnPkt(sp *spkt.ScnPkt, dirTo rcmn.Dir, ctx *rctx.Ctx) (*RtrPkt, 
 	rp.Ctx = ctx
 	totalLen := sp.TotalLen()
 	hdrLen := sp.HdrLen() / common.LineLen
-	rp.TimeIn = monotime.Now()
+	rp.TimeIn = time.Now()
 	rp.Id = logext.RandId(4)
 	rp.Logger = log.New("rpkt", rp.Id)
 	rp.DirFrom = rcmn.DirSelf

--- a/go/lib/overlay/conn/conn.go
+++ b/go/lib/overlay/conn/conn.go
@@ -43,7 +43,7 @@ var sizeIgnore = flag.Bool("overlay.conn.sizeIgnore", true,
 
 type Conn interface {
 	Read(common.RawBytes) (int, *ReadMeta, error)
-	ReadBatch([]ipv4.Message, []ReadMeta) (int, *ReadMeta, error)
+	ReadBatch([]ipv4.Message, []ReadMeta) (int, error)
 	Write(common.RawBytes) (int, error)
 	WriteTo(common.RawBytes, *topology.AddrInfo) (int, error)
 	WriteBatch([]ipv4.Message) (int, error)
@@ -161,7 +161,9 @@ func (c *connUDPIPv4) Read(b common.RawBytes) (int, *ReadMeta, error) {
 	return n, &c.readMeta, err
 }
 
-func (c *connUDPIPv4) ReadBatch(msgs []ipv4.Message, metas []ReadMeta) (int, *ReadMeta, error) {
+// ReadBatch reads up to len(msgs) packets, and stores them in msgs, with their
+// corresponding ReadMeta in metas. It returns the number of packets read, and an error if any.
+func (c *connUDPIPv4) ReadBatch(msgs []ipv4.Message, metas []ReadMeta) (int, error) {
 	if assert.On {
 		assert.Must(len(msgs) == len(metas), "msgs and metas must be the same length")
 	}
@@ -179,7 +181,7 @@ func (c *connUDPIPv4) ReadBatch(msgs []ipv4.Message, metas []ReadMeta) (int, *Re
 		}
 		meta.SetSrc(c.Remote, msg.Addr.(*net.UDPAddr))
 	}
-	return n, nil, err
+	return n, err
 }
 
 func (c *connUDPIPv4) handleCmsg(oob common.RawBytes, meta *ReadMeta) {

--- a/go/lib/overlay/conn/conn.go
+++ b/go/lib/overlay/conn/conn.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build go1.9,linux
+
 package conn
 
 import (
@@ -22,9 +24,9 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/gavv/monotime"
 	log "github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/net/ipv4"
 
 	"github.com/scionproto/scion/go/lib/assert"
 	"github.com/scionproto/scion/go/lib/common"
@@ -35,13 +37,16 @@ import (
 
 const recvBufSize = 1 << 20
 
+var oobSize = syscall.CmsgSpace(SizeOfInt) + syscall.CmsgSpace(SizeOfTimespec)
 var sizeIgnore = flag.Bool("overlay.conn.sizeIgnore", true,
 	"Ignore failing to set the receive buffer size on a socket.")
 
 type Conn interface {
 	Read(common.RawBytes) (int, *ReadMeta, error)
+	ReadBatch([]ipv4.Message, []ReadMeta) (int, *ReadMeta, error)
 	Write(common.RawBytes) (int, error)
 	WriteTo(common.RawBytes, *topology.AddrInfo) (int, error)
+	WriteBatch([]ipv4.Message) (int, error)
 	LocalAddr() *topology.AddrInfo
 	RemoteAddr() *topology.AddrInfo
 	Close() error
@@ -84,6 +89,7 @@ func New(listen, remote *topology.AddrInfo, labels prometheus.Labels) (Conn, err
 
 type connUDPIPv4 struct {
 	conn      *net.UDPConn
+	pconn     *ipv4.PacketConn
 	Listen    *topology.AddrInfo
 	Remote    *topology.AddrInfo
 	oob       common.RawBytes
@@ -129,6 +135,7 @@ func newConnUDPIPv4(c *net.UDPConn, listen, remote *topology.AddrInfo,
 	oob := make(common.RawBytes, syscall.CmsgSpace(SizeOfInt)+syscall.CmsgSpace(SizeOfTimespec))
 	return &connUDPIPv4{
 		conn:      c,
+		pconn:     ipv4.NewPacketConn(c),
 		Listen:    listen,
 		Remote:    remote,
 		oob:       oob,
@@ -138,31 +145,46 @@ func newConnUDPIPv4(c *net.UDPConn, listen, remote *topology.AddrInfo,
 }
 
 func (c *connUDPIPv4) Read(b common.RawBytes) (int, *ReadMeta, error) {
-	c.readMeta.Src = nil
-	c.readMeta.RcvOvfl = 0
-	c.readMeta.Recvd = 0
-	c.readMeta.Read = 0
+	c.readMeta.Reset()
 	n, oobn, _, src, err := c.conn.ReadMsgUDP(b, c.oob)
-	c.readMeta.Read = monotime.Now()
+	c.readMeta.read = time.Now()
 	if oobn > 0 {
-		c.handleCmsg(c.oob[:oobn])
+		c.handleCmsg(c.oob[:oobn], &c.readMeta)
 	}
-	if c.readMeta.Recvd == 0 {
-		c.readMeta.Recvd = c.readMeta.Read
-	}
-	c.readMeta.Src = c.Remote
-	if c.Remote == nil {
-		c.tmpRemote.IP = src.IP
-		c.tmpRemote.L4Port = src.Port
-		c.readMeta.Src = &c.tmpRemote
+	if c.Remote != nil {
+		c.readMeta.Src.IP = c.Remote.IP
+		c.readMeta.Src.L4Port = c.Remote.L4Port
+	} else {
+		c.readMeta.Src.IP = src.IP
+		c.readMeta.Src.L4Port = src.Port
 	}
 	return n, &c.readMeta, err
 }
 
-func (c *connUDPIPv4) handleCmsg(oob common.RawBytes) {
+func (c *connUDPIPv4) ReadBatch(msgs []ipv4.Message, metas []ReadMeta) (int, *ReadMeta, error) {
+	if assert.On {
+		assert.Must(len(msgs) == len(metas), "msgs and metas must be the same length")
+	}
+	for i := range metas {
+		metas[i].Reset()
+	}
+	n, err := c.pconn.ReadBatch(msgs, syscall.MSG_WAITFORONE)
+	readTime := time.Now()
+	for i := 0; i < n; i++ {
+		msg := msgs[i]
+		meta := &metas[i]
+		meta.read = readTime
+		if msg.NN > 0 {
+			c.handleCmsg(msg.OOB[:msg.NN], meta)
+		}
+		meta.SetSrc(c.Remote, msg.Addr.(*net.UDPAddr))
+	}
+	return n, nil, err
+}
+
+func (c *connUDPIPv4) handleCmsg(oob common.RawBytes, meta *ReadMeta) {
 	// Based on https://github.com/golang/go/blob/release-branch.go1.8/src/syscall/sockcmsg_unix.go#L49
 	// and modified to remove most allocations.
-	now := time.Now()
 	sizeofCmsgHdr := syscall.CmsgLen(0)
 	for sizeofCmsgHdr <= len(oob) {
 		hdr := (*syscall.Cmsghdr)(unsafe.Pointer(&oob[0]))
@@ -178,13 +200,14 @@ func (c *connUDPIPv4) handleCmsg(oob common.RawBytes) {
 		}
 		switch {
 		case hdr.Level == syscall.SOL_SOCKET && hdr.Type == syscall.SO_RXQ_OVFL:
-			c.readMeta.RcvOvfl = *(*int)(unsafe.Pointer(&oob[sizeofCmsgHdr]))
+			meta.RcvOvfl = *(*int)(unsafe.Pointer(&oob[sizeofCmsgHdr]))
 		case hdr.Level == syscall.SOL_SOCKET && hdr.Type == syscall.SO_TIMESTAMPNS:
 			tv := *(*Timespec)(unsafe.Pointer(&oob[sizeofCmsgHdr]))
-			since := now.Sub(time.Unix(int64(tv.tv_sec), int64(tv.tv_nsec)))
+			meta.Recvd = time.Unix(int64(tv.tv_sec), int64(tv.tv_nsec))
+			meta.ReadDelay = meta.read.Sub(meta.Recvd)
 			// Guard against leap-seconds.
-			if since > 0 {
-				c.readMeta.Recvd = c.readMeta.Read - since
+			if meta.ReadDelay < 0 {
+				meta.ReadDelay = 0
 			}
 		}
 		// What we actually want is the padded length of the cmsg, but CmsgLen
@@ -208,6 +231,10 @@ func (c *connUDPIPv4) WriteTo(b common.RawBytes, dst *topology.AddrInfo) (int, e
 	return c.conn.WriteTo(b, addr)
 }
 
+func (c *connUDPIPv4) WriteBatch(msgs []ipv4.Message) (int, error) {
+	return c.pconn.WriteBatch(msgs, 0)
+}
+
 func (c *connUDPIPv4) LocalAddr() *topology.AddrInfo {
 	return c.Listen
 }
@@ -225,8 +252,48 @@ func (c *connUDPIPv4) Close() error {
 }
 
 type ReadMeta struct {
-	Src     *topology.AddrInfo
-	RcvOvfl int
-	Recvd   time.Duration
-	Read    time.Duration
+	Src       topology.AddrInfo
+	RcvOvfl   int
+	Recvd     time.Time
+	read      time.Time
+	ReadDelay time.Duration
+}
+
+func (m *ReadMeta) Reset() {
+	m.Src.Reset()
+	m.RcvOvfl = 0
+	m.Recvd = time.Unix(0, 0)
+	m.read = time.Unix(0, 0)
+	m.ReadDelay = 0
+}
+
+func (m *ReadMeta) SetSrc(rai *topology.AddrInfo, raddr *net.UDPAddr) {
+	if rai != nil {
+		m.Src = *rai
+		return
+	}
+	m.Src.Overlay = overlay.UDPIPv4
+	m.Src.IP = raddr.IP
+	m.Src.L4Port = raddr.Port
+	m.Src.OverlayPort = overlay.EndhostPort
+}
+
+func NewReadMessages(n int) []ipv4.Message {
+	m := make([]ipv4.Message, n)
+	for i := range m {
+		// Allocate a single-element, to avoid allocations when setting the buffer.
+		m[i].Buffers = make([][]byte, 1)
+		m[i].OOB = make(common.RawBytes, oobSize)
+	}
+	return m
+}
+
+func NewWriteMessages(n int) []ipv4.Message {
+	m := make([]ipv4.Message, n)
+	for i := range m {
+		// Allocate a single-element, to avoid allocations when setting the buffer.
+		m[i].Buffers = make([][]byte, 1)
+		m[i].Addr = &net.UDPAddr{}
+	}
+	return m
 }

--- a/go/lib/sockctrl/sockopt.go
+++ b/go/lib/sockctrl/sockopt.go
@@ -24,7 +24,7 @@ func GetsockoptInt(c *net.UDPConn, level, opt int) (int, error) {
 	var val int
 	err := SockControl(c, func(fd int) error {
 		var err error
-		val, err = syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+		val, err = syscall.GetsockoptInt(fd, level, opt)
 		return err
 	})
 	return val, err
@@ -32,6 +32,6 @@ func GetsockoptInt(c *net.UDPConn, level, opt int) (int, error) {
 
 func SetsockoptInt(c *net.UDPConn, level, opt, value int) error {
 	return SockControl(c, func(fd int) error {
-		return syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_RXQ_OVFL, 1)
+		return syscall.SetsockoptInt(fd, level, opt, value)
 	})
 }

--- a/go/lib/topology/addr.go
+++ b/go/lib/topology/addr.go
@@ -232,14 +232,21 @@ type AddrInfo struct {
 	OverlayPort int
 }
 
+func (a *AddrInfo) Key() string {
+	return fmt.Sprintf("%s:%d", a.IP, a.L4Port)
+}
+
+func (a *AddrInfo) Reset() {
+	a.Overlay = overlay.Invalid
+	a.IP = a.IP[:0]
+	a.L4Port = 0
+	a.OverlayPort = 0
+}
+
 func (a *AddrInfo) String() string {
 	// using %+v here would cause infinite recursion
 	return fmt.Sprintf("Addrinfo{Overlay: %s, IP: %s, L4Port: %d, OverlayPort: %d}",
 		a.Overlay, a.IP, a.L4Port, a.OverlayPort)
-}
-
-func (a *AddrInfo) Key() string {
-	return fmt.Sprintf("%s:%d", a.IP, a.L4Port)
 }
 
 // Note: TopoAddrV4 and V6 *must* have their pubIP and pubL4Port members set to

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -44,12 +44,6 @@
 			"revisionTime": "2015-05-27T14:46:52Z"
 		},
 		{
-			"checksumSHA1": "4HpMp8lo5lc64CIb3pULsFlr4ms=",
-			"path": "github.com/gavv/monotime",
-			"revision": "47d58efa69556a936a3c15eb2ed42706d968ab01",
-			"revisionTime": "2016-10-10T19:08:48Z"
-		},
-		{
 			"checksumSHA1": "2sj/DbXoXdnPAfjAEyhS0Jj5QL0=",
 			"license": "APL 2.0",
 			"path": "github.com/go-stack/stack",
@@ -331,6 +325,24 @@
 			"path": "golang.org/x/net/context",
 			"revision": "65dfc08770ce66f74becfdff5f8ab01caef4e946",
 			"revisionTime": "2016-10-24T22:38:16Z"
+		},
+		{
+			"checksumSHA1": "YoSf+PgTWvHmFVaF3MrtZz3kX38=",
+			"path": "golang.org/x/net/internal/iana",
+			"revision": "c7086645de248775cbf2373cf5ca4d2fa664b8c1",
+			"revisionTime": "2017-11-10T09:49:23Z"
+		},
+		{
+			"checksumSHA1": "yBGrvq2Acd3ufxsCVtp8zgV7wF0=",
+			"path": "golang.org/x/net/internal/socket",
+			"revision": "c7086645de248775cbf2373cf5ca4d2fa664b8c1",
+			"revisionTime": "2017-11-10T09:49:23Z"
+		},
+		{
+			"checksumSHA1": "ZGMENpNTj2hojdJMcrUO+UPKVgE=",
+			"path": "golang.org/x/net/ipv4",
+			"revision": "c7086645de248775cbf2373cf5ca4d2fa664b8c1",
+			"revisionTime": "2017-11-10T09:49:23Z"
 		},
 		{
 			"checksumSHA1": "tY+5thYxjKDUQyQXYcBqogmMS5U=",


### PR DESCRIPTION
N.B.: this only works with go 1.9+, and on linux.

Go 1.9 added support for reading and writing batches of packets from
sockets, via golang.org/x/net/ipv4. This patch adds support for this to
overlay/conn, and updates the BR to use it. Some performance testing
shows this gives an extra 4-500MBps performance to the BR.

Also:
- Remove gavv/monotime, now that we're on go1.9 which has monotonic time
  handling.
- Fix major bug in sockopt where supplied values were ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1348)
<!-- Reviewable:end -->
