### PR TITLE
Fix CertChain/TRC verification

### DIFF
--- a/go/lib/crypto/cert/chain.go
+++ b/go/lib/crypto/cert/chain.go
@@ -101,6 +101,9 @@ func (c *Chain) Verify(subject *addr.ISD_AS, t *trc.TRC) error {
 			util.TimeToString(c.Leaf.ExpirationTime), "core",
 			util.TimeToString(c.Core.ExpirationTime))
 	}
+	if !c.Core.CanIssue {
+		return common.NewBasicError(CoreCertInvalid, nil, "CanIssue", false)
+	}
 	if err := c.Leaf.Verify(subject, c.Core.SubjectSignKey, c.Core.SignAlgorithm); err != nil {
 		return common.NewBasicError(LeafCertInvalid, err)
 	}

--- a/go/lib/crypto/trc/trc.go
+++ b/go/lib/crypto/trc/trc.go
@@ -151,6 +151,9 @@ func (t *TRC) CoreASList() []*addr.ISD_AS {
 // CheckActive checks if TRC is active and can be used for certificate chain verification. MaxTRC is
 // the newest active TRC of the same ISD which we know of.
 func (t *TRC) CheckActive(maxTRC *TRC) error {
+	if t.Quarantine {
+		return common.NewBasicError(EarlyAnnouncement, nil)
+	}
 	currTime := uint64(time.Now().Unix())
 	if currTime < t.CreationTime {
 		return common.NewBasicError(EarlyUsage, nil,

--- a/python/lib/crypto/certificate_chain.py
+++ b/python/lib/crypto/certificate_chain.py
@@ -129,6 +129,9 @@ class CertificateChain(object):
                 "AS certificate verification failed: Leaf expires after core certificate. Leaf: %s "
                 "Core: %s" % (iso_timestamp(leaf.expiration_time),
                               iso_timestamp(core.expiration_time)))
+        if not core.can_issue:
+            raise SCIONVerificationError(
+                "AS certificate verification failed: Core certificate cannot issue certificates")
         try:
             leaf.verify(subject, core.subject_sig_key_raw)
         except SCIONVerificationError as e:

--- a/python/lib/crypto/trc.py
+++ b/python/lib/crypto/trc.py
@@ -298,6 +298,8 @@ class TRC(object):
         :param TRC max_trc: newest available TRC for same ISD. (If none, self is newest TRC)
         :raises: SCIONVerificationError
         """
+        if self.quarantine:
+            raise SCIONVerificationError("Early announcement")
         now = int(time.time())
         if not (self.create_time <= now <= self.exp_time):
             raise SCIONVerificationError("Current time outside of validity period. "


### PR DESCRIPTION
Fix certificate chain verification and TRC active check
- make sure that core certificate can be used to issue certificates
- make sure TRC is only active if not in quarantine

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1381)
<!-- Reviewable:end -->
