### PR TITLE
Fix loop var reference issue in pathmgr

### DIFF
--- a/go/lib/pathmgr/resolver.go
+++ b/go/lib/pathmgr/resolver.go
@@ -68,8 +68,10 @@ func (r *resolver) run() {
 				} else {
 					wait = r.normalRefire
 				}
+				// Make a copy of loop var for closure.
+				req := request
 				time.AfterFunc(wait, func() {
-					r.requestQueue <- request
+					r.requestQueue <- req
 				})
 			}
 		default:


### PR DESCRIPTION
The loop variable, `request`, is re-used, which means that referencing
it later from a closure will not yield the expected value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1392)
<!-- Reviewable:end -->
