### PR TITLE
IFID messages hop-by-hop

### DIFF
--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -825,13 +825,12 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
             # send keep-alives on all known BR interfaces
             for ifid in self.ifid2br:
                 br = self.ifid2br[ifid]
-                dst_ia = br.interfaces[ifid].isd_as
-                host, port = br.interfaces[ifid].remote[0]
+                src_ia = self.topology.isd_as
+                host, port = br.int_addrs[0].public[0]
                 one_hop_path = self._create_one_hop_path(ifid)
                 meta = self._build_meta(
-                    ia=dst_ia, host=host, port=port, path=one_hop_path, one_hop=True)
-                self.send_meta(CtrlPayload(IFIDPayload.from_values(ifid)),
-                               meta, next_hop_port=br.int_addrs[0].public[0])
+                    ia=src_ia, host=host, port=port, path=one_hop_path, one_hop=True)
+                self.send_meta(CtrlPayload(IFIDPayload.from_values(ifid)), meta)
 
     def _init_metrics(self):
         super()._init_metrics()


### PR DESCRIPTION
This PR fixes a problem introduced by #1476.
IFID msgs are now sent from BS to local BR and from there forwarded to the remote BR which forwards it to the local BS.
Like that IFID msgs will not generate SCMP revocations at the BR if the interface has recently come up.