### PR TITLE
Fixed int overflow on 32 bit systems

### DIFF
--- a/go/lib/infra/transport/rudp.go
+++ b/go/lib/infra/transport/rudp.go
@@ -113,7 +113,7 @@ type RUDP struct {
 func NewRUDP(conn net.PacketConn, logger log.Logger) *RUDP {
 	t := &RUDP{
 		conn:       conn,
-		nextPktID:  uint56(generator.Intn(maxUint56 + 1)),
+		nextPktID:  uint56(generator.Int63n(maxUint56 + 1)),
 		readEvents: make(chan *readEventDesc, maxReadEvents),
 		closedChan: make(chan struct{}),
 		doneChan:   make(chan struct{}),


### PR DESCRIPTION
On 32bit systems `Intn` function gets an overflow. Changed it to explicit int size instead

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1439)
<!-- Reviewable:end -->
