### PR TITLE
scion-pki: Make the output directory separately configurable

### DIFF
--- a/go/lib/infra/modules/trust/trust_test.go
+++ b/go/lib/infra/modules/trust/trust_test.go
@@ -67,14 +67,6 @@ func regenerateCrypto() error {
 	dir, cleanF := xtest.MustTempDir("", "test-trust")
 	defer cleanF()
 
-	// Generate output dir structure.
-	for _, ia := range ias {
-		path := filepath.Join(dir, fmt.Sprintf("ISD%s/AS%s", ia.I, ia.A))
-		if err := os.MkdirAll(path, 0755); err != nil {
-			panic(err)
-		}
-	}
-
 	b := &loader.Binary{
 		Target: "github.com/scionproto/scion/go/tools/scion-pki",
 		Dir:    dir,

--- a/go/lib/infra/modules/trust/trust_test.go
+++ b/go/lib/infra/modules/trust/trust_test.go
@@ -52,9 +52,13 @@ var (
 		xtest.MustParseIA("5-ff00:0:d"), xtest.MustParseIA("5-ff00:0:e"),
 		xtest.MustParseIA("5-ff00:0:f"),
 	}
+	tmpDir string
 )
 
 func TestMain(m *testing.M) {
+	var cleanF func()
+	tmpDir, cleanF = xtest.MustTempDir("", "test-trust")
+	defer cleanF()
 	if err := regenerateCrypto(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -64,12 +68,9 @@ func TestMain(m *testing.M) {
 }
 
 func regenerateCrypto() error {
-	dir, cleanF := xtest.MustTempDir("", "test-trust")
-	defer cleanF()
-
 	b := &loader.Binary{
 		Target: "github.com/scionproto/scion/go/tools/scion-pki",
-		Dir:    dir,
+		Dir:    tmpDir,
 	}
 	if err := b.Build(); err != nil {
 		panic(err)
@@ -80,17 +81,17 @@ func regenerateCrypto() error {
 		return err
 	}
 	confDir := filepath.Join(wd, "/testdata")
-	cmd := b.Cmd("keys", "gen", "-d", confDir, "-o", dir, "*-*")
+	cmd := b.Cmd("keys", "gen", "-d", confDir, "-o", tmpDir, "*-*")
 	if msg, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("scion-pki: %s", msg)
 	}
 
-	cmd = b.Cmd("trc", "gen", "-d", confDir, "-o", dir, "*")
+	cmd = b.Cmd("trc", "gen", "-d", confDir, "-o", tmpDir, "*")
 	if msg, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("scion-pki: %s", msg)
 	}
 
-	cmd = b.Cmd("certs", "gen", "-d", confDir, "-o", dir, "*-*")
+	cmd = b.Cmd("certs", "gen", "-d", confDir, "-o", tmpDir, "*-*")
 	if msg, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("scion-pki: %s", msg)
 	}
@@ -742,12 +743,12 @@ func loadCrypto(t *testing.T, isds []addr.ISD,
 }
 
 func getTRCFileName(isd addr.ISD, version uint64) string {
-	return fmt.Sprintf("testdata/ISD%d/trcs/ISD%d-V%d.trc", isd, isd, version)
+	return fmt.Sprintf("%s/ISD%d/trcs/ISD%d-V%d.trc", tmpDir, isd, isd, version)
 }
 
 func getChainFileName(ia addr.IA, version uint64) string {
-	return fmt.Sprintf("testdata/ISD%d/AS%s/certs/ISD%d-AS%s-V%d.crt",
-		ia.I, ia.A.FileFmt(), ia.I, ia.A.FileFmt(), version)
+	return fmt.Sprintf("%s/ISD%d/AS%s/certs/ISD%d-AS%s-V%d.crt",
+		tmpDir, ia.I, ia.A.FileFmt(), ia.I, ia.A.FileFmt(), version)
 }
 
 func initStore(t *testing.T, ia addr.IA, msger infra.Messenger) (*Store, func()) {

--- a/go/lib/infra/modules/trust/trust_test.go
+++ b/go/lib/infra/modules/trust/trust_test.go
@@ -67,6 +67,14 @@ func regenerateCrypto() error {
 	dir, cleanF := xtest.MustTempDir("", "test-trust")
 	defer cleanF()
 
+	// Generate output dir structure.
+	for _, ia := range ias {
+		path := filepath.Join(dir, fmt.Sprintf("ISD%s/AS%s", ia.I, ia.A))
+		if err := os.MkdirAll(path, 0755); err != nil {
+			panic(err)
+		}
+	}
+
 	b := &loader.Binary{
 		Target: "github.com/scionproto/scion/go/tools/scion-pki",
 		Dir:    dir,
@@ -79,21 +87,18 @@ func regenerateCrypto() error {
 	if err != nil {
 		return err
 	}
-
-	cmd := b.Cmd("keys", "gen", "-f", "*-*")
-	cmd.Dir = filepath.Join(wd, "/testdata")
+	confDir := filepath.Join(wd, "/testdata")
+	cmd := b.Cmd("keys", "gen", "-d", confDir, "-o", dir, "*-*")
 	if msg, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("scion-pki: %s", msg)
 	}
 
-	cmd = b.Cmd("trc", "gen", "-f", "*")
-	cmd.Dir = filepath.Join(wd, "/testdata")
+	cmd = b.Cmd("trc", "gen", "-d", confDir, "-o", dir, "*")
 	if msg, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("scion-pki: %s", msg)
 	}
 
-	cmd = b.Cmd("certs", "gen", "-f", "*-*")
-	cmd.Dir = filepath.Join(wd, "/testdata")
+	cmd = b.Cmd("certs", "gen", "-d", confDir, "-o", dir, "*-*")
 	if msg, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("scion-pki: %s", msg)
 	}

--- a/go/tools/scion-pki/internal/certs/verify.go
+++ b/go/tools/scion-pki/internal/certs/verify.go
@@ -61,7 +61,7 @@ func verifyChain(chain *cert.Chain, subject addr.IA) error {
 
 func loadTRC(subject addr.IA, version uint64) (*trc.TRC, error) {
 	fname := fmt.Sprintf(pkicmn.TrcNameFmt, subject.I, version)
-	trcPath := filepath.Join(pkicmn.RootDir, fmt.Sprintf("ISD%d", subject.I), pkicmn.TRCsDir, fname)
+	trcPath := filepath.Join(pkicmn.GetIsdPath(pkicmn.OutDir, subject.I), pkicmn.TRCsDir, fname)
 	trcRaw, err := ioutil.ReadFile(trcPath)
 	if err != nil {
 		return nil, err

--- a/go/tools/scion-pki/internal/cmd/cmd.go
+++ b/go/tools/scion-pki/internal/cmd/cmd.go
@@ -33,6 +33,12 @@ var RootCmd = &cobra.Command{
 	Short: "Scion Public Key Infrastructure Management Tool",
 	Long: `scion-pki is a tool to generate keys, certificates, and trust
 root configuration files used in the SCION control plane PKI.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Initialize global OutDir if not set on the cmdline.
+		if pkicmn.OutDir == "" {
+			pkicmn.OutDir = pkicmn.RootDir
+		}
+	},
 }
 
 const (
@@ -81,7 +87,10 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&pkicmn.Force, "force", "f", false,
 		"Overwrite existing keys/certs/trcs")
 	RootCmd.PersistentFlags().StringVarP(&pkicmn.RootDir, "root", "d", ".",
-		"root directory of all certificates and keys")
+		"Root directory where scion-pki looks for configuration files. Is also used as output "+
+			"directory if -out/-o is not specified.")
+	RootCmd.PersistentFlags().StringVarP(&pkicmn.OutDir, "out", "o", "",
+		"Output directory where certificates and keys will be placed. Defaults to -root/-d.")
 	autoCompleteCmd.PersistentFlags().BoolVarP(&zsh, "zsh", "z", false,
 		"Generate autocompletion script for zsh")
 

--- a/go/tools/scion-pki/internal/keys/gen.go
+++ b/go/tools/scion-pki/internal/keys/gen.go
@@ -44,12 +44,12 @@ func runGenKey(args []string) {
 		pkicmn.ErrorAndExit("Error: %s\n", err)
 	}
 	for isd, ases := range asMap {
-		iconf, err := conf.LoadIsdConf(pkicmn.GetIsdPath(isd))
+		iconf, err := conf.LoadIsdConf(pkicmn.GetIsdPath(pkicmn.RootDir, isd))
 		if err != nil {
 			pkicmn.ErrorAndExit("Error reading isd.ini: %s\n", err)
 		}
 		for _, ia := range ases {
-			dir := pkicmn.GetAsPath(ia)
+			dir := pkicmn.GetAsPath(pkicmn.OutDir, ia)
 			core := pkicmn.Contains(iconf.Trc.CoreIAs, ia)
 			fmt.Println("Generating keys for", ia)
 			if err = genAll(filepath.Join(dir, pkicmn.KeysDir), core); err != nil {

--- a/go/tools/scion-pki/internal/pkicmn/pkicmn.go
+++ b/go/tools/scion-pki/internal/pkicmn/pkicmn.go
@@ -40,6 +40,7 @@ const (
 
 var (
 	RootDir string
+	OutDir  string
 	Force   bool
 )
 
@@ -149,12 +150,12 @@ func WriteToFile(raw common.RawBytes, path string, perm os.FileMode) error {
 	return nil
 }
 
-func GetAsPath(ia addr.IA) string {
-	return filepath.Join(RootDir, fmt.Sprintf("ISD%d/AS%s", ia.I, ia.A.FileFmt()))
+func GetAsPath(baseDir string, ia addr.IA) string {
+	return filepath.Join(baseDir, fmt.Sprintf("ISD%d/AS%s", ia.I, ia.A.FileFmt()))
 }
 
-func GetIsdPath(isd addr.ISD) string {
-	return filepath.Join(RootDir, fmt.Sprintf("ISD%d", isd))
+func GetIsdPath(baseDir string, isd addr.ISD) string {
+	return filepath.Join(baseDir, fmt.Sprintf("ISD%d", isd))
 }
 
 func ErrorAndExit(format string, a ...interface{}) {

--- a/go/tools/scion-pki/internal/tmpl/as.go
+++ b/go/tools/scion-pki/internal/tmpl/as.go
@@ -29,7 +29,7 @@ func runGenAsTmpl(args []string) {
 	}
 	fmt.Println("Generating cert config templates.")
 	for isd, ases := range asMap {
-		iconf, err := conf.LoadIsdConf(pkicmn.GetIsdPath(isd))
+		iconf, err := conf.LoadIsdConf(pkicmn.GetIsdPath(pkicmn.RootDir, isd))
 		if err != nil {
 			pkicmn.ErrorAndExit("Error reading %s: %s\n", conf.IsdConfFileName, err)
 		}
@@ -45,7 +45,7 @@ func runGenAsTmpl(args []string) {
 func genAsTmpl(ia addr.IA, isdConf *conf.Isd) error {
 	core := pkicmn.Contains(isdConf.Trc.CoreIAs, ia)
 	a := conf.NewTemplateAsConf(ia, isdConf.Trc.Version, core)
-	dir := pkicmn.GetAsPath(ia)
+	dir := pkicmn.GetAsPath(pkicmn.RootDir, ia)
 	fpath := filepath.Join(dir, conf.AsConfFileName)
 	if err := a.Write(fpath, pkicmn.Force); err != nil {
 		return err

--- a/go/tools/scion-pki/internal/tmpl/isd.go
+++ b/go/tools/scion-pki/internal/tmpl/isd.go
@@ -35,7 +35,7 @@ func runGenIsdTmpl(args []string) {
 }
 
 func genIsdTmpl(isd addr.ISD) error {
-	dir := pkicmn.GetIsdPath(isd)
+	dir := pkicmn.GetIsdPath(pkicmn.RootDir, isd)
 	fmt.Printf("Generating configuration template for ISD%d\n", isd)
 	i := &conf.Isd{Trc: &conf.Trc{Version: 1}}
 	return i.Write(filepath.Join(dir, conf.IsdConfFileName), pkicmn.Force)


### PR DESCRIPTION
Users of `scion-pki` can now specify an output directory for keys, certs, and TRCs using the `-o/--out` cmdline parameter (so far this was the same as the root directory for the configuration files). If not specified, the output directory will be the same as the root directory (`-d/--root`).

Fixes #1575.

Also:
Change `trust_test.go` to use the new capabilities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1589)
<!-- Reviewable:end -->
