### PR TITLE
DRKey: representation of first order messages

### DIFF
--- a/go/lib/ctrl/ctrl.go
+++ b/go/lib/ctrl/ctrl.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/proto"
 )
@@ -59,6 +60,16 @@ func NewCertMgmtPld(u proto.Cerealizable, certD *cert_mgmt.Data, ctrlD *Data) (*
 	return NewPld(cpld, ctrlD)
 }
 
+// NewDRKeyMgmtPld creates a new control payload, containing a new drkey_mgmt payload,
+// which in turn contains the supplied Cerealizable instance.
+func NewDRKeyMgmtPld(u proto.Cerealizable, drkeyD *drkey_mgmt.Data, ctrlD *Data) (*Pld, error) {
+	kpld, err := drkey_mgmt.NewPld(u, drkeyD)
+	if err != nil {
+		return nil, err
+	}
+	return NewPld(kpld, ctrlD)
+}
+
 func NewPldFromRaw(b common.RawBytes) (*Pld, error) {
 	p := &Pld{Data: &Data{}}
 	return p, proto.ParseFromRaw(p, proto.CtrlPld_TypeID, b)
@@ -83,7 +94,7 @@ func (p *Pld) GetCertMgmt() (*cert_mgmt.Pld, *Data, error) {
 	return certP, p.Data, nil
 }
 
-// GetCertMgmt returns the PathMgmt payload and the CtrlPld's non-union Data.
+// GetPathMgmt returns the PathMgmt payload and the CtrlPld's non-union Data.
 // If the union type is not PathMgmt, an error is returned.
 func (p *Pld) GetPathMgmt() (*path_mgmt.Pld, *Data, error) {
 	u, err := p.Union()
@@ -96,6 +107,21 @@ func (p *Pld) GetPathMgmt() (*path_mgmt.Pld, *Data, error) {
 			"expected", "*path_mgmt.Pld", "actual", common.TypeOf(u))
 	}
 	return pathP, p.Data, nil
+}
+
+// GetDRKeyMgmt returns the DRKeyMgmt payload and the CtrlPld's non-union Data.
+// If the union type is not DRKeyMgmt, an error is returned.
+func (p *Pld) GetDRKeyMgmt() (*drkey_mgmt.Pld, *Data, error) {
+	u, err := p.Union()
+	if err != nil {
+		return nil, nil, err
+	}
+	drkeyP, ok := u.(*drkey_mgmt.Pld)
+	if !ok {
+		return nil, nil, common.NewBasicError("Non-matching ctrl pld contents", nil,
+			"expected", "*drkey_mgmt.Pld", "actual", common.TypeOf(u))
+	}
+	return drkeyP, p.Data, nil
 }
 
 func (p *Pld) Len() int {

--- a/go/lib/ctrl/drkey_mgmt/drkey_mgmt.go
+++ b/go/lib/ctrl/drkey_mgmt/drkey_mgmt.go
@@ -1,0 +1,91 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkey_mgmt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/proto"
+)
+
+type union struct {
+	Which        proto.DRKeyMgmt_Which
+	DRKeyLvl1Req *DRKeyLvl1Req `capnp:"DRKeyLvl1Req"`
+	DRKeyLvl1Rep *DRKeyLvl1Rep `capnp:"DRKeyLvl1Rep"`
+}
+
+func (u *union) set(c proto.Cerealizable) error {
+	switch p := c.(type) {
+	case *DRKeyLvl1Req:
+		u.Which = proto.DRKeyMgmt_Which_drkeyLvl1Req
+		u.DRKeyLvl1Req = p
+	case *DRKeyLvl1Rep:
+		u.Which = proto.DRKeyMgmt_Which_drkeyLvl1Rep
+		u.DRKeyLvl1Rep = p
+	default:
+		return common.NewBasicError("Unsupported drkey mgmt union type (set)",
+			nil, "type", common.TypeOf(c))
+	}
+	return nil
+}
+
+func (u *union) get() (proto.Cerealizable, error) {
+	switch u.Which {
+	case proto.DRKeyMgmt_Which_drkeyLvl1Req:
+		return u.DRKeyLvl1Req, nil
+	case proto.DRKeyMgmt_Which_drkeyLvl1Rep:
+		return u.DRKeyLvl1Rep, nil
+	}
+	return nil, common.NewBasicError("Unsupported drkey mgmt union type (get)",
+		nil, "type", u.Which)
+}
+
+var _ proto.Cerealizable = (*Pld)(nil)
+
+type Pld struct {
+	union
+	*Data
+}
+
+// NewPld creates a new drkey mgmt payload, containing the supplied Cerealizable instance.
+func NewPld(u proto.Cerealizable, d *Data) (*Pld, error) {
+	p := &Pld{Data: d}
+	return p, p.union.set(u)
+}
+
+func (p *Pld) Union() (proto.Cerealizable, error) {
+	return p.union.get()
+}
+
+func (p *Pld) ProtoId() proto.ProtoIdType {
+	return proto.DRKeyMgmt_TypeID
+}
+
+func (p *Pld) String() string {
+	desc := []string{"DRKeyMgmt: Union:"}
+	u, err := p.Union()
+	if err != nil {
+		desc = append(desc, err.Error())
+	} else {
+		desc = append(desc, fmt.Sprintf("%+v", u))
+	}
+	return strings.Join(desc, " ")
+}
+
+type Data struct {
+	// For passing any future non-union data.
+}

--- a/go/lib/ctrl/drkey_mgmt/drkey_rep.go
+++ b/go/lib/ctrl/drkey_mgmt/drkey_rep.go
@@ -1,0 +1,55 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains the Go representation of first order DRKey responses.
+
+package drkey_mgmt
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/proto"
+)
+
+var _ proto.Cerealizable = (*DRKeyLvl1Rep)(nil)
+
+type DRKeyLvl1Rep struct {
+	SrcIA      addr.IAInt `capnp:"isdas"`
+	ExpTime    uint32
+	Cipher     common.RawBytes
+	CertVerSrc uint64
+	CertVerDst uint64
+}
+
+func (c *DRKeyLvl1Rep) IA() addr.IA {
+	return c.SrcIA.IA()
+}
+
+func (c *DRKeyLvl1Rep) ProtoId() proto.ProtoIdType {
+	return proto.DRKeyLvl1Rep_TypeID
+}
+
+// Time returns the expiration time
+func (c *DRKeyLvl1Rep) Time() time.Time {
+	return util.USecsToTime(uint64(c.ExpTime))
+}
+
+func (c *DRKeyLvl1Rep) String() string {
+	return fmt.Sprintf("SrcIA: %v ExpTime: %v CertVerSig: %d CertVerEnc: %d",
+		c.IA(), util.TimeToString(c.Time()), c.CertVerSrc, c.CertVerDst)
+}

--- a/go/lib/ctrl/drkey_mgmt/drkey_req.go
+++ b/go/lib/ctrl/drkey_mgmt/drkey_req.go
@@ -1,0 +1,50 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains the Go representation of first order DRKey requests.
+
+package drkey_mgmt
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/proto"
+)
+
+var _ proto.Cerealizable = (*DRKeyLvl1Req)(nil)
+
+type DRKeyLvl1Req struct {
+	SrcIA   addr.IAInt `capnp:"isdas"`
+	ValTime uint32
+}
+
+func (c *DRKeyLvl1Req) IA() addr.IA {
+	return c.SrcIA.IA()
+}
+
+func (c *DRKeyLvl1Req) ProtoId() proto.ProtoIdType {
+	return proto.DRKeyLvl1Req_TypeID
+}
+
+// Time returns the validity time
+func (c *DRKeyLvl1Req) Time() time.Time {
+	return util.USecsToTime(uint64(c.ValTime))
+}
+
+func (c *DRKeyLvl1Req) String() string {
+	return fmt.Sprintf("SrcIA: %s ValTime: %v", c.IA(), util.TimeToString(c.Time()))
+}

--- a/go/lib/ctrl/union.go
+++ b/go/lib/ctrl/union.go
@@ -17,6 +17,7 @@ package ctrl
 import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/extn"
 	"github.com/scionproto/scion/go/lib/ctrl/ifid"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
@@ -32,8 +33,8 @@ type union struct {
 	IfID        *ifid.IFID       `capnp:"ifid"`
 	CertMgmt    *cert_mgmt.Pld
 	PathMgmt    *path_mgmt.Pld
-	Sibra       []byte `capnp:"-"` // Omit for now
-	DRKeyMgmt   []byte `capnp:"-"` // Omit for now
+	Sibra       []byte          `capnp:"-"` // Omit for now
+	DRKeyMgmt   *drkey_mgmt.Pld `capnp:"drkeyMgmt"`
 	Sig         *sigmgmt.Pld
 	Extn        *extn.CtrlExtnDataList
 }
@@ -49,6 +50,9 @@ func (u *union) set(c proto.Cerealizable) error {
 	case *path_mgmt.Pld:
 		u.Which = proto.CtrlPld_Which_pathMgmt
 		u.PathMgmt = p
+	case *drkey_mgmt.Pld:
+		u.Which = proto.CtrlPld_Which_drkeyMgmt
+		u.DRKeyMgmt = p
 	case *sigmgmt.Pld:
 		u.Which = proto.CtrlPld_Which_sig
 		u.Sig = p
@@ -73,6 +77,8 @@ func (u *union) get() (proto.Cerealizable, error) {
 		return u.IfID, nil
 	case proto.CtrlPld_Which_pathMgmt:
 		return u.PathMgmt, nil
+	case proto.CtrlPld_Which_drkeyMgmt:
+		return u.DRKeyMgmt, nil
 	case proto.CtrlPld_Which_sig:
 		return u.Sig, nil
 	case proto.CtrlPld_Which_certMgmt:

--- a/proto/drkey_mgmt.capnp
+++ b/proto/drkey_mgmt.capnp
@@ -4,8 +4,9 @@ using Go = import "go.capnp";
 $Go.package("proto");
 $Go.import("github.com/scionproto/scion/go/proto");
 
-struct DRKeyReq {
+struct DRKeyLvl1Req {
     isdas @0 :UInt64;      # Src ISD-AS of the requested DRKey
+<<<<<<< HEAD
     timestamp @1 :UInt32;  # Timestamp, seconds since Unix Epoch
     signature @2 :Data;    # Signature of (isdas, prefetch, timestamp)
     certVer @3 :UInt32;    # Version cert used to sign
@@ -14,10 +15,14 @@ struct DRKeyReq {
         prefetch @5 :Bool; # Indicator request for current (false) or next (true) DRKey
     }
 
+=======
+    valTime @1 :UInt32;    # Point in time where requested DRKey is valid
+>>>>>>> 621dc11... Mapping of FirstOrder Messages of Capnp to go/lib
 }
 
-struct DRKeyRep {
+struct DRKeyLvl1Rep {
     isdas @0 :UInt64;      # Src ISD-AS of the DRKey
+<<<<<<< HEAD
     timestamp @1 :UInt32;  # Timestamp, seconds since Unix Epoch
     expTime @2 :UInt32;    # Expiration time of the DRKey, seconds since Unix Epoch
     cipher @3 :Data;       # Encrypted DRKey
@@ -25,12 +30,18 @@ struct DRKeyRep {
     certVerSrc @5 :UInt32; # Version of cert used to sign
     certVerDst @6 :UInt32; # Version of cert of public key used to encrypt
     trcVer @7 :UInt32;     # Version of TRC, of signing cert
+=======
+    expTime @1 :UInt32;    # Expiration time of the DRKey
+    cipher @2 :Data;       # Encrypted DRKey
+    certVerSrc @3 :UInt64; # Version of cert used to sign
+    certVerDst @4 :UInt64; # Version of cert of public key used to encrypt
+>>>>>>> 621dc11... Mapping of FirstOrder Messages of Capnp to go/lib
 }
 
 struct DRKeyMgmt {
     union {
         unset @0 :Void;
-        drkeyReq @1 :DRKeyReq;
-        drkeyRep @2 :DRKeyRep;
+        drkeyLvl1Req @1 :DRKeyLvl1Req;
+        drkeyLvl1Rep @2 :DRKeyLvl1Rep;
     }
 }

--- a/python/lib/drkey/drkey_mgmt.py
+++ b/python/lib/drkey/drkey_mgmt.py
@@ -36,7 +36,7 @@ class DRKeyMgmt(CerealBox):  # pragma: no cover
 class DRKeyRequest(Cerealizable):
     """ First order DRKey request. """
     NAME = "DRKeyRequest"
-    P_CLS = P.DRKeyReq
+    P_CLS = P.DRKeyLvl1Req
 
     def __init__(self, p):
         super().__init__(p)
@@ -68,7 +68,7 @@ class DRKeyRequest(Cerealizable):
 
 class DRKeyReply(Cerealizable):
     NAME = "DRKeyReply"
-    P_CLS = P.DRKeyRep
+    P_CLS = P.DRKeyLvl1Rep
 
     def __init__(self, p):
         super().__init__(p)

--- a/python/lib/types.py
+++ b/python/lib/types.py
@@ -145,8 +145,8 @@ class PathSegmentType(TypeBase):
 
 
 class DRKeyMgmtType(object):
-    FIRST_ORDER_REQUEST = "drkeyReq"
-    FIRST_ORDER_REPLY = "drkeyRep"
+    FIRST_ORDER_REQUEST = "drkeyLvl1Req"
+    FIRST_ORDER_REPLY = "drkeyLvl1Rep"
 
 
 ############################


### PR DESCRIPTION
- Mapping of `drkey_mgmt.capnp` to go/lib.
- Update of `drkey_mgmt.capnp` to reflect the changes in book
- Remove signature and timestamp as they are abstracted in SignedPld.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1588)
<!-- Reviewable:end -->
