### PR TITLE
Rework go error nesting.

### DIFF
--- a/go/border/conf/conf.go
+++ b/go/border/conf/conf.go
@@ -65,7 +65,7 @@ func Load(id, confDir string) (*Conf, error) {
 	// Find the config for this router.
 	topoBR, ok := conf.Topo.BR[id]
 	if !ok {
-		return nil, common.NewCError("Unable to find element ID in topology",
+		return nil, common.NewBasicError("Unable to find element ID in topology", nil,
 			"id", id, "path", topoPath)
 	}
 	conf.BR = &topoBR

--- a/go/border/gen.go
+++ b/go/border/gen.go
@@ -83,7 +83,8 @@ func (r *Router) genPkt(dstIA *addr.ISD_AS, dstHost addr.HostAddr, dstL4Port int
 	} else {
 		ifid, ok := ctx.Conf.Net.IFAddrMap[srcAddr.Key()]
 		if !ok {
-			return common.NewCError("genPkt: unable to find ifid for address", "addr", srcAddr)
+			return common.NewBasicError("genPkt: unable to find ifid for address",
+				nil, "addr", srcAddr)
 		}
 		rp.Egress = append(rp.Egress, rpkt.EgressPair{S: ctx.ExtSockOut[ifid]})
 	}
@@ -110,16 +111,12 @@ func (r *Router) genIFIDPkt(ifID common.IFIDType, ctx *rctx.Ctx) {
 	srcAddr := intf.IFAddr.PublicAddrInfo(intf.IFAddr.Overlay)
 	scpld, err := ctrl.NewSignedPldFromUnion(&ifid.IFID{OrigIfID: uint64(ifID)})
 	if err != nil {
-		cerr := err.(*common.CError)
-		cerr.AddCtx("desc", cerr.Desc)
-		logger.Error("Error generating IFID payload", cerr.Ctx...)
+		logger.Error("Error generating IFID payload", "err", common.FmtError(err))
 		return
 	}
 	if err := r.genPkt(intf.RemoteIA, addr.HostFromIP(intf.RemoteAddr.IP),
 		intf.RemoteAddr.L4Port, srcAddr, scpld); err != nil {
-		cerr := err.(*common.CError)
-		cerr.AddCtx("desc", cerr.Desc)
-		logger.Error("Error generating IFID packet", cerr.Ctx...)
+		logger.Error("Error generating IFID packet", "err", common.FmtError(err))
 	}
 }
 
@@ -146,14 +143,10 @@ func (r *Router) genIFStateReq() {
 	srcAddr := ctx.Conf.Net.LocAddr[0].PublicAddrInfo(ctx.Conf.Net.LocAddr[0].Overlay)
 	scpld, err := ctrl.NewSignedPathMgmtPld(&path_mgmt.IFStateReq{})
 	if err != nil {
-		cerr := err.(*common.CError)
-		cerr.AddCtx("desc", cerr.Desc)
-		log.Error("Error generating IFStateReq payload", cerr.Ctx...)
+		log.Error("Error generating IFStateReq payload", "err", common.FmtError(err))
 		return
 	}
 	if err := r.genPkt(ctx.Conf.IA, addr.SvcBS.Multicast(), 0, srcAddr, scpld); err != nil {
-		cerr := err.(*common.CError)
-		cerr.AddCtx("desc", cerr.Desc)
-		log.Error("Error generating IFStateReq packet", cerr.Ctx...)
+		log.Error("Error generating IFStateReq packet", "err", common.FmtError(err))
 	}
 }

--- a/go/border/ifstate/ifstate.go
+++ b/go/border/ifstate/ifstate.go
@@ -67,8 +67,7 @@ func Process(ifStates *path_mgmt.IFStateInfos) {
 			var err error
 			rawRev, err = proto.PackRoot(info.RevInfo)
 			if err != nil {
-				cerr := err.(*common.CError)
-				log.Error("Unable to pack RevInfo", cerr.Ctx...)
+				log.Error("Unable to pack RevInfo", "err", common.FmtError(err))
 				return
 			}
 		}
@@ -102,7 +101,7 @@ func Activate(ifID common.IFIDType) error {
 	defer S.Unlock()
 	ifState, ok := S.M[ifID]
 	if !ok {
-		return common.NewCError("Trying to activate non-existing interface", "intf", ifID)
+		return common.NewBasicError("Trying to activate non-existing interface", nil, "intf", ifID)
 	}
 	ifState.Info.Active = true
 	return nil

--- a/go/border/main.go
+++ b/go/border/main.go
@@ -55,8 +55,7 @@ func main() {
 	setupSignals()
 	r, err := NewRouter(*id, *confDir)
 	if err != nil {
-		cerr := err.(*common.CError)
-		log.Crit("Startup failed", cerr.Ctx...)
+		log.Crit("Startup failed", "err", common.FmtError(err))
 		liblog.Flush()
 		os.Exit(1)
 	}
@@ -67,8 +66,7 @@ func main() {
 	}
 	log.Info("Starting up", "id", *id, "pid", os.Getpid())
 	if err := r.Run(); err != nil {
-		cerr := err.(*common.CError)
-		log.Crit("Run failed", cerr.Ctx...)
+		log.Crit("Run failed", "err", common.FmtError(err))
 		liblog.Flush()
 		os.Exit(1)
 	}

--- a/go/border/metrics/metrics.go
+++ b/go/border/metrics/metrics.go
@@ -139,7 +139,7 @@ func Init(elem string) {
 func Start() error {
 	ln, err := net.Listen("tcp", *promAddr)
 	if err != nil {
-		return common.NewCError("Unable to bind prometheus metrics port", "err", err)
+		return common.NewBasicError("Unable to bind prometheus metrics port", err)
 	}
 	log.Info("Exporting prometheus metrics", "addr", *promAddr)
 	go http.Serve(ln, nil)

--- a/go/border/netconf/interface.go
+++ b/go/border/netconf/interface.go
@@ -58,14 +58,14 @@ func FromTopo(intfs []common.IFIDType, infomap map[common.IFIDType]topology.IFIn
 	for _, ifid := range intfs {
 		ifinfo := infomap[ifid]
 		if v, ok := locIdxes[ifinfo.InternalAddrIdx]; ok && v != ifinfo.InternalAddr {
-			return nil, common.NewCError("Duplicate local address index",
+			return nil, common.NewBasicError("Duplicate local address index", nil,
 				"idx", ifinfo.InternalAddrIdx, "first", v, "second", ifinfo.InternalAddr)
 		}
 		locIdxes[ifinfo.InternalAddrIdx] = ifinfo.InternalAddr
 		v, ok := n.IFs[ifid]
 		newIF := intfFromTopoIF(&ifinfo, ifid)
 		if ok {
-			return nil, common.NewCError("Duplicate ifid",
+			return nil, common.NewBasicError("Duplicate ifid", nil,
 				"ifid", ifid, "first", v, "second", newIF)
 		}
 		n.IFs[ifid] = newIF
@@ -78,7 +78,8 @@ func FromTopo(intfs []common.IFIDType, infomap map[common.IFIDType]topology.IFIn
 	for idx := 0; idx < len(locIdxes); idx++ {
 		taddr, ok := locIdxes[idx]
 		if !ok {
-			return nil, common.NewCError("Non-contiguous local address indexes", "missing", idx)
+			return nil, common.NewBasicError("Non-contiguous local address indexes", nil,
+				"missing", idx)
 		}
 		n.LocAddr[idx] = taddr
 		if taddr.IPv4 != nil {

--- a/go/border/revinfo.go
+++ b/go/border/revinfo.go
@@ -59,12 +59,10 @@ func (r *Router) fwdRevInfo(revInfo *path_mgmt.RevInfo, dstHost addr.HostAddr) {
 	srcAddr := ctx.Conf.Net.LocAddr[0].PublicAddrInfo(ctx.Conf.Topo.Overlay)
 	scpld, err := ctrl.NewSignedPathMgmtPld(revInfo)
 	if err != nil {
-		cerr := err.(*common.CError)
-		log.Error("Error generating RevInfo payload", cerr.Ctx...)
+		log.Error("Error generating RevInfo payload", "err", common.FmtError(err))
 		return
 	}
 	if err = r.genPkt(ctx.Conf.IA, *dstHost.(*addr.HostSVC), 0, srcAddr, scpld); err != nil {
-		cerr := err.(*common.CError)
-		log.Error("Error generating RevInfo packet", cerr.Ctx...)
+		log.Error("Error generating RevInfo packet", "err", common.FmtError(err))
 	}
 }

--- a/go/border/router.go
+++ b/go/border/router.go
@@ -88,13 +88,11 @@ func (r *Router) confSig() {
 		var err error
 		var config *conf.Conf
 		if config, err = r.loadNewConfig(); err != nil {
-			cerr := err.(*common.CError)
-			log.Error("Error reloading config", cerr.Ctx...)
+			log.Error("Error reloading config", "err", common.FmtError(err))
 			continue
 		}
 		if err := r.setupNewContext(config); err != nil {
-			cerr := err.(*common.CError)
-			log.Error("Error setting up new context", cerr.Ctx...)
+			log.Error("Error setting up new context", "err", common.FmtError(err))
 			continue
 		}
 		log.Info("Config reloaded")
@@ -150,8 +148,7 @@ func (r *Router) processPacket(rp *rpkt.RtrPkt) {
 	// Check if the packet needs to be processed locally, and if so register
 	// hooks for doing so.
 	if err := rp.NeedsLocalProcessing(); err != nil {
-		cerr := err.(*common.CError)
-		rp.Error("Error checking for local processing", cerr.Ctx...)
+		rp.Error("Error checking for local processing", "err", common.FmtError(err))
 		return
 	}
 	// Parse the packet payload, if a previous step has registered a relevant
@@ -159,8 +156,7 @@ func (r *Router) processPacket(rp *rpkt.RtrPkt) {
 	if _, err := rp.Payload(true); err != nil {
 		// Any errors at this point are application-level, and hence not
 		// calling handlePktError, as no SCMP errors will be sent.
-		cerr := err.(*common.CError)
-		rp.Error("Error parsing payload", cerr.Ctx...)
+		rp.Error("Error parsing payload", "err", common.FmtError(err))
 		return
 	}
 	// Process the packet, if a previous step has registered a relevant hook

--- a/go/border/rpkt/addr.go
+++ b/go/border/rpkt/addr.go
@@ -27,7 +27,7 @@ func (rp *RtrPkt) DstIA() (*addr.ISD_AS, error) {
 		var err error
 		rp.dstIA, err = rp.hookIA(rp.hooks.DstIA, rp.idxs.dstIA)
 		if err != nil {
-			return nil, common.NewCError("Unable to retrieve destination ISD-AS", "err", err)
+			return nil, common.NewBasicError("Unable to retrieve destination ISD-AS", err)
 		}
 	}
 	return rp.dstIA, nil
@@ -39,7 +39,7 @@ func (rp *RtrPkt) SrcIA() (*addr.ISD_AS, error) {
 		var err error
 		rp.srcIA, err = rp.hookIA(rp.hooks.SrcIA, rp.idxs.srcIA)
 		if err != nil {
-			return nil, common.NewCError("Unable to retrieve source ISD-AS", "err", err)
+			return nil, common.NewBasicError("Unable to retrieve source ISD-AS", err)
 		}
 	}
 	return rp.srcIA, nil
@@ -68,7 +68,7 @@ func (rp *RtrPkt) DstHost() (addr.HostAddr, error) {
 		var err error
 		rp.dstHost, err = rp.hookHost(rp.hooks.DstHost, rp.idxs.dstHost, rp.CmnHdr.DstType)
 		if err != nil {
-			return nil, common.NewCError("Unable to retrieve destination host", "err", err)
+			return nil, common.NewBasicError("Unable to retrieve destination host", err)
 		}
 	}
 	return rp.dstHost, nil
@@ -80,7 +80,7 @@ func (rp *RtrPkt) SrcHost() (addr.HostAddr, error) {
 		var err error
 		rp.srcHost, err = rp.hookHost(rp.hooks.SrcHost, rp.idxs.srcHost, rp.CmnHdr.SrcType)
 		if err != nil {
-			return nil, common.NewCError("Unable to retrieve source host", "err", err)
+			return nil, common.NewBasicError("Unable to retrieve source host", err)
 		}
 	}
 	return rp.srcHost, nil

--- a/go/border/rpkt/extn_scmp_auth_drkey.go
+++ b/go/border/rpkt/extn_scmp_auth_drkey.go
@@ -58,8 +58,8 @@ func (s *rSCMPAuthDRKeyExtn) RegisterHooks(h *hooks) error {
 
 func (s *rSCMPAuthDRKeyExtn) Validate() (HookResult, error) {
 	if len(s.raw) != scmp_auth.DRKeyTotalLength {
-		return HookError, common.NewCError("Invalid header length", "expected",
-			scmp_auth.DRKeyTotalLength, "actual", len(s.raw))
+		return HookError, common.NewBasicError("Invalid header length", nil,
+			"expected", scmp_auth.DRKeyTotalLength, "actual", len(s.raw))
 	}
 	return HookContinue, nil
 }
@@ -89,8 +89,8 @@ func (s *rSCMPAuthDRKeyExtn) MAC() common.RawBytes {
 
 func (s *rSCMPAuthDRKeyExtn) SetMAC(mac common.RawBytes) error {
 	if len(mac) != scmp_auth.MACLength {
-		return common.NewCError("Invalid MAC length", "expected", len(s.MAC()),
-			"actual", len(mac))
+		return common.NewBasicError("Invalid MAC length", nil,
+			"expected", len(s.MAC()), "actual", len(mac))
 	}
 	copy(s.MAC(), mac)
 	return nil

--- a/go/border/rpkt/extn_scmp_auth_hashtree.go
+++ b/go/border/rpkt/extn_scmp_auth_hashtree.go
@@ -58,12 +58,12 @@ func (s *rSCMPAuthHashTreeExtn) RegisterHooks(h *hooks) error {
 
 func (s *rSCMPAuthHashTreeExtn) Validate() (HookResult, error) {
 	if s.Height() > scmp_auth.MaxHeight {
-		return HookError, common.NewCError("Invalid height", "height", s.Height(),
-			"max height", scmp_auth.MaxHeight)
+		return HookError, common.NewBasicError("Invalid height", nil,
+			"height", s.Height(), "max height", scmp_auth.MaxHeight)
 	}
 	if len(s.raw) != s.TotalLength() {
-		return HookError, common.NewCError("Invalid header length", "expected", s.TotalLength(),
-			"actual", len(s.raw))
+		return HookError, common.NewBasicError("Invalid header length", nil,
+			"expected", s.TotalLength(), "actual", len(s.raw))
 	}
 	return HookContinue, nil
 }
@@ -95,8 +95,8 @@ func (s *rSCMPAuthHashTreeExtn) Order() common.RawBytes {
 
 func (s *rSCMPAuthHashTreeExtn) SetOrder(order common.RawBytes) error {
 	if len(order) != scmp_auth.OrderLength {
-		return common.NewCError("Invalid order length.", "expected", scmp_auth.OrderLength,
-			"actual", len(order))
+		return common.NewBasicError("Invalid order length", nil,
+			"expected", scmp_auth.OrderLength, "actual", len(order))
 	}
 	copy(s.raw[scmp_auth.OrderOffset:scmp_auth.SignatureOffset], order)
 	return nil
@@ -109,8 +109,8 @@ func (s *rSCMPAuthHashTreeExtn) Signature() common.RawBytes {
 
 func (s *rSCMPAuthHashTreeExtn) SetSignature(signature common.RawBytes) error {
 	if len(signature) != scmp_auth.SignatureLength {
-		return common.NewCError("Invalid signature length.", "expected", scmp_auth.SignatureLength,
-			"actual", len(signature))
+		return common.NewBasicError("Invalid signature length", nil,
+			"expected", scmp_auth.SignatureLength, "actual", len(signature))
 	}
 	copy(s.raw[scmp_auth.SignatureOffset:scmp_auth.HashesOffset], signature)
 	return nil
@@ -122,8 +122,8 @@ func (s *rSCMPAuthHashTreeExtn) Hashes() common.RawBytes {
 
 func (s *rSCMPAuthHashTreeExtn) SetHashes(hashes common.RawBytes) error {
 	if len(hashes) != scmpAuthHashesLength(s.Height()) {
-		return common.NewCError("Invalid hashes length", "expected",
-			scmpAuthHashesLength(s.Height()), "actual", len(hashes))
+		return common.NewBasicError("Invalid hashes length", nil,
+			"expected", scmpAuthHashesLength(s.Height()), "actual", len(hashes))
 	}
 	copy(s.raw[scmp_auth.HashesOffset:s.TotalLength()], hashes)
 	return nil

--- a/go/border/rpkt/l4.go
+++ b/go/border/rpkt/l4.go
@@ -54,7 +54,7 @@ func (rp *RtrPkt) L4Hdr(verify bool) (l4.L4Header, error) {
 		*/
 		default:
 			// Can't return an SCMP error as we don't understand the L4 header
-			return nil, common.NewCError(UnsupportedL4, "type", rp.L4Type)
+			return nil, common.NewBasicError(UnsupportedL4, nil, "type", rp.L4Type)
 		}
 	}
 	if verify {
@@ -86,13 +86,15 @@ func (rp *RtrPkt) findL4() (bool, error) {
 		offset += hdrLen
 		if hdrLen == 0 {
 			// FIXME(kormat): Can't return an SCMP error as we can't parse the headers
-			return false, common.NewCError("0-length header", "nextHdr", nextHdr, "offset", offset)
+			return false, common.NewBasicError("0-length header", nil,
+				"nextHdr", nextHdr, "offset", offset)
 		}
 	}
 	if offset > len(rp.Raw) {
 		// FIXME(kormat): Can't generally return an SCMP error as parsing the
 		// headers has failed.
-		return false, common.NewCError(errExtChainTooLong, "curr", offset, "max", len(rp.Raw))
+		return false, common.NewBasicError(ErrExtChainTooLong, nil,
+			"curr", offset, "max", len(rp.Raw))
 	}
 	rp.idxs.nextHdrIdx.Type = nextHdr
 	rp.idxs.nextHdrIdx.Index = offset
@@ -151,7 +153,7 @@ func (rp *RtrPkt) updateL4() error {
 			return err
 		}
 	default:
-		return common.NewCError("Updating l4 payload not supported", "type", rp.L4Type)
+		return common.NewBasicError("Updating l4 payload not supported", nil, "type", rp.L4Type)
 	}
 	return nil
 }

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -87,18 +87,16 @@ func (rp *RtrPkt) parseBasic() error {
 	// Set index for destination host address and calculate its length.
 	rp.idxs.dstHost = rp.idxs.srcIA + addr.IABytes
 	if dstLen, err = addr.HostLen(rp.CmnHdr.DstType); err != nil {
-		cerr := err.(*common.CError)
-		if cerr.Desc == addr.ErrorBadHostAddrType {
-			cerr.Data = scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadDstType, nil)
+		if common.GetErrorMsg(err) == addr.ErrorBadHostAddrType {
+			err = scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadDstType, nil, err)
 		}
 		return err
 	}
 	// Set index for source host address and calculate its length.
 	rp.idxs.srcHost = rp.idxs.dstHost + int(dstLen)
 	if srcLen, err = addr.HostLen(rp.CmnHdr.SrcType); err != nil {
-		cerr := err.(*common.CError)
-		if cerr.Desc == addr.ErrorBadHostAddrType {
-			cerr.Data = scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadSrcType, nil)
+		if common.GetErrorMsg(err) == addr.ErrorBadHostAddrType {
+			err = scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadSrcType, nil, err)
 		}
 		return err
 	}
@@ -109,7 +107,7 @@ func (rp *RtrPkt) parseBasic() error {
 	rp.idxs.path = spkt.CmnHdrLen + addrLen + addrPad
 	if rp.idxs.path > hdrLen {
 		// Can't generate SCMP error as we can't parse anything after the address header
-		return common.NewCError("Header length indicated in common header is too small",
+		return common.NewBasicError("Header length indicated in common header is too small", nil,
 			"min", rp.idxs.path, "hdrLen", rp.CmnHdr.HdrLen, "byteSize", hdrLen)
 	}
 	return nil
@@ -145,7 +143,7 @@ func (rp *RtrPkt) parseHopExtns() error {
 	if *offset > len(rp.Raw) {
 		// FIXME(kormat): Can't generate SCMP error in general as we can't
 		// parse anything after the hbh extensions (e.g. a layer 4 header).
-		return common.NewCError(errExtChainTooLong, "curr", offset, "max", len(rp.Raw))
+		return common.NewBasicError(ErrExtChainTooLong, nil, "curr", offset, "max", len(rp.Raw))
 	}
 	return nil
 }

--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -45,35 +45,36 @@ func (rp *RtrPkt) validatePath(dirFrom rcmn.Dir) error {
 			// this router.
 			return nil
 		}
-		sdata := scmp.NewErrData(scmp.C_Path, scmp.T_P_PathRequired, nil)
-		return common.NewCErrorData("Path required", sdata)
+		return common.NewBasicError("Path required",
+			scmp.NewError(scmp.C_Path, scmp.T_P_PathRequired, nil, nil))
 	}
 	// A verify-only Hop Field cannot be used for routing.
 	if rp.hopF.VerifyOnly {
-		sdata := scmp.NewErrData(scmp.C_Path, scmp.T_P_NonRoutingHopF, rp.mkInfoPathOffsets())
-		return common.NewCErrorData("Hop field is VERIFY_ONLY", sdata)
+		return common.NewBasicError("Hop field is VERIFY_ONLY",
+			scmp.NewError(scmp.C_Path, scmp.T_P_NonRoutingHopF, rp.mkInfoPathOffsets(), nil))
 	}
 	// A forward-only Hop Field cannot be used for local delivery.
 	if rp.hopF.ForwardOnly && rp.dstIA == rp.Ctx.Conf.IA {
-		sdata := scmp.NewErrData(scmp.C_Path, scmp.T_P_DeliveryFwdOnly, rp.mkInfoPathOffsets())
-		return common.NewCErrorData("Hop field is FORWARD_ONLY", sdata)
+		return common.NewBasicError("Hop field is FORWARD_ONLY",
+
+			scmp.NewError(scmp.C_Path, scmp.T_P_DeliveryFwdOnly, rp.mkInfoPathOffsets(), nil))
 	}
 	// Check if Hop Field has expired.
 	hopfExpiry := rp.infoF.Timestamp().Add(
 		time.Duration(rp.hopF.ExpTime) * spath.ExpTimeUnit * time.Second)
 	if time.Now().After(hopfExpiry) {
-		sdata := scmp.NewErrData(scmp.C_Path, scmp.T_P_ExpiredHopF, rp.mkInfoPathOffsets())
-		return common.NewCErrorData("Hop field expired", sdata, "expiry", hopfExpiry)
+		return common.NewBasicError(
+			"Hop field expired",
+			scmp.NewError(scmp.C_Path, scmp.T_P_ExpiredHopF, rp.mkInfoPathOffsets(), nil),
+			"expiry", hopfExpiry,
+		)
 	}
 	// Verify the Hop Field MAC.
 	hfmac := rp.Ctx.Conf.HFMacPool.Get().(hash.Hash)
 	err := rp.hopF.Verify(hfmac, rp.infoF.TsInt, rp.getHopFVer(dirFrom))
 	rp.Ctx.Conf.HFMacPool.Put(hfmac)
-	if err != nil {
-		cerr := err.(*common.CError)
-		if cerr.Desc == spath.ErrorHopFBadMac {
-			cerr.Data = scmp.NewErrData(scmp.C_Path, scmp.T_P_BadMac, rp.mkInfoPathOffsets())
-		}
+	if err != nil && common.GetErrorMsg(err) == spath.ErrorHopFBadMac {
+		err = scmp.NewError(scmp.C_Path, scmp.T_P_BadMac, rp.mkInfoPathOffsets(), err)
 	}
 	return err
 }
@@ -83,12 +84,15 @@ func (rp *RtrPkt) validatePath(dirFrom rcmn.Dir) error {
 // destination is this router.
 func (rp *RtrPkt) validateLocalIF(ifid *common.IFIDType) error {
 	if ifid == nil {
-		return common.NewCError("validateLocalIF: Interface is nil")
+		return common.NewBasicError("validateLocalIF: Interface is nil", nil)
 	}
 	if _, ok := rp.Ctx.Conf.Topo.IFInfoMap[common.IFIDType(*ifid)]; !ok {
 		// No such interface.
-		sdata := scmp.NewErrData(scmp.C_Path, scmp.T_P_BadIF, rp.mkInfoPathOffsets())
-		return common.NewCErrorData("Unknown IF", sdata, "ifid", ifid)
+		return common.NewBasicError(
+			"Unknown IF",
+			scmp.NewError(scmp.C_Path, scmp.T_P_BadIF, rp.mkInfoPathOffsets(), nil),
+			"ifid", ifid,
+		)
 	}
 	ifstate.S.RLock()
 	info, ok := ifstate.S.M[*ifid]
@@ -115,8 +119,11 @@ func (rp *RtrPkt) validateLocalIF(ifid *common.IFIDType) error {
 	sinfo := scmp.NewInfoRevocation(
 		uint16(rp.CmnHdr.CurrInfoF), uint16(rp.CmnHdr.CurrHopF), uint16(*ifid),
 		rp.DirFrom == rcmn.DirExternal, info.RawRev)
-	sdata := scmp.NewErrData(scmp.C_Path, scmp.T_P_RevokedIF, sinfo)
-	return common.NewCErrorData(errIntfRevoked, sdata, "ifid", ifid)
+	return common.NewBasicError(
+		errIntfRevoked,
+		scmp.NewError(scmp.C_Path, scmp.T_P_RevokedIF, sinfo, nil),
+		"ifid", ifid,
+	)
 }
 
 // mkInfoPathOffsets is a helper function to create an scmp.InfoPathOffsets
@@ -150,13 +157,17 @@ func (rp *RtrPkt) InfoF() (*spath.InfoField, error) {
 		case rp.CmnHdr.CurrHopF == rp.CmnHdr.CurrInfoF:
 			// There is no path, so do nothing.
 		case hOff < rp.idxs.path: // Error
-			sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadInfoFOffset, nil)
-			return nil, common.NewCErrorData("Info field index too small", sdata,
-				"min", rp.idxs.path/common.LineLen, "actual", rp.CmnHdr.CurrInfoF)
+			return nil, common.NewBasicError(
+				"Info field index too small",
+				scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadInfoFOffset, nil, nil),
+				"min", rp.idxs.path/common.LineLen, "actual", rp.CmnHdr.CurrInfoF,
+			)
 		case rp.CmnHdr.CurrInfoF > rp.CmnHdr.HdrLen: // Error
-			sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadInfoFOffset, nil)
-			return nil, common.NewCErrorData("Info field index too large", sdata,
-				"max", rp.CmnHdr.HdrLen, "actual", rp.CmnHdr.CurrInfoF)
+			return nil, common.NewBasicError(
+				"Info field index too large",
+				scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadInfoFOffset, nil, nil),
+				"max", rp.CmnHdr.HdrLen, "actual", rp.CmnHdr.CurrInfoF,
+			)
 		case rp.CmnHdr.CurrInfoF < rp.CmnHdr.HdrLen: // Parse
 			var err error
 			if rp.infoF, err = spath.InfoFFromRaw(rp.Raw[hOff:]); err != nil {
@@ -191,14 +202,18 @@ func (rp *RtrPkt) HopF() (*spath.HopField, error) {
 		case rp.CmnHdr.CurrHopF == rp.CmnHdr.CurrInfoF:
 			// There is no path, so do nothing.
 		case hOff < iOff+spath.InfoFieldLength: // Error
-			sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadHopFOffset, nil)
-			return nil, common.NewCErrorData("Hop field index too small", sdata, "min",
-				(iOff+spath.InfoFieldLength)/common.LineLen, "actual", rp.CmnHdr.CurrHopF)
+			return nil, common.NewBasicError(
+				"Hop field index too small",
+				scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadHopFOffset, nil, nil),
+				"min", (iOff+spath.InfoFieldLength)/common.LineLen, "actual", rp.CmnHdr.CurrHopF,
+			)
 		case rp.CmnHdr.CurrHopF >= rp.CmnHdr.HdrLen: // Error
-			sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadHopFOffset, nil)
-			return nil, common.NewCErrorData("Hop field index too large", sdata, "max",
-				(rp.CmnHdr.HdrLenBytes()-spath.HopFieldLength)/common.LineLen,
-				"actual", rp.CmnHdr.CurrHopF)
+			return nil, common.NewBasicError(
+				"Hop field index too large",
+				scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadHopFOffset, nil, nil),
+				"max", (rp.CmnHdr.HdrLenBytes()-spath.HopFieldLength)/common.LineLen,
+				"actual", rp.CmnHdr.CurrHopF,
+			)
 		default: // Parse
 			var err error
 			if rp.hopF, err = spath.HopFFromRaw(rp.Raw[hOff:]); err != nil {
@@ -321,7 +336,8 @@ func (rp *RtrPkt) IncPath() (bool, error) {
 		vOnly++
 	}
 	if hOff > hdrLen {
-		return false, common.NewCError("New HopF offset > header length", "max", hdrLen, "actual", hOff)
+		return false, common.NewBasicError("New HopF offset > header length", nil,
+			"max", hdrLen, "actual", hOff)
 	}
 	// Update common header, and packet's InfoF/HopF fields.
 	segChgd := iOff != rp.CmnHdr.InfoFOffBytes()
@@ -343,13 +359,13 @@ func (rp *RtrPkt) IncPath() (bool, error) {
 	}
 	// Check that there's no VERIFY_ONLY fields in the middle of a segment.
 	if vOnly > 0 && !segChgd {
-		sdata := scmp.NewErrData(scmp.C_Path, scmp.T_P_BadHopField, rp.mkInfoPathOffsets())
-		return segChgd, common.NewCError("VERIFY_ONLY in middle of segment", sdata)
+		return segChgd, common.NewBasicError("VERIFY_ONLY in middle of segment",
+			scmp.NewError(scmp.C_Path, scmp.T_P_BadHopField, rp.mkInfoPathOffsets(), nil))
 	}
 	// Check that the segment didn't change from a down-segment to an up-segment.
 	if !origUp && *rp.upFlag {
-		sdata := scmp.NewErrData(scmp.C_Path, scmp.T_P_BadSegment, rp.mkInfoPathOffsets())
-		return segChgd, common.NewCError("Switched from down-segment to up-segment", sdata)
+		return segChgd, common.NewBasicError("Switched from down-segment to up-segment",
+			scmp.NewError(scmp.C_Path, scmp.T_P_BadSegment, rp.mkInfoPathOffsets(), nil))
 	}
 	return segChgd, nil
 }
@@ -403,7 +419,8 @@ func (rp *RtrPkt) IFCurr() (*common.IFIDType, error) {
 			case rcmn.DirExternal:
 				ingress = !*rp.upFlag
 			default:
-				return nil, common.NewCError("DirFrom value unsupported", "val", rp.DirFrom)
+				return nil, common.NewBasicError("DirFrom value unsupported", nil,
+					"val", rp.DirFrom)
 			}
 			if ingress {
 				return rp.checkSetCurrIF(&rp.hopF.Ingress)
@@ -419,10 +436,10 @@ func (rp *RtrPkt) IFCurr() (*common.IFIDType, error) {
 // valid before setting the ifCurr field and returning the value.
 func (rp *RtrPkt) checkSetCurrIF(ifid *common.IFIDType) (*common.IFIDType, error) {
 	if ifid == nil {
-		return nil, common.NewCError("No interface found")
+		return nil, common.NewBasicError("No interface found", nil)
 	}
 	if _, ok := rp.Ctx.Conf.Net.IFs[*ifid]; !ok {
-		return nil, common.NewCError("Unknown interface", "ifid", *ifid)
+		return nil, common.NewBasicError("Unknown interface", nil, "ifid", *ifid)
 	}
 	rp.ifCurr = ifid
 	return rp.ifCurr, nil

--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -91,7 +91,7 @@ func (rp *RtrPkt) validateLocalIF(ifid *common.IFIDType) error {
 		return common.NewBasicError(
 			"Unknown IF",
 			scmp.NewError(scmp.C_Path, scmp.T_P_BadIF, rp.mkInfoPathOffsets(), nil),
-			"ifid", ifid,
+			"ifid", *ifid,
 		)
 	}
 	ifstate.S.RLock()

--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -86,7 +86,7 @@ func (rp *RtrPkt) validateLocalIF(ifid *common.IFIDType) error {
 	if ifid == nil {
 		return common.NewBasicError("validateLocalIF: Interface is nil", nil)
 	}
-	if _, ok := rp.Ctx.Conf.Topo.IFInfoMap[common.IFIDType(*ifid)]; !ok {
+	if _, ok := rp.Ctx.Conf.Topo.IFInfoMap[*ifid]; !ok {
 		// No such interface.
 		return common.NewBasicError(
 			"Unknown IF",

--- a/go/border/rpkt/validate.go
+++ b/go/border/rpkt/validate.go
@@ -33,27 +33,26 @@ const (
 func (rp *RtrPkt) Validate() error {
 	intf, ok := rp.Ctx.Conf.Net.IFs[*rp.ifCurr]
 	if !ok {
-		return common.NewCError(errCurrIntfInvalid, "ifid", *rp.ifCurr)
+		return common.NewBasicError(errCurrIntfInvalid, nil, "ifid", *rp.ifCurr)
 	}
 	// XXX(kormat): the rest of the common header is checked by the parsing phase.
 	if !addr.HostTypeCheck(rp.CmnHdr.DstType) {
-		sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadDstType, nil)
-		return common.NewCErrorData("Unsupported destination address type", sdata,
-			"type", rp.CmnHdr.DstType)
+		return common.NewBasicError("Unsupported destination address type",
+			scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadDstType, nil, nil), "type", rp.CmnHdr.DstType)
 	}
 	if !addr.HostTypeCheck(rp.CmnHdr.SrcType) || rp.CmnHdr.SrcType == addr.HostTypeSVC {
 		// Either the source address type isn't supported, or it is an SVC
 		// address (which is forbidden).
-		sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadSrcType, nil)
-		return common.NewCErrorData("Unsupported source address type", sdata,
-			"type", rp.CmnHdr.SrcType)
+		return common.NewBasicError("Unsupported source address type",
+			scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadSrcType, nil, nil), "type", rp.CmnHdr.SrcType)
 	}
 	if int(rp.CmnHdr.TotalLen) != len(rp.Raw) {
-		sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadPktLen,
-			&scmp.InfoPktSize{Size: uint16(len(rp.Raw)), MTU: uint16(intf.MTU)})
-		return common.NewCErrorData(
-			"Total length specified in common header doesn't match bytes received", sdata,
-			"totalLen", rp.CmnHdr.TotalLen, "actual", len(rp.Raw))
+		return common.NewBasicError(
+			"Total length specified in common header doesn't match bytes received",
+			scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadPktLen,
+				&scmp.InfoPktSize{Size: uint16(len(rp.Raw)), MTU: uint16(intf.MTU)}, nil),
+			"totalLen", rp.CmnHdr.TotalLen, "actual", len(rp.Raw),
+		)
 	}
 	if err := rp.validatePath(rp.DirFrom); err != nil {
 		return err
@@ -71,7 +70,8 @@ func (rp *RtrPkt) Validate() error {
 		case ret == HookFinish:
 			break
 		default:
-			return common.NewCError(errHookResponse, "hook", "Validate", "idx", i, "val", ret)
+			return common.NewBasicError(errHookResponse, nil,
+				"hook", "Validate", "idx", i, "val", ret)
 		}
 	}
 	return nil

--- a/go/border/setup.go
+++ b/go/border/setup.go
@@ -96,7 +96,7 @@ func (r *Router) setup() error {
 func (r *Router) clearCapabilities() error {
 	caps, err := capability.NewPid(0)
 	if err != nil {
-		return common.NewCError("Error retrieving capabilities", "err", err)
+		return common.NewBasicError("Error retrieving capabilities", err)
 	}
 	log.Debug("Startup capabilities", "caps", caps)
 	caps.Clear(capability.CAPS)
@@ -253,7 +253,7 @@ func addPosixLocal(r *Router, ctx *rctx.Ctx, idx int, ba *topology.AddrInfo,
 	// Listen on the socket.
 	over, err := conn.New(ba, nil, labels)
 	if err != nil {
-		return common.NewCError("Unable to listen on local socket", "err", err)
+		return common.NewBasicError("Unable to listen on local socket", err)
 	}
 	// Find interfaces that use this local address.
 	var ifids []common.IFIDType
@@ -320,7 +320,7 @@ func addPosixIntf(r *Router, ctx *rctx.Ctx, intf *netconf.Interface,
 	ba := intf.IFAddr.BindAddrInfo(intf.IFAddr.Overlay)
 	c, err := conn.New(ba, intf.RemoteAddr, labels)
 	if err != nil {
-		return common.NewCError("Unable to listen on external socket", "err", err)
+		return common.NewBasicError("Unable to listen on external socket", err)
 	}
 	ifids := []common.IFIDType{intf.Id}
 	// Setup input goroutine.

--- a/go/cert_srv/io.go
+++ b/go/cert_srv/io.go
@@ -95,7 +95,7 @@ func (d *Dispatcher) dispatch(addr *snet.Addr, buf common.RawBytes) error {
 			d.trcHandler.HandleReq(addr, pld.(*cert_mgmt.TRCReq))
 		}
 	default:
-		return common.NewCError("Not implemented", "protoID", c.ProtoId())
+		return common.NewBasicError("Not implemented", nil, "protoID", c.ProtoId())
 	}
 	return nil
 }

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -94,12 +94,12 @@ func checkFlags() error {
 		*sciondPath = os.Getenv("SCIOND_PATH")
 		if *sciondPath == "" {
 			flag.Usage()
-			return common.NewCError("No SCIOND path specified")
+			return common.NewBasicError("No SCIOND path specified", nil)
 		}
 	}
 	if *confDir == "" {
 		flag.Usage()
-		return common.NewCError("No configuration directory specified")
+		return common.NewBasicError("No configuration directory specified", nil)
 	}
 	return nil
 }
@@ -107,11 +107,12 @@ func checkFlags() error {
 // loadTopo loads topology from the configuration file and sets the local address.
 func loadTopo() (err error) {
 	if topo, err = topology.LoadFromFile(filepath.Join(*confDir, topology.CfgName)); err != nil {
-		return common.NewCError("Unable to load topology", "err", err)
+		return common.NewBasicError("Unable to load topology", err)
 	}
 	topoAddr, ok := topo.CS[*id]
 	if !ok {
-		return common.NewCError("Unable to load addresses. Element ID not found", "id", *id)
+		return common.NewBasicError("Unable to load addresses. Element ID not found", nil,
+			"id", *id)
 	}
 	publicInfo := topoAddr.PublicAddrInfo(topo.Overlay)
 	public = &snet.Addr{IA: topo.ISD_AS, Host: addr.HostFromIP(publicInfo.IP),

--- a/go/cert_srv/trc.go
+++ b/go/cert_srv/trc.go
@@ -98,7 +98,7 @@ func (h *TRCHandler) sendTRCReq(req *cert_mgmt.TRCReq) error {
 	pathSet := snet.DefNetwork.PathResolver().Query(public.IA, req.IA())
 	path := pathSet.GetAppPath("")
 	if path == nil {
-		return common.NewCError("Unable to find core AS")
+		return common.NewBasicError("Unable to find core AS", nil)
 	}
 	a := &snet.Addr{IA: path.Entry.Path.DstIA(), Host: addr.SvcCS}
 	log.Debug("Send TRC request", "req", req, "addr", a)

--- a/go/lib/addr/host.go
+++ b/go/lib/addr/host.go
@@ -237,7 +237,7 @@ func HostFromRaw(b common.RawBytes, htype HostAddrType) (HostAddr, error) {
 	case HostTypeSVC:
 		return HostSVC(binary.BigEndian.Uint16(b)), nil
 	default:
-		return nil, common.NewCError(ErrorBadHostAddrType, "type", htype)
+		return nil, common.NewBasicError(ErrorBadHostAddrType, nil, "type", htype)
 	}
 }
 
@@ -262,7 +262,7 @@ func HostLen(htype HostAddrType) (uint8, error) {
 	case HostTypeSVC:
 		length = HostLenSVC
 	default:
-		return 0, common.NewCError(ErrorBadHostAddrType, "type", htype)
+		return 0, common.NewBasicError(ErrorBadHostAddrType, nil, "type", htype)
 	}
 	return length, nil
 }

--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -49,24 +49,24 @@ func IAFromRaw(b common.RawBytes) *ISD_AS {
 func IAFromString(s string) (*ISD_AS, error) {
 	parts := strings.Split(s, "-")
 	if len(parts) != 2 {
-		return nil, common.NewCError("Invalid ISD-AS", "val", s)
+		return nil, common.NewBasicError("Invalid ISD-AS", nil, "val", s)
 	}
 	isd, err := strconv.Atoi(parts[0])
 	if err != nil {
-		e := err.(*strconv.NumError)
-		return nil, common.NewCError("Unable to parse ISD", "val", s, "err", e.Err)
+		// err.Error() will contain the original value
+		return nil, common.NewBasicError("Unable to parse ISD", err)
 	}
 	if isd > MaxISD {
-		return nil, common.NewCError("Invalid ISD-AS: ISD too large",
+		return nil, common.NewBasicError("Invalid ISD-AS: ISD too large", nil,
 			"max", MaxISD, "actual", isd, "raw", s)
 	}
 	as, err := strconv.Atoi(parts[1])
 	if err != nil {
-		e := err.(*strconv.NumError)
-		return nil, common.NewCError("Unable to parse AS", "val", s, "err", e.Err)
+		// err.Error() will contain the original value
+		return nil, common.NewBasicError("Unable to parse AS", err)
 	}
 	if as > MaxAS {
-		return nil, common.NewCError("Invalid ISD-AS: AS too large",
+		return nil, common.NewBasicError("Invalid ISD-AS: AS too large", nil,
 			"max", MaxAS, "actual", as, "raw", s)
 	}
 	return &ISD_AS{I: isd, A: as}, nil

--- a/go/lib/as_conf/conf.go
+++ b/go/lib/as_conf/conf.go
@@ -44,7 +44,7 @@ var CurrConf *ASConf
 func Load(path string) error {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		return common.NewCError(ErrorOpen, "err", err)
+		return common.NewBasicError(ErrorOpen, err)
 	}
 	return Parse(b, path)
 }
@@ -52,7 +52,7 @@ func Load(path string) error {
 func Parse(data []byte, path string) error {
 	c := &ASConf{}
 	if err := yaml.Unmarshal(data, c); err != nil {
-		return common.NewCError(ErrorParse, "err", err, "path", path)
+		return common.NewBasicError(ErrorParse, err, "path", path)
 	}
 	CurrConf = c
 	return nil

--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -95,7 +95,6 @@ func IsTimeoutErr(e error) bool {
 	return false
 }
 
-var _ error = BasicError{}
 var _ ErrorMsger = BasicError{}
 var _ ErrorNester = BasicError{}
 

--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -122,10 +122,11 @@ func NewBasicError(msg string, e error, logCtx ...interface{}) error {
 }
 
 func (be BasicError) Error() string {
-	s := make([]string, 1+(len(be.logCtx)/2))
+	s := make([]string, 0, 1+(len(be.logCtx)/2))
+	s = append(s, be.Msg)
 	s[0] = be.Msg
 	for i := 0; i < len(be.logCtx); i += 2 {
-		s[i/2] = fmt.Sprintf("%s=\"%v\"", be.logCtx[i], be.logCtx[i+1])
+		s = append(s, fmt.Sprintf("%s=\"%v\"", be.logCtx[i], be.logCtx[i+1]))
 	}
 	return strings.Join(s, " ")
 }

--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -18,50 +18,154 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kormat/fmt15"
+	"github.com/scionproto/scion/go/lib/assert"
 )
 
-type ErrCtx fmt15.FCtx
-
-type ErrorData interface{}
-
-var _ error = (*CError)(nil)
-
-type CError struct {
-	Desc string
-	Ctx  ErrCtx
-	Data ErrorData
-	Cerr *CError
+// ErrorMsg allows extracting the message from an error. This means a caller
+// can determine the type of error by comparing the returned message with a
+// const error string. E.g.:
+// if GetErrorMsg(err) == addr.ErrorBadHostAddrType {
+//    // Handle bad host addr error
+// }
+type ErrorMsg interface {
+	GetMsg() string
 }
 
-func NewCError(desc string, ctx ...interface{}) error {
-	return &CError{Desc: desc, Ctx: ctx}
-}
-
-func NewCErrorData(desc string, data ErrorData, ctx ...interface{}) error {
-	return &CError{Desc: desc, Ctx: ctx, Data: data}
-}
-
-func (c CError) Error() string {
-	// FIXME(kormat): handle nesting.
-	s := []string{}
-	s = append(s, c.Desc)
-	for i := 0; i < len(c.Ctx); i += 2 {
-		s = append(s, fmt.Sprintf("%s=\"%s\"", c.Ctx[i], c.Ctx[i+1]))
+// GetErrorMsg extracts the message from e, if e implements the ErrorMsg
+// interface. As a fall-back, if e implements ErrorNest, GetErrorMsg recurses on
+// the nested error. Otherwise returns an empty string.
+func GetErrorMsg(e error) string {
+	if e, _ := e.(ErrorMsg); e != nil {
+		// e implements ErrorMsg and is not nil
+		return e.GetMsg()
 	}
-	return strings.Join(s, " ")
+	if n := GetNestedError(e); n != nil {
+		return GetErrorMsg(n)
+	}
+	return ""
 }
 
-func (c *CError) AddCtx(ctx ...interface{}) error {
-	c.Ctx = append(c.Ctx, ctx...)
-	return c
+// ErrorNest allows recursing into nested errors.
+type ErrorNest interface {
+	GetErr() error
 }
 
+// GetNestedError returns the nested error, if any. Returns nil otherwise.
+func GetNestedError(e error) error {
+	if n, _ := e.(ErrorNest); n != nil {
+		// e implements ErrorNest and is not nil
+		return n.GetErr()
+	}
+	return nil
+}
+
+// Temporary allows signalling of a temporary error. Based on https://golang.org/pkg/net/#Error
 type Temporary interface {
 	Temporary() bool
 }
 
+// IsTemporaryErr determins if e is a temporary Error. As a fall-back, if e implements ErrorNest,
+// IsTemporaryErr recurses on the nested error. Otherwise returns false.
 func IsTemporaryErr(e error) bool {
-	t, ok := e.(Temporary)
-	return ok && t.Temporary()
+	if t, _ := e.(Temporary); t != nil {
+		// e implements Temporary and is not nil
+		return t.Temporary()
+	}
+	if n := GetNestedError(e); n != nil {
+		return IsTemporaryErr(n)
+	}
+	return false
+}
+
+// Temporary allows signalling of a timeout error. Based on https://golang.org/pkg/net/#Error
+type Timeout interface {
+	Timeout() bool
+}
+
+// IsTimeoutErr determins if e is a temporary Error. As a fall-back, if e implements ErrorNest,
+// IsTimeoutErr recurses on the nested error. Otherwise returns false.
+func IsTimeoutErr(e error) bool {
+	if t, _ := e.(Timeout); t != nil {
+		// e implements Timeout and is not nil
+		return t.Timeout()
+	}
+	if n := GetNestedError(e); n != nil {
+		return IsTimeoutErr(n)
+	}
+	return false
+}
+
+var _ error = BasicError{}
+var _ ErrorMsg = BasicError{}
+var _ ErrorNest = BasicError{}
+
+// BasicError is a simple error type that implements ErrorMsg and ErrorNest,
+// and can contain context (slice of [string, val, string, val...]) for logging purposes.
+type BasicError struct {
+	// Error message
+	Msg string
+	// Error context, for logging purposes only
+	logCtx []interface{}
+	// Nested error, if any.
+	Err error
+}
+
+func NewBasicError(msg string, e error, logCtx ...interface{}) error {
+	if assert.On {
+		assert.Must(len(logCtx)%2 == 0, "Log context must have an even number of elements")
+		for i := 0; i < len(logCtx); i += 2 {
+			_, ok := logCtx[i].(string)
+			assert.Must(ok, "First element of each log context pair must be a string")
+		}
+	}
+	return BasicError{Msg: msg, logCtx: logCtx, Err: e}
+}
+
+func (be BasicError) Error() string {
+	s := make([]string, 1+(len(be.logCtx)/2))
+	s[0] = be.Msg
+	for i := 0; i < len(be.logCtx); i += 2 {
+		s[i/2] = fmt.Sprintf("%s=\"%v\"", be.logCtx[i], be.logCtx[i+1])
+	}
+	return strings.Join(s, " ")
+}
+
+func (be BasicError) GetMsg() string {
+	return be.Msg
+}
+
+func (be BasicError) GetErr() error {
+	return be.Err
+}
+
+// FmtError formats e for logging. It walks through all nested errors, putting each on a new line,
+// and indenting multi-line errors.
+func FmtError(e error) string {
+	var s, ns []string
+	for {
+		ns, e = innerFmtError(e)
+		s = append(s, ns...)
+		if e == nil {
+			break
+		}
+	}
+	return strings.Join(s, "\n    ")
+}
+
+func innerFmtError(e error) ([]string, error) {
+	var s []string
+	lines := strings.Split(e.Error(), "\n")
+	for i, line := range lines {
+		if i == len(lines)-1 && len(line) == 0 {
+			// Don't output an empty line if caused by a trailing newline in
+			// the input.
+			break
+		}
+		if i == 0 {
+			s = append(s, line)
+		} else {
+			s = append(s, ">   "+line)
+		}
+	}
+	return s, GetNestedError(e)
 }

--- a/go/lib/common/errors_test.go
+++ b/go/lib/common/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 ETH Zurich
+// Copyright 2018 ETH Zurich
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,27 +16,21 @@ package common
 
 import (
 	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
-var _ Payload = (*RawBytes)(nil)
-
-type RawBytes []byte
-
-func (r RawBytes) String() string {
-	return fmt.Sprintf("%x", []byte(r))
-}
-
-func (r RawBytes) Len() int {
-	return len(r)
-}
-
-func (r RawBytes) Copy() (Payload, error) {
-	return append(RawBytes{}, r...), nil
-}
-
-func (r RawBytes) WritePld(b RawBytes) (int, error) {
-	if len(b) < len(r) {
-		return 0, NewBasicError("Insufficient space", nil, "expected", len(r), "actual", len(b))
-	}
-	return copy(b, r), nil
+func Test_FmtError(t *testing.T) {
+	var err error = NewBasicError(
+		"level0\nlevel0.1",
+		fmt.Errorf("level1\nlevel1.1"),
+		"k0", "v0", "k1", 1,
+	)
+	Convey("FmtError formats correctly", t, func() {
+		So(FmtError(err), ShouldEqual, `level0
+    >   level0.1 k0="v0" k1="1"
+    level1
+    >   level1.1`)
+	})
 }

--- a/go/lib/crypto/asym.go
+++ b/go/lib/crypto/asym.go
@@ -36,12 +36,12 @@ func Sign(sigInput, signKey common.RawBytes, signAlgo string) (common.RawBytes, 
 	switch strings.ToLower(signAlgo) {
 	case Ed25519:
 		if len(signKey) != ed25519.PrivateKeySize {
-			return nil, common.NewCError(InvalidKeySize, "expected",
+			return nil, common.NewBasicError(InvalidKeySize, nil, "expected",
 				ed25519.PrivateKeySize, "actual", len(signKey))
 		}
 		return ed25519.Sign(ed25519.PrivateKey(signKey), sigInput), nil
 	default:
-		return nil, common.NewCError(UnsupportedSignAlgo, "algo", signAlgo)
+		return nil, common.NewBasicError(UnsupportedSignAlgo, nil, "algo", signAlgo)
 	}
 }
 
@@ -51,14 +51,14 @@ func Verify(sigInput, sig, verifyKey common.RawBytes, signAlgo string) error {
 	switch strings.ToLower(signAlgo) {
 	case Ed25519:
 		if len(verifyKey) != ed25519.PublicKeySize {
-			return common.NewCError(InvalidKeySize, "expected",
-				ed25519.PublicKeySize, "actual", len(verifyKey))
+			return common.NewBasicError(InvalidKeySize, nil,
+				"expected", ed25519.PublicKeySize, "actual", len(verifyKey))
 		}
 		if !ed25519.Verify(ed25519.PublicKey(verifyKey), sigInput, sig) {
-			return common.NewCError(InvalidSignature)
+			return common.NewBasicError(InvalidSignature, nil)
 		}
 		return nil
 	default:
-		return common.NewCError(UnsupportedSignAlgo, "algo", signAlgo)
+		return common.NewBasicError(UnsupportedSignAlgo, nil, "algo", signAlgo)
 	}
 }

--- a/go/lib/crypto/cert/cert.go
+++ b/go/lib/crypto/cert/cert.go
@@ -68,7 +68,7 @@ type Certificate struct {
 func CertificateFromRaw(raw common.RawBytes) (*Certificate, error) {
 	cert := &Certificate{}
 	if err := json.Unmarshal(raw, cert); err != nil {
-		return nil, common.NewCError("Unable to parse Certificate", "err", err)
+		return nil, common.NewBasicError("Unable to parse Certificate", err)
 	}
 	return cert, nil
 }
@@ -78,17 +78,17 @@ func CertificateFromRaw(raw common.RawBytes) (*Certificate, error) {
 // subject, and that it is valid at the current time.
 func (c *Certificate) Verify(subject *addr.ISD_AS, verifyKey common.RawBytes, signAlgo string) error {
 	if !subject.Eq(c.Subject) {
-		return common.NewCError(InvalidSubject, "expected", c.Subject,
-			"actual", subject)
+		return common.NewBasicError(InvalidSubject, nil,
+			"expected", c.Subject, "actual", subject)
 	}
 	currTime := uint64(time.Now().Unix())
 	if currTime < c.IssuingTime {
-		return common.NewCError(EarlyUsage, "IssuingTime",
-			timeToString(c.IssuingTime), "current", timeToString(currTime))
+		return common.NewBasicError(EarlyUsage, nil,
+			"IssuingTime", timeToString(c.IssuingTime), "current", timeToString(currTime))
 	}
 	if currTime > c.ExpirationTime {
-		return common.NewCError(Expired, "Expiration Time",
-			timeToString(c.ExpirationTime), "current", timeToString(currTime))
+		return common.NewBasicError(Expired, nil,
+			"Expiration Time", timeToString(c.ExpirationTime), "current", timeToString(currTime))
 	}
 	return c.VerifySignature(verifyKey, signAlgo)
 }
@@ -98,7 +98,7 @@ func (c *Certificate) Verify(subject *addr.ISD_AS, verifyKey common.RawBytes, si
 func (c *Certificate) VerifySignature(verifyKey common.RawBytes, signAlgo string) error {
 	sigInput, err := c.sigPack()
 	if err != nil {
-		return common.NewCError(UnableSigPack, "error", err)
+		return common.NewBasicError(UnableSigPack, err)
 	}
 	return crypto.Verify(sigInput, c.Signature, verifyKey, signAlgo)
 }

--- a/go/lib/crypto/cert/chain.go
+++ b/go/lib/crypto/cert/chain.go
@@ -61,8 +61,8 @@ func ChainFromRaw(raw common.RawBytes, lz4_ bool) (*Chain, error) {
 		// not exhaust the available memory.
 		byteLen := binary.LittleEndian.Uint32(raw[:4])
 		if byteLen > MaxChainByteLength {
-			return nil, common.NewCError("Certificate chain LZ4 block too large", "max",
-				MaxChainByteLength, "actual", byteLen)
+			return nil, common.NewBasicError("Certificate chain LZ4 block too large", nil,
+				"max", MaxChainByteLength, "actual", byteLen)
 		}
 		buf := make([]byte, byteLen)
 		n, err := lz4.UncompressBlock(raw[4:], buf, 0)

--- a/go/lib/crypto/trc/entries.go
+++ b/go/lib/crypto/trc/entries.go
@@ -93,7 +93,7 @@ func (c *CertLog) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if len(m) != 1 {
-		return common.NewCError("Invalid number of sub-entries in CertLogEntry",
+		return common.NewBasicError("Invalid number of sub-entries in CertLogEntry", nil,
 			"expect", 1, "actual", len(m))
 	}
 	for key, cert := range m {
@@ -120,15 +120,15 @@ func (a *Addr) String() string {
 func (a *Addr) ParseString(addr_ string) error {
 	l := strings.Split(addr_, ",")
 	if len(l) != 2 {
-		return common.NewCError("Invalid address", "raw", addr_, "err", "wrong format")
+		return common.NewBasicError("Invalid address", nil, "raw", addr_, "err", "wrong format")
 	}
 	ia, err := addr.IAFromString(l[0])
 	if err != nil {
-		return common.NewCError("Invalid address", "raw", addr_, "err", err)
+		return common.NewBasicError("Invalid address", nil, "raw", addr_, "err", err)
 	}
 	ip := net.ParseIP(l[1])
 	if ip == nil {
-		return common.NewCError("Invalid address", "raw", addr_, "err", "Invalid IP")
+		return common.NewBasicError("Invalid address", nil, "raw", addr_, "err", "Invalid IP")
 	}
 	a.IA = ia
 	a.IP = ip

--- a/go/lib/ctrl/cert_mgmt/cert_mgmt.go
+++ b/go/lib/ctrl/cert_mgmt/cert_mgmt.go
@@ -48,7 +48,8 @@ func (u *union) set(c proto.Cerealizable) error {
 		u.Which = proto.CertMgmt_Which_trc
 		u.TRCRep = p
 	default:
-		return common.NewCError("Unsupported cert mgmt union type (set)", "type", common.TypeOf(c))
+		return common.NewBasicError("Unsupported cert mgmt union type (set)", nil,
+			"type", common.TypeOf(c))
 	}
 	return nil
 }
@@ -64,7 +65,7 @@ func (u *union) get() (proto.Cerealizable, error) {
 	case proto.CertMgmt_Which_trc:
 		return u.TRCRep, nil
 	}
-	return nil, common.NewCError("Unsupported cert mgmt union type (get)", "type", u.Which)
+	return nil, common.NewBasicError("Unsupported cert mgmt union type (get)", nil, "type", u.Which)
 }
 
 var _ proto.Cerealizable = (*Pld)(nil)

--- a/go/lib/ctrl/extn/extn.go
+++ b/go/lib/ctrl/extn/extn.go
@@ -64,7 +64,7 @@ type CtrlExtnData struct {
 func NewCtrlExtnDataFromValues(e Extension, arenaSize int) (*CtrlExtnData, error) {
 	raw, err := e.Pack()
 	if err != nil {
-		return nil, common.NewCError("Unable to pack extension", "extn", e, "err", err)
+		return nil, common.NewBasicError("Unable to pack extension", err, "extn", e)
 	}
 	return &CtrlExtnData{Type: e.CtrlExtnType(), Data: raw}, nil
 }

--- a/go/lib/ctrl/path_mgmt/path_mgmt.go
+++ b/go/lib/ctrl/path_mgmt/path_mgmt.go
@@ -60,7 +60,8 @@ func (u *union) set(c proto.Cerealizable) error {
 		u.Which = proto.PathMgmt_Which_ifStateInfos
 		u.IFStateInfos = p
 	default:
-		return common.NewCError("Unsupported path mgmt union type (set)", "type", common.TypeOf(c))
+		return common.NewBasicError("Unsupported path mgmt union type (set)", nil,
+			"type", common.TypeOf(c))
 	}
 	return nil
 }
@@ -82,7 +83,7 @@ func (u *union) get() (proto.Cerealizable, error) {
 	case proto.PathMgmt_Which_ifStateInfos:
 		return u.IFStateInfos, nil
 	}
-	return nil, common.NewCError("Unsupported path mgmt union type (get)", "type", u.Which)
+	return nil, common.NewBasicError("Unsupported path mgmt union type (get)", nil, "type", u.Which)
 }
 
 var _ proto.Cerealizable = (*Pld)(nil)

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -139,7 +139,7 @@ func (ps *PathSegment) MaxAEIdx() int {
 
 func (ps *PathSegment) validateIdx(idx int) error {
 	if idx < 0 || idx > ps.MaxAEIdx() {
-		return common.NewCError("Invalid ASEntry index",
+		return common.NewBasicError("Invalid ASEntry index", nil,
 			"min", 0, "max", ps.MaxAEIdx(), "actual", idx)
 	}
 	return nil

--- a/go/lib/ctrl/signed.go
+++ b/go/lib/ctrl/signed.go
@@ -70,7 +70,7 @@ func NewSignedPldFromRaw(b common.RawBytes) (*SignedPld, error) {
 	sp := &SignedPld{}
 	n := common.Order.Uint32(b)
 	if int(n)+4 != len(b) {
-		return nil, common.NewCError("Invalid ctrl payload length",
+		return nil, common.NewBasicError("Invalid ctrl payload length", nil,
 			"expected", n+4, "actual", len(b))
 	}
 	return sp, proto.ParseFromRaw(sp, sp.ProtoId(), b[4:])

--- a/go/lib/ctrl/union.go
+++ b/go/lib/ctrl/union.go
@@ -62,7 +62,8 @@ func (u *union) set(c proto.Cerealizable) error {
 		u.Which = proto.CtrlPld_Which_extn
 		u.Extn = p
 	default:
-		return common.NewCError("Unsupported ctrl union type (set)", "type", common.TypeOf(c))
+		return common.NewBasicError("Unsupported ctrl union type (set)", nil,
+			"type", common.TypeOf(c))
 	}
 	return nil
 }
@@ -82,5 +83,5 @@ func (u *union) get() (proto.Cerealizable, error) {
 	case proto.CtrlPld_Which_extn:
 		return u.Extn, nil
 	}
-	return nil, common.NewCError("Unsupported ctrl union type (get)", "type", u.Which)
+	return nil, common.NewBasicError("Unsupported ctrl union type (get)", nil, "type", u.Which)
 }

--- a/go/lib/hpkt/read.go
+++ b/go/lib/hpkt/read.go
@@ -103,7 +103,7 @@ func (p *parseCtx) parse() error {
 	// extensions can override 5-6.
 
 	if err := p.CmnHdrParser(); err != nil {
-		return common.NewCError("Unable to parse common header", "err", err)
+		return common.NewBasicError("Unable to parse common header", err)
 	}
 	p.nextHdr = p.cmnHdr.NextHdr
 
@@ -114,26 +114,26 @@ func (p *parseCtx) parse() error {
 	p.offset = p.extHdrOffsets.start
 
 	if err := p.HBHAllExtsParser(); err != nil {
-		return common.NewCError("Unable to parse HBH extensions", "err", err)
+		return common.NewBasicError("Unable to parse HBH extensions", err)
 	}
 
 	if err := p.E2EAllExtsParser(); err != nil {
-		return common.NewCError("Unable to parse E2E extensions", "err", err)
+		return common.NewBasicError("Unable to parse E2E extensions", err)
 	}
 
 	// Return to the start of the address header
 	p.offset = p.cmnHdrOffsets.end
 	if err := p.AddrHdrParser(); err != nil {
-		return common.NewCError("Unable to parse address header", "err", err)
+		return common.NewBasicError("Unable to parse address header", err)
 	}
 	if err := p.FwdPathParser(); err != nil {
-		return common.NewCError("Unable to parse path header", "err", err)
+		return common.NewBasicError("Unable to parse path header", err)
 	}
 
 	// Jump after extensions
 	p.offset = p.extHdrOffsets.end
 	if err := p.L4Parser(); err != nil {
-		return common.NewCError("Unable to parse L4 content", "err", err)
+		return common.NewBasicError("Unable to parse L4 content", err)
 	}
 	return nil
 }
@@ -147,8 +147,8 @@ func (p *parseCtx) CmnHdrParser() error {
 	p.cmnHdrOffsets.end = p.offset
 
 	if int(p.cmnHdr.TotalLen) != len(p.b) {
-		return common.NewCError("Malformed total packet length", "expected", p.cmnHdr.TotalLen,
-			"actual", len(p.b))
+		return common.NewBasicError("Malformed total packet length", nil,
+			"expected", p.cmnHdr.TotalLen, "actual", len(p.b))
 	}
 	return nil
 }
@@ -162,12 +162,12 @@ func (p *parseCtx) HBHAllExtsParser() error {
 	for p.nextHdr == common.HopByHopClass {
 		p.hbhCounter += 1
 		if err := p.HBHExtParser(); err != nil {
-			return common.NewCError("Unable to parse HBH extension", "err", err)
+			return common.NewBasicError("Unable to parse HBH extension", err)
 		}
 		if p.hbhCounter > p.hbhLimit {
 			ext := p.s.HBHExt[len(p.s.HBHExt)-1]
-			return common.NewCError("HBH extension limit exceeded", "type", ext.Class(),
-				"position", p.hbhCounter-1, "limit", p.hbhLimit)
+			return common.NewBasicError("HBH extension limit exceeded", nil,
+				"type", ext.Class(), "position", p.hbhCounter-1, "limit", p.hbhLimit)
 		}
 	}
 	return nil
@@ -176,7 +176,7 @@ func (p *parseCtx) HBHAllExtsParser() error {
 func (p *parseCtx) E2EAllExtsParser() error {
 	for p.nextHdr == common.End2EndClass {
 		if err := p.E2EExtParser(); err != nil {
-			return common.NewCError("Unable to parse E2E extension", "err", err)
+			return common.NewBasicError("Unable to parse E2E extension", err)
 		}
 	}
 	return nil
@@ -184,7 +184,7 @@ func (p *parseCtx) E2EAllExtsParser() error {
 
 func (p *parseCtx) DefaultHBHExtParser() error {
 	if len(p.b[p.offset:]) < common.LineLen {
-		return common.NewCError("Truncated extension")
+		return common.NewBasicError("Truncated extension", nil)
 	}
 
 	// Parse 3-byte extension header first
@@ -200,21 +200,21 @@ func (p *parseCtx) DefaultHBHExtParser() error {
 	case common.ExtnSCMPType.Type:
 		if p.hbhCounter != 1 {
 			// SCMP HBH extensions must come immediately after the path header
-			return common.NewCError("Invalid placement of HBH SCMP extension (must be first)",
-				"position", p.hbhCounter-1, "offset", p.offset)
+			return common.NewBasicError("Invalid placement of HBH SCMP extension (must be first)",
+				nil, "position", p.hbhCounter-1, "offset", p.offset)
 		}
 		// SCMP HBH extensions increase the limit of HBH extensions by 1
 		p.hbhLimit += 1
 
 		extn, err := scmp.ExtnFromRaw(p.b[p.offset+common.ExtnSubHdrLen : p.extHdrOffsets.end])
 		if err != nil {
-			return common.NewCError("Unable to parse extension header", "type", extn.Class(),
-				"position", p.hbhCounter-1, "err", err)
+			return common.NewBasicError("Unable to parse extension header", nil,
+				"type", extn.Class(), "position", p.hbhCounter-1, "err", err)
 		}
 		p.s.HBHExt = append(p.s.HBHExt, extn)
 	default:
-		return common.NewCError("Unsupported HBH extension type", "type", extnType,
-			"position", p.hbhCounter-1)
+		return common.NewBasicError("Unsupported HBH extension type", nil,
+			"type", extnType, "position", p.hbhCounter-1)
 	}
 
 	p.offset = p.extHdrOffsets.end
@@ -222,7 +222,7 @@ func (p *parseCtx) DefaultHBHExtParser() error {
 }
 
 func (p *parseCtx) DefaultE2EExtParser() error {
-	return common.NewCError("Not implemented")
+	return common.NewBasicError("Not implemented", nil)
 }
 
 func (p *parseCtx) DefaultAddrHdrParser() error {
@@ -233,20 +233,18 @@ func (p *parseCtx) DefaultAddrHdrParser() error {
 	p.s.SrcIA.Parse(p.b[p.offset:])
 	p.offset += addr.IABytes
 	if p.s.DstHost, err = addr.HostFromRaw(p.b[p.offset:], p.cmnHdr.DstType); err != nil {
-		return common.NewCError("Unable to parse destination host address",
-			"err", err)
+		return common.NewBasicError("Unable to parse destination host address", err)
 	}
 	p.offset += p.s.DstHost.Size()
 	if p.s.SrcHost, err = addr.HostFromRaw(p.b[p.offset:], p.cmnHdr.SrcType); err != nil {
-		return common.NewCError("Unable to parse source host address",
-			"err", err)
+		return common.NewBasicError("Unable to parse source host address", err)
 	}
 	p.offset += p.s.SrcHost.Size()
 	// Validate address padding bytes
 	padBytes := util.CalcPadding(p.offset, common.LineLen)
 	if pos, ok := isZeroMemory(p.b[p.offset : p.offset+padBytes]); !ok {
-		return common.NewCError("Invalid padding", "position", pos,
-			"expected", 0, "actual", p.b[p.offset+pos])
+		return common.NewBasicError("Invalid padding", nil,
+			"position", pos, "expected", 0, "actual", p.b[p.offset+pos])
 	}
 	p.offset += padBytes
 	p.addrHdrOffsets.end = p.offset
@@ -276,15 +274,15 @@ func (p *parseCtx) DefaultL4Parser() error {
 	switch p.nextHdr {
 	case common.L4UDP:
 		if p.s.L4, err = l4.UDPFromRaw(p.b[p.offset : p.offset+l4.UDPLen]); err != nil {
-			return common.NewCError("Unable to parse UDP header", "err", err)
+			return common.NewBasicError("Unable to parse UDP header", err)
 		}
 	case common.L4SCMP:
 		if p.s.L4, err = scmp.HdrFromRaw(p.b[p.offset : p.offset+scmp.HdrLen]); err != nil {
-			return common.NewCError("Unable to parse SCMP header", "err", err)
+			return common.NewBasicError("Unable to parse SCMP header", err)
 		}
 	default:
-		return common.NewCError("Unsupported NextHdr value", "expected",
-			common.L4UDP, "actual", p.nextHdr)
+		return common.NewBasicError("Unsupported NextHdr value", nil,
+			"expected", common.L4UDP, "actual", p.nextHdr)
 	}
 	p.offset += p.s.L4.L4Len()
 	p.l4HdrOffsets.end = p.offset
@@ -293,7 +291,7 @@ func (p *parseCtx) DefaultL4Parser() error {
 	p.pldOffsets.start = p.offset
 	pldLen := len(p.b) - p.pldOffsets.start
 	if err = p.s.L4.Validate(pldLen); err != nil {
-		return common.NewCError("L4 validation failed", "err", err)
+		return common.NewBasicError("L4 validation failed", err)
 	}
 	switch p.nextHdr {
 	case common.L4UDP:
@@ -301,12 +299,13 @@ func (p *parseCtx) DefaultL4Parser() error {
 	case common.L4SCMP:
 		hdr, ok := p.s.L4.(*scmp.Hdr)
 		if !ok {
-			return common.NewCError("Unable to extract SCMP payload, type assertion failed.")
+			return common.NewBasicError(
+				"Unable to extract SCMP payload, type assertion failed", nil)
 		}
 		p.s.Pld, err = scmp.PldFromRaw(p.b[p.offset:p.offset+pldLen],
 			scmp.ClassType{Class: hdr.Class, Type: hdr.Type})
 		if err != nil {
-			return common.NewCError("Unable to parse SCMP payload", "err", err)
+			return common.NewBasicError("Unable to parse SCMP payload", err)
 		}
 	}
 	p.offset += pldLen
@@ -316,7 +315,7 @@ func (p *parseCtx) DefaultL4Parser() error {
 	err = l4.CheckCSum(p.s.L4, p.b[p.addrHdrOffsets.start:p.addrHdrOffsets.end],
 		p.b[p.pldOffsets.start:p.pldOffsets.end])
 	if err != nil {
-		return common.NewCError("Checksum failed", "err", err)
+		return common.NewBasicError("Checksum failed", err)
 	}
 	return nil
 }

--- a/go/lib/hpkt/write.go
+++ b/go/lib/hpkt/write.go
@@ -31,10 +31,10 @@ func WriteScnPkt(s *spkt.ScnPkt, b common.RawBytes) (int, error) {
 	offset := 0
 
 	if s.E2EExt != nil {
-		return 0, common.NewCError("E2E extensions not supported", "ext", s.E2EExt)
+		return 0, common.NewBasicError("E2E extensions not supported", nil, "ext", s.E2EExt)
 	}
 	if s.HBHExt != nil {
-		return 0, common.NewCError("HBH extensions not supported", "ext", s.HBHExt)
+		return 0, common.NewBasicError("HBH extensions not supported", nil, "ext", s.HBHExt)
 	}
 
 	// Compute header lengths
@@ -48,8 +48,8 @@ func WriteScnPkt(s *spkt.ScnPkt, b common.RawBytes) (int, error) {
 	scionHdrLen := spkt.CmnHdrLen + addrHdrLen + pathHdrLen
 	pktLen := scionHdrLen + s.L4.L4Len() + s.Pld.Len()
 	if len(b) < pktLen {
-		return 0, common.NewCError("Buffer too small", "expected", pktLen,
-			"actual", len(b))
+		return 0, common.NewBasicError("Buffer too small", nil,
+			"expected", pktLen, "actual", len(b))
 	}
 
 	// Compute preliminary common header, but do not write it to the packet yet
@@ -99,7 +99,7 @@ func WriteScnPkt(s *spkt.ScnPkt, b common.RawBytes) (int, error) {
 	// SCION/UDP Header
 	err = l4.SetCSum(s.L4, addrSlice, pldSlice)
 	if err != nil {
-		return 0, common.NewCError("Unable to compute checksum", "err", err)
+		return 0, common.NewBasicError("Unable to compute checksum", err)
 	}
 	s.L4.Write(l4Slice)
 

--- a/go/lib/infra/messaging/messaging.go
+++ b/go/lib/infra/messaging/messaging.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	ErrClosed      = common.NewCError("Messaging transport closed")
-	ErrContextDone = common.NewCError("Context expired while waiting")
+	ErrClosed      = common.NewBasicError("Messaging transport closed", nil)
+	ErrContextDone = common.NewBasicError("Context expired while waiting", nil)
 )
 
 // Transport layers must be safe for concurrent use by multiple goroutines.

--- a/go/lib/l4/common.go
+++ b/go/lib/l4/common.go
@@ -67,7 +67,7 @@ func CheckCSum(h L4Header, addr, pld common.RawBytes) error {
 	}
 	exp := h.GetCSum()
 	if bytes.Compare(exp, calc) != 0 {
-		return common.NewCError(ErrorInvalidChksum,
+		return common.NewBasicError(ErrorInvalidChksum, nil,
 			"expected", exp, "actual", calc, "proto", h.L4Type())
 	}
 	return nil

--- a/go/lib/l4/udp.go
+++ b/go/lib/l4/udp.go
@@ -36,14 +36,14 @@ type UDP struct {
 func UDPFromRaw(b common.RawBytes) (*UDP, error) {
 	u := &UDP{Checksum: make(common.RawBytes, 2)}
 	if err := u.Parse(b); err != nil {
-		return nil, common.NewCError("Error unpacking UDP header", "err", err)
+		return nil, common.NewBasicError("Error unpacking UDP header", err)
 	}
 	return u, nil
 }
 
 func (u *UDP) Validate(plen int) error {
 	if plen+UDPLen != int(u.TotalLen) {
-		return common.NewCError("UDP header total length doesn't match",
+		return common.NewBasicError("UDP header total length doesn't match", nil,
 			"expected", u.TotalLen, "actual", plen)
 	}
 	return nil
@@ -64,7 +64,7 @@ func (u *UDP) Parse(b common.RawBytes) error {
 func (u *UDP) Pack(csum bool) (common.RawBytes, error) {
 	b := make(common.RawBytes, UDPLen)
 	if err := u.Write(b); err != nil {
-		return nil, common.NewCError("Error packing UDP header", "err", err)
+		return nil, common.NewBasicError("Error packing UDP header", err)
 	}
 	if csum {
 		// Zero out the checksum field if this is being used for checksum calculation.

--- a/go/lib/overlay/defs.go
+++ b/go/lib/overlay/defs.go
@@ -78,7 +78,7 @@ func TypeFromString(s string) (Type, error) {
 	case strings.ToLower(UDPIPv46Name):
 		return UDPIPv46, nil
 	default:
-		return Invalid, common.NewCError("Unknown overlay type", "type", s)
+		return Invalid, common.NewBasicError("Unknown overlay type", nil, "type", s)
 	}
 }
 

--- a/go/lib/pathdb/pathdb.go
+++ b/go/lib/pathdb/pathdb.go
@@ -37,7 +37,7 @@ func New(path string, backend string) (*DB, error) {
 	case "sqlite":
 		db.conn, err = sqlite.New(path)
 	default:
-		return nil, common.NewCError("Unknown backend", "backend", backend)
+		return nil, common.NewBasicError("Unknown backend", nil, "backend", backend)
 	}
 	if err != nil {
 		return nil, err

--- a/go/lib/pathdb/sqlite/sqlite.go
+++ b/go/lib/pathdb/sqlite/sqlite.go
@@ -59,14 +59,14 @@ func New(path string) (*Backend, error) {
 	var version int
 	err := b.db.QueryRow("PRAGMA user_version;").Scan(&version)
 	if err != nil {
-		return nil, common.NewCError("Failed to check schema version", "err", err)
+		return nil, common.NewBasicError("Failed to check schema version", err)
 	}
 	if version == 0 {
 		if err := b.setup(); err != nil {
 			return nil, err
 		}
 	} else if version != SchemaVersion {
-		return nil, common.NewCError("Database schema version mismatch",
+		return nil, common.NewBasicError("Database schema version mismatch", nil,
 			"expected", SchemaVersion, "have", version)
 	}
 	return b, nil
@@ -79,19 +79,19 @@ func (b *Backend) open(path string) error {
 	uri := fmt.Sprintf("%s?_foreign_keys=1", path)
 	var err error
 	if b.db, err = sql.Open("sqlite3", uri); err != nil {
-		return common.NewCError("Couldn't open SQLite database", "err", err)
+		return common.NewBasicError("Couldn't open SQLite database", err)
 	}
 	// Ensure foreign keys are supported and enabled.
 	var enabled bool
 	err = b.db.QueryRow("PRAGMA foreign_keys;").Scan(&enabled)
 	if err == sql.ErrNoRows {
-		return common.NewCError("Foreign keys not supported", "err", err)
+		return common.NewBasicError("Foreign keys not supported", err)
 	}
 	if err != nil {
-		return common.NewCError("Failed to check for foreign key support", "err", err)
+		return common.NewBasicError("Failed to check for foreign key support", err)
 	}
 	if !enabled {
-		return common.NewCError("Failed to enable foreign key support")
+		return common.NewBasicError("Failed to enable foreign key support", nil)
 	}
 	return nil
 }
@@ -100,16 +100,16 @@ func (b *Backend) setup() error {
 	b.Lock()
 	defer b.Unlock()
 	if b.db == nil {
-		return common.NewCError("No database open")
+		return common.NewBasicError("No database open", nil)
 	}
 	_, err := b.db.Exec(Schema)
 	if err != nil {
-		return common.NewCError("Failed to set up SQLite database", "err", err)
+		return common.NewBasicError("Failed to set up SQLite database", err)
 	}
 	// Write schema version to database.
 	_, err = b.db.Exec(fmt.Sprintf("PRAGMA user_version = %d", SchemaVersion))
 	if err != nil {
-		return common.NewCError("Failed to write schema version", "err", err)
+		return common.NewBasicError("Failed to write schema version", err)
 	}
 	return nil
 }
@@ -118,21 +118,21 @@ func (b *Backend) close() error {
 	b.Lock()
 	defer b.Unlock()
 	if b.db == nil {
-		return common.NewCError("No database open")
+		return common.NewBasicError("No database open", nil)
 	}
 	if err := b.db.Close(); err != nil {
-		return common.NewCError("Failed to close SQLite database", "err", err)
+		return common.NewBasicError("Failed to close SQLite database", err)
 	}
 	return nil
 }
 
 func (b *Backend) begin() error {
 	if b.tx != nil {
-		return common.NewCError("A transaction already exists")
+		return common.NewBasicError("A transaction already exists", nil)
 	}
 	var err error
 	if b.tx, err = b.db.Begin(); err != nil {
-		return common.NewCError("Failed to create transaction", "err", err)
+		return common.NewBasicError("Failed to create transaction", err)
 	}
 	return nil
 }
@@ -140,22 +140,22 @@ func (b *Backend) begin() error {
 func (b *Backend) prepareAndExec(inst string, args ...interface{}) (sql.Result, error) {
 	stmt, err := b.tx.Prepare(inst)
 	if err != nil {
-		return nil, common.NewCError("Failed to prepare statement", "stmt", inst, "err", err)
+		return nil, common.NewBasicError("Failed to prepare statement", err, "stmt", inst)
 	}
 	res, err := stmt.Exec(args...)
 	if err != nil {
-		return nil, common.NewCError("Failed to execute statement", "stmt", inst, "err", err)
+		return nil, common.NewBasicError("Failed to execute statement", err, "stmt", inst)
 	}
 	return res, nil
 }
 
 func (b *Backend) commit() error {
 	if b.tx == nil {
-		return common.NewCError("No transaction to commit")
+		return common.NewBasicError("No transaction to commit", nil)
 	}
 	if err := b.tx.Commit(); err != nil {
 		b.tx = nil
-		return common.NewCError("Failed to commit transaction", "err", err)
+		return common.NewBasicError("Failed to commit transaction", err)
 	}
 	b.tx = nil
 	return nil
@@ -170,7 +170,7 @@ func (b *Backend) InsertWithHPCfgIDs(pseg *seg.PathSegment,
 	b.Lock()
 	defer b.Unlock()
 	if b.db == nil {
-		return 0, common.NewCError("No database open")
+		return 0, common.NewBasicError("No database open", nil)
 	}
 	// Check if we already have a path segment.
 	segID, err := pseg.ID()
@@ -206,7 +206,7 @@ func (b *Backend) InsertWithHPCfgIDs(pseg *seg.PathSegment,
 func (b *Backend) get(segID common.RawBytes) (*segMeta, error) {
 	rows, err := b.db.Query("SELECT * FROM Segments WHERE SegID=?", segID)
 	if err != nil {
-		return nil, common.NewCError("Failed to lookup segment", "err", err)
+		return nil, common.NewBasicError("Failed to lookup segment", err)
 	}
 	defer rows.Close()
 	for rows.Next() {
@@ -215,7 +215,7 @@ func (b *Backend) get(segID common.RawBytes) (*segMeta, error) {
 		var rawSeg sql.RawBytes
 		err = rows.Scan(&meta.RowID, &meta.SegID, &lastUpdated, &rawSeg)
 		if err != nil {
-			return nil, common.NewCError("Failed to extract data", "err", err)
+			return nil, common.NewBasicError("Failed to extract data", err)
 		}
 		meta.LastUpdated = time.Unix(int64(lastUpdated), 0)
 		var err error
@@ -268,7 +268,7 @@ func (b *Backend) updateSeg(meta *segMeta) error {
 	stmtStr := `UPDATE Segments SET LastUpdated=?, Segment=? WHERE RowID=?`
 	_, err = b.prepareAndExec(stmtStr, meta.LastUpdated.Unix(), packedSeg, meta.RowID)
 	if err != nil {
-		return common.NewCError("Failed to update segment", "err", err)
+		return common.NewBasicError("Failed to update segment", err)
 	}
 	return nil
 }
@@ -277,7 +277,7 @@ func (b *Backend) insertType(segRowID int64, segType seg.Type) error {
 	_, err := b.prepareAndExec("INSERT INTO SegTypes (SegRowID, Type) VALUES (?, ?)",
 		segRowID, segType)
 	if err != nil {
-		return common.NewCError("Failed to insert type", "err", err)
+		return common.NewBasicError("Failed to insert type", err)
 	}
 	return nil
 }
@@ -287,7 +287,7 @@ func (b *Backend) insertHPCfgID(segRowID int64, hpCfgID *query.HPCfgID) error {
 		"INSERT INTO HpCfgIds (SegRowID, IsdID, AsID, CfgID) VALUES (?, ?, ?, ?)",
 		segRowID, hpCfgID.IA.I, hpCfgID.IA.A, hpCfgID.ID)
 	if err != nil {
-		return common.NewCError("Failed to insert hpCfgID", "err", err)
+		return common.NewBasicError("Failed to insert hpCfgID", err)
 	}
 	return nil
 }
@@ -311,12 +311,12 @@ func (b *Backend) insertFull(pseg *seg.PathSegment,
 	res, err := b.prepareAndExec(inst, segID, time.Now().Unix(), packedSeg)
 	if err != nil {
 		b.tx.Rollback()
-		return common.NewCError("Failed to insert path segment", "err", err)
+		return common.NewBasicError("Failed to insert path segment", err)
 	}
 	segRowID, err := res.LastInsertId()
 	if err != nil {
 		b.tx.Rollback()
-		return common.NewCError("Failed to retrieve segRowID of inserted segment", "err", err)
+		return common.NewBasicError("Failed to retrieve segRowID of inserted segment", err)
 	}
 	// Insert all interfaces.
 	if err = b.insertInterfaces(pseg.ASEntries, segRowID); err != nil {
@@ -361,25 +361,25 @@ func (b *Backend) insertInterfaces(ases []*seg.ASEntry, segRowID int64) error {
 		stmtStr := `INSERT INTO IntfToSeg (IsdID, ASID, IntfID, SegRowID) VALUES (?, ?, ?, ?)`
 		stmt, err := b.tx.Prepare(stmtStr)
 		if err != nil {
-			return common.NewCError("Failed to prepare insert into IntfToSeg", "err", err)
+			return common.NewBasicError("Failed to prepare insert into IntfToSeg", err)
 		}
 		defer stmt.Close()
 		for idx, hop := range as.HopEntries {
 			hof, err := hop.HopField()
 			if err != nil {
-				return common.NewCError("Failed to extract hop field", "err", err)
+				return common.NewBasicError("Failed to extract hop field", err)
 			}
 			if hof.Ingress != 0 {
 				_, err = stmt.Exec(ia.I, ia.A, hof.Ingress, segRowID)
 				if err != nil {
-					return common.NewCError("Failed to insert Ingress into IntfToSeg", "err", err)
+					return common.NewBasicError("Failed to insert Ingress into IntfToSeg", err)
 				}
 			}
 			// Only insert the Egress interface for the first hop entry in an AS entry.
 			if idx == 0 && hof.Egress != 0 {
 				_, err := stmt.Exec(ia.I, ia.A, hof.Egress, segRowID)
 				if err != nil {
-					return common.NewCError("Failed to insert Egress into IntfToSeg", "err", err)
+					return common.NewBasicError("Failed to insert Egress into IntfToSeg", err)
 				}
 			}
 		}
@@ -393,7 +393,7 @@ func (b *Backend) insertStartOrEnd(as *seg.ASEntry, segRowID int64,
 	stmtStr := fmt.Sprintf("INSERT INTO %s (IsdID, AsID, SegRowID) VALUES (?, ?, ?)", tableName)
 	_, err := b.prepareAndExec(stmtStr, ia.I, ia.A, segRowID)
 	if err != nil {
-		return common.NewCError(fmt.Sprintf("Failed to insert into %s", tableName), "err", err)
+		return common.NewBasicError(fmt.Sprintf("Failed to insert into %s", tableName), err)
 	}
 	return nil
 }
@@ -402,7 +402,7 @@ func (b *Backend) Delete(segID common.RawBytes) (int, error) {
 	b.Lock()
 	defer b.Unlock()
 	if b.db == nil {
-		return 0, common.NewCError("No database open")
+		return 0, common.NewBasicError("No database open", nil)
 	}
 	// Create new transaction
 	if err := b.begin(); err != nil {
@@ -411,7 +411,7 @@ func (b *Backend) Delete(segID common.RawBytes) (int, error) {
 	res, err := b.prepareAndExec("DELETE FROM Segments WHERE SegID=?", segID)
 	if err != nil {
 		b.tx.Rollback()
-		return 0, common.NewCError("Failed to delete segment", "err", err)
+		return 0, common.NewBasicError("Failed to delete segment", err)
 	}
 	// Commit transaction
 	if err := b.commit(); err != nil {
@@ -425,7 +425,7 @@ func (b *Backend) DeleteWithIntf(intf query.IntfSpec) (int, error) {
 	b.Lock()
 	defer b.Unlock()
 	if b.db == nil {
-		return 0, common.NewCError("No database open")
+		return 0, common.NewBasicError("No database open", nil)
 	}
 	// Create new transaction
 	if err := b.begin(); err != nil {
@@ -436,7 +436,7 @@ func (b *Backend) DeleteWithIntf(intf query.IntfSpec) (int, error) {
 	res, err := b.prepareAndExec(delStmt, intf.IA.I, intf.IA.A, intf.IfID)
 	if err != nil {
 		b.tx.Rollback()
-		return 0, common.NewCError("Failed to delete segments", "err", err)
+		return 0, common.NewBasicError("Failed to delete segments", err)
 	}
 	// Commit transaction
 	if err := b.commit(); err != nil {
@@ -450,12 +450,12 @@ func (b *Backend) Get(params *query.Params) ([]*query.Result, error) {
 	b.RLock()
 	defer b.RUnlock()
 	if b.db == nil {
-		return nil, common.NewCError("No database open")
+		return nil, common.NewBasicError("No database open", nil)
 	}
 	stmt := b.buildQuery(params)
 	rows, err := b.db.Query(stmt)
 	if err != nil {
-		return nil, common.NewCError("Error looking up path segment", "q", stmt, "err", err)
+		return nil, common.NewBasicError("Error looking up path segment", err, "q", stmt)
 	}
 	defer rows.Close()
 	res := []*query.Result{}
@@ -467,7 +467,7 @@ func (b *Backend) Get(params *query.Params) ([]*query.Result, error) {
 		hpCfgID := &query.HPCfgID{IA: &addr.ISD_AS{}}
 		err = rows.Scan(&segRowID, &rawSeg, &hpCfgID.IA.I, &hpCfgID.IA.A, &hpCfgID.ID)
 		if err != nil {
-			return nil, common.NewCError("Error reading DB response", "err", err)
+			return nil, common.NewBasicError("Error reading DB response", err)
 		}
 		// Check if we have a new segment.
 		if segRowID != prevID {
@@ -478,7 +478,7 @@ func (b *Backend) Get(params *query.Params) ([]*query.Result, error) {
 			var err error
 			curRes.Seg, err = seg.NewSegFromRaw(common.RawBytes(rawSeg))
 			if err != nil {
-				return nil, common.NewCError("Error unmarshalling segment", "err", err)
+				return nil, common.NewBasicError("Error unmarshalling segment", err)
 			}
 		}
 		// Append hpCfgID to result

--- a/go/lib/pathmgr/cache.go
+++ b/go/lib/pathmgr/cache.go
@@ -163,7 +163,7 @@ func (c *cache) removeWatch(src, dst *addr.ISD_AS, filter *PathPredicate) error 
 	if entry, ok := c.getEntry(src, dst); ok {
 		pf, ok := entry.fs[key]
 		if !ok {
-			return common.NewCError("Unable to delete path filter, filter not found",
+			return common.NewBasicError("Unable to delete path filter, filter not found", nil,
 				"src", src, "dst", dst, "filter", key)
 		}
 		pf.refCount--
@@ -172,7 +172,7 @@ func (c *cache) removeWatch(src, dst *addr.ISD_AS, filter *PathPredicate) error 
 		}
 		return nil
 	}
-	return common.NewCError("Unable to delete path filter, src and dst are not watched",
+	return common.NewBasicError("Unable to delete path filter, src and dst are not watched", nil,
 		"src", src, "dst", dst)
 }
 

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -107,7 +107,7 @@ func New(srvc sciond.Service, timers *Timers, logger log.Logger) (*PR, error) {
 	sciondConn, err := srvc.Connect()
 	if err != nil {
 		// Let external code handle initial failure
-		return nil, common.NewCError("Unable to connect to SCIOND", "err", err)
+		return nil, common.NewBasicError("Unable to connect to SCIOND", err)
 	}
 	if timers == nil {
 		timers = &Timers{}

--- a/go/lib/pathmgr/pred.go
+++ b/go/lib/pathmgr/pred.go
@@ -87,7 +87,7 @@ func (pp *PathPredicate) UnmarshalJSON(b []byte) error {
 	}
 	other, err := NewPathPredicate(s)
 	if err != nil {
-		return common.NewCError("Unable to parse PathPredicate operand", "err", err)
+		return common.NewBasicError("Unable to parse PathPredicate operand", err)
 	}
 	pp.Match = other.Match
 	return nil
@@ -97,7 +97,7 @@ func ppParseIface(str string) (sciond.PathInterface, error) {
 	tokens := strings.Split(str, "#")
 	if len(tokens) != 2 {
 		return sciond.PathInterface{},
-			common.NewCError("Failed to parse interface spec", "value", str)
+			common.NewBasicError("Failed to parse interface spec", nil, "value", str)
 	}
 	var iface sciond.PathInterface
 	ia, err := addr.IAFromString(tokens[0])

--- a/go/lib/pktcls/action_map.go
+++ b/go/lib/pktcls/action_map.go
@@ -33,7 +33,7 @@ func NewActionMap() ActionMap {
 func (am ActionMap) Add(c Action) error {
 	_, ok := am[c.GetName()]
 	if ok {
-		return common.NewCError("Action name exists", "name", c.GetName())
+		return common.NewBasicError("Action name exists", nil, "name", c.GetName())
 	}
 	am[c.GetName()] = c
 	return nil
@@ -42,7 +42,7 @@ func (am ActionMap) Add(c Action) error {
 func (am ActionMap) Get(name string) (Action, error) {
 	class, ok := am[name]
 	if !ok {
-		return nil, common.NewCError("Action not found", "name", name)
+		return nil, common.NewBasicError("Action not found", nil, "name", name)
 	}
 	return class, nil
 }
@@ -50,7 +50,7 @@ func (am ActionMap) Get(name string) (Action, error) {
 func (am ActionMap) Remove(name string) error {
 	_, ok := am[name]
 	if !ok {
-		return common.NewCError("Action not found", "name", name)
+		return common.NewBasicError("Action not found", nil, "name", name)
 	}
 	delete(am, name)
 	return nil

--- a/go/lib/pktcls/class_map.go
+++ b/go/lib/pktcls/class_map.go
@@ -33,7 +33,7 @@ func NewClassMap() ClassMap {
 func (cm ClassMap) Add(c *Class) error {
 	_, ok := cm[c.name]
 	if ok {
-		return common.NewCError("Class name exists", "name", c.name)
+		return common.NewBasicError("Class name exists", nil, "name", c.name)
 	}
 	cm[c.name] = c
 	return nil
@@ -42,7 +42,7 @@ func (cm ClassMap) Add(c *Class) error {
 func (cm ClassMap) Get(name string) (*Class, error) {
 	class, ok := cm[name]
 	if !ok {
-		return nil, common.NewCError("Class not found", "name", name)
+		return nil, common.NewBasicError("Class not found", nil, "name", name)
 	}
 	return class, nil
 }
@@ -50,7 +50,7 @@ func (cm ClassMap) Get(name string) (*Class, error) {
 func (cm ClassMap) Remove(name string) error {
 	_, ok := cm[name]
 	if !ok {
-		return common.NewCError("Class not found", "name", name)
+		return common.NewBasicError("Class not found", nil, "name", name)
 	}
 	delete(cm, name)
 	return nil

--- a/go/lib/pktcls/json.go
+++ b/go/lib/pktcls/json.go
@@ -112,7 +112,7 @@ func unmarshalInterface(b []byte) (Typer, error) {
 			err := json.Unmarshal(*v, &p)
 			return &p, err
 		default:
-			return nil, common.NewCError("Unknown type", "type", k)
+			return nil, common.NewBasicError("Unknown type", nil, "type", k)
 		}
 	}
 	return nil, nil
@@ -126,7 +126,7 @@ func unmarshalCond(b []byte) (Cond, error) {
 	}
 	c, ok := t.(Cond)
 	if !ok {
-		return nil, common.NewCError("Unable to extract Cond from interface")
+		return nil, common.NewBasicError("Unable to extract Cond from interface", nil)
 	}
 	return c, nil
 }
@@ -139,7 +139,7 @@ func unmarshalAction(b []byte) (Action, error) {
 	}
 	a, ok := t.(Action)
 	if !ok {
-		return nil, common.NewCError("Unable to extract Cond from interface")
+		return nil, common.NewBasicError("Unable to extract Cond from interface", nil)
 	}
 	return a, nil
 }
@@ -152,7 +152,7 @@ func unmarshalPredicate(b []byte) (IPv4Predicate, error) {
 	}
 	p, ok := t.(IPv4Predicate)
 	if !ok {
-		return nil, common.NewCError("Unable to extract Cond from interface")
+		return nil, common.NewBasicError("Unable to extract Cond from interface", nil)
 	}
 	return p, nil
 }
@@ -196,11 +196,11 @@ func unmarshalStringField(b []byte, name, field string) (string, error) {
 	}
 	v, ok := jc[field]
 	if !ok {
-		return "", common.NewCError("String field missing", "name", name, "field", field)
+		return "", common.NewBasicError("String field missing", nil, "name", name, "field", field)
 	}
 	s, ok := v.(string)
 	if !ok {
-		return "", common.NewCError("Field is non-string",
+		return "", common.NewBasicError("Field is non-string", nil,
 			"name", name, "field", field, "type", common.TypeOf(v))
 	}
 	return s, nil
@@ -213,8 +213,8 @@ func unmarshalUintField(b []byte, name, field string, width int) (uint64, error)
 	}
 	i, err := strconv.ParseUint(s, 0, width)
 	if err != nil {
-		return 0, common.NewCError("Unable to parse uint field",
-			"name", name, "field", field, "err", err)
+		return 0, common.NewBasicError("Unable to parse uint field", err,
+			"name", name, "field", field)
 	}
 	return i, nil
 }

--- a/go/lib/pktcls/pred_ipv4.go
+++ b/go/lib/pktcls/pred_ipv4.go
@@ -62,7 +62,7 @@ func (m *IPv4MatchSource) UnmarshalJSON(b []byte) error {
 	}
 	_, network, err := net.ParseCIDR(s)
 	if err != nil {
-		return common.NewCError("Unable to parse MatchSource operand", "err", err)
+		return common.NewBasicError("Unable to parse MatchSource operand", err)
 	}
 	m.Net = network
 	return nil
@@ -96,7 +96,7 @@ func (m *IPv4MatchDestination) UnmarshalJSON(b []byte) error {
 	s, err := unmarshalStringField(b, "MatchDestination", "Net")
 	_, network, err := net.ParseCIDR(s)
 	if err != nil {
-		return common.NewCError("Unable to parse MatchDestination operand", "err", err)
+		return common.NewBasicError("Unable to parse MatchDestination operand", err)
 	}
 	m.Net = network
 	return nil

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -36,7 +36,6 @@ import (
 	"github.com/patrickmn/go-cache"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/sock/reliable"
 	"github.com/scionproto/scion/go/proto"
@@ -135,7 +134,7 @@ func (c *connector) nextID() uint64 {
 func (c *connector) send(p *Pld) error {
 	raw, err := proto.PackRoot(p)
 	if err != nil {
-		return tryExtractNetError(err)
+		return err
 	}
 	_, err = c.conn.Write(raw)
 	return err
@@ -145,7 +144,7 @@ func (c *connector) receive() (*Pld, error) {
 	p := &Pld{}
 	err := proto.ParseFromReader(p, proto.SCIONDMsg_TypeID, c.conn)
 	if err != nil {
-		return nil, tryExtractNetError(err)
+		return nil, err
 	}
 	return p, nil
 }
@@ -343,16 +342,4 @@ func (c *connector) Close() error {
 // desynchronized. Establishing a fresh connection to SCIOND is recommended.
 func (c *connector) SetDeadline(t time.Time) error {
 	return c.conn.SetDeadline(t)
-}
-
-// If err embeds a net.Error, return only the embedded error
-func tryExtractNetError(err error) error {
-	cErr, ok := err.(*common.CError)
-	if ok {
-		netErr, ok := cErr.Data.(net.Error)
-		if ok {
-			return netErr
-		}
-	}
-	return err
 }

--- a/go/lib/sciond/sciond_test.go
+++ b/go/lib/sciond/sciond_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
 )
 
 var (
@@ -79,7 +80,6 @@ func TestAPITimeout(t *testing.T) {
 			})
 
 			Convey("Path request should timeout", func() {
-				var expectedT *net.OpError
 				src, _ := addr.IAFromString("1-1")
 				dst, _ := addr.IAFromString("2-2")
 				conn.SetDeadline(time.Now().Add(3 * time.Second))
@@ -91,13 +91,10 @@ func TestAPITimeout(t *testing.T) {
 					before.Add(4*time.Second))
 
 				SoMsg("reply", reply, ShouldBeNil)
-				SoMsg("err underlying type", err, ShouldHaveSameTypeAs, expectedT)
-				opErr := err.(*net.OpError)
-				SoMsg("timeout", opErr.Timeout(), ShouldBeTrue)
+				SoMsg("timeout", common.IsTimeoutErr(err), ShouldBeTrue)
 			})
 
 			Convey("Revocation notification should timeout", func() {
-				var expectedT *net.OpError
 				conn.SetDeadline(time.Now().Add(3 * time.Second))
 
 				before := time.Now()
@@ -107,9 +104,7 @@ func TestAPITimeout(t *testing.T) {
 					before.Add(4*time.Second))
 
 				SoMsg("reply", reply, ShouldBeNil)
-				SoMsg("err underlying type", err, ShouldHaveSameTypeAs, expectedT)
-				opErr := err.(*net.OpError)
-				SoMsg("timeout", opErr.Timeout(), ShouldBeTrue)
+				SoMsg("timeout", common.IsTimeoutErr(err), ShouldBeTrue)
 			})
 		})
 	})

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -108,7 +108,7 @@ func (p *Pld) union() (interface{}, error) {
 	case proto.SCIONDMsg_Which_serviceInfoReply:
 		return p.ServiceInfoReply, nil
 	}
-	return nil, common.NewCError("Unsupported SCIOND union type", "type", p.Which)
+	return nil, common.NewBasicError("Unsupported SCIOND union type", nil, "type", p.Which)
 }
 
 type PathReq struct {

--- a/go/lib/scmp/error.go
+++ b/go/lib/scmp/error.go
@@ -1,0 +1,61 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scmp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+var _ error = (*Error)(nil)
+var _ common.ErrorNest = (*Error)(nil)
+
+type Error struct {
+	CT   ClassType
+	Info Info
+	Err  error
+}
+
+func NewError(class Class, type_ Type, info Info, e error) error {
+	return &Error{CT: ClassType{class, type_}, Info: info, Err: e}
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	var s []string
+	s = append(s, fmt.Sprintf("CT: %v", e.CT))
+	if e.Info != nil {
+		s = append(s, fmt.Sprintf("Info: %v", e.Info))
+	}
+	return strings.Join(s, " ")
+}
+
+func (e *Error) GetErr() error {
+	return e.Err
+}
+
+func ToError(e error) *Error {
+	if e, ok := e.(*Error); ok {
+		return e
+	}
+	if n := common.GetNestedError(e); n != nil {
+		return ToError(n)
+	}
+	return nil
+}

--- a/go/lib/scmp/error.go
+++ b/go/lib/scmp/error.go
@@ -22,7 +22,7 @@ import (
 )
 
 var _ error = (*Error)(nil)
-var _ common.ErrorNest = (*Error)(nil)
+var _ common.ErrorNester = (*Error)(nil)
 
 type Error struct {
 	CT   ClassType

--- a/go/lib/scmp/error.go
+++ b/go/lib/scmp/error.go
@@ -24,12 +24,15 @@ import (
 var _ error = (*Error)(nil)
 var _ common.ErrorNester = (*Error)(nil)
 
+// Error represents an SCMP error, with an optional nested error.
 type Error struct {
 	CT   ClassType
 	Info Info
 	Err  error
 }
 
+// NewError creates a new SCMP Error with the specified scmp Class/Type/Info,
+// and optional nested error.
 func NewError(class Class, type_ Type, info Info, e error) error {
 	return &Error{CT: ClassType{class, type_}, Info: info, Err: e}
 }
@@ -50,6 +53,8 @@ func (e *Error) GetErr() error {
 	return e.Err
 }
 
+// ToError converts an e to an Error. If that fails, it recurses on the nested
+// error, if any, and otherwise returns nil.
 func ToError(e error) *Error {
 	if e, ok := e.(*Error); ok {
 		return e

--- a/go/lib/scmp/error.go
+++ b/go/lib/scmp/error.go
@@ -21,7 +21,6 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 )
 
-var _ error = (*Error)(nil)
 var _ common.ErrorNester = (*Error)(nil)
 
 // Error represents an SCMP error, with an optional nested error.

--- a/go/lib/scmp/hdr.go
+++ b/go/lib/scmp/hdr.go
@@ -54,14 +54,14 @@ func NewHdr(ct ClassType, len int) *Hdr {
 func HdrFromRaw(b common.RawBytes) (*Hdr, error) {
 	h := &Hdr{}
 	if err := restruct.Unpack(b, common.Order, h); err != nil {
-		return nil, common.NewCError(ErrorSCMPHdrUnpack, "err", err)
+		return nil, common.NewBasicError(ErrorSCMPHdrUnpack, err)
 	}
 	return h, nil
 }
 
 func (h *Hdr) Validate(plen int) error {
 	if plen+HdrLen != int(h.TotalLen) {
-		return common.NewCError("SCMP header total length doesn't match",
+		return common.NewBasicError("SCMP header total length doesn't match", nil,
 			"expected", h.TotalLen, "actual", plen)
 	}
 	return nil
@@ -74,10 +74,10 @@ func (h *Hdr) SetPldLen(l int) {
 func (h *Hdr) Write(b common.RawBytes) error {
 	out, err := restruct.Pack(common.Order, h)
 	if err != nil {
-		return common.NewCError("Error packing SCMP header", "err", err)
+		return common.NewBasicError("Error packing SCMP header", err)
 	}
 	if count := copy(b, out); count != HdrLen {
-		return common.NewCError("Partial write of SCMP header",
+		return common.NewBasicError("Partial write of SCMP header", nil,
 			"expected(B)", HdrLen, "actual(B)", count)
 	}
 	return nil

--- a/go/lib/scmp/info.go
+++ b/go/lib/scmp/info.go
@@ -65,7 +65,7 @@ type InfoEcho struct {
 func InfoEchoFromRaw(b common.RawBytes) (*InfoEcho, error) {
 	e := &InfoEcho{}
 	if err := restruct.Unpack(b, common.Order, e); err != nil {
-		return nil, common.NewCError("Failed to unpack SCMP ECHO info", "err", err)
+		return nil, common.NewBasicError("Failed to unpack SCMP ECHO info", err)
 	}
 	return e, nil
 }
@@ -99,7 +99,7 @@ type InfoPktSize struct {
 func InfoPktSizeFromRaw(b common.RawBytes) (*InfoPktSize, error) {
 	p := &InfoPktSize{}
 	if err := restruct.Unpack(b, common.Order, p); err != nil {
-		return nil, common.NewCError("Failed to unpack SCMP Pkt Size info", "err", err)
+		return nil, common.NewBasicError("Failed to unpack SCMP Pkt Size info", err)
 	}
 	return p, nil
 }
@@ -186,7 +186,7 @@ func InfoRevocationFromRaw(b common.RawBytes) (*InfoRevocation, error) {
 	p := &InfoRevocation{}
 	p.InfoPathOffsets, err = InfoPathOffsetsFromRaw(b)
 	if err != nil {
-		return nil, common.NewCError("Unable to parse path offsets", "err", err)
+		return nil, common.NewBasicError("Unable to parse path offsets", err)
 	}
 	p.RevToken = b[8:]
 	return p, nil

--- a/go/lib/scmp/meta.go
+++ b/go/lib/scmp/meta.go
@@ -40,7 +40,7 @@ const (
 func MetaFromRaw(b []byte) (*Meta, error) {
 	m := &Meta{}
 	if err := restruct.Unpack(b, binary.BigEndian, m); err != nil {
-		return nil, common.NewCError("Failed to unpack SCMP Metadata", "err", err)
+		return nil, common.NewBasicError("Failed to unpack SCMP Metadata", err)
 	}
 	return m, nil
 }
@@ -56,7 +56,7 @@ func (m *Meta) Copy() *Meta {
 func (m *Meta) Write(b common.RawBytes) error {
 	out, err := restruct.Pack(common.Order, m)
 	if err != nil {
-		return common.NewCError("Error packing SCMP Metadata", "err", err)
+		return common.NewBasicError("Error packing SCMP Metadata", err)
 	}
 	copy(b, out)
 	return nil

--- a/go/lib/scmp/scmp.go
+++ b/go/lib/scmp/scmp.go
@@ -143,17 +143,3 @@ const (
 	RawExtHdrs
 	RawL4Hdr
 )
-
-// Used as part of common.NewErrorData to indicate which SCMP error should be generated.
-type ErrData struct {
-	CT   ClassType
-	Info Info
-}
-
-func NewErrData(class Class, type_ Type, info Info) *ErrData {
-	return &ErrData{CT: ClassType{class, type_}, Info: info}
-}
-
-func (e *ErrData) String() string {
-	return fmt.Sprintf("CT: %v Info: %v", e.CT, e.Info)
-}

--- a/go/lib/snet/addr.go
+++ b/go/lib/snet/addr.go
@@ -101,17 +101,17 @@ func AddrFromString(s string) (*Addr, error) {
 
 	ia, err := addr.IAFromString(parts["ia"])
 	if err != nil {
-		return nil, common.NewCError("Invalid IA string", "ia", ia, "err", err)
+		return nil, common.NewBasicError("Invalid IA string", err, "ia", ia)
 	}
 
 	ip := net.ParseIP(parts["host"])
 	if ip == nil {
-		return nil, common.NewCError("Invalid IP address string", "ip", parts["host"])
+		return nil, common.NewBasicError("Invalid IP address string", nil, "ip", parts["host"])
 	}
 
 	port, err := strconv.ParseUint(parts["port"], 10, 16)
 	if err != nil {
-		return nil, common.NewCError("Invalid port string", "port", parts["port"], "err", err)
+		return nil, common.NewBasicError("Invalid port string", err, "port", parts["port"])
 	}
 	return &Addr{IA: ia, Host: addr.HostFromIP(ip), L4Port: uint16(port)}, nil
 }
@@ -121,7 +121,7 @@ func parseAddr(s string) (map[string]string, error) {
 	match := addrRegexp.FindStringSubmatch(s)
 	// If we do not have all submatches (ia, host, port), return an error
 	if len(match) != 4 {
-		return nil, common.NewCError("Invalid address", "addr", s)
+		return nil, common.NewBasicError("Invalid address", nil, "addr", s)
 	}
 	for i, name := range addrRegexp.SubexpNames() {
 		if i != 0 {

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -46,7 +46,7 @@ func Init(keyPath, pemPath string) error {
 	}
 	cert, err := tls.LoadX509KeyPair(pemPath, keyPath)
 	if err != nil {
-		return common.NewCError("squic: Unable to load TLS cert/key", "err", err)
+		return common.NewBasicError("squic: Unable to load TLS cert/key", err)
 	}
 	srvTlsCfg.Certificates = []tls.Certificate{cert}
 	return nil
@@ -73,7 +73,7 @@ func ListenSCION(network *snet.Network, laddr *snet.Addr) (quic.Listener, error)
 func ListenSCIONWithBindSVC(network *snet.Network, laddr, baddr *snet.Addr,
 	svc addr.HostSVC) (quic.Listener, error) {
 	if len(srvTlsCfg.Certificates) == 0 {
-		return nil, common.NewCError("squic: No server TLS certificate configured")
+		return nil, common.NewBasicError("squic: No server TLS certificate configured", nil)
 	}
 	sconn, err := sListen(network, laddr, baddr, svc)
 	if err != nil {

--- a/go/lib/sock/reliable/appaddr.go
+++ b/go/lib/sock/reliable/appaddr.go
@@ -42,8 +42,8 @@ func AppAddrFromRaw(buf common.RawBytes, addrType addr.HostAddrType) (*AppAddr, 
 	}
 	// Add 2 for port
 	if len(buf) < int(addrLen)+2 {
-		return nil, common.NewCError("Buffer too small for address type", "expected", addrLen+2,
-			"actual", len(buf))
+		return nil, common.NewBasicError("Buffer too small for address type", nil,
+			"expected", addrLen+2, "actual", len(buf))
 	}
 
 	a.Addr, err = addr.HostFromRaw(buf, addrType)
@@ -56,7 +56,7 @@ func AppAddrFromRaw(buf common.RawBytes, addrType addr.HostAddrType) (*AppAddr, 
 
 func (a *AppAddr) Write(buf common.RawBytes) (int, error) {
 	if len(buf) < a.Len() {
-		return 0, common.NewCError("Unable to write AppAddr, buffer too small",
+		return 0, common.NewBasicError("Unable to write AppAddr, buffer too small", nil,
 			"expected", a.Len(), "actual", len(buf))
 	}
 	a.writeAddr(buf)

--- a/go/lib/sockctrl/sockctrl.go
+++ b/go/lib/sockctrl/sockctrl.go
@@ -27,17 +27,17 @@ import (
 func SockControl(c *net.UDPConn, f func(int) error) error {
 	rawConn, err := c.SyscallConn()
 	if err != nil {
-		return common.NewCError("sockctrl: error accessing raw connection", "err", err)
+		return common.NewBasicError("sockctrl: error accessing raw connection", err)
 	}
 	var ctrlErr error
 	err = rawConn.Control(func(fd uintptr) {
 		ctrlErr = f(int(fd))
 	})
 	if err != nil {
-		return common.NewCError("sockctrl: RawConn.Control error", "err", err)
+		return common.NewBasicError("sockctrl: RawConn.Control error", err)
 	}
 	if ctrlErr != nil {
-		return common.NewCError("sockctrl: control function error", "err", ctrlErr)
+		return common.NewBasicError("sockctrl: control function error", ctrlErr)
 	}
 	return nil
 }

--- a/go/lib/sockctrl/sockctrl_prego19.go
+++ b/go/lib/sockctrl/sockctrl_prego19.go
@@ -19,7 +19,7 @@ import (
 func SockControl(c *net.UDPConn, f func(int) error) error {
 	fd, err := socketOf(c)
 	if err != nil {
-		return common.NewCError("sockctrl: unable to get socket fd", "err", err)
+		return common.NewBasicError("sockctrl: unable to get socket fd", err)
 	}
 	return f(int(fd))
 }

--- a/go/lib/spath/hop.go
+++ b/go/lib/spath/hop.go
@@ -59,7 +59,8 @@ func NewHopField(b common.RawBytes, in common.IFIDType, out common.IFIDType) *Ho
 
 func HopFFromRaw(b []byte) (*HopField, error) {
 	if len(b) < HopFieldLength {
-		return nil, common.NewCError(ErrorHopFTooShort, "min", HopFieldLength, "actual", len(b))
+		return nil, common.NewBasicError(ErrorHopFTooShort, nil,
+			"min", HopFieldLength, "actual", len(b))
 	}
 	h := &HopField{}
 	h.data = b[:HopFieldLength]
@@ -118,7 +119,7 @@ func (h *HopField) Verify(mac hash.Hash, tsInt uint32, prev common.RawBytes) err
 	if mac, err := h.CalcMac(mac, tsInt, prev); err != nil {
 		return err
 	} else if !bytes.Equal(h.Mac, mac) {
-		return common.NewCError(ErrorHopFBadMac, "expected", h.Mac, "actual", mac)
+		return common.NewBasicError(ErrorHopFBadMac, nil, "expected", h.Mac, "actual", mac)
 	}
 	return nil
 }

--- a/go/lib/spath/info.go
+++ b/go/lib/spath/info.go
@@ -39,7 +39,8 @@ type InfoField struct {
 
 func InfoFFromRaw(b []byte) (*InfoField, error) {
 	if len(b) < InfoFieldLength {
-		return nil, common.NewCError(ErrorInfoFTooShort, "min", InfoFieldLength, "actual", len(b))
+		return nil, common.NewBasicError(ErrorInfoFTooShort, nil,
+			"min", InfoFieldLength, "actual", len(b))
 	}
 	inf := &InfoField{}
 	flags := b[0]

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -60,7 +60,7 @@ func (p *Path) Reverse() error {
 		if origOff == len(p.Raw) {
 			break
 		} else if origOff > len(p.Raw) {
-			return common.NewCError("Unable to reverse corrupt path",
+			return common.NewBasicError("Unable to reverse corrupt path", nil,
 				"currOff", origOff, "max", len(p.Raw))
 		}
 	}
@@ -112,7 +112,7 @@ func (path *Path) InitOffsets() error {
 	path.HopOff = common.LineLen
 	// Cannot initialize an empty path
 	if path == nil || len(path.Raw) == 0 {
-		return common.NewCError("Unable to initialize empty path")
+		return common.NewBasicError("Unable to initialize empty path", nil)
 	}
 	// Skip Peer with Xover HF
 	if infoF, err = path.getInfoField(path.InfOff); err != nil {
@@ -131,8 +131,7 @@ func (path *Path) InitOffsets() error {
 		return err
 	}
 	if path.InfOff != 0 {
-		return common.NewCError("Unable to find routing Hop Field in first path" +
-			"segment")
+		return common.NewBasicError("Unable to find routing Hop Field in first path segment", nil)
 	}
 	return nil
 }
@@ -147,8 +146,7 @@ func (path *Path) IncOffsets() error {
 		return path.InitOffsets()
 	}
 	if hopF, err = path.getHopField(path.HopOff); err != nil {
-		return common.NewCError("Hop Field parse error",
-			"offset", path.HopOff, "err", err)
+		return common.NewBasicError("Hop Field parse error", err, "offset", path.HopOff)
 	}
 	return path.incOffsets(hopF.Len())
 }
@@ -159,8 +157,7 @@ func (path *Path) incOffsets(skip int) error {
 	var hopF *HopField
 	infoF, err := path.getInfoField(path.InfOff)
 	if err != nil {
-		return common.NewCError("Info Field parse error", "offset", path.InfOff,
-			"err", err)
+		return common.NewBasicError("Info Field parse error", err, "offset", path.InfOff)
 	}
 	path.HopOff += skip
 	for {
@@ -169,14 +166,12 @@ func (path *Path) incOffsets(skip int) error {
 			path.InfOff = path.HopOff
 			infoF, err = path.getInfoField(path.InfOff)
 			if err != nil {
-				return common.NewCError("Info Field parse error",
-					"offset", path.InfOff, "err", err)
+				return common.NewBasicError("Info Field parse error", err, "offset", path.InfOff)
 			}
 			path.HopOff += common.LineLen
 		}
 		if hopF, err = path.getHopField(path.HopOff); err != nil {
-			return common.NewCError("Hop Field parse error",
-				"offset", path.HopOff, "err", err)
+			return common.NewBasicError("Hop Field parse error", err, "offset", path.HopOff)
 		}
 		if !hopF.VerifyOnly {
 			break
@@ -188,22 +183,22 @@ func (path *Path) incOffsets(skip int) error {
 
 func (path *Path) getInfoField(offset int) (*InfoField, error) {
 	if offset < 0 {
-		return nil, common.NewCError("Negative offset", "offset", offset)
+		return nil, common.NewBasicError("Negative InfoF offset", nil, "offset", offset)
 	}
 	infoF, err := InfoFFromRaw(path.Raw[offset:])
 	if err != nil {
-		return nil, common.NewCError("Unable to parse Info Field", "err", err)
+		return nil, common.NewBasicError("Unable to parse Info Field", err, "offset", offset)
 	}
 	return infoF, nil
 }
 
 func (path *Path) getHopField(offset int) (*HopField, error) {
 	if offset < 0 {
-		return nil, common.NewCError("Negative offset", "offset", offset)
+		return nil, common.NewBasicError("Negative HopF offset", nil, "offset", offset)
 	}
 	hopF, err := HopFFromRaw(path.Raw[offset:])
 	if err != nil {
-		return nil, common.NewCError("Unable to parse Hop Field", "err", err)
+		return nil, common.NewBasicError("Unable to parse Hop Field", err, "offset", offset)
 	}
 	return hopF, nil
 }

--- a/go/lib/spkt/cmnhdr.go
+++ b/go/lib/spkt/cmnhdr.go
@@ -69,9 +69,11 @@ func (c *CmnHdr) Parse(b common.RawBytes) error {
 	if c.Ver != SCIONVersion {
 		// This can only usefully be replied to if the version specified is one
 		// that the current router supports, but has deprecated.
-		sdata := scmp.NewErrData(scmp.C_CmnHdr, scmp.T_C_BadVersion, nil)
-		return common.NewCErrorData(ErrorUnsuppVersion, sdata,
-			"expected", SCIONVersion, "actual", c.Ver)
+		return common.NewBasicError(
+			ErrorUnsuppVersion,
+			scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadVersion, nil, nil),
+			"expected", SCIONVersion, "actual", c.Ver,
+		)
 	}
 	return nil
 }

--- a/go/lib/spkt/cmnhdr_test.go
+++ b/go/lib/spkt/cmnhdr_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/scmp"
 )
 
@@ -44,10 +43,9 @@ func Test_CmnHdr_Parse(t *testing.T) {
 		input[0] |= 0x30
 		err := cmn.Parse(input)
 		So(err, ShouldNotBeNil)
-		cerr := err.(*common.CError)
-		data, ok := cerr.Data.(*scmp.ErrData)
-		So(ok, ShouldBeTrue)
-		So(data.CT, ShouldResemble, scmp.ClassType{Class: scmp.C_CmnHdr, Type: scmp.T_C_BadVersion})
+		serr := scmp.ToError(err)
+		So(serr, ShouldNotBeNil)
+		So(serr.CT, ShouldResemble, scmp.ClassType{Class: scmp.C_CmnHdr, Type: scmp.T_C_BadVersion})
 		So(cmn.Ver, ShouldEqual, 0x3)
 	})
 }

--- a/go/lib/spkt/extn_traceroute.go
+++ b/go/lib/spkt/extn_traceroute.go
@@ -48,7 +48,7 @@ func (t *Traceroute) TotalHops() int {
 
 func (t *Traceroute) Write(b common.RawBytes) error {
 	if len(b) < t.Len() {
-		return common.NewCError("Buffer too short", "method", "Traceroute.Write")
+		return common.NewBasicError("Buffer too short", nil, "method", "Traceroute.Write")
 	}
 	b[0] = uint8(t.NumHops())
 	offset := common.ExtnSubHdrLen

--- a/go/lib/spse/scmp_auth/drkey.go
+++ b/go/lib/spse/scmp_auth/drkey.go
@@ -94,7 +94,7 @@ func NewDRKeyExtn() *DRKeyExtn {
 
 func (s DRKeyExtn) SetDirection(dir Dir) error {
 	if dir > HostToHostReversed {
-		return common.NewCError("Invalid direction", "dir", dir)
+		return common.NewBasicError("Invalid direction", nil, "dir", dir)
 	}
 	s.Direction = dir
 	return nil
@@ -102,7 +102,8 @@ func (s DRKeyExtn) SetDirection(dir Dir) error {
 
 func (s DRKeyExtn) SetMAC(mac common.RawBytes) error {
 	if len(mac) != MACLength {
-		return common.NewCError("Invalid MAC size", "expexted", MACLength, "actual", len(mac))
+		return common.NewBasicError("Invalid MAC size", nil,
+			"expected", MACLength, "actual", len(mac))
 	}
 	copy(s.MAC, mac)
 	return nil
@@ -110,8 +111,8 @@ func (s DRKeyExtn) SetMAC(mac common.RawBytes) error {
 
 func (s *DRKeyExtn) Write(b common.RawBytes) error {
 	if len(b) < s.Len() {
-		return common.NewCError("Buffer too short", "method", "SCMPAuthDRKeyExtn.Write",
-			"expected", s.Len(), "actual", len(b))
+		return common.NewBasicError("Buffer too short", nil,
+			"method", "SCMPAuthDRKeyExtn.Write", "expected", s.Len(), "actual", len(b))
 	}
 	b[0] = uint8(s.SecMode)
 	b[DirectionOffset] = uint8(s.Direction)

--- a/go/lib/spse/scmp_auth/hashtree.go
+++ b/go/lib/spse/scmp_auth/hashtree.go
@@ -69,8 +69,8 @@ const (
 
 func NewHashTreeExtn(height uint8) (*HashTreeExtn, error) {
 	if height > MaxHeight {
-		return nil, common.NewCError("Invalid height", "height", height,
-			"max height", MaxHeight)
+		return nil, common.NewBasicError("Invalid height", nil,
+			"height", height, "max height", MaxHeight)
 	}
 
 	extn := &HashTreeExtn{BaseExtn: &spse.BaseExtn{SecMode: spse.ScmpAuthHashTree}}
@@ -84,8 +84,8 @@ func NewHashTreeExtn(height uint8) (*HashTreeExtn, error) {
 
 func (s HashTreeExtn) SetOrder(order common.RawBytes) error {
 	if len(order) != OrderLength {
-		return common.NewCError("Invalid order length", "expected", OrderLength,
-			"actual", len(order))
+		return common.NewBasicError("Invalid order length", nil,
+			"expected", OrderLength, "actual", len(order))
 	}
 	copy(s.Order, order)
 	return nil
@@ -94,8 +94,8 @@ func (s HashTreeExtn) SetOrder(order common.RawBytes) error {
 
 func (s HashTreeExtn) SetSignature(signature common.RawBytes) error {
 	if len(signature) != SignatureLength {
-		return common.NewCError("Invalid signature length", "expected", SignatureLength,
-			"actual", len(signature))
+		return common.NewBasicError("Invalid signature length", nil,
+			"expected", SignatureLength, "actual", len(signature))
 	}
 	copy(s.Signature, signature)
 	return nil
@@ -104,8 +104,8 @@ func (s HashTreeExtn) SetSignature(signature common.RawBytes) error {
 
 func (s HashTreeExtn) SetHashes(hashes common.RawBytes) error {
 	if len(hashes) != len(s.Hashes) {
-		return common.NewCError("Invalid hashes length", "expected", len(s.Hashes),
-			"actual", len(hashes))
+		return common.NewBasicError("Invalid hashes length", nil,
+			"expected", len(s.Hashes), "actual", len(hashes))
 	}
 	copy(s.Hashes, hashes)
 	return nil
@@ -114,8 +114,8 @@ func (s HashTreeExtn) SetHashes(hashes common.RawBytes) error {
 
 func (s *HashTreeExtn) Write(b common.RawBytes) error {
 	if len(b) < s.Len() {
-		return common.NewCError("Buffer too short", "method", "SCMPAuthHashTreeExtn.Write",
-			"expected min", s.Len(), "actual", len(b))
+		return common.NewBasicError("Buffer too short", nil,
+			"method", "SCMPAuthHashTreeExtn.Write", "expected min", s.Len(), "actual", len(b))
 	}
 	b[0] = uint8(s.SecMode)
 	b[HeightOffset] = s.Height

--- a/go/lib/spse/spse.go
+++ b/go/lib/spse/spse.go
@@ -135,7 +135,7 @@ func NewExtn(secMode SecMode) (*Extn, error) {
 		metaLen = GcmAes128MetaLength
 		authLen = GcmAes128AuthLength
 	default:
-		return nil, common.NewCError("Invalid SecMode code.", "SecMode", secMode)
+		return nil, common.NewBasicError("Invalid SecMode code", nil, "SecMode", secMode)
 	}
 
 	s.Metadata = make(common.RawBytes, metaLen)
@@ -147,7 +147,7 @@ func NewExtn(secMode SecMode) (*Extn, error) {
 // Set the Metadata.
 func (s *Extn) SetMetadata(metadata common.RawBytes) error {
 	if len(s.Metadata) != len(metadata) {
-		return common.NewCError("The length does not match",
+		return common.NewBasicError("The length does not match", nil,
 			"expected", len(s.Metadata), "actual", len(metadata))
 	}
 	copy(s.Metadata, metadata)
@@ -157,7 +157,7 @@ func (s *Extn) SetMetadata(metadata common.RawBytes) error {
 // Set the Authenticator.
 func (s *Extn) SetAuthenticator(authenticator common.RawBytes) error {
 	if len(s.Authenticator) != len(authenticator) {
-		return common.NewCError("The length does not match",
+		return common.NewBasicError("The length does not match", nil,
 			"expected", len(s.Authenticator), "actual", len(authenticator))
 	}
 	copy(s.Authenticator, authenticator)
@@ -166,8 +166,8 @@ func (s *Extn) SetAuthenticator(authenticator common.RawBytes) error {
 
 func (s *Extn) Write(b common.RawBytes) error {
 	if len(b) < s.Len() {
-		return common.NewCError("Buffer too short", "method", "SCIONPacketSecurityExtn.Write",
-			"expected min", s.Len(), "actual", len(b))
+		return common.NewBasicError("Buffer too short", nil,
+			"method", "SCIONPacketSecurityExtn.Write", "expected min", s.Len(), "actual", len(b))
 	}
 	b[0] = uint8(s.SecMode)
 

--- a/go/lib/topology/addr.go
+++ b/go/lib/topology/addr.go
@@ -52,7 +52,7 @@ func TopoAddrFromRAI(s *RawAddrInfo, ot overlay.Type) (*TopoAddr, error) {
 	case overlay.IPv4, overlay.IPv6, overlay.IPv46, overlay.UDPIPv4,
 		overlay.UDPIPv6, overlay.UDPIPv46:
 	default:
-		return nil, common.NewCError("Unsupported overlay type", "type", ot)
+		return nil, common.NewBasicError("Unsupported overlay type", nil, "type", ot)
 	}
 	t := &TopoAddr{Overlay: ot}
 	if err := t.FromRAI(s); err != nil {
@@ -65,7 +65,7 @@ func TopoAddrFromRAI(s *RawAddrInfo, ot overlay.Type) (*TopoAddr, error) {
 		t.IPv6.OverlayPort = overlay.EndhostPort
 	}
 	if desc := t.validate(); len(desc) > 0 {
-		return nil, common.NewCError(desc, "addr", s, "overlay", t.Overlay)
+		return nil, common.NewBasicError(desc, nil, "addr", s, "overlay", t.Overlay)
 	}
 	return t, nil
 }
@@ -75,16 +75,16 @@ func (t *TopoAddr) FromRAI(s *RawAddrInfo) error {
 	for _, pub := range s.Public {
 		ip := net.ParseIP(pub.Addr)
 		if ip == nil {
-			return common.NewCError(ErrInvalidPub, "addr", s, "ip", pub.Addr)
+			return common.NewBasicError(ErrInvalidPub, nil, "addr", s, "ip", pub.Addr)
 		}
 		if ip.To4() != nil {
 			if t.IPv4 != nil {
-				return common.NewCError(ErrTooManyPubV4, "addr", s)
+				return common.NewBasicError(ErrTooManyPubV4, nil, "addr", s)
 			}
 			t.IPv4 = &topoAddrInt{pubIP: ip, pubL4Port: pub.L4Port, OverlayPort: pub.OverlayPort}
 		} else {
 			if t.IPv6 != nil {
-				return common.NewCError(ErrTooManyPubV6, "addr", s)
+				return common.NewBasicError(ErrTooManyPubV6, nil, "addr", s)
 			}
 			t.IPv6 = &topoAddrInt{pubIP: ip, pubL4Port: pub.L4Port, OverlayPort: pub.OverlayPort}
 		}
@@ -93,23 +93,23 @@ func (t *TopoAddr) FromRAI(s *RawAddrInfo) error {
 	for _, bind := range s.Bind {
 		ip := net.ParseIP(bind.Addr)
 		if ip == nil {
-			return common.NewCError(ErrInvalidBind, "addr", s, "ip", bind.Addr)
+			return common.NewBasicError(ErrInvalidBind, nil, "addr", s, "ip", bind.Addr)
 		}
 		if ip.To4() != nil {
 			if t.IPv4 == nil {
-				return common.NewCError(ErrBindWithoutPubV4, "addr", s, "ip", bind.Addr)
+				return common.NewBasicError(ErrBindWithoutPubV4, nil, "addr", s, "ip", bind.Addr)
 			}
 			if t.IPv4.bindIP != nil {
-				return common.NewCError(ErrTooManyBindV4, "addr", s)
+				return common.NewBasicError(ErrTooManyBindV4, nil, "addr", s)
 			}
 			t.IPv4.bindIP = ip
 			t.IPv4.bindL4Port = bind.L4Port
 		} else {
 			if t.IPv6 == nil {
-				return common.NewCError(ErrBindWithoutPubV6, "addr", s, "ip", bind.Addr)
+				return common.NewBasicError(ErrBindWithoutPubV6, nil, "addr", s, "ip", bind.Addr)
 			}
 			if t.IPv6.bindIP != nil {
-				return common.NewCError(ErrTooManyBindV6, "addr", s)
+				return common.NewBasicError(ErrTooManyBindV6, nil, "addr", s)
 			}
 			t.IPv6.bindIP = ip
 			t.IPv6.bindL4Port = bind.L4Port
@@ -145,26 +145,29 @@ func (t *TopoAddr) PubL4PortFromAddr(a addr.HostAddr) (int, bool, error) {
 	switch a.Type() {
 	case addr.HostTypeIPv4:
 		if t.IPv4 == nil {
-			return 0, false, common.NewCError("HostAddr is v4, but Topoaddr does not have v4 address",
-				"topoaddr", t, "hostaddr", a)
+			return 0, false, common.NewBasicError(
+				"HostAddr is v4, but Topoaddr does not have v4 address", nil,
+				"topoaddr", t, "hostaddr", a,
+			)
 		}
 		if !t.Overlay.IsIPv4() {
-			return 0, false, common.NewCError("HostAddr is v4, but TopoAddr has non-v4 overlay",
-				"topoaddr", t, "hostaddr", a)
+			return 0, false, common.NewBasicError("HostAddr is v4, but TopoAddr has non-v4 overlay",
+				nil, "topoaddr", t, "hostaddr", a)
 		}
 		return t.IPv4.pubL4Port, t.IPv4.pubIP.Equal(a.IP()), nil
 	case addr.HostTypeIPv6:
 		if t.IPv6 == nil {
-			return 0, false, common.NewCError("HostAddr is v6, but Topoaddr does not have v6 address",
+			return 0, false, common.NewBasicError(
+				"HostAddr is v6, but Topoaddr does not have v6 address", nil,
 				"topoaddr", t, "hostaddr", a)
 		}
 		if !t.Overlay.IsIPv6() {
-			return 0, false, common.NewCError("HostAddr is v6, but TopoAddr has non-v6 overlay",
-				"topoaddr", t, "hostaddr", a)
+			return 0, false, common.NewBasicError("HostAddr is v6, but TopoAddr has non-v6 overlay",
+				nil, "topoaddr", t, "hostaddr", a)
 		}
 		return t.IPv6.pubL4Port, t.IPv6.pubIP.Equal(a.IP()), nil
 	default:
-		return 0, false, common.NewCError("Unknown HostAddr type", "type", a)
+		return 0, false, common.NewBasicError("Unknown HostAddr type", nil, "type", a)
 	}
 }
 

--- a/go/lib/topology/addr_test.go
+++ b/go/lib/topology/addr_test.go
@@ -238,8 +238,7 @@ func Test_ToTopoAddr_Errors(t *testing.T) {
 			Convey(desc, t, func() {
 				_, err := test.in.ToTopoAddr(ot)
 				SoMsg("Error returned", err, ShouldNotBeNil)
-				cerr := err.(*common.CError)
-				SoMsg("Error description", cerr.Desc, shouldBeInStrings, test.errDesc)
+				SoMsg("Error description", common.GetErrorMsg(err), shouldBeInStrings, test.errDesc)
 			})
 		}
 	}

--- a/go/lib/topology/raw.go
+++ b/go/lib/topology/raw.go
@@ -100,7 +100,8 @@ func (b RawBRIntf) localTopoAddr(o overlay.Type) (*TopoAddr, error) {
 func (b RawBRIntf) remoteAddrInfo(o overlay.Type) (*AddrInfo, error) {
 	ip := net.ParseIP(b.Remote.Addr)
 	if ip == nil {
-		return nil, common.NewCError("Could not parse remote IP from string", "ip", b.Remote.Addr)
+		return nil, common.NewBasicError("Could not parse remote IP from string", nil,
+			"ip", b.Remote.Addr)
 	}
 	ai := &AddrInfo{Overlay: o, IP: ip, L4Port: b.Remote.L4Port}
 	if o.IsUDP() {
@@ -150,11 +151,11 @@ func (a RawAddrPortOverlay) String() string {
 func Load(b common.RawBytes) (*Topo, error) {
 	rt := &RawTopo{}
 	if err := json.Unmarshal(b, rt); err != nil {
-		return nil, common.NewCError(ErrorParse, "err", err)
+		return nil, common.NewBasicError(ErrorParse, err)
 	}
 	ct, err := TopoFromRaw(rt)
 	if err != nil {
-		return nil, common.NewCError(ErrorConvert, "err", err)
+		return nil, common.NewBasicError(ErrorConvert, err)
 	}
 	return ct, nil
 }
@@ -162,7 +163,7 @@ func Load(b common.RawBytes) (*Topo, error) {
 func LoadFromFile(path string) (*Topo, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, common.NewCError(ErrorOpen, "err", err, "path", path)
+		return nil, common.NewBasicError(ErrorOpen, err, "path", path)
 	}
 	return Load(b)
 }
@@ -170,7 +171,7 @@ func LoadFromFile(path string) (*Topo, error) {
 func LoadRaw(b common.RawBytes) (*RawTopo, error) {
 	rt := &RawTopo{}
 	if err := json.Unmarshal(b, rt); err != nil {
-		return nil, common.NewCError(ErrorParse, "err", err)
+		return nil, common.NewBasicError(ErrorParse, err)
 	}
 	return rt, nil
 }
@@ -178,7 +179,7 @@ func LoadRaw(b common.RawBytes) (*RawTopo, error) {
 func LoadRawFromFile(path string) (*RawTopo, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, common.NewCError(ErrorOpen, "err", err, "path", path)
+		return nil, common.NewBasicError(ErrorOpen, err, "path", path)
 	}
 	return LoadRaw(b)
 }

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -182,9 +182,9 @@ func svcMapFromRaw(rais map[string]RawAddrInfo, stype string, smap map[string]To
 	for name, svc := range rais {
 		svcTopoAddr, err := svc.ToTopoAddr(ot)
 		if err != nil {
-			return nil, common.NewCError(
-				"Could not convert RawAddrInfo to TopoAddr", "servicetype", stype, "RawAddrInfo",
-				svc, "name", name, "err", err)
+			return nil, common.NewBasicError(
+				"Could not convert RawAddrInfo to TopoAddr", err,
+				"servicetype", stype, "RawAddrInfo", svc, "name", name)
 		}
 		smap[name] = *svcTopoAddr
 		snames = append(snames, name)

--- a/go/lib/topology/types.go
+++ b/go/lib/topology/types.go
@@ -50,7 +50,7 @@ func LinkTypeFromString(s string) (LinkType, error) {
 	case PeerLinkName:
 		return PeerLink, nil
 	default:
-		return InvalidLink, common.NewCError("Unknown link type", "type", s)
+		return InvalidLink, common.NewBasicError("Unknown link type", nil, "type", s)
 	}
 }
 

--- a/go/lib/util/aslist.go
+++ b/go/lib/util/aslist.go
@@ -39,12 +39,12 @@ func LoadASList(fileName string) (*ASList, error) {
 	asList := &ASList{}
 	buffer, err := ioutil.ReadFile(fileName)
 	if err != nil {
-		return nil, common.NewCError("Unable to read from file", "name", fileName, "err", err)
+		return nil, common.NewBasicError("Unable to read from file", err, "name", fileName)
 	}
 	var locations asData
 	err = yaml.Unmarshal(buffer, &locations)
 	if err != nil {
-		return nil, common.NewCError("Unable to parse YAML data", "err", err)
+		return nil, common.NewBasicError("Unable to parse YAML data", err)
 	}
 	asList.Core, err = parse(locations.Core)
 	if err != nil {
@@ -62,7 +62,7 @@ func parse(names []string) ([]*addr.ISD_AS, error) {
 	for _, name := range names {
 		ia, err := addr.IAFromString(name)
 		if err != nil {
-			return nil, common.NewCError("Unable to parse AS Name", "ISDAS", name, "err", err)
+			return nil, common.NewBasicError("Unable to parse AS Name", err, "ISDAS", name)
 		}
 		iaList = append(iaList, ia)
 	}

--- a/go/lib/util/mac.go
+++ b/go/lib/util/mac.go
@@ -19,7 +19,6 @@ import (
 	"hash"
 
 	"github.com/dchest/cmac"
-	log "github.com/inconshreveable/log15"
 
 	"github.com/scionproto/scion/go/lib/common"
 )
@@ -32,11 +31,11 @@ const (
 func InitMac(key common.RawBytes) (hash.Hash, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, common.NewCError(ErrorCipherFailure, log.Ctx{"err": err})
+		return nil, common.NewBasicError(ErrorCipherFailure, err)
 	}
 	mac, err := cmac.New(block)
 	if err != nil {
-		return nil, common.NewCError(ErrorMacFailure, log.Ctx{"err": err})
+		return nil, common.NewBasicError(ErrorMacFailure, err)
 	}
 	return mac, nil
 }

--- a/go/proto/gen.go
+++ b/go/proto/gen.go
@@ -65,13 +65,16 @@ func NewRootStruct(id ProtoIdType, seg *capnp.Segment) (capnp.Struct, error) {
 	case {{.}}_TypeID:
 		v, err := NewRoot{{.}}(seg)
 		if err != nil {
-			return blank, common.NewCError("Error creating new {{.}} capnp struct", "err", err)
+			return blank, common.NewBasicError("Error creating new {{.}} capnp struct", err)
 		}
 		return v.Struct, nil
 	{{- end }}
 	}
-	return blank, common.NewCError(
-		"Unsupported capnp struct type (i.e. not listed in go/proto/gen.go:RootTypes)", "id", id)
+	return blank, common.NewBasicError(
+		"Unsupported capnp struct type (i.e. not listed in go/proto/gen.go:RootTypes)",
+		nil,
+		"id", id,
+	)
 }
 {{ range .RootTypes }}
 func (s {{.}}) GetStruct() capnp.Struct {

--- a/go/proto/sign.go
+++ b/go/proto/sign.go
@@ -48,7 +48,7 @@ func (s *SignS) Sign(key, message common.RawBytes) (common.RawBytes, error) {
 	case SignType_ed25519:
 		return crypto.Sign(message, key, crypto.Ed25519)
 	}
-	return nil, common.NewCError("SignS.Sign: Unsupported SignType", "type", s.Type)
+	return nil, common.NewBasicError("SignS.Sign: Unsupported SignType", nil, "type", s.Type)
 }
 
 func (s *SignS) SignAndSet(key, message common.RawBytes) error {
@@ -64,7 +64,7 @@ func (s *SignS) Verify(key, message common.RawBytes) error {
 	case SignType_ed25519:
 		return crypto.Verify(message, s.Signature, key, crypto.Ed25519)
 	}
-	return common.NewCError("SignS.Verify: Unsupported SignType", "type", s.Type)
+	return common.NewBasicError("SignS.Verify: Unsupported SignType", nil, "type", s.Type)
 }
 
 func (s *SignS) Pack() common.RawBytes {

--- a/go/sig/base/map.go
+++ b/go/sig/base/map.go
@@ -78,8 +78,7 @@ func (am *ASMap) addNewIAs(cfg *config.Cfg) bool {
 		log.Info("ReloadConfig: Adding AS...", "ia", ia)
 		ae, err := am.AddIA(ia)
 		if err != nil {
-			cerr := err.(*common.CError)
-			log.Error(cerr.Desc, cerr.Ctx...)
+			log.Error("ReloadConfig: Adding AS failed", "err", common.FmtError(err))
 			s = false
 			continue
 		}
@@ -99,8 +98,7 @@ func (am *ASMap) delOldIAs(cfg *config.Cfg) bool {
 			// Deletion also handles session/tun device cleanup
 			err := am.DelIA(ia)
 			if err != nil {
-				cerr := err.(*common.CError)
-				log.Error(cerr.Desc, cerr.Ctx...)
+				log.Error("ReloadConfig: Deleting AS failed", "err", common.FmtError(err))
 				s = false
 				return true
 			}
@@ -115,7 +113,7 @@ func (am *ASMap) delOldIAs(cfg *config.Cfg) bool {
 func (am *ASMap) AddIA(ia *addr.ISD_AS) (*ASEntry, error) {
 	if ia.I == 0 || ia.A == 0 {
 		// A 0 for either ISD or AS indicates a wildcard, and not a specific ISD-AS.
-		return nil, common.NewCError("AddIA: ISD and AS must not be 0", "ia", ia)
+		return nil, common.NewBasicError("AddIA: ISD and AS must not be 0", nil, "ia", ia)
 	}
 	key := ia.IAInt()
 	ae, ok := am.Load(key)
@@ -135,7 +133,7 @@ func (am *ASMap) DelIA(ia *addr.ISD_AS) error {
 	key := ia.IAInt()
 	ae, ok := am.Load(key)
 	if !ok {
-		return common.NewCError("DelIA: No entry found", "ia", ia)
+		return common.NewBasicError("DelIA: No entry found", nil, "ia", ia)
 	}
 	am.Delete(key)
 	return ae.Cleanup()

--- a/go/sig/base/nets.go
+++ b/go/sig/base/nets.go
@@ -35,16 +35,16 @@ func newNetEntry(link netlink.Link, ipnet *net.IPNet) (*NetEntry, error) {
 
 func (ne *NetEntry) setup() error {
 	if err := netlink.RouteAdd(ne.Route); err != nil {
-		return common.NewCError("Unable to add route for remote network",
-			"route", ne.Route, "err", err)
+		return common.NewBasicError("Unable to add route for remote network", err,
+			"route", ne.Route)
 	}
 	return nil
 }
 
 func (ne *NetEntry) Cleanup() error {
 	if err := netlink.RouteDel(ne.Route); err != nil {
-		return common.NewCError("Unable to delete route for remote network",
-			"route", ne.Route, "err", err)
+		return common.NewBasicError("Unable to delete route for remote network", err,
+			"route", ne.Route)
 	}
 	return nil
 }

--- a/go/sig/config/config.go
+++ b/go/sig/config/config.go
@@ -35,14 +35,14 @@ type Cfg struct {
 func LoadFromFile(path string) (*Cfg, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, common.NewCError("Unable to open SIG config", "err", err)
+		return nil, common.NewBasicError("Unable to open SIG config", err)
 	}
 	cfg, err := Parse(b)
 	if err != nil {
 		return nil, err
 	}
 	if len(cfg.ASes) == 0 {
-		return nil, common.NewCError("Empty ASTable in config")
+		return nil, common.NewBasicError("Empty ASTable in config", nil)
 	}
 	return cfg, nil
 }
@@ -51,7 +51,7 @@ func LoadFromFile(path string) (*Cfg, error) {
 func Parse(b common.RawBytes) (*Cfg, error) {
 	cfg := &Cfg{}
 	if err := json.Unmarshal(b, cfg); err != nil {
-		return nil, common.NewCError("Unable to parse SIG config", "err", err)
+		return nil, common.NewBasicError("Unable to parse SIG config", err)
 	}
 	// Populate IDs
 	for _, as := range cfg.ASes {
@@ -74,11 +74,11 @@ type IPNet net.IPNet
 func (in *IPNet) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
-		return common.NewCError("Unable to unmarshal IPnet from JSON", "raw", b, "err", err)
+		return common.NewBasicError("Unable to unmarshal IPnet from JSON", err, "raw", b)
 	}
 	_, ipnet, err := net.ParseCIDR(s)
 	if err != nil {
-		return common.NewCError("Unable to parse IPnet string", "raw", s, "err", err)
+		return common.NewBasicError("Unable to parse IPnet string", err, "raw", s)
 	}
 	*in = IPNet(*ipnet)
 	return nil

--- a/go/sig/disp/disp.go
+++ b/go/sig/disp/disp.go
@@ -78,7 +78,7 @@ func (dm *dispRegistry) Register(regType RegType, key RegPollKey, c RegPldChan) 
 	case RegPollRep:
 		dm.pollRep[key] = c
 	default:
-		return common.NewCError("Register: Unsupported dispatcher RegType", "v", regType)
+		return common.NewBasicError("Register: Unsupported dispatcher RegType", nil, "v", regType)
 	}
 	return nil
 }
@@ -90,7 +90,7 @@ func (dm *dispRegistry) Unregister(regType RegType, key RegPollKey) error {
 	case RegPollRep:
 		delete(dm.pollRep, key)
 	default:
-		return common.NewCError("Unregister: Unsupported dispatcher RegType", "v", regType)
+		return common.NewBasicError("Unregister: Unsupported dispatcher RegType", nil, "v", regType)
 	}
 	return nil
 }

--- a/go/sig/egress/session.go
+++ b/go/sig/egress/session.go
@@ -93,11 +93,10 @@ func (s *Session) Cleanup() error {
 	<-s.sessMonStopped
 	s.Debug("egress.Session Cleanup: closing conn")
 	if err := s.conn.Close(); err != nil {
-		return common.NewCError("Unable to close conn", "err", err)
+		return common.NewBasicError("Unable to close conn", err)
 	}
 	if err := sigcmn.PathMgr.Unwatch(sigcmn.IA, s.IA); err != nil {
-		return common.NewCError("Unable to unwatch src-dst", "src", sigcmn.IA, "dst", s.IA,
-			"err", err)
+		return common.NewBasicError("Unable to unwatch src-dst", err, "src", sigcmn.IA, "dst", s.IA)
 	}
 	return nil
 }

--- a/go/sig/egress/worker.go
+++ b/go/sig/egress/worker.go
@@ -164,7 +164,7 @@ func (w *worker) write(f *frame) error {
 	snetAddr := w.currSig.EncapSnetAddr()
 	snetAddr.Path = spath.New(w.currPathEntry.Path.FwdPath)
 	if err := snetAddr.Path.InitOffsets(); err != nil {
-		return common.NewCError("Error initializing path offsets", "err", err)
+		return common.NewBasicError("Error initializing path offsets", err)
 	}
 	snetAddr.NextHopHost = w.currPathEntry.HostInfo.Host()
 	snetAddr.NextHopPort = w.currPathEntry.HostInfo.Port
@@ -180,7 +180,7 @@ func (w *worker) write(f *frame) error {
 	}
 	bytesWritten, err := w.sess.conn.WriteToSCION(f.raw(), snetAddr)
 	if err != nil {
-		return common.NewCError("Egress write error", "err", err)
+		return common.NewBasicError("Egress write error", err)
 	}
 	metrics.FramesSent.WithLabelValues(w.iaString).Inc()
 	metrics.FrameBytesSent.WithLabelValues(w.iaString).Add(float64(bytesWritten))

--- a/go/sig/ingress/dispatcher.go
+++ b/go/sig/ingress/dispatcher.go
@@ -69,11 +69,11 @@ func (d *Dispatcher) Run() error {
 	var err error
 	extConn, err = snet.ListenSCION("udp4", d.laddr)
 	if err != nil {
-		return common.NewCError("Unable to initialize extConn", "err", err)
+		return common.NewBasicError("Unable to initialize extConn", err)
 	}
 	_, tunIO, err = xnet.ConnectTun(tunDevName)
 	if err != nil {
-		return common.NewCError("Unable to connect to tunIO", "err", err)
+		return common.NewBasicError("Unable to connect to tunIO", err)
 	}
 	d.read()
 	return nil

--- a/go/sig/ingress/rlist.go
+++ b/go/sig/ingress/rlist.go
@@ -185,8 +185,7 @@ func (l *ReassemblyList) collectAndWrite() {
 	} else {
 		// Write the packet to the wire.
 		if err := send(l.buf.Bytes()); err != nil {
-			cerr := err.(*common.CError)
-			log.Error("Unable to send reassembled packet; "+cerr.Desc, cerr.Ctx...)
+			log.Error("Unable to send reassembled packet", "err", common.FmtError(err))
 		}
 	}
 	// Process the complete packets in the last frame

--- a/go/sig/ingress/worker.go
+++ b/go/sig/ingress/worker.go
@@ -144,7 +144,7 @@ func (w *Worker) cleanup() {
 func send(packet common.RawBytes) error {
 	bytesWritten, err := tunIO.Write(packet)
 	if err != nil {
-		return common.NewCError("Unable to write to internal ingress", "err", err,
+		return common.NewBasicError("Unable to write to internal ingress", err,
 			"length", len(packet))
 	}
 	metrics.PktsSent.WithLabelValues(tunDevName).Inc()

--- a/go/sig/metrics/metrics.go
+++ b/go/sig/metrics/metrics.go
@@ -97,7 +97,7 @@ func init() {
 func Start() error {
 	ln, err := net.Listen("tcp", *promAddr)
 	if err != nil {
-		return common.NewCError("Unable to bind prometheus metrics port", "err", err)
+		return common.NewBasicError("Unable to bind prometheus metrics port", err)
 	}
 	log.Info("Exporting prometheus metrics", "addr", *promAddr)
 	go http.Serve(ln, nil)

--- a/go/sig/mgmt/pld.go
+++ b/go/sig/mgmt/pld.go
@@ -44,7 +44,8 @@ func (u *union) set(c proto.Cerealizable) error {
 		u.Which = proto.SIGCtrl_Which_pollRep
 		u.PollRep = p
 	default:
-		return common.NewCError("Unsupported SIG ctrl union type (set)", "type", common.TypeOf(c))
+		return common.NewBasicError("Unsupported SIG ctrl union type (set)", nil,
+			"type", common.TypeOf(c))
 	}
 	return nil
 }
@@ -56,7 +57,8 @@ func (u *union) get() (proto.Cerealizable, error) {
 	case proto.SIGCtrl_Which_pollRep:
 		return u.PollRep, nil
 	}
-	return nil, common.NewCError("Unsupported SIG ctrl union type (get)", "type", u.Which)
+	return nil, common.NewBasicError("Unsupported SIG ctrl union type (get)", nil,
+		"type", u.Which)
 }
 
 var _ proto.Cerealizable = (*Pld)(nil)

--- a/go/sig/sig.go
+++ b/go/sig/sig.go
@@ -121,8 +121,7 @@ func reloadOnSIGHUP(path string) {
 func loadConfig(path string) bool {
 	cfg, err := config.LoadFromFile(path)
 	if err != nil {
-		cerr := err.(*common.CError)
-		log.Error(cerr.Desc, cerr.Ctx...)
+		log.Error("loadConfig: Failed", "err", common.FmtError(err))
 		return false
 	}
 	return base.Map.ReloadConfig(cfg)

--- a/go/sig/sigcmn/common.go
+++ b/go/sig/sigcmn/common.go
@@ -68,13 +68,13 @@ func Init(ia *addr.ISD_AS, ip net.IP) error {
 	// Initialize SCION local networking module
 	err = snet.Init(ia, *sciondPath, *dispatcherPath)
 	if err != nil {
-		return common.NewCError("Error creating local SCION Network context", "err", err)
+		return common.NewBasicError("Error creating local SCION Network context", err)
 	}
 	PathMgr = snet.DefNetwork.PathResolver()
 	CtrlConn, err = snet.ListenSCION(
 		"udp4", &snet.Addr{IA: IA, Host: Host, L4Port: uint16(*CtrlPort)})
 	if err != nil {
-		return common.NewCError("Error creating ctrl socket", "err", err)
+		return common.NewBasicError("Error creating ctrl socket", err)
 	}
 	return nil
 }
@@ -93,7 +93,7 @@ func EncapSnetAddr() *snet.Addr {
 
 func ValidatePort(desc string, port int) error {
 	if port < 1 || port > MaxPort {
-		return common.NewCError(fmt.Sprintf("Invalid %s port", desc),
+		return common.NewBasicError(fmt.Sprintf("Invalid %s port", desc), nil,
 			"min", 1, "max", MaxPort, "actual", port)
 	}
 	return nil

--- a/go/sig/xnet/xnet.go
+++ b/go/sig/xnet/xnet.go
@@ -45,18 +45,17 @@ func ConnectTun(name string) (netlink.Link, io.ReadWriteCloser, error) {
 	if err != nil {
 		tun.Close()
 		// Should clean up the tun device, but if we can't find it...
-		return nil, nil, common.NewCError("Unable to find new TUN device",
-			"name", name, "err", err)
+		return nil, nil, common.NewBasicError("Unable to find new TUN device", err, "name", name)
 	}
 	err = netlink.LinkSetUp(link)
 	if err != nil {
-		err = common.NewCError("Unable to set new TUN device Up", "name", name, "err", err)
+		err = common.NewBasicError("Unable to set new TUN device Up", err, "name", name)
 		goto Cleanup
 	}
 	err = netlink.LinkSetTxQLen(link, SIGTxQlen)
 	if err != nil {
-		err = common.NewCError("Unable to set Tx queue lenght on new TUN device",
-			"name", name, "err", err)
+		err = common.NewBasicError("Unable to set Tx queue length on new TUN device", err,
+			"name", name)
 		goto Cleanup
 	}
 	return link, tun, nil


### PR DESCRIPTION
The existing error system does not work well for nested errors, and
tends to cause part of the data to be lost (e.g. merging a CError.Ctx
with the current CError, but losing the Desc field). This makes it hard
to work with, and error-prone.

This patch changes the go codebase to use an interface-based approach to
errors, with the ErrorNest interface as the base. This allows generic
handling of nested errors, and FmtError works with this to allow clear
logging of nested errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1369)
<!-- Reviewable:end -->
