### PR TITLE
SIG: Add healthy flag to NetworkChanged event and version to ASEntry

### DIFF
--- a/go/sig/base/as.go
+++ b/go/sig/base/as.go
@@ -47,6 +47,7 @@ type ASEntry struct {
 	egressRing        *ringbuf.Ring
 	sigMgrStop        chan struct{}
 	healthMonitorStop chan struct{}
+	version           uint64 // used to track certain changes made to ASEntry
 	log.Logger
 
 	Session *egress.Session
@@ -133,10 +134,12 @@ func (ae *ASEntry) addNet(ipnet *net.IPNet) error {
 		return err
 	}
 	ae.Nets[key] = ipnet
+	ae.version++
 	// Generate NetworkChanged event
 	params := NetworkChangedParams{
 		RemoteIA: ae.IA,
 		IpNet:    *ipnet,
+		Healthy:  ae.checkHealth(),
 		Added:    true,
 	}
 	NetworkChanged(params)
@@ -160,14 +163,16 @@ func (ae *ASEntry) delNet(ipnet *net.IPNet) error {
 		return err
 	}
 	delete(ae.Nets, key)
-	ae.Info("Removed network", "net", ipnet)
+	ae.version++
 	// Generate NetworkChanged event
 	params := NetworkChangedParams{
 		RemoteIA: ae.IA,
 		IpNet:    *ipnet,
+		Healthy:  ae.checkHealth(),
 		Added:    false,
 	}
 	NetworkChanged(params)
+	ae.Info("Removed network", "net", ipnet)
 	return nil
 }
 
@@ -283,24 +288,25 @@ func (ae *ASEntry) monitorHealth() {
 	defer ticker.Stop()
 	ae.Info("Health monitor starting")
 	prevHealth := false
+	prevVersion := uint64(0)
 Top:
 	for {
 		select {
 		case <-ae.healthMonitorStop:
 			break Top
 		case <-ticker.C:
-			prevHealth = ae.performHealthCheck(prevHealth)
+			prevHealth, prevVersion = ae.performHealthCheck(prevHealth, prevVersion)
 		}
 	}
 	close(ae.healthMonitorStop)
 	ae.Info("Health monitor stopping")
 }
 
-func (ae *ASEntry) performHealthCheck(prevHealth bool) bool {
+func (ae *ASEntry) performHealthCheck(prevHealth bool, prevVersion uint64) (bool, uint64) {
 	ae.RLock()
 	defer ae.RUnlock()
 	curHealth := ae.checkHealth()
-	if curHealth != prevHealth {
+	if curHealth != prevHealth || ae.version != prevVersion {
 		// Generate slice of networks.
 		// XXX: This could become a bottleneck, namely in case of a large number
 		// of remote prefixes and flappy health.
@@ -316,7 +322,7 @@ func (ae *ASEntry) performHealthCheck(prevHealth bool) bool {
 		}
 		RemoteHealthChanged(params)
 	}
-	return curHealth
+	return curHealth, ae.version
 }
 
 func (ae *ASEntry) checkHealth() bool {

--- a/go/sig/base/as.go
+++ b/go/sig/base/as.go
@@ -295,18 +295,18 @@ Top:
 		case <-ae.healthMonitorStop:
 			break Top
 		case <-ticker.C:
-			prevHealth, prevVersion = ae.performHealthCheck(prevHealth, prevVersion)
+			ae.performHealthCheck(&prevHealth, &prevVersion)
 		}
 	}
 	close(ae.healthMonitorStop)
 	ae.Info("Health monitor stopping")
 }
 
-func (ae *ASEntry) performHealthCheck(prevHealth bool, prevVersion uint64) (bool, uint64) {
+func (ae *ASEntry) performHealthCheck(prevHealth *bool, prevVersion *uint64) {
 	ae.RLock()
 	defer ae.RUnlock()
 	curHealth := ae.checkHealth()
-	if curHealth != prevHealth || ae.version != prevVersion {
+	if curHealth != *prevHealth || ae.version != *prevVersion {
 		// Generate slice of networks.
 		// XXX: This could become a bottleneck, namely in case of a large number
 		// of remote prefixes and flappy health.
@@ -322,7 +322,8 @@ func (ae *ASEntry) performHealthCheck(prevHealth bool, prevVersion uint64) (bool
 		}
 		RemoteHealthChanged(params)
 	}
-	return curHealth, ae.version
+	*prevHealth = curHealth
+	*prevVersion = ae.version
 }
 
 func (ae *ASEntry) checkHealth() bool {

--- a/go/sig/base/events.go
+++ b/go/sig/base/events.go
@@ -34,6 +34,8 @@ type NetworkChangedParams struct {
 	RemoteIA addr.IA
 	// IpNet contains the network prefix that was added/removed.
 	IpNet net.IPNet
+	// Healthy is true if the remote IA can be reached.
+	Healthy bool
 	// Added is true if the prefix was added, false otherwise.
 	Added bool
 }


### PR DESCRIPTION
The NetworkChanged event now includes if the remote AS to which the network belongs is reachable or not. Furthermore, `version` keeps track of remote network changes through configuration changes or discoveries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1557)
<!-- Reviewable:end -->
