### PR TITLE
Add PathSegment ASEntry-ordering validation.

### DIFF
--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -108,6 +108,9 @@ func (ia *ISD_AS) Copy() *ISD_AS {
 }
 
 func (ia *ISD_AS) Eq(other *ISD_AS) bool {
+	if (ia == nil) || (other == nil) {
+		return ia == other
+	}
 	return ia.I == other.I && ia.A == other.A
 }
 

--- a/go/lib/ctrl/seg/hop.go
+++ b/go/lib/ctrl/seg/hop.go
@@ -18,15 +18,16 @@ package seg
 
 import (
 	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/spath"
 )
 
 type HopEntry struct {
 	RawInIA     addr.IAInt `capnp:"inIA"`
-	RemoteInIF  uint64
+	RemoteInIF  common.IFIDType
 	InMTU       uint16     `capnp:"inMTU"`
 	RawOutIA    addr.IAInt `capnp:"outIA"`
-	RemoteOutIF uint64
+	RemoteOutIF common.IFIDType
 	RawHopField []byte `capnp:"hopF"`
 }
 

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/proto"
@@ -64,7 +65,7 @@ func NewSegFromRaw(b common.RawBytes) (*PathSegment, error) {
 		}
 		ps.ASEntries = append(ps.ASEntries, ase)
 	}
-	return ps, nil
+	return ps, ps.Validate()
 }
 
 func (ps *PathSegment) ID() (common.RawBytes, error) {
@@ -86,6 +87,31 @@ func (ps *PathSegment) ID() (common.RawBytes, error) {
 
 func (ps *PathSegment) InfoF() (*spath.InfoField, error) {
 	return ps.SData.InfoF()
+}
+
+func (ps *PathSegment) Validate() error {
+	if len(ps.RawASEntries) == 0 {
+		return common.NewBasicError("PathSegment has no ASEntry's", nil)
+	}
+	if len(ps.ASEntries) != len(ps.RawASEntries) {
+		return common.NewBasicError(
+			"PathSegment has mismatched number of raw and parsed ASEntry's", nil,
+			"ASEntries", len(ps.ASEntries), "RawASEntries", len(ps.RawASEntries),
+		)
+	}
+	for i := range ps.ASEntries {
+		var prevIA, nextIA *addr.ISD_AS
+		if i > 0 {
+			prevIA = ps.ASEntries[i-1].IA()
+		}
+		if i < len(ps.ASEntries)-1 {
+			nextIA = ps.ASEntries[i+1].IA()
+		}
+		if err := ps.ASEntries[i].Validate(prevIA, nextIA); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (ps *PathSegment) AddASEntry(ase *ASEntry, signType proto.SignType,

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -91,16 +91,17 @@ func (ps *PathSegment) InfoF() (*spath.InfoField, error) {
 
 func (ps *PathSegment) Validate() error {
 	if len(ps.RawASEntries) == 0 {
-		return common.NewBasicError("PathSegment has no ASEntry's", nil)
+		return common.NewBasicError("PathSegment has no AS Entries", nil)
 	}
 	if len(ps.ASEntries) != len(ps.RawASEntries) {
 		return common.NewBasicError(
-			"PathSegment has mismatched number of raw and parsed ASEntry's", nil,
+			"PathSegment has mismatched number of raw and parsed AS Entries", nil,
 			"ASEntries", len(ps.ASEntries), "RawASEntries", len(ps.RawASEntries),
 		)
 	}
 	for i := range ps.ASEntries {
-		var prevIA, nextIA *addr.ISD_AS
+		prevIA := &addr.ISD_AS{}
+		nextIA := &addr.ISD_AS{}
 		if i > 0 {
 			prevIA = ps.ASEntries[i-1].IA()
 		}

--- a/go/lib/pathdb/sqlite/sqlite_test.go
+++ b/go/lib/pathdb/sqlite/sqlite_test.go
@@ -74,20 +74,20 @@ func allocPathSegment(ifs []uint64, expiration uint32) (*seg.PathSegment, common
 		{
 			RawIA: ia13.IAInt(),
 			HopEntries: []*seg.HopEntry{
-				allocHopEntry(ia13, ia16, rawHops[0]),
+				allocHopEntry(&addr.ISD_AS{}, ia16, rawHops[0]),
 			},
 		},
 		{
 			RawIA: ia16.IAInt(),
 			HopEntries: []*seg.HopEntry{
 				allocHopEntry(ia13, ia19, rawHops[1]),
-				allocHopEntry(ia13, ia14, rawHops[2]),
+				allocHopEntry(ia14, ia19, rawHops[2]),
 			},
 		},
 		{
 			RawIA: ia19.IAInt(),
 			HopEntries: []*seg.HopEntry{
-				allocHopEntry(ia16, ia19, rawHops[3]),
+				allocHopEntry(ia16, &addr.ISD_AS{}, rawHops[3]),
 			},
 		},
 	}


### PR DESCRIPTION
This prevents a malicious AS from removing ASEntries from a PathSegment
during beaconing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1394)
<!-- Reviewable:end -->
