### PR TITLE
Don't use a reference to a loop var

### DIFF
--- a/go/sig/base/map.go
+++ b/go/sig/base/map.go
@@ -74,7 +74,7 @@ func (am *ASMap) ReloadConfig(cfg *config.Cfg) bool {
 func (am *ASMap) addNewIAs(cfg *config.Cfg) bool {
 	s := true
 	for iaVal, cfgEntry := range cfg.ASes {
-		ia := &iaVal
+		ia := iaVal.Copy()
 		log.Info("ReloadConfig: Adding AS...", "ia", ia)
 		ae, err := am.AddIA(ia)
 		if err != nil {


### PR DESCRIPTION
This caused a very subtle bug in the SIG that only manifests once
you have multiple remote ASes in the config. All ASes configured in a
single config load would end up with the same IA in some parts of the
logic, leading to utter sanity loss.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1387)
<!-- Reviewable:end -->
