### PR TITLE
Fix misnamed caches

### DIFF
--- a/go/cert_srv/trc.go
+++ b/go/cert_srv/trc.go
@@ -120,9 +120,9 @@ func (h *TRCHandler) HandleRep(a *snet.Addr, rep *cert_mgmt.TRC, config *conf.Co
 		return
 	}
 	key := t.Key()
-	reqVer := chainReqCache.Pop(key.String())
+	reqVer := trcReqCache.Pop(key.String())
 	key.Ver = cert_mgmt.NewestVersion
-	reqNew := chainReqCache.Pop(key.String())
+	reqNew := trcReqCache.Pop(key.String())
 	key.Ver = t.Version
 	if reqVer == nil && reqNew == nil { // No pending requests
 		return


### PR DESCRIPTION
Prevents handling of TRC requests to mistakenly access the cache of certificate chain requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1540)
<!-- Reviewable:end -->
