### PR TITLE
Fix file logging; support for unbuffered logging

### DIFF
--- a/go/lib/log/log.go
+++ b/go/lib/log/log.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/inconshreveable/log15"
@@ -74,15 +75,34 @@ func SetupLogFile(name string, logDir string, logLevel string, logSize int, logA
 	if err != nil {
 		return common.NewBasicError("Unable to parse log.level flag:", err)
 	}
-	logBuf = newSyncBuf(mkLogfile(name))
+
+	// Strip .log extension s.t. config files can contain the exact filename
+	// while not breaking existing behavior for apps that don't contain the
+	// extension.
+	name = strings.TrimSuffix(name, ".log")
+	var fileLogger io.WriteCloser
+	fileLogger = &lumberjack.Logger{
+		Filename: fmt.Sprintf("%s/%s.log", logDir, name),
+		MaxSize:  logSize, // MiB
+		MaxAge:   logAge,  // days
+	}
+
+	if logFlush != 0 {
+		logBuf = newSyncBuf(fileLogger)
+		fileLogger = logBuf
+	}
+
 	logFileHandler = log15.LvlFilterHandler(logLvl,
-		log15.StreamHandler(logBuf, fmt15.Fmt15Format(nil)))
+		log15.StreamHandler(fileLogger, fmt15.Fmt15Format(nil)))
 	setHandlers()
-	go func() {
-		for range time.Tick(time.Duration(logFlush) * time.Second) {
-			Flush()
-		}
-	}()
+
+	if logFlush > 0 {
+		go func() {
+			for range time.Tick(time.Duration(logFlush) * time.Second) {
+				Flush()
+			}
+		}()
+	}
 	return nil
 }
 
@@ -124,14 +144,6 @@ func AddLogFileFlags() {
 	flag.IntVar(&logFlush, "log.flush", 5, "How frequently to flush to the log file, in seconds")
 }
 
-func mkLogfile(name string) io.WriteCloser {
-	return &lumberjack.Logger{
-		Filename: fmt.Sprintf("%s/%s.log", logDir, name),
-		MaxSize:  logSize, // MiB
-		MaxAge:   logAge,  // days
-	}
-}
-
 func LogPanicAndExit() {
 	if msg := recover(); msg != nil {
 		log15.Crit("Panic", "msg", msg, "stack", string(debug.Stack()))
@@ -141,7 +153,9 @@ func LogPanicAndExit() {
 }
 
 func Flush() {
-	logBuf.Flush()
+	if logBuf != nil {
+		logBuf.Flush()
+	}
 }
 
 func New(ctx ...interface{}) Logger {

--- a/go/lib/log/log.go
+++ b/go/lib/log/log.go
@@ -73,11 +73,10 @@ func SetupFromFlags(name string) error {
 // logLevel can be one of debug, info, warn, error, and crit and states the
 // minimum level of logging events that get written to the file. logSize is the
 // maximum size, in MiB, until the log rotates. logAge is the maximum number of
-// days to retain old log files. logFlush is the interval, in seconds, on which
-// log messages are flushed from memory to file; a logFlush of 0 means always
-// flush each message immediately, and a negative logFlush means never flush
-// automatically. In the latter case, the log can still be flushed by calling
-// Flush manually.
+// days to retain old log files. If logFlush > 0, logging output is buffered,
+// and flushed every logFlush seconds.  If logFlush < 0: logging output is
+// buffered, but must be manually flushed by calling Flush(). If logFlush = 0
+// logging output is unbuffered and Flush() is a no-op.
 func SetupLogFile(name string, logDir string, logLevel string, logSize int, logAge int,
 	logFlush int) error {
 

--- a/go/lib/log/log.go
+++ b/go/lib/log/log.go
@@ -68,6 +68,16 @@ func SetupFromFlags(name string) error {
 	return err
 }
 
+// SetupLogFile initializes a file for logging. The path is logDir/name.log if
+// name doesn't already contain the .log extension, or logDir/name otherwise.
+// logLevel can be one of debug, info, warn, error, and crit and states the
+// minimum level of logging events that get written to the file. logSize is the
+// maximum size, in MiB, until the log rotates. logAge is the maximum number of
+// days to retain old log files. logFlush is the interval, in seconds, on which
+// log messages are flushed from memory to file; a logFlush of 0 means always
+// flush each message immediately, and a negative logFlush means never flush
+// automatically. In the latter case, the log can still be flushed by calling
+// Flush manually.
 func SetupLogFile(name string, logDir string, logLevel string, logSize int, logAge int,
 	logFlush int) error {
 


### PR DESCRIPTION
`log.SetupLogFile` now correctly initializes file logging from function arguments instead of flags.

Also changes the semantics behind a 0 value flush timer from "never flush" to a more intuitive "always flush immediately" (unbuffered logging). The old "never flush" behavior can now be selected by passing in a negative flush timer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1579)
<!-- Reviewable:end -->
