### PR TITLE
Make up/down ingress/egress less ambiguous for paths

### DIFF
--- a/go/border/rpkt/create.go
+++ b/go/border/rpkt/create.go
@@ -194,7 +194,7 @@ func (rp *RtrPkt) CreateReply(sp *spkt.ScnPkt) (*RtrPkt, error) {
 		}
 		if hopF != nil && hopF.Xover {
 			reply.InfoF()
-			reply.UpFlag()
+			reply.ConsDirFlag()
 			// Always increment reversed path on a xover point.
 			if _, err := reply.IncPath(); err != nil {
 				return nil, err
@@ -210,7 +210,7 @@ func (rp *RtrPkt) CreateReply(sp *spkt.ScnPkt) (*RtrPkt, error) {
 			}
 		} else if rp.DirFrom == rcmn.DirExternal {
 			reply.InfoF()
-			reply.UpFlag()
+			reply.ConsDirFlag()
 			// Increase path if the current HOF is not xover and
 			// this router is an ingress router.
 			if _, err := reply.IncPath(); err != nil {

--- a/go/border/rpkt/extn_onehoppath.go
+++ b/go/border/rpkt/extn_onehoppath.go
@@ -61,7 +61,7 @@ func (o *rOneHopPath) HopF() (HookResult, *spath.HopField, error) {
 	if err != nil {
 		return HookError, nil, err
 	}
-	if currHopF.Ingress != 0 || currHopF.Egress != 0 {
+	if currHopF.ConsIngress != 0 || currHopF.ConsEgress != 0 {
 		// The current hop field has already been generated.
 		return HookContinue, nil, nil
 	}

--- a/go/border/rpkt/hooks.go
+++ b/go/border/rpkt/hooks.go
@@ -42,20 +42,20 @@ type hookRoute func() (HookResult, error)
 // of the router register to handle certain functions by adding a callback to
 // the relevant slice.
 type hooks struct {
-	DstIA    []hookIA
-	SrcIA    []hookIA
-	DstHost  []hookHost
-	SrcHost  []hookHost
-	Infof    []hookInfoF
-	HopF     []hookHopF
-	UpFlag   []hookBool
-	IFCurr   []hookIntf
-	IFNext   []hookIntf
-	Validate []hookValidate
-	L4       []hookL4
-	Payload  []hookPayload
-	Process  []hookProcess
-	Route    []hookRoute
+	DstIA       []hookIA
+	SrcIA       []hookIA
+	DstHost     []hookHost
+	SrcHost     []hookHost
+	Infof       []hookInfoF
+	HopF        []hookHopF
+	ConsDirFlag []hookBool
+	IFCurr      []hookIntf
+	IFNext      []hookIntf
+	Validate    []hookValidate
+	L4          []hookL4
+	Payload     []hookPayload
+	Process     []hookProcess
+	Route       []hookRoute
 }
 
 type HookResult int

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -54,7 +54,7 @@ func (rp *RtrPkt) Parse() error {
 	if _, err := rp.HopF(); err != nil {
 		return err
 	}
-	if _, err := rp.UpFlag(); err != nil {
+	if _, err := rp.ConsDirFlag(); err != nil {
 		return err
 	}
 	if _, err := rp.IFCurr(); err != nil {

--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -245,22 +245,22 @@ func (rp *RtrPkt) getHopFVer(dirFrom rcmn.Dir) common.RawBytes {
 			// interface, and another from the upstream interface, used for
 			// verification only.
 			switch {
-			case ingress && rp.infoF.Up:
-				offset = +2
-			case ingress && !rp.infoF.Up:
+			case ingress && rp.infoF.ConsDir:
 				offset = +1
-			case !ingress && rp.infoF.Up:
-				offset = -1
-			case !ingress && !rp.infoF.Up:
+			case ingress && !rp.infoF.ConsDir:
+				offset = +2
+			case !ingress && rp.infoF.ConsDir:
 				offset = -2
+			case !ingress && !rp.infoF.ConsDir:
+				offset = -1
 			}
 		case false:
 			// Non-peer shortcut paths have an extra HOF above the last hop,
 			// used for verification of the last hop in that segment.
 			switch {
-			case ingress && !rp.infoF.Up:
+			case ingress && rp.infoF.ConsDir:
 				offset = -1
-			case !ingress && rp.infoF.Up:
+			case !ingress && !rp.infoF.ConsDir:
 				offset = +1
 			}
 		}
@@ -270,19 +270,19 @@ func (rp *RtrPkt) getHopFVer(dirFrom rcmn.Dir) common.RawBytes {
 
 // getHopFVerNormalOffset is a helper function for getHopFVer, to handle cases
 // where the verification Hop Field (if any) is directly before or after
-// (depending on the Up flag) the current Hop Field.
+// (depending on the ConsDir flag) the current Hop Field.
 func (rp *RtrPkt) getHopFVerNormalOffset() int {
 	iOff := rp.CmnHdr.InfoFOffBytes()
 	hOff := rp.CmnHdr.HopFOffBytes()
 	// If this is the last hop of an Up path, or the first hop of a Down path, there's no previous
 	// HOF to verify against.
-	if (rp.infoF.Up &&
+	if (!rp.infoF.ConsDir &&
 		hOff == (iOff+spath.InfoFieldLength+int(rp.infoF.Hops-1)*spath.HopFieldLength)) ||
-		(!rp.infoF.Up && hOff == (iOff+spath.InfoFieldLength)) {
+		(rp.infoF.ConsDir && hOff == (iOff+spath.InfoFieldLength)) {
 		return 0
 	}
-	// Otherwise use the next/prev HOF based on the up flag.
-	if rp.infoF.Up {
+	// Otherwise use the next/prev HOF based on the consDir flag.
+	if !rp.infoF.ConsDir {
 		return 1
 	}
 	return -1
@@ -309,7 +309,7 @@ func (rp *RtrPkt) IncPath() (bool, error) {
 		return false, nil
 	}
 	if assert.On {
-		assert.Mustf(rp.upFlag != nil, rp.ErrStr, "rp.upFlag must not be nil")
+		assert.Mustf(rp.consDirFlag != nil, rp.ErrStr, "rp.consDirFlag must not be nil")
 	}
 	var err error
 	var hopF *spath.HopField
@@ -319,7 +319,7 @@ func (rp *RtrPkt) IncPath() (bool, error) {
 	hOff := rp.CmnHdr.HopFOffBytes()
 	hdrLen := rp.CmnHdr.HdrLenBytes()
 	vOnly := 0
-	origUp := *rp.upFlag
+	origConsDir := *rp.consDirFlag
 	for {
 		hOff += spath.HopFieldLength
 		if hOff-iOff > int(infoF.Hops*spath.HopFieldLength) {
@@ -353,9 +353,9 @@ func (rp *RtrPkt) IncPath() (bool, error) {
 	rp.hopF = hopF
 	rp.IncrementedPath = true
 	if segChgd {
-		// Extract new Up flag.
-		rp.upFlag = nil
-		if _, err = rp.UpFlag(); err != nil {
+		// Extract new ConsDir flag.
+		rp.consDirFlag = nil
+		if _, err = rp.ConsDirFlag(); err != nil {
 			return segChgd, err
 		}
 	}
@@ -370,39 +370,38 @@ func (rp *RtrPkt) IncPath() (bool, error) {
 			scmp.NewError(scmp.C_Path, scmp.T_P_BadHopField, rp.mkInfoPathOffsets(), nil))
 	}
 	// Check that the segment didn't change from a down-segment to an up-segment.
-	if !origUp && *rp.upFlag {
+	if origConsDir && !*rp.consDirFlag {
 		return segChgd, common.NewBasicError("Switched from down-segment to up-segment",
 			scmp.NewError(scmp.C_Path, scmp.T_P_BadSegment, rp.mkInfoPathOffsets(), nil))
 	}
 	return segChgd, nil
 }
 
-// UpFlag retrieves the current path segment's Up flag if not already known.
-// (Up is defined as being the opposite to the direction in which the segment
-// was created.)
-func (rp *RtrPkt) UpFlag() (*bool, error) {
-	if rp.upFlag != nil {
-		return rp.upFlag, nil
+// ConsDirFlag retrieves the current path segment's ConsDir flag if not already known.
+// (Consdir is defined as being the direction in which the segment was created.)
+func (rp *RtrPkt) ConsDirFlag() (*bool, error) {
+	if rp.consDirFlag != nil {
+		return rp.consDirFlag, nil
 	}
-	// Try to get Up flag from extensions
-	for _, f := range rp.hooks.UpFlag {
-		ret, up, err := f()
+	// Try to get ConsDir flag from extensions
+	for _, f := range rp.hooks.ConsDirFlag {
+		ret, consDir, err := f()
 		switch {
 		case err != nil:
 			return nil, err
 		case ret == HookContinue:
 			continue
 		case ret == HookFinish:
-			rp.upFlag = &up
-			return rp.upFlag, nil
+			rp.consDirFlag = &consDir
+			return rp.consDirFlag, nil
 		}
 	}
-	// Try to get Up flag from InfoField
+	// Try to get ConsDir flag from InfoField
 	if rp.infoF == nil {
 		return nil, nil
 	}
-	rp.upFlag = &rp.infoF.Up
-	return rp.upFlag, nil
+	rp.consDirFlag = &rp.infoF.ConsDir
+	return rp.consDirFlag, nil
 }
 
 // IFCurr retrieves the current interface ID if not already known.
@@ -410,9 +409,9 @@ func (rp *RtrPkt) IFCurr() (*common.IFIDType, error) {
 	if rp.ifCurr != nil {
 		return rp.ifCurr, nil
 	}
-	if rp.upFlag != nil {
+	if rp.consDirFlag != nil {
 		// Try to get IFID from registered hooks.
-		if ifid, err := rp.hookIF(*rp.upFlag, rp.hooks.IFCurr); err != nil {
+		if ifid, err := rp.hookIF(*rp.consDirFlag, rp.hooks.IFCurr); err != nil {
 			return nil, err
 		} else if ifid != nil {
 			return rp.checkSetCurrIF(ifid)
@@ -422,17 +421,17 @@ func (rp *RtrPkt) IFCurr() (*common.IFIDType, error) {
 			var ingress bool
 			switch rp.DirFrom {
 			case rcmn.DirSelf, rcmn.DirLocal:
-				ingress = *rp.upFlag
+				ingress = !*rp.consDirFlag
 			case rcmn.DirExternal:
-				ingress = !*rp.upFlag
+				ingress = *rp.consDirFlag
 			default:
 				return nil, common.NewBasicError("DirFrom value unsupported", nil,
 					"val", rp.DirFrom)
 			}
 			if ingress {
-				return rp.checkSetCurrIF(&rp.hopF.Ingress)
+				return rp.checkSetCurrIF(&rp.hopF.ConsIngress)
 			}
-			return rp.checkSetCurrIF(&rp.hopF.Egress)
+			return rp.checkSetCurrIF(&rp.hopF.ConsEgress)
 		}
 	}
 	// Default to the first IfID from Ingress.IfIDs
@@ -455,19 +454,19 @@ func (rp *RtrPkt) checkSetCurrIF(ifid *common.IFIDType) (*common.IFIDType, error
 // IFNext retrieves the next interface ID if not already known. As this may be
 // an interface in an external ISD-AS, this is not sanity-checked.
 func (rp *RtrPkt) IFNext() (*common.IFIDType, error) {
-	if rp.ifNext == nil && rp.upFlag != nil {
+	if rp.ifNext == nil && rp.consDirFlag != nil {
 		var err error
 		// Try to get IFID from registered hooks.
-		if rp.ifNext, err = rp.hookIF(*rp.upFlag, rp.hooks.IFNext); err != nil {
+		if rp.ifNext, err = rp.hookIF(*rp.consDirFlag, rp.hooks.IFNext); err != nil {
 			return nil, err
 		} else if rp.ifNext != nil {
 			return rp.ifNext, nil
 		}
 		// Get IFID from HopField
-		if *rp.upFlag {
-			rp.ifNext = &rp.hopF.Ingress
+		if *rp.consDirFlag {
+			rp.ifNext = &rp.hopF.ConsEgress
 		} else {
-			rp.ifNext = &rp.hopF.Egress
+			rp.ifNext = &rp.hopF.ConsIngress
 		}
 	}
 	return rp.ifNext, nil
@@ -475,9 +474,9 @@ func (rp *RtrPkt) IFNext() (*common.IFIDType, error) {
 
 // hookIF is a helper function used by IFCurr/IFNext to run interface ID
 // retrival hooks.
-func (rp *RtrPkt) hookIF(up bool, hooks []hookIntf) (*common.IFIDType, error) {
+func (rp *RtrPkt) hookIF(consDir bool, hooks []hookIntf) (*common.IFIDType, error) {
 	for _, f := range hooks {
-		ret, intf, err := f(up, rp.DirFrom, rp.DirTo)
+		ret, intf, err := f(consDir, rp.DirFrom, rp.DirTo)
 		switch {
 		case err != nil:
 			return nil, err

--- a/go/border/rpkt/route.go
+++ b/go/border/rpkt/route.go
@@ -226,7 +226,7 @@ func (rp *RtrPkt) xoverFromExternal() error {
 		}
 		origIF := origIFNext
 		newIF := *rp.ifNext
-		if infoF.Up {
+		if !infoF.ConsDir {
 			rp.ifCurr = nil
 			if _, err = rp.IFCurr(); err != nil {
 				return err
@@ -255,7 +255,7 @@ func (rp *RtrPkt) xoverFromExternal() error {
 			scmp.NewError(scmp.C_Path, scmp.T_P_BadSegment, rp.mkInfoPathOffsets(), nil))
 	}
 	// Only allowed to switch from up- to up-segment if the next link is CORE.
-	if infoF.Up && rp.infoF.Up && nextLink != topology.CoreLink {
+	if !infoF.ConsDir && !rp.infoF.ConsDir && nextLink != topology.CoreLink {
 		return common.NewBasicError(
 			"Segment change from up segment to up segment with non-CORE next link",
 			scmp.NewError(scmp.C_Path, scmp.T_P_BadSegment, rp.mkInfoPathOffsets(), nil),
@@ -263,7 +263,7 @@ func (rp *RtrPkt) xoverFromExternal() error {
 		)
 	}
 	// Only allowed to switch from down- to down-segment if the previous link is CORE.
-	if !infoF.Up && !rp.infoF.Up && prevLink != topology.CoreLink {
+	if infoF.ConsDir && rp.infoF.ConsDir && prevLink != topology.CoreLink {
 		return common.NewBasicError(
 			"Segment change from down segment to down segment with non-CORE previous link",
 			scmp.NewError(scmp.C_Path, scmp.T_P_BadSegment, rp.mkInfoPathOffsets(), nil),

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -101,8 +101,8 @@ type RtrPkt struct {
 	ifCurr *common.IFIDType
 	// ifNext is the next interface ID, if any. (PARSE)
 	ifNext *common.IFIDType
-	// upFlag indicates if the packet is currently on an up path. (PARSE)
-	upFlag *bool
+	// consDirFlag indicates if the packet is currently on a down path. (PARSE)
+	consDirFlag *bool
 	// HBHExt is the list of Hop-by-hop extensions, if any. (PARSE)
 	HBHExt []rExtension
 	// E2EExt is the list of end2end extensions, if any. (PARSE, only if needed)
@@ -235,7 +235,7 @@ func (rp *RtrPkt) Reset() {
 	rp.hopF = nil
 	rp.ifCurr = nil
 	rp.ifNext = nil
-	rp.upFlag = nil
+	rp.consDirFlag = nil
 	rp.HBHExt = rp.HBHExt[:0]
 	rp.E2EExt = rp.E2EExt[:0]
 	rp.L4Type = common.L4None

--- a/go/border/rpkt/rpkt_hook_test.go
+++ b/go/border/rpkt/rpkt_hook_test.go
@@ -177,24 +177,24 @@ func TestHooksHopf(t *testing.T) {
 }
 
 func TestHooksUp(t *testing.T) {
-	Convey("Fetch UpFlag via hook functions", t, func() {
+	Convey("Fetch ConsDirFlag via hook functions", t, func() {
 		rpkt := setupRtrPktHookTest()
 		rpkt.hooks = hooks{
-			UpFlag: []hookBool{func() (HookResult, bool, error) {
+			ConsDirFlag: []hookBool{func() (HookResult, bool, error) {
 				fetched++
-				return HookFinish, true, nil
+				return HookFinish, false, nil
 			}},
 		}
-		var up *bool
+		var consDir *bool
 
-		up, err = rpkt.UpFlag()
-		SoMsg("Wrong UpFlag on the fetch call", *up, ShouldBeTrue)
-		SoMsg("Should be no error when calling UpFlag for fetch", err, ShouldBeNil)
+		consDir, err = rpkt.ConsDirFlag()
+		SoMsg("Wrong ConsDirFlag on the fetch call", *consDir, ShouldBeFalse)
+		SoMsg("Should be no error when calling ConsDirFlag for fetch", err, ShouldBeNil)
 
-		up, err = rpkt.UpFlag()
-		SoMsg("Wrong UpFlag on the cached getter call", *up, ShouldBeTrue)
-		SoMsg("Should be no error when calling UpFlag getter for cached value", err, ShouldBeNil)
-		SoMsg("Regardless of the two calls, only one fetch of UpFlag expected", fetched,
+		consDir, err = rpkt.ConsDirFlag()
+		SoMsg("Wrong ConsDirFlag on the cached getter call", *consDir, ShouldBeFalse)
+		SoMsg("Should be no error when calling ConsDirFlag getter for cached value", err, ShouldBeNil)
+		SoMsg("Regardless of the two calls, only one fetch of ConsDirFlag expected", fetched,
 			ShouldEqual, 1)
 	})
 }

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -78,8 +78,8 @@ func (ps *PathSegment) ID() (common.RawBytes, error) {
 			if err != nil {
 				return nil, err
 			}
-			binary.Write(h, common.Order, hopf.Ingress)
-			binary.Write(h, common.Order, hopf.Egress)
+			binary.Write(h, common.Order, hopf.ConsIngress)
+			binary.Write(h, common.Order, hopf.ConsEgress)
 		}
 		ps.id = h.Sum(nil)
 	}
@@ -203,12 +203,12 @@ func (ps *PathSegment) String() string {
 			continue
 		}
 		hop_desc := []string{}
-		if hop.Ingress > 0 {
-			hop_desc = append(hop_desc, fmt.Sprintf("%v ", hop.Ingress))
+		if hop.ConsIngress > 0 {
+			hop_desc = append(hop_desc, fmt.Sprintf("%v ", hop.ConsIngress))
 		}
 		hop_desc = append(hop_desc, ase.IA().String())
-		if hop.Egress > 0 {
-			hop_desc = append(hop_desc, fmt.Sprintf(" %v", hop.Egress))
+		if hop.ConsEgress > 0 {
+			hop_desc = append(hop_desc, fmt.Sprintf(" %v", hop.ConsEgress))
 		}
 		hops_desc = append(hops_desc, strings.Join(hop_desc, ""))
 	}

--- a/go/lib/pathdb/sqlite/sqlite.go
+++ b/go/lib/pathdb/sqlite/sqlite.go
@@ -292,15 +292,15 @@ func (b *Backend) insertInterfaces(ases []*seg.ASEntry, segRowID int64) error {
 			if err != nil {
 				return common.NewBasicError("Failed to extract hop field", err)
 			}
-			if hof.Ingress != 0 {
-				_, err = stmt.Exec(ia.I, ia.A, hof.Ingress, segRowID)
+			if hof.ConsIngress != 0 {
+				_, err = stmt.Exec(ia.I, ia.A, hof.ConsIngress, segRowID)
 				if err != nil {
 					return common.NewBasicError("Failed to insert Ingress into IntfToSeg", err)
 				}
 			}
 			// Only insert the Egress interface for the first hop entry in an AS entry.
-			if idx == 0 && hof.Egress != 0 {
-				_, err := stmt.Exec(ia.I, ia.A, hof.Egress, segRowID)
+			if idx == 0 && hof.ConsEgress != 0 {
+				_, err := stmt.Exec(ia.I, ia.A, hof.ConsEgress, segRowID)
 				if err != nil {
 					return common.NewBasicError("Failed to insert Egress into IntfToSeg", err)
 				}

--- a/go/lib/spath/hop.go
+++ b/go/lib/spath/hop.go
@@ -30,8 +30,8 @@ type HopField struct {
 	ForwardOnly bool
 	Recurse     bool
 	ExpTime     uint8
-	Ingress     common.IFIDType
-	Egress      common.IFIDType
+	ConsIngress common.IFIDType
+	ConsEgress  common.IFIDType
 	Mac         common.RawBytes
 	length      int
 }
@@ -49,8 +49,8 @@ func NewHopField(b common.RawBytes, in common.IFIDType, out common.IFIDType) *Ho
 	h := &HopField{}
 	h.data = b
 	h.ExpTime = DefaultHopFExpiry
-	h.Ingress = in
-	h.Egress = out
+	h.ConsIngress = in
+	h.ConsEgress = out
 	h.Write()
 	return h
 }
@@ -71,8 +71,8 @@ func HopFFromRaw(b []byte) (*HopField, error) {
 	h.ExpTime = h.data[offset]
 	offset += 1
 	// Interface IDs are 12b each, encoded into 3B
-	h.Ingress = common.IFIDType(int(h.data[offset])<<4 | int(h.data[offset+1])>>4)
-	h.Egress = common.IFIDType((int(h.data[offset+1])&0xF)<<8 | int(h.data[offset+2]))
+	h.ConsIngress = common.IFIDType(int(h.data[offset])<<4 | int(h.data[offset+1])>>4)
+	h.ConsEgress = common.IFIDType((int(h.data[offset+1])&0xF)<<8 | int(h.data[offset+2]))
 	offset += 3
 	h.Mac = h.data[offset:]
 	h.length = common.LineLen
@@ -101,16 +101,16 @@ func (h *HopField) Write() {
 	h.data[0] = flags
 	h.data[1] = h.ExpTime
 	// Interface IDs are 12b each, encoded into 3B
-	h.data[2] = byte(h.Ingress >> 4)
-	h.data[3] = byte((h.Ingress&0x0F)<<4 | h.Egress>>8)
-	h.data[4] = byte(h.Egress & 0xFF)
+	h.data[2] = byte(h.ConsIngress >> 4)
+	h.data[3] = byte((h.ConsIngress&0x0F)<<4 | h.ConsEgress>>8)
+	h.data[4] = byte(h.ConsEgress & 0xFF)
 	copy(h.data[5:], h.Mac)
 }
 
 func (h *HopField) String() string {
 	return fmt.Sprintf(
-		"Ingress: %v Egress: %v ExpTime: %v Xover: %v VerifyOnly: %v ForwardOnly: %v Mac: %v",
-		h.Ingress, h.Egress, h.ExpTime, h.Xover, h.VerifyOnly, h.ForwardOnly, h.Mac)
+		"ConsIngress: %v ConsEgress: %v ExpTime: %v Xover: %v VerifyOnly: %v ForwardOnly: %v Mac: %v",
+		h.ConsIngress, h.ConsEgress, h.ExpTime, h.Xover, h.VerifyOnly, h.ForwardOnly, h.Mac)
 }
 
 func (h *HopField) Verify(mac hash.Hash, tsInt uint32, prev common.RawBytes) error {

--- a/go/lib/spath/hop.go
+++ b/go/lib/spath/hop.go
@@ -108,8 +108,8 @@ func (h *HopField) Write() {
 }
 
 func (h *HopField) String() string {
-	return fmt.Sprintf(
-		"ConsIngress: %v ConsEgress: %v ExpTime: %v Xover: %v VerifyOnly: %v ForwardOnly: %v Mac: %v",
+	return fmt.Sprintf("ConsIngress: %v ConsEgress: %v ExpTime: %v Xover: %v VerifyOnly: %v "+
+		"ForwardOnly: %v Mac: %v",
 		h.ConsIngress, h.ConsEgress, h.ExpTime, h.Xover, h.VerifyOnly, h.ForwardOnly, h.Mac)
 }
 

--- a/go/lib/spath/info.go
+++ b/go/lib/spath/info.go
@@ -27,7 +27,8 @@ const (
 )
 
 type InfoField struct {
-	Up       bool
+	// Previously Up, ConsDir = !Up
+	ConsDir  bool
 	Shortcut bool
 	Peer     bool
 	TsInt    uint32
@@ -42,7 +43,7 @@ func InfoFFromRaw(b []byte) (*InfoField, error) {
 	}
 	inf := &InfoField{}
 	flags := b[0]
-	inf.Up = flags&0x1 != 0
+	inf.ConsDir = flags&0x1 != 0
 	inf.Shortcut = flags&0x2 != 0
 	inf.Peer = flags&0x4 != 0
 	offset := 1
@@ -56,7 +57,7 @@ func InfoFFromRaw(b []byte) (*InfoField, error) {
 
 func (inf *InfoField) Write(b common.RawBytes) {
 	b[0] = 0
-	if inf.Up {
+	if inf.ConsDir {
 		b[0] |= 0x1
 	}
 	if inf.Shortcut {
@@ -74,8 +75,8 @@ func (inf *InfoField) Write(b common.RawBytes) {
 }
 
 func (inf *InfoField) String() string {
-	return fmt.Sprintf("ISD: %v TS: %v Hops: %v Up: %v Shortcut: %v Peer: %v",
-		inf.ISD, inf.Timestamp(), inf.Hops, inf.Up, inf.Shortcut, inf.Peer)
+	return fmt.Sprintf("ISD: %v TS: %v Hops: %v ConsDir: %v Shortcut: %v Peer: %v",
+		inf.ISD, inf.Timestamp(), inf.Hops, inf.ConsDir, inf.Shortcut, inf.Peer)
 }
 
 func (inf *InfoField) Timestamp() time.Time {

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -80,7 +80,7 @@ func (p *Path) Reverse() error {
 			p.InfOff = revOff
 		}
 		infoF := infoFs[i]
-		infoF.Up = !infoF.Up // Reverse Up flag
+		infoF.ConsDir = !infoF.ConsDir // Reverse ConsDir flag
 		infoF.Write(revRaw[revOff:])
 		infoF, _ = InfoFFromRaw(revRaw[revOff:])
 		revOff += InfoFieldLength

--- a/go/lib/spath/path_test.go
+++ b/go/lib/spath/path_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 type pathCase struct {
-	up   bool
-	hops []uint8
+	consDir bool
+	hops    []uint8
 }
 
 var pathReverseCases = []struct {
@@ -90,7 +90,7 @@ func Test_Path_Reverse(t *testing.T) {
 					prefix := fmt.Sprintf("seg %d", seg)
 					infof, err := InfoFFromRaw(path.Raw[offset:])
 					SoMsg(prefix+" InfoF parse", err, ShouldBeNil)
-					SoMsg(prefix+" InfoF up", infof.Up, ShouldEqual, out.up)
+					SoMsg(prefix+" InfoF consDir", infof.ConsDir, ShouldEqual, out.consDir)
 					SoMsg(prefix+" InfoF ISD "+infof.String(),
 						infof.ISD, ShouldEqual, len(c.in)-seg-1)
 					SoMsg(prefix+" InfoF Offset", path.InfOff, ShouldEqual, c.outOffs[j][0])
@@ -118,14 +118,14 @@ func mkPathRevCase(in []pathCase, inInfOff, inHopfOff int) *Path {
 	path.Raw = make(common.RawBytes, plen)
 	offset := 0
 	for i, seg := range in {
-		makeSeg(path.Raw[offset:], seg.up, uint16(i), seg.hops)
+		makeSeg(path.Raw[offset:], seg.consDir, uint16(i), seg.hops)
 		offset += InfoFieldLength + len(seg.hops)*HopFieldLength
 	}
 	return path
 }
 
-func makeSeg(b common.RawBytes, up bool, isd uint16, hops []uint8) {
-	infof := InfoField{Up: up, ISD: isd, Hops: uint8(len(hops))}
+func makeSeg(b common.RawBytes, consDir bool, isd uint16, hops []uint8) {
+	infof := InfoField{ConsDir: consDir, ISD: isd, Hops: uint8(len(hops))}
 	infof.Write(b)
 	for i, hop := range hops {
 		for j := 0; j < HopFieldLength; j++ {

--- a/python/lib/flagtypes.py
+++ b/python/lib/flagtypes.py
@@ -42,7 +42,7 @@ PathSegFlags = FlagBase((
 ))
 
 InfoOFFlags = FlagBase((
-    (1, "UP", "DOWN"),
+    (1, "CONS_DIR", "NOT_CONS_DIR"),
     (2, "SHORTCUT", ""),
     (4, "PEER_SHORTCUT", ""),
 ))

--- a/python/lib/packet/opaque_field.py
+++ b/python/lib/packet/opaque_field.py
@@ -156,7 +156,7 @@ class InfoOpaqueField(OpaqueField):
     NAME = "InfoOpaqueField"
 
     def __init__(self, raw=None):  # pragma: no cover
-        self.up_flag = False
+        self.cons_dir_flag = False
         self.shortcut = False
         self.peer = False
         self.timestamp = 0
@@ -171,8 +171,8 @@ class InfoOpaqueField(OpaqueField):
         self._parse_flags(flags)
 
     def _parse_flags(self, flags):  # pragma: no cover
-        if flags & InfoOFFlags.UP:
-            self.up_flag = True
+        if flags & InfoOFFlags.CONS_DIR:
+            self.cons_dir_flag = True
         if flags & InfoOFFlags.SHORTCUT:
             self.shortcut = True
         if flags & InfoOFFlags.PEER_SHORTCUT:
@@ -184,10 +184,10 @@ class InfoOpaqueField(OpaqueField):
         assert not(not self.shortcut and self.peer)
 
     @classmethod
-    def from_values(cls, timestamp, isd, up_flag=False, shortcut=False,
+    def from_values(cls, timestamp, isd, cons_dir_flag=True, shortcut=False,
                     peer=False, hops=0):  # pragma: no cover
         inst = cls()
-        inst.up_flag = up_flag
+        inst.cons_dir_flag = cons_dir_flag
         inst.shortcut = shortcut
         inst.peer = peer
         inst.timestamp = timestamp
@@ -203,8 +203,8 @@ class InfoOpaqueField(OpaqueField):
     def _pack_flags(self):  # pragma: no cover
         self._check_flags()
         flags = 0
-        if self.up_flag:
-            flags |= InfoOFFlags.UP
+        if self.cons_dir_flag:
+            flags |= InfoOFFlags.CONS_DIR
         if self.shortcut:
             flags |= InfoOFFlags.SHORTCUT
         if self.peer:
@@ -374,9 +374,9 @@ class OpaqueFieldList(object):
             raise SCIONKeyError("Opaque field label (%s) unknown"
                                 % label) from None
 
-    def reverse_up_flag(self, label):
+    def reverse_cons_dir_flag(self, label):
         """
-        Reverse the Up flag of the first OF in a label, assuming the label isn't
+        Reverse the ConsDir flag of the first OF in a label, assuming the label isn't
         empty. Used to change direction of IOFs.
 
         :param str label: The label to modify.
@@ -389,7 +389,7 @@ class OpaqueFieldList(object):
             raise SCIONKeyError("Opaque field label (%s) unknown"
                                 % label) from None
         if len(group) > 0:
-            group[0].up_flag ^= True
+            group[0].cons_dir_flag ^= True
 
     def pack(self):
         """

--- a/python/lib/packet/path.py
+++ b/python/lib/packet/path.py
@@ -195,16 +195,16 @@ class SCIONPath(Serializable):
             # Peer shortcut paths have two extra HOFs; 1 for the peering
             # interface, and another from the upstream interface, used for
             # verification only.
-            ingress_up = {(True, False): +2, (True, True): +1,
-                          (False, False): -1, (False, True): -2}
+            ingress_cons_dir = {(True, False): +2, (True, True): +1,
+                                (False, False): -1, (False, True): -2}
         else:
             # Non-peer shortcut paths have an extra HOF above the last hop, used
             # for verification of the last hop in that segment.
-            ingress_up = {(True, False): None, (True, True): -1,
-                          (False, False): +1, (False, True): None}
+            ingress_cons_dir = {(True, False): None, (True, True): -1,
+                                (False, False): +1, (False, True): None}
         # Map the local direction of travel and the IOF consDir flag to the required
         # offset of the verification HOF (or None, if there's no relevant HOF).
-        offset = ingress_up[ingress, iof.cons_dir_flag]
+        offset = ingress_cons_dir[ingress, iof.cons_dir_flag]
         if offset is None:
             return None
         return self._ofs.get_by_idx(self._hof_idx + offset)

--- a/python/lib/packet/path.py
+++ b/python/lib/packet/path.py
@@ -162,7 +162,7 @@ class SCIONPath(Serializable):
             self._ofs.swap(self.A_HOFS, swap_hof)
         # Reverse IOF flags.
         for label in self.IOF_LABELS:
-            self._ofs.reverse_up_flag(label)
+            self._ofs.reverse_cons_dir_flag(label)
         # Reverse HOF lists.
         for label in self.HOF_LABELS:
             self._ofs.reverse_label(label)
@@ -195,16 +195,16 @@ class SCIONPath(Serializable):
             # Peer shortcut paths have two extra HOFs; 1 for the peering
             # interface, and another from the upstream interface, used for
             # verification only.
-            ingress_up = {(True, True): +2, (True, False): +1,
-                          (False, True): -1, (False, False): -2}
+            ingress_up = {(True, False): +2, (True, True): +1,
+                          (False, False): -1, (False, True): -2}
         else:
             # Non-peer shortcut paths have an extra HOF above the last hop, used
             # for verification of the last hop in that segment.
-            ingress_up = {(True, True): None, (True, False): -1,
-                          (False, True): +1, (False, False): None}
-        # Map the local direction of travel and the IOF up flag to the required
+            ingress_up = {(True, False): None, (True, True): -1,
+                          (False, False): +1, (False, True): None}
+        # Map the local direction of travel and the IOF consDir flag to the required
         # offset of the verification HOF (or None, if there's no relevant HOF).
-        offset = ingress_up[ingress, iof.up_flag]
+        offset = ingress_up[ingress, iof.cons_dir_flag]
         if offset is None:
             return None
         return self._ofs.get_by_idx(self._hof_idx + offset)
@@ -212,11 +212,11 @@ class SCIONPath(Serializable):
     def _get_hof_ver_normal(self, iof):
         # If this is the last hop of an Up path, or the first hop of a Down
         # path, there's no previous HOF to verify against.
-        if (iof.up_flag and self._hof_idx == self._iof_idx + iof.hops) or (
-                not iof.up_flag and self._hof_idx == self._iof_idx + 1):
+        if (not iof.cons_dir_flag and self._hof_idx == self._iof_idx + iof.hops) or (
+                iof.cons_dir_flag and self._hof_idx == self._iof_idx + 1):
             return None
-        # Otherwise use the next/prev HOF based on the up flag.
-        offset = 1 if iof.up_flag else -1
+        # Otherwise use the next/prev HOF based on the consDir flag.
+        offset = -1 if iof.cons_dir_flag else 1
         return self._ofs.get_by_idx(self._hof_idx + offset)
 
     def get_iof(self):  # pragma: no cover
@@ -261,9 +261,9 @@ class SCIONPath(Serializable):
             return 0
         iof = self.get_iof()
         hof = self.get_hof()
-        if iof.up_flag:
-            return hof.ingress_if
-        return hof.egress_if
+        if iof.cons_dir_flag:
+            return hof.egress_if
+        return hof.ingress_if
 
     def get_curr_if(self, ingress=True):  # pragma: no cover
         """
@@ -272,9 +272,9 @@ class SCIONPath(Serializable):
         """
         hof = self.get_hof()
         iof = self.get_iof()
-        if ingress == iof.up_flag:
-            return hof.egress_if
-        return hof.ingress_if
+        if ingress == iof.cons_dir_flag:
+            return hof.ingress_if
+        return hof.egress_if
 
     def get_as_hops(self):
         total = 0

--- a/python/lib/packet/pcb.py
+++ b/python/lib/packet/pcb.py
@@ -212,7 +212,7 @@ class PathSegment(Cerealizable):
         asms = list(self.iter_asms())
         if reverse_direction:
             asms = reversed(asms)
-            info.up_flag ^= True
+            info.cons_dir_flag ^= True
         for asm in asms:
             hofs.append(asm.pcbm(0).hof())
         return SCIONPath.from_values(info, hofs)

--- a/python/lib/sibra/ext/steady.py
+++ b/python/lib/sibra/ext/steady.py
@@ -115,9 +115,9 @@ class SibraExtSteady(SibraExtBase):
             return
         iof = spkt.path.get_iof()
         hof = spkt.path.get_hof()
-        if iof.up_flag:
-            if1, if2 = hof.egress_if, hof.ingress_if
-        else:
+        if iof.cons_dir_flag:
             if1, if2 = hof.ingress_if, hof.egress_if
+        else:
+            if1, if2 = hof.egress_if, hof.ingress_if
         prev_raw = self._get_prev_raw(req=True)
         self.req_block.add_hop(if1, if2, prev_raw, key, self.path_ids)

--- a/python/lib/sibra/pcb_ext.py
+++ b/python/lib/sibra/pcb_ext.py
@@ -42,8 +42,8 @@ class SibraPCBExt(Cerealizable):  # pragma: no cover
         self.info = ResvInfoSteady(p.info)
 
     @classmethod
-    def from_values(cls, id_, info, sofs, up=True):
-        p = cls.P_CLS.new_message(id=id_, info=info.pack(), up=up)
+    def from_values(cls, id_, info, sofs, cons_dir=False):
+        p = cls.P_CLS.new_message(id=id_, info=info.pack(), cons_dir=cons_dir)
         p.init("sofs", len(sofs))
         for i, sof in enumerate(sofs):
             p.sofs[i] = sof.pack()
@@ -72,7 +72,7 @@ class SibraPCBExt(Cerealizable):  # pragma: no cover
         b = []
         b.append(self.p.id)
         b.append(self.p.info)
-        b.append(self.p.up.to_bytes(1, 'big'))
+        b.append(self.p.cons_dir.to_bytes(1, 'big'))
         for sof in self.p.sofs:
             b.append(sof)
         return b"".join(b)
@@ -86,8 +86,8 @@ class SibraPCBExt(Cerealizable):  # pragma: no cover
 
     def short_desc(self):
         a = []
-        a.append("%s: id: %s (owner: %s) Up? %s" %
-                 (self.NAME, hex_str(self.p.id), self.isd_as(), self.p.up))
+        a.append("%s: id: %s (owner: %s) ConsDir? %s" %
+                 (self.NAME, hex_str(self.p.id), self.isd_as(), self.p.cons_dir))
         for line in str(self.info).splitlines():
             a.append("  %s" % line)
         return "\n".join(a)

--- a/python/sibra_server/util.py
+++ b/python/sibra_server/util.py
@@ -39,10 +39,10 @@ def find_last_ifid(pkt, ext):
         path = pkt.path
         iof = path.get_iof()
         hof = path.get_hof()
-        if iof.up_flag:
-            return hof.egress_if
-        else:
+        if iof.cons_dir_flag:
             return hof.ingress_if
+        else:
+            return hof.egress_if
     sof = ext.active_blocks[0].sofs[ext.curr_hop]
     if ext.fwd:
         return sof.ingress

--- a/python/test/lib/packet/opaque_field_test.py
+++ b/python/test/lib/packet/opaque_field_test.py
@@ -301,29 +301,29 @@ class TestOpaqueFieldListReverseLabel(object):
         ntools.assert_raises(SCIONKeyError, inst.reverse_label, "nope")
 
 
-class TestOpaqueFieldListReverseUpFlag(object):
+class TestOpaqueFieldListReverseConsDirFlag(object):
     """
-    Unit tests for lib.packet.opaque_field.OpaqueFieldList.reverse_up_flag
+    Unit tests for lib.packet.opaque_field.OpaqueFieldList.reverse_cons_dir_flag
     """
     def test_basic(self):
         inst = _of_list_setup()
-        iof = create_mock(["up_flag"])
-        iof.up_flag = True
+        iof = create_mock(["cons_dir_flag"])
+        iof.cons_dir_flag = True
         inst._labels["down"] = [iof]
         # Call
-        inst.reverse_up_flag("down")
+        inst.reverse_cons_dir_flag("down")
         # Tests
-        ntools.assert_false(iof.up_flag)
+        ntools.assert_false(iof.cons_dir_flag)
 
     def test_empty(self):
         inst = _of_list_setup()
         # Call
-        inst.reverse_up_flag("down")
+        inst.reverse_cons_dir_flag("down")
 
     def test_label_error(self):
         inst = _of_list_setup()
         # Call
-        ntools.assert_raises(SCIONKeyError, inst.reverse_up_flag, "nope")
+        ntools.assert_raises(SCIONKeyError, inst.reverse_cons_dir_flag, "nope")
 
 
 class TestOpaqueFieldListPack(object):

--- a/python/test/lib/packet/pcb_test.py
+++ b/python/test/lib/packet/pcb_test.py
@@ -82,11 +82,11 @@ class TestPathSegmentGetPath(object):
     @patch("lib.packet.pcb.PathSegment._setup", autospec=True)
     def test_fwd(self, _, info, scion_path):
         inst = self._setup()
-        info.return_value = create_mock_full({"up_flag": True})
+        info.return_value = create_mock_full({"cons_dir_flag": False})
         # Call
         ntools.eq_(inst.get_path(), scion_path.from_values.return_value)
         # Tests
-        ntools.eq_(info.return_value.up_flag, True)
+        ntools.eq_(info.return_value.cons_dir_flag, False)
         scion_path.from_values.assert_called_once_with(
             info.return_value, ["hof 0", "hof 1", "hof 2"])
 
@@ -95,11 +95,11 @@ class TestPathSegmentGetPath(object):
     @patch("lib.packet.pcb.PathSegment._setup", autospec=True)
     def test_reverse(self, _, info, scion_path):
         inst = self._setup()
-        info.return_value = create_mock_full({"up_flag": True})
+        info.return_value = create_mock_full({"cons_dir_flag": False})
         # Call
         ntools.eq_(inst.get_path(True), scion_path.from_values.return_value)
         # Tests
-        ntools.eq_(info.return_value.up_flag, False)
+        ntools.eq_(info.return_value.cons_dir_flag, True)
         scion_path.from_values.assert_called_once_with(
             info.return_value, ["hof 2", "hof 1", "hof 0"])
 

--- a/python/test/lib/sibra/ext/steady_test.py
+++ b/python/test/lib/sibra/ext/steady_test.py
@@ -63,13 +63,13 @@ class TestSibraExtSteadyAddHop(object):
         # Tests
         super_addhop.assert_called_once_with(inst, "key")
 
-    def _check_setup(self, up):
+    def _check_setup(self, cons_dir):
         inst = SibraExtSteady()
         inst._get_prev_raw = create_mock()
         inst.setup = True
         inst.path_ids = "path ids"
-        iof = create_mock(["up_flag"])
-        iof.up_flag = up
+        iof = create_mock(["cons_dir_flag"])
+        iof.cons_dir_flag = cons_dir
         hof = create_mock(["egress_if", "ingress_if"])
         path = create_mock(["get_hof", "get_iof"])
         path.get_iof.return_value = iof
@@ -81,13 +81,13 @@ class TestSibraExtSteadyAddHop(object):
         # Call
         inst._add_hop("key", spkt)
         # Tests
-        if up:
+        if cons_dir:
             req.add_hop.assert_called_once_with(
-                hof.egress_if, hof.ingress_if, inst._get_prev_raw.return_value,
+                hof.ingress_if, hof.egress_if, inst._get_prev_raw.return_value,
                 "key", "path ids")
         else:
             req.add_hop.assert_called_once_with(
-                hof.ingress_if, hof.egress_if, inst._get_prev_raw.return_value,
+                hof.egress_if, hof.ingress_if, inst._get_prev_raw.return_value,
                 "key", "path ids")
 
     def test_setup(self):

--- a/tools/wireshark/scion.lua
+++ b/tools/wireshark/scion.lua
@@ -136,8 +136,8 @@ local scion_path_info_flags_peer = ProtoField.bool("scion.path.info.flags.peer",
     "Peer", 8, nil, 0x4)
 local scion_path_info_flags_shortcut = ProtoField.bool("scion.path.info.flags.shortcut",
     "Shortcut", 8, nil, 0x2)
-local scion_path_info_flags_up = ProtoField.bool("scion.path.info.flags.up",
-    "Up", 8, nil, 0x1)
+local scion_path_info_flags_cons_dir = ProtoField.bool("scion.path.info.flags.cons_dir",
+    "ConsDir", 8, nil, 0x1)
 -- XXX(kormat): This *should* be base.UTC, but that seems to be bugged in ubuntu 16.04's
 -- version of wireshark. Amazingly, using the raw enum value works.
 -- https://github.com/wireshark/wireshark/blob/2832f4e97d77324b4e46aac40dae0ce898ae559d/epan/time_fmt.h#L44
@@ -235,7 +235,7 @@ scion_proto.fields={
     scion_path_info_flags,
     scion_path_info_flags_peer,
     scion_path_info_flags_shortcut,
-    scion_path_info_flags_up,
+    scion_path_info_flags_cons_dir,
     scion_path_info_ts,
     scion_path_info_isd,
     scion_path_info_hops,
@@ -488,7 +488,7 @@ function parse_info_field(buffer, tree)
     flagsT:append_text(", " .. info_flag_desc(flags:uint()))
     flagsT:add(scion_path_info_flags_peer, flags)
     flagsT:add(scion_path_info_flags_shortcut, flags)
-    flagsT:add(scion_path_info_flags_up, flags)
+    flagsT:add(scion_path_info_flags_cons_dir, flags)
     local ts = buffer(1, 4):uint()
     t:add(scion_path_info_ts, buffer(1, 4))
     t:add(scion_path_info_isd, buffer(5, 2))
@@ -501,9 +501,9 @@ end
 function info_flag_desc(flag)
     local desc = {}
     if bit.band(flag, 0x1) > 0 then
-        table.insert(desc, "UP")
+        table.insert(desc, "CONS_DIR")
     else
-        table.insert(desc, "DOWN")
+        table.insert(desc, "NOT_CONS_DIR")
     end
     if bit.band(flag, 0x2) > 0 then
         if bit.band(flag, 0x4) > 0 then


### PR DESCRIPTION
Make up/down ingress/egress less ambiguous for paths, fixes #1479

- `up` becomes `!consDir` (as the current "up" is the opposite of the construction direction)
- `ingress` becomes `consIngress`
- `egress` becomes `consEgress`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1527)
<!-- Reviewable:end -->
