### PR TITLE
Include address and path header lengths in SIG frame size calculation.

### DIFF
--- a/go/lib/spkt/spkt.go
+++ b/go/lib/spkt/spkt.go
@@ -85,8 +85,7 @@ func (s *ScnPkt) Reverse() error {
 }
 
 func (s *ScnPkt) AddrLen() int {
-	addrLen := addr.IABytes*2 + s.DstHost.Size() + s.SrcHost.Size()
-	return addrLen + util.CalcPadding(addrLen, common.LineLen)
+	return AddrHdrLen(s.DstHost, s.SrcHost)
 }
 
 // HdrLen returns the length of the header, in bytes.
@@ -113,4 +112,11 @@ func (s *ScnPkt) TotalLen() int {
 		l += s.Pld.Len()
 	}
 	return l
+}
+
+// AddrHdrLen calculates the length of a SCION address header (including
+// padding) for the specified address types.
+func AddrHdrLen(dst addr.HostAddr, src addr.HostAddr) int {
+	addrLen := addr.IABytes*2 + dst.Size() + src.Size()
+	return addrLen + util.CalcPadding(addrLen, common.LineLen)
 }

--- a/go/sig/egress/worker.go
+++ b/go/sig/egress/worker.go
@@ -189,19 +189,23 @@ func (w *worker) write(f *frame) error {
 
 func (w *worker) resetFrame(f *frame) {
 	var mtu uint16 = common.MinMTU
+	var addrLen, pathLen uint16
 	remote := w.sess.Remote()
 	if remote != nil {
 		w.currSig = remote.Sig
+		if w.currSig != nil {
+			addrLen = uint16(spkt.AddrHdrLen(w.currSig.Host, sigcmn.Host))
+		}
 		if remote.sessPath != nil {
 			w.currPathEntry = remote.sessPath.pathEntry
 		}
 		if w.currPathEntry != nil {
 			mtu = w.currPathEntry.Path.Mtu
+			pathLen = uint16(len(w.currPathEntry.Path.FwdPath))
 		}
 	}
-	// FIXME(kormat): to do this properly, need to calculate the address header size,
-	// and account for any ext headers.
-	f.reset(mtu - spkt.CmnHdrLen - 40 - l4.UDPLen)
+	// FIXME(kormat): to do this properly, need to account for any ext headers.
+	f.reset(mtu - spkt.CmnHdrLen - addrLen - pathLen - l4.UDPLen)
 }
 
 type frame struct {


### PR DESCRIPTION
The current SIG code assumes that the address+path headers are <= 40B
long. This only happens to work because the existing environmets have a
single hop involving a core AS, and using IPv4 addresses. This fixes the
SIG to calculate the actual address+path header sizes, and use those.

N.b. it still does not include any extensions that might be in use. That
will eventually depend on snet providing that information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1388)
<!-- Reviewable:end -->
