### PR TITLE
Infra dispatcher now cleanly stops on EOF

### DIFF
--- a/go/lib/infra/disp/disp.go
+++ b/go/lib/infra/disp/disp.go
@@ -172,43 +172,52 @@ func (d *Dispatcher) goBackgroundReceiver() {
 		d.log.Info("Started")
 		defer d.log.Info("Stopped")
 		defer close(d.stoppedChan)
+	Loop:
 		for {
 			// On each iteration, check for termination signal
 			select {
 			case <-d.closedChan:
 				return
 			default:
-				d.recvNext()
+				if fatal := d.recvNext(); fatal {
+					// fatal error
+					break Loop
+				}
 			}
 		}
 	}()
 }
 
-func (d *Dispatcher) recvNext() {
+// recvNext reads the next packet from the transport. On fatal errors, it
+// returns true.
+func (d *Dispatcher) recvNext() (fatalError bool) {
 	// Once the transport is closed, RecvFrom returns immediately.
 	b, address, err := d.transport.RecvFrom(context.Background())
 	if err != nil {
 		d.log.Warn("error", "err",
 			common.NewBasicError(infra.StrTransportError, err, "op", "RecvFrom"))
-		return
+		if err.Error() == "EOF" {
+			return true
+		}
+		return false
 	}
 
 	msg, err := d.adapter.RawToMsg(b)
 	if err != nil {
 		d.log.Warn("error", "err",
 			common.NewBasicError(infra.StrAdapterError, err, "op", "RawToMsg"))
-		return
+		return false
 	}
 
 	found, err := d.waitTable.reply(msg)
 	if err != nil {
 		d.log.Warn("error", "err",
 			common.NewBasicError(infra.StrInternalError, err, "op", "waitTable.Reply"))
-		return
+		return false
 	}
 	if found {
 		// If a waiting goroutine was found the message has already been forwarded
-		return
+		return false
 	}
 
 	event := &readEventDesc{address: address, msg: msg}
@@ -218,6 +227,7 @@ func (d *Dispatcher) recvNext() {
 	default:
 		d.log.Warn("Internal queue full, dropped message", "msg", msg)
 	}
+	return false
 }
 
 // Close shuts down the background goroutine and closes the transport.

--- a/go/lib/infra/disp/disp.go
+++ b/go/lib/infra/disp/disp.go
@@ -40,6 +40,7 @@ package disp
 
 import (
 	"context"
+	"io"
 	"net"
 	"sync"
 
@@ -196,7 +197,7 @@ func (d *Dispatcher) recvNext() bool {
 	if err != nil {
 		d.log.Warn("error", "err",
 			common.NewBasicError(infra.StrTransportError, err, "op", "RecvFrom"))
-		if err.Error() == "EOF" {
+		if err == io.EOF {
 			return true
 		}
 		return false

--- a/go/lib/infra/disp/disp.go
+++ b/go/lib/infra/disp/disp.go
@@ -190,7 +190,7 @@ func (d *Dispatcher) goBackgroundReceiver() {
 
 // recvNext reads the next packet from the transport. On fatal errors, it
 // returns true.
-func (d *Dispatcher) recvNext() (fatalError bool) {
+func (d *Dispatcher) recvNext() bool {
 	// Once the transport is closed, RecvFrom returns immediately.
 	b, address, err := d.transport.RecvFrom(context.Background())
 	if err != nil {


### PR DESCRIPTION
Whenever the receiver of an infra dispatcher message decides to close the connection (this can happen when receiving a malformed message on a connection that can be closed, e.g., reliable socket), Go will produce an EOF when the sender reads back. The sender logs the message, but continues to try to read, getting stuck in an infinite error print loop.

This PR changes the behavior and makes the sender cleanly shutdown on EOF.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1582)
<!-- Reviewable:end -->
