### PR TITLE
Add sign/verify capability to CSGO

### DIFF
--- a/go/cert_srv/conf/conf.go
+++ b/go/cert_srv/conf/conf.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/topology"
@@ -62,6 +63,14 @@ type Conf struct {
 	ConfDir string
 	// StateDir is the state directory.
 	StateDir string
+	// signer is used to sign ctrl payloads.
+	signer ctrl.Signer
+	// SignerLock guards signer.
+	SignerLock sync.RWMutex
+	// verifier is used to verify ctrl payloads.
+	verifier ctrl.SigVerifier
+	// VerifierLock guards verifier.
+	VerifierLock sync.RWMutex
 }
 
 // Load initializes the configuration by loading it from confDir.
@@ -153,4 +162,32 @@ func (c *Conf) GetOnRootKey() common.RawBytes {
 	c.keyConfLock.RLock()
 	defer c.keyConfLock.RUnlock()
 	return c.keyConf.OnRootKey
+}
+
+// GetSigner returns the signer of the current configuration.
+func (c *Conf) GetSigner() ctrl.Signer {
+	c.SignerLock.RLock()
+	defer c.SignerLock.RUnlock()
+	return c.signer
+}
+
+// SetSigner sets the signer of the current configuration.
+func (c *Conf) SetSigner(signer ctrl.Signer) {
+	c.SignerLock.Lock()
+	defer c.SignerLock.Unlock()
+	c.signer = signer
+}
+
+// GetVerifier returns the verifier of the current configuration.
+func (c *Conf) GetVerifier() ctrl.SigVerifier {
+	c.VerifierLock.RLock()
+	defer c.VerifierLock.RUnlock()
+	return c.verifier
+}
+
+// SetVerifier sets the verifier of the current configuration.
+func (c *Conf) SetVerifier(verifier ctrl.SigVerifier) {
+	c.VerifierLock.Lock()
+	defer c.VerifierLock.Unlock()
+	c.verifier = verifier
 }

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -83,7 +83,7 @@ func main() {
 		fatal(err.Error())
 	}
 	config.SetSigner(ctrl.NewBasicSigner(sign, config.GetSigningKey()))
-	config.SetVerifier(&SigVerifier{})
+	config.SetVerifier(&SigVerifier{&ctrl.BasicSigVerifier{}})
 	// initialize snet with retries
 	if err = initSNET(initAttempts, initInterval); err != nil {
 		fatal("Unable to create local SCION Network context", "err", err)

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/scionproto/scion/go/cert_srv/conf"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
 	liblog "github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
 )
@@ -76,6 +77,13 @@ func main() {
 	if config, err = conf.Load(*id, *confDir, *cacheDir, *stateDir); err != nil {
 		fatal(err.Error())
 	}
+	// Set signer and verifier
+	sign, err := CreateSign()
+	if err != nil {
+		fatal(err.Error())
+	}
+	config.SetSigner(ctrl.NewBasicSigner(sign, config.GetSigningKey()))
+	config.SetVerifier(&SigVerifier{})
 	// initialize snet with retries
 	if err = initSNET(initAttempts, initInterval); err != nil {
 		fatal("Unable to create local SCION Network context", "err", err)

--- a/go/cert_srv/signed_util.go
+++ b/go/cert_srv/signed_util.go
@@ -1,0 +1,136 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"time"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/crypto"
+	"github.com/scionproto/scion/go/lib/crypto/cert"
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/proto"
+)
+
+const SignatureValidity = 2 * time.Second
+
+func CreateSign() (*proto.SignS, error) {
+	c := config.Store.GetNewestChain(config.PublicAddr.IA)
+	if c == nil {
+		return nil, common.NewBasicError("Unable to find local certificate chain", nil)
+	}
+	t := config.Store.GetNewestTRC(config.PublicAddr.IA.I)
+	if t == nil {
+		return nil, common.NewBasicError("Unable to find local TRC", nil)
+	}
+	var sigType proto.SignType
+	switch c.Leaf.SignAlgorithm {
+	case crypto.Ed25519:
+		sigType = proto.SignType_ed25519
+	default:
+		return nil, common.NewBasicError("Unsupported signing algorithm", nil, "algo",
+			c.Leaf.SignAlgorithm)
+	}
+	src := &ctrl.SignSrcDef{
+		IA:       config.PublicAddr.IA,
+		ChainVer: c.Leaf.Version,
+		TRCVer:   t.Version}
+	return proto.NewSignS(sigType, src.Pack()), nil
+}
+
+var _ ctrl.SigVerifier = (*SigVerifier)(nil)
+
+// SigVerifier is a SigVerifier that ignores signatures on cert_mgmt.TRC
+// cert_mgmt.Chain and cert_mgmt.ChainIssRep messages, to avoid dependency cycles.
+type SigVerifier struct {
+	*ctrl.BasicSigVerifier
+}
+
+func (v *SigVerifier) Verify(p *ctrl.SignedPld) error {
+	cpld, err := p.Pld()
+	if err != nil {
+		return err
+	}
+	if v.ignoreSign(cpld) {
+		return nil
+	}
+	diff := time.Now().Sub(time.Unix(int64(p.Sign.Timestamp), 0))
+	if diff < 0 {
+		return common.NewBasicError("Invalid timestamp. Signed before current time", nil, "ts",
+			util.TimeToString(p.Sign.Timestamp), "now", util.TimeToString(uint64(time.Now().Unix())))
+	}
+	if diff > SignatureValidity {
+		return common.NewBasicError("Invalid timestamp. Signature expired", nil, "ts",
+			util.TimeToString(p.Sign.Timestamp), "now", util.TimeToString(uint64(time.Now().Unix())))
+	}
+	vKey, err := v.getVerifyKeyForSign(p.Sign)
+	if err != nil {
+		return err
+	}
+	return p.Sign.Verify(vKey, p.Blob)
+}
+
+func (v *SigVerifier) ignoreSign(p *ctrl.Pld) bool {
+	u0, _ := p.Union()
+	outer, ok := u0.(*cert_mgmt.Pld)
+	if !ok {
+		return false
+	}
+	u1, _ := outer.Union()
+	switch u1.(type) {
+	case *cert_mgmt.Chain, *cert_mgmt.TRC, *cert_mgmt.ChainIssRep:
+		return true
+	default:
+		return false
+	}
+}
+
+func (v *SigVerifier) getVerifyKeyForSign(s *proto.SignS) (common.RawBytes, error) {
+	if s.Type == proto.SignType_none {
+		return nil, nil
+	}
+	sigSrc, err := ctrl.NewSignSrcDefFromRaw(s.Src)
+	if err != nil {
+		return nil, err
+	}
+	chain, err := v.getChainForSign(sigSrc)
+	if err != nil {
+		return nil, err
+	}
+	return chain.Leaf.SubjectSignKey, nil
+}
+
+func (v *SigVerifier) getChainForSign(s *ctrl.SignSrcDef) (*cert.Chain, error) {
+	c := config.Store.GetChain(s.IA, s.ChainVer)
+	if c == nil {
+		return nil, common.NewBasicError("Unable to get certificate chain", nil,
+			"ISD-AS", s.IA, "ver", s.ChainVer)
+	}
+	t := config.Store.GetTRC(s.IA.I, s.TRCVer)
+	if t == nil {
+		return nil, common.NewBasicError("Unable to get TRC", nil, "ISD", s.IA.I, "ver", s.TRCVer)
+	}
+	maxTRC := config.Store.GetNewestTRC(t.ISD)
+	if err := t.CheckActive(maxTRC); err != nil {
+		// The certificate chain might still be verifiable with the max TRC
+		t = maxTRC
+	}
+	if err := c.Verify(c.Leaf.Subject, t); err != nil {
+		return nil, common.NewBasicError("Unable to verify certificate chain", err)
+	}
+	return c, nil
+}

--- a/go/cert_srv/signed_util.go
+++ b/go/cert_srv/signed_util.go
@@ -72,12 +72,13 @@ func (v *SigVerifier) Verify(p *ctrl.SignedPld) error {
 	ts := p.Sign.Time()
 	diff := now.Sub(ts)
 	if diff < 0 {
-		return common.NewBasicError("Invalid timestamp. Signed before current time", nil,
+		return common.NewBasicError("Invalid timestamp. Signature from future", nil,
 			"ts", util.TimeToString(ts), "now", util.TimeToString(now))
 	}
 	if diff > SignatureValidity {
 		return common.NewBasicError("Invalid timestamp. Signature expired", nil,
-			"ts", util.TimeToString(ts), "now", util.TimeToString(now))
+			"ts", util.TimeToString(ts), "now", util.TimeToString(now),
+			"validity", SignatureValidity)
 	}
 	vKey, err := v.getVerifyKeyForSign(p.Sign)
 	if err != nil {

--- a/go/lib/crypto/cert/cert.go
+++ b/go/lib/crypto/cert/cert.go
@@ -96,12 +96,14 @@ func (c *Certificate) Verify(subject addr.IA, verifyKey common.RawBytes, signAlg
 // not check the validity of the signature.
 func (c *Certificate) VerifyTime(ts uint64) error {
 	if ts < c.IssuingTime {
-		return common.NewBasicError(EarlyUsage, nil, "IssuingTime",
-			util.TimeToString(c.IssuingTime), "current", util.TimeToString(ts))
+		return common.NewBasicError(EarlyUsage, nil,
+			"IssuingTime", util.TimeToString(util.Uint64ToTime(c.IssuingTime)),
+			"current", util.TimeToString(util.Uint64ToTime(ts)))
 	}
 	if ts > c.ExpirationTime {
-		return common.NewBasicError(Expired, nil, "ExpirationTime",
-			util.TimeToString(c.ExpirationTime), "current", util.TimeToString(ts))
+		return common.NewBasicError(Expired, nil,
+			"ExpirationTime", util.TimeToString(util.Uint64ToTime(c.ExpirationTime)),
+			"current", util.TimeToString(util.Uint64ToTime(ts)))
 	}
 	return nil
 }

--- a/go/lib/crypto/cert/cert.go
+++ b/go/lib/crypto/cert/cert.go
@@ -97,13 +97,13 @@ func (c *Certificate) Verify(subject addr.IA, verifyKey common.RawBytes, signAlg
 func (c *Certificate) VerifyTime(ts uint64) error {
 	if ts < c.IssuingTime {
 		return common.NewBasicError(EarlyUsage, nil,
-			"IssuingTime", util.TimeToString(util.Uint64ToTime(c.IssuingTime)),
-			"current", util.TimeToString(util.Uint64ToTime(ts)))
+			"IssuingTime", util.TimeToString(util.USecsToTime(c.IssuingTime)),
+			"current", util.TimeToString(util.USecsToTime(ts)))
 	}
 	if ts > c.ExpirationTime {
 		return common.NewBasicError(Expired, nil,
-			"ExpirationTime", util.TimeToString(util.Uint64ToTime(c.ExpirationTime)),
-			"current", util.TimeToString(util.Uint64ToTime(ts)))
+			"ExpirationTime", util.TimeToString(util.USecsToTime(c.ExpirationTime)),
+			"current", util.TimeToString(util.USecsToTime(ts)))
 	}
 	return nil
 }

--- a/go/lib/crypto/cert/chain.go
+++ b/go/lib/crypto/cert/chain.go
@@ -124,13 +124,13 @@ func ChainFromSlice(certs []*Certificate) (*Chain, error) {
 func (c *Chain) Verify(subject addr.IA, t *trc.TRC) error {
 	if c.Leaf.IssuingTime < c.Issuer.IssuingTime {
 		return common.NewBasicError(LeafIssuedBefore, nil,
-			"leaf", util.TimeToString(util.Uint64ToTime(c.Leaf.IssuingTime)),
-			"issuer", util.TimeToString(util.Uint64ToTime(c.Issuer.IssuingTime)))
+			"leaf", util.TimeToString(util.USecsToTime(c.Leaf.IssuingTime)),
+			"issuer", util.TimeToString(util.USecsToTime(c.Issuer.IssuingTime)))
 	}
 	if c.Leaf.ExpirationTime > c.Issuer.ExpirationTime {
 		return common.NewBasicError(LeafExpiresAfter, nil,
-			"leaf", util.TimeToString(util.Uint64ToTime(c.Leaf.ExpirationTime)),
-			"issuer", util.TimeToString(util.Uint64ToTime(c.Issuer.ExpirationTime)))
+			"leaf", util.TimeToString(util.USecsToTime(c.Leaf.ExpirationTime)),
+			"issuer", util.TimeToString(util.USecsToTime(c.Issuer.ExpirationTime)))
 	}
 	if !c.Issuer.CanIssue {
 		return common.NewBasicError(IssCertInvalid, nil, "CanIssue", false)
@@ -140,8 +140,8 @@ func (c *Chain) Verify(subject addr.IA, t *trc.TRC) error {
 	}
 	if c.Issuer.ExpirationTime > t.ExpirationTime {
 		return common.NewBasicError(IssExpiresAfter, nil,
-			"issuer", util.TimeToString(util.Uint64ToTime(c.Issuer.ExpirationTime)),
-			"TRC", util.TimeToString(util.Uint64ToTime(t.ExpirationTime)))
+			"issuer", util.TimeToString(util.USecsToTime(c.Issuer.ExpirationTime)),
+			"TRC", util.TimeToString(util.USecsToTime(t.ExpirationTime)))
 	}
 	coreAS, ok := t.CoreASes[c.Issuer.Issuer]
 	if !ok {

--- a/go/lib/crypto/cert/chain.go
+++ b/go/lib/crypto/cert/chain.go
@@ -123,14 +123,14 @@ func ChainFromSlice(certs []*Certificate) (*Chain, error) {
 
 func (c *Chain) Verify(subject addr.IA, t *trc.TRC) error {
 	if c.Leaf.IssuingTime < c.Issuer.IssuingTime {
-		return common.NewBasicError(LeafIssuedBefore, nil, "leaf",
-			util.TimeToString(c.Leaf.IssuingTime), "issuer",
-			util.TimeToString(c.Issuer.IssuingTime))
+		return common.NewBasicError(LeafIssuedBefore, nil,
+			"leaf", util.TimeToString(util.Uint64ToTime(c.Leaf.IssuingTime)),
+			"issuer", util.TimeToString(util.Uint64ToTime(c.Issuer.IssuingTime)))
 	}
 	if c.Leaf.ExpirationTime > c.Issuer.ExpirationTime {
-		return common.NewBasicError(LeafExpiresAfter, nil, "leaf",
-			util.TimeToString(c.Leaf.ExpirationTime), "issuer",
-			util.TimeToString(c.Issuer.ExpirationTime))
+		return common.NewBasicError(LeafExpiresAfter, nil,
+			"leaf", util.TimeToString(util.Uint64ToTime(c.Leaf.ExpirationTime)),
+			"issuer", util.TimeToString(util.Uint64ToTime(c.Issuer.ExpirationTime)))
 	}
 	if !c.Issuer.CanIssue {
 		return common.NewBasicError(IssCertInvalid, nil, "CanIssue", false)
@@ -139,9 +139,9 @@ func (c *Chain) Verify(subject addr.IA, t *trc.TRC) error {
 		return common.NewBasicError(LeafCertInvalid, err)
 	}
 	if c.Issuer.ExpirationTime > t.ExpirationTime {
-		return common.NewBasicError(IssExpiresAfter, nil, "issuer",
-			util.TimeToString(c.Issuer.ExpirationTime), "TRC",
-			util.TimeToString(t.ExpirationTime))
+		return common.NewBasicError(IssExpiresAfter, nil,
+			"issuer", util.TimeToString(util.Uint64ToTime(c.Issuer.ExpirationTime)),
+			"TRC", util.TimeToString(util.Uint64ToTime(t.ExpirationTime)))
 	}
 	coreAS, ok := t.CoreASes[c.Issuer.Issuer]
 	if !ok {

--- a/go/lib/crypto/trc/trc.go
+++ b/go/lib/crypto/trc/trc.go
@@ -27,6 +27,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/crypto"
+	"github.com/scionproto/scion/go/lib/util"
 )
 
 const (
@@ -324,5 +325,5 @@ func (t *TRC) String() string {
 }
 
 func timeToString(t uint64) string {
-	return time.Unix(int64(t), 0).UTC().Format(common.TimeFmt)
+	return util.TimeToString(util.Uint64ToTime(t))
 }

--- a/go/lib/crypto/trc/trc.go
+++ b/go/lib/crypto/trc/trc.go
@@ -325,5 +325,5 @@ func (t *TRC) String() string {
 }
 
 func timeToString(t uint64) string {
-	return util.TimeToString(util.Uint64ToTime(t))
+	return util.TimeToString(util.USecsToTime(t))
 }

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -25,6 +25,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/spath"
+	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/proto"
 )
 
@@ -192,7 +193,7 @@ func (ps *PathSegment) String() string {
 		desc = append(desc, id.String())
 	}
 	info, _ := ps.InfoF()
-	desc = append(desc, info.Timestamp().UTC().Format(common.TimeFmt))
+	desc = append(desc, util.TimeToString(info.Timestamp()))
 	hops_desc := []string{}
 	for _, ase := range ps.ASEntries {
 		hop_entry := ase.HopEntries[0]

--- a/go/lib/util/time.go
+++ b/go/lib/util/time.go
@@ -20,6 +20,14 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 )
 
-func TimeToString(t uint64) string {
-	return time.Unix(int64(t), 0).UTC().Format(common.TimeFmt)
+func Uint64ToTime(t uint64) time.Time {
+	return time.Unix(int64(t), 0)
+}
+
+func Int64ToTime(t int64) time.Time {
+	return time.Unix(t, 0)
+}
+
+func TimeToString(t time.Time) string {
+	return t.UTC().Format(common.TimeFmt)
 }

--- a/go/lib/util/time.go
+++ b/go/lib/util/time.go
@@ -20,11 +20,13 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 )
 
-func Uint64ToTime(t uint64) time.Time {
+// USecsToTime takes seconds stored in a uint64.
+func USecsToTime(t uint64) time.Time {
 	return time.Unix(int64(t), 0)
 }
 
-func Int64ToTime(t int64) time.Time {
+// SecsToTime takes seconds stored in a int64.
+func SecsToTime(t int64) time.Time {
 	return time.Unix(t, 0)
 }
 

--- a/go/proto/sign.go
+++ b/go/proto/sign.go
@@ -68,6 +68,14 @@ func (s *SignS) SignAndSet(key, message common.RawBytes) error {
 	return err
 }
 
+// Time returns the timestamp. If the receiver is nil, the zero value of time.Time is returned.
+func (s *SignS) Time() time.Time {
+	if s != nil {
+		return time.Unix(int64(s.Timestamp), 0)
+	}
+	return time.Time{}
+}
+
 func (s *SignS) Verify(key, message common.RawBytes) error {
 	switch s.Type {
 	case SignType_none:
@@ -93,7 +101,7 @@ func (s *SignS) ProtoId() ProtoIdType {
 
 func (s *SignS) String() string {
 	return fmt.Sprintf("SignType: %s Timestamp: %s SignSrc: %s Signature: %s", s.Type,
-		util.TimeToString(s.Timestamp), s.Src, s.Signature)
+		util.TimeToString(util.Uint64ToTime(s.Timestamp)), s.Src, s.Signature)
 }
 
 var _ Cerealizable = (*SignedBlobS)(nil)

--- a/go/proto/sign.go
+++ b/go/proto/sign.go
@@ -68,7 +68,7 @@ func (s *SignS) SignAndSet(key, message common.RawBytes) error {
 	return err
 }
 
-// Time returns the timestamp. If the receiver is nil, the zero value of time.Time is returned.
+// Time returns the timestamp. If the receiver is nil, the zero value is returned.
 func (s *SignS) Time() time.Time {
 	if s != nil {
 		return time.Unix(int64(s.Timestamp), 0)

--- a/go/proto/sign.go
+++ b/go/proto/sign.go
@@ -71,7 +71,7 @@ func (s *SignS) SignAndSet(key, message common.RawBytes) error {
 // Time returns the timestamp. If the receiver is nil, the zero value is returned.
 func (s *SignS) Time() time.Time {
 	if s != nil {
-		return time.Unix(int64(s.Timestamp), 0)
+		return util.USecsToTime(s.Timestamp)
 	}
 	return time.Time{}
 }
@@ -101,7 +101,7 @@ func (s *SignS) ProtoId() ProtoIdType {
 
 func (s *SignS) String() string {
 	return fmt.Sprintf("SignType: %s Timestamp: %s SignSrc: %s Signature: %s", s.Type,
-		util.TimeToString(util.Uint64ToTime(s.Timestamp)), s.Src, s.Signature)
+		util.TimeToString(s.Time()), s.Src, s.Signature)
 }
 
 var _ Cerealizable = (*SignedBlobS)(nil)


### PR DESCRIPTION
Enables the go certificate server to create and verify signed payloads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1431)
<!-- Reviewable:end -->
