### PR TITLE
Support _-separated AS identifier strings.

### DIFF
--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -58,7 +58,29 @@ func IAFromString(s string) (IA, error) {
 		// err.Error() will contain the original value
 		return IA{}, common.NewBasicError("Unable to parse ISD", err)
 	}
-	as, err := strconv.ParseUint(parts[1], 10, ASBits)
+	var as uint64
+	var asStr = parts[1]
+	if strings.Index(parts[1], "_") != -1 {
+		// Support AS nubmers that have _ as thousands-separators. E.g. `281474976710655`
+		// can also be written as `281_474_976_710_655`.
+		as_parts := strings.Split(parts[1], "_")
+		for i := range as_parts {
+			pLen := len(as_parts[i])
+			if i == 0 {
+				if pLen == 0 || pLen > 3 {
+					// Make sure the first part isn't either 0, or too long
+					return IA{}, common.NewBasicError("Malformed _-separated AS", nil, "val", s)
+				}
+				continue
+			}
+			if pLen != 3 {
+				// Ensure that there are 3 chars for every part after the first
+				return IA{}, common.NewBasicError("Malformed _-separated AS", nil, "val", s)
+			}
+		}
+		asStr = strings.Join(as_parts, "")
+	}
+	as, err = strconv.ParseUint(asStr, 10, ASBits)
 	if err != nil {
 		// err.Error() will contain the original value
 		return IA{}, common.NewBasicError("Unable to parse AS", err)

--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -34,6 +34,27 @@ const (
 type ISD uint16
 type AS uint64
 
+func (as AS) String() string {
+	decStr := strconv.FormatUint(uint64(as), 10)
+	if as > MaxAS {
+		return fmt.Sprintf("%s [Illegal AS: larger than %d]", decStr, MaxAS)
+	}
+	l := len(decStr)
+	parts := make([]string, 0, (l/3)+1)
+	start := 0
+	end := l % 3
+	if end == 0 {
+		end = 3
+	}
+	for end <= l {
+		parts = append(parts, decStr[start:end])
+		start = end
+		end += 3
+	}
+	return strings.Join(parts, "_")
+}
+
+var _ fmt.Stringer = IA{}
 var _ encoding.TextUnmarshaler = (*IA)(nil)
 
 // IA represents the ISD (Isolation Domain) and AS (Autonomous System) Id of a given SCION AS.
@@ -123,7 +144,7 @@ func (ia IA) Eq(other IA) bool {
 }
 
 func (ia IA) String() string {
-	return fmt.Sprintf("%d-%d", ia.I, ia.A)
+	return fmt.Sprintf("%d-%s", ia.I, ia.A)
 }
 
 type IAInt uint64

--- a/go/lib/addr/isdas_test.go
+++ b/go/lib/addr/isdas_test.go
@@ -37,6 +37,60 @@ func Test_IAFromRaw(t *testing.T) {
 	})
 }
 
+func Test_IAFromString(t *testing.T) {
+	var testCases = []struct {
+		src string
+		ia  *IA
+	}{
+		{"", nil},
+		{"a", nil},
+		{"1a-2b", nil},
+		{"-", nil},
+		{"1-", nil},
+		{"-1", nil},
+		{"-1-", nil},
+		{"1--1", nil},
+		{"0-0", &IA{0, 0}},
+		{"1-1", &IA{1, 1}},
+		{"65535-1", &IA{MaxISD, 1}},
+		{"65536-1", nil},
+		{"1-281474976710655", &IA{1, MaxAS}},
+		{"1-281474976710656", nil},
+		{"65535-281474976710655", &IA{MaxISD, MaxAS}},
+		{"1-_", nil},
+		{"1-_0", nil},
+		{"1-_00", nil},
+		{"1-_000", nil},
+		{"1-_0000", nil},
+		{"1-1_0", nil},
+		{"1-1_00", nil},
+		{"1-1_000", &IA{1, 1000}},
+		{"1-1_0000", nil},
+		{"1-11_000", &IA{1, 11000}},
+		{"1-111_000", &IA{1, 111000}},
+		{"1-1111_000", nil},
+		{"65535-281_474_976_710_655", &IA{MaxISD, MaxAS}},
+		{"65535-281_474_976_710_656", nil},
+		{"65535-281_474_976_7106_55", nil},
+		{"65535-281_474_976_71_0655", nil},
+		{"65535-1281_474_976_710", nil},
+	}
+	Convey("IAFromString should parse strings correctly", t, func() {
+		for _, tc := range testCases {
+			Convey(tc.src, func() {
+				ia, err := IAFromString(tc.src)
+				if tc.ia == nil {
+					SoMsg("Must raise parse error", err, ShouldNotBeNil)
+					return
+				}
+				SoMsg("Must parse cleanly", err, ShouldBeNil)
+				SoMsg("Parsed IA must be correct", ia, ShouldResemble, *tc.ia)
+			})
+		}
+
+	})
+}
+
 func Test_IA_Write(t *testing.T) {
 	Convey("ISD_AS.Write() should output bytes correctly", t, func() {
 		output := make([]byte, IABytes)

--- a/go/lib/addr/isdas_test.go
+++ b/go/lib/addr/isdas_test.go
@@ -15,7 +15,6 @@
 package addr
 
 import (
-	"fmt"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -26,8 +25,34 @@ var (
 	ia    = IA{I: 0xF011, A: 0xF23344556677}
 )
 
-// Interface assertions
-var _ fmt.Stringer = (*IA)(nil)
+func Test_AS_String(t *testing.T) {
+	var testCases = []struct {
+		as  AS
+		out string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{999, "999"},
+		{1000, "1_000"},
+		{11000, "11_000"},
+		{999999, "999_999"},
+		{1000000, "1_000_000"},
+		{999999999, "999_999_999"},
+		{1000000000, "1_000_000_000"},
+		{999999999999, "999_999_999_999"},
+		{1000000000000, "1_000_000_000_000"},
+		{281474976710655, "281_474_976_710_655"},
+		{281474976710656, "281474976710656 [Illegal AS: larger than 281474976710655]"},
+	}
+	Convey("AS.String() should format correctly", t, func() {
+		for _, tc := range testCases {
+			Convey(tc.out, func() {
+				s := tc.as.String()
+				SoMsg("Format must match", s, ShouldEqual, tc.out)
+			})
+		}
+	})
+}
 
 func Test_IAFromRaw(t *testing.T) {
 	Convey("IAFromRaw should parse bytes correctly", t, func() {
@@ -100,8 +125,22 @@ func Test_IA_Write(t *testing.T) {
 }
 
 func Test_IA_String(t *testing.T) {
-	Convey("String() should return ISD-AS", t, func() {
-		ia := IA{33, 55}
-		So(ia.String(), ShouldEqual, "33-55")
+	var testCases = []struct {
+		ia  IA
+		out string
+	}{
+		{IA{0, 0}, "0-0"},
+		{IA{1, 1}, "1-1"},
+		{IA{65535, 1}, "65535-1"},
+		{IA{65535, 281474976710655}, "65535-281_474_976_710_655"},
+		{IA{1, 281474976710656}, "1-281474976710656 [Illegal AS: larger than 281474976710655]"},
+	}
+	Convey("IA.String() should format correctly", t, func() {
+		for _, tc := range testCases {
+			Convey(tc.out, func() {
+				s := tc.ia.String()
+				SoMsg("Format must match", s, ShouldEqual, tc.out)
+			})
+		}
 	})
 }

--- a/python/lib/packet/scion_addr.py
+++ b/python/lib/packet/scion_addr.py
@@ -147,10 +147,30 @@ class ISD_AS(Serializable):
         yield self._isd
         yield self._as
 
-    def __str__(self):
-        return "%s-%s" % (self._isd, self._as)
+    def isd_str(self):
+        s = "%s" % self._isd
+        if self._isd > self.MAX_ISD:
+            return "%s [Illegal ISD: larger than %d]" % (s, self.MAX_ISD)
+        return s
 
-    def __repr__(self):
+    def as_str(self):
+        dec_str = "%s" % self._as
+        if self._as > self.MAX_AS:
+            return "%s [Illegal AS: larger than %d]" % (dec_str, self.MAX_AS)
+        l = len(dec_str)
+        s = []
+        start = 0
+        end = (l % 3) or 3
+        while end <= l:
+            s.append(dec_str[start:end])
+            start = end
+            end += 3
+        return "_".join(s)
+
+    def __str__(self):
+        return "%s-%s" % (self.isd_str(), self.as_str())
+
+    def __repr__(self):  # pragma: no cover
         return "ISD_AS(isd=%s, as=%s)" % (self._isd, self._as)
 
     def __len__(self):  # pragma: no cover

--- a/python/lib/packet/scion_addr.py
+++ b/python/lib/packet/scion_addr.py
@@ -37,8 +37,9 @@ class ISD_AS(Serializable):
     NAME = "ISD_AS"
     LEN = 8
     ISD_BITS = 16
+    MAX_ISD = (1 << ISD_BITS) - 1
     AS_BITS = 48
-    AS_MASK = (1 << AS_BITS) - 1
+    MAX_AS = (1 << AS_BITS) - 1
 
     def __init__(self, raw=None):
         self._isd = 0
@@ -65,22 +66,39 @@ class ISD_AS(Serializable):
         """
         :param str raw: a string of the format "isd-as".
         """
-        isd, as_ = raw.split("-", 1)
+        parts = raw.split("-")
+        if len(parts) != 2:
+            raise SCIONParseError("Unable to split ISD-AS in string: %s" % raw)
+        isd_s, as_s = parts
         try:
-            self._isd = int(isd)
+            self._isd = int(isd_s)
         except ValueError:
             raise SCIONParseError("Unable to parse ISD from string: %s" % raw)
+        if self._isd > self.MAX_ISD:
+            raise SCIONParseError("ISD too large (max: %d): %s" % (self.MAX_ISD, raw))
+        if '_' in as_s:
+            as_parts = as_s.split("_")
+            for i, s in enumerate(as_parts):
+                if i == 0:
+                    if len(s) == 0 or len(s) > 3:
+                        raise SCIONParseError("Malformed _-separated AS: %s" % raw)
+                    continue
+                if len(s) != 3:
+                        raise SCIONParseError("Malformed _-separated AS: %s" % raw)
+            as_s = "".join(as_parts)
         try:
-            self._as = int(as_)
+            self._as = int(as_s)
         except ValueError:
             raise SCIONParseError("Unable to parse AS from string: %s" % raw)
+        if self._as > self.MAX_AS:
+            raise SCIONParseError("AS too large (max: %d): %s" % (self.MAX_AS, raw))
 
     def _parse_int(self, raw):
         """
         :param int raw: a 64-bit unsigned integer
         """
         self._isd = raw >> self.AS_BITS
-        self._as = raw & self.AS_MASK
+        self._as = raw & self.MAX_AS
 
     @classmethod
     def from_values(cls, isd, as_):  # pragma: no cover
@@ -94,7 +112,7 @@ class ISD_AS(Serializable):
 
     def int(self):
         isd_as = self._isd << self.AS_BITS
-        isd_as |= self._as & self.AS_MASK
+        isd_as |= self._as & self.MAX_AS
         return isd_as
 
     def any_as(self):  # pragma: no cover

--- a/python/lib/packet/scion_addr.py
+++ b/python/lib/packet/scion_addr.py
@@ -148,13 +148,13 @@ class ISD_AS(Serializable):
         yield self._as
 
     def isd_str(self):
-        s = "%s" % self._isd
+        s = str(self._isd)
         if self._isd > self.MAX_ISD:
             return "%s [Illegal ISD: larger than %d]" % (s, self.MAX_ISD)
         return s
 
     def as_str(self):
-        dec_str = "%s" % self._as
+        dec_str = str(self._as)
         if self._as > self.MAX_AS:
             return "%s [Illegal AS: larger than %d]" % (dec_str, self.MAX_AS)
         l = len(dec_str)

--- a/python/test/lib/packet/scion_addr_test.py
+++ b/python/test/lib/packet/scion_addr_test.py
@@ -50,13 +50,27 @@ class TestISDASParseStr(object):
     """
     Unit tests for lib.packet.scion_addr.ISD_AS._parse_str
     """
-    def test_success(self):
+    def _check_success(self, ia_s, isd, as_):
         inst = ISD_AS()
         # Call
-        inst._parse_str("4095-99")
+        inst._parse_str(ia_s)
         # Tests
-        ntools.eq_(inst._isd, 4095)
-        ntools.eq_(inst._as, 99)
+        ntools.eq_(inst._isd, isd)
+        ntools.eq_(inst._as, as_)
+
+    def test_success(self):
+        for ia_s, isd, as_ in (
+            ("0-0", 0, 0),
+            ("1-1", 1, 1),
+            ("65535-1", ISD_AS.MAX_ISD, 1),
+            ("1-281474976710655", 1, ISD_AS.MAX_AS),
+            ("65535-281474976710655", ISD_AS.MAX_ISD, ISD_AS.MAX_AS),
+            ("1-1_000", 1, 1000),
+            ("1-11_000", 1, 11000),
+            ("1-111_000", 1, 111000),
+            ("65535-281_474_976_710_655", ISD_AS.MAX_ISD, ISD_AS.MAX_AS),
+        ):
+            yield self._check_success, ia_s, isd, as_
 
     def _check_excp(self, isd_as):
         inst = ISD_AS()
@@ -64,7 +78,31 @@ class TestISDASParseStr(object):
         ntools.assert_raises(SCIONParseError, inst._parse_str, isd_as)
 
     def test_excp(self):
-        for isd_as in ("0-nope", "argh-99"):
+        for isd_as in (
+            "",
+            "a",
+            "1a-2b",
+            "-",
+            "1-",
+            "-1",
+            "-1-",
+            "1--1",
+            "1-_",
+            "1-_0",
+            "1-_00",
+            "1-_000",
+            "1-_0000",
+            "1-1_0",
+            "1-1_00",
+            "65536-1",
+            "1-281474976710656",
+            "1-1_0000",
+            "1-1111_000",
+            "65535-281_474_976_710_656",
+            "65535-281_474_976_7106_55",
+            "65535-281_474_976_71_0655",
+            "65535-1281_474_976_710",
+        ):
             yield self._check_excp, isd_as
 
 

--- a/python/test/lib/packet/scion_addr_test.py
+++ b/python/test/lib/packet/scion_addr_test.py
@@ -25,7 +25,7 @@ import nose.tools as ntools
 # SCION
 from lib.errors import SCIONParseError
 from lib.packet.scion_addr import SCIONAddr, ISD_AS
-from test.testcommon import assert_these_calls, create_mock
+from test.testcommon import assert_these_calls, create_mock, create_mock_full
 
 
 class TestISDASParseBytes(object):
@@ -129,6 +129,67 @@ class TestISDASPack(object):
         inst._as = 0xF23344556677
         # Call
         ntools.eq_(inst.pack(), bytes.fromhex("F011F23344556677"))
+
+
+class TestISDASIsdStr(object):
+    """
+    Unit tests for lib.packet.scion_addr.ISD_AS.isd_str
+    """
+    def _check(self, isd, s):
+        inst = ISD_AS()
+        inst._isd = isd
+        # Call
+        ntools.eq_(inst.isd_str(), s)
+
+    def test(self):
+        for isd, s in (
+            (0, "0"),
+            (1, "1"),
+            (65535, "65535"),
+            (65536, "65536 [Illegal ISD: larger than 65535]"),
+        ):
+            yield self._check, isd, s
+
+
+class TestISDASAsStr(object):
+    """
+    Unit tests for lib.packet.scion_addr.ISD_AS.as_str
+    """
+    def _check(self, as_, s):
+        inst = ISD_AS()
+        inst._as = as_
+        # Call
+        ntools.eq_(inst.as_str(), s)
+
+    def test(self):
+        for as_, s in (
+            (0, "0"),
+            (1, "1"),
+            (999, "999"),
+            (1000, "1_000"),
+            (11000, "11_000"),
+            (999999, "999_999"),
+            (1000000, "1_000_000"),
+            (999999999, "999_999_999"),
+            (1000000000, "1_000_000_000"),
+            (999999999999, "999_999_999_999"),
+            (1000000000000, "1_000_000_000_000"),
+            (281474976710655, "281_474_976_710_655"),
+            (281474976710656, "281474976710656 [Illegal AS: larger than 281474976710655]"),
+        ):
+            yield self._check, as_, s
+
+
+class TestISDASStr(object):
+    """
+    Unit tests for lib.packet.scion_addr.ISD_AS.__str__
+    """
+    def test(self):
+        inst = ISD_AS()
+        inst.isd_str = create_mock_full()
+        inst.as_str = create_mock_full()
+        # Call
+        ntools.eq_(str(inst), "%s-%s" % (inst.isd_str.return_value, inst.as_str.return_value))
 
 
 class TestSCIONAddrParse(object):


### PR DESCRIPTION
This makes it much easier for humans to parse, which is especially
relevant with 48-bit AS numbers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1457)
<!-- Reviewable:end -->
