### PR TITLE
Store actual online/offline key in file

### DIFF
--- a/python/lib/crypto/util.py
+++ b/python/lib/crypto/util.py
@@ -28,12 +28,26 @@ def get_online_key_file_path(conf_dir):
     """
     Return the online key file path.
     """
+    return os.path.join(conf_dir, KEYS_DIR, "online-root.seed")
+
+
+def get_online_key_raw_file_path(conf_dir):
+    """
+    Return the raw online key file path.
+    """
     return os.path.join(conf_dir, KEYS_DIR, "online-root.key")
 
 
 def get_offline_key_file_path(conf_dir):
     """
     Return the offline key file path.
+    """
+    return os.path.join(conf_dir, KEYS_DIR, "offline-root.seed")
+
+
+def get_offline_key_raw_file_path(conf_dir):
+    """
+    Return the raw offline key file path.
     """
     return os.path.join(conf_dir, KEYS_DIR, "offline-root.key")
 

--- a/python/topology/generator.py
+++ b/python/topology/generator.py
@@ -64,7 +64,6 @@ from lib.crypto.util import (
     get_offline_key_raw_file_path,
     get_online_key_file_path,
     get_online_key_raw_file_path,
-    KEYS_DIR,
 )
 from lib.defines import (
     AS_CONF_FILE,

--- a/python/topology/generator.py
+++ b/python/topology/generator.py
@@ -61,7 +61,10 @@ from lib.crypto.util import (
     get_ca_cert_file_path,
     get_ca_private_key_file_path,
     get_offline_key_file_path,
+    get_offline_key_raw_file_path,
     get_online_key_file_path,
+    get_online_key_raw_file_path,
+    KEYS_DIR,
 )
 from lib.defines import (
     AS_CONF_FILE,
@@ -348,9 +351,15 @@ class CertGenerator(object):
             self.pub_offline_root_keys[topo_id] = off_root_pub
             self.priv_offline_root_keys[topo_id] = off_root_priv
             online_key_path = get_online_key_file_path("")
+            online_key_raw_path = get_online_key_raw_file_path("")
             offline_key_path = get_offline_key_file_path("")
+            offline_key_raw_path = get_offline_key_raw_file_path("")
             self.cert_files[topo_id][online_key_path] = base64.b64encode(on_root_priv).decode()
+            self.cert_files[topo_id][online_key_raw_path] = base64.b64encode(
+                SigningKey(on_root_priv)._signing_key).decode()
             self.cert_files[topo_id][offline_key_path] = base64.b64encode(off_root_priv).decode()
+            self.cert_files[topo_id][offline_key_raw_path] = base64.b64encode(
+                SigningKey(off_root_priv)._signing_key).decode()
 
     def _gen_as_certs(self, topo_id, as_conf):
         # Self-signed if cert_issuer is missing.


### PR DESCRIPTION
pynacl encodes the seed, instead of the actual signing key.
The go library, however, needs the actual key for signing.

Change to naming scheme:

The seed is now stored in online-root.seed and offline-root.seed
The actual key is stored in online-root.key and offline-root.key

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1363)
<!-- Reviewable:end -->
