### PR TITLE
Add cert reissue req/rep

### DIFF
--- a/go/cert_srv/io.go
+++ b/go/cert_srv/io.go
@@ -93,9 +93,12 @@ func (d *Dispatcher) dispatch(addr *snet.Addr, buf common.RawBytes) error {
 			d.trcHandler.HandleRep(addr, pld.(*cert_mgmt.TRC))
 		case proto.TRCReq_TypeID:
 			d.trcHandler.HandleReq(addr, pld.(*cert_mgmt.TRCReq))
+		default:
+			return common.NewBasicError("Handler for cert_mgmt.pld not implemented", nil,
+				"protoID", pld.ProtoId())
 		}
 	default:
-		return common.NewBasicError("Not implemented", nil, "protoID", c.ProtoId())
+		return common.NewBasicError("Handler for cpld not implemented", nil, "protoID", c.ProtoId())
 	}
 	return nil
 }

--- a/go/cert_srv/io.go
+++ b/go/cert_srv/io.go
@@ -22,7 +22,6 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/snet"
-	"github.com/scionproto/scion/go/proto"
 )
 
 const MaxReadBufSize = 2 << 16
@@ -78,20 +77,20 @@ func (d *Dispatcher) dispatch(addr *snet.Addr, buf common.RawBytes) error {
 	if err != nil {
 		return err
 	}
-	switch c.ProtoId() {
-	case proto.CertMgmt_TypeID:
+	switch c.(type) {
+	case *cert_mgmt.Pld:
 		pld, err := c.(*cert_mgmt.Pld).Union()
 		if err != nil {
 			return err
 		}
-		switch pld.ProtoId() {
-		case proto.CertChain_TypeID:
+		switch pld.(type) {
+		case *cert_mgmt.Chain:
 			d.chainHandler.HandleRep(addr, pld.(*cert_mgmt.Chain))
-		case proto.CertChainReq_TypeID:
+		case *cert_mgmt.ChainReq:
 			d.chainHandler.HandleReq(addr, pld.(*cert_mgmt.ChainReq))
-		case proto.TRC_TypeID:
+		case *cert_mgmt.TRC:
 			d.trcHandler.HandleRep(addr, pld.(*cert_mgmt.TRC))
-		case proto.TRCReq_TypeID:
+		case *cert_mgmt.TRCReq:
 			d.trcHandler.HandleReq(addr, pld.(*cert_mgmt.TRCReq))
 		default:
 			return common.NewBasicError("Handler for cert_mgmt.pld not implemented", nil,

--- a/go/lib/ctrl/cert_mgmt/cert_mgmt.go
+++ b/go/lib/ctrl/cert_mgmt/cert_mgmt.go
@@ -26,11 +26,13 @@ import (
 const NewestVersion = math.MaxUint64
 
 type union struct {
-	Which    proto.CertMgmt_Which
-	ChainReq *ChainReq `capnp:"certChainReq"`
-	ChainRep *Chain    `capnp:"certChain"`
-	TRCReq   *TRCReq   `capnp:"trcReq"`
-	TRCRep   *TRC      `capnp:"trc"`
+	Which       proto.CertMgmt_Which
+	ChainReq    *ChainReq    `capnp:"certChainReq"`
+	ChainRep    *Chain       `capnp:"certChain"`
+	ChainIssReq *ChainIssReq `capnp:"certChainIssReq"`
+	ChainIssRep *ChainIssRep `capnp:"certChainIssRep"`
+	TRCReq      *TRCReq      `capnp:"trcReq"`
+	TRCRep      *TRC         `capnp:"trc"`
 }
 
 func (u *union) set(c proto.Cerealizable) error {
@@ -41,6 +43,12 @@ func (u *union) set(c proto.Cerealizable) error {
 	case *Chain:
 		u.Which = proto.CertMgmt_Which_certChain
 		u.ChainRep = p
+	case *ChainIssReq:
+		u.Which = proto.CertMgmt_Which_certChainIssReq
+		u.ChainIssReq = p
+	case *ChainIssRep:
+		u.Which = proto.CertMgmt_Which_certChainIssRep
+		u.ChainIssRep = p
 	case *TRCReq:
 		u.Which = proto.CertMgmt_Which_trcReq
 		u.TRCReq = p
@@ -60,6 +68,10 @@ func (u *union) get() (proto.Cerealizable, error) {
 		return u.ChainReq, nil
 	case proto.CertMgmt_Which_certChain:
 		return u.ChainRep, nil
+	case proto.CertMgmt_Which_certChainIssReq:
+		return u.ChainIssReq, nil
+	case proto.CertMgmt_Which_certChainIssRep:
+		return u.ChainIssRep, nil
 	case proto.CertMgmt_Which_trcReq:
 		return u.TRCReq, nil
 	case proto.CertMgmt_Which_trc:

--- a/go/lib/ctrl/cert_mgmt/chain_iss_rep.go
+++ b/go/lib/ctrl/cert_mgmt/chain_iss_rep.go
@@ -1,0 +1,45 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cert_mgmt
+
+import (
+	"fmt"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/crypto/cert"
+	"github.com/scionproto/scion/go/proto"
+)
+
+var _ proto.Cerealizable = (*ChainIssRep)(nil)
+
+type ChainIssRep struct {
+	RawChain common.RawBytes `capnp:"chain"`
+}
+
+func (c *ChainIssRep) Chain() (*cert.Chain, error) {
+	return cert.ChainFromRaw(c.RawChain, true)
+}
+
+func (c *ChainIssRep) ProtoId() proto.ProtoIdType {
+	return proto.CertChainIssRep_TypeID
+}
+
+func (c *ChainIssRep) String() string {
+	chain, err := c.Chain()
+	if err != nil {
+		return fmt.Sprintf("Invalid certificate chain: %v", err)
+	}
+	return chain.String()
+}

--- a/go/lib/ctrl/cert_mgmt/chain_iss_req.go
+++ b/go/lib/ctrl/cert_mgmt/chain_iss_req.go
@@ -1,0 +1,45 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cert_mgmt
+
+import (
+	"fmt"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/crypto/cert"
+	"github.com/scionproto/scion/go/proto"
+)
+
+var _ proto.Cerealizable = (*ChainIssReq)(nil)
+
+type ChainIssReq struct {
+	RawCert common.RawBytes `capnp:"cert"`
+}
+
+func (c *ChainIssReq) Cert() (*cert.Certificate, error) {
+	return cert.CertificateFromRaw(c.RawCert)
+}
+
+func (c *ChainIssReq) ProtoId() proto.ProtoIdType {
+	return proto.CertChainIssReq_TypeID
+}
+
+func (c *ChainIssReq) String() string {
+	crt, err := c.Cert()
+	if err != nil {
+		return fmt.Sprintf("Invalid certificate: %v", err)
+	}
+	return crt.String()
+}

--- a/proto/cert_mgmt.capnp
+++ b/proto/cert_mgmt.capnp
@@ -13,6 +13,14 @@ struct CertChain {
     chain @0 :Data;
 }
 
+struct CertChainIssReq {
+    cert @0 :Data;        # Raw Certificate with desired values
+}
+
+struct CertChainIssRep {
+    chain @0 :Data;
+}
+
 struct TRCReq {
     isd @0 :UInt16;
     version @1 :UInt64;
@@ -30,5 +38,7 @@ struct CertMgmt {
         certChain @2 :CertChain;
         trcReq @3 :TRCReq;
         trc @4 :TRC;
+        certChainIssReq @5 :CertChainIssReq;
+        certChainIssRep @6 :CertChainIssRep;
     }
 }


### PR DESCRIPTION
Add certificate chain reissuance request and response.
The requests consists of the desired leaf certificate.
The response consists of the reissued certificate chain.

Request signatures are added to signed payload.
Code for signing an verifying requests will follow in a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1401)
<!-- Reviewable:end -->
