### PR TITLE
Change addr.ISD_AS to value and rename to addr.IA

### DIFF
--- a/go/border/conf/conf.go
+++ b/go/border/conf/conf.go
@@ -37,7 +37,7 @@ type Conf struct {
 	// of interface IDs to routers, and the actual topology.
 	Topo *topology.Topo
 	// IA is the current ISD-AS.
-	IA *addr.ISD_AS
+	IA addr.IA
 	// BR is the topology information of this router.
 	BR *topology.BRInfo
 	// ASConf is the local AS configuration.

--- a/go/border/gen.go
+++ b/go/border/gen.go
@@ -46,7 +46,7 @@ const (
 )
 
 // genPkt is a generic function to generate packets that originate at the router.
-func (r *Router) genPkt(dstIA *addr.ISD_AS, dstHost addr.HostAddr, dstL4Port int,
+func (r *Router) genPkt(dstIA addr.IA, dstHost addr.HostAddr, dstL4Port int,
 	srcAddr *topology.AddrInfo, pld common.Payload) error {
 	ctx := rctx.Get()
 	dirTo := rcmn.DirExternal

--- a/go/border/netconf/interface.go
+++ b/go/border/netconf/interface.go
@@ -135,7 +135,7 @@ type Interface struct {
 	// of the link.
 	RemoteAddr *topology.AddrInfo
 	// RemoteIA is the ISD-AS of the other end of the link.
-	RemoteIA *addr.ISD_AS
+	RemoteIA addr.IA
 	// BW is the bandwidth of the link.
 	BW int
 	// MTU is the maximum packet size allowed on the link, in bytes.

--- a/go/border/rpkt/addr.go
+++ b/go/border/rpkt/addr.go
@@ -22,24 +22,24 @@ import (
 )
 
 // DstIA retrieves the destination ISD-AS if it isn't already known.
-func (rp *RtrPkt) DstIA() (*addr.ISD_AS, error) {
-	if rp.dstIA == nil {
+func (rp *RtrPkt) DstIA() (addr.IA, error) {
+	if rp.dstIA.IsUnset() {
 		var err error
 		rp.dstIA, err = rp.hookIA(rp.hooks.DstIA, rp.idxs.dstIA)
 		if err != nil {
-			return nil, common.NewBasicError("Unable to retrieve destination ISD-AS", err)
+			return addr.EmptyIA, common.NewBasicError("Unable to retrieve destination ISD-AS", err)
 		}
 	}
 	return rp.dstIA, nil
 }
 
 // SrcIA retrieves the source ISD-AS if it isn't already known.
-func (rp *RtrPkt) SrcIA() (*addr.ISD_AS, error) {
-	if rp.srcIA == nil {
+func (rp *RtrPkt) SrcIA() (addr.IA, error) {
+	if rp.srcIA.IsUnset() {
 		var err error
 		rp.srcIA, err = rp.hookIA(rp.hooks.SrcIA, rp.idxs.srcIA)
 		if err != nil {
-			return nil, common.NewBasicError("Unable to retrieve source ISD-AS", err)
+			return addr.EmptyIA, common.NewBasicError("Unable to retrieve source ISD-AS", err)
 		}
 	}
 	return rp.srcIA, nil
@@ -47,12 +47,12 @@ func (rp *RtrPkt) SrcIA() (*addr.ISD_AS, error) {
 
 // hookIA is a helper method used by DstIA/SrcIA to run ISD-AS retrieval hooks,
 // falling back to parsing the address header directly otherwise.
-func (rp *RtrPkt) hookIA(hooks []hookIA, idx int) (*addr.ISD_AS, error) {
+func (rp *RtrPkt) hookIA(hooks []hookIA, idx int) (addr.IA, error) {
 	for _, f := range hooks {
 		ret, ia, err := f()
 		switch {
 		case err != nil:
-			return nil, err
+			return addr.EmptyIA, err
 		case ret == HookContinue:
 			continue
 		case ret == HookFinish:

--- a/go/border/rpkt/addr.go
+++ b/go/border/rpkt/addr.go
@@ -23,11 +23,11 @@ import (
 
 // DstIA retrieves the destination ISD-AS if it isn't already known.
 func (rp *RtrPkt) DstIA() (addr.IA, error) {
-	if rp.dstIA.IsUnset() {
+	if rp.dstIA.IsZero() {
 		var err error
 		rp.dstIA, err = rp.hookIA(rp.hooks.DstIA, rp.idxs.dstIA)
 		if err != nil {
-			return addr.EmptyIA, common.NewBasicError("Unable to retrieve destination ISD-AS", err)
+			return addr.IA{}, common.NewBasicError("Unable to retrieve destination ISD-AS", err)
 		}
 	}
 	return rp.dstIA, nil
@@ -35,11 +35,11 @@ func (rp *RtrPkt) DstIA() (addr.IA, error) {
 
 // SrcIA retrieves the source ISD-AS if it isn't already known.
 func (rp *RtrPkt) SrcIA() (addr.IA, error) {
-	if rp.srcIA.IsUnset() {
+	if rp.srcIA.IsZero() {
 		var err error
 		rp.srcIA, err = rp.hookIA(rp.hooks.SrcIA, rp.idxs.srcIA)
 		if err != nil {
-			return addr.EmptyIA, common.NewBasicError("Unable to retrieve source ISD-AS", err)
+			return addr.IA{}, common.NewBasicError("Unable to retrieve source ISD-AS", err)
 		}
 	}
 	return rp.srcIA, nil
@@ -52,7 +52,7 @@ func (rp *RtrPkt) hookIA(hooks []hookIA, idx int) (addr.IA, error) {
 		ret, ia, err := f()
 		switch {
 		case err != nil:
-			return addr.EmptyIA, err
+			return addr.IA{}, err
 		case ret == HookContinue:
 			continue
 		case ret == HookFinish:

--- a/go/border/rpkt/extn_traceroute.go
+++ b/go/border/rpkt/extn_traceroute.go
@@ -75,7 +75,7 @@ func (t *rTraceroute) Entry(idx int) (*spkt.TracerouteEntry, error) {
 	}
 	entry := spkt.TracerouteEntry{}
 	offset := common.ExtnFirstLineLen + common.LineLen*idx
-	entry.IA = *addr.IAFromRaw(t.raw[offset:])
+	entry.IA = addr.IAFromRaw(t.raw[offset:])
 	offset += addr.IABytes
 	entry.IfID = common.Order.Uint16(t.raw[offset:])
 	offset += 2
@@ -105,7 +105,7 @@ func (t *rTraceroute) Process() (HookResult, error) {
 	// Take the current time in milliseconds, and truncate it to 16bits.
 	ts := (time.Now().UnixNano() / 1000) % (1 << 16)
 	entry := spkt.TracerouteEntry{
-		IA: *t.rp.Ctx.Conf.IA, IfID: uint16(*t.rp.ifCurr), TimeStamp: uint16(ts),
+		IA: t.rp.Ctx.Conf.IA, IfID: uint16(*t.rp.ifCurr), TimeStamp: uint16(ts),
 	}
 	if err := t.Add(&entry); err != nil {
 		t.Error("Unable to add entry", "err", err)

--- a/go/border/rpkt/hooks.go
+++ b/go/border/rpkt/hooks.go
@@ -25,7 +25,7 @@ import (
 	"github.com/scionproto/scion/go/lib/spath"
 )
 
-type hookIA func() (HookResult, *addr.ISD_AS, error)
+type hookIA func() (HookResult, addr.IA, error)
 type hookHost func() (HookResult, addr.HostAddr, error)
 type hookInfoF func() (HookResult, *spath.InfoField, error)
 type hookHopF func() (HookResult, *spath.HopField, error)

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -42,7 +42,7 @@ func (rp *RtrPkt) Parse() error {
 	if _, err := rp.DstIA(); err != nil {
 		return err
 	}
-	if *rp.dstIA == *rp.Ctx.Conf.IA {
+	if rp.dstIA.Eq(rp.Ctx.Conf.IA) {
 		// If the destination is local, parse the destination host as well.
 		if _, err := rp.DstHost(); err != nil {
 			return err
@@ -63,7 +63,7 @@ func (rp *RtrPkt) Parse() error {
 	if _, err := rp.IFNext(); err != nil {
 		return err
 	}
-	if *rp.dstIA != *rp.Ctx.Conf.IA {
+	if !rp.dstIA.Eq(rp.Ctx.Conf.IA) {
 		// If the destination isn't local, parse the next interface ID as well.
 		if _, err := rp.IFNext(); err != nil {
 			return err
@@ -156,7 +156,7 @@ func (rp *RtrPkt) setDirTo() {
 		assert.Mustf(rp.DirFrom != rcmn.DirUnset, rp.ErrStr, "DirFrom must not be DirUnset.")
 		assert.Mustf(rp.ifCurr != nil, rp.ErrStr, "rp.ifCurr must not be nil.")
 	}
-	if *rp.dstIA != *rp.Ctx.Conf.IA {
+	if !rp.dstIA.Eq(rp.Ctx.Conf.IA) {
 		// Packet is not destined to the local AS, so it can't be DirSelf.
 		if rp.DirFrom == rcmn.DirLocal {
 			rp.DirTo = rcmn.DirExternal

--- a/go/border/rpkt/process.go
+++ b/go/border/rpkt/process.go
@@ -42,7 +42,7 @@ const (
 // NeedsLocalProcessing determines if the router needs to do more than just
 // forward a packet (e.g. resolve an SVC destination address).
 func (rp *RtrPkt) NeedsLocalProcessing() error {
-	if *rp.dstIA != *rp.Ctx.Conf.IA {
+	if !rp.dstIA.Eq(rp.Ctx.Conf.IA) {
 		// Packet isn't to this ISD-AS, so just forward.
 		rp.hooks.Route = append(rp.hooks.Route, rp.forward)
 		return nil

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -85,9 +85,9 @@ type RtrPkt struct {
 	// packet. (PARSE)
 	idxs packetIdxs
 	// dstIA is the destination ISD-AS. (PARSE)
-	dstIA *addr.ISD_AS
+	dstIA addr.IA
 	// srcIA is the source ISD-AS. (PARSE, only if needed)
-	srcIA *addr.ISD_AS
+	srcIA addr.IA
 	// dstHost is the destination Host. (PARSE, only if dstIA is local)
 	dstHost addr.HostAddr
 	// srcHost is the source Host. (PARSE, only if needed)
@@ -226,8 +226,8 @@ func (rp *RtrPkt) Reset() {
 	// CmnHdr doesn't contain any references.
 	rp.IncrementedPath = false
 	rp.idxs = packetIdxs{}
-	rp.dstIA = nil
-	rp.srcIA = nil
+	rp.dstIA = addr.EmptyIA
+	rp.srcIA = addr.EmptyIA
 	rp.dstHost = nil
 	rp.srcHost = nil
 	rp.infoF = nil

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -226,8 +226,8 @@ func (rp *RtrPkt) Reset() {
 	// CmnHdr doesn't contain any references.
 	rp.IncrementedPath = false
 	rp.idxs = packetIdxs{}
-	rp.dstIA = addr.EmptyIA
-	rp.srcIA = addr.EmptyIA
+	rp.dstIA = addr.IA{}
+	rp.srcIA = addr.IA{}
 	rp.dstHost = nil
 	rp.srcHost = nil
 	rp.infoF = nil

--- a/go/border/rpkt/rpkt_hook_test.go
+++ b/go/border/rpkt/rpkt_hook_test.go
@@ -42,38 +42,38 @@ func TestHooksSrcDstIA(t *testing.T) {
 	Convey("Fetch SrcIA, DstIA via hook functions", t, func() {
 		rpkt := setupRtrPktHookTest()
 
-		srcIA := &addr.ISD_AS{I: 1, A: 2}
-		dstIA := &addr.ISD_AS{I: 3, A: 4}
+		srcIA := addr.IA{I: 1, A: 2}
+		dstIA := addr.IA{I: 3, A: 4}
 
 		rpkt.hooks = hooks{
-			SrcIA: []hookIA{func() (HookResult, *addr.ISD_AS, error) {
+			SrcIA: []hookIA{func() (HookResult, addr.IA, error) {
 				fetched++
 				return HookFinish, srcIA, nil
 			}},
-			DstIA: []hookIA{func() (HookResult, *addr.ISD_AS, error) {
+			DstIA: []hookIA{func() (HookResult, addr.IA, error) {
 				fetched++
 				return HookFinish, dstIA, nil
 			}},
 		}
-		var ia *addr.ISD_AS
+		var ia addr.IA
 
 		ia, err = rpkt.DstIA()
-		SoMsg("Destination address wrong", ia, ShouldEqual, dstIA)
+		SoMsg("Destination address wrong", ia, ShouldResemble, dstIA)
 		SoMsg("Should be no error when calling destination address getter", err, ShouldBeNil)
 
 		ia, err = rpkt.DstIA()
-		SoMsg("Destination address wrong on second getter call", ia, ShouldEqual, dstIA)
+		SoMsg("Destination address wrong on second getter call", ia, ShouldResemble, dstIA)
 		SoMsg("Destination address must only be fetched once, cached value must be reused on the"+
 			" second call", fetched, ShouldEqual, 1)
 		SoMsg("Should be no error when calling destination address getter for cached value", err,
 			ShouldBeNil)
 
 		ia, err = rpkt.SrcIA()
-		SoMsg("Source address wrong", ia, ShouldEqual, srcIA)
+		SoMsg("Source address wrong", ia, ShouldResemble, srcIA)
 		SoMsg("Should be no error when calling source address getter", err, ShouldBeNil)
 
 		ia, err = rpkt.SrcIA()
-		SoMsg("Source address wrong on cached getter call", ia, ShouldEqual, srcIA)
+		SoMsg("Source address wrong on cached getter call", ia, ShouldResemble, srcIA)
 		SoMsg("Should be no error when calling destination address getter for cached value", err,
 			ShouldBeNil)
 		SoMsg("Two fetches are expected (both source and destination address, each exactly once)",

--- a/go/border/rpkt/rpkt_test.go
+++ b/go/border/rpkt/rpkt_test.go
@@ -46,7 +46,7 @@ func prepareRtrPacketSample() *RtrPkt {
 	r.Raw = packet
 	// Set some other data that are required for the parsing to succeed:
 	var config = &conf.Conf{
-		IA: &addr.ISD_AS{I: 1, A: 2},
+		IA: addr.IA{I: 1, A: 2},
 		Net: &netconf.NetConf{
 			IFs: map[common.IFIDType]*netconf.Interface{777: nil},
 		},
@@ -66,8 +66,8 @@ func TestParseBasic(t *testing.T) {
 		srcHost, _ := r.SrcHost()
 		dstHost, _ := r.DstHost()
 
-		SoMsg("Source IA", *srcIA, ShouldResemble, addr.ISD_AS{I: 1, A: 14})
-		SoMsg("Destination IA", *dstIA, ShouldResemble, addr.ISD_AS{I: 1, A: 17})
+		SoMsg("Source IA", srcIA, ShouldResemble, addr.IA{I: 1, A: 14})
+		SoMsg("Destination IA", dstIA, ShouldResemble, addr.IA{I: 1, A: 17})
 		SoMsg("Source host IP", srcHost, ShouldResemble, addr.HostIPv4{127, 0, 0, 26})
 		SoMsg("Destination host IP", dstHost, ShouldResemble, addr.HostIPv4{127, 0, 0, 27})
 		SoMsg("CmnHdr", r.CmnHdr, ShouldResemble, spkt.CmnHdr{

--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -42,7 +42,7 @@ const (
 	ReplyMsg        = "pong!"
 )
 
-func GetDefaultSCIONDPath(ia *addr.ISD_AS) string {
+func GetDefaultSCIONDPath(ia addr.IA) string {
 	return fmt.Sprintf("/run/shm/sciond/sd%v.sock", ia)
 }
 

--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -24,102 +24,94 @@ import (
 )
 
 const (
-	IABytes = 4
-	MaxISD  = (1 << 12) - 1
-	MaxAS   = (1 << 20) - 1
+	IABytes       = 4
+	MaxISD        = (1 << 12) - 1
+	MaxAS         = (1 << 20) - 1
+	ErrorIAUnpack = "Unable to unpack ISD-AS"
 )
 
-var _ encoding.TextUnmarshaler = (*ISD_AS)(nil)
+var EmptyIA = IA{}
 
-type ISD_AS struct {
+var _ encoding.TextUnmarshaler = (*IA)(nil)
+
+// IA represents the ISD (Isolation Domain) and AS (Autonomous System) Id of a given SCION AS.
+type IA struct {
 	I int
 	A int
 }
 
-const (
-	ErrorIAUnpack = "Unable to unpack ISD-AS"
-)
-
-func IAFromRaw(b common.RawBytes) *ISD_AS {
-	ia := &ISD_AS{}
+func IAFromRaw(b common.RawBytes) IA {
+	ia := &IA{}
 	ia.Parse(b)
-	return ia
+	return *ia
 }
 
-func IAFromString(s string) (*ISD_AS, error) {
+func IAFromString(s string) (IA, error) {
 	parts := strings.Split(s, "-")
 	if len(parts) != 2 {
-		return nil, common.NewBasicError("Invalid ISD-AS", nil, "val", s)
+		return EmptyIA, common.NewBasicError("Invalid ISD-AS", nil, "val", s)
 	}
 	isd, err := strconv.Atoi(parts[0])
 	if err != nil {
 		// err.Error() will contain the original value
-		return nil, common.NewBasicError("Unable to parse ISD", err)
+		return EmptyIA, common.NewBasicError("Unable to parse ISD", err)
 	}
 	if isd > MaxISD {
-		return nil, common.NewBasicError("Invalid ISD-AS: ISD too large", nil,
+		return EmptyIA, common.NewBasicError("Invalid ISD-AS: ISD too large", nil,
 			"max", MaxISD, "actual", isd, "raw", s)
 	}
 	as, err := strconv.Atoi(parts[1])
 	if err != nil {
 		// err.Error() will contain the original value
-		return nil, common.NewBasicError("Unable to parse AS", err)
+		return EmptyIA, common.NewBasicError("Unable to parse AS", err)
 	}
 	if as > MaxAS {
-		return nil, common.NewBasicError("Invalid ISD-AS: AS too large", nil,
+		return EmptyIA, common.NewBasicError("Invalid ISD-AS: AS too large", nil,
 			"max", MaxAS, "actual", as, "raw", s)
 	}
-	return &ISD_AS{I: isd, A: as}, nil
+	return IA{I: isd, A: as}, nil
 }
 
-func (ia ISD_AS) MarshalText() ([]byte, error) {
+func (ia IA) MarshalText() ([]byte, error) {
 	return []byte(ia.String()), nil
 }
 
 // allows ISD_AS to be used as a map key in JSON.
-func (ia *ISD_AS) UnmarshalText(text []byte) error {
+func (ia *IA) UnmarshalText(text []byte) error {
 	newIA, err := IAFromString(string(text))
 	if err != nil {
 		return err
 	}
-	*ia = *newIA
+	*ia = newIA
 	return nil
 }
 
-func (ia *ISD_AS) Parse(b common.RawBytes) {
-	newIA := IAInt(common.Order.Uint32(b)).IA()
-	*ia = *newIA
+func (ia *IA) Parse(b common.RawBytes) {
+	*ia = IAInt(common.Order.Uint32(b)).IA()
 }
 
-func (ia *ISD_AS) Write(b common.RawBytes) {
+func (ia IA) Write(b common.RawBytes) {
 	common.Order.PutUint32(b, uint32(ia.IAInt()))
 }
 
-func (ia *ISD_AS) IAInt() IAInt {
+func (ia IA) IAInt() IAInt {
 	return IAInt((ia.I << 20) | (ia.A & 0x000FFFFF))
 }
 
-func (ia *ISD_AS) SizeOf() int {
-	return IABytes
+func (ia IA) IsUnset() bool {
+	return ia.I == 0 && ia.A == 0
 }
 
-func (ia *ISD_AS) Copy() *ISD_AS {
-	return &ISD_AS{I: ia.I, A: ia.A}
-}
-
-func (ia *ISD_AS) Eq(other *ISD_AS) bool {
-	if (ia == nil) || (other == nil) {
-		return ia == other
-	}
+func (ia IA) Eq(other IA) bool {
 	return ia.I == other.I && ia.A == other.A
 }
 
-func (ia ISD_AS) String() string {
+func (ia IA) String() string {
 	return fmt.Sprintf("%d-%d", ia.I, ia.A)
 }
 
 type IAInt uint32
 
-func (iaI IAInt) IA() *ISD_AS {
-	return &ISD_AS{I: int(iaI >> 20), A: int(iaI & 0x000FFFFF)}
+func (iaI IAInt) IA() IA {
+	return IA{I: int(iaI >> 20), A: int(iaI & 0x000FFFFF)}
 }

--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -24,13 +24,10 @@ import (
 )
 
 const (
-	IABytes       = 4
-	MaxISD        = (1 << 12) - 1
-	MaxAS         = (1 << 20) - 1
-	ErrorIAUnpack = "Unable to unpack ISD-AS"
+	IABytes = 4
+	MaxISD  = (1 << 12) - 1
+	MaxAS   = (1 << 20) - 1
 )
-
-var EmptyIA = IA{}
 
 var _ encoding.TextUnmarshaler = (*IA)(nil)
 
@@ -49,24 +46,24 @@ func IAFromRaw(b common.RawBytes) IA {
 func IAFromString(s string) (IA, error) {
 	parts := strings.Split(s, "-")
 	if len(parts) != 2 {
-		return EmptyIA, common.NewBasicError("Invalid ISD-AS", nil, "val", s)
+		return IA{}, common.NewBasicError("Invalid ISD-AS", nil, "val", s)
 	}
 	isd, err := strconv.Atoi(parts[0])
 	if err != nil {
 		// err.Error() will contain the original value
-		return EmptyIA, common.NewBasicError("Unable to parse ISD", err)
+		return IA{}, common.NewBasicError("Unable to parse ISD", err)
 	}
 	if isd > MaxISD {
-		return EmptyIA, common.NewBasicError("Invalid ISD-AS: ISD too large", nil,
+		return IA{}, common.NewBasicError("Invalid ISD-AS: ISD too large", nil,
 			"max", MaxISD, "actual", isd, "raw", s)
 	}
 	as, err := strconv.Atoi(parts[1])
 	if err != nil {
 		// err.Error() will contain the original value
-		return EmptyIA, common.NewBasicError("Unable to parse AS", err)
+		return IA{}, common.NewBasicError("Unable to parse AS", err)
 	}
 	if as > MaxAS {
-		return EmptyIA, common.NewBasicError("Invalid ISD-AS: AS too large", nil,
+		return IA{}, common.NewBasicError("Invalid ISD-AS: AS too large", nil,
 			"max", MaxAS, "actual", as, "raw", s)
 	}
 	return IA{I: isd, A: as}, nil
@@ -98,7 +95,7 @@ func (ia IA) IAInt() IAInt {
 	return IAInt((ia.I << 20) | (ia.A & 0x000FFFFF))
 }
 
-func (ia IA) IsUnset() bool {
+func (ia IA) IsZero() bool {
 	return ia.I == 0 && ia.A == 0
 }
 

--- a/go/lib/addr/isdas_test.go
+++ b/go/lib/addr/isdas_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Interface assertions
-var _ fmt.Stringer = (*ISD_AS)(nil)
+var _ fmt.Stringer = (*IA)(nil)
 
 func Test_IAFromRaw(t *testing.T) {
 	Convey("IAFromRaw should parse bytes correctly", t, func() {
@@ -36,7 +36,7 @@ func Test_IAFromRaw(t *testing.T) {
 func Test_IA_Write(t *testing.T) {
 	Convey("ISD_AS.Write() should output bytes correctly", t, func() {
 		output := make([]byte, 4)
-		ia := &ISD_AS{I: 33, A: 44}
+		ia := &IA{I: 33, A: 44}
 		ia.Write(output)
 		So(output, ShouldResemble, []byte{0x02, 0x10, 0x00, 0x2c})
 	})
@@ -44,7 +44,7 @@ func Test_IA_Write(t *testing.T) {
 
 func Test_IA_String(t *testing.T) {
 	Convey("String() should return ISD-AS", t, func() {
-		ia := ISD_AS{33, 55}
+		ia := IA{33, 55}
 		So(ia.String(), ShouldEqual, "33-55")
 	})
 }

--- a/go/lib/crypto/cert/cert.go
+++ b/go/lib/crypto/cert/cert.go
@@ -48,7 +48,7 @@ type Certificate struct {
 	// ExpirationTime is the unix timestamp in seconds at which the certificate expires.
 	ExpirationTime uint64
 	// Issuer is the certificate issuer. It can only be a core AS.
-	Issuer *addr.ISD_AS
+	Issuer addr.IA
 	// IssuingTime is the unix timestamp in seconds at which the certificate was created.
 	IssuingTime uint64
 	// SignAlgorithm is the algorithm associated with SubjectSigKey.
@@ -56,7 +56,7 @@ type Certificate struct {
 	// Signature is the certificate signature. It is computed over the rest of the certificate.
 	Signature common.RawBytes `json:",omitempty"`
 	// Subject is the certificate subject.
-	Subject *addr.ISD_AS
+	Subject addr.IA
 	// SubjectEncKey is the public key used for encryption.
 	SubjectEncKey common.RawBytes
 	// SubjectSignKey the public key used for signature verification.
@@ -81,7 +81,7 @@ func CertificateFromRaw(raw common.RawBytes) (*Certificate, error) {
 // Verify checks the signature of the certificate based on a trusted verifying key and the
 // associated signature algorithm. Further, it verifies that the certificate belongs to the given
 // subject, and that it is valid at the current time.
-func (c *Certificate) Verify(subject *addr.ISD_AS, verifyKey common.RawBytes, signAlgo string) error {
+func (c *Certificate) Verify(subject addr.IA, verifyKey common.RawBytes, signAlgo string) error {
 	if !subject.Eq(c.Subject) {
 		return common.NewBasicError(InvalidSubject, nil,
 			"expected", c.Subject, "actual", subject)
@@ -162,11 +162,11 @@ func (c *Certificate) Copy() *Certificate {
 		Comment:        c.Comment,
 		EncAlgorithm:   c.EncAlgorithm,
 		ExpirationTime: c.ExpirationTime,
-		Issuer:         c.Issuer.Copy(),
+		Issuer:         c.Issuer,
 		IssuingTime:    c.IssuingTime,
 		SignAlgorithm:  c.SignAlgorithm,
 		Signature:      make(common.RawBytes, len(c.Signature)),
-		Subject:        c.Subject.Copy(),
+		Subject:        c.Subject,
 		SubjectEncKey:  make(common.RawBytes, len(c.SubjectEncKey)),
 		SubjectSignKey: make(common.RawBytes, len(c.SubjectSignKey)),
 		TRCVersion:     c.TRCVersion,

--- a/go/lib/crypto/cert/cert_test.go
+++ b/go/lib/crypto/cert/cert_test.go
@@ -81,7 +81,7 @@ func Test_Certificate_Verify(t *testing.T) {
 	Convey("Load Certificate from Raw and init values", t, func() {
 		cert := loadCert(fnLeaf, t)
 		pub, priv, _ := ed25519.GenerateKey(nil)
-		subject := &addr.ISD_AS{I: 1, A: 10}
+		subject := addr.IA{I: 1, A: 10}
 		pubRaw, privRaw := []byte(pub), []byte(priv)
 
 		cert.IssuingTime = uint64(time.Now().Unix())
@@ -94,7 +94,7 @@ func Test_Certificate_Verify(t *testing.T) {
 		})
 
 		Convey("Wrong subject throws error", func() {
-			err := cert.Verify(&addr.ISD_AS{I: 1, A: 14}, pubRaw, crypto.Ed25519)
+			err := cert.Verify(addr.IA{I: 1, A: 14}, pubRaw, crypto.Ed25519)
 			SoMsg("err", err, ShouldNotBeNil)
 		})
 
@@ -191,7 +191,7 @@ func Test_Certificate_Eq(t *testing.T) {
 			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (Issuer)", func() {
-			c1.Issuer = &addr.ISD_AS{I: 13, A: 37}
+			c1.Issuer = addr.IA{I: 13, A: 37}
 			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (IssuingTime)", func() {
@@ -207,7 +207,7 @@ func Test_Certificate_Eq(t *testing.T) {
 			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (Subject)", func() {
-			c1.Subject = &addr.ISD_AS{I: 13, A: 37}
+			c1.Subject = addr.IA{I: 13, A: 37}
 			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (SubjectEncKey)", func() {

--- a/go/lib/crypto/cert/chain.go
+++ b/go/lib/crypto/cert/chain.go
@@ -48,12 +48,12 @@ const (
 )
 
 type Key struct {
-	IA  addr.ISD_AS
+	IA  addr.IA
 	Ver uint64
 }
 
-func NewKey(ia *addr.ISD_AS, ver uint64) *Key {
-	return &Key{IA: *ia, Ver: ver}
+func NewKey(ia addr.IA, ver uint64) *Key {
+	return &Key{IA: ia, Ver: ver}
 }
 
 func (k *Key) String() string {
@@ -94,7 +94,7 @@ func ChainFromRaw(raw common.RawBytes, lz4_ bool) (*Chain, error) {
 	return c, nil
 }
 
-func (c *Chain) Verify(subject *addr.ISD_AS, t *trc.TRC) error {
+func (c *Chain) Verify(subject addr.IA, t *trc.TRC) error {
 	if c.Leaf.IssuingTime < c.Core.IssuingTime {
 		return common.NewBasicError(LeafIssuedBefore, nil, "leaf",
 			util.TimeToString(c.Leaf.IssuingTime), "core",
@@ -116,7 +116,7 @@ func (c *Chain) Verify(subject *addr.ISD_AS, t *trc.TRC) error {
 			util.TimeToString(c.Core.ExpirationTime), "TRC",
 			util.TimeToString(t.ExpirationTime))
 	}
-	coreAS, ok := t.CoreASes[*c.Core.Issuer]
+	coreAS, ok := t.CoreASes[c.Core.Issuer]
 	if !ok {
 		return common.NewBasicError(IssASNotFound, nil, "isdas", c.Core.Issuer, "coreASes",
 			t.CoreASes)
@@ -163,7 +163,7 @@ func (c *Chain) Eq(o *Chain) bool {
 	return c.Leaf.Eq(o.Leaf) && c.Core.Eq(o.Core)
 }
 
-func (c *Chain) IAVer() (*addr.ISD_AS, uint64) {
+func (c *Chain) IAVer() (addr.IA, uint64) {
 	return c.Leaf.Subject, c.Leaf.Version
 }
 

--- a/go/lib/crypto/cert/chain_test.go
+++ b/go/lib/crypto/cert/chain_test.go
@@ -112,9 +112,9 @@ func Test_Chain_Verify(t *testing.T) {
 		chain.Core.ExpirationTime = chain.Leaf.IssuingTime + 1<<20
 		chain.Core.Sign(privTRCRaw, crypto.Ed25519)
 
-		trc_.CoreASes[*chain.Core.Issuer].OnlineKey = pubTRCRaw
+		trc_.CoreASes[chain.Core.Issuer].OnlineKey = pubTRCRaw
 		trc_.ExpirationTime = chain.Core.ExpirationTime
-		err := chain.Verify(&addr.ISD_AS{I: 1, A: 10}, trc_)
+		err := chain.Verify(addr.IA{I: 1, A: 10}, trc_)
 		SoMsg("err", err, ShouldBeNil)
 	})
 }
@@ -150,7 +150,7 @@ func Test_Chain_IAVer(t *testing.T) {
 	Convey("IA version tuple is returned correctly", t, func() {
 		chain := loadChain(fnChain, t)
 		ia, ver := chain.IAVer()
-		SoMsg("IA", ia.Eq(&addr.ISD_AS{I: 1, A: 10}), ShouldBeTrue)
+		SoMsg("IA", ia.Eq(addr.IA{I: 1, A: 10}), ShouldBeTrue)
 		SoMsg("Ver", ver, ShouldEqual, 1)
 	})
 }
@@ -178,13 +178,13 @@ func Test_Chain_Key(t *testing.T) {
 	Convey("Key is returned correctly", t, func() {
 		chain := loadChain(fnChain, t)
 		key := *chain.Key()
-		SoMsg("Key", key, ShouldResemble, Key{IA: addr.ISD_AS{I: 1, A: 10}, Ver: 1})
+		SoMsg("Key", key, ShouldResemble, Key{IA: addr.IA{I: 1, A: 10}, Ver: 1})
 	})
 }
 
 func Test_Key_String(t *testing.T) {
 	Convey("Key represented as string correctly", t, func() {
-		SoMsg("Key", (&Key{IA: addr.ISD_AS{I: 1, A: 10}, Ver: 1}).String(), ShouldEqual,
+		SoMsg("Key", (&Key{IA: addr.IA{I: 1, A: 10}, Ver: 1}).String(), ShouldEqual,
 			"1-10v1")
 	})
 }

--- a/go/lib/crypto/trc/entries.go
+++ b/go/lib/crypto/trc/entries.go
@@ -107,7 +107,7 @@ func (c *CertLog) UnmarshalJSON(b []byte) error {
 // Addr is the (ISD-AS IP)-tuple used for entity addresses in the TRC file.
 type Addr struct {
 	// IA is the ISD-AS.
-	IA *addr.ISD_AS
+	IA addr.IA
 	// IP is the IP.
 	IP net.IP
 }

--- a/go/lib/crypto/trc/trc_test.go
+++ b/go/lib/crypto/trc/trc_test.go
@@ -58,7 +58,7 @@ func Test_TRCFromRaw(t *testing.T) {
 			SoMsg("Log2", trc.CertLogs["Log2"], ShouldNotBeNil)
 			ip := net.ParseIP("127.0.0.75")
 			SoMsg("Log1 addr", trc.CertLogs["Log1"].Addr, ShouldResemble,
-				&Addr{IA: &addr.ISD_AS{I: 1, A: 11}, IP: ip})
+				&Addr{IA: addr.IA{I: 1, A: 11}, IP: ip})
 			SoMsg("Log1 cert", trc.CertLogs["Log1"].Certificate, ShouldResemble,
 				common.RawBytes{0xe3, 0x48, 0x78, 0xbc, 0xee, 0x40, 0x28, 0x71,
 					0x87, 0x93, 0x72, 0x31, 0xa3, 0x7d, 0xaf, 0xcb, 0xf0, 0x07,
@@ -67,9 +67,9 @@ func Test_TRCFromRaw(t *testing.T) {
 		})
 
 		Convey("CoreASes parsed correctly", func() {
-			SoMsg("1-11", trc.CoreASes[addr.ISD_AS{I: 1, A: 11}], ShouldNotBeNil)
-			SoMsg("1-12", trc.CoreASes[addr.ISD_AS{I: 1, A: 12}], ShouldNotBeNil)
-			SoMsg("1-13", trc.CoreASes[addr.ISD_AS{I: 1, A: 13}], ShouldNotBeNil)
+			SoMsg("1-11", trc.CoreASes[addr.IA{I: 1, A: 11}], ShouldNotBeNil)
+			SoMsg("1-12", trc.CoreASes[addr.IA{I: 1, A: 12}], ShouldNotBeNil)
+			SoMsg("1-13", trc.CoreASes[addr.IA{I: 1, A: 13}], ShouldNotBeNil)
 			entry := &CoreAS{OfflineKeyAlg: crypto.Ed25519, OnlineKeyAlg: crypto.Ed25519}
 			entry.OfflineKey = []byte{0x2b, 0x75, 0x84, 0xd7, 0xb4, 0x3d, 0xb3, 0xff,
 				0x38, 0x76, 0x38, 0x9d, 0xd3, 0x44, 0x51, 0x12, 0x77, 0xba, 0x48,
@@ -80,7 +80,7 @@ func Test_TRCFromRaw(t *testing.T) {
 				0x8d, 0xee, 0x4c, 0xf7, 0xc3, 0x70, 0xd5, 0x98, 0xf7, 0x0e, 0x42,
 				0x91, 0xd4}
 
-			SoMsg("CoreAS 1-11", trc.CoreASes[addr.ISD_AS{I: 1, A: 11}], ShouldResemble,
+			SoMsg("CoreAS 1-11", trc.CoreASes[addr.IA{I: 1, A: 11}], ShouldResemble,
 				entry)
 		})
 
@@ -97,7 +97,7 @@ func Test_TRCFromRaw(t *testing.T) {
 					0x8b, 0xdc, 0x0c, 0x78})
 			ip := net.ParseIP("127.0.0.107")
 			SoMsg("TRCSrv", trc.RAINS.TRCSrv[0], ShouldResemble,
-				&Addr{IA: &addr.ISD_AS{I: 1, A: 12}, IP: ip})
+				&Addr{IA: addr.IA{I: 1, A: 12}, IP: ip})
 			SoMsg("TRCSrv size", len(trc.RAINS.TRCSrv), ShouldEqual, 3)
 		})
 
@@ -117,8 +117,8 @@ func Test_TRCFromRaw(t *testing.T) {
 				0x1f, 0xad}
 			ipA := net.ParseIP("127.0.0.70")
 			ipT := net.ParseIP("127.0.0.71")
-			entry.ARPKISrv = []*Addr{{IA: &addr.ISD_AS{I: 1, A: 11}, IP: ipA}}
-			entry.TRCSrv = []*Addr{{IA: &addr.ISD_AS{I: 1, A: 11}, IP: ipT}}
+			entry.ARPKISrv = []*Addr{{IA: addr.IA{I: 1, A: 11}, IP: ipA}}
+			entry.TRCSrv = []*Addr{{IA: addr.IA{I: 1, A: 11}, IP: ipT}}
 			SoMsg("RootCA CA1-1", trc.RootCAs["CA1-1"], ShouldResemble, entry)
 		})
 
@@ -145,7 +145,7 @@ func Test_TRCFromRaw(t *testing.T) {
 	})
 }
 
-type ISDAS []*addr.ISD_AS
+type ISDAS []addr.IA
 
 func (i ISDAS) Len() int           { return len(i) }
 func (i ISDAS) Swap(k, j int)      { i[k], i[j] = i[j], i[k] }
@@ -156,7 +156,7 @@ func Test_TRC_CoreASList(t *testing.T) {
 		trc := loadTRC(fnTRC, t)
 		list := trc.CoreASList()
 		sort.Sort(ISDAS(list))
-		SoMsg("CoreASList", list, ShouldResemble, []*addr.ISD_AS{{I: 1, A: 11},
+		SoMsg("CoreASList", list, ShouldResemble, []addr.IA{{I: 1, A: 11},
 			{I: 1, A: 12}, {I: 1, A: 13}})
 	})
 }
@@ -166,7 +166,7 @@ func Test_TRC_Sign(t *testing.T) {
 		trc := loadTRC(fnTRC, t)
 		packd, _ := trc.sigPack()
 		err := crypto.Verify(packd, trc.Signatures["1-11"],
-			trc.CoreASes[addr.ISD_AS{I: 1, A: 11}].OnlineKey, crypto.Ed25519)
+			trc.CoreASes[addr.IA{I: 1, A: 11}].OnlineKey, crypto.Ed25519)
 		SoMsg("err", err, ShouldBeNil)
 		key := []byte{0xaf, 0x00, 0x0e, 0xb6, 0x26, 0x4f, 0xbd, 0x20, 0xd1, 0x36, 0xed,
 			0xae, 0x42, 0x65, 0xeb, 0x29, 0x15, 0x8e, 0xa6, 0x35, 0xef, 0x3d, 0x2a,

--- a/go/lib/ctrl/cert_mgmt/chain_req.go
+++ b/go/lib/ctrl/cert_mgmt/chain_req.go
@@ -31,7 +31,7 @@ type ChainReq struct {
 	CacheOnly bool
 }
 
-func (c *ChainReq) IA() *addr.ISD_AS {
+func (c *ChainReq) IA() addr.IA {
 	return c.RawIA.IA()
 }
 

--- a/go/lib/ctrl/cert_mgmt/trc_req.go
+++ b/go/lib/ctrl/cert_mgmt/trc_req.go
@@ -31,8 +31,8 @@ type TRCReq struct {
 	CacheOnly bool
 }
 
-func (t *TRCReq) IA() *addr.ISD_AS {
-	return &addr.ISD_AS{I: int(t.ISD), A: 0}
+func (t *TRCReq) IA() addr.IA {
+	return addr.IA{I: int(t.ISD), A: 0}
 }
 
 func (t *TRCReq) ProtoId() proto.ProtoIdType {

--- a/go/lib/ctrl/path_mgmt/rev_info.go
+++ b/go/lib/ctrl/path_mgmt/rev_info.go
@@ -45,7 +45,7 @@ func NewRevInfoFromRaw(b common.RawBytes) (*RevInfo, error) {
 	return r, proto.ParseFromRaw(r, r.ProtoId(), b)
 }
 
-func (r *RevInfo) IA() *addr.ISD_AS {
+func (r *RevInfo) IA() addr.IA {
 	return r.RawIsdas.IA()
 }
 func (r *RevInfo) ProtoId() proto.ProtoIdType {

--- a/go/lib/ctrl/path_mgmt/seg_req.go
+++ b/go/lib/ctrl/path_mgmt/seg_req.go
@@ -47,11 +47,11 @@ func NewSegReqFromRaw(b common.RawBytes) (*SegReq, error) {
 	return s, proto.ParseFromRaw(s, s.ProtoId(), b)
 }
 
-func (s *SegReq) SrcIA() *addr.ISD_AS {
+func (s *SegReq) SrcIA() addr.IA {
 	return s.RawSrcIA.IA()
 }
 
-func (s *SegReq) DstIA() *addr.ISD_AS {
+func (s *SegReq) DstIA() addr.IA {
 	return s.RawDstIA.IA()
 }
 

--- a/go/lib/ctrl/seg/as.go
+++ b/go/lib/ctrl/seg/as.go
@@ -45,11 +45,11 @@ func newASEntryFromRaw(b common.RawBytes) (*ASEntry, error) {
 	return ase, proto.ParseFromRaw(ase, ase.ProtoId(), b)
 }
 
-func (ase *ASEntry) IA() *addr.ISD_AS {
+func (ase *ASEntry) IA() addr.IA {
 	return ase.RawIA.IA()
 }
 
-func (ase *ASEntry) Validate(prevIA *addr.ISD_AS, nextIA *addr.ISD_AS) error {
+func (ase *ASEntry) Validate(prevIA addr.IA, nextIA addr.IA) error {
 	if len(ase.HopEntries) == 0 {
 		return common.NewBasicError("ASEntry has no HopEntries", nil, "ia", ase.IA())
 	}

--- a/go/lib/ctrl/seg/hop.go
+++ b/go/lib/ctrl/seg/hop.go
@@ -31,11 +31,11 @@ type HopEntry struct {
 	RawHopField []byte `capnp:"hopF"`
 }
 
-func (e *HopEntry) InIA() *addr.ISD_AS {
+func (e *HopEntry) InIA() addr.IA {
 	return e.RawInIA.IA()
 }
 
-func (e *HopEntry) OutIA() *addr.ISD_AS {
+func (e *HopEntry) OutIA() addr.IA {
 	return e.RawOutIA.IA()
 }
 

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -100,8 +100,8 @@ func (ps *PathSegment) Validate() error {
 		)
 	}
 	for i := range ps.ASEntries {
-		prevIA := &addr.ISD_AS{}
-		nextIA := &addr.ISD_AS{}
+		prevIA := addr.IA{}
+		nextIA := addr.IA{}
 		if i > 0 {
 			prevIA = ps.ASEntries[i-1].IA()
 		}

--- a/go/lib/ctrl/signed_util.go
+++ b/go/lib/ctrl/signed_util.go
@@ -149,7 +149,7 @@ const (
 )
 
 type SignSrcDef struct {
-	IA       *addr.ISD_AS
+	IA       addr.IA
 	ChainVer uint64
 	TRCVer   uint64
 }

--- a/go/lib/hpkt/hpkt_test.go
+++ b/go/lib/hpkt/hpkt_test.go
@@ -93,8 +93,8 @@ var (
 func Test_ParseScnPkt(t *testing.T) {
 	Convey("ScnPkt.Parse should load values correctly", t, func() {
 		s := &spkt.ScnPkt{
-			DstIA: &addr.ISD_AS{},
-			SrcIA: &addr.ISD_AS{},
+			DstIA: addr.IA{},
+			SrcIA: addr.IA{},
 		}
 		err := ParseScnPkt(s, common.RawBytes(testParsePkt))
 
@@ -130,8 +130,8 @@ func Test_ParseScnPkt(t *testing.T) {
 func Test_ParseSCMP(t *testing.T) {
 	Convey("ScnPkt.Parse should load SCMP values correctly", t, func() {
 		s := &spkt.ScnPkt{
-			DstIA: &addr.ISD_AS{},
-			SrcIA: &addr.ISD_AS{},
+			DstIA: addr.IA{},
+			SrcIA: addr.IA{},
 			Path:  &spath.Path{},
 		}
 		err := ParseScnPkt(s, common.RawBytes(testParseSCMP))
@@ -159,8 +159,8 @@ func Test_ParseSCMP(t *testing.T) {
 func Test_ScnPkt_Write(t *testing.T) {
 	Convey("ScnPkt.Write should write values correctly", t, func() {
 		s := &spkt.ScnPkt{
-			DstIA: &addr.ISD_AS{},
-			SrcIA: &addr.ISD_AS{},
+			DstIA: addr.IA{},
+			SrcIA: addr.IA{},
 			Path:  &spath.Path{},
 		}
 		s.DstIA, _ = addr.IAFromString("42-1")

--- a/go/lib/pathdb/query/query.go
+++ b/go/lib/pathdb/query/query.go
@@ -22,13 +22,13 @@ import (
 
 // TODO(shitz): This should be moved when we have hidden path sets.
 type HPCfgID struct {
-	IA *addr.ISD_AS
+	IA addr.IA
 	ID uint64
 }
 
 func NewHPCfgID(isd int, as int, ID uint64) *HPCfgID {
 	return &HPCfgID{
-		IA: &addr.ISD_AS{I: isd, A: as},
+		IA: addr.IA{I: isd, A: as},
 		ID: ID,
 	}
 }
@@ -40,7 +40,7 @@ func (h *HPCfgID) Eq(other *HPCfgID) bool {
 var NullHpCfgID = HPCfgID{IA: addr.IAInt(0).IA(), ID: 0}
 
 type IntfSpec struct {
-	IA   *addr.ISD_AS
+	IA   addr.IA
 	IfID uint64
 }
 
@@ -49,8 +49,8 @@ type Params struct {
 	SegTypes []seg.Type
 	HpCfgIDs []*HPCfgID
 	Intfs    []*IntfSpec
-	StartsAt []*addr.ISD_AS
-	EndsAt   []*addr.ISD_AS
+	StartsAt []addr.IA
+	EndsAt   []addr.IA
 }
 
 type Result struct {

--- a/go/lib/pathdb/sqlite/sqlite.go
+++ b/go/lib/pathdb/sqlite/sqlite.go
@@ -387,7 +387,7 @@ func (b *Backend) Get(params *query.Params) ([]*query.Result, error) {
 	for rows.Next() {
 		var segRowID int
 		var rawSeg sql.RawBytes
-		hpCfgID := &query.HPCfgID{IA: &addr.ISD_AS{}}
+		hpCfgID := &query.HPCfgID{IA: addr.IA{}}
 		err = rows.Scan(&segRowID, &rawSeg, &hpCfgID.IA.I, &hpCfgID.IA.A, &hpCfgID.ID)
 		if err != nil {
 			return nil, common.NewBasicError("Error reading DB response", err)

--- a/go/lib/pathdb/sqlite/sqlite_test.go
+++ b/go/lib/pathdb/sqlite/sqlite_test.go
@@ -32,10 +32,10 @@ import (
 )
 
 var (
-	ia13 = &addr.ISD_AS{I: 1, A: 13}
-	ia14 = &addr.ISD_AS{I: 1, A: 14}
-	ia16 = &addr.ISD_AS{I: 1, A: 16}
-	ia19 = &addr.ISD_AS{I: 1, A: 19}
+	ia13 = addr.IA{I: 1, A: 13}
+	ia14 = addr.IA{I: 1, A: 14}
+	ia16 = addr.IA{I: 1, A: 16}
+	ia19 = addr.IA{I: 1, A: 19}
 
 	ifs1 = []uint64{0, 5, 2, 3, 6, 3, 1, 0}
 	ifs2 = []uint64{0, 4, 2, 3, 1, 3, 2, 0}
@@ -74,7 +74,7 @@ func allocPathSegment(ifs []uint64, expiration uint32) (*seg.PathSegment, common
 		{
 			RawIA: ia13.IAInt(),
 			HopEntries: []*seg.HopEntry{
-				allocHopEntry(&addr.ISD_AS{}, ia16, rawHops[0]),
+				allocHopEntry(addr.IA{}, ia16, rawHops[0]),
 			},
 		},
 		{
@@ -87,7 +87,7 @@ func allocPathSegment(ifs []uint64, expiration uint32) (*seg.PathSegment, common
 		{
 			RawIA: ia19.IAInt(),
 			HopEntries: []*seg.HopEntry{
-				allocHopEntry(ia16, &addr.ISD_AS{}, rawHops[3]),
+				allocHopEntry(ia16, addr.IA{}, rawHops[3]),
 			},
 		},
 	}
@@ -106,7 +106,7 @@ func allocPathSegment(ifs []uint64, expiration uint32) (*seg.PathSegment, common
 	return pseg, segID
 }
 
-func allocHopEntry(inIA, outIA *addr.ISD_AS, hopF common.RawBytes) *seg.HopEntry {
+func allocHopEntry(inIA, outIA addr.IA, hopF common.RawBytes) *seg.HopEntry {
 	return &seg.HopEntry{
 		RawInIA:     inIA.IAInt(),
 		RawOutIA:    outIA.IAInt(),
@@ -179,7 +179,7 @@ func checkIntfToSeg(t *testing.T, b *Backend, segRowID int, intfs []query.IntfSp
 	SoMsg("No IF 0", count, ShouldEqual, 0)
 }
 
-func checkStartsAtOrEndsAt(t *testing.T, b *Backend, table string, segRowID int, ia *addr.ISD_AS) {
+func checkStartsAtOrEndsAt(t *testing.T, b *Backend, table string, segRowID int, ia addr.IA) {
 	var segID int
 	queryStr := fmt.Sprintf("SELECT SegRowID FROM %s WHERE IsdID=%v AND AsID=%v", table, ia.I, ia.A)
 	err := b.db.QueryRow(queryStr).Scan(&segID)
@@ -234,8 +234,8 @@ type ExpectedInsert struct {
 	SegID    common.RawBytes
 	TS       uint32
 	Intfs    []query.IntfSpec
-	StartsAt *addr.ISD_AS
-	EndsAt   *addr.ISD_AS
+	StartsAt addr.IA
+	EndsAt   addr.IA
 	Types    []seg.Type
 	HpCfgIDs []*query.HPCfgID
 }
@@ -422,12 +422,12 @@ func Test_GetStartsAtEndsAt(t *testing.T) {
 		insertSeg(t, b, pseg1, types, hpCfgIDs)
 		insertSeg(t, b, pseg2, types[:1], hpCfgIDs[:1])
 		// Call
-		res, err := b.Get(&query.Params{StartsAt: []*addr.ISD_AS{ia13, ia19}})
+		res, err := b.Get(&query.Params{StartsAt: []addr.IA{ia13, ia19}})
 		if err != nil {
 			t.Fatal(err)
 		}
 		SoMsg("Result count", len(res), ShouldEqual, 2)
-		res, err = b.Get(&query.Params{EndsAt: []*addr.ISD_AS{ia13, ia19}})
+		res, err = b.Get(&query.Params{EndsAt: []addr.IA{ia13, ia19}})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/go/lib/pathmgr/cache.go
+++ b/go/lib/pathmgr/cache.go
@@ -60,7 +60,7 @@ func newCache(maxAge time.Duration) *cache {
 }
 
 // update the set of paths between src and dst to aps.
-func (c *cache) update(src, dst *addr.ISD_AS, aps AppPathSet) {
+func (c *cache) update(src, dst addr.IA, aps AppPathSet) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	entry, ok := c.getEntry(src, dst)
@@ -77,7 +77,7 @@ func (c *cache) update(src, dst *addr.ISD_AS, aps AppPathSet) {
 
 // getAPS returns the paths between src and dst. If the paths are stale or
 // missing, the second return value is false.
-func (c *cache) getAPS(src, dst *addr.ISD_AS) (AppPathSet, bool) {
+func (c *cache) getAPS(src, dst addr.IA) (AppPathSet, bool) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	if entry, ok := c.getEntry(src, dst); ok {
@@ -92,7 +92,7 @@ func (c *cache) getAPS(src, dst *addr.ISD_AS) (AppPathSet, bool) {
 
 // watch adds periodic lookups for paths between src and dst. If filter is non-nil,
 // the paths are filtered according to it.
-func (c *cache) watch(src, dst *addr.ISD_AS, filter *PathPredicate) {
+func (c *cache) watch(src, dst addr.IA, filter *PathPredicate) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	var key string
@@ -123,7 +123,7 @@ func (c *cache) watch(src, dst *addr.ISD_AS, filter *PathPredicate) {
 // yet using watch, getWatch returns nil. If filter is nil, a reference to an
 // unfiltered object is returned. The object is shared between callers, so
 // callers must never write to it.
-func (c *cache) getWatch(src, dst *addr.ISD_AS, filter *PathPredicate) (*SyncPaths, bool) {
+func (c *cache) getWatch(src, dst addr.IA, filter *PathPredicate) (*SyncPaths, bool) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	var key string
@@ -141,7 +141,7 @@ func (c *cache) getWatch(src, dst *addr.ISD_AS, filter *PathPredicate) (*SyncPat
 }
 
 // isWatched returns true if src and dst are registered for periodic lookups.
-func (c *cache) isWatched(src, dst *addr.ISD_AS) bool {
+func (c *cache) isWatched(src, dst addr.IA) bool {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	if entry, ok := c.getEntry(src, dst); ok {
@@ -151,7 +151,7 @@ func (c *cache) isWatched(src, dst *addr.ISD_AS) bool {
 }
 
 // removeWatch deletes a watch.
-func (c *cache) removeWatch(src, dst *addr.ISD_AS, filter *PathPredicate) error {
+func (c *cache) removeWatch(src, dst addr.IA, filter *PathPredicate) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	var key string
@@ -184,7 +184,7 @@ func (c *cache) revoke(u uifid) {
 	for _, ap := range aps {
 		src := ap.Entry.Path.SrcIA()
 		dst := ap.Entry.Path.DstIA()
-		if src == nil || dst == nil {
+		if src.IsUnset() || dst.IsUnset() {
 			log.Warn("Unable to extract src and dst IAs from path", "path", ap)
 			continue
 		}
@@ -193,7 +193,7 @@ func (c *cache) revoke(u uifid) {
 }
 
 // remove (internal) one path from the set of paths between src and dst.
-func (c *cache) remove(src, dst *addr.ISD_AS, ap *AppPath) {
+func (c *cache) remove(src, dst addr.IA, ap *AppPath) {
 	entry, ok := c.getEntry(src, dst)
 	if !ok {
 		log.Warn("Attempted to remove known path, but no path set found", "path",
@@ -208,14 +208,14 @@ func (c *cache) remove(src, dst *addr.ISD_AS, ap *AppPath) {
 }
 
 // getEntry (internal) retrieves the cache entry for src and dst.
-func (c *cache) getEntry(src, dst *addr.ISD_AS) (*cacheEntry, bool) {
+func (c *cache) getEntry(src, dst addr.IA) (*cacheEntry, bool) {
 	k := IAKey{src: src.IAInt(), dst: dst.IAInt()}
 	entry, ok := c.m[k]
 	return entry, ok
 }
 
 // addEntry (internal) initializes a cache entry for src and dst.
-func (c *cache) addEntry(src, dst *addr.ISD_AS) *cacheEntry {
+func (c *cache) addEntry(src, dst addr.IA) *cacheEntry {
 	entry := &cacheEntry{
 		aps:       make(AppPathSet),
 		fs:        make(filterSet),

--- a/go/lib/pathmgr/cache.go
+++ b/go/lib/pathmgr/cache.go
@@ -184,7 +184,7 @@ func (c *cache) revoke(u uifid) {
 	for _, ap := range aps {
 		src := ap.Entry.Path.SrcIA()
 		dst := ap.Entry.Path.DstIA()
-		if src.IsUnset() || dst.IsUnset() {
+		if src.IsZero() || dst.IsZero() {
 			log.Warn("Unable to extract src and dst IAs from path", "path", ap)
 			continue
 		}

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -136,7 +136,7 @@ func New(srvc sciond.Service, timers *Timers, logger log.Logger) (*PR, error) {
 // Query returns a slice of paths between src and dst. If the paths are not
 // found in the path resolver's cache, a query to SCIOND is issued and the
 // function blocks until the reply is received.
-func (r *PR) Query(src, dst *addr.ISD_AS) AppPathSet {
+func (r *PR) Query(src, dst addr.IA) AppPathSet {
 	r.Lock()
 	defer r.Unlock()
 	if aps, ok := r.cache.getAPS(src, dst); ok {
@@ -160,7 +160,7 @@ func (r *PR) Query(src, dst *addr.ISD_AS) AppPathSet {
 	return AppPathSet{}
 }
 
-func (r *PR) QueryFilter(src, dst *addr.ISD_AS, filter *PathPredicate) AppPathSet {
+func (r *PR) QueryFilter(src, dst addr.IA, filter *PathPredicate) AppPathSet {
 	aps := r.Query(src, dst)
 	// Delete paths that do not match the predicate
 	for k, ap := range aps {
@@ -179,11 +179,11 @@ func (r *PR) QueryFilter(src, dst *addr.ISD_AS, filter *PathPredicate) AppPathSe
 // a reference to a structure containing the currently available paths.
 //
 // On registration failure an error is returned.
-func (r *PR) Watch(src, dst *addr.ISD_AS) (*SyncPaths, error) {
+func (r *PR) Watch(src, dst addr.IA) (*SyncPaths, error) {
 	return r.WatchFilter(src, dst, nil)
 }
 
-func (r *PR) Unwatch(src, dst *addr.ISD_AS) error {
+func (r *PR) Unwatch(src, dst addr.IA) error {
 	return r.UnwatchFilter(src, dst, nil)
 }
 
@@ -193,7 +193,7 @@ func (r *PR) Unwatch(src, dst *addr.ISD_AS) error {
 //
 // WatchFilter also adds pair src-dst to the list of tracked paths (if it
 // wasn't already tracked).
-func (r *PR) WatchFilter(src, dst *addr.ISD_AS, filter *PathPredicate) (*SyncPaths, error) {
+func (r *PR) WatchFilter(src, dst addr.IA, filter *PathPredicate) (*SyncPaths, error) {
 	r.Lock()
 	defer r.Unlock()
 	// If the src and dst are not monitored yet, add the request to the resolver's queue
@@ -217,7 +217,7 @@ func (r *PR) WatchFilter(src, dst *addr.ISD_AS, filter *PathPredicate) (*SyncPat
 }
 
 // UnwatchFilter deletes a previously registered filter.
-func (r *PR) UnwatchFilter(src, dst *addr.ISD_AS, filter *PathPredicate) error {
+func (r *PR) UnwatchFilter(src, dst addr.IA, filter *PathPredicate) error {
 	r.Lock()
 	defer r.Unlock()
 	return r.cache.removeWatch(src, dst, filter)

--- a/go/lib/pathmgr/pathmgr_test.go
+++ b/go/lib/pathmgr/pathmgr_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 var (
-	iaX = &addr.ISD_AS{I: 1, A: 11}
-	iaY = &addr.ISD_AS{I: 1, A: 12}
-	iaZ = &addr.ISD_AS{I: 2, A: 21}
+	iaX = addr.IA{I: 1, A: 11}
+	iaY = addr.IA{I: 1, A: 12}
+	iaZ = addr.IA{I: 2, A: 21}
 )
 
 var (
@@ -137,7 +137,7 @@ type mockSCIONDConn struct {
 	replies []*sciond.PathReply
 }
 
-func (m *mockSCIONDConn) Paths(dst, src *addr.ISD_AS, max uint16,
+func (m *mockSCIONDConn) Paths(dst, src addr.IA, max uint16,
 	f sciond.PathReqFlags) (*sciond.PathReply, error) {
 	if m.index >= len(m.replies) {
 		return buildSCIONDReply(), nil
@@ -147,7 +147,7 @@ func (m *mockSCIONDConn) Paths(dst, src *addr.ISD_AS, max uint16,
 	return entry, nil
 }
 
-func (m *mockSCIONDConn) ASInfo(ia *addr.ISD_AS) (*sciond.ASInfoReply, error) {
+func (m *mockSCIONDConn) ASInfo(ia addr.IA) (*sciond.ASInfoReply, error) {
 	return nil, nil
 }
 
@@ -343,7 +343,7 @@ func TestRevoke(t *testing.T) {
 			SoMsg("aps register filter", spd.APS, ShouldResemble, buildAPS(pathXYZ))
 			Convey("Revoke a path that's not part of any path set", func() {
 				// Call revoke directly on the cache to avoid parsing a raw rev notification
-				ia := &addr.ISD_AS{I: 5, A: 5}
+				ia := addr.IA{I: 5, A: 5}
 				pm.cache.revoke(uifidFromValues(ia, 50))
 				aps := pm.Query(iaX, iaY)
 				SoMsg("aps", aps, ShouldResemble, buildAPS(pathXY1, pathXY2))

--- a/go/lib/pathmgr/resolver.go
+++ b/go/lib/pathmgr/resolver.go
@@ -80,7 +80,7 @@ func (r *resolver) run() {
 }
 
 // lookup queries SCIOND, blocking while waiting for the response.
-func (r *resolver) lookup(src, dst *addr.ISD_AS) AppPathSet {
+func (r *resolver) lookup(src, dst addr.IA) AppPathSet {
 	reply, err := r.sciondConn.Paths(dst, src, numReqPaths, sciond.PathReqFlags{})
 	if err != nil {
 		log.Error("SCIOND network error", "err", err)
@@ -120,8 +120,8 @@ const (
 
 // resolverRequest describes the items contained in the resolver's request queue.
 type resolverRequest struct {
-	src     *addr.ISD_AS
-	dst     *addr.ISD_AS
+	src     addr.IA
+	dst     addr.IA
 	reqType reqType
 	done    chan struct{}
 }

--- a/go/lib/pathmgr/revtable.go
+++ b/go/lib/pathmgr/revtable.go
@@ -27,7 +27,7 @@ type uifid struct {
 	ifid common.IFIDType
 }
 
-func uifidFromValues(isdas *addr.ISD_AS, ifid common.IFIDType) uifid {
+func uifidFromValues(isdas addr.IA, ifid common.IFIDType) uifid {
 	return uifid{
 		ia:   isdas.IAInt(),
 		ifid: ifid,

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -91,9 +91,9 @@ func (s *service) ConnectTimeout(timeout time.Duration) (Connector, error) {
 type Connector interface {
 	// Paths requests from SCIOND a set of end to end paths between src and
 	// dst. max specifices the maximum number of paths returned.
-	Paths(dst, src *addr.ISD_AS, max uint16, f PathReqFlags) (*PathReply, error)
+	Paths(dst, src addr.IA, max uint16, f PathReqFlags) (*PathReply, error)
 	// ASInfo requests from SCIOND information about AS ia.
-	ASInfo(ia *addr.ISD_AS) (*ASInfoReply, error)
+	ASInfo(ia addr.IA) (*ASInfoReply, error)
 	// IFInfo requests from SCIOND addresses and ports of interfaces.  Slice
 	// ifs contains interface IDs of BRs. If empty, a fresh (i.e., uncached)
 	// answer containing all interfaces is returned.
@@ -177,7 +177,7 @@ func (c *connector) receive() (*Pld, error) {
 	return p, nil
 }
 
-func (c *connector) Paths(dst, src *addr.ISD_AS, max uint16, f PathReqFlags) (*PathReply, error) {
+func (c *connector) Paths(dst, src addr.IA, max uint16, f PathReqFlags) (*PathReply, error) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -199,7 +199,7 @@ func (c *connector) Paths(dst, src *addr.ISD_AS, max uint16, f PathReqFlags) (*P
 	return &reply.PathReply, nil
 }
 
-func (c *connector) ASInfo(ia *addr.ISD_AS) (*ASInfoReply, error) {
+func (c *connector) ASInfo(ia addr.IA) (*ASInfoReply, error) {
 	c.Lock()
 	defer c.Unlock()
 

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -164,18 +164,18 @@ type FwdPathMeta struct {
 	Interfaces []PathInterface
 }
 
-func (fpm FwdPathMeta) SrcIA() *addr.ISD_AS {
+func (fpm FwdPathMeta) SrcIA() addr.IA {
 	ifaces := fpm.Interfaces
 	if len(ifaces) == 0 {
-		return nil
+		return addr.EmptyIA
 	}
 	return ifaces[0].ISD_AS()
 }
 
-func (fpm FwdPathMeta) DstIA() *addr.ISD_AS {
+func (fpm FwdPathMeta) DstIA() addr.IA {
 	ifaces := fpm.Interfaces
 	if len(ifaces) == 0 {
-		return nil
+		return addr.EmptyIA
 	}
 	return ifaces[len(ifaces)-1].ISD_AS()
 }
@@ -193,7 +193,7 @@ type PathInterface struct {
 	IfID     uint64
 }
 
-func (iface *PathInterface) ISD_AS() *addr.ISD_AS {
+func (iface *PathInterface) ISD_AS() addr.IA {
 	return iface.RawIsdas.IA()
 }
 
@@ -215,7 +215,7 @@ type ASInfoReplyEntry struct {
 	IsCore   bool
 }
 
-func (entry *ASInfoReplyEntry) ISD_AS() *addr.ISD_AS {
+func (entry *ASInfoReplyEntry) ISD_AS() addr.IA {
 	return entry.RawIsdas.IA()
 }
 

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -167,7 +167,7 @@ type FwdPathMeta struct {
 func (fpm FwdPathMeta) SrcIA() addr.IA {
 	ifaces := fpm.Interfaces
 	if len(ifaces) == 0 {
-		return addr.EmptyIA
+		return addr.IA{}
 	}
 	return ifaces[0].ISD_AS()
 }
@@ -175,7 +175,7 @@ func (fpm FwdPathMeta) SrcIA() addr.IA {
 func (fpm FwdPathMeta) DstIA() addr.IA {
 	ifaces := fpm.Interfaces
 	if len(ifaces) == 0 {
-		return addr.EmptyIA
+		return addr.IA{}
 	}
 	return ifaces[len(ifaces)-1].ISD_AS()
 }

--- a/go/lib/snet/addr.go
+++ b/go/lib/snet/addr.go
@@ -30,7 +30,7 @@ var _ net.Addr = (*Addr)(nil)
 var addrRegexp = regexp.MustCompile(`^(?P<ia>\d+-\d+),\[(?P<host>[^\]]+)\]:(?P<port>\d+)$`)
 
 type Addr struct {
-	IA          *addr.ISD_AS
+	IA          addr.IA
 	Host        addr.HostAddr
 	L4Port      uint16
 	Path        *spath.Path
@@ -77,7 +77,7 @@ func (a *Addr) Copy() *Addr {
 		return nil
 	}
 	newA := &Addr{
-		IA:          a.IA.Copy(),
+		IA:          a.IA,
 		Host:        a.Host.Copy(),
 		L4Port:      a.L4Port,
 		NextHopPort: a.NextHopPort,

--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -153,8 +153,8 @@ func (c *Conn) read(b []byte, from bool) (int, *Addr, error) {
 		lastHop = nil
 	}
 	pkt := &spkt.ScnPkt{
-		DstIA: &addr.ISD_AS{},
-		SrcIA: &addr.ISD_AS{},
+		DstIA: addr.IA{},
+		SrcIA: addr.IA{},
 		Path:  &spath.Path{},
 	}
 	err = hpkt.ParseScnPkt(pkt, c.recvBuffer[:n])

--- a/go/lib/snet/integration_test.go
+++ b/go/lib/snet/integration_test.go
@@ -36,8 +36,8 @@ import (
 var _ = log.Root
 
 var (
-	asList  []*addr.ISD_AS
-	localIA *addr.ISD_AS
+	asList  []addr.IA
+	localIA addr.IA
 )
 
 const (
@@ -46,8 +46,8 @@ const (
 )
 
 type TestCase struct {
-	srcIA *addr.ISD_AS
-	dstIA *addr.ISD_AS
+	srcIA addr.IA
+	dstIA addr.IA
 
 	srcLocal addr.HostAddr
 	dstLocal addr.HostAddr
@@ -59,7 +59,7 @@ type TestCase struct {
 	reply   []byte
 }
 
-func generateTests(asList []*addr.ISD_AS, count int) []TestCase {
+func generateTests(asList []addr.IA, count int) []TestCase {
 	rand.Seed(time.Now().UnixNano())
 	tests := make([]TestCase, 0, 0)
 	var cIndex, sIndex int32

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -64,7 +64,7 @@ var (
 )
 
 // Init initializes the default SCION networking context.
-func Init(ia *addr.ISD_AS, sPath string, dPath string) error {
+func Init(ia addr.IA, sPath string, dPath string) error {
 	network, err := NewNetwork(ia, sPath, dPath)
 	if err != nil {
 		return err
@@ -82,11 +82,11 @@ func InitWithNetwork(network *Network) error {
 }
 
 // IA returns the default ISD-AS
-func IA() *addr.ISD_AS {
+func IA() addr.IA {
 	if DefNetwork == nil {
-		return nil
+		return addr.EmptyIA
 	}
-	return DefNetwork.localIA.Copy()
+	return DefNetwork.localIA
 }
 
 // SCION networking context, containing local ISD-AS, SCIOND, Dispatcher and
@@ -95,12 +95,12 @@ type Network struct {
 	sciondPath     string
 	dispatcherPath string
 	pathResolver   *pathmgr.PR
-	localIA        *addr.ISD_AS
+	localIA        addr.IA
 }
 
 // NewNetworkBasic creates a minimal networking context without a path resolver.
 // It is meant to be amended with a custom path resolver.
-func NewNetworkBasic(ia *addr.ISD_AS, sPath string, dPath string) *Network {
+func NewNetworkBasic(ia addr.IA, sPath string, dPath string) *Network {
 	return &Network{
 		sciondPath:     sPath,
 		dispatcherPath: dPath,
@@ -111,7 +111,7 @@ func NewNetworkBasic(ia *addr.ISD_AS, sPath string, dPath string) *Network {
 // NewNetwork creates a new networking context, on which future Dial or Listen
 // calls can be made. The new connections use the SCIOND server at sPath, the
 // dispatcher at dPath, and ia for the local ISD-AS.
-func NewNetwork(ia *addr.ISD_AS, sPath string, dPath string) (*Network, error) {
+func NewNetwork(ia addr.IA, sPath string, dPath string) (*Network, error) {
 	network := NewNetworkBasic(ia, sPath, dPath)
 	sd := sciond.NewService(sPath)
 	timers := &pathmgr.Timers{
@@ -210,7 +210,7 @@ func (n *Network) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr,
 	}
 	regAddr.Addr = conn.laddr.Host
 
-	if conn.laddr.IA == nil {
+	if conn.laddr.IA.IsUnset() {
 		conn.laddr.IA = n.IA()
 	}
 
@@ -254,7 +254,7 @@ func (n *Network) SetPathResolver(resolver *pathmgr.PR) {
 	n.pathResolver = resolver
 }
 
-// IA returns a copy of the ISD-AS assigned to n
-func (n *Network) IA() *addr.ISD_AS {
-	return n.localIA.Copy()
+// IA returns the ISD-AS assigned to n
+func (n *Network) IA() addr.IA {
+	return n.localIA
 }

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -84,7 +84,7 @@ func InitWithNetwork(network *Network) error {
 // IA returns the default ISD-AS
 func IA() addr.IA {
 	if DefNetwork == nil {
-		return addr.EmptyIA
+		return addr.IA{}
 	}
 	return DefNetwork.localIA
 }
@@ -210,7 +210,7 @@ func (n *Network) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr,
 	}
 	regAddr.Addr = conn.laddr.Host
 
-	if conn.laddr.IA.IsUnset() {
+	if conn.laddr.IA.IsZero() {
 		conn.laddr.IA = n.IA()
 	}
 

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -144,7 +144,7 @@ func newConn(c net.Conn) *Conn {
 //
 // To check for timeout errors, type assert the returned error to *net.OpError and
 // call method Timeout().
-func RegisterTimeout(dispatcher string, ia *addr.ISD_AS, public, bind *AppAddr, svc addr.HostSVC,
+func RegisterTimeout(dispatcher string, ia addr.IA, public, bind *AppAddr, svc addr.HostSVC,
 	timeout time.Duration) (*Conn, uint16, error) {
 	if public.Addr.Type() == addr.HostTypeNone {
 		return nil, 0, common.NewBasicError("Cannot register with NoneType address", nil)
@@ -235,7 +235,7 @@ func writeAppAddr(request []byte, a *AppAddr) (int, error) {
 // Register connects to a SCION Dispatcher's UNIX socket.
 // Future messages for address a in AS ia which arrive at the dispatcher can be read by
 // calling Read on the returned Conn structure.
-func Register(dispatcher string, ia *addr.ISD_AS, public, bind *AppAddr,
+func Register(dispatcher string, ia addr.IA, public, bind *AppAddr,
 	svc addr.HostSVC) (*Conn, uint16, error) {
 	return RegisterTimeout(dispatcher, ia, public, bind, svc, time.Duration(0))
 }

--- a/go/lib/sock/reliable/reliable_test.go
+++ b/go/lib/sock/reliable/reliable_test.go
@@ -31,7 +31,7 @@ import (
 
 type TestCase struct {
 	msg       string
-	ia        *addr.ISD_AS
+	ia        addr.IA
 	dst       *AppAddr
 	bind      *AppAddr
 	svc       addr.HostSVC
@@ -42,7 +42,7 @@ type TestCase struct {
 func TestRegister(t *testing.T) {
 	testCases := []TestCase{
 		{
-			ia: &addr.ISD_AS{I: 1, A: 10},
+			ia: addr.IA{I: 1, A: 10},
 			dst: &AppAddr{
 				Addr: addr.HostNone{},
 				Port: 0,
@@ -50,7 +50,7 @@ func TestRegister(t *testing.T) {
 			bind: nil, svc: addr.SvcNone,
 			want: nil, timeoutOK: true,
 		}, {
-			ia: &addr.ISD_AS{I: 2, A: 21},
+			ia: addr.IA{I: 2, A: 21},
 			dst: &AppAddr{
 				Addr: addr.HostFromIP(net.IPv4(127, 0, 0, 1)),
 				Port: 80,
@@ -60,7 +60,7 @@ func TestRegister(t *testing.T) {
 				3, 17, 0, 32, 0, 21, 0, 80, 1, 127, 0, 0, 1},
 			timeoutOK: false,
 		}, {
-			ia:   &addr.ISD_AS{I: 2, A: 21},
+			ia:   addr.IA{I: 2, A: 21},
 			dst:  &AppAddr{Addr: addr.HostFromIP(net.IPv6loopback), Port: 80},
 			bind: nil, svc: addr.SvcNone,
 			want: []byte{0xde, 0, 0xad, 1, 0xbe, 2, 0xef, 3, 0, 0, 0, 0, 25,
@@ -68,7 +68,7 @@ func TestRegister(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 			timeoutOK: false,
 		}, {
-			ia: &addr.ISD_AS{I: 2, A: 21},
+			ia: addr.IA{I: 2, A: 21},
 			dst: &AppAddr{
 				Addr: addr.HostFromIP(net.IPv4(127, 0, 0, 1)),
 				Port: 80,
@@ -81,7 +81,7 @@ func TestRegister(t *testing.T) {
 				7, 17, 0, 32, 0, 21, 0, 80, 1, 127, 0, 0, 1, 0, 81, 1, 127, 0, 0, 2},
 			timeoutOK: false,
 		}, {
-			ia: &addr.ISD_AS{I: 2, A: 21},
+			ia: addr.IA{I: 2, A: 21},
 			dst: &AppAddr{
 				Addr: addr.HostFromIP(net.IPv4(127, 0, 0, 1)),
 				Port: 80,
@@ -140,7 +140,7 @@ func TestRegisterTimeout(t *testing.T) {
 		})
 		Convey("Register to \"dispatcher\" returns timeout error", func() {
 			var expectedT *net.OpError
-			ia := &addr.ISD_AS{I: 1, A: 10}
+			ia := addr.IA{I: 1, A: 10}
 			appAddr := &AppAddr{Addr: addr.HostFromIP(net.IPv4(1, 2, 3, 4)), Port: 0}
 
 			before := time.Now()

--- a/go/lib/spkt/extn_traceroute.go
+++ b/go/lib/spkt/extn_traceroute.go
@@ -103,7 +103,7 @@ func (t *Traceroute) String() string {
 }
 
 type TracerouteEntry struct {
-	IA        addr.ISD_AS
+	IA        addr.IA
 	IfID      uint16
 	TimeStamp uint16
 }

--- a/go/lib/spkt/spkt.go
+++ b/go/lib/spkt/spkt.go
@@ -25,8 +25,8 @@ import (
 // SCION Packet structure.
 type ScnPkt struct {
 	CmnHdr  *CmnHdr // FIXME(scrye): remove this once the SIG no longer needs it
-	DstIA   *addr.ISD_AS
-	SrcIA   *addr.ISD_AS
+	DstIA   addr.IA
+	SrcIA   addr.IA
 	DstHost addr.HostAddr
 	SrcHost addr.HostAddr
 	Path    *spath.Path
@@ -39,12 +39,8 @@ type ScnPkt struct {
 func (s *ScnPkt) Copy() (*ScnPkt, error) {
 	var err error
 	c := &ScnPkt{}
-	if s.DstIA != nil {
-		c.DstIA = s.DstIA.Copy()
-	}
-	if s.SrcIA != nil {
-		c.SrcIA = s.SrcIA.Copy()
-	}
+	c.DstIA = s.DstIA
+	c.SrcIA = s.SrcIA
 	if s.DstHost != nil {
 		c.DstHost = s.DstHost.Copy()
 	}

--- a/go/lib/topology/doc.go
+++ b/go/lib/topology/doc.go
@@ -26,7 +26,7 @@ The basic layout is as follows:
 type Topo struct {
     Timestamp      int64
     TimestampHuman string
-    ISD_AS         *addr.ISD_AS
+    ISD_AS         addr.IA
     Overlay        overlay.Type
     MTU            int
     Core           bool
@@ -75,7 +75,7 @@ type IFInfo struct {
     Remote          *AddrInfo
     RemoteIFID      common.IFIDType
     Bandwidth       int
-    ISD_AS          *addr.ISD_AS
+    ISD_AS          addr.IA
     LinkType        LinkType
     MTU             int
 }

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -32,7 +32,7 @@ import (
 type Topo struct {
 	Timestamp      time.Time
 	TimestampHuman string // This can vary wildly in format and is only for informational purposes.
-	ISD_AS         *addr.ISD_AS
+	ISD_AS         addr.IA
 	Overlay        overlay.Type
 	MTU            int
 	Core           bool
@@ -222,7 +222,7 @@ type IFInfo struct {
 	Remote          *AddrInfo
 	RemoteIFID      common.IFIDType
 	Bandwidth       int
-	ISD_AS          *addr.ISD_AS
+	ISD_AS          addr.IA
 	LinkType        LinkType
 	MTU             int
 }

--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -74,7 +74,7 @@ func Test_Meta(t *testing.T) {
 		// Is testing this piece of data really useful?
 		SoMsg("Checking field 'TimestampHuman", c.TimestampHuman,
 			ShouldContainSubstring, "1975-05-06 01:02:03.000000+0000")
-		SoMsg("Checking field 'ISD_AS'", c.ISD_AS, ShouldResemble, &addr.ISD_AS{I: 1, A: 11})
+		SoMsg("Checking field 'ISD_AS'", c.ISD_AS, ShouldResemble, addr.IA{I: 1, A: 11})
 		SoMsg("Checking field 'Overlay'", c.Overlay, ShouldEqual, overlay.IPv46)
 		SoMsg("Checking field 'MTU'", c.MTU, ShouldEqual, 1472)
 		SoMsg("Checking field 'Core'", c.Core, ShouldBeFalse)

--- a/go/lib/util/aslist.go
+++ b/go/lib/util/aslist.go
@@ -29,8 +29,8 @@ type asData struct {
 }
 
 type ASList struct {
-	Core    []*addr.ISD_AS
-	NonCore []*addr.ISD_AS
+	Core    []addr.IA
+	NonCore []addr.IA
 }
 
 // LoadASList parses the yaml file fileName and returns a structure with
@@ -57,8 +57,8 @@ func LoadASList(fileName string) (*ASList, error) {
 	return asList, nil
 }
 
-func parse(names []string) ([]*addr.ISD_AS, error) {
-	var iaList []*addr.ISD_AS
+func parse(names []string) ([]addr.IA, error) {
+	var iaList []addr.IA
 	for _, name := range names {
 		ia, err := addr.IAFromString(name)
 		if err != nil {

--- a/go/sig/base/as.go
+++ b/go/sig/base/as.go
@@ -41,7 +41,7 @@ type ASEntry struct {
 	sync.RWMutex
 	Nets       map[string]*NetEntry
 	Sigs       *siginfo.SigMap
-	IA         *addr.ISD_AS
+	IA         addr.IA
 	IAString   string
 	Session    *egress.Session
 	DevName    string
@@ -51,7 +51,7 @@ type ASEntry struct {
 	log.Logger
 }
 
-func newASEntry(ia *addr.ISD_AS) (*ASEntry, error) {
+func newASEntry(ia addr.IA) (*ASEntry, error) {
 	ae := &ASEntry{
 		Logger:     log.New("ia", ia),
 		IA:         ia,

--- a/go/sig/base/map.go
+++ b/go/sig/base/map.go
@@ -73,8 +73,7 @@ func (am *ASMap) ReloadConfig(cfg *config.Cfg) bool {
 // addNewIAs adds the ASes in cfg that are not currently configured.
 func (am *ASMap) addNewIAs(cfg *config.Cfg) bool {
 	s := true
-	for iaVal, cfgEntry := range cfg.ASes {
-		ia := iaVal.Copy()
+	for ia, cfgEntry := range cfg.ASes {
 		log.Info("ReloadConfig: Adding AS...", "ia", ia)
 		ae, err := am.AddIA(ia)
 		if err != nil {
@@ -93,7 +92,7 @@ func (am *ASMap) delOldIAs(cfg *config.Cfg) bool {
 	// Delete all ASes that currently exist but are not in cfg
 	am.Range(func(iaInt addr.IAInt, as *ASEntry) bool {
 		ia := iaInt.IA()
-		if _, ok := cfg.ASes[*ia]; !ok {
+		if _, ok := cfg.ASes[ia]; !ok {
 			log.Info("ReloadConfig: Deleting AS...", "ia", ia)
 			// Deletion also handles session/tun device cleanup
 			err := am.DelIA(ia)
@@ -110,7 +109,7 @@ func (am *ASMap) delOldIAs(cfg *config.Cfg) bool {
 }
 
 // AddIA idempotently adds an entry for a remote IA.
-func (am *ASMap) AddIA(ia *addr.ISD_AS) (*ASEntry, error) {
+func (am *ASMap) AddIA(ia addr.IA) (*ASEntry, error) {
 	if ia.I == 0 || ia.A == 0 {
 		// A 0 for either ISD or AS indicates a wildcard, and not a specific ISD-AS.
 		return nil, common.NewBasicError("AddIA: ISD and AS must not be 0", nil, "ia", ia)
@@ -129,7 +128,7 @@ func (am *ASMap) AddIA(ia *addr.ISD_AS) (*ASEntry, error) {
 }
 
 // DelIA removes an entry for a remote IA.
-func (am *ASMap) DelIA(ia *addr.ISD_AS) error {
+func (am *ASMap) DelIA(ia addr.IA) error {
 	key := ia.IAInt()
 	ae, ok := am.Load(key)
 	if !ok {
@@ -140,7 +139,7 @@ func (am *ASMap) DelIA(ia *addr.ISD_AS) error {
 }
 
 // ASEntry returns the entry for the specified remote IA, or nil if not present.
-func (am *ASMap) ASEntry(ia *addr.ISD_AS) *ASEntry {
+func (am *ASMap) ASEntry(ia addr.IA) *ASEntry {
 	if as, ok := am.Load(ia.IAInt()); ok {
 		return as
 	}

--- a/go/sig/config/config.go
+++ b/go/sig/config/config.go
@@ -28,7 +28,7 @@ import (
 
 // Cfg is a direct Go representation of the JSON file format.
 type Cfg struct {
-	ASes          map[addr.ISD_AS]*ASEntry
+	ASes          map[addr.IA]*ASEntry
 	ConfigVersion uint64
 }
 

--- a/go/sig/disp/disp.go
+++ b/go/sig/disp/disp.go
@@ -151,6 +151,6 @@ func dispFunc(dp *pktdisp.DispPkt) {
 
 type RegPollKey string
 
-func MkRegPollKey(ia *addr.ISD_AS, session mgmt.SessionType) RegPollKey {
+func MkRegPollKey(ia addr.IA, session mgmt.SessionType) RegPollKey {
 	return RegPollKey(fmt.Sprintf("%s-%s", ia, session))
 }

--- a/go/sig/egress/session.go
+++ b/go/sig/egress/session.go
@@ -36,7 +36,7 @@ import (
 // as well as maintaining the currently favoured path and remote SIG to use.
 type Session struct {
 	log.Logger
-	IA     *addr.ISD_AS
+	IA     addr.IA
 	SessId mgmt.SessionType
 	// pool of paths, managed by pathmgr
 	pool *pathmgr.SyncPaths
@@ -53,7 +53,7 @@ type Session struct {
 	workerStopped  chan struct{}
 }
 
-func NewSession(dstIA *addr.ISD_AS, sessId mgmt.SessionType,
+func NewSession(dstIA addr.IA, sessId mgmt.SessionType,
 	sigMap *siginfo.SigMap, logger log.Logger) (*Session, error) {
 	var err error
 	s := &Session{

--- a/go/sig/sigcmn/common.go
+++ b/go/sig/sigcmn/common.go
@@ -44,14 +44,14 @@ var (
 )
 
 var (
-	IA       *addr.ISD_AS
+	IA       addr.IA
 	Host     addr.HostAddr
 	PathMgr  *pathmgr.PR
 	CtrlConn *snet.Conn
 	MgmtAddr *mgmt.Addr
 )
 
-func Init(ia *addr.ISD_AS, ip net.IP) error {
+func Init(ia addr.IA, ip net.IP) error {
 	var err error
 	IA = ia
 	Host = addr.HostFromIP(ip)

--- a/go/sig/siginfo/sig.go
+++ b/go/sig/siginfo/sig.go
@@ -85,7 +85,7 @@ func (sm *SigMap) GetSig(currSigId SigIdType) *Sig {
 }
 
 type Sig struct {
-	IA          *addr.ISD_AS
+	IA          addr.IA
 	Id          SigIdType
 	Host        addr.HostAddr
 	CtrlL4Port  int
@@ -98,7 +98,7 @@ type Sig struct {
 	statsFailCount uint16
 }
 
-func NewSig(ia *addr.ISD_AS, id SigIdType, host addr.HostAddr,
+func NewSig(ia addr.IA, id SigIdType, host addr.HostAddr,
 	ctrlPort, encapPort int, static bool) *Sig {
 	return &Sig{
 		IA: ia, Id: id, Host: host, CtrlL4Port: ctrlPort,

--- a/go/tools/showpaths/paths.go
+++ b/go/tools/showpaths/paths.go
@@ -38,8 +38,8 @@ var (
 )
 
 var (
-	dstIA *addr.ISD_AS
-	srcIA *addr.ISD_AS
+	dstIA addr.IA
+	srcIA addr.IA
 )
 
 func main() {

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -379,12 +379,6 @@
 			"revisionTime": "2016-11-11T21:39:39Z"
 		},
 		{
-			"checksumSHA1": "o6uoZozSLnj3Ph+hj399ZPqJYhE=",
-			"path": "golang.org/x/tools/go/gcimporter15",
-			"revision": "71657689f07604379fce067b57ff757f42c0bf3d",
-			"revisionTime": "2017-12-06T15:54:56Z"
-		},
-		{
 			"checksumSHA1": "+mjMyJPLBPu7vIHaXkDuvqcDk0s=",
 			"license": "3-BSD",
 			"path": "golang.org/x/tools/imports",


### PR DESCRIPTION
Currently most of the code uses *addr.ISD_AS despite not needing to.
This leads to bugs which are very painful to debug where an IA is
inadvertently changed or reused after being shared.
There are very few places in the code where the fact that *addr.IA is a
pointer rather than a value is relied upon (the BR is the main
exception), and these are fairly easy to work around.

The rename is due to popular demand :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1438)
<!-- Reviewable:end -->
