### PR TITLE
Separate out AS parsing for use by apps.

### DIFF
--- a/go/cert_srv/conf/customers.go
+++ b/go/cert_srv/conf/customers.go
@@ -47,7 +47,7 @@ func (c *Conf) LoadCustomers() (Customers, error) {
 	activeKeys := make(map[addr.IA]string)
 	activeVers := make(map[addr.IA]uint64)
 	for _, file := range files {
-		re := regexp.MustCompile(`ISD(\d+)-AS(\d+)-V(\d+)\.key$`)
+		re := regexp.MustCompile(`ISD(\d+)-AS([\d_]+)-V(\d+)\.key$`)
 		s := re.FindStringSubmatch(file)
 		ia, err := addr.IAFromString(fmt.Sprintf("%s-%s", s[1], s[2]))
 		if err != nil {
@@ -100,7 +100,7 @@ func (c *Conf) SetVerifyingKey(ia addr.IA, ver uint64, newKey, oldKey common.Raw
 	// Key has to be written to file system, only if it has changed
 	if !bytes.Equal(newKey, currKey) {
 		var err error
-		name := fmt.Sprintf("ISD%d-AS%d-V%d.key", ia.I, ia.A, ver)
+		name := fmt.Sprintf("ISD%d-AS%s-V%d.key", ia.I, ia.A, ver)
 		path := filepath.Join(c.StateDir, CustomersDir, name)
 		if _, err = os.Stat(path); !os.IsNotExist(err) {
 			return err

--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -32,7 +32,47 @@ const (
 )
 
 type ISD uint16
+
+func ISDFromString(s string) (ISD, error) {
+	isd, err := strconv.ParseUint(s, 10, ISDBits)
+	if err != nil {
+		// err.Error() will contain the original value
+		return 0, common.NewBasicError("Unable to parse ISD", err)
+	}
+	return ISD(isd), nil
+}
+
 type AS uint64
+
+func ASFromString(s string) (AS, error) {
+	asStr := s
+	if strings.Index(s, "_") != -1 {
+		// Support AS nubmers that have _ as thousands-separators. E.g. `281474976710655`
+		// can also be written as `281_474_976_710_655`.
+		parts := strings.Split(s, "_")
+		for i := range parts {
+			pLen := len(parts[i])
+			if i == 0 {
+				if pLen == 0 || pLen > 3 {
+					// Make sure the first part isn't either 0, or too long
+					return 0, common.NewBasicError("Malformed _-separated AS", nil, "val", s)
+				}
+				continue
+			}
+			if pLen != 3 {
+				// Ensure that there are 3 chars for every part after the first
+				return 0, common.NewBasicError("Malformed _-separated AS", nil, "val", s)
+			}
+		}
+		asStr = strings.Join(parts, "")
+	}
+	as, err := strconv.ParseUint(asStr, 10, ASBits)
+	if err != nil {
+		// err.Error() will contain the original value
+		return 0, common.NewBasicError("Unable to parse AS", err)
+	}
+	return AS(as), nil
+}
 
 func (as AS) String() string {
 	decStr := strconv.FormatUint(uint64(as), 10)
@@ -74,39 +114,15 @@ func IAFromString(s string) (IA, error) {
 	if len(parts) != 2 {
 		return IA{}, common.NewBasicError("Invalid ISD-AS", nil, "val", s)
 	}
-	isd, err := strconv.ParseUint(parts[0], 10, ISDBits)
+	isd, err := ISDFromString(parts[0])
 	if err != nil {
-		// err.Error() will contain the original value
-		return IA{}, common.NewBasicError("Unable to parse ISD", err)
+		return IA{}, err
 	}
-	var as uint64
-	var asStr = parts[1]
-	if strings.Index(parts[1], "_") != -1 {
-		// Support AS nubmers that have _ as thousands-separators. E.g. `281474976710655`
-		// can also be written as `281_474_976_710_655`.
-		as_parts := strings.Split(parts[1], "_")
-		for i := range as_parts {
-			pLen := len(as_parts[i])
-			if i == 0 {
-				if pLen == 0 || pLen > 3 {
-					// Make sure the first part isn't either 0, or too long
-					return IA{}, common.NewBasicError("Malformed _-separated AS", nil, "val", s)
-				}
-				continue
-			}
-			if pLen != 3 {
-				// Ensure that there are 3 chars for every part after the first
-				return IA{}, common.NewBasicError("Malformed _-separated AS", nil, "val", s)
-			}
-		}
-		asStr = strings.Join(as_parts, "")
-	}
-	as, err = strconv.ParseUint(asStr, 10, ASBits)
+	as, err := ASFromString(parts[1])
 	if err != nil {
-		// err.Error() will contain the original value
-		return IA{}, common.NewBasicError("Unable to parse AS", err)
+		return IA{}, err
 	}
-	return IA{I: ISD(isd), A: AS(as)}, nil
+	return IA{I: ISD(isd), A: as}, nil
 }
 
 func (ia IA) MarshalText() ([]byte, error) {

--- a/go/lib/addr/isdas_test.go
+++ b/go/lib/addr/isdas_test.go
@@ -25,6 +25,77 @@ var (
 	ia    = IA{I: 0xF011, A: 0xF23344556677}
 )
 
+func Test_ISDFromString(t *testing.T) {
+	var testCases = []struct {
+		src string
+		isd ISD
+		ok  bool
+	}{
+		{"", 0, false},
+		{"0", 0, true},
+		{"1", 1, true},
+		{"65535", MaxISD, true},
+		{"65536", 0, false},
+	}
+	Convey("ISDFromString should parse strings correctly", t, func() {
+		for _, tc := range testCases {
+			Convey(tc.src, func() {
+				isd, err := ISDFromString(tc.src)
+				if !tc.ok {
+					SoMsg("Must raise parse error", err, ShouldNotBeNil)
+					return
+				}
+				SoMsg("Must parse cleanly", err, ShouldBeNil)
+				SoMsg("Parsed ISD must be correct", isd, ShouldEqual, tc.isd)
+			})
+		}
+	})
+}
+
+func Test_ASFromString(t *testing.T) {
+	var testCases = []struct {
+		src string
+		as  AS
+		ok  bool
+	}{
+		{"", 0, false},
+		{"2b", 0, false},
+		{"0", 0, true},
+		{"1", 1, true},
+		{"1 1", 0, false},
+		{"281474976710655", MaxAS, true},
+		{"281474976710656", 0, false},
+		{"_000", 0, false},
+		{"000_", 0, false},
+		{"_000_", 0, false},
+		{"1_0", 0, false},
+		{"1_00", 0, false},
+		{"1_000", 1000, true},
+		{"1_0000", 0, false},
+		{"11_000", 11000, true},
+		{"111_000", 111000, true},
+		{"1111_000", 0, false},
+		{"281_474_976_710_655", MaxAS, true},
+		{"281_474_976_710_656", 0, false},
+		{"281_474_976_7106_55", 0, false},
+		{"281_474_976_71_0655", 0, false},
+		{"1281_474_976_710", 0, false},
+	}
+	Convey("ASFromString should parse strings correctly", t, func() {
+		for _, tc := range testCases {
+			Convey(tc.src, func() {
+				as, err := ASFromString(tc.src)
+				if !tc.ok {
+					SoMsg("Must raise parse error", err, ShouldNotBeNil)
+					return
+				}
+				SoMsg("Must parse cleanly", err, ShouldBeNil)
+				SoMsg("Parsed AS must be correct", as, ShouldEqual, tc.as)
+			})
+		}
+	})
+}
+
 func Test_AS_String(t *testing.T) {
 	var testCases = []struct {
 		as  AS
@@ -82,23 +153,6 @@ func Test_IAFromString(t *testing.T) {
 		{"1-281474976710655", &IA{1, MaxAS}},
 		{"1-281474976710656", nil},
 		{"65535-281474976710655", &IA{MaxISD, MaxAS}},
-		{"1-_", nil},
-		{"1-_0", nil},
-		{"1-_00", nil},
-		{"1-_000", nil},
-		{"1-_0000", nil},
-		{"1-1_0", nil},
-		{"1-1_00", nil},
-		{"1-1_000", &IA{1, 1000}},
-		{"1-1_0000", nil},
-		{"1-11_000", &IA{1, 11000}},
-		{"1-111_000", &IA{1, 111000}},
-		{"1-1111_000", nil},
-		{"65535-281_474_976_710_655", &IA{MaxISD, MaxAS}},
-		{"65535-281_474_976_710_656", nil},
-		{"65535-281_474_976_7106_55", nil},
-		{"65535-281_474_976_71_0655", nil},
-		{"65535-1281_474_976_710", nil},
 	}
 	Convey("IAFromString should parse strings correctly", t, func() {
 		for _, tc := range testCases {

--- a/go/lib/pathdb/sqlite/sqlite_test.go
+++ b/go/lib/pathdb/sqlite/sqlite_test.go
@@ -181,7 +181,7 @@ func checkIntfToSeg(t *testing.T, b *Backend, segRowID int, intfs []query.IntfSp
 
 func checkStartsAtOrEndsAt(t *testing.T, b *Backend, table string, segRowID int, ia addr.IA) {
 	var segID int
-	queryStr := fmt.Sprintf("SELECT SegRowID FROM %s WHERE IsdID=%v AND AsID=%v", table, ia.I, ia.A)
+	queryStr := fmt.Sprintf("SELECT SegRowID FROM %s WHERE IsdID=%d AND AsID=%d", table, ia.I, ia.A)
 	err := b.db.QueryRow(queryStr).Scan(&segID)
 	if err != nil {
 		t.Fatal("CheckStartsAtOrEndsAt", "err", err)

--- a/go/lib/pathmgr/pred.go
+++ b/go/lib/pathmgr/pred.go
@@ -70,7 +70,7 @@ func (pp *PathPredicate) String() string {
 	var desc []string
 	for _, iface := range pp.Match {
 		isdas := iface.ISD_AS()
-		desc = append(desc, fmt.Sprintf("%d-%d#%d", isdas.I, isdas.A, iface.IfID))
+		desc = append(desc, fmt.Sprintf("%d-%s#%d", isdas.I, isdas.A, iface.IfID))
 	}
 	return strings.Join(desc, ",")
 }

--- a/go/lib/trust/store.go
+++ b/go/lib/trust/store.go
@@ -161,7 +161,7 @@ func (s *Store) AddTRC(trc *trc.TRC, write bool) error {
 // writeChain writes certificate chain to the filesystem, if it does not already exist.
 func (s *Store) writeChain(chain *cert.Chain) error {
 	ia, ver := chain.IAVer()
-	name := fmt.Sprintf("%s-ISD%d-AS%d-V%d.crt", s.eName, ia.I, ia.A, ver)
+	name := fmt.Sprintf("%s-ISD%d-AS%s-V%d.crt", s.eName, ia.I, ia.A, ver)
 	return s.writeJSON(chain, filepath.Join(s.cacheDir, name))
 }
 


### PR DESCRIPTION
- Update string formatting of AS numbers everywhere (mostly %d->%s, but
  also %v->%d for pathdb/sqlite).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1462)
<!-- Reviewable:end -->
