### PR TITLE
Remove ~all calls to common.FmtError

### DIFF
--- a/go/border/error.go
+++ b/go/border/error.go
@@ -35,7 +35,7 @@ func (r *Router) handlePktError(rp *rpkt.RtrPkt, perr error, desc string) {
 	serr := scmp.ToError(perr)
 	// XXX(kormat): uncomment for debugging:
 	// perr = common.NewBasicError("Raw packet", perr, "raw", rp.Raw)
-	rp.Error(desc, "err", common.FmtError(perr))
+	rp.Error(desc, "err", perr)
 	if serr == nil || rp.DirFrom == rcmn.DirSelf || rp.SCMPError {
 		// No scmp error data, packet is from self, or packet is already an SCMPError, so no reply.
 		return
@@ -72,7 +72,7 @@ func (r *Router) handlePktError(rp *rpkt.RtrPkt, perr error, desc string) {
 	}
 	reply, err := r.createSCMPErrorReply(rp, serr.CT, serr.Info)
 	if err != nil {
-		rp.Error("Error creating SCMP response", "err", common.FmtError(err))
+		rp.Error("Error creating SCMP response", "err", err)
 		return
 	}
 	reply.Route()

--- a/go/border/gen.go
+++ b/go/border/gen.go
@@ -111,17 +111,17 @@ func (r *Router) genIFIDPkt(ifID common.IFIDType, ctx *rctx.Ctx) {
 	srcAddr := intf.IFAddr.PublicAddrInfo(intf.IFAddr.Overlay)
 	cpld, err := ctrl.NewPld(&ifid.IFID{OrigIfID: uint64(ifID)}, nil)
 	if err != nil {
-		logger.Error("Error generating IFID Ctrl payload", "err", common.FmtError(err))
+		logger.Error("Error generating IFID Ctrl payload", "err", err)
 		return
 	}
 	scpld, err := cpld.SignedPld(ctrl.NullSigner)
 	if err != nil {
-		logger.Error("Error generating IFID signed Ctrl payload", "err", common.FmtError(err))
+		logger.Error("Error generating IFID signed Ctrl payload", "err", err)
 		return
 	}
 	if err := r.genPkt(intf.RemoteIA, addr.HostFromIP(intf.RemoteAddr.IP),
 		intf.RemoteAddr.L4Port, srcAddr, scpld); err != nil {
-		logger.Error("Error generating IFID packet", "err", common.FmtError(err))
+		logger.Error("Error generating IFID packet", "err", err)
 	}
 }
 
@@ -148,15 +148,15 @@ func (r *Router) genIFStateReq() {
 	srcAddr := ctx.Conf.Net.LocAddr[0].PublicAddrInfo(ctx.Conf.Net.LocAddr[0].Overlay)
 	cpld, err := ctrl.NewPathMgmtPld(&path_mgmt.IFStateReq{}, nil, nil)
 	if err != nil {
-		log.Error("Error generating IFStateReq Ctrl payload", "err", common.FmtError(err))
+		log.Error("Error generating IFStateReq Ctrl payload", "err", err)
 		return
 	}
 	scpld, err := cpld.SignedPld(ctrl.NullSigner)
 	if err != nil {
-		log.Error("Error generating IFStateReq signed Ctrl payload", "err", common.FmtError(err))
+		log.Error("Error generating IFStateReq signed Ctrl payload", "err", err)
 		return
 	}
 	if err := r.genPkt(ctx.Conf.IA, addr.SvcBS.Multicast(), 0, srcAddr, scpld); err != nil {
-		log.Error("Error generating IFStateReq packet", "err", common.FmtError(err))
+		log.Error("Error generating IFStateReq packet", "err", err)
 	}
 }

--- a/go/border/ifstate/ifstate.go
+++ b/go/border/ifstate/ifstate.go
@@ -67,7 +67,7 @@ func Process(ifStates *path_mgmt.IFStateInfos) {
 			var err error
 			rawRev, err = proto.PackRoot(info.RevInfo)
 			if err != nil {
-				log.Error("Unable to pack RevInfo", "err", common.FmtError(err))
+				log.Error("Unable to pack RevInfo", "err", err)
 				return
 			}
 		}

--- a/go/border/io-hsr.go
+++ b/go/border/io-hsr.go
@@ -29,7 +29,6 @@ import (
 	"github.com/scionproto/scion/go/border/metrics"
 	"github.com/scionproto/scion/go/border/rctx"
 	"github.com/scionproto/scion/go/border/rpkt"
-	"github.com/scionproto/scion/go/lib/common"
 	liblog "github.com/scionproto/scion/go/lib/log"
 )
 

--- a/go/border/io-hsr.go
+++ b/go/border/io-hsr.go
@@ -85,7 +85,7 @@ func readHSRInput(r *Router, stopChan chan struct{}, stoppedChan chan struct{}) 
 			// Read packets from libhsr.
 			count, err := h.GetPackets(rpkts, usedPorts)
 			if err != nil {
-				log.Error("Error getting packets from HSR", "err", common.FmtError(err))
+				log.Error("Error getting packets from HSR", "err", err)
 				// Zero the port counters for next loop
 				for i := range usedPorts {
 					usedPorts[i] = false

--- a/go/border/io.go
+++ b/go/border/io.go
@@ -94,7 +94,7 @@ Top:
 		// Loop until a read succeeds, or a non-trivial error occurs
 		if pktsRead, err = r.posixInputRead(msgs[:toRead], readMetas[:toRead], s.Conn); err != nil {
 			inputReadErrs.Inc()
-			log.Error("Error reading from socket", "socket", dst, "err", common.FmtError(err))
+			log.Error("Error reading from socket", "socket", dst, "err", err)
 			// The most likely reason for errors is that the socket has
 			// been closed, so jump back to the top to see if the stop
 			// signal has been sent.
@@ -220,7 +220,7 @@ func (r *Router) posixOutput(s *rctx.Sock, _, stopped chan struct{}) {
 		var pktsWritten int
 		if pktsWritten, err = s.Conn.WriteBatch(msgs[:toWrite]); err != nil {
 			outputWriteErrs.Inc()
-			log.Error("Error sending packet(s)", "src", src, "err", common.FmtError(err))
+			log.Error("Error sending packet(s)", "src", src, "err", err)
 			// If some packets were still sent, continue processing. Otherwise:
 			if pktsWritten < 0 {
 				// If we know the error is temporary, retry sending, otherwise drop

--- a/go/border/main.go
+++ b/go/border/main.go
@@ -50,7 +50,7 @@ func main() {
 	liblog.Setup(*id)
 	defer liblog.LogPanicAndExit()
 	if err := checkPerms(); err != nil {
-		log.Crit("Permissions checks failed", "err", common.FmtError(err))
+		log.Crit("Permissions checks failed", "err", err)
 		liblog.Flush()
 		os.Exit(1)
 	}
@@ -61,7 +61,7 @@ func main() {
 	setupSignals()
 	r, err := NewRouter(*id, *confDir)
 	if err != nil {
-		log.Crit("Startup failed", "err", common.FmtError(err))
+		log.Crit("Startup failed", "err", err)
 		liblog.Flush()
 		os.Exit(1)
 	}
@@ -72,7 +72,7 @@ func main() {
 	}
 	log.Info("Starting up", "id", *id, "pid", os.Getpid())
 	if err := r.Run(); err != nil {
-		log.Crit("Run failed", "err", common.FmtError(err))
+		log.Crit("Run failed", "err", err)
 		liblog.Flush()
 		os.Exit(1)
 	}

--- a/go/border/rctx/io.go
+++ b/go/border/rctx/io.go
@@ -94,7 +94,7 @@ func (s *Sock) Stop() {
 		close(s.stop)
 		s.Ring.Close()
 		if err := s.Conn.Close(); err != nil {
-			log.Error("Error stopping socket", "err", common.FmtError(err))
+			log.Error("Error stopping socket", "err", err)
 		}
 		if s.Writer != nil {
 			<-s.writerStopped

--- a/go/border/revinfo.go
+++ b/go/border/revinfo.go
@@ -22,7 +22,6 @@ import (
 	"github.com/scionproto/scion/go/border/rctx"
 	"github.com/scionproto/scion/go/border/rpkt"
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/log"
@@ -59,15 +58,15 @@ func (r *Router) fwdRevInfo(revInfo *path_mgmt.RevInfo, dstHost addr.HostAddr) {
 	srcAddr := ctx.Conf.Net.LocAddr[0].PublicAddrInfo(ctx.Conf.Topo.Overlay)
 	cpld, err := ctrl.NewPathMgmtPld(revInfo, nil, nil)
 	if err != nil {
-		log.Error("Error generating RevInfo Ctrl payload", "err", common.FmtError(err))
+		log.Error("Error generating RevInfo Ctrl payload", "err", err)
 		return
 	}
 	scpld, err := cpld.SignedPld(ctrl.NullSigner)
 	if err != nil {
-		log.Error("Error generating RevInfo signed Ctrl payload", "err", common.FmtError(err))
+		log.Error("Error generating RevInfo signed Ctrl payload", "err", err)
 		return
 	}
 	if err = r.genPkt(ctx.Conf.IA, *dstHost.(*addr.HostSVC), 0, srcAddr, scpld); err != nil {
-		log.Error("Error generating RevInfo packet", "err", common.FmtError(err))
+		log.Error("Error generating RevInfo packet", "err", err)
 	}
 }

--- a/go/border/router.go
+++ b/go/border/router.go
@@ -30,7 +30,6 @@ import (
 	"github.com/scionproto/scion/go/border/rctx"
 	"github.com/scionproto/scion/go/border/rpkt"
 	"github.com/scionproto/scion/go/lib/assert"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/ringbuf"
 )
@@ -88,11 +87,11 @@ func (r *Router) confSig() {
 		var err error
 		var config *conf.Conf
 		if config, err = r.loadNewConfig(); err != nil {
-			log.Error("Error reloading config", "err", common.FmtError(err))
+			log.Error("Error reloading config", "err", err)
 			continue
 		}
 		if err := r.setupNewContext(config); err != nil {
-			log.Error("Error setting up new context", "err", common.FmtError(err))
+			log.Error("Error setting up new context", "err", err)
 			continue
 		}
 		log.Info("Config reloaded")
@@ -148,7 +147,7 @@ func (r *Router) processPacket(rp *rpkt.RtrPkt) {
 	// Check if the packet needs to be processed locally, and if so register
 	// hooks for doing so.
 	if err := rp.NeedsLocalProcessing(); err != nil {
-		rp.Error("Error checking for local processing", "err", common.FmtError(err))
+		rp.Error("Error checking for local processing", "err", err)
 		return
 	}
 	// Parse the packet payload, if a previous step has registered a relevant
@@ -156,7 +155,7 @@ func (r *Router) processPacket(rp *rpkt.RtrPkt) {
 	if _, err := rp.Payload(true); err != nil {
 		// Any errors at this point are application-level, and hence not
 		// calling handlePktError, as no SCMP errors will be sent.
-		rp.Error("Error parsing payload", "err", common.FmtError(err))
+		rp.Error("Error parsing payload", "err", err)
 		return
 	}
 	// Process the packet, if a previous step has registered a relevant hook

--- a/go/border/rpkt/extn_traceroute.go
+++ b/go/border/rpkt/extn_traceroute.go
@@ -108,7 +108,7 @@ func (t *rTraceroute) Process() (HookResult, error) {
 		IA: *t.rp.Ctx.Conf.IA, IfID: uint16(*t.rp.ifCurr), TimeStamp: uint16(ts),
 	}
 	if err := t.Add(&entry); err != nil {
-		t.Error("Unable to add entry", "err", common.FmtError(err))
+		t.Error("Unable to add entry", "err", err)
 	}
 	// Update the raw buffer with the number of hops.
 	t.raw[0] = t.NumHops

--- a/go/cert_srv/cert.go
+++ b/go/cert_srv/cert.go
@@ -20,7 +20,6 @@ import (
 	log "github.com/inconshreveable/log15"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/crypto/cert"
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
@@ -53,15 +52,15 @@ func (h *ChainHandler) HandleReq(addr *snet.Addr, req *cert_mgmt.ChainReq) {
 	srcLocal := config.PublicAddr.IA.Eq(addr.IA)
 	if chain != nil {
 		if err := h.sendChainRep(addr, chain); err != nil {
-			log.Error("Unable to send certificate chain reply", "addr", addr, "req",
-				req, "err", common.FmtError(err))
+			log.Error("Unable to send certificate chain reply",
+				"addr", addr, "req", req, "err", err)
 		}
 	} else if !srcLocal || req.CacheOnly {
 		log.Info("Dropping certificate chain request", "addr", addr, "req", req,
 			"err", "certificate chain not found")
 	} else {
 		if err := h.fetchChain(addr, req); err != nil {
-			log.Error("Unable to fetch certificate chain", "req", req, "err", common.FmtError(err))
+			log.Error("Unable to fetch certificate chain", "req", req, "err", err)
 		}
 	}
 }
@@ -108,11 +107,10 @@ func (h *ChainHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.Chain) {
 	log.Info("Received certificate chain reply", "addr", addr, "rep", rep)
 	chain, err := rep.Chain()
 	if err != nil {
-		log.Error("Unable to parse certificate reply", "err", common.FmtError(err))
+		log.Error("Unable to parse certificate reply", "err", err)
 	}
 	if err = store.AddChain(chain, true); err != nil {
-		log.Error("Unable to store certificate chain", "key", chain.Key(),
-			"err", common.FmtError(err))
+		log.Error("Unable to store certificate chain", "key", chain.Key(), "err", err)
 		return
 	}
 	key := chain.Key()
@@ -125,8 +123,7 @@ func (h *ChainHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.Chain) {
 	}
 	cpld, err := ctrl.NewCertMgmtPld(rep, nil, nil)
 	if err != nil {
-		log.Error("Unable to create certificate chain reply", "key", key,
-			"err", common.FmtError(err))
+		log.Error("Unable to create certificate chain reply", "key", key, "err", err)
 		return
 	}
 	h.answerReqs(reqVer, cpld, key)
@@ -140,8 +137,7 @@ func (h *ChainHandler) answerReqs(reqs *AddrSet, cpld *ctrl.Pld, key *cert.Key) 
 	}
 	for _, dst := range reqs.Addrs {
 		if err := SendPayload(h.conn, cpld, dst); err != nil {
-			log.Error("Unable to write certificate chain reply", "key", key,
-				"err", common.FmtError(err))
+			log.Error("Unable to write certificate chain reply", "key", key, "err", err)
 			continue
 		}
 	}

--- a/go/cert_srv/io.go
+++ b/go/cert_srv/io.go
@@ -52,13 +52,13 @@ func (d *Dispatcher) run() {
 	for {
 		read, addr, err := d.conn.ReadFromSCION(d.buf)
 		if err != nil {
-			log.Error("Unable to read from network", "err", common.FmtError(err))
+			log.Error("Unable to read from network", "err", err)
 			continue
 		}
 		buf := make(common.RawBytes, read)
 		copy(buf, d.buf[:read])
 		if err = d.dispatch(addr, buf); err != nil {
-			log.Error("Unable to dispatch", "err", common.FmtError(err))
+			log.Error("Unable to dispatch", "err", err)
 		}
 
 	}

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -70,16 +70,16 @@ func main() {
 	}
 	// initialize Trust Store
 	if store, err = trust.NewStore(filepath.Join(*confDir, "certs"), *cacheDir, *id); err != nil {
-		fatal("Unable to initialize TrustStore", "err", common.FmtError(err))
+		fatal("Unable to initialize TrustStore", "err", err)
 	}
 	// initialize snet with retries
 	if err = initSNET(initAttempts, initInterval); err != nil {
-		fatal("Unable to create local SCION Network context", "err", common.FmtError(err))
+		fatal("Unable to create local SCION Network context", "err", err)
 	}
 	// initialize dispatcher
 	dispatcher, err := NewDispatcher(config.PublicAddr, config.BindAddr)
 	if err != nil {
-		fatal("Unable to initialize dispatcher", "err", common.FmtError(err))
+		fatal("Unable to initialize dispatcher", "err", err)
 	}
 	dispatcher.run()
 
@@ -109,7 +109,7 @@ func initSNET(attempts int, sleep time.Duration) (err error) {
 		if err = snet.Init(config.PublicAddr.IA, *sciondPath, *dispPath); err == nil {
 			break
 		}
-		log.Error("Unable to initialize snet", "Retry interval", sleep, "err", common.FmtError(err))
+		log.Error("Unable to initialize snet", "Retry interval", sleep, "err", err)
 		time.Sleep(sleep)
 	}
 	return err

--- a/go/cert_srv/trc.go
+++ b/go/cert_srv/trc.go
@@ -53,14 +53,13 @@ func (h *TRCHandler) HandleReq(addr *snet.Addr, req *cert_mgmt.TRCReq) {
 	srcLocal := config.PublicAddr.IA.Eq(addr.IA)
 	if t != nil {
 		if err := h.sendTRCRep(addr, t); err != nil {
-			log.Error("Unable to send TRC reply", "addr", addr, "req", req,
-				"err", common.FmtError(err))
+			log.Error("Unable to send TRC reply", "addr", addr, "req", req, "err", err)
 		}
 	} else if !srcLocal || req.CacheOnly {
 		log.Info("Dropping TRC requeset", "addr", addr, "req", req, "err", "TRC not found")
 	} else {
 		if err := h.fetchTRC(addr, req); err != nil {
-			log.Error("Unable to fetch TRC", "req", req, "err", common.FmtError(err))
+			log.Error("Unable to fetch TRC", "req", req, "err", err)
 		}
 	}
 }
@@ -111,11 +110,11 @@ func (h *TRCHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.TRC) {
 	log.Info("Received TRC reply", "addr", addr, "rep", rep)
 	t, err := rep.TRC()
 	if err != nil {
-		log.Error("Unable to parse TRC reply", "err", common.FmtError(err))
+		log.Error("Unable to parse TRC reply", "err", err)
 		return
 	}
 	if err = store.AddTRC(t, true); err != nil {
-		log.Error("Unable to store TRC", "key", t.Key(), "err", common.FmtError(err))
+		log.Error("Unable to store TRC", "key", t.Key(), "err", err)
 		return
 	}
 	key := t.Key()
@@ -128,7 +127,7 @@ func (h *TRCHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.TRC) {
 	}
 	cpld, err := ctrl.NewCertMgmtPld(rep, nil, nil)
 	if err != nil {
-		log.Error("Unable to create TRC reply", "key", t.Key(), "err", common.FmtError(err))
+		log.Error("Unable to create TRC reply", "key", t.Key(), "err", err)
 		return
 	}
 	h.answerReqs(reqVer, cpld, key)
@@ -142,7 +141,7 @@ func (h *TRCHandler) answerReqs(reqs *AddrSet, cpld *ctrl.Pld, key *trc.Key) {
 	}
 	for _, dst := range reqs.Addrs {
 		if err := SendPayload(h.conn, cpld, dst); err != nil {
-			log.Error("Unable to write TRC reply", "key", key, "err", common.FmtError(err))
+			log.Error("Unable to write TRC reply", "key", key, "err", err)
 			continue
 		}
 	}

--- a/go/lib/infra/disp/disp.go
+++ b/go/lib/infra/disp/disp.go
@@ -193,21 +193,21 @@ func (d *Dispatcher) recvNext() {
 	b, address, err := d.transport.RecvFrom(context.Background())
 	if err != nil {
 		d.log.Warn("error", "err",
-			common.FmtError(common.NewBasicError(infra.StrTransportError, err, "op", "RecvFrom")))
+			common.NewBasicError(infra.StrTransportError, err, "op", "RecvFrom"))
 		return
 	}
 
 	msg, err := d.adapter.RawToMsg(b)
 	if err != nil {
 		d.log.Warn("error", "err",
-			common.FmtError(common.NewBasicError(infra.StrAdapterError, err, "op", "RawToMsg")))
+			common.NewBasicError(infra.StrAdapterError, err, "op", "RawToMsg"))
 		return
 	}
 
 	found, err := d.waitTable.reply(msg)
 	if err != nil {
 		d.log.Warn("error", "err",
-			common.FmtError(common.NewBasicError(infra.StrInternalError, err, "op", "waitTable.Reply")))
+			common.NewBasicError(infra.StrInternalError, err, "op", "waitTable.Reply"))
 		return
 	}
 	if found {

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -257,7 +257,7 @@ func (m *Messenger) ListenAndServe() {
 				// CloseServer was called
 				return
 			default:
-				m.log.Error("Receive error", "err", common.FmtError(err))
+				m.log.Error("Receive error", "err", err)
 			}
 			continue
 		}
@@ -271,13 +271,13 @@ func (m *Messenger) ListenAndServe() {
 
 		err = m.verifier.Verify(signedPld)
 		if err != nil {
-			m.log.Error("Verification error", "err", common.FmtError(err))
+			m.log.Error("Verification error", "err", err)
 			continue
 		}
 
 		pld, err := signedPld.Pld()
 		if err != nil {
-			m.log.Error("Unable to extract Pld from CtrlPld", "err", common.FmtError(err))
+			m.log.Error("Unable to extract Pld from CtrlPld", "err", err)
 			continue
 		}
 		m.serve(pld, address)
@@ -289,8 +289,7 @@ func (m *Messenger) serve(pld *ctrl.Pld, address net.Addr) {
 	// signature is correct.
 	msgType, msg, err := m.validate(pld)
 	if err != nil {
-		m.log.Error("Received message, but unable to validate message", "err",
-			common.FmtError(err))
+		m.log.Error("Received message, but unable to validate message", "err", err)
 		return
 	}
 

--- a/go/lib/infra/transport/udp.go
+++ b/go/lib/infra/transport/udp.go
@@ -269,7 +269,7 @@ func (t *RUDP) goBackgroundReceiver() {
 				} else {
 					// Do not log close events
 					if err != io.EOF {
-						t.log.Error("Read error, shutting down", "err", common.FmtError(err))
+						t.log.Error("Read error, shutting down", "err", err)
 					}
 					bufpool.Put(b)
 					return
@@ -278,7 +278,7 @@ func (t *RUDP) goBackgroundReceiver() {
 
 			flags, id, payload, err := t.popHeader(b.B[:n])
 			if err != nil {
-				t.log.Error("Unable to remove Reliable UDP header", "err", common.FmtError(err))
+				t.log.Error("Unable to remove Reliable UDP header", "err", err)
 				bufpool.Put(b)
 				continue
 			}
@@ -306,7 +306,7 @@ func (t *RUDP) goBackgroundReceiver() {
 				// (if requested)
 				if flags.isSet(flagNeedACK) {
 					if err := t.sendACK(id, address); err != nil {
-						t.log.Warn("Unable to send ACK", "err", common.FmtError(err))
+						t.log.Warn("Unable to send ACK", "err", err)
 					}
 				}
 			default:

--- a/go/lib/pathdb/sqlite/sqlite_test.go
+++ b/go/lib/pathdb/sqlite/sqlite_test.go
@@ -118,7 +118,7 @@ func setupDB(t *testing.T) (*Backend, string) {
 	tmpFile := tempFilename(t)
 	b, err := New(tmpFile)
 	if err != nil {
-		t.Fatal("Failed to open DB", "err", common.FmtError(err))
+		t.Fatal("Failed to open DB", "err", err)
 	}
 	return b, tmpFile
 }
@@ -147,11 +147,11 @@ func checkSegments(t *testing.T, b *Backend, segRowID int, segID common.RawBytes
 	err := b.db.QueryRow("SELECT RowID, Segment FROM Segments WHERE SegID=?",
 		segID).Scan(&ID, &rawSeg)
 	if err != nil {
-		t.Fatal("checkSegments: Call", "err", common.FmtError(err))
+		t.Fatal("checkSegments: Call", "err", err)
 	}
 	pseg, err := seg.NewSegFromRaw(common.RawBytes(rawSeg))
 	if err != nil {
-		t.Fatal("checkSegments: Parse", "err", common.FmtError(err))
+		t.Fatal("checkSegments: Parse", "err", err)
 	}
 	info, _ := pseg.InfoF()
 	SoMsg("RowID match", ID, ShouldEqual, segRowID)
@@ -166,7 +166,7 @@ func checkIntfToSeg(t *testing.T, b *Backend, segRowID int, intfs []query.IntfSp
 			spec.IA.I, spec.IA.A, spec.IfID, segRowID)
 		err := row.Scan(&count)
 		if err != nil {
-			t.Fatal("CheckIntfToSegTable", "err", common.FmtError(err))
+			t.Fatal("CheckIntfToSegTable", "err", err)
 		}
 		SoMsg(fmt.Sprintf("Has Intf %v:%v", spec.IA, spec.IfID), count, ShouldEqual, 1)
 	}
@@ -174,7 +174,7 @@ func checkIntfToSeg(t *testing.T, b *Backend, segRowID int, intfs []query.IntfSp
 	var count int
 	err := b.db.QueryRow("SELECT COUNT(*) FROM IntfToSeg WHERE IntfID=0").Scan(&count)
 	if err != nil {
-		t.Fatal("CheckIntfToSegTable", "err", common.FmtError(err))
+		t.Fatal("CheckIntfToSegTable", "err", err)
 	}
 	SoMsg("No IF 0", count, ShouldEqual, 0)
 }
@@ -184,7 +184,7 @@ func checkStartsAtOrEndsAt(t *testing.T, b *Backend, table string, segRowID int,
 	queryStr := fmt.Sprintf("SELECT SegRowID FROM %s WHERE IsdID=%v AND AsID=%v", table, ia.I, ia.A)
 	err := b.db.QueryRow(queryStr).Scan(&segID)
 	if err != nil {
-		t.Fatal("CheckStartsAtOrEndsAt", "err", common.FmtError(err))
+		t.Fatal("CheckStartsAtOrEndsAt", "err", err)
 	}
 	SoMsg("StartsAt", segID, ShouldEqual, segRowID)
 }
@@ -195,7 +195,7 @@ func checkSegTypes(t *testing.T, b *Backend, segRowID int, types []seg.Type) {
 		err := b.db.QueryRow("SELECT COUNT(*) FROM SegTypes WHERE SegRowID=? AND Type=?",
 			segRowID, segType).Scan(&count)
 		if err != nil {
-			t.Fatal("checkSegTypes", "err", common.FmtError(err))
+			t.Fatal("checkSegTypes", "err", err)
 		}
 		SoMsg(fmt.Sprintf("Has type %v", segType), count, ShouldEqual, 1)
 	}
@@ -208,7 +208,7 @@ func checkHPCfgIDs(t *testing.T, b *Backend, segRowID int, hpCfgIDs []*query.HPC
 			"SELECT COUNT(*) FROM HPCfgIDs WHERE SegRowID=? AND IsdID=? AND AsID=? AND CfgID=?",
 			segRowID, hpCfgID.IA.I, hpCfgID.IA.A, hpCfgID.ID).Scan(&count)
 		if err != nil {
-			t.Fatal("checkHPCfgIDs", "err", common.FmtError(err))
+			t.Fatal("checkHPCfgIDs", "err", err)
 		}
 		SoMsg(fmt.Sprintf("Has hpCfgID %v", hpCfgID), count, ShouldEqual, 1)
 	}
@@ -304,7 +304,7 @@ func checkEmpty(t *testing.T, b *Backend, table string) {
 	var count int
 	err := b.db.QueryRow(queryStr).Scan(&count)
 	if err != nil {
-		t.Fatal("checkEmpty", "err", common.FmtError(err))
+		t.Fatal("checkEmpty", "err", err)
 	}
 	SoMsg(fmt.Sprintf("Empty %s", table), count, ShouldEqual, 0)
 }

--- a/go/lib/pathmgr/infra_test.go
+++ b/go/lib/pathmgr/infra_test.go
@@ -24,7 +24,6 @@ import (
 	log "github.com/inconshreveable/log15"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/sciond"
 )
 

--- a/go/lib/pathmgr/infra_test.go
+++ b/go/lib/pathmgr/infra_test.go
@@ -39,24 +39,24 @@ func ExamplePR() {
 	var err error
 	src, err := addr.IAFromString(*srcStr)
 	if err != nil {
-		fmt.Println("Unable to parse srcIA", *srcStr, "err", common.FmtError(err))
+		fmt.Println("Unable to parse srcIA", *srcStr, "err", err)
 	}
 	dst, err := addr.IAFromString(*dstStr)
 	if err != nil {
-		fmt.Println("Unable to parse dstIA", *dstStr, "err", common.FmtError(err))
+		fmt.Println("Unable to parse dstIA", *dstStr, "err", err)
 	}
 	// Initialize path resolver
 	sciondPath := fmt.Sprintf("/run/shm/sciond/sd%s.sock", src.String())
 	sciondService := sciond.NewService(sciondPath)
 	pr, err := New(sciondService, time.Second, time.Minute, log.Root())
 	if err != nil {
-		fmt.Println("Failed to connect to SCIOND", "err", common.FmtError(err))
+		fmt.Println("Failed to connect to SCIOND", "err", err)
 		return
 	}
 	// Register source and destination
 	sp, err := pr.Watch(src, dst)
 	if err != nil {
-		fmt.Println("Failed to register", "err", common.FmtError(err))
+		fmt.Println("Failed to register", "err", err)
 	}
 	// sp will always point to an up to date slice of paths, or nil if none
 	// available

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -240,24 +240,22 @@ func (r *PR) revoke(revInfo common.RawBytes) {
 	parsedRev, err := path_mgmt.NewRevInfoFromRaw(revInfo)
 	if err != nil {
 		log.Error("Revocation failed, unable to parse revocation info",
-			"revInfo", revInfo, "err", common.FmtError(err))
+			"revInfo", revInfo, "err", err)
 		return
 	}
 	conn, err := r.sciondService.Connect()
 	if err != nil {
-		log.Error("Revocation failed, unable to connect to SCIOND", "err", common.FmtError(err))
+		log.Error("Revocation failed, unable to connect to SCIOND", "err", err)
 		return
 	}
 	reply, err := conn.RevNotification(parsedRev)
 	if err != nil {
-		log.Error("Revocation failed, unable to inform SCIOND about revocation",
-			"err", common.FmtError(err))
+		log.Error("Revocation failed, unable to inform SCIOND about revocation", "err", err)
 		return
 	}
 	err = conn.Close()
 	if err != nil {
-		log.Error("Revocation error, unable to close SCIOND connection",
-			"err", common.FmtError(err))
+		log.Error("Revocation error, unable to close SCIOND connection", "err", err)
 		// Continue with revocation
 	}
 	switch reply.Result {

--- a/go/lib/pathmgr/resolver.go
+++ b/go/lib/pathmgr/resolver.go
@@ -22,7 +22,6 @@ import (
 	liblog "github.com/scionproto/scion/go/lib/log"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/sciond"
 )
 
@@ -84,7 +83,7 @@ func (r *resolver) run() {
 func (r *resolver) lookup(src, dst *addr.ISD_AS) AppPathSet {
 	reply, err := r.sciondConn.Paths(dst, src, numReqPaths, sciond.PathReqFlags{})
 	if err != nil {
-		log.Error("SCIOND network error", "err", common.FmtError(err))
+		log.Error("SCIOND network error", "err", err)
 		r.reconnect()
 	}
 	if reply.ErrorCode != sciond.ErrorOk {
@@ -100,7 +99,7 @@ func (r *resolver) reconnect() {
 	for {
 		sciondConn, err := r.sciondService.Connect()
 		if err != nil {
-			log.Error("Unable to connect to sciond", "err", common.FmtError(err))
+			log.Error("Unable to connect to sciond", "err", err)
 			// wait for three seconds before trying again
 			time.Sleep(reconnectInterval)
 			continue

--- a/go/lib/pktdisp/disp.go
+++ b/go/lib/pktdisp/disp.go
@@ -41,7 +41,7 @@ func PktDispatcher(c *snet.Conn, f DispatchFunc) {
 		dp.Raw = dp.Raw[:cap(dp.Raw)]
 		n, dp.Addr, err = c.ReadFromSCION(dp.Raw)
 		if err != nil {
-			log.Error("PktDispatcher: Error reading from connection", "err", common.FmtError(err))
+			log.Error("PktDispatcher: Error reading from connection", "err", err)
 			// FIXME(shitz): Continuing here is only a temporary solution. Different
 			// errors need to be handled different, for some it should break and others
 			// are recoverable.

--- a/go/sig/base/as.go
+++ b/go/sig/base/as.go
@@ -84,7 +84,7 @@ func (ae *ASEntry) addNewNets(ipnets []*config.IPNet) bool {
 	for _, ipnet := range ipnets {
 		err := ae.addNet(ipnet.IPNet())
 		if err != nil {
-			ae.Error("Unable to add network", "net", ipnet, "err", common.FmtError(err))
+			ae.Error("Unable to add network", "net", ipnet, "err", err)
 			s = false
 		}
 	}
@@ -103,7 +103,7 @@ Top:
 		}
 		err := ae.delNet(ne.Net)
 		if err != nil {
-			ae.Error("Unable to delete network", "NetEntry", ne, "err", common.FmtError(err))
+			ae.Error("Unable to delete network", "NetEntry", ne, "err", err)
 			s = false
 		}
 	}
@@ -171,7 +171,7 @@ func (ae *ASEntry) addNewSIGS(sigs config.SIGSet) bool {
 		}
 		err := ae.AddSig(sig.Id, sig.Addr, ctrlPort, encapPort, true)
 		if err != nil {
-			ae.Error("Unable to add SIG", "sig", sig, "err", common.FmtError(err))
+			ae.Error("Unable to add SIG", "sig", sig, "err", err)
 			s = false
 		}
 	}
@@ -188,7 +188,7 @@ func (ae *ASEntry) delOldSIGS(sigs config.SIGSet) bool {
 		if _, ok := sigs[sig.Id]; !ok {
 			err := ae.DelSig(sig.Id)
 			if err != nil {
-				ae.Error("Unable to delete SIG", "err", common.FmtError(err))
+				ae.Error("Unable to delete SIG", "err", err)
 				s = false
 			}
 		}
@@ -270,7 +270,7 @@ func (ae *ASEntry) Cleanup() error {
 	ae.sigMgrStop <- struct{}{}
 	// Clean up the egress dispatcher.
 	if err := ae.tunIO.Close(); err != nil {
-		ae.Error("Error closing TUN io", "dev", ae.DevName, "err", common.FmtError(err))
+		ae.Error("Error closing TUN io", "dev", ae.DevName, "err", err)
 	}
 	// Clean up sessions, and associated workers.
 	ae.cleanSessions()
@@ -285,7 +285,7 @@ func (ae *ASEntry) Cleanup() error {
 
 func (ae *ASEntry) cleanSessions() {
 	if err := ae.Session.Cleanup(); err != nil {
-		ae.Session.Error("Error cleaning up session", "err", common.FmtError(err))
+		ae.Session.Error("Error cleaning up session", "err", err)
 	}
 }
 

--- a/go/sig/base/map.go
+++ b/go/sig/base/map.go
@@ -78,7 +78,7 @@ func (am *ASMap) addNewIAs(cfg *config.Cfg) bool {
 		log.Info("ReloadConfig: Adding AS...", "ia", ia)
 		ae, err := am.AddIA(ia)
 		if err != nil {
-			log.Error("ReloadConfig: Adding AS failed", "err", common.FmtError(err))
+			log.Error("ReloadConfig: Adding AS failed", "err", err)
 			s = false
 			continue
 		}
@@ -98,7 +98,7 @@ func (am *ASMap) delOldIAs(cfg *config.Cfg) bool {
 			// Deletion also handles session/tun device cleanup
 			err := am.DelIA(ia)
 			if err != nil {
-				log.Error("ReloadConfig: Deleting AS failed", "err", common.FmtError(err))
+				log.Error("ReloadConfig: Deleting AS failed", "err", err)
 				s = false
 				return true
 			}

--- a/go/sig/base/pollhdlr.go
+++ b/go/sig/base/pollhdlr.go
@@ -39,23 +39,22 @@ func PollReqHdlr() {
 		//log.Debug("PollReqHdlr: got PollReq", "src", rpld.Addr, "pld", req)
 		spld, err := mgmt.NewPld(rpld.Id, mgmt.NewPollRep(sigcmn.MgmtAddr, req.Session))
 		if err != nil {
-			log.Error("PollReqHdlr: Error creating SIGCtrl payload", "err", common.FmtError(err))
+			log.Error("PollReqHdlr: Error creating SIGCtrl payload", "err", err)
 			break
 		}
 		cpld, err := ctrl.NewPld(spld, nil)
 		if err != nil {
-			log.Error("PollReqHdlr: Error creating Ctrl payload", "err", common.FmtError(err))
+			log.Error("PollReqHdlr: Error creating Ctrl payload", "err", err)
 			break
 		}
 		scpld, err := cpld.SignedPld(ctrl.NullSigner)
 		if err != nil {
-			log.Error("PollReqHdlr: Error creating signed Ctrl payload",
-				"err", common.FmtError(err))
+			log.Error("PollReqHdlr: Error creating signed Ctrl payload", "err", err)
 			break
 		}
 		raw, err := scpld.PackPld()
 		if err != nil {
-			log.Error("PollReqHdlr: Error packing signed Ctrl payload", "err", common.FmtError(err))
+			log.Error("PollReqHdlr: Error packing signed Ctrl payload", "err", err)
 			break
 		}
 		sigCtrlAddr := &snet.Addr{
@@ -65,8 +64,7 @@ func PollReqHdlr() {
 		}
 		_, err = sigcmn.CtrlConn.WriteToSCION(raw, sigCtrlAddr)
 		if err != nil {
-			log.Error("PollReqHdlr: Error sending Ctrl payload", "dest", rpld.Addr,
-				"err", common.FmtError(err))
+			log.Error("PollReqHdlr: Error sending Ctrl payload", "dest", rpld.Addr, "err", err)
 		}
 	}
 	log.Info("PollReqHdlr: stopped")

--- a/go/sig/disp/disp.go
+++ b/go/sig/disp/disp.go
@@ -100,7 +100,7 @@ func (dm *dispRegistry) sigCtrl(pld *mgmt.Pld, addr *snet.Addr) {
 	defer dm.Unlock()
 	u, err := pld.Union()
 	if err != nil {
-		log.Error("Unable to extract SIG ctrl union", "src", addr, "err", common.FmtError(err))
+		log.Error("Unable to extract SIG ctrl union", "src", addr, "err", err)
 		return
 	}
 	msgId := pld.Id
@@ -128,17 +128,17 @@ func dispFunc(dp *pktdisp.DispPkt) {
 	scpld, err := ctrl.NewSignedPldFromRaw(dp.Raw)
 	src := dp.Addr.Copy()
 	if err != nil {
-		log.Error("Unable to parse signed ctrl payload", "src", src, "err", common.FmtError(err))
+		log.Error("Unable to parse signed ctrl payload", "src", src, "err", err)
 		return
 	}
 	cpld, err := scpld.Pld()
 	if err != nil {
-		log.Error("Unable to parse ctrl payload", "src", src, "err", common.FmtError(err))
+		log.Error("Unable to parse ctrl payload", "src", src, "err", err)
 		return
 	}
 	u, err := cpld.Union()
 	if err != nil {
-		log.Error("Unable to extract ctrl payload union", "src", src, "err", common.FmtError(err))
+		log.Error("Unable to extract ctrl payload union", "src", src, "err", err)
 		return
 	}
 	switch pld := u.(type) {

--- a/go/sig/egress/dispatcher.go
+++ b/go/sig/egress/dispatcher.go
@@ -90,7 +90,7 @@ BatchLoop:
 						break BatchLoop
 					}
 				}
-				ed.Error("EgressDispatcher: error reading from devIO", "err", common.FmtError(err))
+				ed.Error("EgressDispatcher: error reading from devIO", "err", err)
 				continue
 			}
 			buf = buf[:length]

--- a/go/sig/egress/sessmon.go
+++ b/go/sig/egress/sessmon.go
@@ -96,8 +96,7 @@ Top:
 	err := disp.Dispatcher.Unregister(disp.RegPollRep, disp.MkRegPollKey(sm.sess.IA,
 		sm.sess.SessId))
 	if err != nil {
-		log.Error("sessMonitor: unable to unregister from ctrl dispatcher",
-			"err", common.FmtError(err))
+		log.Error("sessMonitor: unable to unregister from ctrl dispatcher", "err", err)
 	}
 	sm.Info("sessMonitor: stopped")
 }
@@ -186,28 +185,28 @@ func (sm *sessMonitor) sendReq() {
 	}
 	spld, err := mgmt.NewPld(msgId, mgmt.NewPollReq(sigcmn.MgmtAddr, sm.sess.SessId))
 	if err != nil {
-		sm.Error("sessMonitor: Error creating SIGCtrl payload", "err", common.FmtError(err))
+		sm.Error("sessMonitor: Error creating SIGCtrl payload", "err", err)
 		return
 	}
 	cpld, err := ctrl.NewPld(spld, nil)
 	if err != nil {
-		sm.Error("sessMonitor: Error creating Ctrl payload", "err", common.FmtError(err))
+		sm.Error("sessMonitor: Error creating Ctrl payload", "err", err)
 		return
 	}
 	scpld, err := cpld.SignedPld(ctrl.NullSigner)
 	if err != nil {
-		sm.Error("sessMonitor: Error creating signed Ctrl payload", "err", common.FmtError(err))
+		sm.Error("sessMonitor: Error creating signed Ctrl payload", "err", err)
 		return
 	}
 	raw, err := scpld.PackPld()
 	if err != nil {
-		sm.Error("sessMonitor: Error packing signed Ctrl payload", "err", common.FmtError(err))
+		sm.Error("sessMonitor: Error packing signed Ctrl payload", "err", err)
 		return
 	}
 	raddr := sm.smRemote.Sig.CtrlSnetAddr()
 	raddr.Path = spath.New(sm.smRemote.sessPath.pathEntry.Path.FwdPath)
 	if err := raddr.Path.InitOffsets(); err != nil {
-		sm.Error("sessMonitor: Error initializing path offsets", "err", common.FmtError(err))
+		sm.Error("sessMonitor: Error initializing path offsets", "err", err)
 	}
 	raddr.NextHopHost = sm.smRemote.sessPath.pathEntry.HostInfo.Host()
 	raddr.NextHopPort = sm.smRemote.sessPath.pathEntry.HostInfo.Port
@@ -216,7 +215,7 @@ func (sm *sessMonitor) sendReq() {
 	// goroutines write to it.
 	_, err = sm.sess.conn.WriteToSCION(raw, raddr)
 	if err != nil {
-		sm.Error("sessMonitor: Error sending signed Ctrl payload", "err", common.FmtError(err))
+		sm.Error("sessMonitor: Error sending signed Ctrl payload", "err", err)
 	}
 }
 

--- a/go/sig/egress/worker.go
+++ b/go/sig/egress/worker.go
@@ -95,7 +95,7 @@ TopLoop:
 		} else if len(w.pkts) == 0 {
 			// Didn't read any new packets, send partial frame.
 			if err := w.write(f); err != nil {
-				w.Error("Error sending frame", "err", common.FmtError(err))
+				w.Error("Error sending frame", "err", err)
 			}
 			continue TopLoop
 		}
@@ -103,7 +103,7 @@ TopLoop:
 		for i := range w.pkts {
 			pkt := w.pkts[i].(common.RawBytes)
 			if err := w.processPkt(f, pkt); err != nil {
-				w.Error("Error sending frame", "err", common.FmtError(err))
+				w.Error("Error sending frame", "err", err)
 			}
 		}
 		// Return processed pkts to the free pool, and remove references.

--- a/go/sig/ingress/dispatcher.go
+++ b/go/sig/ingress/dispatcher.go
@@ -88,8 +88,7 @@ func (d *Dispatcher) read() {
 			frame := frames[i].(*FrameBuf)
 			read, src, err := extConn.ReadFromSCION(frame.raw)
 			if err != nil {
-				log.Error("IngressDispatcher: Unable to read from external ingress",
-					"err", common.FmtError(err))
+				log.Error("IngressDispatcher: Unable to read from external ingress", "err", err)
 				frame.Release()
 			} else {
 				frame.frameLen = read

--- a/go/sig/ingress/framebuf.go
+++ b/go/sig/ingress/framebuf.go
@@ -102,7 +102,7 @@ func (fb *FrameBuf) ProcessCompletePkts() {
 		//log.Debug("ProcessCompletePkts: directly write pkt", "seqNr", fb.seqNr,
 		//	"offset", offset, "len", pktLen)
 		if err := send(rawPkt[:pktLen]); err != nil {
-			log.Error("Unable to send packet", "err", common.FmtError(err))
+			log.Error("Unable to send packet", "err", err)
 		}
 		offset += pktLen
 		// Packet always starts at 8-byte boundary.

--- a/go/sig/ingress/rlist.go
+++ b/go/sig/ingress/rlist.go
@@ -185,7 +185,7 @@ func (l *ReassemblyList) collectAndWrite() {
 	} else {
 		// Write the packet to the wire.
 		if err := send(l.buf.Bytes()); err != nil {
-			log.Error("Unable to send reassembled packet", "err", common.FmtError(err))
+			log.Error("Unable to send reassembled packet", "err", err)
 		}
 	}
 	// Process the complete packets in the last frame

--- a/go/sig/sig.go
+++ b/go/sig/sig.go
@@ -63,25 +63,25 @@ func main() {
 	defer liblog.LogPanicAndExit()
 	setupSignals()
 	if err := checkPerms(); err != nil {
-		fatal("Permissions checks failed", "err", common.FmtError(err))
+		fatal("Permissions checks failed", "err", err)
 	}
 
 	// Export prometheus metrics.
 	metrics.Init(*id)
 	if err := metrics.Start(); err != nil {
-		fatal("Unable to export prometheus metrics", "err", common.FmtError(err))
+		fatal("Unable to export prometheus metrics", "err", err)
 	}
 	// Parse basic flags
 	ia, err := addr.IAFromString(*isdas)
 	if err != nil {
-		fatal("Unable to parse local ISD-AS", "ia", *isdas, "err", common.FmtError(err))
+		fatal("Unable to parse local ISD-AS", "ia", *isdas, "err", err)
 	}
 	ip := net.ParseIP(*ipStr)
 	if ip == nil {
 		fatal("unable to parse IP address", "addr", *ipStr)
 	}
 	if err = sigcmn.Init(ia, ip); err != nil {
-		fatal("Error during initialization", "err", common.FmtError(err))
+		fatal("Error during initialization", "err", err)
 	}
 	egress.Init()
 	disp.Init(sigcmn.CtrlConn)
@@ -95,7 +95,7 @@ func main() {
 
 	// Spawn ingress Dispatcher.
 	if err := ingress.Init(); err != nil {
-		fatal("Unable to spawn ingress dispatcher", "err", common.FmtError(err))
+		fatal("Unable to spawn ingress dispatcher", "err", err)
 	}
 }
 
@@ -144,7 +144,7 @@ func reloadOnSIGHUP(path string) {
 func loadConfig(path string) bool {
 	cfg, err := config.LoadFromFile(path)
 	if err != nil {
-		log.Error("loadConfig: Failed", "err", common.FmtError(err))
+		log.Error("loadConfig: Failed", "err", err)
 		return false
 	}
 	return base.Map.ReloadConfig(cfg)

--- a/go/tools/showpaths/paths.go
+++ b/go/tools/showpaths/paths.go
@@ -56,11 +56,11 @@ func main() {
 	sd := sciond.NewService(*sciondPath)
 	sdConn, err := sd.ConnectTimeout(*timeout)
 	if err != nil {
-		LogFatal("Failed to connect to SCIOND", "err", common.FmtError(err))
+		LogFatal("Failed to connect to SCIOND", "err", err)
 	}
 	reply, err := sdConn.Paths(dstIA, srcIA, uint16(*maxPaths), sciond.PathReqFlags{})
 	if err != nil {
-		LogFatal("Failed to retrieve paths from SCIOND", "err", common.FmtError(err))
+		LogFatal("Failed to retrieve paths from SCIOND", "err", err)
 	}
 	fmt.Println("Available paths to", dstIA)
 	i := 0
@@ -77,7 +77,7 @@ func validateFlags() {
 
 	dstIA, err = addr.IAFromString(*dstIAStr)
 	if err != nil {
-		LogFatal("Unable to parse destination IA:", "err", common.FmtError(err))
+		LogFatal("Unable to parse destination IA:", "err", err)
 	}
 	if *sciondPath == "" {
 		if *srcIAStr == "" {
@@ -93,7 +93,7 @@ func validateFlags() {
 	}
 	srcIA, err = addr.IAFromString(*srcIAStr)
 	if err != nil {
-		LogFatal("Unable to parse source IA:", "err", common.FmtError(err))
+		LogFatal("Unable to parse source IA:", "err", err)
 	}
 }
 

--- a/go/tools/showpaths/paths.go
+++ b/go/tools/showpaths/paths.go
@@ -24,7 +24,6 @@ import (
 	log "github.com/inconshreveable/log15"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
 	liblog "github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/sciond"
 )


### PR DESCRIPTION
Now that https://github.com/scionproto/scion/pull/1396 is merged,
explicitly calling FmtError is no longer needed (outside of error types
themselves).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1408)
<!-- Reviewable:end -->
