### PR TITLE
Avoid panic during SignedPld parsing

### DIFF
--- a/go/lib/ctrl/signed.go
+++ b/go/lib/ctrl/signed.go
@@ -55,7 +55,7 @@ func newSignedPld(cpld *Pld, sign *proto.SignS, key common.RawBytes) (*SignedPld
 func NewSignedPldFromRaw(b common.RawBytes) (*SignedPld, error) {
 	sp := &SignedPld{}
 	if len(b) < 4 {
-		return nil, common.NewBasicError("Invalid ctrl payload length", nil,
+		return nil, common.NewBasicError("Ctrl payload length field to short", nil,
 			"minimum", 4, "actual", len(b))
 	}
 	n := common.Order.Uint32(b)

--- a/go/lib/ctrl/signed.go
+++ b/go/lib/ctrl/signed.go
@@ -54,6 +54,10 @@ func newSignedPld(cpld *Pld, sign *proto.SignS, key common.RawBytes) (*SignedPld
 
 func NewSignedPldFromRaw(b common.RawBytes) (*SignedPld, error) {
 	sp := &SignedPld{}
+	if len(b) < 4 {
+		return nil, common.NewBasicError("Invalid ctrl payload length", nil,
+			"minimum", 4, "actual", len(b))
+	}
 	n := common.Order.Uint32(b)
 	if int(n)+4 != len(b) {
 		return nil, common.NewBasicError("Invalid ctrl payload length", nil,

--- a/go/lib/ctrl/signed.go
+++ b/go/lib/ctrl/signed.go
@@ -55,7 +55,7 @@ func newSignedPld(cpld *Pld, sign *proto.SignS, key common.RawBytes) (*SignedPld
 func NewSignedPldFromRaw(b common.RawBytes) (*SignedPld, error) {
 	sp := &SignedPld{}
 	if len(b) < 4 {
-		return nil, common.NewBasicError("Ctrl payload length field to short", nil,
+		return nil, common.NewBasicError("Ctrl payload length field too short", nil,
 			"minimum", 4, "actual", len(b))
 	}
 	n := common.Order.Uint32(b)


### PR DESCRIPTION
Return error if buffer is too small to avoid panic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1552)
<!-- Reviewable:end -->
