### PR TITLE
Fix parsing of SignSrcDef

### DIFF
--- a/go/lib/ctrl/signed_util.go
+++ b/go/lib/ctrl/signed_util.go
@@ -145,7 +145,7 @@ const (
 	// SrcDefaultPrefix is the default prefix for proto.SignS.Src.
 	SrcDefaultPrefix = "DEFAULT: "
 	// SrcDefaultFmt is the default format for proto.SignS.Src.
-	SrcDefaultFmt = `^` + SrcDefaultPrefix + `IA: (\d+-\d+) CHAIN: (\d+) TRC: (\d+)$`
+	SrcDefaultFmt = `^` + SrcDefaultPrefix + `IA: (\S+) CHAIN: (\d+) TRC: (\d+)$`
 )
 
 type SignSrcDef struct {


### PR DESCRIPTION
SignSrcDef parsing now accepts the canonical format of ISD-AS.

This change is also compatible with #1512.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1519)
<!-- Reviewable:end -->
