### PR TITLE
Keep-alives from BS

### DIFF
--- a/go/border/gen.go
+++ b/go/border/gen.go
@@ -28,7 +28,6 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl"
-	"github.com/scionproto/scion/go/lib/ctrl/ifid"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/l4"
 	"github.com/scionproto/scion/go/lib/log"
@@ -89,40 +88,6 @@ func (r *Router) genPkt(dstIA addr.IA, dstHost addr.HostAddr, dstL4Port int,
 		rp.Egress = append(rp.Egress, rpkt.EgressPair{S: ctx.ExtSockOut[ifid]})
 	}
 	return rp.Route()
-}
-
-// SyncInterface handles generating periodic Interface ID (IFID) packets that are
-// sent to the Beacon Service in the neighbouring AS. These function as both
-// keep-alives, and to inform the neighbour of the local interface ID.
-func (r *Router) SyncInterface() {
-	defer liblog.LogPanicAndExit()
-	for range time.Tick(ifIDFreq) {
-		ctx := rctx.Get()
-		for ifid := range ctx.Conf.Net.IFs {
-			r.genIFIDPkt(ifid, ctx)
-		}
-	}
-}
-
-// genIFIDPkt generates an IFID-packet for the specified interface.
-func (r *Router) genIFIDPkt(ifID common.IFIDType, ctx *rctx.Ctx) {
-	logger := log.New("ifid", ifID)
-	intf := ctx.Conf.Net.IFs[ifID]
-	srcAddr := intf.IFAddr.PublicAddrInfo(intf.IFAddr.Overlay)
-	cpld, err := ctrl.NewPld(&ifid.IFID{OrigIfID: uint64(ifID)}, nil)
-	if err != nil {
-		logger.Error("Error generating IFID Ctrl payload", "err", err)
-		return
-	}
-	scpld, err := cpld.SignedPld(ctrl.NullSigner)
-	if err != nil {
-		logger.Error("Error generating IFID signed Ctrl payload", "err", err)
-		return
-	}
-	if err := r.genPkt(intf.RemoteIA, addr.HostFromIP(intf.RemoteAddr.IP),
-		intf.RemoteAddr.L4Port, srcAddr, scpld); err != nil {
-		logger.Error("Error generating IFID packet", "err", err)
-	}
 }
 
 // IFStateUpdate handles generating periodic Interface State Request (IFStateReq)

--- a/go/border/gen.go
+++ b/go/border/gen.go
@@ -37,8 +37,6 @@ import (
 )
 
 const (
-	// ifIDFreq is how often IFID packets are sent to the neighbouring AS.
-	ifIDFreq = 1 * time.Second
 	// ifStateFreq is how often the router will request an Interface State update
 	// from the beacon service.
 	ifStateFreq = 30 * time.Second

--- a/go/border/router.go
+++ b/go/border/router.go
@@ -71,7 +71,6 @@ func NewRouter(id, confDir string) (*Router, error) {
 // Run sets up networking, and starts go routines for handling the main packet
 // processing as well as various other router functions.
 func (r *Router) Run() error {
-	go r.SyncInterface()
 	go r.IFStateUpdate()
 	go r.RevInfoFwd()
 	go r.PacketError()

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -819,19 +819,18 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
 
             # only master sends keep-alive messages
             if not self.zk.have_lock():
-                pass
+                continue
 
             # send keep-alives on all known BR interfaces
             for ifid in self.ifid2br:
                 br = self.ifid2br[ifid]
                 dst_ia = br.interfaces[ifid].isd_as
-                host = br.interfaces[ifid].remote[0][0]
-                port = br.interfaces[ifid].remote[0][1]
+                host, port = br.interfaces[ifid].remote[0]
                 one_hop_path = self._create_one_hop_path(ifid)
                 meta = self._build_meta(
                     ia=dst_ia, host=host, port=port, path=one_hop_path, one_hop=True)
-                self.send_meta(CtrlPayload(IFIDPayload.from_values(
-                    ifid)), meta, next_hop_port=br.int_addrs[0].public[0])
+                self.send_meta(CtrlPayload(IFIDPayload.from_values(ifid)),
+                               meta, next_hop_port=br.int_addrs[0].public[0])
 
     def _init_metrics(self):
         super()._init_metrics()

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -830,8 +830,10 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
                 host = br.interfaces[ifid].remote[0][0]
                 port = br.interfaces[ifid].remote[0][1]
                 one_hop_path = self._create_one_hop_path(ifid)
-                meta = self._build_meta(ia=dst_ia, host=host, port=port, path=one_hop_path, one_hop=True)
-                self.send_meta(CtrlPayload(IFIDPayload.from_values(ifid)), meta, next_hop_port=br.int_addrs[0].public[0])
+                meta = self._build_meta(
+                    ia=dst_ia, host=host, port=port, path=one_hop_path, one_hop=True)
+                self.send_meta(CtrlPayload(IFIDPayload.from_values(
+                    ifid)), meta, next_hop_port=br.int_addrs[0].public[0])
 
     def _init_metrics(self):
         super()._init_metrics()

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -825,11 +825,12 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
 
             # send keep-alives on all known BR interfaces
             for ifid in self.ifid2br:
-                one_hop_path = self._create_one_hop_path(ifid)
                 br = self.ifid2br[ifid]
                 dst_ia = br.interfaces[ifid].isd_as
-                meta = self._build_meta(ia=dst_ia, host=SVCType.BS_M, path=one_hop_path, one_hop=True)
-                print("send ifid", meta)
+                host = br.interfaces[ifid].remote[0][0]
+                port = br.interfaces[ifid].remote[0][1]
+                one_hop_path = self._create_one_hop_path(ifid)
+                meta = self._build_meta(ia=dst_ia, host=host, port=port, path=one_hop_path, one_hop=True)
                 self.send_meta(CtrlPayload(IFIDPayload.from_values(ifid)), meta, next_hop_port=br.int_addrs[0].public[0])
 
     def _init_metrics(self):

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -433,8 +433,6 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         pld = cpld.union
         assert isinstance(pld, IFIDPayload), type(pld)
         ifid = pld.p.relayIF
-        print("received ifid update", pld)
-        print(cpld)
         with self.ifid_state_lock:
             if ifid not in self.ifid_state:
                 raise SCIONKeyError("Invalid IF %d in IFIDPayload" % ifid)


### PR DESCRIPTION
Keep-alive messages are now sent from the BS to the neighboring BR, instead of from BR to BR. BR further propagate these to their local BS. This fixes #1473.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1476)
<!-- Reviewable:end -->
