### PR TITLE
sciond: Avoid failing on duplicate path reply

### DIFF
--- a/python/sciond/req.py
+++ b/python/sciond/req.py
@@ -35,7 +35,7 @@ class RequestState:  # pragma: no cover
             if self._done:
                 return
             if self._segs_to_verify > 0:
-                logging.error("Received duplicate reply")
+                logging.error("Received duplicate reply %s", reply)
                 return
             self._segs_to_verify = reply.recs().num_segs()
             if self._segs_to_verify > 0:

--- a/python/sciond/req.py
+++ b/python/sciond/req.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # Stdlib
+import logging
 import threading
 
 # How long to wait (at most) after segments are received before considering the request done.
@@ -32,6 +33,9 @@ class RequestState:  # pragma: no cover
     def notify_reply(self, reply):
         with self._lock:
             if self._done:
+                return
+            if self._segs_to_verify > 0:
+                logging.error("Received duplicate reply")
                 return
             self._segs_to_verify = reply.recs().num_segs()
             if self._segs_to_verify > 0:

--- a/python/sciond/sciond.py
+++ b/python/sciond/sciond.py
@@ -208,11 +208,12 @@ class SCIONDaemon(SCIONElement):
 
         req = path_reply.req()
         key = req.dst_ia(), req.flags()
-        r = self.requested_paths.get(key)
-        if r:
-            r.notify_reply(path_reply)
-        else:
-            logging.warning("No outstanding request found for %s", key)
+        with self.req_path_lock:
+            r = self.requested_paths.get(key)
+            if r:
+                r.notify_reply(path_reply)
+            else:
+                logging.warning("No outstanding request found for %s", key)
         for type_, pcb in recs.iter_pcbs():
             seg_meta = PathSegMeta(pcb, self.continue_seg_processing,
                                    meta, type_, params=(r,))


### PR DESCRIPTION
Grab lock when handling RequestState in handle_path_reply.
Log error on duplicate path reply.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1554)
<!-- Reviewable:end -->
