### PR TITLE
Update python infra to use CtrlPld.reqId

### DIFF
--- a/proto/path_mgmt.capnp
+++ b/proto/path_mgmt.capnp
@@ -8,7 +8,7 @@ using IFState = import "if_state.capnp";
 using RevInfo = import "rev_info.capnp";
 
 struct SegReq {
-    id @0 :UInt64;  # Request ID
+    id @0 :UInt64;  # Obsolete.
     srcIA @1 :UInt32;
     dstIA @2 :UInt32;
     flags :group {

--- a/proto/path_mgmt.capnp
+++ b/proto/path_mgmt.capnp
@@ -8,12 +8,11 @@ using IFState = import "if_state.capnp";
 using RevInfo = import "rev_info.capnp";
 
 struct SegReq {
-    id @0 :UInt64;  # Obsolete.
-    srcIA @1 :UInt32;
-    dstIA @2 :UInt32;
+    srcIA @0 :UInt32;
+    dstIA @1 :UInt32;
     flags :group {
-        sibra @3 :Bool;
-        cacheOnly @4 :Bool;
+        sibra @2 :Bool;
+        cacheOnly @3 :Bool;
     }
 
 }

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -306,7 +306,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
                           pcb.short_desc())
             return
         seg_meta = PathSegMeta(pcb, self.continue_seg_processing, meta)
-        self._process_path_seg(seg_meta)
+        self._process_path_seg(seg_meta, cpld.req_id)
 
     def continue_seg_processing(self, seg_meta):
         """

--- a/python/cert_server/main.py
+++ b/python/cert_server/main.py
@@ -326,7 +326,7 @@ class CertServer(SCIONElement):
             else:
                 self.trc_requests.put((key, (meta, req, cpld.req_id)))
             return
-        self._reply_trc(key, (meta, req))
+        self._reply_trc(key, (meta, req, cpld.req_id))
 
     def process_trc_reply(self, cpld, meta, from_zk=False):
         """
@@ -358,7 +358,7 @@ class CertServer(SCIONElement):
 
     def _fetch_trc(self, key, req_info):
         # Do not attempt to fetch the TRC from a remote AS if the cacheOnly flag is set.
-        _, orig_req = req_info
+        _, orig_req, _ = req_info
         if orig_req.p.cacheOnly:
             return
         self._send_trc_request(*key)

--- a/python/cert_server/main.py
+++ b/python/cert_server/main.py
@@ -252,7 +252,7 @@ class CertServer(SCIONElement):
             else:
                 self.cc_requests.put((key, (meta, req, cpld.req_id)))
             return
-        self._reply_cc(key, (meta, req))
+        self._reply_cc(key, (meta, req, cpld.req_id))
 
     def process_cert_chain_reply(self, cpld, meta, from_zk=False):
         """Process a certificate chain reply."""
@@ -279,7 +279,7 @@ class CertServer(SCIONElement):
 
     def _fetch_cc(self, key, req_info):
         # Do not attempt to fetch the CertChain from a remote AS if the cacheOnly flag is set.
-        _, orig_req = req_info
+        _, orig_req, _ = req_info
         if orig_req.p.cacheOnly:
             return
         self._send_cc_request(*key)

--- a/python/cert_server/main.py
+++ b/python/cert_server/main.py
@@ -56,7 +56,7 @@ from lib.packet.cert_mgmt import (
     TRCReply,
     TRCRequest,
 )
-from lib.packet.ctrl_pld import CtrlPayload
+from lib.packet.ctrl_pld import CtrlPayload, mk_ctrl_req_id
 from lib.packet.svc import SVCType
 from lib.requests import RequestHandler
 from lib.thread import thread_safety_net
@@ -250,7 +250,7 @@ class CertServer(SCIONElement):
                     "CC not found && requester is not local)",
                     meta, *key)
             else:
-                self.cc_requests.put((key, (meta, req)))
+                self.cc_requests.put((key, (meta, req, cpld.req_id)))
             return
         self._reply_cc(key, (meta, req))
 
@@ -289,9 +289,10 @@ class CertServer(SCIONElement):
         path_meta = self._get_path_via_sciond(isd_as)
         if path_meta:
             meta = self._build_meta(isd_as, host=SVCType.CS_A, path=path_meta.fwd_path())
-            self.send_meta(CtrlPayload(CertMgmt(req)), meta)
-            logging.info("Cert chain request sent to %s via [%s]: %s",
-                         meta, path_meta.short_desc(), req.short_desc())
+            req_id = mk_ctrl_req_id()
+            self.send_meta(CtrlPayload(CertMgmt(req), req_id=req_id), meta)
+            logging.info("Cert chain request sent to %s via [%s]: %s [id: %016x]",
+                         meta, path_meta.short_desc(), req.short_desc(), req_id)
         else:
             logging.warning("Cert chain request (for %s) not sent: "
                             "no path found", req.short_desc())
@@ -300,9 +301,11 @@ class CertServer(SCIONElement):
         isd_as, ver = key
         ver = None if ver == CertChainRequest.NEWEST_VERSION else ver
         meta = req_info[0]
+        req_id = req_info[2]
         cert_chain = self.trust_store.get_cert(isd_as, ver)
-        self.send_meta(CtrlPayload(CertMgmt(CertChainReply.from_values(cert_chain))), meta)
-        logging.info("Cert chain for %sv%s sent to %s", isd_as, ver, meta)
+        self.send_meta(
+            CtrlPayload(CertMgmt(CertChainReply.from_values(cert_chain)), req_id=req_id), meta)
+        logging.info("Cert chain for %sv%s sent to %s [id: %016x]", isd_as, ver, meta, req_id)
 
     def process_trc_request(self, cpld, meta):
         """Process a TRC request."""
@@ -310,7 +313,8 @@ class CertServer(SCIONElement):
         req = cmgt.union
         assert isinstance(req, TRCRequest), type(req)
         key = req.isd_as()[0], req.p.version
-        logging.info("TRC request received for %sv%s from %s", *key, meta)
+        logging.info("TRC request received for %sv%s from %s [id: %s]",
+                     *key, meta, cpld.req_id_str())
         REQS_TOTAL.labels(**self._labels, type="trc").inc()
         local = meta.ia == self.addr.isd_as
         if not self._check_trc(key):
@@ -320,7 +324,7 @@ class CertServer(SCIONElement):
                     "TRC not found && requester is not local)",
                     meta, *key)
             else:
-                self.trc_requests.put((key, (meta, req)))
+                self.trc_requests.put((key, (meta, req, cpld.req_id)))
             return
         self._reply_trc(key, (meta, req))
 
@@ -335,8 +339,8 @@ class CertServer(SCIONElement):
         trc_rep = cmgt.union
         assert isinstance(trc_rep, TRCReply), type(trc_rep)
         isd, ver = trc_rep.trc.get_isd_ver()
-        logging.info("TRCReply received for ISD %sv%s, ZK: %s",
-                     isd, ver, from_zk)
+        logging.info("TRCReply received for ISD %sv%s, ZK: %s [id: %s]",
+                     isd, ver, from_zk, cpld.req_id_str())
         self.trust_store.add_trc(trc_rep.trc)
         if not from_zk:
             self._share_object(trc_rep.trc, is_trc=True)
@@ -365,9 +369,10 @@ class CertServer(SCIONElement):
         if path_meta:
             meta = self._build_meta(
                 path_meta.dst_ia(), host=SVCType.CS_A, path=path_meta.fwd_path())
-            self.send_meta(CtrlPayload(CertMgmt(trc_req)), meta)
-            logging.info("TRC request sent to %s via [%s]: %s",
-                         meta, path_meta.short_desc(), trc_req.short_desc())
+            req_id = mk_ctrl_req_id()
+            self.send_meta(CtrlPayload(CertMgmt(trc_req), req_id=req_id), meta)
+            logging.info("TRC request sent to %s via [%s]: %s [id: %016x]",
+                         meta, path_meta.short_desc(), trc_req.short_desc(), req_id)
         else:
             logging.warning("TRC request not sent for %s: no path found.", trc_req.short_desc())
 
@@ -375,9 +380,10 @@ class CertServer(SCIONElement):
         isd, ver = key
         ver = None if ver == TRCRequest.NEWEST_VERSION else ver
         meta = req_info[0]
+        req_id = req_info[2]
         trc = self.trust_store.get_trc(isd, ver)
-        self.send_meta(CtrlPayload(CertMgmt(TRCReply.from_values(trc))), meta)
-        logging.info("TRC for %sv%s sent to %s", isd, ver, meta)
+        self.send_meta(CtrlPayload(CertMgmt(TRCReply.from_values(trc)), req_id=req_id), meta)
+        logging.info("TRC for %sv%s sent to %s [id: %016x]", isd, ver, meta, req_id)
 
     def process_drkey_request(self, cpld, meta):
         """
@@ -389,7 +395,8 @@ class CertServer(SCIONElement):
         dpld = cpld.union
         req = dpld.union
         assert isinstance(req, DRKeyRequest), type(req)
-        logging.info("DRKeyRequest received from %s: %s", meta, req.short_desc())
+        logging.info("DRKeyRequest received from %s: %s [id: %s]",
+                     meta, req.short_desc(), cpld.req_id_str())
         REQS_TOTAL.labels(**self._labels, type="drkey").inc()
         try:
             cert = self._verify_drkey_request(req, meta)
@@ -402,8 +409,9 @@ class CertServer(SCIONElement):
         trc_version = self.trust_store.get_trc(self.addr.isd_as[0]).version
         rep = get_drkey_reply(sv, self.addr.isd_as, meta.ia, self.private_key,
                               self.signing_key, cert_version, cert, trc_version)
-        self.send_meta(CtrlPayload(DRKeyMgmt(rep)), meta)
-        logging.info("DRKeyReply sent to %s: %s", meta, req.short_desc())
+        self.send_meta(CtrlPayload(DRKeyMgmt(rep), req_id=cpld.req_id), meta)
+        logging.info("DRKeyReply sent to %s: %s [id: %s]",
+                     meta, req.short_desc(), cpld.req_id_str())
 
     def _verify_drkey_request(self, req, meta):
         """
@@ -450,7 +458,8 @@ class CertServer(SCIONElement):
         dpld = cpld.union
         rep = dpld.union
         assert isinstance(rep, DRKeyReply), type(rep)
-        logging.info("DRKeyReply received from %s: %s", meta, rep.short_desc())
+        logging.info("DRKeyReply received from %s: %s [id: %s]",
+                     meta, rep.short_desc(), cpld.req_id_str())
         src = meta or "ZK"
 
         try:
@@ -540,8 +549,10 @@ class CertServer(SCIONElement):
         path_meta = self._get_path_via_sciond(drkey.src_ia)
         if path_meta:
             meta = self._build_meta(drkey.src_ia, host=SVCType.CS_A, path=path_meta.fwd_path())
+            req_id = mk_ctrl_req_id()
             self.send_meta(CtrlPayload(DRKeyMgmt(req)), meta)
-            logging.info("DRKeyRequest (%s) sent to %s via %s", req.short_desc(), meta, path_meta)
+            logging.info("DRKeyRequest (%s) sent to %s via %s [id: %016x]",
+                         req.short_desc(), meta, path_meta, req_id)
         else:
             logging.warning("DRKeyRequest (for %s) not sent", req.short_desc())
 

--- a/python/lib/packet/ctrl_pld.py
+++ b/python/lib/packet/ctrl_pld.py
@@ -16,6 +16,7 @@
 =========================================
 """
 # Stdlib
+import random
 import struct
 
 # External
@@ -90,6 +91,9 @@ class CtrlPayload(CerealBox):
 
     def __init__(self, union, req_id=0, trace_id=b''):
         self.union = union
+        if req_id == 0:
+            # If no request id is specified, generate a random id.
+            req_id = mk_ctrl_req_id()
         self.req_id = req_id
         self.trace_id = trace_id
 
@@ -113,12 +117,19 @@ class CtrlPayload(CerealBox):
             "traceId": self.trace_id,
         })
 
+    def req_id_str(self):
+        return "%016x" % self.req_id
+
     def __str__(self):
         return "%s(%dB): req_id=%s trace_id=%s %s" % (
-            self.NAME, len(self), self.req_id, self.trace_id, self.union)
+            self.NAME, len(self), self.req_id_str(), self.trace_id, self.union)
 
     def new_signed_pld(self):
         return SignedCtrlPayload.from_values(self.proto().to_bytes_packed())
 
     def pack(self):  # pragma: no cover
         return self.new_signed_pld().pack()
+
+
+def mk_ctrl_req_id():
+    return random.randrange(1, 1 << 64)

--- a/python/lib/packet/path_mgmt/seg_req.py
+++ b/python/lib/packet/path_mgmt/seg_req.py
@@ -32,19 +32,15 @@ class PathSegmentReq(Cerealizable):  # pragma: no cover
     P_CLS = P.SegReq
 
     @classmethod
-    def from_values(cls, req_id, src_ia, dst_ia, flags=None):
+    def from_values(cls, src_ia, dst_ia, flags=None):
         if not flags:
             flags = set()
-        p = cls.P_CLS.new_message(
-            id=req_id, srcIA=int(src_ia), dstIA=int(dst_ia))
+        p = cls.P_CLS.new_message(srcIA=int(src_ia), dstIA=int(dst_ia))
         if PATH_FLAG_SIBRA in flags:
             p.flags.sibra = True
         if PATH_FLAG_CACHEONLY in flags:
             p.flags.cacheOnly = True
         return cls(p)
-
-    def req_id(self):
-        return self.p.id
 
     def src_ia(self):
         return ISD_AS(self.p.srcIA)
@@ -61,15 +57,12 @@ class PathSegmentReq(Cerealizable):  # pragma: no cover
         return tuple(flags)
 
     def __eq__(self, other):
-        return (self.p.id == other.p.id and self.p.srcIA == other.p.srcIA and
-                self.p.dstIA == other.p.dstIA and self.flags() == other.flags())
-
-    def __hash__(self):
-        return self.p.id
+        return (self.p.srcIA == other.p.srcIA and
+                self.p.dstIA == other.p.dstIA and
+                self.flags() == other.flags())
 
     def short_desc(self):
-        return "Id: %016x %s -> %s  %s" % (
-            self.req_id(), self.src_ia(), self.dst_ia(), self.flags())
+        return "%s -> %s  %s" % (self.src_ia(), self.dst_ia(), self.flags())
 
 
 class PathSegmentReply(Cerealizable):  # pragma: no cover

--- a/python/lib/util.py
+++ b/python/lib/util.py
@@ -21,7 +21,6 @@ Various utilities for SCION functionality.
 import json
 import logging
 import os
-import random
 import shutil
 import signal
 import sys
@@ -275,11 +274,6 @@ def recv_all(sock, total_len, flags):
             return None
         barr += buf
     return bytes(barr)
-
-
-def random_uint64():
-    """Returns a random number in the range [0, 2**64 - 1]"""
-    return random.randint(0, 2**64 - 1)
 
 
 class SCIONTime(object):

--- a/python/path_server/local.py
+++ b/python/path_server/local.py
@@ -75,7 +75,7 @@ class LocalPathServer(PathServer):
         req = pmgt.union
         assert isinstance(req, PathSegmentReq), type(req)
         if logger is None:
-            logger = self.get_request_logger(req, meta)
+            logger = self.get_request_logger(cpld.req_id_str(), meta)
         dst_ia = req.dst_ia()
         if new_request:
             logger.info("PATH_REQ received: %s", req)
@@ -92,11 +92,12 @@ class LocalPathServer(PathServer):
         else:
             self._resolve_not_core(req, up_segs, core_segs, down_segs)
         if up_segs | core_segs | down_segs:
-            self._send_path_segments(req, meta, logger, up_segs, core_segs, down_segs)
+            self._send_path_segments(req, cpld.req_id, meta, logger, up_segs, core_segs, down_segs)
             return True
         if new_request:
             self._request_paths_from_core(req, logger)
-            self.pending_req[(dst_ia, req.p.flags.sibra)][req.req_id()] = (req, meta, logger)
+            self.pending_req[(dst_ia, req.p.flags.sibra)][str(meta)] = (
+                req, cpld.req_id, meta, logger)
         return False
 
     def _resolve_core(self, req, up_segs, core_segs):


### PR DESCRIPTION
Also:
- Obsolete SegReq.id, as it's no longer useful.
- Removed a now-unsed random_uint64() function from util, and made a
  similar one in ctrl_pld.py (which specifically avoids 0 as a value).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1403)
<!-- Reviewable:end -->
