### PR TITLE
Basic QUIC/SCION support for Go.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
     build:
         docker:
-            - image: scionproto/scion_base@sha256:78c53b6a8554fdb5f4df048aa3df32741099b53a8ee3cc14ce76ce35bb59ebfe
+            - image: scionproto/scion_base@sha256:5e0e04b721280e206054cb8c05e14f5e6de29a58f2b1d32fd63d5547fb803a60
         <<: *job
         steps:
             - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Thumbs.db
 !/logs/.keepme
 /gen/
 /gen-cache/
+/gen-certs/
 /traces/
 
 # Python generated files #

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -1,0 +1,91 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// QUIC/SCION implementation.
+package squic
+
+import (
+	"crypto/tls"
+
+	//log "github.com/inconshreveable/log15"
+	"github.com/lucas-clemente/quic-go"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/snet"
+)
+
+const (
+	defKeyPath = "gen-certs/tls.key"
+	defPemPath = "gen-certs/tls.pem"
+)
+
+var (
+	// Don't verify the server's cert, as we are not using the TLS PKI.
+	cliTlsCfg = &tls.Config{InsecureSkipVerify: true}
+	srvTlsCfg = &tls.Config{}
+)
+
+func Init(keyPath, pemPath string) error {
+	if keyPath == "" {
+		keyPath = defKeyPath
+	}
+	if pemPath == "" {
+		pemPath = defPemPath
+	}
+	cert, err := tls.LoadX509KeyPair(pemPath, keyPath)
+	if err != nil {
+		return common.NewCError("squic: Unable to load TLS cert/key", "err", err)
+	}
+	srvTlsCfg.Certificates = []tls.Certificate{cert}
+	return nil
+}
+
+func DialSCION(s_net *snet.Network, laddr, raddr *snet.Addr) (quic.Session, error) {
+	return DialSCIONWithBindSVC(s_net, laddr, raddr, nil, addr.SvcNone)
+}
+
+func DialSCIONWithBindSVC(s_net *snet.Network, laddr, raddr, baddr *snet.Addr,
+	svc addr.HostSVC) (quic.Session, error) {
+	sconn, err := sListen(s_net, laddr, baddr, svc)
+	if err != nil {
+		return nil, err
+	}
+	// Use dummy hostname, as it's used for SNI, and we're not doing cert verification.
+	return quic.Dial(sconn, raddr, "host:0", cliTlsCfg, nil)
+}
+
+func ListenSCION(s_net *snet.Network, laddr *snet.Addr) (quic.Listener, error) {
+	return ListenSCIONWithBindSVC(s_net, laddr, nil, addr.SvcNone)
+}
+
+func ListenSCIONWithBindSVC(s_net *snet.Network, laddr, baddr *snet.Addr,
+	svc addr.HostSVC) (quic.Listener, error) {
+	if len(srvTlsCfg.Certificates) == 0 {
+		return nil, common.NewCError("squic: No server TLS certificate configured")
+	}
+	sconn, err := sListen(s_net, laddr, baddr, svc)
+	if err != nil {
+		return nil, err
+	}
+	return quic.Listen(sconn, srvTlsCfg, nil)
+}
+
+func sListen(s_net *snet.Network, laddr, baddr *snet.Addr,
+	svc addr.HostSVC) (*snet.Conn, error) {
+	if s_net == nil {
+		s_net = snet.DefNetwork
+	}
+	return s_net.ListenSCIONWithBindSVC("udp4", laddr, baddr, svc)
+}

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -52,13 +52,13 @@ func Init(keyPath, pemPath string) error {
 	return nil
 }
 
-func DialSCION(s_net *snet.Network, laddr, raddr *snet.Addr) (quic.Session, error) {
-	return DialSCIONWithBindSVC(s_net, laddr, raddr, nil, addr.SvcNone)
+func DialSCION(network *snet.Network, laddr, raddr *snet.Addr) (quic.Session, error) {
+	return DialSCIONWithBindSVC(network, laddr, raddr, nil, addr.SvcNone)
 }
 
-func DialSCIONWithBindSVC(s_net *snet.Network, laddr, raddr, baddr *snet.Addr,
+func DialSCIONWithBindSVC(network *snet.Network, laddr, raddr, baddr *snet.Addr,
 	svc addr.HostSVC) (quic.Session, error) {
-	sconn, err := sListen(s_net, laddr, baddr, svc)
+	sconn, err := sListen(network, laddr, baddr, svc)
 	if err != nil {
 		return nil, err
 	}
@@ -66,26 +66,26 @@ func DialSCIONWithBindSVC(s_net *snet.Network, laddr, raddr, baddr *snet.Addr,
 	return quic.Dial(sconn, raddr, "host:0", cliTlsCfg, nil)
 }
 
-func ListenSCION(s_net *snet.Network, laddr *snet.Addr) (quic.Listener, error) {
-	return ListenSCIONWithBindSVC(s_net, laddr, nil, addr.SvcNone)
+func ListenSCION(network *snet.Network, laddr *snet.Addr) (quic.Listener, error) {
+	return ListenSCIONWithBindSVC(network, laddr, nil, addr.SvcNone)
 }
 
-func ListenSCIONWithBindSVC(s_net *snet.Network, laddr, baddr *snet.Addr,
+func ListenSCIONWithBindSVC(network *snet.Network, laddr, baddr *snet.Addr,
 	svc addr.HostSVC) (quic.Listener, error) {
 	if len(srvTlsCfg.Certificates) == 0 {
 		return nil, common.NewCError("squic: No server TLS certificate configured")
 	}
-	sconn, err := sListen(s_net, laddr, baddr, svc)
+	sconn, err := sListen(network, laddr, baddr, svc)
 	if err != nil {
 		return nil, err
 	}
 	return quic.Listen(sconn, srvTlsCfg, nil)
 }
 
-func sListen(s_net *snet.Network, laddr, baddr *snet.Addr,
+func sListen(network *snet.Network, laddr, baddr *snet.Addr,
 	svc addr.HostSVC) (*snet.Conn, error) {
-	if s_net == nil {
-		s_net = snet.DefNetwork
+	if network == nil {
+		network = snet.DefNetwork
 	}
-	return s_net.ListenSCIONWithBindSVC("udp4", laddr, baddr, svc)
+	return network.ListenSCIONWithBindSVC("udp4", laddr, baddr, svc)
 }

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -3,6 +3,18 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "vN3qcK0Nkk4AhOfhTEA8ZUMu2RY=",
+			"path": "github.com/aead/chacha20",
+			"revision": "8d6ce0550041f9d97e7f15ec27ed489f8bbbb0fb",
+			"revisionTime": "2017-06-14T05:10:14Z"
+		},
+		{
+			"checksumSHA1": "zmmUB5W1Oz/czit5mixwbVQq31A=",
+			"path": "github.com/aead/chacha20/chacha",
+			"revision": "8d6ce0550041f9d97e7f15ec27ed489f8bbbb0fb",
+			"revisionTime": "2017-06-14T05:10:14Z"
+		},
+		{
 			"checksumSHA1": "YNhwvoScUezhDwq58QMY8vUwuqg=",
 			"license": "MIT,3-BSD",
 			"path": "github.com/axw/gocov",
@@ -36,6 +48,48 @@
 			"path": "github.com/beorn7/perks/quantile",
 			"revision": "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9",
 			"revisionTime": "2016-08-04T10:47:26Z"
+		},
+		{
+			"checksumSHA1": "7wknjQuGJ8gr8VsM8cTLgu1M8vw=",
+			"path": "github.com/bifurcation/mint",
+			"revision": "a544bfbca6a083ce9ddeb2c5f570cb240837355a",
+			"revisionTime": "2017-12-09T20:11:46Z"
+		},
+		{
+			"checksumSHA1": "PZNcjO1c9gV/LZzppwpVRl6+QAY=",
+			"path": "github.com/bifurcation/mint/syntax",
+			"revision": "a544bfbca6a083ce9ddeb2c5f570cb240837355a",
+			"revisionTime": "2017-12-09T20:11:46Z"
+		},
+		{
+			"checksumSHA1": "aMwr5c9Dy2gRQrypsrTCoDVDi/8=",
+			"path": "github.com/clipperhouse/linkedlist",
+			"revision": "bf5ab6f9daf9ae25214b7cf666233cde3274357a",
+			"revisionTime": "2014-11-29T04:44:12Z"
+		},
+		{
+			"checksumSHA1": "BlfYVRUk8gVLCXtbqy4JBVFMPTg=",
+			"path": "github.com/clipperhouse/set",
+			"revision": "c425a638bbb3034eaa3dfe8c2f0f4bc29129b7fc",
+			"revisionTime": "2015-03-04T20:45:47Z"
+		},
+		{
+			"checksumSHA1": "C+JncsAI7+mxsVAvx/7lo1p9Pvs=",
+			"path": "github.com/clipperhouse/slice",
+			"revision": "3ae82e00044e045370183e264317ec785b8f0da3",
+			"revisionTime": "2015-03-01T17:33:39Z"
+		},
+		{
+			"checksumSHA1": "NM+gxNbuon8DgHMmdVwHUhwmMyI=",
+			"path": "github.com/clipperhouse/stringer",
+			"revision": "a8382ce6af9a129cab27e7595ef44a4c2b817360",
+			"revisionTime": "2016-04-10T22:32:32Z"
+		},
+		{
+			"checksumSHA1": "APx+deQijXJSBgYle3eao7O+yLE=",
+			"path": "github.com/clipperhouse/typewriter",
+			"revision": "c1a48da378ebb7db1db9f35981b5cc24bf2e5b85",
+			"revisionTime": "2016-12-20T22:28:20Z"
 		},
 		{
 			"checksumSHA1": "s8t6UaijV8WMK0RMdX00OPI5z0o=",
@@ -83,6 +137,18 @@
 			"revisionTime": "2016-10-23T18:47:00Z"
 		},
 		{
+			"checksumSHA1": "d9PxF1XQGLMJZRct2R8qVM/eYlE=",
+			"path": "github.com/hashicorp/golang-lru",
+			"revision": "0a025b7e63adc15a622f29b0b2c4c3848243bbf6",
+			"revisionTime": "2016-08-13T22:13:03Z"
+		},
+		{
+			"checksumSHA1": "9hffs0bAIU6CquiRhKQdzjHnKt0=",
+			"path": "github.com/hashicorp/golang-lru/simplelru",
+			"revision": "0a025b7e63adc15a622f29b0b2c4c3848243bbf6",
+			"revisionTime": "2016-08-13T22:13:03Z"
+		},
+		{
 			"checksumSHA1": "S1lxMekj2Rxqp/lA47z9UGeNHjs=",
 			"license": "APL 2.0",
 			"path": "github.com/inconshreveable/log15",
@@ -116,6 +182,84 @@
 			"path": "github.com/kormat/fmt15",
 			"revision": "aeb535ae78961b7591ea7f7740b74fc6560c88a8",
 			"revisionTime": "2016-11-22T15:41:03Z"
+		},
+		{
+			"checksumSHA1": "2RFzGcdTeQrFkkhT70WhQcMWF6c=",
+			"path": "github.com/lucas-clemente/aes12",
+			"revision": "cd47fb39b79f867c6e4e5cd39cf7abd799f71670",
+			"revisionTime": "2017-10-27T16:34:21Z"
+		},
+		{
+			"checksumSHA1": "ne1X+frkx5fJcpz9FaZPuUZ7amM=",
+			"path": "github.com/lucas-clemente/fnv128a",
+			"revision": "393af48d391698c6ae4219566bfbdfef67269997",
+			"revisionTime": "2016-05-04T15:23:51Z"
+		},
+		{
+			"checksumSHA1": "O9BCxwHi0Y0iYjZYD7SkGe0cjY0=",
+			"path": "github.com/lucas-clemente/quic-go",
+			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
+			"revisionTime": "2017-12-12T10:29:19Z"
+		},
+		{
+			"checksumSHA1": "OA9E+y7g05x/mWJJHmA7oPxWKQo=",
+			"path": "github.com/lucas-clemente/quic-go-certificates",
+			"revision": "d2f86524cced5186554df90d92529757d22c1cb6",
+			"revisionTime": "2016-08-23T09:51:56Z"
+		},
+		{
+			"checksumSHA1": "ly+Jnp9L2/tZnCH/JLjo6x1XEO8=",
+			"path": "github.com/lucas-clemente/quic-go/ackhandler",
+			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
+			"revisionTime": "2017-12-12T10:29:19Z"
+		},
+		{
+			"checksumSHA1": "X4/8oG5h9ffPOXFCYl39QUNuN9U=",
+			"path": "github.com/lucas-clemente/quic-go/congestion",
+			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
+			"revisionTime": "2017-12-12T10:29:19Z"
+		},
+		{
+			"checksumSHA1": "Nod9iZCew4XEWOtK7008B6PPNa8=",
+			"path": "github.com/lucas-clemente/quic-go/internal/crypto",
+			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
+			"revisionTime": "2017-12-12T10:29:19Z"
+		},
+		{
+			"checksumSHA1": "w+Tez/nWPqzt4R3qGF2Yfw0eswU=",
+			"path": "github.com/lucas-clemente/quic-go/internal/flowcontrol",
+			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
+			"revisionTime": "2017-12-12T10:29:19Z"
+		},
+		{
+			"checksumSHA1": "kGh1OYfUamQrE32YzeRZJyWvnhU=",
+			"path": "github.com/lucas-clemente/quic-go/internal/handshake",
+			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
+			"revisionTime": "2017-12-12T10:29:19Z"
+		},
+		{
+			"checksumSHA1": "FHefA0nAsT8tJpFK5wUCi0tsL5w=",
+			"path": "github.com/lucas-clemente/quic-go/internal/protocol",
+			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
+			"revisionTime": "2017-12-12T10:29:19Z"
+		},
+		{
+			"checksumSHA1": "vCZjWwNZq8dsS3YCSnDLv553VfI=",
+			"path": "github.com/lucas-clemente/quic-go/internal/utils",
+			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
+			"revisionTime": "2017-12-12T10:29:19Z"
+		},
+		{
+			"checksumSHA1": "dGwcTMV/AOdJU6IXMJsEcuX6O04=",
+			"path": "github.com/lucas-clemente/quic-go/internal/wire",
+			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
+			"revisionTime": "2017-12-12T10:29:19Z"
+		},
+		{
+			"checksumSHA1": "RaG0jfP+lFzgedW98Bfp0Uri7EY=",
+			"path": "github.com/lucas-clemente/quic-go/qerr",
+			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
+			"revisionTime": "2017-12-12T10:29:19Z"
 		},
 		{
 			"checksumSHA1": "SaVXxoFG75x104SdXULcP0g7uwc=",
@@ -295,6 +439,12 @@
 			"revisionTime": "2017-02-14T06:09:35Z"
 		},
 		{
+			"checksumSHA1": "IQkUIOnvlf0tYloFx9mLaXSvXWQ=",
+			"path": "golang.org/x/crypto/curve25519",
+			"revision": "94eea52f7b742c7cbe0b03b22f0c4c8631ece122",
+			"revisionTime": "2017-11-28T01:43:40Z"
+		},
+		{
 			"checksumSHA1": "X6Q8nYb+KXh+64AKHwWOOcyijHQ=",
 			"path": "golang.org/x/crypto/ed25519",
 			"revision": "9419663f5a44be8b34ca85f08abc5fe1be11f8a3",
@@ -305,6 +455,12 @@
 			"path": "golang.org/x/crypto/ed25519/internal/edwards25519",
 			"revision": "9419663f5a44be8b34ca85f08abc5fe1be11f8a3",
 			"revisionTime": "2017-09-30T17:45:11Z"
+		},
+		{
+			"checksumSHA1": "4D8hxMIaSDEW5pCQk22Xj4DcDh4=",
+			"path": "golang.org/x/crypto/hkdf",
+			"revision": "94eea52f7b742c7cbe0b03b22f0c4c8631ece122",
+			"revisionTime": "2017-11-28T01:43:40Z"
 		},
 		{
 			"checksumSHA1": "1MGpGDQqnUoRpv7VEcQrXOBydXE=",
@@ -383,6 +539,12 @@
 			"path": "golang.org/x/tools/go/ast/astutil",
 			"revision": "5e2ae75eb72a62985e086eed33a5982a929e4fff",
 			"revisionTime": "2016-11-11T21:39:39Z"
+		},
+		{
+			"checksumSHA1": "o6uoZozSLnj3Ph+hj399ZPqJYhE=",
+			"path": "golang.org/x/tools/go/gcimporter15",
+			"revision": "71657689f07604379fce067b57ff757f42c0bf3d",
+			"revisionTime": "2017-12-06T15:54:56Z"
 		},
 		{
 			"checksumSHA1": "+mjMyJPLBPu7vIHaXkDuvqcDk0s=",

--- a/scion.sh
+++ b/scion.sh
@@ -31,6 +31,15 @@ cmd_run() {
         echo "Compiling..."
         cmd_build || exit 1
     fi
+    if [ ! -e "gen-certs/tls.pem" -o ! -e "gen-certs/tls.key" ]; then
+        local old=$(umask)
+        echo "Generating TLS cert"
+        mkdir -p "gen-certs"
+        umask 0177
+        openssl genrsa -out "gen-certs/tls.key" 2048
+        umask "$old"
+        openssl req -new -x509 -key "gen-certs/tls.key" -out "gen-certs/tls.pem" -days 3650 -subj /CN=scion_def_srv
+    fi
     echo "Running the network..."
     if [ -e gen/zk_datalog_dirs.sh ]; then
         bash gen/zk_datalog_dirs.sh || exit 1


### PR DESCRIPTION
This is based on the https://github.com/lucas-clemente/quic-go
implementation, with a thin wrapper to work on top of UDP/SCION.

echoscion is updated to use QUIC/SCION as an example application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1361)
<!-- Reviewable:end -->
