### PR TITLE
Unit tests for Rpkt and Udp

### DIFF
--- a/go/border/rpkt/rpkt_hook_test.go
+++ b/go/border/rpkt/rpkt_hook_test.go
@@ -63,9 +63,10 @@ func TestHooksSrcDstIA(t *testing.T) {
 
 		ia, err = rpkt.DstIA()
 		SoMsg("Destination address wrong on second getter call", ia, ShouldEqual, dstIA)
-		SoMsg("Destination address must only be fetched once, cached value must be reused on the second call",
-			fetched, ShouldEqual, 1)
-		SoMsg("Should be no error when calling destination address getter for cached value", err, ShouldBeNil)
+		SoMsg("Destination address must only be fetched once, cached value must be reused on the"+
+			" second call", fetched, ShouldEqual, 1)
+		SoMsg("Should be no error when calling destination address getter for cached value", err,
+			ShouldBeNil)
 
 		ia, err = rpkt.SrcIA()
 		SoMsg("Source address wrong", ia, ShouldEqual, srcIA)
@@ -73,7 +74,8 @@ func TestHooksSrcDstIA(t *testing.T) {
 
 		ia, err = rpkt.SrcIA()
 		SoMsg("Source address wrong on cached getter call", ia, ShouldEqual, srcIA)
-		SoMsg("Should be no error when calling destination address getter for cached value", err, ShouldBeNil)
+		SoMsg("Should be no error when calling destination address getter for cached value", err,
+			ShouldBeNil)
 		SoMsg("Two fetches are expected (both source and destination address, each exactly once)",
 			fetched, ShouldEqual, 2)
 	})
@@ -104,9 +106,10 @@ func TestHooksSrcDstHost(t *testing.T) {
 
 		host, err = rpkt.DstHost()
 		SoMsg("Destination host wrong on second getter call", host, ShouldEqual, dstHost)
-		SoMsg("Should be no error when calling destination host getter for cached value", err, ShouldBeNil)
-		SoMsg("Destination host must only be fetched once, cached value must be reused on the second call",
-			fetched, ShouldEqual, 1)
+		SoMsg("Should be no error when calling destination host getter for cached value", err,
+			ShouldBeNil)
+		SoMsg("Destination host must only be fetched once, cached value must be reused on the "+
+			"second call", fetched, ShouldEqual, 1)
 
 		host, err = rpkt.SrcHost()
 		SoMsg("Source host wrong", host, ShouldEqual, srcHost)
@@ -114,7 +117,8 @@ func TestHooksSrcDstHost(t *testing.T) {
 
 		host, err = rpkt.SrcHost()
 		SoMsg("Source host wrong on cached getter call", host, ShouldEqual, srcHost)
-		SoMsg("Should be no error when calling destination host getter for cached value", err, ShouldBeNil)
+		SoMsg("Should be no error when calling destination host getter for cached value", err,
+			ShouldBeNil)
 		SoMsg("Two fetches are expected (both source and destination host, each exactly once)",
 			fetched, ShouldEqual, 2)
 	})
@@ -138,7 +142,8 @@ func TestHooksInfof(t *testing.T) {
 		SoMsg("Wrong InfoField on the fetch call", *info, ShouldResemble, infof)
 
 		info, err = rpkt.InfoF()
-		SoMsg("Should be no error when calling InfoField getter for cached value", err, ShouldBeNil)
+		SoMsg("Should be no error when calling InfoField getter for cached value", err,
+			ShouldBeNil)
 		SoMsg("Wrong InfoField on the cached getter call", *info, ShouldResemble, infof)
 		SoMsg("Regardless of the two calls, only one fetch of InfoField expected", fetched,
 			ShouldEqual, 1)
@@ -163,9 +168,11 @@ func TestHooksHopf(t *testing.T) {
 		SoMsg("Should be no error when calling HopF for fetch", err, ShouldBeNil)
 
 		hopf, err = rpkt.HopF()
-		SoMsg("Wrong HopF on the cached getter call", hopf.VerifyOnly, ShouldEqual, hopfield.VerifyOnly)
+		SoMsg("Wrong HopF on the cached getter call", hopf.VerifyOnly, ShouldEqual,
+			hopfield.VerifyOnly)
 		SoMsg("Should be no error when calling HopF getter for cached value", err, ShouldBeNil)
-		SoMsg("Regardless of the two calls, only one fetch of HopF expected", fetched, ShouldEqual, 1)
+		SoMsg("Regardless of the two calls, only one fetch of HopF expected", fetched,
+			ShouldEqual, 1)
 	})
 }
 
@@ -187,7 +194,8 @@ func TestHooksUp(t *testing.T) {
 		up, err = rpkt.UpFlag()
 		SoMsg("Wrong UpFlag on the cached getter call", *up, ShouldBeTrue)
 		SoMsg("Should be no error when calling UpFlag getter for cached value", err, ShouldBeNil)
-		SoMsg("Regardless of the two calls, only one fetch of UpFlag expected", fetched, ShouldEqual, 1)
+		SoMsg("Regardless of the two calls, only one fetch of UpFlag expected", fetched,
+			ShouldEqual, 1)
 	})
 }
 
@@ -205,14 +213,14 @@ func TestLifecycle(t *testing.T) {
 
 		rpkt.Release()
 		SoMsg("Release() must decrement ref count from 3 to 2", rpkt.refCnt, ShouldEqual, 2)
-		SoMsg("Incorrectly freed, 2 refs remaining", free, ShouldBeFalse)
+		SoMsg("Not freed yet, 2 refs remaining", free, ShouldBeFalse)
 
 		rpkt.Release()
-		SoMsg("Incorrectly freed, 1 ref remaining", free, ShouldBeFalse)
+		SoMsg("Not freed yet, 1 ref remaining", free, ShouldBeFalse)
 
 		rpkt.Release()
 		SoMsg("Should be no more refs remaining by now", rpkt.refCnt, ShouldEqual, 0)
-		SoMsg("Due no refs remaining by now be freed now", free, ShouldBeTrue)
+		SoMsg("Freed due to no refs remaining", free, ShouldBeTrue)
 
 		rpkt.Reset()
 		SoMsg("Reset() must set refcount to 1", rpkt.refCnt, ShouldEqual, 1)

--- a/go/border/rpkt/rpkt_hook_test.go
+++ b/go/border/rpkt/rpkt_hook_test.go
@@ -1,0 +1,221 @@
+// Copyright 2017 Audrius Meskauskas with all possible permissions granted
+// to ETH Zurich and Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test hook functions as much as possible. Some hook functions do not define the returned
+// value alone and are not testable this way.
+package rpkt
+
+import (
+	"net"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/spath"
+)
+
+// Track if the hook is only queued once
+var fetched = 0
+var err error
+
+func setupRtrPktHookTest() *RtrPkt {
+	rpkt := NewRtrPkt()
+	rpkt.Id = "id"
+	fetched = 0
+	return rpkt
+}
+
+func TestHooksSrcDstIA(t *testing.T) {
+	Convey("Fetch SrcIA, DstIA via hook functions", t, func() {
+		rpkt := setupRtrPktHookTest()
+
+		srcIA := &addr.ISD_AS{I: 1, A: 2}
+		dstIA := &addr.ISD_AS{I: 3, A: 4}
+
+		rpkt.hooks = hooks{
+			SrcIA: []hookIA{func() (HookResult, *addr.ISD_AS, error) {
+				fetched++
+				return HookFinish, srcIA, nil
+			}},
+			DstIA: []hookIA{func() (HookResult, *addr.ISD_AS, error) {
+				fetched++
+				return HookFinish, dstIA, nil
+			}},
+		}
+		var ia *addr.ISD_AS
+
+		ia, err = rpkt.DstIA()
+		SoMsg("Destination address wrong", ia, ShouldEqual, dstIA)
+		SoMsg("Should be no error when calling destination address getter", err, ShouldBeNil)
+
+		ia, err = rpkt.DstIA()
+		SoMsg("Destination address wrong on second getter call", ia, ShouldEqual, dstIA)
+		SoMsg("Destination address must only be fetched once, cached value must be reused on the second call",
+			fetched, ShouldEqual, 1)
+		SoMsg("Should be no error when calling destination address getter for cached value", err, ShouldBeNil)
+
+		ia, err = rpkt.SrcIA()
+		SoMsg("Source address wrong", ia, ShouldEqual, srcIA)
+		SoMsg("Should be no error when calling source address getter", err, ShouldBeNil)
+
+		ia, err = rpkt.SrcIA()
+		SoMsg("Source address wrong on cached getter call", ia, ShouldEqual, srcIA)
+		SoMsg("Should be no error when calling destination address getter for cached value", err, ShouldBeNil)
+		SoMsg("Two fetches are expected (both source and destination address, each exactly once)",
+			fetched, ShouldEqual, 2)
+	})
+}
+
+func TestHooksSrcDstHost(t *testing.T) {
+	Convey("Fetch SrcHost, DstHost via hook functions", t, func() {
+		rpkt := setupRtrPktHookTest()
+
+		srcHost := addr.HostFromIP(net.IPv4(192, 168, 1, 37))
+		dstHost := addr.HostFromIP(net.IPv4(192, 168, 1, 38))
+
+		rpkt.hooks = hooks{
+			SrcHost: []hookHost{func() (HookResult, addr.HostAddr, error) {
+				fetched++
+				return HookFinish, srcHost, nil
+			}},
+			DstHost: []hookHost{func() (HookResult, addr.HostAddr, error) {
+				fetched++
+				return HookFinish, dstHost, nil
+			}},
+		}
+		var host addr.HostAddr
+
+		host, err = rpkt.DstHost()
+		SoMsg("Destination host wrong", host, ShouldEqual, dstHost)
+		SoMsg("Should be no error when calling destination host getter", err, ShouldBeNil)
+
+		host, err = rpkt.DstHost()
+		SoMsg("Destination host wrong on second getter call", host, ShouldEqual, dstHost)
+		SoMsg("Should be no error when calling destination host getter for cached value", err, ShouldBeNil)
+		SoMsg("Destination host must only be fetched once, cached value must be reused on the second call",
+			fetched, ShouldEqual, 1)
+
+		host, err = rpkt.SrcHost()
+		SoMsg("Source host wrong", host, ShouldEqual, srcHost)
+		SoMsg("Should be no error when calling source host getter", err, ShouldBeNil)
+
+		host, err = rpkt.SrcHost()
+		SoMsg("Source host wrong on cached getter call", host, ShouldEqual, srcHost)
+		SoMsg("Should be no error when calling destination host getter for cached value", err, ShouldBeNil)
+		SoMsg("Two fetches are expected (both source and destination host, each exactly once)",
+			fetched, ShouldEqual, 2)
+	})
+}
+
+func TestHooksInfof(t *testing.T) {
+	Convey("Fetch Infof via hook functions", t, func() {
+		rpkt := setupRtrPktHookTest()
+		infof := spath.InfoField{TsInt: 10, ISD: 11, Hops: 3}
+
+		rpkt.hooks = hooks{
+			Infof: []hookInfoF{func() (HookResult, *spath.InfoField, error) {
+				fetched++
+				return HookFinish, &infof, nil
+			}},
+		}
+		var info *spath.InfoField
+
+		info, err = rpkt.InfoF()
+		SoMsg("Should be no error when calling InfoField getter for fetch", err, ShouldBeNil)
+		SoMsg("Wrong InfoField on the fetch call", *info, ShouldResemble, infof)
+
+		info, err = rpkt.InfoF()
+		SoMsg("Should be no error when calling InfoField getter for cached value", err, ShouldBeNil)
+		SoMsg("Wrong InfoField on the cached getter call", *info, ShouldResemble, infof)
+		SoMsg("Regardless of the two calls, only one fetch of InfoField expected", fetched,
+			ShouldEqual, 1)
+	})
+}
+
+func TestHooksHopf(t *testing.T) {
+	Convey("Fetch HopF via hook functions", t, func() {
+		rpkt := setupRtrPktHookTest()
+		hopfield := spath.HopField{VerifyOnly: true}
+
+		rpkt.hooks = hooks{
+			HopF: []hookHopF{func() (HookResult, *spath.HopField, error) {
+				fetched++
+				return HookFinish, &hopfield, nil
+			}},
+		}
+		var hopf *spath.HopField
+
+		hopf, err = rpkt.HopF()
+		SoMsg("Wrong HopF on the fetch call", hopf.VerifyOnly, ShouldEqual, hopfield.VerifyOnly)
+		SoMsg("Should be no error when calling HopF for fetch", err, ShouldBeNil)
+
+		hopf, err = rpkt.HopF()
+		SoMsg("Wrong HopF on the cached getter call", hopf.VerifyOnly, ShouldEqual, hopfield.VerifyOnly)
+		SoMsg("Should be no error when calling HopF getter for cached value", err, ShouldBeNil)
+		SoMsg("Regardless of the two calls, only one fetch of HopF expected", fetched, ShouldEqual, 1)
+	})
+}
+
+func TestHooksUp(t *testing.T) {
+	Convey("Fetch UpFlag via hook functions", t, func() {
+		rpkt := setupRtrPktHookTest()
+		rpkt.hooks = hooks{
+			UpFlag: []hookBool{func() (HookResult, bool, error) {
+				fetched++
+				return HookFinish, true, nil
+			}},
+		}
+		var up *bool
+
+		up, err = rpkt.UpFlag()
+		SoMsg("Wrong UpFlag on the fetch call", *up, ShouldBeTrue)
+		SoMsg("Should be no error when calling UpFlag for fetch", err, ShouldBeNil)
+
+		up, err = rpkt.UpFlag()
+		SoMsg("Wrong UpFlag on the cached getter call", *up, ShouldBeTrue)
+		SoMsg("Should be no error when calling UpFlag getter for cached value", err, ShouldBeNil)
+		SoMsg("Regardless of the two calls, only one fetch of UpFlag expected", fetched, ShouldEqual, 1)
+	})
+}
+
+func TestLifecycle(t *testing.T) {
+	Convey("Track references", t, func() {
+		rpkt := setupRtrPktHookTest()
+		var free = false
+		rpkt.Free = func(pkt *RtrPkt) {
+			free = true
+		}
+		SoMsg("Must be created with one ref count", rpkt.refCnt, ShouldEqual, 1)
+
+		rpkt.refInc(2)
+		SoMsg("refInc() must increment ref coount from 1 by 2", rpkt.refCnt, ShouldEqual, 3)
+
+		rpkt.Release()
+		SoMsg("Release() must decrement ref count from 3 to 2", rpkt.refCnt, ShouldEqual, 2)
+		SoMsg("Incorrectly freed, 2 refs remaining", free, ShouldBeFalse)
+
+		rpkt.Release()
+		SoMsg("Incorrectly freed, 1 ref remaining", free, ShouldBeFalse)
+
+		rpkt.Release()
+		SoMsg("Should be no more refs remaining by now", rpkt.refCnt, ShouldEqual, 0)
+		SoMsg("Due no refs remaining by now be freed now", free, ShouldBeTrue)
+
+		rpkt.Reset()
+		SoMsg("Reset() must set refcount to 1", rpkt.refCnt, ShouldEqual, 1)
+		SoMsg("Reset() must set id to empty", rpkt.Id, ShouldBeEmpty)
+	})
+}

--- a/go/border/rpkt/rpkt_test.go
+++ b/go/border/rpkt/rpkt_test.go
@@ -1,0 +1,98 @@
+// Copyright 2017 Audrius Meskauskas with all possible permissions granted
+// to ETH Zurich and Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpkt
+
+import (
+	"encoding/hex"
+
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/border/conf"
+	"github.com/scionproto/scion/go/border/netconf"
+	"github.com/scionproto/scion/go/border/rctx"
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/l4"
+	"github.com/scionproto/scion/go/lib/spkt"
+)
+
+// The packet sample from node 1-14 to 1-17 as logged 20.11.2016
+const sample = "0041003f03000011001000110010000e7f00001b7f00001ac350c35000270" +
+	"a160000001b1008400211056a51080102ff100550010101021000070201330002"
+
+// Prepare the packet from raw
+func prepareRtrPacketSample() *RtrPkt {
+	var err error
+	packet, err := hex.DecodeString(sample)
+	if err != nil {
+		panic(err)
+	}
+	r := NewRtrPkt()
+	r.Raw = packet
+	// Set some other data that are required for the parsing to succeed:
+	var config = &conf.Conf{
+		IA: &addr.ISD_AS{I: 1, A: 2},
+		Net: &netconf.NetConf{
+			IFs: map[common.IFIDType]*netconf.Interface{777: nil},
+		},
+	}
+	r.Ctx = rctx.New(config, 777)
+	r.Ingress = addrIFPair{IfIDs: []common.IFIDType{1, 2}}
+	return r
+}
+
+func TestParseBasic(t *testing.T) {
+	Convey("Parse packet, basic", t, func() {
+		r := prepareRtrPacketSample()
+
+		r.parseBasic()
+		srcIA, _ := r.SrcIA()
+		dstIA, _ := r.DstIA()
+		srcHost, _ := r.SrcHost()
+		dstHost, _ := r.DstHost()
+
+		SoMsg("Source IA", *srcIA, ShouldResemble, addr.ISD_AS{I: 1, A: 14})
+		SoMsg("Destination IA", *dstIA, ShouldResemble, addr.ISD_AS{I: 1, A: 17})
+		SoMsg("Source host IP", srcHost, ShouldResemble, addr.HostIPv4{127, 0, 0, 26})
+		SoMsg("Destination host IP", dstHost, ShouldResemble, addr.HostIPv4{127, 0, 0, 27})
+		SoMsg("CmnHdr", r.CmnHdr, ShouldResemble, spkt.CmnHdr{
+			Ver:      0,
+			DstType:  1,
+			SrcType:  1,
+			TotalLen: 63,
+			HdrLen:   3,
+			NextHdr:  17,
+		})
+	})
+}
+
+func TestParse(t *testing.T) {
+	r := prepareRtrPacketSample()
+
+	// Verify additional fields that appear after complete parse only
+	Convey("Parse packet, complete", t, func() {
+		r.Parse()
+		l4hdr, _ := r.L4Hdr(false)
+		SoMsg("L4Hdr must be expected UDP", l4hdr, ShouldResemble, &l4.UDP{
+			SrcPort:  50000,
+			DstPort:  50000,
+			TotalLen: 39,
+			Checksum: common.RawBytes{0x0a, 0x16},
+		})
+	})
+}

--- a/go/lib/l4/udp_test.go
+++ b/go/lib/l4/udp_test.go
@@ -1,0 +1,87 @@
+// Copyright 2017 Audrius Meskauskas with all possible permissions granted
+// to ETH Zurich and Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l4
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+// Create UDP structure
+func createUDP() UDP {
+	// Use hex, easier seen in binary dump
+	return UDP{0x1234, 0x5678, 0xA, make(common.RawBytes, 2)}
+}
+
+func TestUDPFromRaw(t *testing.T) {
+	Convey("Content must match", t, func() {
+		raw := common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0}
+		original := createUDP()
+
+		fromRaw, err := UDPFromRaw(raw)
+		SoMsg("Must build from raw without error", err, ShouldBeNil)
+		SoMsg("Wrongly rebuilt from raw", fromRaw, ShouldResemble, &original)
+	})
+}
+
+func TestUDPValidate(t *testing.T) {
+	Convey("It is structure of size 10, must be ok", t, func() {
+		u := createUDP()
+
+		So(u.TotalLen, ShouldEqual, 10)
+		err := u.Validate(int(u.TotalLen) - UDPLen)
+		SoMsg("This structure must be seen as valid", err, ShouldBeNil)
+	})
+}
+
+func TestUDPParse(t *testing.T) {
+	Convey("Must parse into the same representation", t, func() {
+		// assuming we have tested UDPPack
+		u := createUDP()
+		raw, err := u.Pack(true)
+		u2 := UDP{0, 0, 0xA,
+			make(common.RawBytes, 2)}
+
+		u2.Parse(raw)
+		SoMsg("Must parse this valid input", err, ShouldBeNil)
+		SoMsg("Parsed content must match expected", u2, ShouldResemble, u)
+	})
+}
+
+func TestUDPPack(t *testing.T) {
+	Convey("Binary content must match", t, func() {
+		u := createUDP()
+		raw, err := u.Pack(true)
+
+		SoMsg("Must pack without error", err, ShouldBeNil)
+		SoMsg("Packed content must match expected", raw, ShouldResemble,
+			common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0})
+	})
+}
+
+func TestUDPWrite(t *testing.T) {
+	Convey("Binary content must match", t, func() {
+		u := createUDP()
+		raw := make(common.RawBytes, 8)
+		err := u.Write(raw)
+
+		SoMsg("Must write without error", err, ShouldBeNil)
+		SoMsg("Wrong content written", raw, ShouldResemble, common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0})
+	})
+}


### PR DESCRIPTION
Here is the new version with (hopefully) all review findings by Scrye applied:

* SoMsg is now used everywhere with the reason explaining the test failure
* The number of blank lines is now much reduced.
* Basically everything is now moved into Convey
* ShouldResemble is consistently used everywhere.
* Underscores are removed from names.
* Cache test is removed from this pull request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1355)
<!-- Reviewable:end -->
