### PR TITLE
SIG: Add base events that modules can subscribe to

### DIFF
--- a/go/sig/base/as.go
+++ b/go/sig/base/as.go
@@ -32,17 +32,21 @@ import (
 	"github.com/scionproto/scion/go/sig/siginfo"
 )
 
-const sigMgrTick = 10 * time.Second
+const (
+	sigMgrTick        = 10 * time.Second
+	healthMonitorTick = 5 * time.Second
+)
 
 // ASEntry contains all of the information required to interact with a remote AS.
 type ASEntry struct {
 	sync.RWMutex
-	Nets       map[string]*net.IPNet
-	Sigs       *siginfo.SigMap
-	IA         addr.IA
-	IAString   string
-	egressRing *ringbuf.Ring
-	sigMgrStop chan struct{}
+	Nets              map[string]*net.IPNet
+	Sigs              *siginfo.SigMap
+	IA                addr.IA
+	IAString          string
+	egressRing        *ringbuf.Ring
+	sigMgrStop        chan struct{}
+	healthMonitorStop chan struct{}
 	log.Logger
 
 	Session *egress.Session
@@ -50,12 +54,13 @@ type ASEntry struct {
 
 func newASEntry(ia addr.IA) (*ASEntry, error) {
 	ae := &ASEntry{
-		Logger:     log.New("ia", ia),
-		IA:         ia,
-		IAString:   ia.String(),
-		Nets:       make(map[string]*net.IPNet),
-		Sigs:       &siginfo.SigMap{},
-		sigMgrStop: make(chan struct{}),
+		Logger:            log.New("ia", ia),
+		IA:                ia,
+		IAString:          ia.String(),
+		Nets:              make(map[string]*net.IPNet),
+		Sigs:              &siginfo.SigMap{},
+		sigMgrStop:        make(chan struct{}),
+		healthMonitorStop: make(chan struct{}),
 	}
 	var err error
 	if ae.Session, err = egress.NewSession(ia, 0, ae.Sigs, ae.Logger); err != nil {
@@ -128,6 +133,13 @@ func (ae *ASEntry) addNet(ipnet *net.IPNet) error {
 		return err
 	}
 	ae.Nets[key] = ipnet
+	// Generate NetworkChanged event
+	params := NetworkChangedParams{
+		RemoteIA: ae.IA,
+		IpNet:    *ipnet,
+		Added:    true,
+	}
+	NetworkChanged(params)
 	ae.Info("Added network", "net", ipnet)
 	return nil
 }
@@ -149,6 +161,13 @@ func (ae *ASEntry) delNet(ipnet *net.IPNet) error {
 	}
 	delete(ae.Nets, key)
 	ae.Info("Removed network", "net", ipnet)
+	// Generate NetworkChanged event
+	params := NetworkChangedParams{
+		RemoteIA: ae.IA,
+		IpNet:    *ipnet,
+		Added:    false,
+	}
+	NetworkChanged(params)
 	return nil
 }
 
@@ -258,11 +277,46 @@ Top:
 	ae.Info("sigMgr stopping")
 }
 
+func (ae *ASEntry) monitorHealth() {
+	defer liblog.LogPanicAndExit()
+	ticker := time.NewTicker(healthMonitorTick)
+	defer ticker.Stop()
+	ae.Info("Health monitor starting")
+	lastHealth := false
+Top:
+	for {
+		select {
+		case <-ae.healthMonitorStop:
+			break Top
+		case <-ticker.C:
+			curHealth := ae.checkHealth()
+			if curHealth != lastHealth {
+				// Overall health has changed. Generate event.
+				params := RemoteHealthChangedParams{
+					RemoteIA: ae.IA,
+					Nets:     ae.Nets,
+					Healthy:  curHealth,
+				}
+				RemoteHealthChanged(params)
+				lastHealth = curHealth
+			}
+		}
+	}
+	close(ae.healthMonitorStop)
+	ae.Info("Health monitor stopping")
+}
+
+func (ae *ASEntry) checkHealth() bool {
+	return ae.Session.Healthy()
+}
+
 func (ae *ASEntry) Cleanup() error {
 	ae.Lock()
 	defer ae.Unlock()
 	// Clean up sigMgr goroutine.
 	ae.sigMgrStop <- struct{}{}
+	// Clean up health monitor
+	ae.healthMonitorStop <- struct{}{}
 	// Clean up NetMap entries
 	for _, v := range ae.Nets {
 		if err := ae.delNet(v); err != nil {
@@ -286,6 +340,7 @@ func (ae *ASEntry) setupNet() error {
 		prometheus.Labels{"ringId": ae.IAString, "sessId": ""})
 	go egress.NewDispatcher(ae.IA, ae.egressRing, ae.Session).Run()
 	go ae.sigMgr()
+	go ae.monitorHealth()
 	ae.Session.Start()
 	ae.Info("Network setup done")
 	return nil

--- a/go/sig/base/as.go
+++ b/go/sig/base/as.go
@@ -282,37 +282,41 @@ func (ae *ASEntry) monitorHealth() {
 	ticker := time.NewTicker(healthMonitorTick)
 	defer ticker.Stop()
 	ae.Info("Health monitor starting")
-	lastHealth := false
+	prevHealth := false
 Top:
 	for {
 		select {
 		case <-ae.healthMonitorStop:
 			break Top
 		case <-ticker.C:
-			ae.RLock()
-			curHealth := ae.checkHealth()
-			if curHealth != lastHealth {
-				// Generate slice of networks.
-				// XXX: This could become a bottleneck, namely in case of a large number
-				// of remote prefixes and flappy health.
-				nets := make([]*net.IPNet, 0, len(ae.Nets))
-				for _, n := range ae.Nets {
-					nets = append(nets, n)
-				}
-				// Overall health has changed. Generate event.
-				params := RemoteHealthChangedParams{
-					RemoteIA: ae.IA,
-					Nets:     nets,
-					Healthy:  curHealth,
-				}
-				RemoteHealthChanged(params)
-				lastHealth = curHealth
-			}
-			ae.RUnlock()
+			prevHealth = ae.performHealthCheck(prevHealth)
 		}
 	}
 	close(ae.healthMonitorStop)
 	ae.Info("Health monitor stopping")
+}
+
+func (ae *ASEntry) performHealthCheck(prevHealth bool) bool {
+	ae.RLock()
+	defer ae.RUnlock()
+	curHealth := ae.checkHealth()
+	if curHealth != prevHealth {
+		// Generate slice of networks.
+		// XXX: This could become a bottleneck, namely in case of a large number
+		// of remote prefixes and flappy health.
+		nets := make([]*net.IPNet, 0, len(ae.Nets))
+		for _, n := range ae.Nets {
+			nets = append(nets, n)
+		}
+		// Overall health has changed. Generate event.
+		params := RemoteHealthChangedParams{
+			RemoteIA: ae.IA,
+			Nets:     nets,
+			Healthy:  curHealth,
+		}
+		RemoteHealthChanged(params)
+	}
+	return curHealth
 }
 
 func (ae *ASEntry) checkHealth() bool {

--- a/go/sig/base/events.go
+++ b/go/sig/base/events.go
@@ -1,0 +1,102 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"net"
+	"sync"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/sig/siginfo"
+)
+
+type (
+	NetworkChangedCb      func(NetworkChangedParams)
+	RemoteHealthChangedCb func(RemoteHealthChangedParams)
+	SigChangedCb          func(SigChangedParams)
+)
+
+type NetworkChangedParams struct {
+	RemoteIA addr.IA
+	IpNet    net.IPNet
+	Added    bool
+}
+
+type RemoteHealthChangedParams struct {
+	RemoteIA addr.IA
+	Nets     map[string]*net.IPNet
+	Healthy  bool
+}
+
+type SigChangedParams struct {
+	RemoteIA  addr.IA
+	Id        siginfo.SigIdType
+	Host      addr.HostAddr
+	CtrlPort  int
+	EncapPort int
+	Static    bool
+	Added     bool
+}
+
+type EventCallbacks struct {
+	NetworkChanged      NetworkChangedCb
+	SigChanged          SigChangedCb
+	RemoteHealthChanged RemoteHealthChangedCb
+}
+
+var lock sync.RWMutex
+var listeners map[string]EventCallbacks = make(map[string]EventCallbacks)
+
+func AddEventListener(moduleName string, cbs EventCallbacks) {
+	lock.Lock()
+	defer lock.Unlock()
+	listeners[moduleName] = cbs
+}
+
+func RemoveEventListener(listenerName string) {
+	lock.Lock()
+	defer lock.Unlock()
+	delete(listeners, listenerName)
+}
+
+func NetworkChanged(params NetworkChangedParams) {
+	lock.RLock()
+	defer lock.RUnlock()
+	for _, cbs := range listeners {
+		if cbs.NetworkChanged != nil {
+			go cbs.NetworkChanged(params)
+		}
+	}
+}
+
+func RemoteHealthChanged(params RemoteHealthChangedParams) {
+	lock.RLock()
+	defer lock.RUnlock()
+	for _, cbs := range listeners {
+		if cbs.RemoteHealthChanged != nil {
+			go cbs.RemoteHealthChanged(params)
+		}
+	}
+}
+
+func SigChanged(params SigChangedParams) {
+	lock.RLock()
+	defer lock.RUnlock()
+	for _, cbs := range listeners {
+		if cbs.SigChanged != nil {
+			go cbs.SigChanged(params)
+		}
+	}
+}

--- a/go/sig/base/events.go
+++ b/go/sig/base/events.go
@@ -75,6 +75,7 @@ type EventCallbacks struct {
 	// NetworkChanged is called when a remote network was added or removed from the configuration.
 	NetworkChanged NetworkChangedCb
 	// SigChanged is called when a remote SIG is was added or removed from the configuration.
+	// TODO(shitz): This event does not get generated yet.
 	SigChanged SigChangedCb
 	// RemoteHealthChanged is called when the reachability status of a remote AS changed.
 	RemoteHealthChanged RemoteHealthChangedCb


### PR DESCRIPTION
Types of events that are being added:
* `NetworkChanged`: `NetworkChanged` is called when a remote network was added or removed from the configuration.
* `SigChanged`: `SigChanged` is called when a remote SIG is was added or removed from the configuration. Note, this event does not get generated yet.
* `RemoteHealthChanged`: `RemoteHealthChanged` is called when the reachability status of a remote AS changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1551)
<!-- Reviewable:end -->
