### PR TITLE
CSGO: Add Certificate Reissuance

### DIFF
--- a/go/cert_srv/cert.go
+++ b/go/cert_srv/cert.go
@@ -46,6 +46,9 @@ func (h *ChainHandler) HandleReq(a *snet.Addr, req *cert_mgmt.ChainReq, config *
 	var chain *cert.Chain
 	if req.Version == cert_mgmt.NewestVersion {
 		chain = config.Store.GetNewestChain(req.IA())
+		if chain != nil && chain.Leaf.VerifyTime(uint64(time.Now().Unix())) != nil {
+			chain = nil
+		}
 	} else {
 		chain = config.Store.GetChain(req.IA(), req.Version)
 	}
@@ -108,6 +111,7 @@ func (h *ChainHandler) HandleRep(a *snet.Addr, rep *cert_mgmt.Chain, config *con
 	chain, err := rep.Chain()
 	if err != nil {
 		log.Error("Unable to parse certificate reply", "err", err)
+		return
 	}
 	if err = config.Store.AddChain(chain, true); err != nil {
 		log.Error("Unable to store certificate chain", "key", chain.Key(), "err", err)

--- a/go/cert_srv/conf/conf.go
+++ b/go/cert_srv/conf/conf.go
@@ -18,9 +18,11 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/crypto/cert"
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
 	"github.com/scionproto/scion/go/lib/snet"
@@ -29,7 +31,17 @@ import (
 )
 
 const (
+	// LeafReissTime is the default value for Conf.LeafReissTime. It is the same
+	// as the default segment TTL in order to provide optimal coverage.
+	LeafReissTime = 6 * time.Hour
+	// IssuerReissTime is the default value for Conf.IssuerReissTime. It is the same
+	// as the leaf certificate validity period in order to provide optimal coverage.
+	IssuerReissTime = cert.DefaultLeafCertValidity * time.Second
+	// ReissReqRate is the default interval between two consecutive reissue requests.
+	ReissReqRate = 10 * time.Second
+
 	ErrorAddr      = "Unable to load addresses"
+	ErrorIssCert   = "Unable to load issuer certificate"
 	ErrorKeyConf   = "Unable to load KeyConf"
 	ErrorConfNil   = "Unable to reload conf from nil value"
 	ErrorStore     = "Unable to load TrustStore"
@@ -73,15 +85,24 @@ type Conf struct {
 	verifier ctrl.SigVerifier
 	// verifierLock guards verifier.
 	verifierLock sync.RWMutex
+	// LeafReissTime is the time between starting reissue requests and leaf cert expiration.
+	LeafReissTime time.Duration
+	// IssuerReissTime is the time between self issuing core cert and core cert expiration.
+	IssuerReissTime time.Duration
+	// ReissRate is the interval between two consecutive reissue requests.
+	ReissRate time.Duration
 }
 
 // Load initializes the configuration by loading it from confDir.
 func Load(id string, confDir string, cacheDir string, stateDir string) (*Conf, error) {
 	c := &Conf{
-		ID:       id,
-		ConfDir:  confDir,
-		CacheDir: cacheDir,
-		StateDir: stateDir,
+		ID:              id,
+		ConfDir:         confDir,
+		CacheDir:        cacheDir,
+		StateDir:        stateDir,
+		LeafReissTime:   LeafReissTime,
+		IssuerReissTime: IssuerReissTime,
+		ReissRate:       ReissReqRate,
 	}
 	if err := c.loadTopo(); err != nil {
 		return nil, err
@@ -100,6 +121,9 @@ func Load(id string, confDir string, cacheDir string, stateDir string) (*Conf, e
 		if c.Customers, err = c.LoadCustomers(); err != nil {
 			return nil, common.NewBasicError(ErrorCustomers, err)
 		}
+		if err = c.loadIssCert(); err != nil {
+			return nil, err
+		}
 	}
 	return c, nil
 }
@@ -112,12 +136,15 @@ func ReloadConf(oldConf *Conf) (*Conf, error) {
 	// FIXME(roosd): Changing keys for customers outside of the process on-disk
 	// requires a restart of the certificate server in order to be visible.
 	c := &Conf{
-		ID:        oldConf.ID,
-		TrustDB:   oldConf.TrustDB,
-		Customers: oldConf.Customers,
-		ConfDir:   oldConf.ConfDir,
-		CacheDir:  oldConf.CacheDir,
-		StateDir:  oldConf.StateDir,
+		ID:              oldConf.ID,
+		TrustDB:         oldConf.TrustDB,
+		Customers:       oldConf.Customers,
+		ConfDir:         oldConf.ConfDir,
+		CacheDir:        oldConf.CacheDir,
+		StateDir:        oldConf.StateDir,
+		LeafReissTime:   LeafReissTime,
+		IssuerReissTime: IssuerReissTime,
+		ReissRate:       ReissReqRate,
 	}
 	if err := c.loadTopo(); err != nil {
 		return nil, err
@@ -127,6 +154,11 @@ func ReloadConf(oldConf *Conf) (*Conf, error) {
 	}
 	if err := c.loadKeyConf(); err != nil {
 		return nil, err
+	}
+	if c.Topo.Core {
+		if err := c.loadIssCert(); err != nil {
+			return nil, err
+		}
 	}
 	return c, nil
 }
@@ -181,11 +213,30 @@ func (c *Conf) loadKeyConf() (err error) {
 	return nil
 }
 
+// loadKeyConf inserts the issuer certificate of the newest certificate chain into the trustdb.
+func (c *Conf) loadIssCert() error {
+	chain := c.Store.GetNewestChain(c.PublicAddr.IA)
+	if chain == nil {
+		return common.NewBasicError(ErrorIssCert, nil, "err", "No certificate chain present")
+	}
+	if _, err := c.TrustDB.InsertIssCert(chain.Issuer); err != nil {
+		return common.NewBasicError(ErrorIssCert, err)
+	}
+	return nil
+}
+
 // GetSigningKey returns the signing key of the current key configuration.
 func (c *Conf) GetSigningKey() common.RawBytes {
 	c.keyConfLock.RLock()
 	defer c.keyConfLock.RUnlock()
 	return c.keyConf.SignKey
+}
+
+// GetIssSigningKey returns the issuer signing key of the current key configuration.
+func (c *Conf) GetIssSigningKey() common.RawBytes {
+	c.keyConfLock.RLock()
+	defer c.keyConfLock.RUnlock()
+	return c.keyConf.IssSigKey
 }
 
 // GetDecryptKey returns the decryption key of the current key configuration.

--- a/go/cert_srv/io.go
+++ b/go/cert_srv/io.go
@@ -80,7 +80,7 @@ func (d *Dispatcher) Run() {
 	}
 }
 
-// dispatch hands payload over tho the associated handlers.
+// dispatch hands payload over to the associated handlers.
 func (d *Dispatcher) dispatch(addr *snet.Addr, buf common.RawBytes, config *conf.Conf) error {
 	signed, err := ctrl.NewSignedPldFromRaw(buf)
 	if err != nil {

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -43,6 +43,7 @@ var (
 	stateDir = flag.String("stated", "", "State directory (Defaults to confd)")
 	prom     = flag.String("prom", "127.0.0.1:1282", "Address to export prometheus metrics on")
 	disp     *Dispatcher
+	reissReq *ReissRequester
 	sighup   chan os.Signal
 )
 

--- a/go/cert_srv/reiss_handler.go
+++ b/go/cert_srv/reiss_handler.go
@@ -101,7 +101,7 @@ func (h *ReissHandler) HandleReq(addr *snet.Addr, req *cert_mgmt.ChainIssReq,
 	}
 }
 
-// verifySign validates that the signer matches the requester and returns the
+// validateSign validates that the signer matches the requester and returns the
 // certificate chain used when verifying the signature.
 func (h *ReissHandler) validateSign(addr *snet.Addr, signed *ctrl.SignedPld,
 	config *conf.Conf) (*cert.Chain, error) {

--- a/go/cert_srv/reiss_handler.go
+++ b/go/cert_srv/reiss_handler.go
@@ -1,0 +1,251 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"time"
+
+	log "github.com/inconshreveable/log15"
+	"golang.org/x/crypto/ed25519"
+
+	"github.com/scionproto/scion/go/cert_srv/conf"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/crypto"
+	"github.com/scionproto/scion/go/lib/crypto/cert"
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/lib/snet"
+)
+
+// ReissHandler handles certificate chain reissue requests and replies.
+//
+// Reissue requests sent by non-issuer ASes to issuer ASes. The request
+// needs to be signed with the private key associated with the newest
+// verifying key in the customer mapping. Certificate chains are issued
+// automatically by the issuer ASes.
+type ReissHandler struct {
+	conn *snet.Conn
+}
+
+func NewReissHandler(conn *snet.Conn) *ReissHandler {
+	return &ReissHandler{conn: conn}
+}
+
+// HandleReq handles certificate chain reissue requests. If the requested
+// certificate chain is already present, the existing certificate chain is
+// resent. Otherwise, a new certificate chain is issued.
+func (h *ReissHandler) HandleReq(addr *snet.Addr, req *cert_mgmt.ChainIssReq,
+	signed *ctrl.SignedPld, config *conf.Conf) {
+
+	log.Info("Received certificate reissue request", "addr", addr, "req", req)
+	if !config.Topo.Core {
+		log.Warn("Received certificate reissue request as non-issuer AS",
+			"addr", addr, "req", req)
+		return
+	}
+	// Verify the request was correctly signed by the requester
+	verChain, err := h.verifySign(addr, signed, config)
+	if err != nil {
+		h.logDropReq(addr, req, err)
+		return
+	}
+	// Parse the requested certificate
+	crt, err := req.Cert()
+	if err != nil {
+		h.logDropReq(addr, req, err)
+		return
+	}
+	// Respond with max chain for outdated requests.
+	maxChain := config.Store.GetNewestChain(verChain.Leaf.Subject)
+	if maxChain != nil && crt.Version <= maxChain.Leaf.Version {
+		log.Info("Resending certificate chain", "addr", addr, "req", req)
+		if err = h.sendRep(addr, maxChain); err != nil {
+			log.Error("Unable to resend certificate chain", "addr", addr,
+				"req", req, "err", err)
+		}
+		return
+	}
+	// Get the verifying key from the customer mapping
+	verKey, err := config.Customers.GetVerifyingKey(addr.IA)
+	if err != nil {
+		h.logDropReq(addr, req, err)
+		return
+	}
+	// Verify request and check the verifying key matches
+	if err = h.validateReq(crt, verKey, verChain, config); err != nil {
+		h.logDropReq(addr, req, err)
+		return
+	}
+	// Issue certificate chain
+	newChain, err := h.issueChain(crt, verKey, config)
+	if err != nil {
+		log.Error("Unable to reissue certificate chain", "err", err)
+		return
+	}
+	// Send issued certificate chain
+	if err = h.sendRep(addr, newChain); err != nil {
+		log.Error("Unable to send reissued certificate chain", "addr", addr,
+			"req", req, "err", err)
+	}
+}
+
+// verifySign verifies that the signer matches the requester and returns the
+// certificate chain used to verify the signature.
+func (h *ReissHandler) verifySign(addr *snet.Addr, signed *ctrl.SignedPld,
+	config *conf.Conf) (*cert.Chain, error) {
+
+	if signed.Sign == nil {
+		return nil, common.NewBasicError("Sign is nil", nil)
+	}
+	src, err := ctrl.NewSignSrcDefFromRaw(signed.Sign.Src)
+	if err != nil {
+		return nil, err
+	}
+	verChain, err := config.GetVerifier().(*SigVerifier).getChainForSign(src)
+	if err != nil {
+		return nil, err
+	}
+	if signed.Sign.Type.String() != verChain.Leaf.SignAlgorithm {
+		return nil, common.NewBasicError("Invalid sign type", nil, "type", signed.Sign.Type)
+	}
+	// Verify that the requester matches the signer
+	if !verChain.Leaf.Subject.Eq(addr.IA) {
+		return nil, common.NewBasicError("Origin AS does not match signer", nil,
+			"signer", verChain.Leaf.Subject, "origin", addr.IA)
+	}
+	return verChain, nil
+}
+
+// validateReq validates the requested certificate. Additionally, it validates that
+// the request was verified with the same verifying key as in the customer mapping.
+func (h *ReissHandler) validateReq(c *cert.Certificate, key common.RawBytes,
+	chain *cert.Chain, config *conf.Conf) error {
+
+	if !c.Subject.Eq(chain.Leaf.Subject) {
+		return common.NewBasicError("Requester does not match subject", nil, "ia",
+			chain.Leaf.Subject, "sub", c.Subject)
+	}
+	if !c.Issuer.Eq(config.PublicAddr.IA) {
+		return common.NewBasicError("Requested Issuer is not this AS", nil, "iss",
+			c.Issuer, "expected", config.PublicAddr.IA)
+	}
+	if c.CanIssue {
+		return common.NewBasicError("CanIssue not allowed to be true", nil)
+	}
+	if !bytes.Equal(key, chain.Leaf.SubjectSignKey) {
+		return common.NewBasicError("Request signed with wrong signing key", nil)
+	}
+	return nil
+}
+
+// issueChain creates a certificate chain for the certificate and adds it to the
+// trust store.
+func (h *ReissHandler) issueChain(c *cert.Certificate, vKey common.RawBytes,
+	config *conf.Conf) (*cert.Chain, error) {
+
+	issCert, err := getIssuerCert(config)
+	if err != nil {
+		return nil, err
+	}
+	chain := &cert.Chain{Leaf: c.Copy(), Issuer: issCert}
+	chain.Leaf.CanIssue = false
+	chain.Leaf.TRCVersion = chain.Issuer.TRCVersion
+	chain.Leaf.IssuingTime = uint64(time.Now().Unix())
+	chain.Leaf.ExpirationTime = chain.Leaf.IssuingTime + cert.DefaultLeafCertValidity
+	// Leaf certificate must expire before issuer certificate
+	if chain.Issuer.ExpirationTime < chain.Leaf.ExpirationTime {
+		chain.Leaf.ExpirationTime = chain.Issuer.ExpirationTime
+	}
+	if err = chain.Leaf.Sign(config.GetIssSigningKey(), crypto.Ed25519); err != nil {
+		return nil, err
+	}
+	// Set verifying key.
+	err = config.Customers.SetVerifyingKey(c.Subject, c.Version, c.SubjectSignKey, vKey)
+	if err != nil {
+		return nil, err
+	}
+	if err = config.Store.AddChain(chain, true); err != nil {
+		log.Error("Unable to write reissued certificate chain to disk", "err", err)
+	}
+	return chain, nil
+}
+
+// sendRep creates a certificate chain reply and sends it to the requester.
+func (h *ReissHandler) sendRep(addr *snet.Addr, chain *cert.Chain) error {
+	raw, err := chain.Compress()
+	if err != nil {
+		return err
+	}
+	cpld, err := ctrl.NewCertMgmtPld(&cert_mgmt.ChainIssRep{RawChain: raw}, nil, nil)
+	if err != nil {
+		return err
+	}
+	log.Info("Send reissued certificate chain", "chain", chain, "addr", addr)
+	return SendPayload(h.conn, cpld, addr)
+}
+
+// HandleRep handles certificate chain reissue replies.
+func (h *ReissHandler) HandleRep(addr *snet.Addr, rep *cert_mgmt.ChainIssRep, config *conf.Conf) {
+	log.Info("Received certificate reissue reply", "addr", addr, "rep", rep)
+	if config.Topo.Core {
+		log.Warn("Received certificate reissue reply as issuer AS", "addr", addr, "req", rep)
+		return
+	}
+	chain, err := rep.Chain()
+	if err != nil {
+		h.logDropRep(addr, rep, err)
+		return
+	}
+	if err = h.validateRep(chain, config); err != nil {
+		h.logDropRep(addr, rep, err)
+		return
+	}
+	if err = config.Store.AddChain(chain, true); err != nil {
+		log.Error("Unable to write reissued certificate chain to disk", "chain", chain, "err", err)
+		return
+	}
+	sign, err := CreateSign(config.PublicAddr.IA, config.Store)
+	if err != nil {
+		log.Error("Unable to set new signer", "err", err)
+		return
+	}
+	config.SetSigner(ctrl.NewBasicSigner(sign, config.GetSigningKey()))
+}
+
+// validateRep validates that the received certificate chain can be added to the trust store.
+func (h *ReissHandler) validateRep(chain *cert.Chain, config *conf.Conf) error {
+	verKey := common.RawBytes(ed25519.PrivateKey(
+		config.GetSigningKey()).Public().(ed25519.PublicKey))
+	if !bytes.Equal(chain.Leaf.SubjectSignKey, verKey) {
+		return common.NewBasicError("Invalid SubjectSignKey", nil, "expected",
+			verKey, "actual", chain.Leaf.SubjectSignKey)
+	}
+	// FIXME(roosd): validate SubjectEncKey
+	issuer := config.Store.GetNewestChain(config.PublicAddr.IA).Leaf.Issuer
+	if !chain.Leaf.Issuer.Eq(issuer) {
+		return common.NewBasicError("Invalid Issuer", nil, "expected",
+			issuer, "actual", chain.Leaf.Issuer)
+	}
+	return nil
+}
+
+func (h *ReissHandler) logDropReq(addr *snet.Addr, req *cert_mgmt.ChainIssReq, err error) {
+	log.Error("Dropping certificate reissue request", "addr", addr, "req", req, "err", err)
+}
+
+func (h *ReissHandler) logDropRep(addr *snet.Addr, rep *cert_mgmt.ChainIssRep, err error) {
+	log.Error("Dropping certificate reissue reply", "addr", addr, "rep", rep, "err", err)
+}

--- a/go/cert_srv/reiss_tasks.go
+++ b/go/cert_srv/reiss_tasks.go
@@ -1,0 +1,225 @@
+// Copyright 2017 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"time"
+
+	log "github.com/inconshreveable/log15"
+
+	"github.com/scionproto/scion/go/cert_srv/conf"
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/crypto"
+	"github.com/scionproto/scion/go/lib/crypto/cert"
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/util"
+)
+
+// SelfIssuer periodically issues self-signed certificate chains
+// on an issuer AS before the old one expires.
+type SelfIssuer struct{}
+
+// Run periodically issues certificate chains for the local AS.
+func (l *SelfIssuer) Run() {
+	if !conf.Get().Topo.Core {
+		log.Info("Stopping SelfIssuer on non-issuer CS")
+		return
+	}
+	for {
+		var err error
+		now := time.Now()
+		config := conf.Get()
+		issCrt, err := getIssuerCert(config)
+		if err != nil {
+			log.Crit("Unable to get issuer certificate", "err", err)
+			break
+		}
+		leafCrt := config.Store.GetNewestChain(config.PublicAddr.IA).Leaf
+		iSleep := time.Unix(int64(issCrt.ExpirationTime), 0).Sub(now) - config.IssuerReissTime
+		lSleep := time.Unix(int64(leafCrt.ExpirationTime), 0).Sub(now) - config.LeafReissTime
+		if lSleep > 0 && iSleep > 0 {
+			if iSleep < lSleep {
+				time.Sleep(iSleep)
+			} else {
+				time.Sleep(lSleep)
+			}
+			continue
+		}
+		if iSleep > 0 {
+			if err = l.createLeafCert(leafCrt, config); err != nil {
+				log.Error("Unable to issue certificate chain", "err", err)
+				time.Sleep(config.ReissRate)
+				continue
+			}
+		} else {
+			if err = l.createIssuerCert(config); err != nil {
+				log.Error("Unable to create issuer certificate", "err", err)
+				time.Sleep(config.ReissRate)
+				continue
+			}
+		}
+	}
+}
+
+// createLeafCert creates a leaf certificate.
+func (l *SelfIssuer) createLeafCert(leaf *cert.Certificate, config *conf.Conf) error {
+	issCrt, err := getIssuerCert(config)
+	if err != nil {
+		return nil
+	}
+	chain := &cert.Chain{Leaf: leaf.Copy(), Issuer: issCrt}
+	chain.Leaf.Version += 1
+	chain.Leaf.IssuingTime = uint64(time.Now().Unix())
+	chain.Leaf.CanIssue = false
+	chain.Leaf.ExpirationTime = chain.Leaf.IssuingTime + cert.DefaultLeafCertValidity
+	if chain.Issuer.ExpirationTime < chain.Leaf.ExpirationTime {
+		chain.Leaf.ExpirationTime = chain.Issuer.ExpirationTime
+	}
+	if err := chain.Leaf.Sign(config.GetIssSigningKey(), crypto.Ed25519); err != nil {
+		return common.NewBasicError("Unable to sign leaf certificate", err, "chain", chain)
+	}
+	if err := config.Store.AddChain(chain, true); err != nil {
+		return common.NewBasicError("Unable to write certificate chain", err, "chain", chain)
+	}
+	log.Info("Created certificate chain", "chain", chain)
+	sign, err := CreateSign(config.PublicAddr.IA, config.Store)
+	if err != nil {
+		log.Error("Unable to set create new sign", "err", err)
+	}
+	config.SetSigner(ctrl.NewBasicSigner(sign, config.GetSigningKey()))
+	return nil
+}
+
+// createIssuerCert creates an issuer certificate.
+func (l *SelfIssuer) createIssuerCert(config *conf.Conf) error {
+	crt, err := getIssuerCert(config)
+	if err != nil {
+		return err
+	}
+	crt.Version += 1
+	crt.IssuingTime = uint64(time.Now().Unix())
+	crt.CanIssue = true
+	crt.ExpirationTime = crt.IssuingTime + cert.DefaultIssuerCertValidity
+	if err = crt.Sign(config.GetOnRootKey(), crypto.Ed25519); err != nil {
+		return common.NewBasicError("Unable to sign issuer certificate", err, "cert", crt)
+	}
+	if err = setIssuerCert(crt, config); err != nil {
+		return common.NewBasicError("Unable to store issuer certificate", err, "cert", crt)
+	}
+	log.Info("Created issuer certificate", "cert", crt)
+	return nil
+}
+
+func getIssuerCert(config *conf.Conf) (*cert.Certificate, error) {
+	issCrt, err := config.TrustDB.GetIssCertMaxVersion(config.PublicAddr.IA)
+	if err != nil {
+		return nil, err
+	}
+	if issCrt == nil {
+		return nil, common.NewBasicError("Issuer certificate not found", nil,
+			"ia", config.PublicAddr.IA)
+	}
+	return issCrt, nil
+}
+
+func setIssuerCert(crt *cert.Certificate, config *conf.Conf) error {
+	affected, err := config.TrustDB.InsertIssCert(crt)
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return common.NewBasicError("Issuer certificate already exists", nil, "cert", crt)
+	}
+	return nil
+}
+
+// ReissRequester periodically requests reissued certificate chains before
+// expiration of the currently active certificate chain.
+type ReissRequester struct {
+	conn *snet.Conn
+	stop chan struct{}
+}
+
+func NewReissRequester(conn *snet.Conn) *ReissRequester {
+	return &ReissRequester{
+		conn: conn,
+		stop: make(chan struct{}),
+	}
+}
+
+// Run periodically requests reissued certificate chains from the issuer AS.
+func (l *ReissRequester) Run() {
+	if conf.Get().Topo.Core {
+		log.Info("Stopping ReissRequester on issuer CS")
+		return
+	}
+	for {
+		select {
+		case <-l.stop:
+			return
+		default:
+			config := conf.Get()
+			chain := config.Store.GetNewestChain(config.PublicAddr.IA)
+			now := time.Now()
+			exp := util.USecsToTime(chain.Leaf.ExpirationTime)
+			diff := exp.Sub(now)
+			if diff < 0 {
+				log.Error("Certificate expired without being reissued", "ExpirationTime",
+					util.TimeToString(exp), "now", util.TimeToString(now))
+				return
+			}
+			if sleep := diff - config.LeafReissTime; sleep > 0 {
+				time.Sleep(sleep)
+				continue
+			}
+			if err := l.sendReq(chain, config); err != nil {
+				log.Error("Unable to send certificate reissue request", "err", err)
+			}
+			time.Sleep(config.ReissRate)
+		}
+	}
+}
+
+// sendReq creates and sends a certificate chain reissue request based on the newest
+// currently active certificate chain.
+func (l *ReissRequester) sendReq(chain *cert.Chain, config *conf.Conf) error {
+	c := chain.Leaf.Copy()
+	c.IssuingTime = uint64(time.Now().Unix())
+	c.ExpirationTime = c.IssuingTime + (chain.Leaf.ExpirationTime - chain.Leaf.IssuingTime)
+	c.Version += 1
+	if err := c.Sign(config.GetSigningKey(), chain.Leaf.SignAlgorithm); err != nil {
+		return err
+	}
+	raw, err := c.JSON(false)
+	if err != nil {
+		return err
+	}
+	req := &cert_mgmt.ChainIssReq{RawCert: raw}
+	cpld, err := ctrl.NewCertMgmtPld(&cert_mgmt.ChainIssReq{RawCert: raw}, nil, nil)
+	if err != nil {
+		return err
+	}
+	a := &snet.Addr{IA: c.Issuer, Host: addr.SvcCS}
+	log.Debug("Send certificate reissue request", "req", req, "addr", a)
+	return SendSignedPayload(l.conn, cpld, a, config)
+}
+
+// Close terminates the ReissRequester.
+func (l *ReissRequester) Close() {
+	close(l.stop)
+}

--- a/go/cert_srv/signed_util.go
+++ b/go/cert_srv/signed_util.go
@@ -116,14 +116,14 @@ func (v *SigVerifier) getVerifyKeyForSign(s *proto.SignS) (common.RawBytes, erro
 	if err != nil {
 		return nil, err
 	}
-	chain, err := v.getChainForSign(sigSrc)
+	chain, err := getChainForSign(sigSrc)
 	if err != nil {
 		return nil, err
 	}
 	return chain.Leaf.SubjectSignKey, nil
 }
 
-func (v *SigVerifier) getChainForSign(s *ctrl.SignSrcDef) (*cert.Chain, error) {
+func getChainForSign(s *ctrl.SignSrcDef) (*cert.Chain, error) {
 	c := conf.Get().Store.GetChain(s.IA, s.ChainVer)
 	if c == nil {
 		return nil, common.NewBasicError("Unable to get certificate chain", nil,

--- a/go/lib/as_conf/conf.go
+++ b/go/lib/as_conf/conf.go
@@ -27,6 +27,7 @@ import (
 type ASConf struct {
 	CertChainVersion int           `yaml:"CertChainVersion"`
 	MasterASKey      util.B64Bytes `yaml:"MasterASKey"`
+	PathSegmentTTL   int           `yaml:"PathSegmentTTL"`
 	PropagateTime    int           `yaml:"PropagateTime"`
 	RegisterPath     bool          `yaml:"RegisterPath"`
 	RegisterTime     int           `yaml:"RegisterTime"`

--- a/go/lib/as_conf/conf_test.go
+++ b/go/lib/as_conf/conf_test.go
@@ -29,7 +29,7 @@ func Test_ASConf(t *testing.T) {
 		}
 		c := CurrConf
 		So(c, ShouldResemble, &ASConf{
-			1, util.B64Bytes("VV?=tJ\xae\x85s\r8\x9d\xfc\xe5\x94\xa5"), 5, true, 60,
+			1, util.B64Bytes("VV?=tJ\xae\x85s\r8\x9d\xfc\xe5\x94\xa5"), 21600, 5, true, 60,
 		})
 	})
 }

--- a/go/lib/as_conf/testdata/basic.yml
+++ b/go/lib/as_conf/testdata/basic.yml
@@ -1,5 +1,6 @@
 CertChainVersion: 1
 MasterASKey: VlY/PXRKroVzDTid/OWUpQ==
+PathSegmentTTL: 21600
 PropagateTime: 5
 RegisterPath: true
 RegisterTime: 60

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -46,6 +46,7 @@ from lib.errors import (
     SCIONServiceLookupError,
 )
 from lib.msg_meta import UDPMetadata
+from lib.packet.cert_mgmt import CertChainRequest, CertMgmt
 from lib.packet.ext.one_hop_path import OneHopPathExt
 from lib.path_seg_meta import PathSegMeta
 from lib.packet.ctrl_pld import CtrlPayload
@@ -120,6 +121,8 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
     IF_TIMEOUT_INTERVAL = 1
     # Interval to send keep-alive msgs
     IFID_INTERVAL = 1
+    # Interval between two consecutive requests (in seconds).
+    CERT_REQ_RATE = 10
 
     def __init__(self, server_id, conf_dir, spki_cache_dir=GEN_CACHE_PATH, prom_export=None):
         """
@@ -448,6 +451,9 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         threading.Thread(
             target=thread_safety_net, args=(self._check_trc_cert_reqs,),
             name="Elem.check_trc_cert_reqs", daemon=True).start()
+        threading.Thread(
+            target=thread_safety_net, args=(self._check_local_cert,),
+            name="BS._check_local_cert", daemon=True).start()
         super().run()
 
     def worker(self):
@@ -758,6 +764,22 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
                 meta = self._build_meta(host=br_addr, port=br_port)
                 self.send_meta(CtrlPayload(IFIDPayload.from_values(ifid)),
                                meta, (meta.host, meta.port))
+
+    def _check_local_cert(self):
+        while self.run_flag.is_set():
+            chain = self._get_my_cert()
+            exp = min(chain.as_cert.expiration_time, chain.core_as_cert.expiration_time)
+            diff = exp - int(time.time())
+            if diff > self.config.segment_ttl:
+                time.sleep(max(0, diff - self.config.segment_ttl))
+                continue
+            cs_meta = self._get_cs()
+            req = CertChainRequest.from_values(
+                self.addr.isd_as, chain.as_cert.version+1, cache_only=True)
+            logging.info("Request new certificate chain. Req: %s", req)
+            self.send_meta(CtrlPayload(CertMgmt(req)), cs_meta)
+            cs_meta.close()
+            time.sleep(self.CERT_REQ_RATE)
 
     def _init_metrics(self):
         super()._init_metrics()

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -771,7 +771,7 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
             exp = min(chain.as_cert.expiration_time, chain.core_as_cert.expiration_time)
             diff = exp - int(time.time())
             if diff > self.config.segment_ttl:
-                time.sleep(max(0, diff - self.config.segment_ttl))
+                time.sleep(diff - self.config.segment_ttl)
                 continue
             cs_meta = self._get_cs()
             req = CertChainRequest.from_values(


### PR DESCRIPTION
This PR adds certificate reissuance to the infrastructure. (#1183)

Core ASes periodically renew leaf AS and issuer AS certificates.
Non-Core ASes periodically request new certificate chains from their
responsible core AS.
Both these tasks are done on the Certificate Server

Request must be verifiable with the newest verifying key in the
customer mapping of the core AS.

The non-core Certificate Servers start to automatically request
reissued certificate chains one path segment validity time before
expiration to provide optimal coverage.

The reissued certificate chains are disseminated by the Beacon server.
They start polling the certificate server for new certificate chains
when the available certificate no longer covers the desired segment
validity period.

Missing:
Useful integration test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1558)
<!-- Reviewable:end -->
