### PR TITLE
Adds sciond request for segments used to construct paths

### DIFF
--- a/proto/sciond.capnp
+++ b/proto/sciond.capnp
@@ -4,6 +4,7 @@ $Go.package("proto");
 $Go.import("github.com/scionproto/scion/go/proto");
 
 using RevInfo = import "rev_info.capnp";
+using PSeg = import "path_seg.capnp";
 
 struct SCIONDMsg {
     id @0 :UInt64;  # Request ID
@@ -19,6 +20,8 @@ struct SCIONDMsg {
         serviceInfoRequest @9 :ServiceInfoRequest;
         serviceInfoReply @10 :ServiceInfoReply;
         revReply @11 :RevReply;
+        segTypeHopReq @12 :SegTypeHopReq;
+        segTypeHopReply @13 :SegTypeHopReply;
     }
 }
 
@@ -116,4 +119,18 @@ struct ServiceInfoReplyEntry {
     serviceType @0 :ServiceInfoRequest.ServiceType;  # The service ID of the service.
     ttl @1 :UInt32;  # The TTL for the service record in seconds (currently unused).
     hostInfos @2 :List(HostInfo);  # The host infos of the service.
+}
+
+struct SegTypeHopReq {
+    type @0 :PSeg.PathSegType;  # The path segments type: up, down, core.
+}
+
+struct SegTypeHopReply {
+    entries @0 :List(SegTypeHopReplyEntry);  # List of path segments matching type request, if any
+}
+
+struct SegTypeHopReplyEntry {
+    interfaces @0 :List(PathInterface);  # List of interfaces for the segment
+    timestamp @1 :UInt64;  # Creation timestamp, seconds since Unix Epoch
+    expTime @2 :UInt64;  # Expiration timestamp, seconds since Unix Epoch
 }

--- a/python/lib/sciond_api/base.py
+++ b/python/lib/sciond_api/base.py
@@ -26,6 +26,7 @@ from lib.sciond_api.as_req import SCIONDASInfoRequest, SCIONDASInfoReply
 from lib.sciond_api.if_req import SCIONDIFInfoReply, SCIONDIFInfoRequest
 from lib.sciond_api.path_req import SCIONDPathRequest, SCIONDPathReply
 from lib.sciond_api.revocation import SCIONDRevNotification, SCIONDRevReply
+from lib.sciond_api.segment_req import SCIONDSegTypeHopRequest, SCIONDSegTypeHopReply
 from lib.sciond_api.service_req import SCIONDServiceInfoReply, SCIONDServiceInfoRequest
 from lib.types import SCIONDMsgType
 
@@ -44,6 +45,8 @@ class SCIONDMsg(CerealBox):  # pragma: no cover
         SCIONDIFInfoReply: SCIONDMsgType.IF_REPLY,
         SCIONDServiceInfoRequest: SCIONDMsgType.SERVICE_REQUEST,
         SCIONDServiceInfoReply: SCIONDMsgType.SERVICE_REPLY,
+        SCIONDSegTypeHopRequest: SCIONDMsgType.SEGTYPEHOP_REQUEST,
+        SCIONDSegTypeHopReply: SCIONDMsgType.SEGTYPEHOP_REPLY,
     }
 
     def __init__(self, union, id):

--- a/python/lib/sciond_api/segment_req.py
+++ b/python/lib/sciond_api/segment_req.py
@@ -1,0 +1,95 @@
+# Copyright 2018 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+:mod:`segment_req` --- SCIOND segments by type requests and replies
+====================================================
+"""
+# External
+import capnp  # noqa
+from datetime import timedelta
+
+# SCION
+import proto.sciond_capnp as P
+from lib.packet.packet_base import Cerealizable
+from lib.sciond_api.path_meta import PathInterface
+from lib.util import iso_timestamp
+
+
+class SCIONDSegTypeHopRequest(Cerealizable):
+    NAME = "SCIONDSegTypeHopRequest"
+    P_CLS = P.SegTypeHopReq
+
+    @classmethod
+    def from_values(cls, seg_type):
+        p = cls.P_CLS.new_message(type=seg_type)
+        return cls(p)
+
+    def short_desc(self):
+        return "%s: type: %s" % (self.NAME, self.p.type)
+
+
+class SCIONDSegTypeHopReply(Cerealizable):
+    NAME = "SCIONDSegTypeHopReply"
+    P_CLS = P.SegTypeHopReply
+
+    @classmethod
+    def from_values(cls, entries):
+        p = cls.P_CLS.new_message()
+        entry_list = p.init("entries", len(entries))
+        for i, entry in enumerate(entries):
+            entry_list[i] = entry.p
+        return cls(p)
+
+    def entry(self, idx):
+        return SCIONDSegTypeHopReplyEntry(self.p.entries[idx])
+
+    def iter_entries(self):
+        for entry in self.p.entries:
+            yield SCIONDSegTypeHopReplyEntry(entry)
+
+    def short_desc(self):
+        return "\n".join([entry.short_desc() for entry in self.iter_entries()])
+
+
+class SCIONDSegTypeHopReplyEntry(Cerealizable):
+    NAME = "SCIONDSegTypeHopReplyEntry"
+    P_CLS = P.SegTypeHopReplyEntry
+
+    @classmethod
+    def from_values(cls, interfaces, timestamp, expTime):
+        p = cls.P_CLS.new_message(timestamp=timestamp, expTime=expTime)
+        ifs = p.init("interfaces", len(interfaces))
+        for i, if_ in enumerate(interfaces):
+            ifs[i] = if_.p
+        return cls(p)
+
+    def iter_ifs(self):
+        for if_ in self.p.interfaces:
+            yield PathInterface(if_)
+
+    def short_desc(self):
+        desc = []
+        remain = self.p.expTime - self.p.timestamp
+        desc.append("%s, %s, " % (iso_timestamp(
+            self.p.timestamp), timedelta(seconds=remain)))
+        desc.append(", ".join([if_.short_desc() for if_ in self.iter_ifs()]))
+        return "".join(desc)
+
+    def __str__(self):
+        desc = ["%s:" % self.NAME]
+        if_str = ", ".join([if_.short_desc() for if_ in self.iter_ifs()])
+        desc.append("  Interfaces: %s " % if_str)
+        desc.append("  Timestamp: %s" % self.p.timestamp)
+        desc.append("  Expiration: %s" % self.p.expTime)
+        return "\n".join(desc)

--- a/python/lib/types.py
+++ b/python/lib/types.py
@@ -196,6 +196,8 @@ class SCIONDMsgType(TypeBase):
     SERVICE_REPLY = "serviceInfoReply"
     DRKEY_REQUEST = "drkeyRequest"
     DRKEY_REPLY = "drkeyReply"
+    SEGTYPEHOP_REQUEST = "segTypeHopReq"
+    SEGTYPEHOP_REPLY = "segTypeHopReply"
 
 
 #######################

--- a/python/test/lib/app/sciond_test.py
+++ b/python/test/lib/app/sciond_test.py
@@ -28,7 +28,10 @@ from lib.packet.host_addr import HostAddrIPv4, HostAddrSVC
 from lib.packet.scion_addr import ISD_AS, SCIONAddr
 from lib.packet.svc import SVCType
 from lib.sciond_api.path_req import SCIONDPathReplyError as PRE
-from lib.types import SCIONDMsgType as SMT
+from lib.types import (
+    PathSegmentType as PST,
+    SCIONDMsgType as SMT,
+)
 from test.testcommon import create_mock, create_mock_full
 
 
@@ -361,3 +364,31 @@ class TestSCIONDConnectorTryCache:
         key_list = [1, 2, 1, 2]
         # Call
         ntools.eq_(SCIONDConnector._try_cache(cache, key_list), (set(), {1: "a", 2: "b"}))
+
+
+class TestSCIONDConnectorGetTypeSegs(SCIONDConnectorTestBase):
+    """Unit tests for lib.app.sciond.SCIONDConnector.get_segtype_hops"""
+
+    def _setup(self):
+        return self._setup_connector(
+            create_mock_full({"iter_entries()": ["segment"]}))
+
+    @patch("lib.app.sciond.SCIONDSegTypeHopRequest.from_values", new_callable=create_mock)
+    @patch("lib.app.sciond.SCIONDMsg", new_callable=create_mock)
+    def test_valid_type(self, sciond_msg, segment_req):
+        connector = self._setup()
+        seg_type = PST.CORE
+        # Call
+        segments = connector.get_segtype_hops(seg_type)
+        # Tests
+        ntools.eq_(segments, ["segment"])
+        sciond_msg.assert_called_once_with(segment_req.return_value, self.REQ_ID)
+        segment_req.assert_called_once_with(seg_type)
+        connector._create_socket.assert_called_once_with()
+        connector._get_response.assert_called_once_with(ANY, 1, SMT.SEGTYPEHOP_REPLY)
+
+    def test_invalid_type(self):
+        connector = self._setup()
+        seg_type = 'unset'
+        # Call
+        ntools.assert_raises(AssertionError, connector.get_segtype_hops, seg_type)


### PR DESCRIPTION
- Adds ability to request detailed segment data after get_paths
succeeds.
- Returns requested segments data (core, up, down).
- Requested segment data can be used to calculate core ASes in paths.
- Requested segment data can be used to calculate path types.
- Useful for visualizations to display core and path types for every AS
routed through.
- Closes #1299.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1383)
<!-- Reviewable:end -->
