### PR TITLE
scion-pki: Add support for auto-completing scion-pki commands

### DIFF
--- a/go/tools/scion-pki/README.md
+++ b/go/tools/scion-pki/README.md
@@ -134,3 +134,22 @@ Finally, we can generate the new certificate:
 
 `scion-pki certs gen 1-4_294_967_022`
 
+## Autocompleting scion-pki commands
+
+For `bash` follow the following instructions
+
+```
+./bin/scion-pki autocomplete
+sudo mv scion_pki_bash /etc/bash_completion.d
+source ~/.bashrc
+```
+
+For `zsh` follow the following instructions
+
+```
+./bin/scion-pki autocomplete --zsh
+mkdir -p ~/.zsh/completion
+mv _scion-pki ~/.zsh/completion
+echo "fpath=(~/.zsh/completion \$fpath)\nautload -U compinit\ncompinit\nzstyle ':completion:*' menu select=2" >> ~/.zshrc
+source ~/.zshrc
+```


### PR DESCRIPTION
Currently the support is limited to zsh and bash

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1514)
<!-- Reviewable:end -->
