### PR TITLE
Add KeyConfig

### DIFF
--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -51,6 +51,7 @@ var (
 	store    *trust.Store
 	bind     *snet.Addr
 	public   *snet.Addr
+	keyConf  *trust.KeyConf
 )
 
 // main initializes the certificate server and starts the dispatcher.
@@ -69,6 +70,9 @@ func main() {
 		fatal(err.Error())
 	}
 	if err = loadTopo(); err != nil {
+		fatal(err.Error())
+	}
+	if keyConf, err = trust.LoadKeyConf(filepath.Join(*confDir, "keys"), topo.Core); err != nil {
 		fatal(err.Error())
 	}
 	// initialize Trust Store

--- a/go/lib/trust/key_conf.go
+++ b/go/lib/trust/key_conf.go
@@ -1,0 +1,88 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trust
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+type KeyConf struct {
+	// DecryptKey is the AS decryption key.
+	DecryptKey common.RawBytes
+	// OffRootKey is the AS offline root key.
+	OffRootKey common.RawBytes
+	// OnRootKey is the AS online root key.
+	OnRootKey common.RawBytes
+	// SignKey is the AS signing key.
+	SignKey common.RawBytes
+}
+
+const (
+	DecKeyFile = "as-decrypt.key"
+	OffKeyFile = "offline-root.key"
+	OnKeyFile  = "online-root.key"
+	SigKeyFile = "as-sig.key"
+)
+
+const (
+	ErrorOpen  = "Unable to load key"
+	ErrorParse = "Unable to parse key"
+)
+
+// LoadKeyConf loads key configuration from specified path. The loaded config is put into
+// CurrKeyConf.
+func LoadKeyConf(path string, core bool) (*KeyConf, error) {
+	conf := &KeyConf{}
+	var err error
+	if conf.DecryptKey, err = loadKey(filepath.Join(path, DecKeyFile)); err != nil {
+		return nil, err
+	}
+	if conf.SignKey, err = loadKey(filepath.Join(path, SigKeyFile)); err != nil {
+		return nil, err
+	}
+	if core {
+		if conf.OffRootKey, err = loadKey(filepath.Join(path, OffKeyFile)); err != nil {
+			return nil, err
+		}
+		if conf.OnRootKey, err = loadKey(filepath.Join(path, OnKeyFile)); err != nil {
+			return nil, err
+		}
+	}
+	return conf, nil
+}
+
+// loadKey decodes a base64 encoded key stored in file and returns the raw bytes.
+func loadKey(file string) (common.RawBytes, error) {
+	b, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, common.NewBasicError(ErrorOpen, err)
+	}
+	b, err = base64.StdEncoding.DecodeString(string(b))
+	if err != nil {
+		return nil, common.NewBasicError(ErrorParse, err)
+	}
+	return b, nil
+}
+
+func (a *KeyConf) String() string {
+	return fmt.Sprintf(
+		"DecryptKey:%s SigningKey:%s OfflineRootKey:%s OnlineRootKey:%s",
+		a.DecryptKey, a.SignKey, a.OffRootKey, a.OnRootKey)
+}

--- a/go/lib/trust/key_conf.go
+++ b/go/lib/trust/key_conf.go
@@ -46,9 +46,9 @@ const (
 	ErrorParse = "Unable to parse key"
 )
 
-// LoadKeyConf loads key configuration from specified path. The loaded config is put into
-// CurrKeyConf.
-func LoadKeyConf(path string, core bool) (*KeyConf, error) {
+// LoadKeyConf loads key configuration from specified path. If loadRootKeys is set true, the
+// online and offline key are loaded.
+func LoadKeyConf(path string, loadRootKeys bool) (*KeyConf, error) {
 	conf := &KeyConf{}
 	var err error
 	if conf.DecryptKey, err = loadKey(filepath.Join(path, DecKeyFile)); err != nil {
@@ -57,7 +57,7 @@ func LoadKeyConf(path string, core bool) (*KeyConf, error) {
 	if conf.SignKey, err = loadKey(filepath.Join(path, SigKeyFile)); err != nil {
 		return nil, err
 	}
-	if core {
+	if loadRootKeys {
 		if conf.OffRootKey, err = loadKey(filepath.Join(path, OffKeyFile)); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Add key configuration to go lib.
The key configuration holds:
- AS decryption key
- AS signing key
- AS online key (for core AS)
- AS offline key (for core AS)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1371)
<!-- Reviewable:end -->
