### PR TITLE
path_server: handle pending request after PCB processing is complete

### DIFF
--- a/python/path_server/base.py
+++ b/python/path_server/base.py
@@ -401,6 +401,7 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
             seg_meta = PathSegMeta(pcb, self.continue_seg_processing, meta,
                                    type_, params)
             self._process_path_seg(seg_meta, req_id)
+        self._handle_pending_requests()
 
     def continue_seg_processing(self, seg_meta):
         """
@@ -415,7 +416,6 @@ class PathServer(SCIONElement, metaclass=ABCMeta):
         params = seg_meta.params
         self.handle_ext(pcb)
         self._dispatch_segment_record(type_, pcb, **params)
-        self._handle_pending_requests()
 
     def handle_ext(self, pcb):
         """


### PR DESCRIPTION
Currently there is a race condition between Path Server main thread and
worker thread. When a sciond queries a local PS for a path from a non
core AS to a core AS. Local PS forwards that request to core PS for the
core segments and starts populating PathSegmentDB. While the main thread
is busy processing that PCB, worker thread handles pending request and
replies with whatever present inside PathSegmentDB. Usually it is just
one path and rest of the possible paths are neglected.

For example:

```
./bin/showpaths -dstIA 2-ff00:0:210 -srcIA 1-ff00:0:133
INFO[05-27|09:38:27] Started                                  id=df259bab goroutine=dispatcher_bck
Available paths to 2-ff00:0:210
[ 0] Hops: [1-ff00:0:133 86>96 1-ff00:0:132 39>73 1-ff00:0:131 91>95 1-ff00:0:130 59>76 1-ff00:0:120 77>55 1-ff00:0:110 57>19 2-ff00:0:210] Mtu: 1280
```

There are 4 possible paths from 133 to 210 but it only returns one. An
easy way to verify that there are more path just flush the cache of
sciond and query again for the same path and you will find that there
are more paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1573)
<!-- Reviewable:end -->
