### PR TITLE
Fix posixOutput out of bounds error.

### DIFF
--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -56,3 +56,12 @@ func (c *CError) AddCtx(ctx ...interface{}) error {
 	c.Ctx = append(c.Ctx, ctx...)
 	return c
 }
+
+type Temporary interface {
+	Temporary() bool
+}
+
+func IsTemporaryErr(e error) bool {
+	t, ok := e.(Temporary)
+	return ok && t.Temporary()
+}


### PR DESCRIPTION
If WriteBatch returns an error, pktsWritten can be -1. This causes the
copy() at the end of the loop to panic with an out of bounds error.

This patch changes the logic when an error occurs:
- If _some_ packets were sent, process those as normal.
- If no packets were sent, and the error is known to be temporary,
  retry.
- If no packets were sent, and the error is not known to be temporary,
  drop the current batch of packets, and move on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1364)
<!-- Reviewable:end -->
