### PR TITLE
Fix HOF expiration time unit

### DIFF
--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	MaxTTL      = 24 * 60 * 60 // One day in seconds
-	ExpTimeUnit = MaxTTL / 2 << 8
+	ExpTimeUnit = MaxTTL / (1 << 8)
 	macInputLen = 16
 )
 

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -50,6 +50,7 @@ from lib.errors import (
     SCIONServiceLookupError,
 )
 from lib.msg_meta import UDPMetadata
+from lib.packet.ext.one_hop_path import OneHopPathExt
 from lib.path_seg_meta import PathSegMeta
 from lib.packet.ctrl_pld import CtrlPayload
 from lib.packet.ifid import IFIDPayload
@@ -232,7 +233,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
     def _create_one_hop_path(self, egress_if):
         ts = int(SCIONTime.get_time())
         info = InfoOpaqueField.from_values(ts, self.addr.isd_as[0], hops=2)
-        hf1 = HopOpaqueField.from_values(self.hof_exp_time(ts), 0, egress_if)
+        hf1 = HopOpaqueField.from_values(OneHopPathExt.HOF_EXP_TIME, 0, egress_if)
         hf1.set_mac(self.of_gen_key, ts, None)
         # Return a path where second HF is empty.
         return SCIONPath.from_values(info, [hf1, HopOpaqueField()])

--- a/python/lib/defines.py
+++ b/python/lib/defines.py
@@ -27,7 +27,7 @@ DEFAULT_SEGMENT_TTL = 6 * 60 * 60
 #: Max TTL of a PathSegment in realtime seconds.
 MAX_SEGMENT_TTL = 24 * 60 * 60
 #: Time unit for HOF expiration.
-EXP_TIME_UNIT = MAX_SEGMENT_TTL / 2 ** 8
+EXP_TIME_UNIT = int(MAX_SEGMENT_TTL / 2 ** 8)
 #: Max number of supported HopByHop extensions (does not include SCMP)
 MAX_HOPBYHOP_EXT = 3
 #: Number of bytes per 'line'. Used for padding in many places.


### PR DESCRIPTION
This PR adds following changes:
- Fix `spath.ExpTimeUnit`
- floor `EXP_TIME_UNIT` to ensure go and python code evaluate to same value
- Make beacon server one hop path expiration time independent of certificate expiration time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1518)
<!-- Reviewable:end -->
