### PR TITLE
Added support to pass custom networking context to snet

### DIFF
--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -103,13 +103,16 @@ type PR struct {
 // constants). When a query for a path older than maxAge reaches the resolver,
 // SCIOND is used to refresh the path. New returns with an error if a
 // connection to SCIOND could not be established.
-func New(srvc sciond.Service, timers Timers, logger log.Logger) (*PR, error) {
+func New(srvc sciond.Service, timers *Timers, logger log.Logger) (*PR, error) {
 	sciondConn, err := srvc.Connect()
 	if err != nil {
 		// Let external code handle initial failure
 		return nil, common.NewCError("Unable to connect to SCIOND", "err", err)
 	}
-	setDefaultTimers(&timers)
+	if timers == nil {
+		timers = &Timers{}
+	}
+	setDefaultTimers(timers)
 	pr := &PR{
 		sciondService: srvc,
 		requestQueue:  make(chan *resolverRequest, queryChanCap),

--- a/go/lib/pathmgr/pathmgr_test.go
+++ b/go/lib/pathmgr/pathmgr_test.go
@@ -186,7 +186,7 @@ func TestQuery(t *testing.T) {
 		},
 	}
 	Convey("Create path manager (path set max age = 1 second)", t, func() {
-		timers := Timers{
+		timers := &Timers{
 			NormalRefire: 5 * time.Second,
 			ErrorRefire:  5 * time.Second,
 			MaxAge:       time.Second,
@@ -225,7 +225,7 @@ func TestQueryFilter(t *testing.T) {
 		},
 	}
 	Convey("Create path manager", t, func() {
-		pm, err := New(api, Timers{}, log.Root())
+		pm, err := New(api, &Timers{}, log.Root())
 		SoMsg("pm", pm, ShouldNotBeNil)
 		SoMsg("err", err, ShouldBeNil)
 		Convey("Query with filter, only one path should remain", func() {
@@ -253,7 +253,7 @@ func TestRegister(t *testing.T) {
 		},
 	}
 	Convey("Create path manager", t, func() {
-		timers := Timers{
+		timers := &Timers{
 			NormalRefire: time.Second,
 			ErrorRefire:  time.Second,
 			MaxAge:       time.Second,
@@ -280,7 +280,7 @@ func TestRegisterFilter(t *testing.T) {
 		},
 	}
 	Convey("Create path manager", t, func() {
-		timers := Timers{
+		timers := &Timers{
 			NormalRefire: time.Second,
 			ErrorRefire:  time.Second,
 			MaxAge:       time.Second,
@@ -316,7 +316,7 @@ func TestRevoke(t *testing.T) {
 		},
 	}
 	Convey("Create path manager", t, func() {
-		timers := Timers{
+		timers := &Timers{
 			NormalRefire: time.Minute,
 			ErrorRefire:  time.Minute,
 			MaxAge:       time.Minute,

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -65,13 +65,17 @@ var (
 
 // Init initializes the default SCION networking context.
 func Init(ia *addr.ISD_AS, sPath string, dPath string) error {
-	if DefNetwork != nil {
-		return common.NewCError("Cannot initialize global SCION network twice")
-	}
-
-	network, err := NewNetwork(ia, sPath, dPath)
+	network, err := NewDefaultNetwork(ia, sPath, dPath)
 	if err != nil {
 		return err
+	}
+	return InitWithNetwork(network)
+}
+
+// InitWithNetwork initializes snet with the provided SCION networking context.
+func InitWithNetwork(network *Network) error {
+	if DefNetwork != nil {
+		return common.NewCError("Cannot initialize global SCION network twice")
 	}
 	DefNetwork = network
 	return nil
@@ -94,17 +98,23 @@ type Network struct {
 	localIA        *addr.ISD_AS
 }
 
-// NewNetwork creates a new networking context, on which future Dial or Listen
-// calls can be made. The new connections use the SCIOND server at sPath, the
-// dispatcher at dPath, and ia for the local ISD-AS.
-func NewNetwork(ia *addr.ISD_AS, sPath string, dPath string) (*Network, error) {
-	network := &Network{
+// NewNetwork creates a minimal networking context without a path resolver.
+// It is meant to be amended with a custom path resolver.
+func NewNetwork(ia *addr.ISD_AS, sPath string, dPath string) *Network {
+	return &Network{
 		sciondPath:     sPath,
 		dispatcherPath: dPath,
 		localIA:        ia,
 	}
+}
+
+// NewDefaultNetwork creates a new networking context, on which future Dial or Listen
+// calls can be made. The new connections use the SCIOND server at sPath, the
+// dispatcher at dPath, and ia for the local ISD-AS.
+func NewDefaultNetwork(ia *addr.ISD_AS, sPath string, dPath string) (*Network, error) {
+	network := NewNetwork(ia, sPath, dPath)
 	sd := sciond.NewService(sPath)
-	timers := pathmgr.Timers{
+	timers := &pathmgr.Timers{
 		NormalRefire: time.Minute,
 		ErrorRefire:  3 * time.Second,
 		MaxAge:       time.Hour,
@@ -234,6 +244,15 @@ func (n *Network) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr,
 // PathResolver returns the pathmgr.PR that the network is using.
 func (n *Network) PathResolver() *pathmgr.PR {
 	return n.pathResolver
+}
+
+// SetPathResolver set the pathmgr.PR that the networking is using. It can only
+// be set once and will be ignored if there is already a path resolver set.
+func (n *Network) SetPathResolver(resolver *pathmgr.PR) {
+	if n.pathResolver != nil {
+		return
+	}
+	n.pathResolver = resolver
 }
 
 // IA returns a copy of the ISD-AS assigned to n

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -65,7 +65,7 @@ var (
 
 // Init initializes the default SCION networking context.
 func Init(ia *addr.ISD_AS, sPath string, dPath string) error {
-	network, err := NewDefaultNetwork(ia, sPath, dPath)
+	network, err := NewNetwork(ia, sPath, dPath)
 	if err != nil {
 		return err
 	}
@@ -98,9 +98,9 @@ type Network struct {
 	localIA        *addr.ISD_AS
 }
 
-// NewNetwork creates a minimal networking context without a path resolver.
+// NewNetworkBasic creates a minimal networking context without a path resolver.
 // It is meant to be amended with a custom path resolver.
-func NewNetwork(ia *addr.ISD_AS, sPath string, dPath string) *Network {
+func NewNetworkBasic(ia *addr.ISD_AS, sPath string, dPath string) *Network {
 	return &Network{
 		sciondPath:     sPath,
 		dispatcherPath: dPath,
@@ -108,11 +108,11 @@ func NewNetwork(ia *addr.ISD_AS, sPath string, dPath string) *Network {
 	}
 }
 
-// NewDefaultNetwork creates a new networking context, on which future Dial or Listen
+// NewNetwork creates a new networking context, on which future Dial or Listen
 // calls can be made. The new connections use the SCIOND server at sPath, the
 // dispatcher at dPath, and ia for the local ISD-AS.
-func NewDefaultNetwork(ia *addr.ISD_AS, sPath string, dPath string) (*Network, error) {
-	network := NewNetwork(ia, sPath, dPath)
+func NewNetwork(ia *addr.ISD_AS, sPath string, dPath string) (*Network, error) {
+	network := NewNetworkBasic(ia, sPath, dPath)
 	sd := sciond.NewService(sPath)
 	timers := &pathmgr.Timers{
 		NormalRefire: time.Minute,


### PR DESCRIPTION
This allows apps to customize their networking context, e.g., by customizing the path resolver used by the context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1349)
<!-- Reviewable:end -->
