### PR TITLE
Fix replies from BR to BR in the same AS

### DIFF
--- a/go/lib/overlay/conn/conn.go
+++ b/go/lib/overlay/conn/conn.go
@@ -334,7 +334,7 @@ func (m *ReadMeta) SetSrc(rai *topology.AddrInfo, raddr *net.UDPAddr, ot overlay
 	m.Src.Overlay = ot
 	m.Src.IP = raddr.IP
 	m.Src.L4Port = raddr.Port
-	m.Src.OverlayPort = overlay.EndhostPort
+	m.Src.OverlayPort = raddr.Port
 }
 
 func NewReadMessages(n int) []ipv4.Message {


### PR DESCRIPTION
The OverlayPort in the metadata information when reding packets from
an internal interface was always set to the endhost overlay port.

When a BR uses this information to generate a reply it would use the
wrong overlay port.

Fix this problem by setting the source overlay port to the L4 port of
the received packet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1592)
<!-- Reviewable:end -->
