### PR TITLE
Add customer mapping to CS

### DIFF
--- a/go/cert_srv/cert.go
+++ b/go/cert_srv/cert.go
@@ -45,9 +45,9 @@ func (h *ChainHandler) HandleReq(addr *snet.Addr, req *cert_mgmt.ChainReq) {
 	log.Info("Received certificate chain request", "addr", addr, "req", req)
 	var chain *cert.Chain
 	if req.Version == cert_mgmt.NewestVersion {
-		chain = store.GetNewestChain(req.IA())
+		chain = config.Store.GetNewestChain(req.IA())
 	} else {
-		chain = store.GetChain(req.IA(), req.Version)
+		chain = config.Store.GetChain(req.IA(), req.Version)
 	}
 	srcLocal := config.PublicAddr.IA.Eq(addr.IA)
 	if chain != nil {
@@ -109,7 +109,7 @@ func (h *ChainHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.Chain) {
 	if err != nil {
 		log.Error("Unable to parse certificate reply", "err", err)
 	}
-	if err = store.AddChain(chain, true); err != nil {
+	if err = config.Store.AddChain(chain, true); err != nil {
 		log.Error("Unable to store certificate chain", "key", chain.Key(), "err", err)
 		return
 	}

--- a/go/cert_srv/conf/conf.go
+++ b/go/cert_srv/conf/conf.go
@@ -52,11 +52,11 @@ type Conf struct {
 	customers Customers
 	// customersLock guards the customers map.
 	customersLock sync.RWMutex
-	// CacheDir is the configuration directory.
+	// CacheDir is the cache directory.
 	CacheDir string
 	// ConfDir is the configuration directory.
 	ConfDir string
-	// StateDir is the configuration directory.
+	// StateDir is the state directory.
 	StateDir string
 }
 
@@ -66,7 +66,8 @@ func Load(id string, confDir string, cacheDir string, stateDir string) (*Conf, e
 	conf := &Conf{
 		ConfDir:  confDir,
 		CacheDir: cacheDir,
-		StateDir: stateDir}
+		StateDir: stateDir,
+	}
 	// load topology
 	path := filepath.Join(confDir, topology.CfgName)
 	if conf.Topo, err = topology.LoadFromFile(path); err != nil {

--- a/go/cert_srv/conf/conf.go
+++ b/go/cert_srv/conf/conf.go
@@ -16,6 +16,7 @@ package conf
 
 import (
 	"path/filepath"
+	"sync"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
@@ -25,9 +26,11 @@ import (
 )
 
 const (
-	ErrorTopo    = "Unable to load topology"
-	ErrorAddr    = "Unable to load addresses"
-	ErrorKeyConf = "Unable to load KeyConf"
+	ErrorAddr      = "Unable to load addresses"
+	ErrorKeyConf   = "Unable to load KeyConf"
+	ErrorStore     = "Unable to load TrustStore"
+	ErrorTopo      = "Unable to load topology"
+	ErrorCustomers = "Unable to load Customers"
 )
 
 type Conf struct {
@@ -38,14 +41,23 @@ type Conf struct {
 	BindAddr *snet.Addr
 	// PublicAddr is the public address.
 	PublicAddr *snet.Addr
-	// KeyConf contains the AS level keys used for signing and decrypting.
-	KeyConf *trust.KeyConf
+	// Store is the trust store.
+	Store *trust.Store
+	// keyConf contains the AS level keys used for signing and decrypting.
+	keyConf *trust.KeyConf
+	// keyConfLock guards KeyConf, CertVer and TRCVer.
+	keyConfLock sync.RWMutex
+	// customers is a mapping from non-core ASes assigned to this core AS to their public
+	// verifying key.
+	customers Customers
+	// customersLock guards the customers map.
+	customersLock sync.RWMutex
 	// Dir is the configuration directory.
 	Dir string
 }
 
 // Load initializes the configuration by loading it from confDir.
-func Load(id string, confDir string) (*Conf, error) {
+func Load(id string, confDir string, cacheDir string) (*Conf, error) {
 	var err error
 	conf := &Conf{Dir: confDir}
 	// load topology
@@ -68,10 +80,56 @@ func Load(id string, confDir string) (*Conf, error) {
 	if !tmpBind.EqAddr(conf.PublicAddr) {
 		conf.BindAddr = tmpBind
 	}
-	// load keyConf
-	path = filepath.Join(confDir, "keys")
-	if conf.KeyConf, err = trust.LoadKeyConf(path, conf.Topo.Core); err != nil {
+	// load trust store
+	conf.Store, err = trust.NewStore(filepath.Join(confDir, "certs"), cacheDir, id)
+	if err != nil {
+		return nil, common.NewBasicError(ErrorStore, err)
+	}
+	// load key configuration
+	if conf.keyConf, err = conf.loadKeyConf(); err != nil {
 		return nil, common.NewBasicError(ErrorKeyConf, err)
 	}
+	// load customers
+	if conf.customers, err = conf.LoadCustomers(); err != nil {
+		return nil, err
+	}
 	return conf, nil
+}
+
+// ReloadCustomers reloads the mapping from customer to verifying key.
+func (c *Conf) ReloadCustomers() error {
+	c.customersLock.Lock()
+	defer c.customersLock.Unlock()
+	cust, err := c.LoadCustomers()
+	if err != nil {
+		return common.NewBasicError(ErrorCustomers, err)
+	}
+	c.customers = cust
+	return nil
+}
+
+// loadKeyConf loads key configuration.
+func (c *Conf) loadKeyConf() (*trust.KeyConf, error) {
+	return trust.LoadKeyConf(filepath.Join(c.Dir, "keys"), c.Topo.Core)
+}
+
+// GetSigningKey returns the signing key of the current key configuration.
+func (c *Conf) GetSigningKey() common.RawBytes {
+	c.keyConfLock.RLock()
+	defer c.keyConfLock.RUnlock()
+	return c.keyConf.SignKey
+}
+
+// GetDecryptKey returns the decryption key of the current key configuration.
+func (c *Conf) GetDecryptKey() common.RawBytes {
+	c.keyConfLock.RLock()
+	defer c.keyConfLock.RUnlock()
+	return c.keyConf.DecryptKey
+}
+
+// GetOnRootKey returns the online root key of the current key configuration.
+func (c *Conf) GetOnRootKey() common.RawBytes {
+	c.keyConfLock.RLock()
+	defer c.keyConfLock.RUnlock()
+	return c.keyConf.OnRootKey
 }

--- a/go/cert_srv/conf/customers.go
+++ b/go/cert_srv/conf/customers.go
@@ -1,0 +1,117 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conf
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+const (
+	KeyChanged   = "Verifying key has changed in the meantime"
+	NotACustomer = "ISD-AS not in custommer mapping"
+)
+
+type Customers map[addr.ISD_AS]common.RawBytes
+
+// LoadCustomers populates the mapping from assigned non-core ASes to their respective verifying key.
+func (c *Conf) LoadCustomers() (Customers, error) {
+	// Makes sure no new files can be written by SetVerifyingKey in the meantime
+	path := filepath.Join(c.Dir, "customers")
+	files, err := filepath.Glob(fmt.Sprintf("%s/ISD*-AS*-V*.key", path))
+	if err != nil {
+		return nil, err
+	}
+	activeKeys := make(map[addr.ISD_AS]string)
+	activeVers := make(map[addr.ISD_AS]uint64)
+	for _, file := range files {
+		re := regexp.MustCompile(`ISD(\d+)-AS(\d+)-V(\d+)`)
+		s := re.FindAllStringSubmatch(file, -1)
+		ia, err := addr.IAFromString(fmt.Sprintf("%s-%s", s[len(s)-1][1], s[len(s)-1][2]))
+		if err != nil {
+			return nil, common.NewBasicError("Unable to parse IA", err, "file", file)
+		}
+		ver, err := strconv.ParseUint(s[len(s)-1][3], 10, 64)
+		if uint64(ver) >= activeVers[*ia] {
+			activeKeys[*ia] = file
+			activeVers[*ia] = uint64(ver)
+		}
+	}
+	customers := make(map[addr.ISD_AS]common.RawBytes)
+	for ia, file := range activeKeys {
+		b, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+		key, err := base64.StdEncoding.DecodeString(string(b))
+		if err != nil {
+			return nil, common.NewBasicError("Unable to parse key", err, "file", file)
+		}
+		customers[ia] = key
+	}
+	return customers, nil
+}
+
+// GetVerifyingKey returns the verifying key from the requested AS and true if it is in the mapping.
+// Otherwise, nil and false.
+func (c *Conf) GetVerifyingKey(ia *addr.ISD_AS) (common.RawBytes, error) {
+	c.customersLock.RLock()
+	defer c.customersLock.RUnlock()
+	b, ok := c.customers[*ia]
+	if !ok {
+		return nil, common.NewBasicError(NotACustomer, nil)
+	}
+	return b, nil
+}
+
+// SetVerifyingKey sets the verifying key for a specified AS. The key is written to the file system.
+func (c *Conf) SetVerifyingKey(ia *addr.ISD_AS, ver uint64, newKey, oldKey common.RawBytes) error {
+	c.customersLock.Lock()
+	defer c.customersLock.Unlock()
+	currKey, ok := c.customers[*ia]
+	if !ok {
+		return common.NewBasicError(NotACustomer, nil, "ISD-AS", ia)
+	}
+	// Check that the key in the mapping has not changed in the mean time
+	if !bytes.Equal(currKey, oldKey) {
+		return common.NewBasicError(KeyChanged, nil, "ISD-AS", ia)
+	}
+	// Key has to be written to file system, only if it has changed
+	if !bytes.Equal(newKey, currKey) {
+		var err error
+		path := filepath.Join(c.Dir, fmt.Sprintf("ISD%d-AS%d-V%d.key", ia.I, ia.A, ver))
+		if _, err = os.Stat(path); os.IsNotExist(err) {
+			b := base64.StdEncoding.EncodeToString(newKey)
+			if err = ioutil.WriteFile(path, []byte(b), 0644); err != nil {
+				return err
+			}
+			key := make(common.RawBytes, len(newKey))
+			copy(key, newKey)
+			c.customers[*ia] = key
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -139,7 +139,7 @@ func configSig() {
 	defer liblog.LogPanicAndExit()
 	for range sighup {
 		if err := config.ReloadCustomers(); err != nil {
-			log.Error("Error reloading customers", "err", common.FmtError(err))
+			log.Error("Error reloading customers", "err", err)
 			continue
 		}
 		log.Info("Customers reloaded")

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -19,7 +19,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -29,7 +28,6 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	liblog "github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
-	"github.com/scionproto/scion/go/lib/trust"
 )
 
 const (
@@ -47,7 +45,6 @@ var (
 	cacheDir = flag.String("cached", "gen-cache", "Caching directory")
 	prom     = flag.String("prom", "127.0.0.1:1282", "Address to export prometheus metrics on")
 	config   *conf.Conf
-	store    *trust.Store
 )
 
 // main initializes the certificate server and starts the dispatcher.
@@ -65,12 +62,8 @@ func main() {
 	if err = checkFlags(); err != nil {
 		fatal(err.Error())
 	}
-	if config, err = conf.Load(*id, *confDir); err != nil {
+	if config, err = conf.Load(*id, *confDir, *cacheDir); err != nil {
 		fatal(err.Error())
-	}
-	// initialize Trust Store
-	if store, err = trust.NewStore(filepath.Join(*confDir, "certs"), *cacheDir, *id); err != nil {
-		fatal("Unable to initialize TrustStore", "err", err)
 	}
 	// initialize snet with retries
 	if err = initSNET(initAttempts, initInterval); err != nil {
@@ -126,6 +119,20 @@ func setupSignals() {
 		liblog.Flush()
 		os.Exit(1)
 	}()
+	sighup := make(chan os.Signal, 1)
+	signal.Notify(sighup, syscall.SIGHUP)
+	go reloadConfig(sighup)
+}
+
+func reloadConfig(sighup chan os.Signal) {
+	defer liblog.LogPanicAndExit()
+	for range sighup {
+		if err := config.ReloadCustomers(); err != nil {
+			log.Error("Error reloading customers", "err", common.FmtError(err))
+			continue
+		}
+		log.Info("Customers reloaded")
+	}
 }
 
 func fatal(msg string, args ...interface{}) {

--- a/go/cert_srv/trc.go
+++ b/go/cert_srv/trc.go
@@ -46,9 +46,9 @@ func (h *TRCHandler) HandleReq(addr *snet.Addr, req *cert_mgmt.TRCReq) {
 	log.Info("Received TRC request", "addr", addr, "req", req)
 	var t *trc.TRC
 	if req.Version == cert_mgmt.NewestVersion {
-		t = store.GetNewestTRC(req.ISD)
+		t = config.Store.GetNewestTRC(req.ISD)
 	} else {
-		t = store.GetTRC(req.ISD, req.Version)
+		t = config.Store.GetTRC(req.ISD, req.Version)
 	}
 	srcLocal := config.PublicAddr.IA.Eq(addr.IA)
 	if t != nil {
@@ -113,7 +113,7 @@ func (h *TRCHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.TRC) {
 		log.Error("Unable to parse TRC reply", "err", err)
 		return
 	}
-	if err = store.AddTRC(t, true); err != nil {
+	if err = config.Store.AddTRC(t, true); err != nil {
 		log.Error("Unable to store TRC", "key", t.Key(), "err", err)
 		return
 	}

--- a/go/lib/trust/key_conf.go
+++ b/go/lib/trust/key_conf.go
@@ -51,34 +51,35 @@ const (
 func LoadKeyConf(path string, loadRootKeys bool) (*KeyConf, error) {
 	conf := &KeyConf{}
 	var err error
-	if conf.DecryptKey, err = loadKey(filepath.Join(path, DecKeyFile)); err != nil {
+	if conf.DecryptKey, err = LoadKey(filepath.Join(path, DecKeyFile)); err != nil {
 		return nil, err
 	}
-	if conf.SignKey, err = loadKey(filepath.Join(path, SigKeyFile)); err != nil {
+	if conf.SignKey, err = LoadKey(filepath.Join(path, SigKeyFile)); err != nil {
 		return nil, err
 	}
 	if loadRootKeys {
-		if conf.OffRootKey, err = loadKey(filepath.Join(path, OffKeyFile)); err != nil {
+		if conf.OffRootKey, err = LoadKey(filepath.Join(path, OffKeyFile)); err != nil {
 			return nil, err
 		}
-		if conf.OnRootKey, err = loadKey(filepath.Join(path, OnKeyFile)); err != nil {
+		if conf.OnRootKey, err = LoadKey(filepath.Join(path, OnKeyFile)); err != nil {
 			return nil, err
 		}
 	}
 	return conf, nil
 }
 
-// loadKey decodes a base64 encoded key stored in file and returns the raw bytes.
-func loadKey(file string) (common.RawBytes, error) {
+// LoadKey decodes a base64 encoded key stored in file and returns the raw bytes.
+func LoadKey(file string) (common.RawBytes, error) {
 	b, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, common.NewBasicError(ErrorOpen, err)
 	}
-	b, err = base64.StdEncoding.DecodeString(string(b))
+	dbuf := make([]byte, base64.StdEncoding.DecodedLen(len(b)))
+	n, err := base64.StdEncoding.Decode(dbuf, b)
 	if err != nil {
 		return nil, common.NewBasicError(ErrorParse, err)
 	}
-	return b, nil
+	return dbuf[:n], nil
 }
 
 func (a *KeyConf) String() string {


### PR DESCRIPTION
Add customer mapping during topology generation.

Core ASes are responsible for all ASes they issue a certificate for.
Core ASes store verifying keys associated with their customers to verify certificate reissuance requests.
The naming convention is ISDx-ASy-Vz.key, where z denotes the first certificate version of AS x-y which authenticates the key. The keys are stored in cs_config_dir/customers.
For each AS, the key with the highest associated version is loaded.
New key files are only written, when the verifying key changes.

If the core AS needs to remove a customer or change the verifying key manually (e.g. key compromise), the key files
are adjusted as desired and a SIG_HUP is sent to the CS-go process to force reload the customer mapping.

 Additionally:
  - move trust store from cert_srv/main to conf
  - wrap keyConfig in functions to guarantee synchronized acces

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1380)
<!-- Reviewable:end -->
