### PR TITLE
Don't log inside the signal handler

### DIFF
--- a/python/lib/util.py
+++ b/python/lib/util.py
@@ -18,6 +18,7 @@
 Various utilities for SCION functionality.
 """
 # Stdlib
+import atexit
 import json
 import logging
 import os
@@ -226,12 +227,12 @@ def _signal_handler(signum, _):
     """Basic signal handler function."""
     text = "Received %s" % _SIG_MAP[signum]
     if signum == signal.SIGTERM:
-        logging.info(text)
+        atexit.register(lambda: logging.info(text))
         sys.exit(0)
     elif signum == signal.SIGINT:
-        logging.info(text)
+        atexit.register(lambda: logging.info(text))
     else:
-        logging.error(text)
+        atexit.register(lambda: logging.error(text))
     sys.exit(1)
 
 

--- a/python/test/lib/util_test.py
+++ b/python/test/lib/util_test.py
@@ -290,25 +290,24 @@ class TestSignalHandler(object):
     Unit tests for lib.util._signal_handler
     """
     @patch("lib.util.sys.exit", autospec=True)
-    @patch("lib.util.logging.info", autospec=True)
-    def test_term(self, info, exit):
+    @patch("lib.util.atexit.register", autospec=True)
+    def test_term(self, atexit, exit):
         exit.side_effect = SystemExit
         ntools.assert_raises(SystemExit, _signal_handler, SIGTERM, "")
-        ntools.ok_(info.called)
+        ntools.ok_(atexit.called)
         exit.assert_called_once_with(0)
 
     @patch("lib.util.sys.exit", autospec=True)
-    @patch("lib.util.logging.info", autospec=True)
-    def test_int(self, info, exit):
+    @patch("lib.util.atexit.register", autospec=True)
+    def test_int(self, atexit, exit):
         _signal_handler(SIGINT, "")
-        ntools.ok_(info.called)
         exit.assert_called_once_with(1)
 
     @patch("lib.util.sys.exit", autospec=True)
-    @patch("lib.util.logging.error", autospec=True)
-    def test_error(self, error, exit):
+    @patch("lib.util.atexit.register", autospec=True)
+    def test_error(self, atexit, exit):
         _signal_handler(SIGQUIT, "")
-        ntools.ok_(error.called)
+        ntools.ok_(atexit.called)
         exit.assert_called_once_with(1)
 
 


### PR DESCRIPTION
This is not supported by python: https://bugs.python.org/issue24283

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1467)
<!-- Reviewable:end -->
