### PR TITLE
Fix policy logging

### DIFF
--- a/python/lib/path_store.py
+++ b/python/lib/path_store.py
@@ -67,7 +67,7 @@ class PathPolicy(object):
         assert isinstance(pcb, PathSegment), type(pcb)
         isd_as = self._check_unwanted_ases(pcb)
         if isd_as:
-            raise SCIONPathPolicyViolated("Unwanted AS(%s): %s", isd_as, pcb.short_desc())
+            raise SCIONPathPolicyViolated("Unwanted AS(%s): %s" % (isd_as, pcb.short_desc()))
         reasons = self._check_property_ranges(pcb)
         if reasons:
             raise SCIONPathPolicyViolated(", ".join(reasons), pcb.short_desc())


### PR DESCRIPTION
Before: 'Segment dropped due to path policy: Unwanted AS(%s): %s f056531e3b80, 2018-02-22 14:00:35+00:00, 1-11 70'
After: 'Segment dropped due to path policy: Unwanted AS(1-11): f056531e3b80, 2018-02-22 14:02:11+00:00, 1-11 70'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1416)
<!-- Reviewable:end -->
