### PR TITLE
Modify TRCRequest proto

### DIFF
--- a/go/cert_srv/cert.go
+++ b/go/cert_srv/cert.go
@@ -71,7 +71,7 @@ func (h *ChainHandler) sendChainRep(addr *snet.Addr, chain *cert.Chain) error {
 	if err != nil {
 		return err
 	}
-	cpld, err := ctrl.NewCertMgmtPld(&cert_mgmt.ChainRep{RawChain: raw})
+	cpld, err := ctrl.NewCertMgmtPld(&cert_mgmt.Chain{RawChain: raw})
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func (h *ChainHandler) sendChainReq(req *cert_mgmt.ChainReq) error {
 }
 
 // HandleRep handles certificate chain replies. Pending requests are answered and removed.
-func (h *ChainHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.ChainRep) {
+func (h *ChainHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.Chain) {
 	log.Info("Received certificate chain reply", "addr", addr, "rep", rep)
 	chain, err := rep.Chain()
 	if err != nil {

--- a/go/cert_srv/io.go
+++ b/go/cert_srv/io.go
@@ -85,12 +85,12 @@ func (d *Dispatcher) dispatch(addr *snet.Addr, buf common.RawBytes) error {
 			return err
 		}
 		switch pld.ProtoId() {
-		case proto.CertChainRep_TypeID:
-			d.chainHandler.HandleRep(addr, pld.(*cert_mgmt.ChainRep))
+		case proto.CertChain_TypeID:
+			d.chainHandler.HandleRep(addr, pld.(*cert_mgmt.Chain))
 		case proto.CertChainReq_TypeID:
 			d.chainHandler.HandleReq(addr, pld.(*cert_mgmt.ChainReq))
-		case proto.TRCRep_TypeID:
-			d.trcHandler.HandleRep(addr, pld.(*cert_mgmt.TRCRep))
+		case proto.TRC_TypeID:
+			d.trcHandler.HandleRep(addr, pld.(*cert_mgmt.TRC))
 		case proto.TRCReq_TypeID:
 			d.trcHandler.HandleReq(addr, pld.(*cert_mgmt.TRCReq))
 		}

--- a/go/cert_srv/trc.go
+++ b/go/cert_srv/trc.go
@@ -70,7 +70,7 @@ func (h *TRCHandler) sendTRCRep(addr *snet.Addr, t *trc.TRC) error {
 	if err != nil {
 		return err
 	}
-	cpld, err := ctrl.NewCertMgmtPld(&cert_mgmt.TRCRep{RawTRC: raw})
+	cpld, err := ctrl.NewCertMgmtPld(&cert_mgmt.TRC{RawTRC: raw})
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func (h *TRCHandler) sendTRCReq(req *cert_mgmt.TRCReq) error {
 }
 
 // HandleRep handles TRC replies. Pending requests are answered and removed.
-func (h *TRCHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.TRCRep) {
+func (h *TRCHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.TRC) {
 	log.Info("Received TRC reply", "addr", addr, "rep", rep)
 	t, err := rep.TRC()
 	if err != nil {

--- a/go/cert_srv/trc.go
+++ b/go/cert_srv/trc.go
@@ -44,7 +44,12 @@ func NewTRCHandler(conn *snet.Conn) *TRCHandler {
 // or the requester is from a remote AS, the request is dropped.
 func (h *TRCHandler) HandleReq(addr *snet.Addr, req *cert_mgmt.TRCReq) {
 	log.Info("Received TRC request", "addr", addr, "req", req)
-	t := store.GetTRC(uint16(req.ISD()), req.Version)
+	var t *trc.TRC
+	if req.Version == cert_mgmt.NewestVersion {
+		t = store.GetNewestTRC(req.ISD)
+	} else {
+		t = store.GetTRC(req.ISD, req.Version)
+	}
 	srcLocal := public.IA.Eq(addr.IA)
 	if t != nil {
 		if err := h.sendTRCRep(addr, t); err != nil {
@@ -75,7 +80,7 @@ func (h *TRCHandler) sendTRCRep(addr *snet.Addr, t *trc.TRC) error {
 
 // fetchTRC fetches a TRC from the remote AS.
 func (h *TRCHandler) fetchTRC(addr *snet.Addr, req *cert_mgmt.TRCReq) error {
-	key := trc.NewKey(uint16(req.ISD()), req.Version).String()
+	key := trc.NewKey(req.ISD, req.Version).String()
 	sendReq := trcReqCache.Put(key, addr)
 	if sendReq { // rate limit
 		return h.sendTRCReq(req)
@@ -90,8 +95,7 @@ func (h *TRCHandler) sendTRCReq(req *cert_mgmt.TRCReq) error {
 	if err != nil {
 		return err
 	}
-	pathSet := snet.DefNetwork.PathResolver().Query(
-		public.IA, &addr.ISD_AS{I: req.RawIA.IA().I, A: 0})
+	pathSet := snet.DefNetwork.PathResolver().Query(public.IA, req.IA())
 	path := pathSet.GetAppPath("")
 	if path == nil {
 		return common.NewCError("Unable to find core AS")
@@ -113,8 +117,12 @@ func (h *TRCHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.TRCRep) {
 		log.Error("Unable to store TRC", "key", t.Key(), "err", err)
 		return
 	}
-	reqs := trcReqCache.Pop(t.Key().String())
-	if reqs == nil {
+	key := t.Key()
+	reqVer := chainReqCache.Pop(key.String())
+	key.Ver = cert_mgmt.NewestVersion
+	reqNew := chainReqCache.Pop(key.String())
+	key.Ver = t.Version
+	if reqVer == nil && reqNew == nil { // No pending requests
 		return
 	}
 	cpld, err := ctrl.NewCertMgmtPld(rep)
@@ -122,9 +130,18 @@ func (h *TRCHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.TRCRep) {
 		log.Error("Unable to create TRC reply", "key", t.Key(), "err", err)
 		return
 	}
+	h.answerReqs(reqVer, cpld, key)
+	h.answerReqs(reqNew, cpld, key)
+}
+
+// answerReqs responds to pending requests.
+func (h *TRCHandler) answerReqs(reqs *AddrSet, cpld *ctrl.Pld, key *trc.Key) {
+	if reqs == nil {
+		return
+	}
 	for _, dst := range reqs.Addrs {
 		if err := SendPayload(h.conn, cpld, dst); err != nil {
-			log.Error("Unable to write TRC reply", "key", t.Key(), "err", err)
+			log.Error("Unable to write TRC reply", "key", key, "err", err)
 			continue
 		}
 	}

--- a/go/lib/ctrl/cert_mgmt/cert_mgmt.go
+++ b/go/lib/ctrl/cert_mgmt/cert_mgmt.go
@@ -16,11 +16,14 @@ package cert_mgmt
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/proto"
 )
+
+const NewestVersion = math.MaxUint64
 
 type union struct {
 	Which    proto.CertMgmt_Which

--- a/go/lib/ctrl/cert_mgmt/cert_mgmt.go
+++ b/go/lib/ctrl/cert_mgmt/cert_mgmt.go
@@ -28,9 +28,9 @@ const NewestVersion = math.MaxUint64
 type union struct {
 	Which    proto.CertMgmt_Which
 	ChainReq *ChainReq `capnp:"certChainReq"`
-	ChainRep *ChainRep `capnp:"certChainRep"`
+	ChainRep *Chain    `capnp:"certChain"`
 	TRCReq   *TRCReq   `capnp:"trcReq"`
-	TRCRep   *TRCRep   `capnp:"trcRep"`
+	TRCRep   *TRC      `capnp:"trc"`
 }
 
 func (u *union) set(c proto.Cerealizable) error {
@@ -38,14 +38,14 @@ func (u *union) set(c proto.Cerealizable) error {
 	case *ChainReq:
 		u.Which = proto.CertMgmt_Which_certChainReq
 		u.ChainReq = p
-	case *ChainRep:
-		u.Which = proto.CertMgmt_Which_certChainRep
+	case *Chain:
+		u.Which = proto.CertMgmt_Which_certChain
 		u.ChainRep = p
 	case *TRCReq:
 		u.Which = proto.CertMgmt_Which_trcReq
 		u.TRCReq = p
-	case *TRCRep:
-		u.Which = proto.CertMgmt_Which_trcRep
+	case *TRC:
+		u.Which = proto.CertMgmt_Which_trc
 		u.TRCRep = p
 	default:
 		return common.NewCError("Unsupported cert mgmt union type (set)", "type", common.TypeOf(c))
@@ -57,11 +57,11 @@ func (u *union) get() (proto.Cerealizable, error) {
 	switch u.Which {
 	case proto.CertMgmt_Which_certChainReq:
 		return u.ChainReq, nil
-	case proto.CertMgmt_Which_certChainRep:
+	case proto.CertMgmt_Which_certChain:
 		return u.ChainRep, nil
 	case proto.CertMgmt_Which_trcReq:
 		return u.TRCReq, nil
-	case proto.CertMgmt_Which_trcRep:
+	case proto.CertMgmt_Which_trc:
 		return u.TRCRep, nil
 	}
 	return nil, common.NewCError("Unsupported cert mgmt union type (get)", "type", u.Which)

--- a/go/lib/ctrl/cert_mgmt/chain.go
+++ b/go/lib/ctrl/cert_mgmt/chain.go
@@ -22,21 +22,21 @@ import (
 	"github.com/scionproto/scion/go/proto"
 )
 
-var _ proto.Cerealizable = (*ChainRep)(nil)
+var _ proto.Cerealizable = (*Chain)(nil)
 
-type ChainRep struct {
+type Chain struct {
 	RawChain common.RawBytes `capnp:"chain"`
 }
 
-func (c *ChainRep) Chain() (*cert.Chain, error) {
+func (c *Chain) Chain() (*cert.Chain, error) {
 	return cert.ChainFromRaw(c.RawChain, true)
 }
 
-func (c *ChainRep) ProtoId() proto.ProtoIdType {
-	return proto.CertChainRep_TypeID
+func (c *Chain) ProtoId() proto.ProtoIdType {
+	return proto.CertChain_TypeID
 }
 
-func (c *ChainRep) String() string {
+func (c *Chain) String() string {
 	chain, err := c.Chain()
 	if err != nil {
 		return fmt.Sprintf("Invalid CertificateChain: %v", err)

--- a/go/lib/ctrl/cert_mgmt/trc.go
+++ b/go/lib/ctrl/cert_mgmt/trc.go
@@ -28,18 +28,18 @@ type TRC struct {
 	RawTRC common.RawBytes `capnp:"trc"`
 }
 
-func (c *TRC) TRC() (*trc.TRC, error) {
-	return trc.TRCFromRaw(c.RawTRC, true)
+func (t *TRC) TRC() (*trc.TRC, error) {
+	return trc.TRCFromRaw(t.RawTRC, true)
 }
 
-func (c *TRC) ProtoId() proto.ProtoIdType {
+func (t *TRC) ProtoId() proto.ProtoIdType {
 	return proto.TRC_TypeID
 }
 
-func (c *TRC) String() string {
-	t, err := c.TRC()
+func (t *TRC) String() string {
+	u, err := t.TRC()
 	if err != nil {
 		return fmt.Sprintf("Invalid TRC: %v", err)
 	}
-	return t.String()
+	return u.String()
 }

--- a/go/lib/ctrl/cert_mgmt/trc.go
+++ b/go/lib/ctrl/cert_mgmt/trc.go
@@ -22,24 +22,24 @@ import (
 	"github.com/scionproto/scion/go/proto"
 )
 
-var _ proto.Cerealizable = (*TRCRep)(nil)
+var _ proto.Cerealizable = (*TRC)(nil)
 
-type TRCRep struct {
+type TRC struct {
 	RawTRC common.RawBytes `capnp:"trc"`
 }
 
-func (c *TRCRep) TRC() (*trc.TRC, error) {
+func (c *TRC) TRC() (*trc.TRC, error) {
 	return trc.TRCFromRaw(c.RawTRC, true)
 }
 
-func (c *TRCRep) ProtoId() proto.ProtoIdType {
-	return proto.TRCRep_TypeID
+func (c *TRC) ProtoId() proto.ProtoIdType {
+	return proto.TRC_TypeID
 }
 
-func (c *TRCRep) String() string {
-	trc, err := c.TRC()
+func (c *TRC) String() string {
+	t, err := c.TRC()
 	if err != nil {
 		return fmt.Sprintf("Invalid TRC: %v", err)
 	}
-	return trc.String()
+	return t.String()
 }

--- a/go/lib/ctrl/cert_mgmt/trc_req.go
+++ b/go/lib/ctrl/cert_mgmt/trc_req.go
@@ -26,13 +26,13 @@ import (
 var _ proto.Cerealizable = (*TRCReq)(nil)
 
 type TRCReq struct {
-	RawIA     addr.IAInt `capnp:"isdas"`
+	ISD       uint16 `capnp:"isd"`
 	Version   uint64
 	CacheOnly bool
 }
 
-func (t *TRCReq) ISD() int {
-	return t.RawIA.IA().I
+func (t *TRCReq) IA() *addr.ISD_AS {
+	return &addr.ISD_AS{I: int(t.ISD), A: 0}
 }
 
 func (t *TRCReq) ProtoId() proto.ProtoIdType {
@@ -40,5 +40,5 @@ func (t *TRCReq) ProtoId() proto.ProtoIdType {
 }
 
 func (t *TRCReq) String() string {
-	return fmt.Sprintf("ISD: %d Version: %d CacheOnly: %v", t.ISD(), t.Version, t.CacheOnly)
+	return fmt.Sprintf("ISD: %d Version: %d CacheOnly: %v", t.ISD, t.Version, t.CacheOnly)
 }

--- a/proto/cert_mgmt.capnp
+++ b/proto/cert_mgmt.capnp
@@ -9,7 +9,7 @@ struct CertChainReq {
     cacheOnly @2 :Bool;
 }
 
-struct CertChainRep {
+struct CertChain {
     chain @0 :Data;
 }
 
@@ -19,7 +19,7 @@ struct TRCReq {
     cacheOnly @2 :Bool;
 }
 
-struct TRCRep {
+struct TRC {
     trc @0 :Data;
 }
 
@@ -27,8 +27,8 @@ struct CertMgmt {
     union {
         unset @0 :Void;
         certChainReq @1 :CertChainReq;
-        certChainRep @2 :CertChainRep;
+        certChain @2 :CertChain;
         trcReq @3 :TRCReq;
-        trcRep @4 :TRCRep;
+        trc @4 :TRC;
     }
 }

--- a/proto/cert_mgmt.capnp
+++ b/proto/cert_mgmt.capnp
@@ -14,7 +14,7 @@ struct CertChainRep {
 }
 
 struct TRCReq {
-    isdas @0 :UInt32;
+    isd @0 :UInt16;
     version @1 :UInt64;
     cacheOnly @2 :Bool;
 }

--- a/python/integration/cert_req_test.py
+++ b/python/integration/cert_req_test.py
@@ -28,7 +28,7 @@ from lib.packet.ctrl_pld import CtrlPayload
 from lib.packet.cert_mgmt import CertChainRequest, CertMgmt, TRCRequest
 from lib.packet.path import SCIONPath
 from lib.packet.scion import SCIONL4Packet, build_base_hdrs
-from lib.packet.scion_addr import ISD_AS, SCIONAddr
+from lib.packet.scion_addr import SCIONAddr
 from lib.types import ServiceType
 from integration.base_cli_srv import (
     get_sciond_api_addr,
@@ -67,7 +67,7 @@ class TestCertClient(TestClientBase):
         if not self.cert:
             return CtrlPayload(CertMgmt(CertChainRequest.from_values(self.dst_ia, 0)))
         return CtrlPayload(
-            CertMgmt(TRCRequest.from_values(ISD_AS.from_values(self.dst_ia._isd, 0), 0)))
+            CertMgmt(TRCRequest.from_values(self.dst_ia[0], 0)))
 
     def _handle_response(self, spkt):
         cpld = spkt.parse_payload()

--- a/python/lib/packet/cert_mgmt.py
+++ b/python/lib/packet/cert_mgmt.py
@@ -54,7 +54,7 @@ class CertChainRequest(Cerealizable):  # pragma: no cover
 
 class CertChainReply(Cerealizable):  # pragma: no cover
     NAME = "CertChainReply"
-    P_CLS = P.CertChainRep
+    P_CLS = P.CertChain
 
     def __init__(self, p):
         super().__init__(p)
@@ -92,7 +92,7 @@ class TRCRequest(Cerealizable):
 
 class TRCReply(Cerealizable):  # pragma: no cover
     NAME = "TRCReply"
-    P_CLS = P.TRCRep
+    P_CLS = P.TRC
 
     def __init__(self, p):
         super().__init__(p)

--- a/python/lib/packet/cert_mgmt.py
+++ b/python/lib/packet/cert_mgmt.py
@@ -34,7 +34,11 @@ class CertMgmt(CerealBox):  # pragma: no cover
     CLASS_FIELD_MAP = None
 
 
-class CertMgmtRequest(Cerealizable):  # pragma: no cover
+class CertChainRequest(Cerealizable):  # pragma: no cover
+    NAME = "CertChainRequest"
+    P_CLS = P.CertChainReq
+    NEWEST_VERSION = 2**64-1
+
     def isd_as(self):
         return ISD_AS(self.p.isdas)
 
@@ -42,11 +46,6 @@ class CertMgmtRequest(Cerealizable):  # pragma: no cover
     def from_values(cls, isd_as, version, cache_only=False):
         return cls(cls.P_CLS.new_message(isdas=int(isd_as), version=version,
                                          cacheOnly=cache_only))
-
-
-class CertChainRequest(CertMgmtRequest):
-    NAME = "CertChainRequest"
-    P_CLS = P.CertChainReq
 
     def short_desc(self):
         return "%sv%s (Cache only? %s)" % (self.isd_as(), self.p.version,
@@ -73,12 +72,21 @@ class CertChainReply(Cerealizable):  # pragma: no cover
         return "%s: ISD-AS: %s Version: %s" % (self.NAME, isd_as, ver)
 
 
-class TRCRequest(CertMgmtRequest):
+class TRCRequest(Cerealizable):
     NAME = "TRCRequest"
     P_CLS = P.TRCReq
+    NEWEST_VERSION = 2**64-1
+
+    def isd_as(self):
+        return ISD_AS.from_values(self.p.isd, 0)
+
+    @classmethod
+    def from_values(cls, isd, version, cache_only=False):
+        return cls(cls.P_CLS.new_message(isd=isd, version=version,
+                                         cacheOnly=cache_only))
 
     def short_desc(self):
-        return "%sv%s (Cache only? %s)" % (self.isd_as()[0], self.p.version,
+        return "%sv%s (Cache only? %s)" % (self.p.isd, self.p.version,
                                            self.p.cacheOnly)
 
 

--- a/python/lib/types.py
+++ b/python/lib/types.py
@@ -109,9 +109,9 @@ class PayloadClass(object):
 
 class CertMgmtType(object):
     CERT_CHAIN_REQ = "certChainReq"
-    CERT_CHAIN_REPLY = "certChainRep"
+    CERT_CHAIN_REPLY = "certChain"
     TRC_REQ = "trcReq"
-    TRC_REPLY = "trcRep"
+    TRC_REPLY = "trc"
 
 
 class PathMgmtType(object):

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -81,7 +81,7 @@ from lib.packet.scion import (
     build_base_hdrs,
 )
 from lib.packet.svc import SVC_TO_SERVICE, SERVICE_TO_SVC_A
-from lib.packet.scion_addr import ISD_AS, SCIONAddr
+from lib.packet.scion_addr import SCIONAddr
 from lib.packet.scion_udp import SCIONUDPHeader
 from lib.packet.scmp.errors import (
     SCMPBadDstType,
@@ -331,8 +331,7 @@ class SCIONElement(object):
             now = time.time()
             for (isd, ver), (req_time, meta) in self.requested_trcs.items():
                 if now - req_time >= self.TRC_CC_REQ_TIMEOUT:
-                    trc_req = TRCRequest.from_values(ISD_AS.from_values(isd, 0), ver,
-                                                     cache_only=True)
+                    trc_req = TRCRequest.from_values(isd, ver, cache_only=True)
                     meta = meta or self._get_cs()
                     logging.info("Re-Requesting TRC from %s: %s", meta, trc_req.short_desc())
                     self.send_meta(CtrlPayload(CertMgmt(trc_req)), meta)
@@ -445,7 +444,7 @@ class SCIONElement(object):
                     # There is already an outstanding request for the missing TRC
                     # to the local CS and we don't have a new meta.
                     continue
-            trc_req = TRCRequest.from_values(ISD_AS.from_values(isd, 0), ver, cache_only=True)
+            trc_req = TRCRequest.from_values(isd, ver, cache_only=True)
             meta = seg_meta.meta or self._get_cs()
             if not meta:
                 logging.error("Couldn't find a CS to request TRC for PCB %s",


### PR DESCRIPTION
Modifies TRCRequest proto to hold only the isd number instead of ISD-AS.
Adds the capability to request the newest CertChain/TRC
  - Version == maxUint64 indicates that the newest version shall be returned
  - CS responds with the newest in cache

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1354)
<!-- Reviewable:end -->
