### PR TITLE
Fix trc req path bug.

### DIFF
--- a/python/cert_server/main.py
+++ b/python/cert_server/main.py
@@ -361,10 +361,10 @@ class CertServer(SCIONElement):
 
     def _send_trc_request(self, isd, ver):
         trc_req = TRCRequest.from_values(isd, ver, cache_only=True)
-        isd_as = trc_req.isd_as()
-        path_meta = self._get_path_via_sciond(isd_as)
+        path_meta = self._get_path_via_sciond(trc_req.isd_as())
         if path_meta:
-            meta = self._build_meta(isd_as, host=SVCType.CS_A, path=path_meta.fwd_path())
+            meta = self._build_meta(
+                path_meta.dst_ia(), host=SVCType.CS_A, path=path_meta.fwd_path())
             self.send_meta(CtrlPayload(CertMgmt(trc_req)), meta)
             logging.info("TRC request sent to %s via [%s]: %s",
                          meta, path_meta.short_desc(), trc_req.short_desc())

--- a/python/lib/sciond_api/path_meta.py
+++ b/python/lib/sciond_api/path_meta.py
@@ -48,6 +48,12 @@ class FwdPathMeta(Cerealizable):  # pragma: no cover
             self._fwd_path = SCIONPath(self.p.fwdPath)
         return self._fwd_path
 
+    def src_ia(self):
+        return PathInterface(self.p.interfaces[0]).isd_as()
+
+    def dst_ia(self):
+        return PathInterface(self.p.interfaces[-1]).isd_as()
+
     def iter_ifs(self):
         for if_ in self.p.interfaces:
             yield PathInterface(if_)


### PR DESCRIPTION
If a CS needs to send a trc request to a remote AS, it uses `ISD-0` as
the destination AS for the path lookup, which sciond supports. However,
the current code uses the same IA for the data-plane address, which is
illegal.

This patch adds two helpers to `FwdPathMeta` to allow an app to easily
determine the source/destination ASes, and updates the CS to use this
information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1370)
<!-- Reviewable:end -->
