### PR TITLE
Add common.Order.{Put,}UintN

### DIFF
--- a/go/lib/common/binary.go
+++ b/go/lib/common/binary.go
@@ -1,0 +1,57 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+var (
+	Order       = binOrder{binary.BigEndian}
+	NativeOrder binary.ByteOrder
+	IsBigEndian bool
+)
+
+func init() {
+	var v uint16 = 0x11FF
+	if (*[2]uint8)(unsafe.Pointer(&v))[0] == 0x11 {
+		IsBigEndian = true
+		NativeOrder = binary.BigEndian
+	} else {
+		IsBigEndian = false
+		NativeOrder = binary.LittleEndian
+	}
+}
+
+type binOrder struct {
+	binary.ByteOrder
+}
+
+func (bo binOrder) UintN(b []byte, width int) uint64 {
+	_ = b[width-1]
+	var v uint64
+	for i := 0; i < width; i++ {
+		v |= uint64(b[i]) << (uint(width-i-1) * 8)
+	}
+	return v
+}
+
+func (bo binOrder) PutUintN(b []byte, v uint64, width int) {
+	_ = b[width-1]
+	for i := range b[:width] {
+		b[i] = byte(v >> (uint(width-i-1) * 8))
+	}
+}

--- a/go/lib/common/binary.go
+++ b/go/lib/common/binary.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	Order       = binOrder{binary.BigEndian}
-	NativeOrder binary.ByteOrder
+	Order       ByteOrderN = newBigEndianN()
+	NativeOrder ByteOrderN
 	IsBigEndian bool
 )
 
@@ -29,29 +29,73 @@ func init() {
 	var v uint16 = 0x11FF
 	if (*[2]uint8)(unsafe.Pointer(&v))[0] == 0x11 {
 		IsBigEndian = true
-		NativeOrder = binary.BigEndian
+		NativeOrder = newBigEndianN()
 	} else {
 		IsBigEndian = false
-		NativeOrder = binary.LittleEndian
+		NativeOrder = newLittleEndianN()
 	}
 }
 
-type binOrder struct {
+type ByteOrderN interface {
+	binary.ByteOrder
+	// Width is the size of the unsigned int value in bytes.
+	UintN(b []byte, width int) uint64
+	// Width is the size of the unsigned int value in bytes.
+	PutUintN(b []byte, v uint64, width int)
+}
+
+var _ ByteOrderN = bigEndianN{}
+
+// bigEndianN is the big-endian implementation of ByteOrderN
+type bigEndianN struct {
 	binary.ByteOrder
 }
 
-func (bo binOrder) UintN(b []byte, width int) uint64 {
+func newBigEndianN() ByteOrderN {
+	return bigEndianN{binary.BigEndian}
+}
+
+func (be bigEndianN) UintN(b []byte, width int) uint64 {
 	_ = b[width-1]
 	var v uint64
 	for i := 0; i < width; i++ {
-		v |= uint64(b[i]) << (uint(width-i-1) * 8)
+		v = (v << 8) | uint64(b[i])
 	}
 	return v
 }
 
-func (bo binOrder) PutUintN(b []byte, v uint64, width int) {
+func (be bigEndianN) PutUintN(b []byte, v uint64, width int) {
 	_ = b[width-1]
 	for i := range b[:width] {
-		b[i] = byte(v >> (uint(width-i-1) * 8))
+		b[width-i-1] = byte(v)
+		v = v >> 8
+	}
+}
+
+var _ ByteOrderN = littleEndianN{}
+
+// littleEndianN is the little-endian implementation of ByteOrderN
+type littleEndianN struct {
+	binary.ByteOrder
+}
+
+func newLittleEndianN() ByteOrderN {
+	return littleEndianN{binary.LittleEndian}
+}
+
+func (le littleEndianN) UintN(b []byte, width int) uint64 {
+	_ = b[width-1]
+	var v uint64
+	for i := width - 1; i >= 0; i-- {
+		v = (v << 8) | uint64(b[i])
+	}
+	return v
+}
+
+func (le littleEndianN) PutUintN(b []byte, v uint64, width int) {
+	_ = b[width-1]
+	for i := range b[:width] {
+		b[i] = byte(v)
+		v = v >> 8
 	}
 }

--- a/go/lib/common/binary_test.go
+++ b/go/lib/common/binary_test.go
@@ -15,40 +15,81 @@
 package common
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-var binOrderCases = []struct {
+type binTestCase struct {
 	width int
 	val   uint64
 	raw   []byte
-}{
-	{1, 0x01, []byte{0x01}},
-	{2, 0x0102, []byte{0x01, 0x02}},
-	{3, 0x010203, []byte{0x01, 0x02, 0x03}},
-	{4, 0x01020304, []byte{0x01, 0x02, 0x03, 0x04}},
-	{5, 0x0102030405, []byte{0x01, 0x02, 0x03, 0x04, 0x05}},
-	{6, 0x010203040506, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}},
-	{7, 0x01020304050607, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}},
-	{8, 0x0102030405060708, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}},
 }
 
-func Test_binOrder_UintN(t *testing.T) {
-	Convey("binOrder.UintN parse correctly", t, func() {
-		for _, testC := range binOrderCases {
-			ret := Order.UintN(testC.raw, testC.width)
-			So(ret, ShouldEqual, testC.val)
+var bigEndCases []binTestCase
+var littleEndCases []binTestCase
+
+func init() {
+	bigEndCases = []binTestCase{
+		{1, 0x01, []byte{0x01}},
+		{2, 0x0102, []byte{0x01, 0x02}},
+		{3, 0x010203, []byte{0x01, 0x02, 0x03}},
+		{4, 0x01020304, []byte{0x01, 0x02, 0x03, 0x04}},
+		{5, 0x0102030405, []byte{0x01, 0x02, 0x03, 0x04, 0x05}},
+		{6, 0x010203040506, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}},
+		{7, 0x01020304050607, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}},
+		{8, 0x0102030405060708, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}},
+	}
+	// Make a copy of bigEndCases with the raw values reversed.
+	for _, testC := range bigEndCases {
+		newC := testC
+		rawLen := len(testC.raw)
+		newC.raw = make([]byte, rawLen)
+		for i := 0; i < rawLen; i++ {
+			newC.raw[i] = testC.raw[rawLen-i-1]
+		}
+		littleEndCases = append(littleEndCases, newC)
+	}
+}
+
+func Test_bigEndianN_UintN(t *testing.T) {
+	order := newBigEndianN()
+	Convey("bigEndianN.UintN parses correctly", t, func() {
+		for _, testC := range bigEndCases {
+			ret := order.UintN(testC.raw, testC.width)
+			SoMsg(fmt.Sprintf("%x", testC.val), ret, ShouldEqual, testC.val)
 		}
 	})
 }
 
-func Test_binOrder_PutUintN(t *testing.T) {
-	Convey("binOrder.PutUintN packs correctly", t, func() {
-		for _, testC := range binOrderCases {
+func Test_bigEndianN_PutUintN(t *testing.T) {
+	order := newBigEndianN()
+	Convey("bigEndianN.PutUintN packs correctly", t, func() {
+		for _, testC := range bigEndCases {
 			b := make([]byte, testC.width)
-			Order.PutUintN(b, testC.val, testC.width)
+			order.PutUintN(b, testC.val, testC.width)
+			SoMsg(fmt.Sprintf("%x", testC.val), b, ShouldResemble, testC.raw)
+		}
+	})
+}
+
+func Test_littleEndianN_UintN(t *testing.T) {
+	order := newLittleEndianN()
+	Convey("littleEndianN.UintN parses correctly", t, func() {
+		for _, testC := range littleEndCases {
+			ret := order.UintN(testC.raw, testC.width)
+			SoMsg(fmt.Sprintf("%x", testC.val), ret, ShouldEqual, testC.val)
+		}
+	})
+}
+
+func Test_littleEndianN_PutUintN(t *testing.T) {
+	order := newLittleEndianN()
+	Convey("littleEndianN.PutUintN packs correctly", t, func() {
+		for _, testC := range littleEndCases {
+			b := make([]byte, testC.width)
+			order.PutUintN(b, testC.val, testC.width)
 			So(b, ShouldResemble, testC.raw)
 		}
 	})

--- a/go/lib/common/binary_test.go
+++ b/go/lib/common/binary_test.go
@@ -1,0 +1,55 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var binOrderCases = []struct {
+	width int
+	val   uint64
+	raw   []byte
+}{
+	{1, 0x01, []byte{0x01}},
+	{2, 0x0102, []byte{0x01, 0x02}},
+	{3, 0x010203, []byte{0x01, 0x02, 0x03}},
+	{4, 0x01020304, []byte{0x01, 0x02, 0x03, 0x04}},
+	{5, 0x0102030405, []byte{0x01, 0x02, 0x03, 0x04, 0x05}},
+	{6, 0x010203040506, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}},
+	{7, 0x01020304050607, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}},
+	{8, 0x0102030405060708, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}},
+}
+
+func Test_binOrder_UintN(t *testing.T) {
+	Convey("binOrder.UintN parse correctly", t, func() {
+		for _, testC := range binOrderCases {
+			ret := Order.UintN(testC.raw, testC.width)
+			So(ret, ShouldEqual, testC.val)
+		}
+	})
+}
+
+func Test_binOrder_PutUintN(t *testing.T) {
+	Convey("binOrder.PutUintN packs correctly", t, func() {
+		for _, testC := range binOrderCases {
+			b := make([]byte, testC.width)
+			Order.PutUintN(b, testC.val, testC.width)
+			So(b, ShouldResemble, testC.raw)
+		}
+	})
+}

--- a/go/lib/common/defs.go
+++ b/go/lib/common/defs.go
@@ -16,9 +16,6 @@ package common
 
 import (
 	"reflect"
-
-	"encoding/binary"
-	"unsafe"
 )
 
 const (
@@ -28,21 +25,6 @@ const (
 	MaxMTU  = (1 << 16) - 1
 	TimeFmt = "2006-01-02 15:04:05.000000-0700"
 )
-
-var Order = binary.BigEndian
-var NativeOrder binary.ByteOrder
-var IsBigEndian bool
-
-func init() {
-	var v uint16 = 0x11FF
-	if (*[2]uint8)(unsafe.Pointer(&v))[0] == 0x11 {
-		IsBigEndian = true
-		NativeOrder = binary.BigEndian
-	} else {
-		IsBigEndian = false
-		NativeOrder = binary.LittleEndian
-	}
-}
 
 const (
 	BR = "br"

--- a/go/lib/infra/messaging/types.go
+++ b/go/lib/infra/messaging/types.go
@@ -78,19 +78,10 @@ func (u *uint56) Inc() uint56 {
 
 // putUint56 writes a to b in network byte order.
 func (a uint56) putUint56(b common.RawBytes) {
-	_ = b[6]
-	b[0] = byte(a >> 48)
-	b[1] = byte(a >> 40)
-	b[2] = byte(a >> 32)
-	b[3] = byte(a >> 24)
-	b[4] = byte(a >> 16)
-	b[5] = byte(a >> 8)
-	b[6] = byte(a)
+	common.Order.PutUintN(b, uint64(a), 7)
 }
 
 // getUint56 returns the number in b, read in network byte order.
 func getUint56(b common.RawBytes) uint56 {
-	_ = b[6]
-	return uint56(b[0])<<48 | uint56(b[1])<<40 | uint56(b[2])<<32 | uint56(b[3])<<24 |
-		uint56(b[4])<<16 | uint56(b[5])<<8 | uint56(b[6])
+	return uint56(common.Order.UintN(b, 7))
 }

--- a/go/sig/egress/worker.go
+++ b/go/sig/egress/worker.go
@@ -15,8 +15,6 @@
 package egress
 
 import (
-	"bytes"
-	"encoding/binary"
 	"time"
 
 	log "github.com/inconshreveable/log15"
@@ -248,11 +246,8 @@ func (f *frame) startPkt(pktLen uint16) {
 }
 
 func (f *frame) writeHdr(sessId mgmt.SessionType, epoch uint16, seq uint32) {
-	var buf bytes.Buffer
-	binary.Write(&buf, common.Order, seq)
-
 	f.b[0] = uint8(sessId)
 	common.Order.PutUint16(f.b[1:3], epoch)
-	copy(f.b[3:6], buf.Bytes()[1:])
+	common.Order.PutUintN(f.b[3:6], uint64(seq), 3)
 	common.Order.PutUint16(f.b[6:8], f.idx)
 }

--- a/go/sig/ingress/worker.go
+++ b/go/sig/ingress/worker.go
@@ -98,7 +98,7 @@ func (w *Worker) Run() {
 // list if needed.
 func (w *Worker) processFrame(frame *FrameBuf) {
 	epoch := int(common.Order.Uint16(frame.raw[1:3]))
-	seqNr := int(common.Order.Uint32(frame.raw[2:6]) & 0x00FFFFFF)
+	seqNr := int(common.Order.UintN(frame.raw[3:6], 3))
 	index := int(common.Order.Uint16(frame.raw[6:8]))
 	frame.seqNr = seqNr
 	frame.index = index


### PR DESCRIPTION
These two methods allow for reading/writing unsigned integers to/from
big-endian ordered bytes with any width from 1 to 8 bytes. This
simplifies logic where the code needs to, say, parse/pack a 3-Byte uint
field.

The SIG encap protocol code is updated to use this new approach.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1360)
<!-- Reviewable:end -->
