### PR TITLE
standardize sciond socket selection process

### DIFF
--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -27,7 +27,6 @@ import (
 	"github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/qerr"
 
-	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/log"
 	sd "github.com/scionproto/scion/go/lib/sciond"
@@ -44,10 +43,6 @@ const (
 	ReplyMsg        = "pong!"
 	TSLen           = 8
 )
-
-func GetDefaultSCIONDPath(ia addr.IA) string {
-	return fmt.Sprintf("/run/shm/sciond/sd%s.sock", ia.FileFmt(false))
-}
 
 var (
 	local       snet.Addr
@@ -106,7 +101,7 @@ func validateFlags() {
 		LogFatal("Missing local address")
 	}
 	if *sciond == "" {
-		*sciond = GetDefaultSCIONDPath(local.IA)
+		*sciond = sd.GetDefaultSCIONDPath(&local.IA)
 	}
 	if *count < 0 || *count > MaxPings {
 		LogFatal("Invalid count", "min", 0, "max", MaxPings, "actual", *count)

--- a/go/lib/pathmgr/infra_test.go
+++ b/go/lib/pathmgr/infra_test.go
@@ -44,7 +44,7 @@ func ExamplePR() {
 		fmt.Println("Unable to parse dstIA", *dstStr, "err", err)
 	}
 	// Initialize path resolver
-	sciondPath := fmt.Sprintf("/run/shm/sciond/sd%s.sock", src.FileFmt(false))
+	sciondPath := sciond.GetDefaultSCIONDPath(&src)
 	sciondService := sciond.NewService(sciondPath)
 	pr, err := New(sciondService, time.Second, time.Minute, log.Root())
 	if err != nil {

--- a/go/lib/sciond/infra_test.go
+++ b/go/lib/sciond/infra_test.go
@@ -17,7 +17,6 @@
 package sciond
 
 import (
-	"fmt"
 	"math/rand"
 	"os"
 	"testing"
@@ -43,7 +42,7 @@ func TestRevNotification(t *testing.T) {
 		SoMsg("AS selection len", len(asList), ShouldBeGreaterThan, 0)
 		localIA := asList[rand.Intn(len(asList))]
 
-		service := NewService(fmt.Sprintf("/run/shm/sciond/sd%s.sock", localIA.FileFmt(false)))
+		service := NewService(GetDefaultSCIONDPath(&localIA))
 		conn, err := service.Connect()
 		SoMsg("Connect error", err, ShouldBeNil)
 

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -28,6 +28,7 @@ package sciond
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"strconv"
 	"sync"
@@ -338,4 +339,12 @@ func (c *connector) RevNotification(sRevInfo *path_mgmt.SignedRevInfo) (*RevRepl
 
 func (c *connector) Close() error {
 	return c.dispatcher.Close(context.Background())
+}
+
+// GetDefaultSCIONDPath return default sciond path for a given IA
+func GetDefaultSCIONDPath(ia *addr.IA) string {
+	if ia == nil || ia.IsZero() {
+		return "/run/shm/sciond/default.sock"
+	}
+	return fmt.Sprintf("/run/shm/sciond/sd%s.sock", ia.FileFmt(false))
 }

--- a/go/lib/snet/integration_test.go
+++ b/go/lib/snet/integration_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/util"
 )
 
@@ -40,8 +41,7 @@ var (
 )
 
 const (
-	SCIONDPath = "/run/shm/sciond/sd%s.sock"
-	DispPath   = "/run/shm/dispatcher/default.sock"
+	DispPath = "/run/shm/dispatcher/default.sock"
 )
 
 type TestCase struct {
@@ -90,11 +90,9 @@ func ClientServer(idx int, tc TestCase) {
 		tc.dstPort), func(c C) {
 		b := make([]byte, 128)
 
-		clientNet, err := NewNetwork(tc.srcIA, fmt.Sprintf(SCIONDPath, tc.srcIA.FileFmt(false)),
-			DispPath)
+		clientNet, err := NewNetwork(tc.srcIA, sciond.GetDefaultSCIONDPath(&tc.srcIA), DispPath)
 		SoMsg("Client network error", err, ShouldBeNil)
-		serverNet, err := NewNetwork(tc.dstIA, fmt.Sprintf(SCIONDPath, tc.dstIA.FileFmt(false)),
-			DispPath)
+		serverNet, err := NewNetwork(tc.dstIA, sciond.GetDefaultSCIONDPath(&tc.dstIA), DispPath)
 		SoMsg("Server network error", err, ShouldBeNil)
 
 		clientAddr, err := AddrFromString(
@@ -186,8 +184,7 @@ func TestMain(m *testing.M) {
 	asList = append(asStruct.Core, asStruct.NonCore...)
 
 	localIA = asList[rand.Intn(len(asList))]
-	err = Init(localIA, fmt.Sprintf("/run/shm/sciond/sd%s.sock", localIA.FileFmt(false)),
-		"/run/shm/dispatcher/default.sock")
+	err = Init(localIA, sciond.GetDefaultSCIONDPath(&localIA), "/run/shm/dispatcher/default.sock")
 	if err != nil {
 		fmt.Println("Test setup error", err)
 		return

--- a/go/sig/sigcmn/common.go
+++ b/go/sig/sigcmn/common.go
@@ -22,6 +22,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/pathmgr"
+	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/sig/mgmt"
 )
@@ -67,7 +68,7 @@ func Init(ia addr.IA, ip net.IP) error {
 	}
 	MgmtAddr = mgmt.NewAddr(Host, uint16(*CtrlPort), uint16(*EncapPort))
 	if *sciondPath == "" {
-		*sciondPath = fmt.Sprintf("/run/shm/sciond/sd%s.sock", ia.FileFmt(false))
+		*sciondPath = sciond.GetDefaultSCIONDPath(&ia)
 	}
 	// Initialize SCION local networking module
 	err = snet.Init(ia, *sciondPath, *dispatcherPath)

--- a/go/tools/scmp/main.go
+++ b/go/tools/scmp/main.go
@@ -34,10 +34,6 @@ import (
 	"github.com/scionproto/scion/go/tools/scmp/traceroute"
 )
 
-func GetDefaultSCIONDPath(ia addr.IA) string {
-	return fmt.Sprintf("/run/shm/sciond/sd%s.sock", ia.FileFmt(false))
-}
-
 var (
 	sciondPath = flag.String("sciond", "", "Path to sciond socket")
 	dispatcher = flag.String("dispatcher", "/run/shm/dispatcher/default.sock",
@@ -50,7 +46,7 @@ func main() {
 	cmn.ValidateFlags()
 
 	if *sciondPath == "" {
-		*sciondPath = GetDefaultSCIONDPath(cmn.Local.IA)
+		*sciondPath = sciond.GetDefaultSCIONDPath(&cmn.Local.IA)
 	}
 	// Initialize default SCION networking context
 	if err := snet.Init(cmn.Local.IA, *sciondPath, *dispatcher); err != nil {

--- a/python/lib/app/sciond.py
+++ b/python/lib/app/sciond.py
@@ -425,3 +425,16 @@ def get_segtype_hops(seg_type, connector=None):  # pragma: no cover
     if not connector:
         raise SCIONDLibNotInitializedError
     return connector.get_segtype_hops(seg_type)
+
+
+def get_default_sciond_path(ia=None):
+    """Return sciond socket path for a given IA
+    :param ia: ISD_AS addr
+    :returns: Format string representing path of sciond socket
+    """
+    sock_path = ""
+    if ia is None or ia.is_zero():
+        sock_path = SCIOND_API_DEFAULT_SOCK
+    else:
+        sock_path = "sd%s.sock" % (ia.file_fmt())
+    return "%s/%s" % (SCIOND_API_SOCKDIR, sock_path)


### PR DESCRIPTION
In order to obtain sciond socket for a given IA a new API is exposed

`GetDefaultSCIONDSocket` which takes an IA and returns the corresponding
socket string.

Fixes #1543

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1571)
<!-- Reviewable:end -->
