### PR TITLE
Re-enable quic/scion after licensing issue resolved.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
     build:
         docker:
-            - image: scionproto/scion_base@sha256:9b7746fdb9f78e080da3c6a261da34efa1801277eba5891516872439b356472d
+            - image: scionproto/scion_base@sha256:0a959b9a02d21b3a496a21e1356823f747c6205514fb1eba09501ec9918a975d
         <<: *job
         steps:
             - checkout

--- a/go/examples/pingpong/README.md
+++ b/go/examples/pingpong/README.md
@@ -3,12 +3,12 @@ first make sure the infrastructure is running.
 
 Then, start the server using:
 ```
-go run pingpong.go -mode server -local 2-25,[127.0.0.1]:40002 -count 10
+pingpong -mode server -local 2-25,[127.0.0.1]:40002
 ```
 
 Finally, start the client using:
 ```
-go run pingpong.go -mode client -remote 2-25,[127.0.0.1]:40002 -local 1-19,[127.0.0.1]:0 -count 10
+pingpong -mode client -remote 2-25,[127.0.0.1]:40002 -local 1-19,[127.0.0.1]:0 -count 10
 ```
 
 When running the client in interactive mode, the user would be able to choose

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build ignore
-
 // QUIC/SCION implementation.
 package squic
 
@@ -21,7 +19,7 @@ import (
 	"crypto/tls"
 
 	//log "github.com/inconshreveable/log15"
-	//"github.com/lucas-clemente/quic-go"
+	"github.com/lucas-clemente/quic-go"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
@@ -54,26 +52,26 @@ func Init(keyPath, pemPath string) error {
 	return nil
 }
 
-func DialSCION(network *snet.Network, laddr, raddr *snet.Addr) /*quic.Session, */ error {
+func DialSCION(network *snet.Network, laddr, raddr *snet.Addr) (quic.Session, error) {
 	return DialSCIONWithBindSVC(network, laddr, raddr, nil, addr.SvcNone)
 }
 
 func DialSCIONWithBindSVC(network *snet.Network, laddr, raddr, baddr *snet.Addr,
-	svc addr.HostSVC) /*quic.Session, */ error {
+	svc addr.HostSVC) (quic.Session, error) {
 	sconn, err := sListen(network, laddr, baddr, svc)
 	if err != nil {
 		return nil, err
 	}
 	// Use dummy hostname, as it's used for SNI, and we're not doing cert verification.
-	return //quic.Dial(sconn, raddr, "host:0", cliTlsCfg, nil)
+	return quic.Dial(sconn, raddr, "host:0", cliTlsCfg, nil)
 }
 
-func ListenSCION(network *snet.Network, laddr *snet.Addr) /*quic.Listener, */ error {
+func ListenSCION(network *snet.Network, laddr *snet.Addr) (quic.Listener, error) {
 	return ListenSCIONWithBindSVC(network, laddr, nil, addr.SvcNone)
 }
 
 func ListenSCIONWithBindSVC(network *snet.Network, laddr, baddr *snet.Addr,
-	svc addr.HostSVC) /*quic.Listener, */ error {
+	svc addr.HostSVC) (quic.Listener, error) {
 	if len(srvTlsCfg.Certificates) == 0 {
 		return nil, common.NewBasicError("squic: No server TLS certificate configured", nil)
 	}
@@ -81,7 +79,7 @@ func ListenSCIONWithBindSVC(network *snet.Network, laddr, baddr *snet.Addr,
 	if err != nil {
 		return nil, err
 	}
-	return //quic.Listen(sconn, srvTlsCfg, nil)
+	return quic.Listen(sconn, srvTlsCfg, nil)
 }
 
 func sListen(network *snet.Network, laddr, baddr *snet.Addr,

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -3,6 +3,18 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "CRskBANKJfxFhfOCiYbR0aRhw18=",
+			"path": "github.com/aead/chacha20",
+			"revision": "e0d4ab3067da29fbce5b60445bed6d54c41c3c62",
+			"revisionTime": "2018-03-25T21:26:32Z"
+		},
+		{
+			"checksumSHA1": "66BRKRhtPOAXVoZwgMtrgSuFOkw=",
+			"path": "github.com/aead/chacha20/chacha",
+			"revision": "e0d4ab3067da29fbce5b60445bed6d54c41c3c62",
+			"revisionTime": "2018-03-25T21:26:32Z"
+		},
+		{
 			"checksumSHA1": "YNhwvoScUezhDwq58QMY8vUwuqg=",
 			"license": "MIT,3-BSD",
 			"path": "github.com/axw/gocov",
@@ -36,6 +48,24 @@
 			"path": "github.com/beorn7/perks/quantile",
 			"revision": "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9",
 			"revisionTime": "2016-08-04T10:47:26Z"
+		},
+		{
+			"checksumSHA1": "U6Xb8fxRhdSrxoWzL5ehTRk/704=",
+			"path": "github.com/bifurcation/mint",
+			"revision": "198357931e6129b810c9c77c12e0dd754846170c",
+			"revisionTime": "2018-03-06T13:52:33Z"
+		},
+		{
+			"checksumSHA1": "yZuFJmLUlFHTDWyCLxcDqif/H/w=",
+			"path": "github.com/bifurcation/mint/syntax",
+			"revision": "198357931e6129b810c9c77c12e0dd754846170c",
+			"revisionTime": "2018-03-06T13:52:33Z"
+		},
+		{
+			"checksumSHA1": "PYXuf7wvcj492uWhjvmXlyyQUYc=",
+			"path": "github.com/cheekybits/genny/generic",
+			"revision": "9127e812e1e9e501ce899a18121d316ecb52e4ba",
+			"revisionTime": "2017-03-28T20:00:08Z"
 		},
 		{
 			"checksumSHA1": "s8t6UaijV8WMK0RMdX00OPI5z0o=",
@@ -83,6 +113,18 @@
 			"revisionTime": "2016-10-23T18:47:00Z"
 		},
 		{
+			"checksumSHA1": "UquR8kc0nKU285HwLbkievlLQz4=",
+			"path": "github.com/hashicorp/golang-lru",
+			"revision": "0fb14efe8c47ae851c0034ed7a448854d3d34cf3",
+			"revisionTime": "2018-02-01T23:52:37Z"
+		},
+		{
+			"checksumSHA1": "8Z637dcPkbR5HdLQQBp/9jTbx9Y=",
+			"path": "github.com/hashicorp/golang-lru/simplelru",
+			"revision": "0fb14efe8c47ae851c0034ed7a448854d3d34cf3",
+			"revisionTime": "2018-02-01T23:52:37Z"
+		},
+		{
 			"checksumSHA1": "S1lxMekj2Rxqp/lA47z9UGeNHjs=",
 			"license": "APL 2.0",
 			"path": "github.com/inconshreveable/log15",
@@ -116,6 +158,78 @@
 			"path": "github.com/kormat/fmt15",
 			"revision": "aeb535ae78961b7591ea7f7740b74fc6560c88a8",
 			"revisionTime": "2016-11-22T15:41:03Z"
+		},
+		{
+			"checksumSHA1": "2RFzGcdTeQrFkkhT70WhQcMWF6c=",
+			"path": "github.com/lucas-clemente/aes12",
+			"revision": "cd47fb39b79f867c6e4e5cd39cf7abd799f71670",
+			"revisionTime": "2017-10-27T16:34:21Z"
+		},
+		{
+			"checksumSHA1": "cSBXv/4jH3rW01oeFg7WLyT9J0U=",
+			"path": "github.com/lucas-clemente/quic-go",
+			"revision": "5e82335005e9fca83846f46e252031708def8708",
+			"revisionTime": "2018-04-03T10:17:31Z"
+		},
+		{
+			"checksumSHA1": "OA9E+y7g05x/mWJJHmA7oPxWKQo=",
+			"path": "github.com/lucas-clemente/quic-go-certificates",
+			"revision": "d2f86524cced5186554df90d92529757d22c1cb6",
+			"revisionTime": "2016-08-23T09:51:56Z"
+		},
+		{
+			"checksumSHA1": "dTYiy5TEH7AUVcOvpq9VGOxhQ1k=",
+			"path": "github.com/lucas-clemente/quic-go/internal/ackhandler",
+			"revision": "5e82335005e9fca83846f46e252031708def8708",
+			"revisionTime": "2018-04-03T10:17:31Z"
+		},
+		{
+			"checksumSHA1": "fgR0+53I1EVdnNitOUoBSfvrs8Q=",
+			"path": "github.com/lucas-clemente/quic-go/internal/congestion",
+			"revision": "5e82335005e9fca83846f46e252031708def8708",
+			"revisionTime": "2018-04-03T10:17:31Z"
+		},
+		{
+			"checksumSHA1": "z5LMbu1cMUmDvp/L0ayFhxF9EJU=",
+			"path": "github.com/lucas-clemente/quic-go/internal/crypto",
+			"revision": "5e82335005e9fca83846f46e252031708def8708",
+			"revisionTime": "2018-04-03T10:17:31Z"
+		},
+		{
+			"checksumSHA1": "ruhHXEvJ1rJKekXb9nv5h1jmYa0=",
+			"path": "github.com/lucas-clemente/quic-go/internal/flowcontrol",
+			"revision": "5e82335005e9fca83846f46e252031708def8708",
+			"revisionTime": "2018-04-03T10:17:31Z"
+		},
+		{
+			"checksumSHA1": "TRZ6SSq1nsZDcGFmUCc5/ZZFnM0=",
+			"path": "github.com/lucas-clemente/quic-go/internal/handshake",
+			"revision": "5e82335005e9fca83846f46e252031708def8708",
+			"revisionTime": "2018-04-03T10:17:31Z"
+		},
+		{
+			"checksumSHA1": "2fOOJgJgtDfl4b5h+SbUxw0EoNs=",
+			"path": "github.com/lucas-clemente/quic-go/internal/protocol",
+			"revision": "5e82335005e9fca83846f46e252031708def8708",
+			"revisionTime": "2018-04-03T10:17:31Z"
+		},
+		{
+			"checksumSHA1": "Ic0zAQD4P+oIM1qZrDWp8nUek8s=",
+			"path": "github.com/lucas-clemente/quic-go/internal/utils",
+			"revision": "5e82335005e9fca83846f46e252031708def8708",
+			"revisionTime": "2018-04-03T10:17:31Z"
+		},
+		{
+			"checksumSHA1": "Kk2fcnF/GOTBsxh6mtKUrbH0/Cw=",
+			"path": "github.com/lucas-clemente/quic-go/internal/wire",
+			"revision": "5e82335005e9fca83846f46e252031708def8708",
+			"revisionTime": "2018-04-03T10:17:31Z"
+		},
+		{
+			"checksumSHA1": "RDQseWt5/NQ/e+ycN8Q7Ifmj0Nw=",
+			"path": "github.com/lucas-clemente/quic-go/qerr",
+			"revision": "5e82335005e9fca83846f46e252031708def8708",
+			"revisionTime": "2018-04-03T10:17:31Z"
 		},
 		{
 			"checksumSHA1": "SaVXxoFG75x104SdXULcP0g7uwc=",


### PR DESCRIPTION
Now that https://github.com/lucas-clemente/quic-go/pull/1272 is merged,
we can use quic-go again.

Also:
- Update the instructions, and tweak formatting of RTT values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1470)
<!-- Reviewable:end -->
