### PR TITLE
TRIVIAL: Enable interval flag when count is set

### DIFF
--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -122,7 +122,7 @@ func Client() {
 
 	b := make([]byte, 1<<12)
 	for i := 0; i < *count || *count == 0; i++ {
-		if i != 0 {
+		if i != 0 && *interval != 0 {
 			time.Sleep(*interval)
 		}
 


### PR DESCRIPTION
Setting an interval is independent of the number of messages getting sent.
Always use the interval set when non zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1430)
<!-- Reviewable:end -->
