### PR TITLE
Quit when Accept returns error.

### DIFF
--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -244,9 +244,8 @@ func Server() {
 		qsess, err := qsock.Accept()
 		if err != nil {
 			log.Error("Unable to accept quic session", "err", err)
-			// the quic implementation keeps the error present for the
-			// rest of the life of the socket. We quit
-			return
+			// Accept failing means the socket is unusable.
+			break
 		}
 		log.Debug("Quic session accepted", "src", qsess.RemoteAddr())
 		go handleClient(qsess)


### PR DESCRIPTION
As the quic implementation always returns the previous error when calling Accept, we have to avoid calling it after we see an error.

We can reproduce the issue by running pingpong as server, and then stopping SCION. It will output the same error message as if there was no tomorrow. The cause of the huge pingpong logs in SCIONlab is this one, although the reason `Accept` fails is probably other than stopping SCION.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1556)
<!-- Reviewable:end -->
