### PR TITLE
Enable SCIOND-less operation for snet

### DIFF
--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -267,3 +267,7 @@ func (r *PR) revoke(b common.RawBytes) {
 		log.Warn("Found invalid revocation notification", "revInfo", revInfo)
 	}
 }
+
+func (r *PR) Sciond() sciond.Service {
+	return r.sciondService
+}

--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -75,7 +75,7 @@ type Conn struct {
 	writeMutex sync.Mutex
 	recvBuffer common.RawBytes
 	sendBuffer common.RawBytes
-	// Pointer to slice of paths updated by continous lookups; these are
+	// Pointer to slice of paths updated by continuous lookups; these are
 	// used by default when creating a connection via Dial on SCIOND-enabled
 	// networks. For SCIOND-less operation, this is set to nil.
 	sp *pathmgr.SyncPaths

--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -341,7 +341,9 @@ func (c *Conn) write(b []byte, raddr *Addr) (int, error) {
 // running SCIOND-less.
 func (c *Conn) selectPathEntry(raddr *Addr) (*sciond.PathReplyEntry, error) {
 	var pathSet spathmeta.AppPathSet
-	assert.Must(c.scionNet.pathResolver != nil, "must run with SCIOND for path selection")
+	if assert.On {
+		assert.Must(c.scionNet.pathResolver != nil, "must run with SCIOND for path selection")
+	}
 	// If the remote address is fixed, register source and destination for
 	// continous path updates
 	if c.raddr == nil {

--- a/go/lib/snet/integration_test.go
+++ b/go/lib/snet/integration_test.go
@@ -154,11 +154,11 @@ func ClientServer(haveSciond bool, idx int, tc TestCase) {
 		cconn.SetDeadline(time.Now().Add(5 * time.Second))
 		SoMsg("Client deadline error", err, ShouldBeNil)
 
+		n, err := cconn.Write([]byte("Hello!"))
+		xtest.SoMsgError("Client write error", err, tc.expectWriteError)
 		// Only run the message exchange in cases where snet doesn't error out
 		// due to needing a path in SCIOND-less mode of operation.
 		if tc.expectWriteError == false {
-			n, err := cconn.Write([]byte("Hello!"))
-			xtest.SoMsgError("Client write error", err, false)
 			SoMsg("Client written bytes", n, ShouldEqual, len("Hello!"))
 
 			n, raddr, err := sconn.ReadFromSCION(b)

--- a/go/lib/snet/integration_test.go
+++ b/go/lib/snet/integration_test.go
@@ -18,7 +18,6 @@ package snet
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -31,6 +30,7 @@ import (
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 var _ = log.Root
@@ -56,43 +56,84 @@ type TestCase struct {
 
 	request []byte
 	reply   []byte
+
+	expectWriteError bool
 }
 
-func generateTests(asList []addr.IA, count int) []TestCase {
+func generateTests(asList []addr.IA, count int, haveSciond bool) []TestCase {
 	rand.Seed(time.Now().UnixNano())
 	tests := make([]TestCase, 0, 0)
 	var cIndex, sIndex int32
 	for i := 0; i < count; i++ {
 		cIndex = rand.Int31n(int32(len(asList)))
 		sIndex = rand.Int31n(int32(len(asList)))
-		tc := TestCase{srcIA: asList[cIndex], dstIA: asList[sIndex],
-			srcPort: uint16(40000 + 2*i), dstPort: uint16(40001 + 2*i),
+		srcIA := asList[cIndex]
+		dstIA := asList[sIndex]
+		tc := TestCase{
+			srcIA:    srcIA,
+			dstIA:    dstIA,
+			srcPort:  uint16(40000 + 2*i),
+			dstPort:  uint16(40001 + 2*i),
 			srcLocal: addr.HostFromIP(net.IPv4(127, 0, 0, 1)),
 			dstLocal: addr.HostFromIP(net.IPv4(127, 0, 0, 1)),
-			request:  []byte("ping!"), reply: []byte("pong!")}
+			request:  []byte("ping!"),
+			reply:    []byte("pong!"),
+			// if we don't have sciond, we can't talk to a different AS without
+			// an explicit path
+			expectWriteError: haveSciond == false && !srcIA.Eq(dstIA),
+		}
 		tests = append(tests, tc)
 	}
 	return tests
 }
 
 func TestIntegration(t *testing.T) {
-	tests := generateTests(asList, 100)
+	testCases := []struct {
+		Name       string
+		HaveSciond bool
+		Tests      []TestCase
+	}{
+		{
+			Name:       "SCIOND Mode",
+			HaveSciond: true,
+			Tests:      generateTests(asList, 100, true),
+		},
+		{
+			Name:       "SCIOND-less Mode",
+			HaveSciond: false,
+			Tests:      generateTests(asList, 100, false),
+		},
+	}
+
 	Convey("E2E test", t, func() {
-		for idx, test := range tests {
-			ClientServer(idx, test)
+		for _, tc := range testCases {
+			Convey(tc.Name, func() {
+				for idx, test := range tc.Tests {
+					ClientServer(tc.HaveSciond, idx, test)
+				}
+			})
 		}
 	})
 }
 
-func ClientServer(idx int, tc TestCase) {
+func ClientServer(haveSciond bool, idx int, tc TestCase) {
 	Convey(fmt.Sprintf("Test %v: (%v-%v,%v):%v <-> (%v-%v,%v):%v", idx, tc.srcIA.I,
 		tc.srcIA.A, tc.srcLocal, tc.srcPort, tc.dstIA.I, tc.dstIA.A, tc.dstLocal,
 		tc.dstPort), func(c C) {
 		b := make([]byte, 128)
 
-		clientNet, err := NewNetwork(tc.srcIA, sciond.GetDefaultSCIONDPath(&tc.srcIA), DispPath)
+		clientSciond := ""
+		if haveSciond {
+			clientSciond = sciond.GetDefaultSCIONDPath(&tc.srcIA)
+		}
+		clientNet, err := NewNetwork(tc.srcIA, clientSciond, DispPath)
 		SoMsg("Client network error", err, ShouldBeNil)
-		serverNet, err := NewNetwork(tc.dstIA, sciond.GetDefaultSCIONDPath(&tc.dstIA), DispPath)
+
+		serverSciond := ""
+		if haveSciond {
+			serverSciond = sciond.GetDefaultSCIONDPath(&tc.dstIA)
+		}
+		serverNet, err := NewNetwork(tc.dstIA, serverSciond, DispPath)
 		SoMsg("Server network error", err, ShouldBeNil)
 
 		clientAddr, err := AddrFromString(
@@ -113,22 +154,26 @@ func ClientServer(idx int, tc TestCase) {
 		cconn.SetDeadline(time.Now().Add(5 * time.Second))
 		SoMsg("Client deadline error", err, ShouldBeNil)
 
-		n, err := cconn.Write([]byte("Hello!"))
-		SoMsg("Client write error", err, ShouldBeNil)
-		SoMsg("Client written bytes", n, ShouldEqual, len("Hello!"))
+		// Only run the message exchange in cases where snet doesn't error out
+		// due to needing a path in SCIOND-less mode of operation.
+		if tc.expectWriteError == false {
+			n, err := cconn.Write([]byte("Hello!"))
+			xtest.SoMsgError("Client write error", err, tc.expectWriteError)
+			SoMsg("Client written bytes", n, ShouldEqual, len("Hello!"))
 
-		n, raddr, err := sconn.ReadFromSCION(b)
-		SoMsg("Server read error", err, ShouldBeNil)
-		SoMsg("Server remote addr", clientAddr.EqAddr(raddr), ShouldBeTrue)
-		SoMsg("Server read message", b[:n], ShouldResemble, []byte("Hello!"))
+			n, raddr, err := sconn.ReadFromSCION(b)
+			SoMsg("Server read error", err, ShouldBeNil)
+			SoMsg("Server remote addr", clientAddr.EqAddr(raddr), ShouldBeTrue)
+			SoMsg("Server read message", b[:n], ShouldResemble, []byte("Hello!"))
 
-		n, err = sconn.WriteToSCION([]byte("Bye!"), raddr)
-		SoMsg("Server write error", err, ShouldBeNil)
-		SoMsg("Server written bytes", n, ShouldEqual, len("Bye!"))
+			n, err = sconn.WriteToSCION([]byte("Bye!"), raddr)
+			SoMsg("Server write error", err, ShouldBeNil)
+			SoMsg("Server written bytes", n, ShouldEqual, len("Bye!"))
 
-		n, err = cconn.Read(b)
-		SoMsg("Client read error", err, ShouldBeNil)
-		SoMsg("Client read message", b[:n], ShouldResemble, []byte("Bye!"))
+			n, err = cconn.Read(b)
+			SoMsg("Client read error", err, ShouldBeNil)
+			SoMsg("Client read message", b[:n], ShouldResemble, []byte("Bye!"))
+		}
 
 		err = cconn.Close()
 		SoMsg("Client close error", err, ShouldBeNil)
@@ -189,7 +234,7 @@ func TestMain(m *testing.M) {
 		fmt.Println("Test setup error", err)
 		return
 	}
-	// Comment out below for logging during tests
-	log.Root().SetHandler(log.StreamHandler(ioutil.Discard, log.LogfmtFormat()))
+	// Comment the line below for logging during tests
+	log.Root().SetHandler(log.DiscardHandler())
 	os.Exit(m.Run())
 }

--- a/go/lib/snet/integration_test.go
+++ b/go/lib/snet/integration_test.go
@@ -158,7 +158,7 @@ func ClientServer(haveSciond bool, idx int, tc TestCase) {
 		// due to needing a path in SCIOND-less mode of operation.
 		if tc.expectWriteError == false {
 			n, err := cconn.Write([]byte("Hello!"))
-			xtest.SoMsgError("Client write error", err, tc.expectWriteError)
+			xtest.SoMsgError("Client write error", err, false)
 			SoMsg("Client written bytes", n, ShouldEqual, len("Hello!"))
 
 			n, raddr, err := sconn.ReadFromSCION(b)

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -258,7 +258,10 @@ func (n *Network) PathResolver() *pathmgr.PR {
 
 // Sciond returns the sciond.Service that the network is using.
 func (n *Network) Sciond() sciond.Service {
-	return n.pathResolver.Sciond()
+	if n.pathResolver != nil {
+		return n.pathResolver.Sciond()
+	}
+	return nil
 }
 
 // IA returns the ISD-AS assigned to n

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -41,8 +41,9 @@
 // header.
 //
 // Important: not draining SCMP errors via Read calls can cause the dispatcher
-// to block (see Issue #1278). To prevent this on a Conn object with only Write
-// calls, run a separate goroutine that continuously calls Read on the Conn.
+// to shutdown the socket (see PR #1356). To prevent this on a Conn object with
+// only Write calls, run a separate goroutine that continuously calls Read on
+// the Conn.
 package snet
 
 import (
@@ -91,20 +92,19 @@ func IA() addr.IA {
 // SCION networking context, containing local ISD-AS, SCIOND, Dispatcher and
 // Path resolver.
 type Network struct {
-	sciond         sciond.Service
-	sciondPath     string
 	dispatcherPath string
-	pathResolver   *pathmgr.PR
-	localIA        addr.IA
+	// pathResolver references the default source of paths for a Network. This
+	// is set to nil when operating on a SCIOND-less Network.
+	pathResolver *pathmgr.PR
+	localIA      addr.IA
 }
 
-// NewNetworkBasic creates a minimal networking context without a path resolver.
-// It is meant to be amended with a custom path resolver.
-func NewNetworkBasic(ia addr.IA, sPath string, dPath string) *Network {
+// NewNetworkWithPR creates a new networking context with path resolver pr. A
+// nil path resolver means the Network will run without SCIOND.
+func NewNetworkWithPR(ia addr.IA, dPath string, pr *pathmgr.PR) *Network {
 	return &Network{
-		sciond:         sciond.NewService(sPath),
-		sciondPath:     sPath,
 		dispatcherPath: dPath,
+		pathResolver:   pr,
 		localIA:        ia,
 	}
 }
@@ -112,19 +112,28 @@ func NewNetworkBasic(ia addr.IA, sPath string, dPath string) *Network {
 // NewNetwork creates a new networking context, on which future Dial or Listen
 // calls can be made. The new connections use the SCIOND server at sPath, the
 // dispatcher at dPath, and ia for the local ISD-AS.
+//
+// If sPath is the empty string, the network will run without SCIOND. In this
+// mode of operation, the app is fully responsible with supplying paths for
+// sent traffic.
 func NewNetwork(ia addr.IA, sPath string, dPath string) (*Network, error) {
-	network := NewNetworkBasic(ia, sPath, dPath)
-	timers := &pathmgr.Timers{
-		NormalRefire: time.Minute,
-		ErrorRefire:  3 * time.Second,
-		MaxAge:       time.Hour,
+	var pathResolver *pathmgr.PR
+	if sPath != "" {
+		var err error
+		pathResolver, err = pathmgr.New(
+			sciond.NewService(sPath),
+			&pathmgr.Timers{
+				NormalRefire: time.Minute,
+				ErrorRefire:  3 * time.Second,
+				MaxAge:       time.Hour,
+			},
+			log.Root(),
+		)
+		if err != nil {
+			return nil, common.NewBasicError("Unable to initialize path resolver", err)
+		}
 	}
-	pathResolver, err := pathmgr.New(network.sciond, timers, log.Root())
-	if err != nil {
-		return nil, common.NewBasicError("Unable to initialize path resolver", err)
-	}
-	network.pathResolver = pathResolver
-	return network, nil
+	return NewNetworkWithPR(ia, dPath, pathResolver), nil
 }
 
 // DialSCION returns a SCION connection to raddr. Nil values for laddr are not
@@ -147,9 +156,11 @@ func (n *Network) DialSCIONWithBindSVC(network string, laddr, raddr, baddr *Addr
 		return nil, err
 	}
 	conn.raddr = raddr.Copy()
-	conn.sp, err = n.pathResolver.Watch(conn.laddr.IA, conn.raddr.IA)
-	if err != nil {
-		return nil, common.NewBasicError("Unable to establish path", err)
+	if n.pathResolver != nil {
+		conn.sp, err = n.pathResolver.Watch(conn.laddr.IA, conn.raddr.IA)
+		if err != nil {
+			return nil, common.NewBasicError("Unable to establish path", err)
+		}
 	}
 	return conn, nil
 }
@@ -245,18 +256,9 @@ func (n *Network) PathResolver() *pathmgr.PR {
 	return n.pathResolver
 }
 
-// SetPathResolver set the pathmgr.PR that the networking is using. It can only
-// be set once and will be ignored if there is already a path resolver set.
-func (n *Network) SetPathResolver(resolver *pathmgr.PR) {
-	if n.pathResolver != nil {
-		return
-	}
-	n.pathResolver = resolver
-}
-
 // Sciond returns the sciond.Service that the network is using.
 func (n *Network) Sciond() sciond.Service {
-	return n.sciond
+	return n.pathResolver.Sciond()
 }
 
 // IA returns the ISD-AS assigned to n


### PR DESCRIPTION
SCIOND-less operation is needed for applications that need to talk over the network without sciond access (e.g., the sciond server itself).

Also streamlines the API a bit and deletes some unused fields from `snet` types.

SCIOND-less operation can be selected by passing an empty sciond socket path, or by passing in a nil path resolver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1580)
<!-- Reviewable:end -->
