### PR TITLE
KeyConfig reload on CS-Go

### DIFF
--- a/go/cert_srv/cert.go
+++ b/go/cert_srv/cert.go
@@ -46,9 +46,9 @@ func (h *ChainHandler) HandleReq(addr *snet.Addr, req *cert_mgmt.ChainReq) {
 	log.Info("Received certificate chain request", "addr", addr, "req", req)
 	var chain *cert.Chain
 	if req.Version == cert_mgmt.NewestVersion {
-		chain = store.GetNewestChain(req.IA())
+		chain = config.Store.GetNewestChain(req.IA())
 	} else {
-		chain = store.GetChain(req.IA(), req.Version)
+		chain = config.Store.GetChain(req.IA(), req.Version)
 	}
 	srcLocal := config.PublicAddr.IA.Eq(addr.IA)
 	if chain != nil {
@@ -110,7 +110,7 @@ func (h *ChainHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.Chain) {
 	if err != nil {
 		log.Error("Unable to parse certificate reply", "err", common.FmtError(err))
 	}
-	if err = store.AddChain(chain, true); err != nil {
+	if err = config.Store.AddChain(chain, true); err != nil {
 		log.Error("Unable to store certificate chain", "key", chain.Key(),
 			"err", common.FmtError(err))
 		return

--- a/go/cert_srv/conf/conf.go
+++ b/go/cert_srv/conf/conf.go
@@ -15,19 +15,29 @@
 package conf
 
 import (
+	"bytes"
 	"path/filepath"
+	"sync"
+
+	log "github.com/inconshreveable/log15"
+	"golang.org/x/crypto/ed25519"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/crypto/cert"
+	"github.com/scionproto/scion/go/lib/crypto/trc"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/lib/trust"
 )
 
 const (
-	ErrorTopo    = "Unable to load topology"
-	ErrorAddr    = "Unable to load addresses"
-	ErrorKeyConf = "Unable to load KeyConf"
+	ErrorTopo      = "Unable to load topology"
+	ErrorAddr      = "Unable to load addresses"
+	ErrorKeyConf   = "Unable to load KeyConf"
+	ErrorStore     = "Unable to load TrustStore"
+	ErrorFatal     = "Fatal error"
+	InvalidKeyConf = "Invalid KeyConf"
 )
 
 type Conf struct {
@@ -38,8 +48,16 @@ type Conf struct {
 	BindAddr *snet.Addr
 	// PublicAddr is the public address.
 	PublicAddr *snet.Addr
+	// Store is the trust store.
+	Store *trust.Store
+	// TRCVer is the TRC version that is currently used.
+	TRCVer uint64
+	// CertVer is the certificate chain version that is currently used.
+	CertVer uint64
 	// KeyConf contains the AS level keys used for signing and decrypting.
 	KeyConf *trust.KeyConf
+	// KeyConfLock guards KeyConf, CertVer and TRCVer.
+	KeyConfLock sync.RWMutex
 	// Dir is the configuration directory.
 	Dir string
 }
@@ -68,10 +86,150 @@ func Load(id string, confDir string) (*Conf, error) {
 	if !tmpBind.EqAddr(conf.PublicAddr) {
 		conf.BindAddr = tmpBind
 	}
-	// load keyConf
-	path = filepath.Join(confDir, "keys")
-	if conf.KeyConf, err = trust.LoadKeyConf(path, conf.Topo.Core); err != nil {
+	// load trust store
+	conf.Store, err = trust.NewStore(filepath.Join(confDir, "certs"), confDir, id)
+	if err != nil {
+		return nil, common.NewBasicError(ErrorStore, err)
+	}
+	if conf.KeyConf, err = conf.loadKeyConf(); err != nil {
+		return nil, common.NewBasicError(ErrorKeyConf, err)
+	}
+
+	if conf.CertVer, conf.TRCVer, err = conf.checkKeyConf(conf.KeyConf); err != nil {
 		return nil, common.NewBasicError(ErrorKeyConf, err)
 	}
 	return conf, nil
+}
+
+// Reload reloads trust store and and key configuration. KeyConfig is only replaced, if the loaded
+// keys are usable in combination with the active TRC and certificate chain. Otherwise an error is
+// returned. If the error message is ErrorFatal, the old keyConfig is not usable either.
+func (c *Conf) Reload() error {
+	if err := c.Store.Reload(); err != nil {
+		return common.NewBasicError(ErrorStore, err)
+	}
+	c.KeyConfLock.Lock()
+	defer c.KeyConfLock.Unlock()
+	keyConf, err := c.loadKeyConf()
+	if err == nil {
+		var certVer, trcVer uint64
+		if certVer, trcVer, err = c.checkKeyConf(keyConf); err == nil {
+			c.KeyConf = keyConf
+			c.CertVer = certVer
+			c.TRCVer = trcVer
+			return nil
+		}
+	}
+	certVer, trcVer, errO := c.checkKeyConf(c.KeyConf)
+	if errO == nil {
+		c.CertVer = certVer
+		c.TRCVer = trcVer
+		return err
+	}
+	return common.NewBasicError(ErrorFatal, err, "errExistingKeyConf", common.FmtError(errO))
+}
+
+// loadKeyConf loads key configuration.
+func (c *Conf) loadKeyConf() (*trust.KeyConf, error) {
+	return trust.LoadKeyConf(filepath.Join(c.Dir, "keys"), c.Topo.Core)
+}
+
+// checkKeyConf checks if key configuration is usable in combination with the active TRC and
+// certificate chain and returns the associated versions.
+func (c *Conf) checkKeyConf(keyConf *trust.KeyConf) (uint64, uint64, error) {
+	t, graceT, err := c.getTRC(keyConf)
+	if err != nil {
+		return 0, 0, err
+	}
+	chain, usedT, err := c.getChain(keyConf, t, graceT)
+	if err != nil {
+		return 0, 0, err
+	}
+	if usedT == graceT {
+		log.Warn("KeyConf relys on TRC in grace period", "TRC", usedT)
+	}
+	return chain.Leaf.Version, usedT.Version, nil
+}
+
+// getTRC returns the TRCs which are usable with this keyConf or an error. The first return value
+// is the active TRC. The second return value is the TRC still active in the grace period.
+func (c *Conf) getTRC(keyConf *trust.KeyConf) (*trc.TRC, *trc.TRC, error) {
+	t, graceT, err := c.getActiveTRC()
+	if err != nil {
+		return nil, nil, common.NewBasicError(ErrorFatal, err)
+	}
+	if !c.Topo.Core {
+		return t, graceT, nil
+	}
+	onPubKey := ed25519.PrivateKey(keyConf.OnRootKey).Public().(ed25519.PublicKey)
+	offPubKey := ed25519.PrivateKey(keyConf.OffRootKey).Public().(ed25519.PublicKey)
+	if t != nil && (!bytes.Equal(t.CoreASes[*c.PublicAddr.IA].OfflineKey, offPubKey) ||
+		!bytes.Equal(t.CoreASes[*c.PublicAddr.IA].OnlineKey, onPubKey)) {
+		t = nil
+	}
+	if graceT != nil && (!bytes.Equal(graceT.CoreASes[*c.PublicAddr.IA].OfflineKey, offPubKey) ||
+		!bytes.Equal(graceT.CoreASes[*c.PublicAddr.IA].OnlineKey, onPubKey)) {
+		graceT = nil
+	}
+	if t == nil && graceT == nil {
+		return nil, nil, common.NewBasicError(InvalidKeyConf, nil, "err", "No matching TRC")
+	}
+	return t, graceT, nil
+}
+
+// getActiveTRC returns active TRCs if they exist or an error. The first return value is the
+// active TRC. The second return value is the TRC still active in the grace period.
+func (c *Conf) getActiveTRC() (*trc.TRC, *trc.TRC, error) {
+	t := c.Store.GetNewestTRC(uint16(c.PublicAddr.IA.I))
+	if t == nil {
+		return nil, nil, common.NewBasicError("No TRC for own ISD", nil)
+	}
+	for ver := t.Version - 1; ver >= 0; ver-- {
+		log.Debug("loooking at trc", "trc", t)
+		if err := t.CheckActive(t); common.GetErrorMsg(err) != trc.EarlyUsage {
+			break
+		}
+		if t = c.Store.GetTRC(uint16(c.PublicAddr.IA.I), ver-1); t == nil {
+			return nil, nil, common.NewBasicError("Missing TRC", nil, "ver", ver)
+		}
+	}
+	if err := t.CheckActive(t); err != nil {
+		return nil, nil, common.NewBasicError("No active TRC", nil)
+	}
+	if t.Version > 0 {
+		graceT := c.Store.GetTRC(uint16(c.PublicAddr.IA.I), t.Version-1)
+		if err := graceT.CheckActive(t); err != nil {
+			return t, nil, nil
+		}
+		return t, graceT, nil
+	}
+	return t, nil, nil
+}
+
+// getChain returns the newest certificate chain if it is verifiable and authenticates
+// the keys in keyConf. Otherwise, an error is returned. The SubjectSignKey must match in the newest
+// certificate. If this is not the case, the responsible core AS has a different verifying key in
+// its mapping and no certificate reissuance requests will be accepted.
+func (c *Conf) getChain(keyConf *trust.KeyConf, t, graceT *trc.TRC) (*cert.Chain, *trc.TRC, error) {
+	chain := c.Store.GetNewestChain(c.PublicAddr.IA)
+	if chain == nil {
+		return nil, nil, common.NewBasicError(ErrorFatal, nil, "err", "No certificate chain")
+	}
+	verKey := common.RawBytes(ed25519.PrivateKey(keyConf.SignKey).Public().(ed25519.PublicKey))
+	if !bytes.Equal(chain.Leaf.SubjectSignKey, verKey) {
+		// FIXME(roosd): Add check for SubjectEncKey
+		return nil, nil, common.NewBasicError(InvalidKeyConf, nil, "err", "Certificate "+
+			"chain does not authenticate keys", "chain", chain, "verKey", verKey)
+	}
+	if t != nil && chain.Verify(c.PublicAddr.IA, t) == nil {
+		log.Debug("Verifiable with trc", "trc", t)
+		return chain, t, nil
+	}
+	if graceT != nil && chain.Verify(c.PublicAddr.IA, graceT) == nil {
+
+		log.Debug("Verifiable with old trc", "trc", graceT)
+		return chain, graceT, nil
+	}
+	return nil, nil, common.NewBasicError(InvalidKeyConf, nil, "Certificate chain not "+
+		"verifiable", "chain", chain, "trc", t, "graceTRC", graceT)
 }

--- a/go/cert_srv/conf/conf.go
+++ b/go/cert_srv/conf/conf.go
@@ -50,14 +50,10 @@ type Conf struct {
 	PublicAddr *snet.Addr
 	// Store is the trust store.
 	Store *trust.Store
-	// TRCVer is the TRC version that is currently used.
-	TRCVer uint64
-	// CertVer is the certificate chain version that is currently used.
-	CertVer uint64
-	// KeyConf contains the AS level keys used for signing and decrypting.
-	KeyConf *trust.KeyConf
-	// KeyConfLock guards KeyConf, CertVer and TRCVer.
-	KeyConfLock sync.RWMutex
+	// keyConf contains the AS level keys used for signing and decrypting.
+	keyConf *trust.KeyConf
+	// keyConfLock guards KeyConf, CertVer and TRCVer.
+	keyConfLock sync.RWMutex
 	// Dir is the configuration directory.
 	Dir string
 }
@@ -91,11 +87,11 @@ func Load(id string, confDir string) (*Conf, error) {
 	if err != nil {
 		return nil, common.NewBasicError(ErrorStore, err)
 	}
-	if conf.KeyConf, err = conf.loadKeyConf(); err != nil {
+	if conf.keyConf, err = conf.loadKeyConf(); err != nil {
 		return nil, common.NewBasicError(ErrorKeyConf, err)
 	}
 
-	if conf.CertVer, conf.TRCVer, err = conf.checkKeyConf(conf.KeyConf); err != nil {
+	if err = conf.verifyKeyConf(conf.keyConf); err != nil {
 		return nil, common.NewBasicError(ErrorKeyConf, err)
 	}
 	return conf, nil
@@ -108,93 +104,137 @@ func (c *Conf) Reload() error {
 	if err := c.Store.Reload(); err != nil {
 		return common.NewBasicError(ErrorStore, err)
 	}
-	c.KeyConfLock.Lock()
-	defer c.KeyConfLock.Unlock()
+	c.keyConfLock.Lock()
+	defer c.keyConfLock.Unlock()
 	keyConf, err := c.loadKeyConf()
 	if err == nil {
-		var certVer, trcVer uint64
-		if certVer, trcVer, err = c.checkKeyConf(keyConf); err == nil {
-			c.KeyConf = keyConf
-			c.CertVer = certVer
-			c.TRCVer = trcVer
+		// Check if new key config is usable with the current TRC and certificate chain
+		if err = c.verifyKeyConf(keyConf); err == nil {
+			c.keyConf = keyConf
 			return nil
 		}
 	}
-	certVer, trcVer, errO := c.checkKeyConf(c.KeyConf)
-	if errO == nil {
-		c.CertVer = certVer
-		c.TRCVer = trcVer
+	// Check that old key config is usable with the current (possible freshly loaded)
+	// TRC and certificate chain
+	existingErr := c.verifyKeyConf(c.keyConf)
+	if existingErr == nil {
 		return err
 	}
-	return common.NewBasicError(ErrorFatal, err, "errExistingKeyConf", common.FmtError(errO))
+	return common.NewBasicError(ErrorFatal, err, "existingErr", common.FmtError(existingErr))
 }
 
 // loadKeyConf loads key configuration.
 func (c *Conf) loadKeyConf() (*trust.KeyConf, error) {
-	return trust.LoadKeyConf(filepath.Join(c.Dir, "keys"), c.Topo.Core)
+	// Certificate server does not need offline root key during normal operations
+	return trust.LoadKeyConf(filepath.Join(c.Dir, "keys"), c.Topo.Core, false)
 }
 
-// checkKeyConf checks if key configuration is usable in combination with the active TRC and
-// certificate chain and returns the associated versions.
-func (c *Conf) checkKeyConf(keyConf *trust.KeyConf) (uint64, uint64, error) {
-	t, graceT, err := c.getTRC(keyConf)
-	if err != nil {
-		return 0, 0, err
+// verifyKeyConf verifies that the key configuration is usable in combination with the active TRC
+// and certificate chain.
+func (c *Conf) verifyKeyConf(keyConf *trust.KeyConf) error {
+	chain := c.Store.GetNewestChain(c.PublicAddr.IA)
+	if chain == nil {
+		return common.NewBasicError(ErrorFatal, nil, "err", "No certificate chain")
 	}
-	chain, usedT, err := c.getChain(keyConf, t, graceT)
-	if err != nil {
-		return 0, 0, err
+	// Check that the public key config matches the public key in the certificate chain
+	verKey := common.RawBytes(ed25519.PrivateKey(keyConf.SignKey).Public().(ed25519.PublicKey))
+	if !bytes.Equal(chain.Leaf.SubjectSignKey, verKey) {
+		// FIXME(roosd): Add check for SubjectEncKey
+		return common.NewBasicError(InvalidKeyConf, nil, "err", "Certificate "+
+			"chain does not authenticate keys", "chain", chain, "verKey", verKey)
 	}
-	if usedT == graceT {
-		log.Warn("KeyConf relys on TRC in grace period", "TRC", usedT)
+	// Check that the current certificate chain is verifiable with current TRC (or grace TRC)
+	if err := c.verifyCC(chain); err != nil {
+		return err
 	}
-	return chain.Leaf.Version, usedT.Version, nil
+	// Check root keys are authenticated by current TRC (or grace TRC)
+	if c.Topo.Core {
+		// get current TRC (and possibly grace TRC)
+		t, graceT, err := c.getActiveTRC()
+		if err != nil {
+			return common.NewBasicError(ErrorFatal, err)
+		}
+		// Check if root keys authenticated by active TRC
+		if err = c.verifyRootKeys(keyConf, t); err != nil {
+			// Check if root keys authenticated by grace TRC
+			if graceErr := c.verifyRootKeys(keyConf, graceT); graceErr != nil {
+				return common.NewBasicError(ErrorFatal, err, "graceErr",
+					common.FmtError(graceErr))
+			}
+			log.Warn("Current root keys rely on TRC in grace period", "TRC", graceT)
+		}
+	}
+	return nil
 }
 
-// getTRC returns the TRCs which are usable with this keyConf or an error. The first return value
-// is the active TRC. The second return value is the TRC still active in the grace period.
-func (c *Conf) getTRC(keyConf *trust.KeyConf) (*trc.TRC, *trc.TRC, error) {
+// verifyCC verifies that the provided certificate chain is verifiable with the current TRCs.
+func (c *Conf) verifyCC(chain *cert.Chain) error {
 	t, graceT, err := c.getActiveTRC()
 	if err != nil {
-		return nil, nil, common.NewBasicError(ErrorFatal, err)
+		return common.NewBasicError(ErrorFatal, err)
 	}
-	if !c.Topo.Core {
-		return t, graceT, nil
+	if t != nil && chain.Verify(c.PublicAddr.IA, t) == nil {
+		return nil
 	}
+	if graceT != nil && chain.Verify(c.PublicAddr.IA, graceT) == nil {
+		log.Warn("Current certificate chain relies on TRC in grace period", "TRC", graceT)
+		return nil
+	}
+	return common.NewBasicError(InvalidKeyConf, nil, "Certificate chain not verifiable",
+		"chain", chain, "trc", t, "graceTRC", graceT)
+}
+
+// verifyRootKeys verifies that the root keys in keyConf are authenticated by the provided TRC.
+func (c *Conf) verifyRootKeys(keyConf *trust.KeyConf, t *trc.TRC) error {
+	if t == nil {
+		return common.NewBasicError("No TRC provided to verify root keys", nil)
+	}
+	// Check that this AS is part of the core ASes
+	coreEntry := t.CoreASes[*c.PublicAddr.IA]
+	if coreEntry == nil {
+		return common.NewBasicError("Not a core AS", nil, "IA", c.PublicAddr.IA, "TRC", t)
+	}
+	// Check that online key is authenticated by TRC
 	onPubKey := ed25519.PrivateKey(keyConf.OnRootKey).Public().(ed25519.PublicKey)
+	if !bytes.Equal(coreEntry.OnlineKey, onPubKey) {
+		return common.NewBasicError("Online key does not match", nil, "TRC", t)
+	}
+	// Offline key is not available during normal operations
+	if keyConf.OffRootKey == nil {
+		return nil
+	}
+	// Check that offline key is authenticated by TRC
 	offPubKey := ed25519.PrivateKey(keyConf.OffRootKey).Public().(ed25519.PublicKey)
-	if t != nil && (!bytes.Equal(t.CoreASes[*c.PublicAddr.IA].OfflineKey, offPubKey) ||
-		!bytes.Equal(t.CoreASes[*c.PublicAddr.IA].OnlineKey, onPubKey)) {
-		t = nil
+	if !bytes.Equal(coreEntry.OfflineKey, offPubKey) {
+		return common.NewBasicError("Offline key does not match", nil, "TRC", t)
 	}
-	if graceT != nil && (!bytes.Equal(graceT.CoreASes[*c.PublicAddr.IA].OfflineKey, offPubKey) ||
-		!bytes.Equal(graceT.CoreASes[*c.PublicAddr.IA].OnlineKey, onPubKey)) {
-		graceT = nil
-	}
-	if t == nil && graceT == nil {
-		return nil, nil, common.NewBasicError(InvalidKeyConf, nil, "err", "No matching TRC")
-	}
-	return t, graceT, nil
+	return nil
 }
 
 // getActiveTRC returns active TRCs if they exist or an error. The first return value is the
-// active TRC. The second return value is the TRC still active in the grace period.
+// active TRC. The second return value is the grace TRC if the grace period has not passed yet.
 func (c *Conf) getActiveTRC() (*trc.TRC, *trc.TRC, error) {
 	t := c.Store.GetNewestTRC(uint16(c.PublicAddr.IA.I))
 	if t == nil {
 		return nil, nil, common.NewBasicError("No TRC for own ISD", nil)
 	}
+	// This loop iterates through all TRC versions (starting from the newest TRC) and find the
+	// latest TRC which is not early usage
 	for ver := t.Version - 1; ver >= 0; ver-- {
+		// Check if creation time is in the future. GetErrorMsg(nil) returns empty string
 		if err := t.CheckActive(t); common.GetErrorMsg(err) != trc.EarlyUsage {
 			break
 		}
+		// A valid trust store must posses the preceding TRC
 		if t = c.Store.GetTRC(uint16(c.PublicAddr.IA.I), ver-1); t == nil {
 			return nil, nil, common.NewBasicError("Missing TRC", nil, "ver", ver)
 		}
 	}
+	// Check that the TRC is active
 	if err := t.CheckActive(t); err != nil {
 		return nil, nil, common.NewBasicError("No active TRC", nil)
 	}
+	// Also return the grace TRC, if it is active
 	if t.Version > 0 {
 		graceT := c.Store.GetTRC(uint16(c.PublicAddr.IA.I), t.Version-1)
 		if err := graceT.CheckActive(t); err != nil {
@@ -205,27 +245,23 @@ func (c *Conf) getActiveTRC() (*trc.TRC, *trc.TRC, error) {
 	return t, nil, nil
 }
 
-// getChain returns the newest certificate chain if it is verifiable and authenticates
-// the keys in keyConf. Otherwise, an error is returned. The SubjectSignKey must match in the newest
-// certificate. If this is not the case, the responsible core AS has a different verifying key in
-// its mapping and no certificate reissuance requests will be accepted.
-func (c *Conf) getChain(keyConf *trust.KeyConf, t, graceT *trc.TRC) (*cert.Chain, *trc.TRC, error) {
-	chain := c.Store.GetNewestChain(c.PublicAddr.IA)
-	if chain == nil {
-		return nil, nil, common.NewBasicError(ErrorFatal, nil, "err", "No certificate chain")
-	}
-	verKey := common.RawBytes(ed25519.PrivateKey(keyConf.SignKey).Public().(ed25519.PublicKey))
-	if !bytes.Equal(chain.Leaf.SubjectSignKey, verKey) {
-		// FIXME(roosd): Add check for SubjectEncKey
-		return nil, nil, common.NewBasicError(InvalidKeyConf, nil, "err", "Certificate "+
-			"chain does not authenticate keys", "chain", chain, "verKey", verKey)
-	}
-	if t != nil && chain.Verify(c.PublicAddr.IA, t) == nil {
-		return chain, t, nil
-	}
-	if graceT != nil && chain.Verify(c.PublicAddr.IA, graceT) == nil {
-		return chain, graceT, nil
-	}
-	return nil, nil, common.NewBasicError(InvalidKeyConf, nil, "Certificate chain not "+
-		"verifiable", "chain", chain, "trc", t, "graceTRC", graceT)
+// GetSigningKey returns the signing key of the current key configuration.
+func (c *Conf) GetSigningKey() common.RawBytes {
+	c.keyConfLock.RLock()
+	defer c.keyConfLock.RUnlock()
+	return c.keyConf.SignKey
+}
+
+// GetDecryptKey returns the decryption key of the current key configuration.
+func (c *Conf) GetDecryptKey() common.RawBytes {
+	c.keyConfLock.RLock()
+	defer c.keyConfLock.RUnlock()
+	return c.keyConf.DecryptKey
+}
+
+// GetOnRootKey returns the online root key of the current key configuration.
+func (c *Conf) GetOnRootKey() common.RawBytes {
+	c.keyConfLock.RLock()
+	defer c.keyConfLock.RUnlock()
+	return c.keyConf.OnRootKey
 }

--- a/go/cert_srv/conf/conf.go
+++ b/go/cert_srv/conf/conf.go
@@ -185,7 +185,6 @@ func (c *Conf) getActiveTRC() (*trc.TRC, *trc.TRC, error) {
 		return nil, nil, common.NewBasicError("No TRC for own ISD", nil)
 	}
 	for ver := t.Version - 1; ver >= 0; ver-- {
-		log.Debug("loooking at trc", "trc", t)
 		if err := t.CheckActive(t); common.GetErrorMsg(err) != trc.EarlyUsage {
 			break
 		}
@@ -222,12 +221,9 @@ func (c *Conf) getChain(keyConf *trust.KeyConf, t, graceT *trc.TRC) (*cert.Chain
 			"chain does not authenticate keys", "chain", chain, "verKey", verKey)
 	}
 	if t != nil && chain.Verify(c.PublicAddr.IA, t) == nil {
-		log.Debug("Verifiable with trc", "trc", t)
 		return chain, t, nil
 	}
 	if graceT != nil && chain.Verify(c.PublicAddr.IA, graceT) == nil {
-
-		log.Debug("Verifiable with old trc", "trc", graceT)
 		return chain, graceT, nil
 	}
 	return nil, nil, common.NewBasicError(InvalidKeyConf, nil, "Certificate chain not "+

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -125,6 +125,7 @@ func setupSignals() {
 }
 
 func reloadConfig(sighup chan os.Signal) {
+	defer liblog.LogPanicAndExit()
 	for range sighup {
 		if err := config.Reload(); err != nil {
 			if common.GetErrorMsg(err) != conf.ErrorFatal {

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -19,7 +19,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -29,7 +28,6 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	liblog "github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
-	"github.com/scionproto/scion/go/lib/trust"
 )
 
 const (
@@ -47,7 +45,6 @@ var (
 	cacheDir = flag.String("cached", "gen-cache", "Caching directory")
 	prom     = flag.String("prom", "127.0.0.1:1282", "Address to export prometheus metrics on")
 	config   *conf.Conf
-	store    *trust.Store
 )
 
 // main initializes the certificate server and starts the dispatcher.
@@ -67,10 +64,6 @@ func main() {
 	}
 	if config, err = conf.Load(*id, *confDir); err != nil {
 		fatal(err.Error())
-	}
-	// initialize Trust Store
-	if store, err = trust.NewStore(filepath.Join(*confDir, "certs"), *cacheDir, *id); err != nil {
-		fatal("Unable to initialize TrustStore", "err", common.FmtError(err))
 	}
 	// initialize snet with retries
 	if err = initSNET(initAttempts, initInterval); err != nil {
@@ -126,6 +119,23 @@ func setupSignals() {
 		liblog.Flush()
 		os.Exit(1)
 	}()
+	sighup := make(chan os.Signal, 1)
+	signal.Notify(sighup, syscall.SIGHUP)
+	go reloadConfig(sighup)
+}
+
+func reloadConfig(sighup chan os.Signal) {
+	for range sighup {
+		if err := config.Reload(); err != nil {
+			if common.GetErrorMsg(err) != conf.ErrorFatal {
+				log.Error("Error during reloading", "err", common.FmtError(err))
+				continue
+			} else {
+				fatal("Fatal error during reloading", "err", common.FmtError(err))
+			}
+		}
+		log.Info("Config reloaded")
+	}
 }
 
 func fatal(msg string, args ...interface{}) {

--- a/go/cert_srv/trc.go
+++ b/go/cert_srv/trc.go
@@ -46,9 +46,9 @@ func (h *TRCHandler) HandleReq(addr *snet.Addr, req *cert_mgmt.TRCReq) {
 	log.Info("Received TRC request", "addr", addr, "req", req)
 	var t *trc.TRC
 	if req.Version == cert_mgmt.NewestVersion {
-		t = store.GetNewestTRC(req.ISD)
+		t = config.Store.GetNewestTRC(req.ISD)
 	} else {
-		t = store.GetTRC(req.ISD, req.Version)
+		t = config.Store.GetTRC(req.ISD, req.Version)
 	}
 	srcLocal := config.PublicAddr.IA.Eq(addr.IA)
 	if t != nil {
@@ -114,7 +114,7 @@ func (h *TRCHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.TRC) {
 		log.Error("Unable to parse TRC reply", "err", common.FmtError(err))
 		return
 	}
-	if err = store.AddTRC(t, true); err != nil {
+	if err = config.Store.AddTRC(t, true); err != nil {
 		log.Error("Unable to store TRC", "key", t.Key(), "err", common.FmtError(err))
 		return
 	}

--- a/go/lib/trust/key_conf.go
+++ b/go/lib/trust/key_conf.go
@@ -46,9 +46,9 @@ const (
 	ErrorParse = "Unable to parse key"
 )
 
-// LoadKeyConf loads key configuration from specified path. If loadRootKeys is set true, the
-// online and offline key are loaded.
-func LoadKeyConf(path string, loadRootKeys bool) (*KeyConf, error) {
+// LoadKeyConf loads key configuration from specified path. If loadOnlineKey is true, the
+// online is loaded. If loadOfflineKey is true, the offline key is loaded
+func LoadKeyConf(path string, loadOnlineKey, loadOfflineKey bool) (*KeyConf, error) {
 	conf := &KeyConf{}
 	var err error
 	if conf.DecryptKey, err = loadKey(filepath.Join(path, DecKeyFile)); err != nil {
@@ -57,10 +57,12 @@ func LoadKeyConf(path string, loadRootKeys bool) (*KeyConf, error) {
 	if conf.SignKey, err = loadKey(filepath.Join(path, SigKeyFile)); err != nil {
 		return nil, err
 	}
-	if loadRootKeys {
+	if loadOfflineKey {
 		if conf.OffRootKey, err = loadKey(filepath.Join(path, OffKeyFile)); err != nil {
 			return nil, err
 		}
+	}
+	if loadOnlineKey {
 		if conf.OnRootKey, err = loadKey(filepath.Join(path, OnKeyFile)); err != nil {
 			return nil, err
 		}

--- a/go/lib/trust/store.go
+++ b/go/lib/trust/store.go
@@ -67,7 +67,8 @@ func NewStore(certDir, cacheDir, eName string) (*Store, error) {
 	return s, nil
 }
 
-// Reload reloads
+// Reload reloads trust files by populating the trust store with certificate chains and TRCs from
+// certDir and cacheDir.
 func (s *Store) Reload() error {
 	if err := s.initChains(); err != nil {
 		return err

--- a/go/lib/trust/store.go
+++ b/go/lib/trust/store.go
@@ -61,9 +61,21 @@ func NewStore(certDir, cacheDir, eName string) (*Store, error) {
 		maxChainMap: make(map[addr.ISD_AS]uint64),
 		trcMap:      make(map[trc.Key]*trc.TRC),
 		maxTrcMap:   make(map[uint16]uint64)}
-	s.initChains()
-	s.initTRCs()
+	if err := s.Reload(); err != nil {
+		return nil, err
+	}
 	return s, nil
+}
+
+// Reload reloads
+func (s *Store) Reload() error {
+	if err := s.initChains(); err != nil {
+		return err
+	}
+	if err := s.initTRCs(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // initChains loads the certificate chain files from dir and cacheDir and populates chainMap


### PR DESCRIPTION
Enable KeyConfig reload on CS-Go. The reload is started by sending SIG_HUP to the certificate server.
Following is reloaded:
- Trust store
- KeyConfig

The keys are loaded from gen/keys. The keys in KeyConfig are only replaced, if the new keys are usable with the trust files.

Root keys are usable if:
- They are authenticated by an active TRC (newest or in grace period)

Signing keys are usable if:
 - They are authenticated by the newest certificate chain (*)
 - They authenticating certificate chain is verifiable with active TRC (newest or in grace period)

(*) This is necessary since the core AS issuing leaf certificates has a mapping [AS->verifying key] and will only accept reissuance requests if the key matches. 
Thus having a different key (even if authenticated by an older but still active certificate chain) means the certificate server is not fully operational.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1377)
<!-- Reviewable:end -->
