### PR TITLE
Simplify handling of signed ctrl messages.

### DIFF
--- a/go/border/gen.go
+++ b/go/border/gen.go
@@ -109,7 +109,8 @@ func (r *Router) genIFIDPkt(ifID common.IFIDType, ctx *rctx.Ctx) {
 	logger := log.New("ifid", ifID)
 	intf := ctx.Conf.Net.IFs[ifID]
 	srcAddr := intf.IFAddr.PublicAddrInfo(intf.IFAddr.Overlay)
-	scpld, err := ctrl.NewSignedPldFromUnion(&ifid.IFID{OrigIfID: uint64(ifID)})
+	scpld, err := ctrl.MkSPld(ctrl.NewPldF(&ifid.IFID{OrigIfID: uint64(ifID)}, nil),
+		ctrl.NullSigner)
 	if err != nil {
 		logger.Error("Error generating IFID payload", "err", common.FmtError(err))
 		return
@@ -141,7 +142,8 @@ func (r *Router) genIFStateReq() {
 	ctx := rctx.Get()
 	// Pick first local address from topology as source.
 	srcAddr := ctx.Conf.Net.LocAddr[0].PublicAddrInfo(ctx.Conf.Net.LocAddr[0].Overlay)
-	scpld, err := ctrl.NewSignedPathMgmtPld(&path_mgmt.IFStateReq{})
+	scpld, err := ctrl.MkSPld(ctrl.NewPathMgmtPldF(&path_mgmt.IFStateReq{}, nil, nil),
+		ctrl.NullSigner)
 	if err != nil {
 		log.Error("Error generating IFStateReq payload", "err", common.FmtError(err))
 		return

--- a/go/border/gen.go
+++ b/go/border/gen.go
@@ -109,10 +109,14 @@ func (r *Router) genIFIDPkt(ifID common.IFIDType, ctx *rctx.Ctx) {
 	logger := log.New("ifid", ifID)
 	intf := ctx.Conf.Net.IFs[ifID]
 	srcAddr := intf.IFAddr.PublicAddrInfo(intf.IFAddr.Overlay)
-	scpld, err := ctrl.MkSPld(ctrl.NewPldF(&ifid.IFID{OrigIfID: uint64(ifID)}, nil),
-		ctrl.NullSigner)
+	cpld, err := ctrl.NewPld(&ifid.IFID{OrigIfID: uint64(ifID)}, nil)
 	if err != nil {
-		logger.Error("Error generating IFID payload", "err", common.FmtError(err))
+		logger.Error("Error generating IFID Ctrl payload", "err", common.FmtError(err))
+		return
+	}
+	scpld, err := cpld.SignedPld(ctrl.NullSigner)
+	if err != nil {
+		logger.Error("Error generating IFID signed Ctrl payload", "err", common.FmtError(err))
 		return
 	}
 	if err := r.genPkt(intf.RemoteIA, addr.HostFromIP(intf.RemoteAddr.IP),
@@ -142,10 +146,14 @@ func (r *Router) genIFStateReq() {
 	ctx := rctx.Get()
 	// Pick first local address from topology as source.
 	srcAddr := ctx.Conf.Net.LocAddr[0].PublicAddrInfo(ctx.Conf.Net.LocAddr[0].Overlay)
-	scpld, err := ctrl.MkSPld(ctrl.NewPathMgmtPldF(&path_mgmt.IFStateReq{}, nil, nil),
-		ctrl.NullSigner)
+	cpld, err := ctrl.NewPathMgmtPld(&path_mgmt.IFStateReq{}, nil, nil)
 	if err != nil {
-		log.Error("Error generating IFStateReq payload", "err", common.FmtError(err))
+		log.Error("Error generating IFStateReq Ctrl payload", "err", common.FmtError(err))
+		return
+	}
+	scpld, err := cpld.SignedPld(ctrl.NullSigner)
+	if err != nil {
+		log.Error("Error generating IFStateReq signed Ctrl payload", "err", common.FmtError(err))
 		return
 	}
 	if err := r.genPkt(ctx.Conf.IA, addr.SvcBS.Multicast(), 0, srcAddr, scpld); err != nil {

--- a/go/border/revinfo.go
+++ b/go/border/revinfo.go
@@ -57,9 +57,14 @@ func (r *Router) fwdRevInfo(revInfo *path_mgmt.RevInfo, dstHost addr.HostAddr) {
 	ctx := rctx.Get()
 	// Pick first local address from topology as source.
 	srcAddr := ctx.Conf.Net.LocAddr[0].PublicAddrInfo(ctx.Conf.Topo.Overlay)
-	scpld, err := ctrl.MkSPld(ctrl.NewPldF(revInfo, nil), ctrl.NullSigner)
+	cpld, err := ctrl.NewPld(revInfo, nil)
 	if err != nil {
-		log.Error("Error generating RevInfo payload", "err", common.FmtError(err))
+		log.Error("Error generating RevInfo Ctrl payload", "err", common.FmtError(err))
+		return
+	}
+	scpld, err := cpld.SignedPld(ctrl.NullSigner)
+	if err != nil {
+		log.Error("Error generating RevInfo signed Ctrl payload", "err", common.FmtError(err))
 		return
 	}
 	if err = r.genPkt(ctx.Conf.IA, *dstHost.(*addr.HostSVC), 0, srcAddr, scpld); err != nil {

--- a/go/border/revinfo.go
+++ b/go/border/revinfo.go
@@ -57,7 +57,7 @@ func (r *Router) fwdRevInfo(revInfo *path_mgmt.RevInfo, dstHost addr.HostAddr) {
 	ctx := rctx.Get()
 	// Pick first local address from topology as source.
 	srcAddr := ctx.Conf.Net.LocAddr[0].PublicAddrInfo(ctx.Conf.Topo.Overlay)
-	cpld, err := ctrl.NewPld(revInfo, nil)
+	cpld, err := ctrl.NewPathMgmtPld(revInfo, nil, nil)
 	if err != nil {
 		log.Error("Error generating RevInfo Ctrl payload", "err", common.FmtError(err))
 		return

--- a/go/border/revinfo.go
+++ b/go/border/revinfo.go
@@ -57,7 +57,7 @@ func (r *Router) fwdRevInfo(revInfo *path_mgmt.RevInfo, dstHost addr.HostAddr) {
 	ctx := rctx.Get()
 	// Pick first local address from topology as source.
 	srcAddr := ctx.Conf.Net.LocAddr[0].PublicAddrInfo(ctx.Conf.Topo.Overlay)
-	scpld, err := ctrl.NewSignedPathMgmtPld(revInfo)
+	scpld, err := ctrl.MkSPld(ctrl.NewPldF(revInfo, nil), ctrl.NullSigner)
 	if err != nil {
 		log.Error("Error generating RevInfo payload", "err", common.FmtError(err))
 		return

--- a/go/border/rpkt/process.go
+++ b/go/border/rpkt/process.go
@@ -159,7 +159,11 @@ func (rp *RtrPkt) processDestSelf() (HookResult, error) {
 func (rp *RtrPkt) processIFID(ifid *ifid.IFID) (HookResult, error) {
 	// Set the RelayIF field in the payload to the current interface ID.
 	ifid.RelayIfID = uint64(*rp.ifCurr)
-	scpld, err := ctrl.MkSPld(ctrl.NewPldF(ifid, nil), ctrl.NullSigner)
+	cpld, err := ctrl.NewPld(ifid, nil)
+	if err != nil {
+		return HookError, err
+	}
+	scpld, err := cpld.SignedPld(ctrl.NullSigner)
 	if err != nil {
 		return HookError, err
 	}

--- a/go/border/rpkt/process.go
+++ b/go/border/rpkt/process.go
@@ -159,7 +159,7 @@ func (rp *RtrPkt) processDestSelf() (HookResult, error) {
 func (rp *RtrPkt) processIFID(ifid *ifid.IFID) (HookResult, error) {
 	// Set the RelayIF field in the payload to the current interface ID.
 	ifid.RelayIfID = uint64(*rp.ifCurr)
-	scpld, err := ctrl.NewSignedPldFromUnion(ifid)
+	scpld, err := ctrl.MkSPld(ctrl.NewPldF(ifid, nil), ctrl.NullSigner)
 	if err != nil {
 		return HookError, err
 	}

--- a/go/cert_srv/cert.go
+++ b/go/cert_srv/cert.go
@@ -72,7 +72,7 @@ func (h *ChainHandler) sendChainRep(addr *snet.Addr, chain *cert.Chain) error {
 	if err != nil {
 		return err
 	}
-	cpld, err := ctrl.NewCertMgmtPld(&cert_mgmt.Chain{RawChain: raw})
+	cpld, err := ctrl.NewCertMgmtPld(&cert_mgmt.Chain{RawChain: raw}, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func (h *ChainHandler) fetchChain(addr *snet.Addr, req *cert_mgmt.ChainReq) erro
 
 // sendChainReq sends a certificate chain request to the specified remote AS.
 func (h *ChainHandler) sendChainReq(req *cert_mgmt.ChainReq) error {
-	cpld, err := ctrl.NewCertMgmtPld(req)
+	cpld, err := ctrl.NewCertMgmtPld(req, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (h *ChainHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.Chain) {
 	if reqVer == nil && reqNew == nil { // No pending requests
 		return
 	}
-	cpld, err := ctrl.NewCertMgmtPld(rep)
+	cpld, err := ctrl.NewCertMgmtPld(rep, nil, nil)
 	if err != nil {
 		log.Error("Unable to create certificate chain reply", "key", key,
 			"err", common.FmtError(err))

--- a/go/cert_srv/trc.go
+++ b/go/cert_srv/trc.go
@@ -71,7 +71,7 @@ func (h *TRCHandler) sendTRCRep(addr *snet.Addr, t *trc.TRC) error {
 	if err != nil {
 		return err
 	}
-	cpld, err := ctrl.NewCertMgmtPld(&cert_mgmt.TRC{RawTRC: raw})
+	cpld, err := ctrl.NewCertMgmtPld(&cert_mgmt.TRC{RawTRC: raw}, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func (h *TRCHandler) fetchTRC(addr *snet.Addr, req *cert_mgmt.TRCReq) error {
 
 // sendTRCReq sends a TRC request to the specified remote AS.
 func (h *TRCHandler) sendTRCReq(req *cert_mgmt.TRCReq) error {
-	cpld, err := ctrl.NewCertMgmtPld(req)
+	cpld, err := ctrl.NewCertMgmtPld(req, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (h *TRCHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.TRC) {
 	if reqVer == nil && reqNew == nil { // No pending requests
 		return
 	}
-	cpld, err := ctrl.NewCertMgmtPld(rep)
+	cpld, err := ctrl.NewCertMgmtPld(rep, nil, nil)
 	if err != nil {
 		log.Error("Unable to create TRC reply", "key", t.Key(), "err", common.FmtError(err))
 		return

--- a/go/lib/ctrl/cert_mgmt/cert_mgmt.go
+++ b/go/lib/ctrl/cert_mgmt/cert_mgmt.go
@@ -72,11 +72,12 @@ var _ proto.Cerealizable = (*Pld)(nil)
 
 type Pld struct {
 	union
+	*Data
 }
 
 // NewPld creates a new cert mgmt payload, containing the supplied Cerealizable instance.
-func NewPld(u proto.Cerealizable) (*Pld, error) {
-	p := &Pld{}
+func NewPld(u proto.Cerealizable, d *Data) (*Pld, error) {
+	p := &Pld{Data: d}
 	return p, p.union.set(u)
 }
 
@@ -97,4 +98,8 @@ func (p *Pld) String() string {
 		desc = append(desc, fmt.Sprintf("%+v", u))
 	}
 	return strings.Join(desc, " ")
+}
+
+type Data struct {
+	// For passing any future non-union data.
 }

--- a/go/lib/ctrl/ctrl_msg/msg.go
+++ b/go/lib/ctrl/ctrl_msg/msg.go
@@ -1,0 +1,88 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctrl_msg
+
+import (
+	"context"
+	"net"
+
+	//log "github.com/inconshreveable/log15"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/infra/disp"
+	"github.com/scionproto/scion/go/proto"
+)
+
+type notifyF func(context.Context, disp.Message, net.Addr) error
+
+type Requester struct {
+	signer ctrl.Signer
+	sigc   ctrl.SigChecker
+	d      *disp.Dispatcher
+}
+
+func NewRequester(signer ctrl.Signer, sigc ctrl.SigChecker, d *disp.Dispatcher) *Requester {
+	return &Requester{signer: signer, sigc: sigc, d: d}
+}
+
+func (r *Requester) Request(ctx context.Context, plder ctrl.Plder,
+	a net.Addr) (*ctrl.Pld, *proto.SignS, error) {
+	pld, err := plder()
+	if err != nil {
+		return nil, nil, err
+	}
+	spld, err := r.signer(pld)
+	if err != nil {
+		return nil, nil, err
+	}
+	reply, err := r.d.Request(ctx, spld, a)
+	if err != nil {
+		return nil, nil, err
+	}
+	rspld, ok := reply.(*ctrl.SignedPld)
+	if !ok {
+		return nil, nil, common.NewBasicError("ctrl_msg: reply is not a ctrl.SignedPld", nil,
+			"type", common.TypeOf(reply), "reply", reply)
+	}
+	if err := r.sigc(rspld); err != nil {
+		return nil, rspld.Sign, err
+	}
+	rpld, err := rspld.Pld()
+	if err != nil {
+		return nil, rspld.Sign, err
+	}
+	return rpld, rspld.Sign, nil
+}
+
+func (r *Requester) Notify(ctx context.Context, plder ctrl.Plder, a net.Addr) error {
+	return r.notify(ctx, plder, a, r.d.Notify)
+}
+
+func (r *Requester) NotifyUnreliable(ctx context.Context, plder ctrl.Plder, a net.Addr) error {
+	return r.notify(ctx, plder, a, r.d.NotifyUnreliable)
+}
+
+func (r *Requester) notify(ctx context.Context, plder ctrl.Plder, a net.Addr, f notifyF) error {
+	pld, err := plder()
+	if err != nil {
+		return err
+	}
+	spld, err := r.signer(pld)
+	if err != nil {
+		return err
+	}
+	return f(ctx, spld, a)
+}

--- a/go/lib/ctrl/ctrl_msg/msg.go
+++ b/go/lib/ctrl/ctrl_msg/msg.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package ctrl_msg implements a layer for sending SCION Ctrl payload
+// requests/notifications via the infra dispatcher, including integrated
+// signing and signature verification of ctrl payloads.
 package ctrl_msg
 
 import (

--- a/go/lib/ctrl/path_mgmt/path_mgmt.go
+++ b/go/lib/ctrl/path_mgmt/path_mgmt.go
@@ -90,11 +90,12 @@ var _ proto.Cerealizable = (*Pld)(nil)
 
 type Pld struct {
 	union
+	*Data
 }
 
 // NewPld creates a new path mgmt payload, containing the supplied Cerealizable instance.
-func NewPld(u proto.Cerealizable) (*Pld, error) {
-	p := &Pld{}
+func NewPld(u proto.Cerealizable, d *Data) (*Pld, error) {
+	p := &Pld{Data: d}
 	return p, p.union.set(u)
 }
 
@@ -115,4 +116,8 @@ func (p *Pld) String() string {
 		desc = append(desc, fmt.Sprintf("%+v", u))
 	}
 	return strings.Join(desc, " ")
+}
+
+type Data struct {
+	// For passing any future non-union data.
 }

--- a/go/lib/ctrl/signed_util.go
+++ b/go/lib/ctrl/signed_util.go
@@ -1,0 +1,100 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ctrl
+
+import (
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/crypto/cert"
+	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/proto"
+)
+
+type Signer func(*Pld) (*SignedPld, error)
+
+func MkSigner(s *proto.SignS, key common.RawBytes) Signer {
+	return func(p *Pld) (*SignedPld, error) {
+		return newSignedPld(p, s, key)
+	}
+}
+
+func NullSigner(p *Pld) (*SignedPld, error) {
+	return newSignedPld(p, nil, nil)
+}
+
+type trustStore struct{} // TODO(kormat): replace this with the actual trust store.
+
+type SigChecker func(*SignedPld) error
+type SigCheckerInner func(*SignedPld, *trustStore) error
+
+func MkSigchecker(sigCin SigCheckerInner, tStore *trustStore) SigChecker {
+	return func(p *SignedPld) error {
+		// Perform common checks before calling real checker.
+		if p.Sign.Type == proto.SignType_none && len(p.Sign.Signature) == 0 {
+			// Nothing to check.
+			return nil
+		}
+		if p.Sign.Type == proto.SignType_none {
+			return common.NewBasicError("SignedPld has signature of type none", nil)
+		}
+		if len(p.Sign.Signature) == 0 {
+			return common.NewBasicError("SignedPld is missing signature", nil, "type", p.Sign.Type)
+		}
+		return sigCin(p, tStore)
+	}
+}
+
+func BasicSigCheck(p *SignedPld, tStore *trustStore) error {
+	cpld, err := p.Pld()
+	if err != nil {
+		return err
+	}
+	if ignoreSign(cpld) {
+		return nil
+	}
+	c, err := GetCertForSign(p.Sign, tStore)
+	if err != nil {
+		return err
+	}
+	return p.Sign.Verify(c.SubjectSignKey, p.Blob)
+}
+
+func GetCertForSign(s *proto.SignS, tStore *trustStore) (*cert.Certificate, error) {
+	// TODO(kormat): Parse s.Src, query tStore
+	return nil, nil
+}
+
+func ignoreSign(p *Pld) bool {
+	u0, _ := p.Union()
+	outer, ok := u0.(*cert_mgmt.Pld)
+	if !ok {
+		return false
+	}
+	u1, _ := outer.Union()
+	switch u1.(type) {
+	case *cert_mgmt.Chain, *cert_mgmt.TRC:
+		return true
+	default:
+		return false
+	}
+}
+
+// MkSPld creates a SignedPld from the provided Plder and Signer.
+func MkSPld(plder Plder, signer Signer) (*SignedPld, error) {
+	pld, err := plder()
+	if err != nil {
+		return nil, err
+	}
+	return signer(pld)
+}

--- a/go/proto/sign.go
+++ b/go/proto/sign.go
@@ -34,6 +34,9 @@ func NewSignS(type_ SignType, src common.RawBytes) *SignS {
 }
 
 func (s *SignS) Copy() *SignS {
+	if s == nil {
+		return nil
+	}
 	return &SignS{
 		Type:      s.Type,
 		Src:       append(common.RawBytes(nil), s.Src...),

--- a/go/sig/base/pollhdlr.go
+++ b/go/sig/base/pollhdlr.go
@@ -42,7 +42,7 @@ func PollReqHdlr() {
 			log.Error("PollReqHdlr: Error creating SIGCtrl payload", "err", common.FmtError(err))
 			break
 		}
-		scpld, err := ctrl.NewSignedPldFromUnion(spld)
+		scpld, err := ctrl.MkSPld(ctrl.NewPldF(spld, nil), ctrl.NullSigner)
 		if err != nil {
 			log.Error("PollReqHdlr: Error creating Ctrl payload", "err", common.FmtError(err))
 			break

--- a/go/sig/base/pollhdlr.go
+++ b/go/sig/base/pollhdlr.go
@@ -42,14 +42,20 @@ func PollReqHdlr() {
 			log.Error("PollReqHdlr: Error creating SIGCtrl payload", "err", common.FmtError(err))
 			break
 		}
-		scpld, err := ctrl.MkSPld(ctrl.NewPldF(spld, nil), ctrl.NullSigner)
+		cpld, err := ctrl.NewPld(spld, nil)
 		if err != nil {
 			log.Error("PollReqHdlr: Error creating Ctrl payload", "err", common.FmtError(err))
 			break
 		}
+		scpld, err := cpld.SignedPld(ctrl.NullSigner)
+		if err != nil {
+			log.Error("PollReqHdlr: Error creating signed Ctrl payload",
+				"err", common.FmtError(err))
+			break
+		}
 		raw, err := scpld.PackPld()
 		if err != nil {
-			log.Error("PollReqHdlr: Error packing Ctrl payload", "err", common.FmtError(err))
+			log.Error("PollReqHdlr: Error packing signed Ctrl payload", "err", common.FmtError(err))
 			break
 		}
 		sigCtrlAddr := &snet.Addr{

--- a/go/sig/egress/sessmon.go
+++ b/go/sig/egress/sessmon.go
@@ -189,7 +189,7 @@ func (sm *sessMonitor) sendReq() {
 		sm.Error("sessMonitor: Error creating SIGCtrl payload", "err", common.FmtError(err))
 		return
 	}
-	scpld, err := ctrl.NewSignedPldFromUnion(spld)
+	scpld, err := ctrl.MkSPld(ctrl.NewPldF(spld, nil), ctrl.NullSigner)
 	if err != nil {
 		sm.Error("sessMonitor: Error creating Ctrl payload", "err", common.FmtError(err))
 		return

--- a/go/sig/egress/sessmon.go
+++ b/go/sig/egress/sessmon.go
@@ -189,9 +189,14 @@ func (sm *sessMonitor) sendReq() {
 		sm.Error("sessMonitor: Error creating SIGCtrl payload", "err", common.FmtError(err))
 		return
 	}
-	scpld, err := ctrl.MkSPld(ctrl.NewPldF(spld, nil), ctrl.NullSigner)
+	cpld, err := ctrl.NewPld(spld, nil)
 	if err != nil {
 		sm.Error("sessMonitor: Error creating Ctrl payload", "err", common.FmtError(err))
+		return
+	}
+	scpld, err := cpld.SignedPld(ctrl.NullSigner)
+	if err != nil {
+		sm.Error("sessMonitor: Error creating signed Ctrl payload", "err", common.FmtError(err))
 		return
 	}
 	raw, err := scpld.PackPld()

--- a/proto/ctrl_pld.capnp
+++ b/proto/ctrl_pld.capnp
@@ -30,4 +30,6 @@ struct CtrlPld {
         sig @7 :SIG.SIGCtrl;
         extn @8 :CtrlExtn.CtrlExtnDataList;
     }
+    reqId @9 :UInt64;
+    traceId @10 :Data;
 }


### PR DESCRIPTION
This patch reworks how scion ctrl payloads are created/signed/verified.
By using callbacks, an app can create and sign a ctrl payload and only
have a single error value to check, greatly reducing boiler-plate. It
also becomes much more obvious when a message is not being signed.

This patch also adds support for non-union data at the CtrlPld, CertMgmt
and PathMgmt levels. This allows for a unified approach to things like
request IDs, tracing, and error reporting.

Also:
- Cache the parsed CtrlPld in SignedCtrlPld, to reduce the overhead of
  extracting it multiple times.
- Add request ID and trace ID to CtrlPld, though they are currently not
  used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1385)
<!-- Reviewable:end -->
