### PR TITLE
Fix GetMaxVersion in trustdb

### DIFF
--- a/go/lib/infra/modules/trust/trustdb/db.go
+++ b/go/lib/infra/modules/trust/trustdb/db.go
@@ -83,6 +83,7 @@ const (
 		`
 	getIssCertMaxVersionStr = `
 			SELECT Data FROM (SELECT *, MAX(Version) FROM IssuerCerts WHERE IsdID=? AND AsID=?)
+			WHERE Data IS NOT NULL
 		`
 	getIssCertRowIDStr = `
 			SELECT RowID FROM IssuerCerts WHERE IsdID=? AND AsID=? AND Version=?
@@ -95,6 +96,7 @@ const (
 		`
 	getLeafCertMaxVersionStr = `
 			SELECT Data FROM (SELECT *, MAX(Version) FROM LeafCerts WHERE IsdID=? AND AsID=?)
+			WHERE Data IS NOT NULL
 		`
 	insertLeafCertStr = `
 			INSERT OR IGNORE INTO LeafCerts (IsdID, AsID, Version, Data) VALUES (?, ?, ?, ?)
@@ -130,6 +132,7 @@ const (
 		`
 	getTRCMaxVersionStr = `
 			SELECT Data FROM (SELECT *, MAX(Version) FROM TRCs WHERE IsdID=?)
+			WHERE Data IS NOT NULL
 		`
 	insertTRCStr = `
 			INSERT OR IGNORE INTO TRCs (IsdID, Version, Data) VALUES (?, ?, ?)
@@ -423,12 +426,12 @@ func (db *DB) getIssCertRowIDCtx(ctx context.Context, ia addr.IA, ver uint64) (i
 
 // GetTRCVersion returns the specified version of the TRC for
 // isd. If version is 0, this is equivalent to GetTRCMaxVersion.
-func (db *DB) GetTRCVersion(isd uint16, version uint64) (*trc.TRC, error) {
+func (db *DB) GetTRCVersion(isd addr.ISD, version uint64) (*trc.TRC, error) {
 	return db.GetTRCVersionCtx(context.Background(), isd, version)
 }
 
 // GetTRCVersionCtx is the context aware version of GetTRCVersion.
-func (db *DB) GetTRCVersionCtx(ctx context.Context, isd uint16, version uint64) (*trc.TRC, error) {
+func (db *DB) GetTRCVersionCtx(ctx context.Context, isd addr.ISD, version uint64) (*trc.TRC, error) {
 	if version == 0 {
 		return db.GetTRCMaxVersionCtx(ctx, isd)
 	}
@@ -447,11 +450,11 @@ func (db *DB) GetTRCVersionCtx(ctx context.Context, isd uint16, version uint64) 
 	return trcobj, nil
 }
 
-func (db *DB) GetTRCMaxVersion(isd uint16) (*trc.TRC, error) {
+func (db *DB) GetTRCMaxVersion(isd addr.ISD) (*trc.TRC, error) {
 	return db.GetTRCMaxVersionCtx(context.Background(), isd)
 }
 
-func (db *DB) GetTRCMaxVersionCtx(ctx context.Context, isd uint16) (*trc.TRC, error) {
+func (db *DB) GetTRCMaxVersionCtx(ctx context.Context, isd addr.ISD) (*trc.TRC, error) {
 	var raw common.RawBytes
 	err := db.getTRCMaxVersionStmt.QueryRowContext(ctx, isd).Scan(&raw)
 	if err == sql.ErrNoRows {

--- a/go/lib/infra/modules/trust/trustdb/db_test.go
+++ b/go/lib/infra/modules/trust/trustdb/db_test.go
@@ -59,6 +59,14 @@ func TestTRC(t *testing.T) {
 				SoMsg("err", err, ShouldBeNil)
 				SoMsg("trc", newTRCobj, ShouldBeNil)
 			})
+			Convey("Get missing Max TRC from database", func() {
+				newTRCobj, err := db.GetTRCVersion(2, 0)
+				SoMsg("err", err, ShouldBeNil)
+				SoMsg("trc", newTRCobj, ShouldBeNil)
+				newTRCobj, err = db.GetTRCMaxVersion(2)
+				SoMsg("err", err, ShouldBeNil)
+				SoMsg("trc", newTRCobj, ShouldBeNil)
+			})
 		})
 	})
 }
@@ -96,6 +104,15 @@ func TestIssCert(t *testing.T) {
 			Convey("Get missing issuer certificate from database", func() {
 				otherIA := addr.IA{I: 1, A: 2}
 				crt, err := db.GetIssCertVersion(otherIA, 10)
+				SoMsg("err", err, ShouldBeNil)
+				SoMsg("cert", crt, ShouldBeNil)
+			})
+			Convey("Get missing issuer max certificate from database", func() {
+				otherIA := addr.IA{I: 1, A: 2}
+				crt, err := db.GetIssCertVersion(otherIA, 0)
+				SoMsg("err", err, ShouldBeNil)
+				SoMsg("cert", crt, ShouldBeNil)
+				crt, err = db.GetIssCertMaxVersion(otherIA)
 				SoMsg("err", err, ShouldBeNil)
 				SoMsg("cert", crt, ShouldBeNil)
 			})
@@ -139,6 +156,15 @@ func TestLeafCert(t *testing.T) {
 				SoMsg("err", err, ShouldBeNil)
 				SoMsg("cert", crt, ShouldBeNil)
 			})
+			Convey("Get missing leaf max certificate from database", func() {
+				otherIA := addr.IA{I: 1, A: 2}
+				crt, err := db.GetLeafCertVersion(otherIA, 0)
+				SoMsg("err", err, ShouldBeNil)
+				SoMsg("cert", crt, ShouldBeNil)
+				crt, err = db.GetLeafCertMaxVersion(otherIA)
+				SoMsg("err", err, ShouldBeNil)
+				SoMsg("cert", crt, ShouldBeNil)
+			})
 		})
 	})
 }
@@ -173,6 +199,15 @@ func TestChain(t *testing.T) {
 			Convey("Get missing certificate chain from database", func() {
 				otherIA := addr.IA{I: 1, A: 2}
 				newChain, err := db.GetChainVersion(otherIA, 10)
+				SoMsg("err", err, ShouldBeNil)
+				SoMsg("chain", newChain, ShouldBeNil)
+			})
+			Convey("Get missing max certificate chain from database", func() {
+				otherIA := addr.IA{I: 1, A: 2}
+				newChain, err := db.GetChainVersion(otherIA, 0)
+				SoMsg("err", err, ShouldBeNil)
+				SoMsg("chain", newChain, ShouldBeNil)
+				newChain, err = db.GetChainMaxVersion(otherIA)
 				SoMsg("err", err, ShouldBeNil)
 				SoMsg("chain", newChain, ShouldBeNil)
 			})


### PR DESCRIPTION
Avoid throwing an error for missing max cert/TRC version.
Add unit tests to cover requests for missing max cert/chain/TRC.

Change signature of GetTRC* to take addr.ISD instead of uint16.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1465)
<!-- Reviewable:end -->
