### PR TITLE
Dependency licence audit.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
     build:
         docker:
-            - image: scionproto/scion_base@sha256:04b4f8f533a3e8fabc5a4628bb68c64f4e0d490fdf4d0d4460d4bdb37cb04c77
+            - image: scionproto/scion_base@sha256:979e024a79dfbde415e55e9e62dd9d41ef846b2d6b47694e01112831e6674a98
         <<: *job
         steps:
             - checkout

--- a/env/pip3/requirements.txt
+++ b/env/pip3/requirements.txt
@@ -1,9 +1,8 @@
 nose-descriptionfixer==0.0.4 --hash=sha256:4c74bd38f6fcf158b0681ea4ccb6b4f64c09867d039d5ef9a8c1856395dbac7c # Direct dependency
 pockets==0.3 --hash=sha256:dc870d57992cebaf4bb9dabdad55972ef915429521142af77f6a1efb9e3646de
+six==1.10.0 --hash=sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1
 pycapnp==0.6.1 --hash=sha256:ea60837533307849e98bb3494555cea28a52ea0c301cfdf32bce661931940696 # Direct dependency
 PyDbLite==3.0.4 --hash=sha256:79ed97d17b5954c6fa8927d9f36033cb4486d1304005057d506ac1dee999bad6 # Direct dependency
-scapy-python3==0.18 --hash=sha256:23c19d0dbba07b7a7681d97784371f92fb570cdea3ae58e12bf19fe98c7bf7ad # Direct dependency
-six==1.10.0 --hash=sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1
 sphinxcontrib-napoleon==0.5.3 --hash=sha256:a809ab437a5617442ae4f919e50a3f953faff1730e9234bcc502fdf594bbbfbb # Direct dependency
 cryptography==1.8.1 --hash=sha256:323524312bb467565ebca7e50c8ae5e9674e544951d28a2904a50012a8828190 # Direct dependency
 idna==2.5 --hash=sha256:cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70
@@ -14,4 +13,5 @@ cffi==1.10.0 --hash=sha256:b3b02911eb1f6ada203b0763ba924234629b51586f72a21faacc6
 pyparsing==2.2.0 --hash=sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010
 appdirs==1.4.3 --hash=sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e
 pycparser==2.17 --hash=sha256:0aac31e917c24cb3357f5a4d5566f2cc91a19ca41862f6c3c22dc60a629673b6
-prometheus-client==0.0.19 --hash=sha256:ce4ddcb89a870ee771ca5427df123029bf5344ea84f535ded4a1787e29a22a3f
+prometheus-client==0.0.19 --hash=sha256:ce4ddcb89a870ee771ca5427df123029bf5344ea84f535ded4a1787e29a22a3f # Direct dependency
+pypacker==4.1 --hash=sha256:05bc5c873cfef620ce8b07df4aa286ea199e328b5b1eabd0b10aa0bb699c464f # Direct dependency

--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build ignore
+
 // Simple application for SCION connectivity using the snet library.
 package main
 
@@ -23,8 +25,8 @@ import (
 	"time"
 
 	log "github.com/inconshreveable/log15"
-	"github.com/lucas-clemente/quic-go"
-	"github.com/lucas-clemente/quic-go/qerr"
+	//"github.com/lucas-clemente/quic-go"
+	//"github.com/lucas-clemente/quic-go/qerr"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	liblog "github.com/scionproto/scion/go/lib/log"

--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -130,11 +130,11 @@ func Client() {
 		before := time.Now()
 		written, err := qstream.Write([]byte(ReqMsg))
 		if err != nil {
-			qer := qerr.ToQuicError(err)
-			if qer.ErrorCode == qerr.NetworkIdleTimeout {
-				log.Debug("The connection timed out due to no network activity")
-				break
-			}
+			//qer := qerr.ToQuicError(err)
+			//if qer.ErrorCode == qerr.NetworkIdleTimeout {
+			//	log.Debug("The connection timed out due to no network activity")
+			//	break
+			//}
 			log.Error("Unable to write", "err", err)
 			continue
 		}
@@ -151,11 +151,11 @@ func Client() {
 		}
 		read, err := qstream.Read(b)
 		if err != nil {
-			qer := qerr.ToQuicError(err)
-			if qer.ErrorCode == qerr.PeerGoingAway {
-				log.Debug("Quic peer disconnected")
-				break
-			}
+			//qer := qerr.ToQuicError(err)
+			//if qer.ErrorCode == qerr.PeerGoingAway {
+			//	log.Debug("Quic peer disconnected")
+			//	break
+			//}
 			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
 				log.Debug("ReadDeadline missed", "err", err)
 				continue
@@ -206,7 +206,7 @@ func initNetwork() {
 	log.Debug("QUIC/SCION successfully initialized")
 }
 
-func handleClient(qsess quic.Session) {
+func handleClient( /*qsess quic.Session*/ ) {
 	qstream, err := qsess.AcceptStream()
 	if err != nil {
 		LogFatal("Unable to accept quic stream", "err", err)
@@ -217,11 +217,11 @@ func handleClient(qsess quic.Session) {
 		// Receive ping message
 		read, err := qstream.Read(b)
 		if err != nil {
-			qer := qerr.ToQuicError(err)
-			if qer.ErrorCode == qerr.PeerGoingAway {
-				log.Debug("Quic peer disconnected")
-				break
-			}
+			//qer := qerr.ToQuicError(err)
+			//if qer.ErrorCode == qerr.PeerGoingAway {
+			//	log.Debug("Quic peer disconnected")
+			//	break
+			//}
 			log.Error("Unable to read", "err", err)
 			break
 		}

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build ignore
+
 // QUIC/SCION implementation.
 package squic
 
@@ -19,7 +21,7 @@ import (
 	"crypto/tls"
 
 	//log "github.com/inconshreveable/log15"
-	"github.com/lucas-clemente/quic-go"
+	//"github.com/lucas-clemente/quic-go"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -54,26 +54,26 @@ func Init(keyPath, pemPath string) error {
 	return nil
 }
 
-func DialSCION(network *snet.Network, laddr, raddr *snet.Addr) (quic.Session, error) {
+func DialSCION(network *snet.Network, laddr, raddr *snet.Addr) /*quic.Session, */ error {
 	return DialSCIONWithBindSVC(network, laddr, raddr, nil, addr.SvcNone)
 }
 
 func DialSCIONWithBindSVC(network *snet.Network, laddr, raddr, baddr *snet.Addr,
-	svc addr.HostSVC) (quic.Session, error) {
+	svc addr.HostSVC) /*quic.Session, */ error {
 	sconn, err := sListen(network, laddr, baddr, svc)
 	if err != nil {
 		return nil, err
 	}
 	// Use dummy hostname, as it's used for SNI, and we're not doing cert verification.
-	return quic.Dial(sconn, raddr, "host:0", cliTlsCfg, nil)
+	return //quic.Dial(sconn, raddr, "host:0", cliTlsCfg, nil)
 }
 
-func ListenSCION(network *snet.Network, laddr *snet.Addr) (quic.Listener, error) {
+func ListenSCION(network *snet.Network, laddr *snet.Addr) /*quic.Listener, */ error {
 	return ListenSCIONWithBindSVC(network, laddr, nil, addr.SvcNone)
 }
 
 func ListenSCIONWithBindSVC(network *snet.Network, laddr, baddr *snet.Addr,
-	svc addr.HostSVC) (quic.Listener, error) {
+	svc addr.HostSVC) /*quic.Listener, */ error {
 	if len(srvTlsCfg.Certificates) == 0 {
 		return nil, common.NewBasicError("squic: No server TLS certificate configured", nil)
 	}
@@ -81,7 +81,7 @@ func ListenSCIONWithBindSVC(network *snet.Network, laddr, baddr *snet.Addr,
 	if err != nil {
 		return nil, err
 	}
-	return quic.Listen(sconn, srvTlsCfg, nil)
+	return //quic.Listen(sconn, srvTlsCfg, nil)
 }
 
 func sListen(network *snet.Network, laddr, baddr *snet.Addr,

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -3,18 +3,6 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "vN3qcK0Nkk4AhOfhTEA8ZUMu2RY=",
-			"path": "github.com/aead/chacha20",
-			"revision": "8d6ce0550041f9d97e7f15ec27ed489f8bbbb0fb",
-			"revisionTime": "2017-06-14T05:10:14Z"
-		},
-		{
-			"checksumSHA1": "zmmUB5W1Oz/czit5mixwbVQq31A=",
-			"path": "github.com/aead/chacha20/chacha",
-			"revision": "8d6ce0550041f9d97e7f15ec27ed489f8bbbb0fb",
-			"revisionTime": "2017-06-14T05:10:14Z"
-		},
-		{
 			"checksumSHA1": "YNhwvoScUezhDwq58QMY8vUwuqg=",
 			"license": "MIT,3-BSD",
 			"path": "github.com/axw/gocov",
@@ -50,48 +38,6 @@
 			"revisionTime": "2016-08-04T10:47:26Z"
 		},
 		{
-			"checksumSHA1": "7wknjQuGJ8gr8VsM8cTLgu1M8vw=",
-			"path": "github.com/bifurcation/mint",
-			"revision": "a544bfbca6a083ce9ddeb2c5f570cb240837355a",
-			"revisionTime": "2017-12-09T20:11:46Z"
-		},
-		{
-			"checksumSHA1": "PZNcjO1c9gV/LZzppwpVRl6+QAY=",
-			"path": "github.com/bifurcation/mint/syntax",
-			"revision": "a544bfbca6a083ce9ddeb2c5f570cb240837355a",
-			"revisionTime": "2017-12-09T20:11:46Z"
-		},
-		{
-			"checksumSHA1": "aMwr5c9Dy2gRQrypsrTCoDVDi/8=",
-			"path": "github.com/clipperhouse/linkedlist",
-			"revision": "bf5ab6f9daf9ae25214b7cf666233cde3274357a",
-			"revisionTime": "2014-11-29T04:44:12Z"
-		},
-		{
-			"checksumSHA1": "BlfYVRUk8gVLCXtbqy4JBVFMPTg=",
-			"path": "github.com/clipperhouse/set",
-			"revision": "c425a638bbb3034eaa3dfe8c2f0f4bc29129b7fc",
-			"revisionTime": "2015-03-04T20:45:47Z"
-		},
-		{
-			"checksumSHA1": "C+JncsAI7+mxsVAvx/7lo1p9Pvs=",
-			"path": "github.com/clipperhouse/slice",
-			"revision": "3ae82e00044e045370183e264317ec785b8f0da3",
-			"revisionTime": "2015-03-01T17:33:39Z"
-		},
-		{
-			"checksumSHA1": "NM+gxNbuon8DgHMmdVwHUhwmMyI=",
-			"path": "github.com/clipperhouse/stringer",
-			"revision": "a8382ce6af9a129cab27e7595ef44a4c2b817360",
-			"revisionTime": "2016-04-10T22:32:32Z"
-		},
-		{
-			"checksumSHA1": "APx+deQijXJSBgYle3eao7O+yLE=",
-			"path": "github.com/clipperhouse/typewriter",
-			"revision": "c1a48da378ebb7db1db9f35981b5cc24bf2e5b85",
-			"revisionTime": "2016-12-20T22:28:20Z"
-		},
-		{
 			"checksumSHA1": "s8t6UaijV8WMK0RMdX00OPI5z0o=",
 			"path": "github.com/dchest/cmac",
 			"revision": "62ff55a1048c485e83f1882466f535da624e944a",
@@ -118,12 +64,6 @@
 			"revisionTime": "2017-06-05T10:28:22Z"
 		},
 		{
-			"checksumSHA1": "+QK1kuQB3dsLI46R0a856gaLFiQ=",
-			"path": "github.com/google/gopacket/afpacket",
-			"revision": "e20408befa7dcef61c3c35f53df06d3f8a194e60",
-			"revisionTime": "2017-06-05T10:28:22Z"
-		},
-		{
 			"checksumSHA1": "GV4QgbWjIWIAIhOlNAJDt8+MtE4=",
 			"path": "github.com/google/gopacket/layers",
 			"revision": "e20408befa7dcef61c3c35f53df06d3f8a194e60",
@@ -135,18 +75,6 @@
 			"path": "github.com/gopherjs/gopherjs/js",
 			"revision": "6f5a3c4a73badf117936d7d61a046e2fab8e2adb",
 			"revisionTime": "2016-10-23T18:47:00Z"
-		},
-		{
-			"checksumSHA1": "d9PxF1XQGLMJZRct2R8qVM/eYlE=",
-			"path": "github.com/hashicorp/golang-lru",
-			"revision": "0a025b7e63adc15a622f29b0b2c4c3848243bbf6",
-			"revisionTime": "2016-08-13T22:13:03Z"
-		},
-		{
-			"checksumSHA1": "9hffs0bAIU6CquiRhKQdzjHnKt0=",
-			"path": "github.com/hashicorp/golang-lru/simplelru",
-			"revision": "0a025b7e63adc15a622f29b0b2c4c3848243bbf6",
-			"revisionTime": "2016-08-13T22:13:03Z"
 		},
 		{
 			"checksumSHA1": "S1lxMekj2Rxqp/lA47z9UGeNHjs=",
@@ -182,84 +110,6 @@
 			"path": "github.com/kormat/fmt15",
 			"revision": "aeb535ae78961b7591ea7f7740b74fc6560c88a8",
 			"revisionTime": "2016-11-22T15:41:03Z"
-		},
-		{
-			"checksumSHA1": "2RFzGcdTeQrFkkhT70WhQcMWF6c=",
-			"path": "github.com/lucas-clemente/aes12",
-			"revision": "cd47fb39b79f867c6e4e5cd39cf7abd799f71670",
-			"revisionTime": "2017-10-27T16:34:21Z"
-		},
-		{
-			"checksumSHA1": "ne1X+frkx5fJcpz9FaZPuUZ7amM=",
-			"path": "github.com/lucas-clemente/fnv128a",
-			"revision": "393af48d391698c6ae4219566bfbdfef67269997",
-			"revisionTime": "2016-05-04T15:23:51Z"
-		},
-		{
-			"checksumSHA1": "O9BCxwHi0Y0iYjZYD7SkGe0cjY0=",
-			"path": "github.com/lucas-clemente/quic-go",
-			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
-			"revisionTime": "2017-12-12T10:29:19Z"
-		},
-		{
-			"checksumSHA1": "OA9E+y7g05x/mWJJHmA7oPxWKQo=",
-			"path": "github.com/lucas-clemente/quic-go-certificates",
-			"revision": "d2f86524cced5186554df90d92529757d22c1cb6",
-			"revisionTime": "2016-08-23T09:51:56Z"
-		},
-		{
-			"checksumSHA1": "ly+Jnp9L2/tZnCH/JLjo6x1XEO8=",
-			"path": "github.com/lucas-clemente/quic-go/ackhandler",
-			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
-			"revisionTime": "2017-12-12T10:29:19Z"
-		},
-		{
-			"checksumSHA1": "X4/8oG5h9ffPOXFCYl39QUNuN9U=",
-			"path": "github.com/lucas-clemente/quic-go/congestion",
-			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
-			"revisionTime": "2017-12-12T10:29:19Z"
-		},
-		{
-			"checksumSHA1": "Nod9iZCew4XEWOtK7008B6PPNa8=",
-			"path": "github.com/lucas-clemente/quic-go/internal/crypto",
-			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
-			"revisionTime": "2017-12-12T10:29:19Z"
-		},
-		{
-			"checksumSHA1": "w+Tez/nWPqzt4R3qGF2Yfw0eswU=",
-			"path": "github.com/lucas-clemente/quic-go/internal/flowcontrol",
-			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
-			"revisionTime": "2017-12-12T10:29:19Z"
-		},
-		{
-			"checksumSHA1": "kGh1OYfUamQrE32YzeRZJyWvnhU=",
-			"path": "github.com/lucas-clemente/quic-go/internal/handshake",
-			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
-			"revisionTime": "2017-12-12T10:29:19Z"
-		},
-		{
-			"checksumSHA1": "FHefA0nAsT8tJpFK5wUCi0tsL5w=",
-			"path": "github.com/lucas-clemente/quic-go/internal/protocol",
-			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
-			"revisionTime": "2017-12-12T10:29:19Z"
-		},
-		{
-			"checksumSHA1": "vCZjWwNZq8dsS3YCSnDLv553VfI=",
-			"path": "github.com/lucas-clemente/quic-go/internal/utils",
-			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
-			"revisionTime": "2017-12-12T10:29:19Z"
-		},
-		{
-			"checksumSHA1": "dGwcTMV/AOdJU6IXMJsEcuX6O04=",
-			"path": "github.com/lucas-clemente/quic-go/internal/wire",
-			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
-			"revisionTime": "2017-12-12T10:29:19Z"
-		},
-		{
-			"checksumSHA1": "RaG0jfP+lFzgedW98Bfp0Uri7EY=",
-			"path": "github.com/lucas-clemente/quic-go/qerr",
-			"revision": "ded0eb4f6f30a8049bd334a26ff7ff728648fe13",
-			"revisionTime": "2017-12-12T10:29:19Z"
 		},
 		{
 			"checksumSHA1": "SaVXxoFG75x104SdXULcP0g7uwc=",
@@ -439,12 +289,6 @@
 			"revisionTime": "2017-02-14T06:09:35Z"
 		},
 		{
-			"checksumSHA1": "IQkUIOnvlf0tYloFx9mLaXSvXWQ=",
-			"path": "golang.org/x/crypto/curve25519",
-			"revision": "94eea52f7b742c7cbe0b03b22f0c4c8631ece122",
-			"revisionTime": "2017-11-28T01:43:40Z"
-		},
-		{
 			"checksumSHA1": "X6Q8nYb+KXh+64AKHwWOOcyijHQ=",
 			"path": "golang.org/x/crypto/ed25519",
 			"revision": "9419663f5a44be8b34ca85f08abc5fe1be11f8a3",
@@ -455,12 +299,6 @@
 			"path": "golang.org/x/crypto/ed25519/internal/edwards25519",
 			"revision": "9419663f5a44be8b34ca85f08abc5fe1be11f8a3",
 			"revisionTime": "2017-09-30T17:45:11Z"
-		},
-		{
-			"checksumSHA1": "4D8hxMIaSDEW5pCQk22Xj4DcDh4=",
-			"path": "golang.org/x/crypto/hkdf",
-			"revision": "94eea52f7b742c7cbe0b03b22f0c4c8631ece122",
-			"revisionTime": "2017-11-28T01:43:40Z"
 		},
 		{
 			"checksumSHA1": "1MGpGDQqnUoRpv7VEcQrXOBydXE=",

--- a/python/lib/packet/scion_udp.py
+++ b/python/lib/packet/scion_udp.py
@@ -19,7 +19,7 @@
 import struct
 
 # External
-import scapy.utils
+from pypacker import checksum
 
 # SCION
 from lib.errors import SCIONChecksumFailed
@@ -117,7 +117,7 @@ class SCIONUDPHeader(L4HeaderBase):
             b"\x00", struct.pack("!B", L4Proto.UDP),
             self.pack(payload, checksum=bytes(2)), payload,
         ])
-        chk_int = scapy.utils.checksum(pseudo_header)
+        chk_int = checksum.in_cksum(pseudo_header)
         return struct.pack("!H", chk_int)
 
     def reverse(self):

--- a/python/lib/packet/scmp/hdr.py
+++ b/python/lib/packet/scmp/hdr.py
@@ -20,7 +20,7 @@ import struct
 import time
 
 # External
-import scapy.utils
+from pypacker import checksum
 
 # SCION
 from lib.errors import SCIONChecksumFailed
@@ -129,7 +129,7 @@ class SCMPHeader(L4HeaderBase):
             b"\x00", struct.pack("!B", L4Proto.SCMP),
             self.pack(payload, checksum=bytes(2)), payload,
         ])
-        chk_int = scapy.utils.checksum(pseudo_header)
+        chk_int = checksum.in_cksum(pseudo_header)
         return struct.pack("!H", chk_int)
 
     def __len__(self):  # pragma: no cover

--- a/python/test/lib/packet/scion_udp_test.py
+++ b/python/test/lib/packet/scion_udp_test.py
@@ -81,8 +81,8 @@ class TestSCIONUDPHeaderCalcChecksum(object):
     """
     Unit tests for lib.packet.scion_udp.SCIONUDPHeader._calc_checksum
     """
-    @patch("lib.packet.scion_udp.scapy.utils.checksum", autospec=True)
-    def test(self, scapy_checksum):
+    @patch("lib.packet.scion_udp.checksum.in_cksum", autospec=True)
+    def test(self, in_cksum):
         inst = SCIONUDPHeader()
         inst._dst = create_mock_full({
             "isd_as": create_mock_full({"pack()": b"dsIA"}),
@@ -98,11 +98,11 @@ class TestSCIONUDPHeaderCalcChecksum(object):
             b"dsIA", b"srIA", b"dstH", b"srcH", b"\x00", bytes([L4Proto.UDP]),
             b"packed with null checksum", payload,
         ])
-        scapy_checksum.return_value = 0x3412
+        in_cksum.return_value = 0x3412
         # Call
         ntools.eq_(inst._calc_checksum(payload), bytes.fromhex("3412"))
         # Tests
-        scapy_checksum.assert_called_once_with(expected_call)
+        in_cksum.assert_called_once_with(expected_call)
 
 
 class TestSCIONUDPHeaderReverse(object):

--- a/python/test/lib/packet/scmp/hdr_test.py
+++ b/python/test/lib/packet/scmp/hdr_test.py
@@ -81,8 +81,8 @@ class TestSCMPHeaderCalcChecksum(object):
     """
     Unit tests for lib.packet.scmp.hdr.SCMPHeader._calc_checksum
     """
-    @patch("lib.packet.scmp.hdr.scapy.utils.checksum", autospec=True)
-    def test(self, scapy_checksum):
+    @patch("lib.packet.scmp.hdr.checksum.in_cksum", autospec=True)
+    def test(self, in_cksum):
         inst = SCMPHeader()
         src_ia = create_mock_full({"pack()": b"srIA"})
         src_host = create_mock_full({"pack()": b"sHst"})
@@ -97,11 +97,11 @@ class TestSCMPHeaderCalcChecksum(object):
             b"dsIA", b"srIA", b"dHst", b"sHst", b"\x00", bytes([L4Proto.SCMP]),
             b"packed with null checksum", payload,
         ])
-        scapy_checksum.return_value = 0x3412
+        in_cksum.return_value = 0x3412
         # Call
         ntools.eq_(inst._calc_checksum(payload), bytes.fromhex("3412"))
         # Tests
-        scapy_checksum.assert_called_once_with(expected_call)
+        in_cksum.assert_called_once_with(expected_call)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- scapy-python3 uses GPL, so replacing it with pypacker which is
  BSD-licensed.
- quic-go unfortunately depends on 4 repos which are unlicensed, so
  until this can be remedied, all quic-go support is disabled and the
  depdendencies are removed.

Also:
- Remove some unused Go deps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1435)
<!-- Reviewable:end -->
