### PR TITLE
Make cert gen less eager

### DIFF
--- a/go/tools/scion-pki/internal/certs/gen.go
+++ b/go/tools/scion-pki/internal/certs/gen.go
@@ -123,8 +123,6 @@ func genCert(ia addr.IA, isIssuer bool) error {
 		}
 	}
 	// Write the cert to disk.
-	subject := chain.Leaf.Subject
-	fname = fmt.Sprintf(pkicmn.CertNameFmt, subject.I, subject.A, chain.Leaf.Version)
 	raw, err := chain.JSON(true)
 	if err != nil {
 		return common.NewBasicError("Error json-encoding cert", err, "subject", ia)

--- a/go/tools/scion-pki/internal/certs/gen.go
+++ b/go/tools/scion-pki/internal/certs/gen.go
@@ -87,6 +87,12 @@ func genCert(ia addr.IA, isIssuer bool) error {
 		return common.NewBasicError(fmt.Sprintf("'%s' section missing from as.ini",
 			conf.IssuerSectionName), nil, "path", cpath)
 	}
+	// Check if file already exists.
+	fname := fmt.Sprintf(pkicmn.CertNameFmt, ia.I, ia.A, a.AsCert.Version)
+	if _, err := os.Stat(filepath.Join(dir, "certs", fname)); err == nil && !pkicmn.Force {
+		fmt.Printf("%s already exists. Use -f to overwrite.\n", fname)
+		return nil
+	}
 	fmt.Println("Generating Certificate Chain for", ia)
 	// If we are an issuer then we need to generate an issuer cert first.
 	var issuerCert *cert.Certificate
@@ -118,7 +124,7 @@ func genCert(ia addr.IA, isIssuer bool) error {
 	}
 	// Write the cert to disk.
 	subject := chain.Leaf.Subject
-	fname := fmt.Sprintf(pkicmn.CertNameFmt, subject.I, subject.A, chain.Leaf.Version)
+	fname = fmt.Sprintf(pkicmn.CertNameFmt, subject.I, subject.A, chain.Leaf.Version)
 	raw, err := chain.JSON(true)
 	if err != nil {
 		return common.NewBasicError("Error json-encoding cert", err, "subject", ia)


### PR DESCRIPTION
Bugfix OP 149: `scion-pki certs gen <isd-as>` now checks if a cert already exists before creating it. Overwrite works with -f flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1471)
<!-- Reviewable:end -->
