### PR TITLE
Improve representation of fwd path hops.

### DIFF
--- a/go/lib/sciond/mock.go
+++ b/go/lib/sciond/mock.go
@@ -95,7 +95,7 @@ func (m *MockConn) Paths(dst, src addr.IA, max uint16, f PathReqFlags) (*PathRep
 		}
 		entries = append(entries,
 			PathReplyEntry{
-				Path: FwdPathMeta{
+				Path: &FwdPathMeta{
 					Interfaces: pathInterfaces,
 					ExpTime:    uint32(time.Now().Add(spath.MaxTTL * time.Second).Unix()),
 				},

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -131,7 +131,7 @@ type PathReply struct {
 }
 
 type PathReplyEntry struct {
-	Path     FwdPathMeta
+	Path     *FwdPathMeta
 	HostInfo HostInfo
 }
 
@@ -170,7 +170,7 @@ type FwdPathMeta struct {
 	ExpTime    uint32
 }
 
-func (fpm FwdPathMeta) SrcIA() addr.IA {
+func (fpm *FwdPathMeta) SrcIA() addr.IA {
 	ifaces := fpm.Interfaces
 	if len(ifaces) == 0 {
 		return addr.IA{}
@@ -178,7 +178,7 @@ func (fpm FwdPathMeta) SrcIA() addr.IA {
 	return ifaces[0].ISD_AS()
 }
 
-func (fpm FwdPathMeta) DstIA() addr.IA {
+func (fpm *FwdPathMeta) DstIA() addr.IA {
 	ifaces := fpm.Interfaces
 	if len(ifaces) == 0 {
 		return addr.IA{}
@@ -186,16 +186,16 @@ func (fpm FwdPathMeta) DstIA() addr.IA {
 	return ifaces[len(ifaces)-1].ISD_AS()
 }
 
-func (fpm FwdPathMeta) Expiry() time.Time {
+func (fpm *FwdPathMeta) Expiry() time.Time {
 	return util.USecsToTime(uint64(fpm.ExpTime))
 }
 
-func (fpm FwdPathMeta) String() string {
+func (fpm *FwdPathMeta) String() string {
 	hops := fpm.fmtIfaces()
 	return fmt.Sprintf("Hops: [%s] Mtu: %d", strings.Join(hops, ">"), fpm.Mtu)
 }
 
-func (fpm FwdPathMeta) fmtIfaces() []string {
+func (fpm *FwdPathMeta) fmtIfaces() []string {
 	var hops []string
 	if len(fpm.Interfaces) == 0 {
 		return hops

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -191,11 +191,25 @@ func (fpm FwdPathMeta) Expiry() time.Time {
 }
 
 func (fpm FwdPathMeta) String() string {
+	hops := fpm.fmtIfaces()
+	return fmt.Sprintf("Hops: [%s] Mtu: %d", strings.Join(hops, ">"), fpm.Mtu)
+}
+
+func (fpm FwdPathMeta) fmtIfaces() []string {
 	var hops []string
-	for _, intf := range fpm.Interfaces {
-		hops = append(hops, intf.String())
+	if len(fpm.Interfaces) == 0 {
+		return hops
 	}
-	return fmt.Sprintf("Hops: %s Mtu: %d", strings.Join(hops, ">"), fpm.Mtu)
+	intf := fpm.Interfaces[0]
+	hops = append(hops, fmt.Sprintf("%s %d", intf.ISD_AS(), intf.IfID))
+	for i := 1; i < len(fpm.Interfaces)-1; i += 2 {
+		inIntf := fpm.Interfaces[i]
+		outIntf := fpm.Interfaces[i+1]
+		hops = append(hops, fmt.Sprintf("%d %s %d", inIntf.IfID, inIntf.ISD_AS(), outIntf.IfID))
+	}
+	intf = fpm.Interfaces[len(fpm.Interfaces)-1]
+	hops = append(hops, fmt.Sprintf("%d %s", intf.IfID, intf.ISD_AS()))
+	return hops
 }
 
 type PathInterface struct {
@@ -208,7 +222,7 @@ func (iface *PathInterface) ISD_AS() addr.IA {
 }
 
 func (iface PathInterface) String() string {
-	return fmt.Sprintf("%v#%v", iface.ISD_AS(), iface.IfID)
+	return fmt.Sprintf("%s#%d", iface.ISD_AS(), iface.IfID)
 }
 
 type ASInfoReq struct {

--- a/python/lib/sciond_api/path_meta.py
+++ b/python/lib/sciond_api/path_meta.py
@@ -58,9 +58,22 @@ class FwdPathMeta(Cerealizable):  # pragma: no cover
         for if_ in self.p.interfaces:
             yield PathInterface(if_)
 
+    def ifs_desc(self):
+        s = []
+        if len(self.p.interfaces) == 0:
+            return []
+        intf = PathInterface(self.p.interfaces[0])
+        s.append("%s %s" % (intf.isd_as(), intf.p.ifID))
+        for i in range(1, len(self.p.interfaces) - 1, 2):
+            inIntf = PathInterface(self.p.interfaces[i])
+            outIntf = PathInterface(self.p.interfaces[i+1])
+            s.append("%s %s %s" % (inIntf.p.ifID, inIntf.isd_as(), outIntf.p.ifID))
+        intf = PathInterface(self.p.interfaces[-1])
+        s.append("%s %s" % (intf.p.ifID, intf.isd_as()))
+        return s
+
     def short_desc(self):
-        if_str = ", ".join([if_.short_desc() for if_ in self.iter_ifs()])
-        return "Interfaces: %s MTU: %d" % (if_str, self.p.mtu)
+        return "Interfaces: [%s] MTU: %d" % (">".join(self.ifs_desc()), self.p.mtu)
 
     def __eq__(self, other):
         return list(self.iter_ifs()) == list(other.iter_ifs())
@@ -87,7 +100,7 @@ class PathInterface(Cerealizable):  # pragma: no cover
             "Invalid index used on PathInterface object: %d" % idx)
 
     def short_desc(self):
-        return "%s:%s" % (self.isd_as(), self.p.ifID)
+        return "%s#%s" % (self.isd_as(), self.p.ifID)
 
     def __str__(self):
         return self.short_desc()


### PR DESCRIPTION
This change removes the repeated ASes in the output, and instead prints
an AS with the ingress IfID to the left and the egess IfID to the right.
This makes it easier to follow, and more compact.

Go example (from showpaths):
Before:
```
Hops: 1-ff00:0:131#70>1-ff00:0:130#52>1-ff00:0:130#16>1-ff00:0:110#83>1-ff00:0:110#27>1-ff00:0:111#84 Mtu: 1472
```
After:
```
Hops: [1-ff00:0:131 70>52 1-ff00:0:130 16>83 1-ff00:0:110 27>84 1-ff00:0:111] Mtu: 1472
```

Python example (from end2end):
Before:
```
FwdPathMeta: Interfaces: 1-ff00:0:131:70, 1-ff00:0:130:52, 1-ff00:0:130:16, 1-ff00:0:110:83, 1-ff00:0:110:27, 1-ff00:0:111:84 MTU: 1472
```
After:
```
FwdPathMeta: Interfaces: [1-ff00:0:131 70>52 1-ff00:0:130 16>83 1-ff00:0:110 27>84 1-ff00:0:111] MTU: 1472
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1565)
<!-- Reviewable:end -->
