### PR TITLE
Make custom errors be self-formatting.

### DIFF
--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -48,7 +48,7 @@ func GetErrorMsg(e error) string {
 // ErrorNester allows recursing into nested errors.
 type ErrorNester interface {
 	error
-	FmtError() string // should not include the nested error
+	TopError() string // should not include the nested error
 	GetErr() error
 }
 
@@ -123,7 +123,7 @@ func NewBasicError(msg string, e error, logCtx ...interface{}) error {
 	return BasicError{Msg: msg, logCtx: logCtx, Err: e}
 }
 
-func (be BasicError) FmtError() string {
+func (be BasicError) TopError() string {
 	s := make([]string, 0, 1+(len(be.logCtx)/2))
 	s = append(s, be.Msg)
 	s[0] = be.Msg
@@ -164,7 +164,7 @@ func innerFmtError(e error) ([]string, error) {
 	var lines []string
 	switch e := e.(type) {
 	case ErrorNester:
-		lines = strings.Split(e.FmtError(), "\n")
+		lines = strings.Split(e.TopError(), "\n")
 	default:
 		lines = strings.Split(e.Error(), "\n")
 	}

--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -48,6 +48,7 @@ func GetErrorMsg(e error) string {
 // ErrorNester allows recursing into nested errors.
 type ErrorNester interface {
 	error
+	FmtError() string // should not include the nested error
 	GetErr() error
 }
 
@@ -122,7 +123,7 @@ func NewBasicError(msg string, e error, logCtx ...interface{}) error {
 	return BasicError{Msg: msg, logCtx: logCtx, Err: e}
 }
 
-func (be BasicError) Error() string {
+func (be BasicError) FmtError() string {
 	s := make([]string, 0, 1+(len(be.logCtx)/2))
 	s = append(s, be.Msg)
 	s[0] = be.Msg
@@ -130,6 +131,10 @@ func (be BasicError) Error() string {
 		s = append(s, fmt.Sprintf("%s=\"%v\"", be.logCtx[i], be.logCtx[i+1]))
 	}
 	return strings.Join(s, " ")
+}
+
+func (be BasicError) Error() string {
+	return FmtError(be)
 }
 
 func (be BasicError) GetMsg() string {
@@ -156,7 +161,13 @@ func FmtError(e error) string {
 
 func innerFmtError(e error) ([]string, error) {
 	var s []string
-	lines := strings.Split(e.Error(), "\n")
+	var lines []string
+	switch e := e.(type) {
+	case ErrorNester:
+		lines = strings.Split(e.FmtError(), "\n")
+	default:
+		lines = strings.Split(e.Error(), "\n")
+	}
 	for i, line := range lines {
 		if i == len(lines)-1 && len(line) == 0 {
 			// Don't output an empty line if caused by a trailing newline in

--- a/go/lib/scmp/error.go
+++ b/go/lib/scmp/error.go
@@ -36,7 +36,7 @@ func NewError(class Class, type_ Type, info Info, e error) error {
 	return &Error{CT: ClassType{class, type_}, Info: info, Err: e}
 }
 
-func (e *Error) Error() string {
+func (e *Error) FmtError() string {
 	if e == nil {
 		return "<nil>"
 	}
@@ -46,6 +46,10 @@ func (e *Error) Error() string {
 		s = append(s, fmt.Sprintf("Info: %v", e.Info))
 	}
 	return strings.Join(s, " ")
+}
+
+func (e *Error) Error() string {
+	return common.FmtError(e)
 }
 
 func (e *Error) GetErr() error {

--- a/go/lib/scmp/error.go
+++ b/go/lib/scmp/error.go
@@ -36,7 +36,7 @@ func NewError(class Class, type_ Type, info Info, e error) error {
 	return &Error{CT: ClassType{class, type_}, Info: info, Err: e}
 }
 
-func (e *Error) FmtError() string {
+func (e *Error) TopError() string {
 	if e == nil {
 		return "<nil>"
 	}


### PR DESCRIPTION
This solves the issue of errors being logged without the use of
`FmtError` (which currently would just show the first error in the
stack).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1396)
<!-- Reviewable:end -->
