### PR TITLE
Remove unnecessary base.HEX from scion.packet in wireshark plugin.

### DIFF
--- a/tools/wireshark/scion.lua
+++ b/tools/wireshark/scion.lua
@@ -109,7 +109,7 @@ local maxSegTTL = 12 * 60 * 60
 local segExpUnit = maxSegTTL / 2^8
 local us_in_s = UInt64.new(1e6)
 
-local scion_packet = ProtoField.bytes("scion.packet", "Raw SCION packet", base.HEX)
+local scion_packet = ProtoField.bytes("scion.packet", "Raw SCION packet")
 
 local scion_ch_version = ProtoField.uint8("scion.ch.version", "Version", base.HEX)
 local scion_ch_dsttype = ProtoField.uint8("scion.ch.dst_type", "Destination address type", base.HEX, addrTypes)


### PR DESCRIPTION
As mentioned in [1], a bytes field is always represented in HEX. Later
versions of wireshark treat base.HEX as invalid, so removing it makes it
work correctly everywhere.

[1] https://osqa-ask.wireshark.org/questions/63411/multiple-lua-error-during-loading-issues-reported-after-install-of-win64-version-240/63414

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1559)
<!-- Reviewable:end -->
