### PR TITLE
Change infra Transport to work with PacketConn

### DIFF
--- a/go/lib/infra/transport/packet_transport.go
+++ b/go/lib/infra/transport/packet_transport.go
@@ -31,11 +31,12 @@ var _ Transport = (*PacketTransport)(nil)
 // For PacketTransports running on top of UDP, both SendMsgTo and
 // SendUnreliableMsgTo are unreliable.
 //
-// For PacketTransports running on top of UNIX datagram or Reliable socket,
-// both SendMsgTo and SendUnreliableMsgTo are reliable. Note that in this case,
-// the reliability only extends to the guarantee that the message was not lost
-// in transfer. It is not a guarantee that the server has read and processed
-// the message.
+// For PacketTransports running on top of UNIX domain socket with SOCK_DGRAM or
+// Reliable socket, both SendMsgTo and SendUnreliableMsgTo guarantee reliable
+// delivery to the other other end of the socket. Note that in this case, the
+// reliability only extends to the guarantee that the message was not lost in
+// transfer. It is not a guarantee that the server has read and processed the
+// message.
 type PacketTransport struct {
 	conn net.PacketConn
 	// While conn is safe for use from multiple goroutines, deadlines are

--- a/go/lib/infra/transport/packet_transport.go
+++ b/go/lib/infra/transport/packet_transport.go
@@ -22,12 +22,21 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 )
 
-var _ Transport = (*UDP)(nil)
+var _ Transport = (*PacketTransport)(nil)
 
-// UDP implements interface Transport by wrapping around *snet.Conn. For UDP,
-// SendMsgTo is equivalent to SendUnreliableMsgTo and provides no guarantees of
-// reliability.
-type UDP struct {
+// PacketTransport implements interface Transport by wrapping around a
+// net.PacketConn. The reliability of the underlying net.PacketConn defines the
+// semantics behind SendMsgTo and SendUnreliableMsgTo.
+//
+// For PacketTransports running on top of UDP, both SendMsgTo and
+// SendUnreliableMsgTo are unreliable.
+//
+// For PacketTransports running on top of UNIX datagram or Reliable socket,
+// both SendMsgTo and SendUnreliableMsgTo are reliable. Note that in this case,
+// the reliability only extends to the guarantee that the message was not lost
+// in transfer. It is not a guarantee that the server has read and processed
+// the message.
+type PacketTransport struct {
 	conn net.PacketConn
 	// While conn is safe for use from multiple goroutines, deadlines are
 	// global so it is not safe to enforce two at the same time. Thus, to
@@ -36,15 +45,17 @@ type UDP struct {
 	readLock  *channelLock
 }
 
-func NewUDP(conn net.PacketConn) *UDP {
-	return &UDP{
+func NewPacketTransport(conn net.PacketConn) *PacketTransport {
+	return &PacketTransport{
 		conn:      conn,
 		writeLock: newChannelLock(),
 		readLock:  newChannelLock(),
 	}
 }
 
-func (u *UDP) SendUnreliableMsgTo(ctx context.Context, b common.RawBytes, address net.Addr) error {
+func (u *PacketTransport) SendUnreliableMsgTo(ctx context.Context, b common.RawBytes,
+	address net.Addr) error {
+
 	select {
 	case <-u.writeLock.Lock():
 		defer u.writeLock.Unlock()
@@ -61,11 +72,13 @@ func (u *UDP) SendUnreliableMsgTo(ctx context.Context, b common.RawBytes, addres
 	return err
 }
 
-func (u *UDP) SendMsgTo(ctx context.Context, b common.RawBytes, address net.Addr) error {
+func (u *PacketTransport) SendMsgTo(ctx context.Context, b common.RawBytes,
+	address net.Addr) error {
+
 	return u.SendUnreliableMsgTo(ctx, b, address)
 }
 
-func (u *UDP) RecvFrom(ctx context.Context) (common.RawBytes, net.Addr, error) {
+func (u *PacketTransport) RecvFrom(ctx context.Context) (common.RawBytes, net.Addr, error) {
 	select {
 	case <-u.readLock.Lock():
 		defer u.readLock.Unlock()
@@ -80,7 +93,7 @@ func (u *UDP) RecvFrom(ctx context.Context) (common.RawBytes, net.Addr, error) {
 	return b[:n], address, err
 }
 
-func (u *UDP) Close(context.Context) error {
+func (u *PacketTransport) Close(context.Context) error {
 	return u.conn.Close()
 }
 

--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -145,10 +145,11 @@ func (c *Conn) read(b []byte, from bool) (int, *Addr, error) {
 	if c.scionNet == nil {
 		return 0, nil, common.NewBasicError("SCION network not initialized", nil)
 	}
-	n, lastHop, err := c.conn.ReadFrom(c.recvBuffer)
+	n, lastHopNetAddr, err := c.conn.ReadFrom(c.recvBuffer)
 	if err != nil {
 		return 0, nil, common.NewBasicError("Dispatcher read error", err)
 	}
+	lastHop := lastHopNetAddr.(*reliable.AppAddr)
 	if !from {
 		lastHop = nil
 	}
@@ -316,7 +317,7 @@ func (c *Conn) write(b []byte, raddr *Addr) (int, error) {
 	}
 
 	// Send message
-	n, err = c.conn.WriteTo(c.sendBuffer[:n], appAddr)
+	n, err = c.conn.WriteTo(c.sendBuffer[:n], &appAddr)
 	if err != nil {
 		return 0, common.NewBasicError("Dispatcher write error", err)
 	}

--- a/go/lib/sock/reliable/appaddr.go
+++ b/go/lib/sock/reliable/appaddr.go
@@ -15,18 +15,18 @@
 package reliable
 
 import (
+	"fmt"
+
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 )
 
 var (
-	NilAppAddr AppAddr
+	NilAppAddr *AppAddr = &AppAddr{
+		Addr: addr.HostNone{},
+		Port: 0,
+	}
 )
-
-func init() {
-	a, _ := addr.HostFromRaw(nil, addr.HostTypeNone)
-	NilAppAddr = AppAddr{Addr: a, Port: 0}
-}
 
 // AppAddr is a L3 + L4 address container, it currently only supports UDP for L4.
 type AppAddr struct {
@@ -80,4 +80,12 @@ func (a *AppAddr) writePort(buf common.RawBytes) {
 		return
 	}
 	common.Order.PutUint16(buf, a.Port)
+}
+
+func (a *AppAddr) Network() string {
+	return "reliable"
+}
+
+func (a *AppAddr) String() string {
+	return fmt.Sprintf("%s:%d", a.Addr, a.Port)
 }

--- a/go/lib/sock/reliable/appaddr.go
+++ b/go/lib/sock/reliable/appaddr.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	NilAppAddr *AppAddr = &AppAddr{
+	NilAppAddr = &AppAddr{
 		Addr: addr.HostNone{},
 		Port: 0,
 	}

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -380,10 +380,12 @@ func (conn *Conn) Write(buf []byte) (int, error) {
 func (conn *Conn) WriteTo(buf []byte, dst net.Addr) (int, error) {
 	conn.writeMutex.Lock()
 	defer conn.writeMutex.Unlock()
-	appAddr := dst.(*AppAddr)
-	msgs := make([]Msg, 1)
-	msgs[0].Buffer = buf
-	msgs[0].Addr = appAddr
+	msgs := []Msg{
+		{
+			Buffer: buf,
+			Addr:   dst.(*AppAddr),
+		},
+	}
 	for {
 		n, err := conn.writeN(msgs)
 		if err != nil {

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -93,6 +93,9 @@ type Msg struct {
 	Addr   *AppAddr
 }
 
+var _ net.Conn = (*Conn)(nil)
+var _ net.PacketConn = (*Conn)(nil)
+
 // Conn implements the ReliableSocket framing protocol over UNIX sockets.
 type Conn struct {
 	*net.UnixConn
@@ -251,7 +254,7 @@ func (conn *Conn) Read(buf []byte) (int, error) {
 
 // ReadFrom works similarly to Read. In addition to Read, it also returns the last hop
 // (usually, the border router) which sent the message.
-func (conn *Conn) ReadFrom(buf []byte) (int, *AppAddr, error) {
+func (conn *Conn) ReadFrom(buf []byte) (int, net.Addr, error) {
 	msgs := make([]Msg, 1)
 	msgs[0].Buffer = buf
 	_, err := conn.ReadN(msgs)
@@ -374,12 +377,13 @@ func (conn *Conn) Write(buf []byte) (int, error) {
 
 // WriteTo works similarly to Write. In addition to Write, the ReliableSocket message header
 // will contain the address and port information in dst.
-func (conn *Conn) WriteTo(buf []byte, dst AppAddr) (int, error) {
+func (conn *Conn) WriteTo(buf []byte, dst net.Addr) (int, error) {
 	conn.writeMutex.Lock()
 	defer conn.writeMutex.Unlock()
+	appAddr := dst.(*AppAddr)
 	msgs := make([]Msg, 1)
 	msgs[0].Buffer = buf
-	msgs[0].Addr = &dst
+	msgs[0].Addr = appAddr
 	for {
 		n, err := conn.writeN(msgs)
 		if err != nil {
@@ -465,7 +469,7 @@ func (conn *Conn) String() string {
 func (conn *Conn) copyMsg(msg *Msg, index, copiedMsgs int) (int, int, error) {
 	var dst *AppAddr
 	if msg.Addr == nil {
-		dst = &NilAppAddr
+		dst = NilAppAddr
 	} else {
 		dst = msg.Addr
 	}

--- a/go/lib/sock/reliable/reliable_test.go
+++ b/go/lib/sock/reliable/reliable_test.go
@@ -213,7 +213,7 @@ func TestWriteTo(t *testing.T) {
 					cconn, err := DialTimeout(sockName, time.Second)
 					sc.SoMsg("dial err", err, ShouldBeNil)
 
-					n, err := cconn.WriteTo([]byte(tc.msg), *tc.dst)
+					n, err := cconn.WriteTo([]byte(tc.msg), tc.dst)
 					sc.SoMsg("client write err", err, ShouldBeNil)
 					sc.SoMsg("client written bytes", n, ShouldEqual, len(tc.msg))
 


### PR DESCRIPTION
Also, the Go implementation of ReliableSocket now implements `net.PacketConn`, making it usable as a infra transport.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1423)
<!-- Reviewable:end -->
