### PR TITLE
UDP with ACKs for SCION infra

### DIFF
--- a/go/lib/infra/messaging/messaging.go
+++ b/go/lib/infra/messaging/messaging.go
@@ -1,0 +1,39 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"context"
+	"net"
+
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+var (
+	ErrClosed      = common.NewCError("Messaging transport closed")
+	ErrContextDone = common.NewCError("Context expired while waiting")
+)
+
+// Transport layers must be safe for concurrent use by multiple goroutines.
+type Transport interface {
+	// Send a message without expecting an ACK.
+	SendUnreliableMsgTo(context.Context, common.RawBytes, net.Addr) error
+	// Send a message, waiting for it to be ACK'd.
+	SendMsgTo(context.Context, common.RawBytes, net.Addr) error
+	// Receive a message.
+	RecvFrom(context.Context) (common.RawBytes, net.Addr, error)
+	// Clean up.
+	Close(context.Context) error
+}

--- a/go/lib/infra/messaging/messaging.go
+++ b/go/lib/infra/messaging/messaging.go
@@ -28,9 +28,12 @@ var (
 
 // Transport layers must be safe for concurrent use by multiple goroutines.
 type Transport interface {
-	// Send a message without expecting an ACK.
+	// Send an unreliable message. Unreliable transport layers do not request
+	// an ACK. For reliable transport layers, this is the same as SendMsgTo.
 	SendUnreliableMsgTo(context.Context, common.RawBytes, net.Addr) error
-	// Send a message, waiting for it to be ACK'd.
+	// Send a reliable message. Unreliable transport layers block here waiting
+	// for the message to be ACK'd. Reliable transport layers return
+	// immediately.
 	SendMsgTo(context.Context, common.RawBytes, net.Addr) error
 	// Receive a message.
 	RecvFrom(context.Context) (common.RawBytes, net.Addr, error)

--- a/go/lib/infra/messaging/types.go
+++ b/go/lib/infra/messaging/types.go
@@ -60,6 +60,10 @@ func (m *ackTable) Store(key uint56, value chan struct{}) {
 // Supports atomic increments and wraps on 7 bytes.
 type uint56 uint64
 
+const (
+	maxUint56 = (1 << 56) - 1
+)
+
 // Inc atomically increments u, and returns the new value.
 func (u *uint56) Inc() uint56 {
 	for {

--- a/go/lib/infra/messaging/types.go
+++ b/go/lib/infra/messaging/types.go
@@ -1,0 +1,90 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+// ackTable maps packet IDs to channels. Goroutines waiting for an ACK for a
+// session ID create a channel, store it in the map at that ID and wait for the
+// channel to be closed. The background receiving goroutine closes the channel
+// when it receives the corresponding ack.
+type ackTable sync.Map
+
+func (m *ackTable) Delete(key uint56) {
+	(*sync.Map)(m).Delete(key)
+}
+
+func (m *ackTable) Load(key uint56) (chan struct{}, bool) {
+	value, loaded := (*sync.Map)(m).Load(key)
+	if value == nil {
+		return nil, loaded
+	}
+	return value.(chan struct{}), loaded
+}
+
+func (m *ackTable) LoadOrStore(key uint56, value chan struct{}) (chan struct{}, bool) {
+	newValue, loaded := (*sync.Map)(m).LoadOrStore(key, value)
+	if newValue == nil {
+		return nil, loaded
+	}
+	return newValue.(chan struct{}), loaded
+}
+
+func (m *ackTable) Range(f func(uint56, chan struct{}) bool) {
+	(*sync.Map)(m).Range(func(k, v interface{}) bool {
+		return f(k.(uint56), v.(chan struct{}))
+	})
+}
+
+func (m *ackTable) Store(key uint56, value chan struct{}) {
+	(*sync.Map)(m).Store(key, value)
+}
+
+// Supports atomic increments and wraps on 7 bytes.
+type uint56 uint64
+
+// Inc atomically increments u, and returns the new value.
+func (u *uint56) Inc() uint56 {
+	for {
+		old := atomic.LoadUint64((*uint64)(u))
+		new := (old + 1) % (1<<56 - 1)
+		swapped := atomic.CompareAndSwapUint64((*uint64)(u), old, new)
+		if swapped {
+			return uint56(new)
+		}
+	}
+}
+
+func (a uint56) putUint56(b common.RawBytes) {
+	_ = b[6]
+	b[0] = byte(a)
+	b[1] = byte(a >> 8)
+	b[2] = byte(a >> 16)
+	b[3] = byte(a >> 24)
+	b[4] = byte(a >> 32)
+	b[5] = byte(a >> 40)
+	b[6] = byte(a >> 48)
+}
+
+func getUint56(b common.RawBytes) uint56 {
+	_ = b[6]
+	return uint56(b[0]) | uint56(b[1])<<8 | uint56(b[2])<<16 | uint56(b[3])<<24 |
+		uint56(b[4])<<32 | uint56(b[5])<<40 | uint56(b[6])<<48
+}

--- a/go/lib/infra/messaging/udp.go
+++ b/go/lib/infra/messaging/udp.go
@@ -60,6 +60,11 @@ const (
 	maxReadEvents = 1 << 8
 )
 
+var (
+	// Used to initialize the first packet ID
+	generator = rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
+)
+
 var _ Transport = (*RUDP)(nil)
 
 // RUDP (Reliable UDP) implements a simple UDP protocol with ACKs on top of SCION/UDP.
@@ -107,7 +112,7 @@ type RUDP struct {
 func NewRUDP(conn net.PacketConn, logger log.Logger) *RUDP {
 	t := &RUDP{
 		conn:           conn,
-		nextPktID:      uint56(rand.Intn(maxUint56 + 1)),
+		nextPktID:      uint56(generator.Intn(maxUint56 + 1)),
 		readEvents:     make(chan *readEventDesc, maxReadEvents),
 		closed:         make(chan struct{}),
 		backgroundDone: make(chan struct{}),

--- a/go/lib/infra/messaging/udp.go
+++ b/go/lib/infra/messaging/udp.go
@@ -1,0 +1,311 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	log "github.com/inconshreveable/log15"
+
+	liblog "github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/util/freepool"
+
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+type rudpFlag uint8
+
+func (f rudpFlag) isSet(other rudpFlag) bool {
+	return f&other != 0
+}
+
+// Protocol constants.
+const (
+	// Flag field set in sent messages that do not require ACK.
+	flagsNone = rudpFlag(0x00)
+	// Included in sent messages that require ACK.
+	flagNeedACK = rudpFlag(0x01)
+	// Included in ACKs.
+	flagACK = rudpFlag(0x02)
+	// Size of RUDP header.
+	rudpHdrLen = 8
+	// Maximum amount of time to try and put an ACK on the network
+	rudpACKTimeout = 2 * time.Second
+	// If no ACK is received, senders will resend the message every
+	// rudpRetryTimeout seconds for as long as the context is not canceled.
+	rudpRetryTimeout = 2 * time.Second
+)
+
+// Internal constants
+const (
+	maxReadEvents = 1 << 8
+)
+
+var _ Transport = (*RUDP)(nil)
+
+// RUDP (Reliable UDP) implements a simple UDP protocol with ACKs on top of SCION/UDP.
+//
+// Two sending primitives are available:
+//
+// SendUnreliableMsgTo sends a message and returns without waiting for an ACK.
+//
+// SendMsgTo sends a message and waits for a limited amount of time for an
+// ACK; if time allows, also resends the message. Once the parent context is
+// canceled, the function returns immediately with an error.
+//
+// Header format:
+//   0B       1        2        3        4        5        6        7
+//   +--------+--------+--------+--------+--------+--------+--------+--------+
+//   | Flags  |                           PacketID                           |
+//   +--------+--------+--------+--------+--------+--------+--------+--------+
+//
+// RUDP can be safely used by concurrent goroutines.
+//
+// All methods receive a context argument. If the context is canceled prior to
+// completing work, ErrContextDone is returned. If the net.PacketConn
+// connection is closed, running functions terminate with ErrClosed.
+type RUDP struct {
+	conn net.PacketConn
+	// Incrementing packet ID generator
+	nextPktID uint56
+	// Track senders waiting for ACKs
+	ackTable ackTable
+	// Channel for received messages, used between the background goroutine and receivers
+	readEvents chan *readEventDesc
+	// Closed when Close() starts to run
+	closed chan struct{}
+	// Closed when background goroutine finishes shutting down
+	backgroundDone chan struct{}
+	log            log.Logger
+	// Serialize write access to the conn object
+	writeLock sync.Mutex
+}
+
+// NewRUDP creates a new RUDP connection by wrapping around a PacketConn.
+//
+// NewRUDP also spawns a background receiving goroutine that continuously reads
+// from conn and keeps track of ACKs and messages.
+func NewUDPTransport(conn net.PacketConn, logger log.Logger) *RUDP {
+	t := &RUDP{
+		conn:           conn,
+		readEvents:     make(chan *readEventDesc, maxReadEvents),
+		closed:         make(chan struct{}),
+		backgroundDone: make(chan struct{}),
+		log:            logger,
+	}
+	t.goBackgroundReceiver()
+	return t
+}
+
+// SendUnreliableMsgTo sends a message and returns without waiting for an ACK.
+func (t *RUDP) SendUnreliableMsgTo(ctx context.Context, b common.RawBytes, a net.Addr) error {
+	id := t.nextPktID.Inc()
+	msg := t.putHeader(id, flagsNone, b)
+	return t.send(ctx, msg, a)
+}
+
+// SendMsgTo sends a message and waits for an ACK. If no ACK is received for a
+// set amount of time, the message is retransmitted. This process repeats while
+// ctx is not canceled.
+func (t *RUDP) SendMsgTo(ctx context.Context, b common.RawBytes, a net.Addr) error {
+	id := t.nextPktID.Inc()
+	msg := t.putHeader(id, flagNeedACK, b)
+	// Store the channel in the shared table s.t. the background receiver can
+	// close it when it gets the ACK
+	ackChannel := make(chan struct{})
+	_, loaded := t.ackTable.LoadOrStore(id, ackChannel)
+	if loaded {
+		// Packet IDs should be unique, this points to a programming error
+		panic(fmt.Sprintf("Duplicate session ID=%d", id))
+	}
+
+	defer t.ackTable.Delete(id)
+	for {
+		if err := t.send(ctx, msg, a); err != nil {
+			return err
+		}
+		select {
+		case <-ackChannel:
+			// Received ack and can return successfully
+			return nil
+		case <-ctx.Done():
+			// Context was canceled and we are out of time, return with failure
+			return ErrContextDone
+		case <-time.After(rudpRetryTimeout):
+			// Did not get ACK and context is not canceled yet, so do nothing
+			// and try to send again
+		case <-t.closed:
+			// Someone called Close, return immediately
+			return ErrClosed
+		}
+	}
+}
+
+func (t *RUDP) sendACK(id uint56, a net.Addr) error {
+	msg := t.putHeader(id, flagACK, nil)
+	ctx, _ := context.WithTimeout(context.Background(), rudpACKTimeout)
+	return t.send(ctx, msg, a)
+}
+
+func (t *RUDP) send(ctx context.Context, b common.RawBytes, a net.Addr) error {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return common.NewCError("Bad context, missing deadline", "dst", a)
+	}
+	// NOTE(scrye): Even though WriteTo is concurrency-safe, we want to enforce
+	// deadlines on each packet to prevent this function from blocking indefinitely.
+	// Because a connection supports a single deadline, we serialize access via a lock.
+	t.writeLock.Lock()
+	t.conn.SetWriteDeadline(deadline)
+	n, err := t.conn.WriteTo(b, a)
+	t.conn.SetWriteDeadline(time.Time{})
+	t.writeLock.Unlock()
+	if err != nil {
+		return err
+	}
+	if n != len(b) {
+		return common.NewCError("Unable to send complete message (message truncated)",
+			"sent_bytes", n, "msg_length", len(b))
+	}
+	return nil
+}
+
+// putHeader returns a new buffer containing the Reliable UDP header and b.
+func (t *RUDP) putHeader(id uint56, flags rudpFlag, b common.RawBytes) common.RawBytes {
+	packet := make(common.RawBytes, rudpHdrLen)
+	packet[0] = byte(flags)
+	id.putUint56(packet[1:8])
+	packet = append(packet, b...)
+	return packet
+}
+
+// RecvFrom returns the next non-ACK message.
+func (t *RUDP) RecvFrom(ctx context.Context) (common.RawBytes, net.Addr, error) {
+	select {
+	case event := <-t.readEvents:
+		// Propagate message payload to caller
+		return event.buffer.CloneB(), event.address, nil
+	case <-ctx.Done():
+		// We timed out, return with failure
+		return nil, nil, ErrContextDone
+	case <-t.closed:
+		// Some other goroutine closed the transport layer
+		return nil, nil, ErrClosed
+	}
+}
+
+// popHeader returns a slice referring only to the payload of b.
+func (t *RUDP) popHeader(b common.RawBytes) (rudpFlag, uint56, common.RawBytes, error) {
+	if len(b) < rudpHdrLen {
+		return 0, 0, nil, common.NewCError("Packet shorter than min length", "length", len(b),
+			"min_length", rudpHdrLen)
+	}
+	flags := rudpFlag(b[0])
+	id := getUint56(b[1:])
+	return flags, id, b[rudpHdrLen:], nil
+}
+
+// goBackgroundReceiver reads messages from the network and marks received ACKs
+// in the ACK table.
+func (t *RUDP) goBackgroundReceiver() {
+	go func() {
+		liblog.LogPanicAndExit()
+		t.log.Info("UDPTransport background goroutine starting", "conn", t.conn)
+		defer t.log.Info("UDPTransport background goroutine stopped", "connt", t.conn)
+		defer close(t.backgroundDone)
+		for {
+			b := freepool.Get()
+			n, address, err := t.conn.ReadFrom(b.B)
+			if err != nil {
+				// FIXME(scrye): For now just log and continue on SCMP errors,
+				// and destroy the background receiver on other errors.
+				if opErr, ok := err.(*snet.OpError); ok && opErr.SCMP() != nil {
+					t.log.Warn("Received SCMP message", "msg", opErr.SCMP())
+					continue
+				} else {
+					// Do not log close events
+					if err != io.EOF {
+						t.log.Error("Read error, shutting down", "err", err)
+					}
+					return
+				}
+			}
+
+			flags, id, payload, err := t.popHeader(b.B[:n])
+			if err != nil {
+				t.log.Error("Unable to remove Reliable UDP header", "err", err)
+				freepool.Put(b)
+				continue
+			}
+			b.B = payload
+
+			// If the received message is an ACK we do not propagate it up the
+			// stack. Instead, we signal the waiting goroutine by closing its
+			// channel.
+			if flags.isSet(flagACK) {
+				ackChannel, loaded := t.ackTable.Load(id)
+				if !loaded {
+					t.log.Warn("Received ACK, but no one is waiting fot it", "id", id)
+				} else {
+					close(ackChannel)
+				}
+				freepool.Put(b)
+				continue
+			}
+
+			// The received message is for the upper layer.
+			event := &readEventDesc{address: address, buffer: b}
+			select {
+			case t.readEvents <- event:
+				// We reliably sent the message to the upper layer, send ACK
+				// (if requested)
+				if flags.isSet(flagNeedACK) {
+					t.sendACK(id, address)
+				}
+			default:
+				t.log.Warn("Internal queue full, dropped message", "msg_len", n)
+			}
+		}
+	}()
+}
+
+// Close closes the net.PacketConn connection and shuts down the background
+// goroutine. If Close blocks for too long while waiting for the goroutine to
+// terminate, it returns ErrContextDone.
+func (t *RUDP) Close(ctx context.Context) error {
+	close(t.closed)
+	err := t.conn.Close()
+	if err != nil {
+		return common.NewCError("Unable to close conn", "err", err)
+	}
+	// Wait for background goroutine to finish
+	select {
+	case <-ctx.Done():
+		return ErrContextDone
+	case <-t.backgroundDone:
+		return nil
+	}
+}
+
+type readEventDesc struct {
+	buffer  *freepool.Buffer
+	address net.Addr
+}

--- a/go/lib/infra/messaging/udp.go
+++ b/go/lib/infra/messaging/udp.go
@@ -211,6 +211,7 @@ func (t *RUDP) send(ctx context.Context, b common.RawBytes, a net.Addr) error {
 func (t *RUDP) putHeader(id uint56, flags rudpFlag, b common.RawBytes) (*freepool.Buffer, error) {
 	buffer := freepool.Get()
 	if rudpHdrLen+len(b) > len(buffer.B) {
+		freepool.Put(buffer)
 		return nil, common.NewCError("Unable to send, payload too long", "pld_len", len(b),
 			"max_allowed", len(buffer.B)-rudpHdrLen)
 	}

--- a/go/lib/infra/messaging/udp_test.go
+++ b/go/lib/infra/messaging/udp_test.go
@@ -1,0 +1,122 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	log "github.com/inconshreveable/log15"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/xtest/loopback"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSendUnreliableMsgTo(t *testing.T) {
+	Convey("Create RUDP, send unreliable message, and receive same message", t, func() {
+		conn := loopback.New()
+		udp := NewUDPTransport(conn, log.Root())
+
+		ctx, _ := context.WithTimeout(context.Background(), 3*time.Second)
+		err := udp.SendUnreliableMsgTo(ctx, common.RawBytes("1234"), &loopback.Addr{})
+		SoMsg("send err", err, ShouldBeNil)
+
+		b, _, err := udp.RecvFrom(ctx)
+		SoMsg("recv err", err, ShouldBeNil)
+		SoMsg("payload", b, ShouldResemble, common.RawBytes("1234"))
+	})
+}
+
+func TestSendMsgTo(t *testing.T) {
+	Convey("Create RUDP, send reliable message, and receive same message", t, func() {
+		conn := loopback.New()
+		udp := NewUDPTransport(conn, log.Root())
+
+		ctx, _ := context.WithTimeout(context.Background(), 3*time.Second)
+		err := udp.SendMsgTo(ctx, common.RawBytes("1234"), &loopback.Addr{})
+		SoMsg("send err", err, ShouldBeNil)
+
+		b, _, err := udp.RecvFrom(ctx)
+		SoMsg("recv err", err, ShouldBeNil)
+		SoMsg("payload", b, ShouldResemble, common.RawBytes("1234"))
+
+		err = udp.Close(ctx)
+		SoMsg("err", err, ShouldBeNil)
+	})
+}
+
+func TestClose(t *testing.T) {
+	Convey("Create RUDP, and close it", t, func() {
+		conn := loopback.New()
+		udp := NewUDPTransport(conn, log.Root())
+		ctx, _ := context.WithTimeout(context.Background(), 3*time.Second)
+		err := udp.Close(ctx)
+		SoMsg("err", err, ShouldBeNil)
+	})
+}
+
+func TestSendMsgToBadLink(t *testing.T) {
+	Convey("Create RUDP on bad link, send reliable message, should get error", t, func() {
+		conn := NewFaultyLoopback()
+		udp := NewUDPTransport(conn, log.Root())
+
+		ctx, _ := context.WithTimeout(context.Background(), 3*time.Second)
+		err := udp.SendMsgTo(ctx, common.RawBytes("1234"), &loopback.Addr{})
+		SoMsg("send err", err, ShouldNotBeNil)
+
+		ctx2, _ := context.WithTimeout(context.Background(), 3*time.Second)
+		err = udp.Close(ctx2)
+		SoMsg("err", err, ShouldBeNil)
+	})
+}
+
+// Loopback with 100% drop rate
+type BadLoopback struct {
+	*loopback.Conn
+	closed chan struct{}
+}
+
+func NewFaultyLoopback() *BadLoopback {
+	return &BadLoopback{
+		Conn:   loopback.New(),
+		closed: make(chan struct{}),
+	}
+}
+
+func (c *BadLoopback) ReadFrom(b []byte) (int, net.Addr, error) {
+	// Drain conn
+	_, _, err := c.Conn.ReadFrom(b)
+	if err != nil {
+		return 0, nil, err
+	}
+	// Block until closed
+	select {
+	case <-c.closed:
+		return 0, nil, io.EOF
+	}
+}
+
+func (c *BadLoopback) Close() error {
+	err := c.Conn.Close()
+	if err != nil {
+		return err
+	}
+	close(c.closed)
+	return nil
+}

--- a/go/lib/util/bufpool/bufpool.go
+++ b/go/lib/util/bufpool/bufpool.go
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package freepool initializes an elastic pool of free buffers. Buffer have capacity
+// Package bufpool initializes an elastic pool of free buffers. Buffer have capacity
 // common.MaxMTU.
 //
-// Apps can use freepool to ammortize allocations between multiple goroutines
+// Apps can use bufpool to ammortize allocations between multiple goroutines
 // without preallocating a large amount of memory. Details about how the
 // allocation and freeing of resources works can be found in the documentation
 // for sync.Pool.
@@ -23,7 +23,7 @@
 // For apps where the performance penalty of grabbing a single free buffer is
 // non-neglibile (e.g., per packet processing in a router), package ringbuf (and
 // manual management of free buffers) should be used instead.
-package freepool
+package bufpool
 
 import (
 	"sync"

--- a/go/lib/util/freepool/freepool.go
+++ b/go/lib/util/freepool/freepool.go
@@ -1,0 +1,98 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package freepool initializes an elastic pool of free buffers. Buffer have capacity
+// common.MaxMTU.
+//
+// Apps can use freepool to ammortize allocations between multiple goroutines
+// without preallocating a large amount of memory. Details about how the
+// allocation and freeing of resources works can be found in the documentation
+// for sync.Pool.
+//
+// For apps where the performance penalty of grabbing a single free buffer is
+// non-neglibile (e.g., per packet processing in a router), package ringbuf (and
+// manual management of free buffers) should be used instead.
+package freepool
+
+import (
+	"sync"
+
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+var freeList = newFreeListT(common.MaxMTU)
+
+// freeListT is a type-explicit wrapper around sync.Pool for Buffer objects.
+type freeListT sync.Pool
+
+func newFreeListT(capacity int) *freeListT {
+	pool := &sync.Pool{
+		New: func() interface{} {
+			return newBuffer(capacity)
+		},
+	}
+	return (*freeListT)(pool)
+}
+
+func (list *freeListT) get() *Buffer {
+	item := (*sync.Pool)(list).Get()
+	return item.(*Buffer)
+}
+
+func (list *freeListT) put(buffer *Buffer) {
+	buffer.Reset()
+	(*sync.Pool)(list).Put(buffer)
+}
+
+// Get returns a buffer from the free buffer pool. If a buffer is not
+// available, a new one is allocated.
+func Get() *Buffer {
+	return freeList.get()
+}
+
+// Put resets a buffer to its initial length and capacity and returns it to the
+// free buffer pool.
+func Put(buffer *Buffer) {
+	// Prohibit uninitialized buffers from being added to the pool
+	if buffer.arena == nil {
+		panic("invalid Buffer object")
+	}
+	// Resetting happens inside put
+	freeList.put(buffer)
+}
+
+// Buffer is a container for a common.RawBytes object B. B can be safely
+// resliced. Calling Reset will return B to its initial length and capacity.
+type Buffer struct {
+	arena common.RawBytes
+	B     common.RawBytes
+}
+
+func newBuffer(capacity int) *Buffer {
+	arena := make(common.RawBytes, capacity)
+	return &Buffer{
+		arena: arena,
+		B:     arena,
+	}
+}
+
+// Reset restores b.B to its initial length and capacity.
+func (b *Buffer) Reset() {
+	b.B = b.arena
+}
+
+// CloneB returns a copy of the data in b.B.
+func (b *Buffer) CloneB() common.RawBytes {
+	return append(common.RawBytes(nil), b.B...)
+}

--- a/go/lib/xtest/loopback/loopback.go
+++ b/go/lib/xtest/loopback/loopback.go
@@ -1,0 +1,99 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package loopback defines a net.PacketConn implementation where sent messages
+// are echoed back on the same connection.
+package loopback
+
+import (
+	"io"
+	"net"
+	"time"
+)
+
+const (
+	// Number of packets that can fit into Conn buffers until the writer blocks
+	PktBufferSize = 16
+)
+
+// Connects a client-server app to itself to simplify testing.
+type Conn struct {
+	wire chan packet
+}
+
+type packet struct {
+	b []byte
+	a net.Addr
+}
+
+// New creates a new loopback connection with capacity PktBufferSize.
+func New() *Conn {
+	return &Conn{
+		wire: make(chan packet, PktBufferSize),
+	}
+}
+
+func (c *Conn) ReadFrom(b []byte) (int, net.Addr, error) {
+	if pkt, ok := <-c.wire; ok {
+		n := copy(b, pkt.b)
+		return n, pkt.a, nil
+	}
+	return 0, nil, io.EOF
+}
+
+func (c *Conn) WriteTo(b []byte, a net.Addr) (int, error) {
+	c.wire <- packet{
+		b: b,
+		a: a,
+	}
+	return len(b), nil
+}
+
+func (c *Conn) Close() error {
+	close(c.wire)
+	return nil
+}
+
+// LocalAddr always returns nil.
+func (c *Conn) LocalAddr() net.Addr {
+	return nil
+}
+
+// SetDeadline is a NOP.
+func (c *Conn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+// SetReadDeadline is a NOP.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+// SetWriteDeadline is a NOP.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+// Addr implements net.Addr. It always returns the same constant strings.
+type Addr struct{}
+
+// Network always returns "loopback".
+func (a *Addr) Network() string {
+	return "loopback"
+}
+
+// String always returns "loopback address".
+func (a *Addr) String() string {
+	return "loopback address"
+}


### PR DESCRIPTION
Implements a protocol for messages with ACKs on top of a net.PacketConn object.

Also:
  - A dummy loopback connection object for simplified testing;
  - An elastic free buffer pool that multiple goroutines can share (when batching is not a performance concern yet).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1359)
<!-- Reviewable:end -->
