### PR TITLE
Wrapper for asym.crypto around nacl/box

### DIFF
--- a/go/lib/scrypto/asym.go
+++ b/go/lib/scrypto/asym.go
@@ -15,9 +15,11 @@
 package scrypto
 
 import (
+	"crypto/rand"
 	"strings"
 
 	"golang.org/x/crypto/ed25519"
+	"golang.org/x/crypto/nacl/box"
 
 	"github.com/scionproto/scion/go/lib/common"
 )
@@ -28,19 +30,52 @@ const (
 	Curve25519xSalsa20Poly1305 = "curve25519xsalsa20poly1305"
 )
 
+// Constants for nacl/box implementation of Curve25519xSalsa20Poly1305
 const (
-	InvalidKeySize      = "Invalid key size"
-	UnsupportedSignAlgo = "Unsupported signing algorithm"
-	InvalidSignature    = "Invalid signature"
+	NaClBoxNonceSize = 24
+	NaClBoxKeySize   = 32
 )
 
+const (
+	InvalidPubKeySize       = "Invalid public key size"
+	InvalidPrivKeySize      = "Invalid private key size"
+	InvalidSignature        = "Invalid signature"
+	UnableToGenerateKeyPair = "Unable to generate key pair"
+	UnableToDecrypt         = "Unable to decrypt message"
+	UnsupportedAlgo         = "Unsupported algorithm"
+	UnsupportedSignAlgo     = "Unsupported signing algorithm"
+	UnsupportedEncAlgo      = "Unsupported encryption algorithm"
+)
+
+// GenKeyPair generates a public/private key pair.
+func GenKeyPair(algo string) (common.RawBytes, common.RawBytes, error) {
+	switch strings.ToLower(algo) {
+	case Curve25519xSalsa20Poly1305:
+		pubkey, privkey, err := box.GenerateKey(rand.Reader)
+		if err != nil {
+			return nil, nil, common.NewBasicError(UnableToGenerateKeyPair, err,
+				"algo", algo)
+		}
+		return pubkey[:], privkey[:], nil
+	case Ed25519:
+		pubkey, privkey, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			return nil, nil, common.NewBasicError(UnableToGenerateKeyPair, err,
+				"algo", algo)
+		}
+		return common.RawBytes(pubkey), common.RawBytes(privkey), nil
+	default:
+		return nil, nil, common.NewBasicError(UnsupportedAlgo, nil, "algo", algo)
+	}
+}
+
 // Sign takes a signature input and a signing key to create a signature. Currently only
-// ed25519 is supported
+// ed25519 is supported.
 func Sign(sigInput, signKey common.RawBytes, signAlgo string) (common.RawBytes, error) {
 	switch strings.ToLower(signAlgo) {
 	case Ed25519:
 		if len(signKey) != ed25519.PrivateKeySize {
-			return nil, common.NewBasicError(InvalidKeySize, nil, "expected",
+			return nil, common.NewBasicError(InvalidPrivKeySize, nil, "expected",
 				ed25519.PrivateKeySize, "actual", len(signKey))
 		}
 		return ed25519.Sign(ed25519.PrivateKey(signKey), sigInput), nil
@@ -55,7 +90,7 @@ func Verify(sigInput, sig, verifyKey common.RawBytes, signAlgo string) error {
 	switch strings.ToLower(signAlgo) {
 	case Ed25519:
 		if len(verifyKey) != ed25519.PublicKeySize {
-			return common.NewBasicError(InvalidKeySize, nil,
+			return common.NewBasicError(InvalidPubKeySize, nil,
 				"expected", ed25519.PublicKeySize, "actual", len(verifyKey))
 		}
 		if !ed25519.Verify(ed25519.PublicKey(verifyKey), sigInput, sig) {
@@ -65,4 +100,63 @@ func Verify(sigInput, sig, verifyKey common.RawBytes, signAlgo string) error {
 	default:
 		return common.NewBasicError(UnsupportedSignAlgo, nil, "algo", signAlgo)
 	}
+}
+
+// Encrypt takes a message, a nonce and a public/private keypair and
+// returns the encrypted and authenticated message.
+// Note: Nonce must be different for each message that is encrypted with the same key.
+func Encrypt(msg, nonce, pubkey, privkey common.RawBytes, algo string) (common.RawBytes, error) {
+	switch strings.ToLower(algo) {
+	case Curve25519xSalsa20Poly1305:
+		nonceRaw, pubKeyRaw, privKeyRaw, err := prepNaClBox(nonce, pubkey, privkey)
+		if err != nil {
+			return nil, err
+		}
+		return box.Seal(nil, msg, nonceRaw, pubKeyRaw, privKeyRaw), nil
+	default:
+		return nil, common.NewBasicError(UnsupportedEncAlgo, nil, "algo", algo)
+	}
+}
+
+// Decrypt decrypts a message for a given nonce and public/private keypair.
+func Decrypt(msg, nonce, pubkey, privkey common.RawBytes, algo string) (common.RawBytes, error) {
+	switch strings.ToLower(algo) {
+	case Curve25519xSalsa20Poly1305:
+		nonceRaw, pubKeyRaw, privKeyRaw, err := prepNaClBox(nonce, pubkey, privkey)
+		if err != nil {
+			return nil, err
+		}
+		dec, ok := box.Open(nil, msg, nonceRaw, pubKeyRaw, privKeyRaw)
+		if !ok {
+			return nil, common.NewBasicError(UnableToDecrypt, nil, "algo", algo)
+		}
+		return dec, nil
+	default:
+		return nil, common.NewBasicError(UnsupportedEncAlgo, nil, "algo", algo)
+	}
+}
+
+func prepNaClBox(nonce, pubkey, privkey common.RawBytes) (*[NaClBoxNonceSize]byte,
+	*[NaClBoxKeySize]byte, *[NaClBoxKeySize]byte, error) {
+
+	if len(nonce) != NaClBoxNonceSize {
+		return nil, nil, nil, common.NewBasicError(InvalidNonceSize, nil, "algo",
+			Curve25519xSalsa20Poly1305, "expected size", NaClBoxNonceSize, "actual size",
+			len(nonce))
+	}
+	if len(pubkey) != NaClBoxKeySize {
+		return nil, nil, nil, common.NewBasicError(InvalidPubKeySize, nil, "algo",
+			Curve25519xSalsa20Poly1305, "expected size", NaClBoxKeySize, "actual size", len(pubkey))
+	}
+	if len(privkey) != NaClBoxKeySize {
+		return nil, nil, nil, common.NewBasicError(InvalidPrivKeySize, nil, "algo",
+			Curve25519xSalsa20Poly1305, "expected size", NaClBoxKeySize, "actual size",
+			len(privkey))
+	}
+	var nonceRaw [NaClBoxNonceSize]byte
+	var pubKeyRaw, privKeyRaw [NaClBoxKeySize]byte
+	copy(nonceRaw[:], nonce)
+	copy(pubKeyRaw[:], pubkey)
+	copy(privKeyRaw[:], privkey)
+	return &nonceRaw, &pubKeyRaw, &privKeyRaw, nil
 }

--- a/go/lib/scrypto/asym_test.go
+++ b/go/lib/scrypto/asym_test.go
@@ -1,0 +1,199 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scrypto
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"golang.org/x/crypto/ed25519"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/xtest"
+)
+
+var (
+	// Ed25519 test vectors
+	// Taken from the Python test vectors: http://ed25519.cr.yp.to/python/sign.input
+	Ed25519TestPrivateKey = xtest.MustParseHexString(
+		`b18e1d0045995ec3d010c387ccfeb984d783af8fbb0f40fa7db126d889f6dadd`)
+	Ed25519TestPublicKey = xtest.MustParseHexString(
+		`77f48b59caeda77751ed138b0ec667ff50f8768c25d48309a8f386a2bad187fb`)
+	Ed25519TestMsg = xtest.MustParseHexString(
+		`916c7d1d268fc0e77c1bef238432573c39be577bbea0998936add2b50a653171ce18a542b0b7f96c1691a3be60
+		31522894a8634183eda38798a0c5d5d79fbd01dd04a8646d71873b77b221998a81922d8105f892316369d5224c99
+		83372d2313c6b1f4556ea26ba49d46e8b561e0fc76633ac9766e68e21fba7edca93c4c7460376d7f3ac22ff372c1
+		8f613f2ae2e856af40`)
+	Ed25519TestSignature = xtest.MustParseHexString(
+		`6bd710a368c1249923fc7a1610747403040f0cc30815a00f9ff548a896bbda0b4eb2ca19ebcf917f0f34200a9e
+		dbad3901b64ab09cc5ef7b9bcc3c40c0ff7509`)
+
+	// NaClBox test vectors
+	// Taken from the NaCl distribution:
+	// https://github.com/jedisct1/libsodium/blob/1.0.16/test/default/box.c
+	NaClBoxTestPrivateKey = xtest.MustParseHexString(
+		`77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a`)
+	NaClBoxTestPublicKey = xtest.MustParseHexString(
+		`de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f`)
+	NaClBoxTestNonce = xtest.MustParseHexString(`69696ee955b62b73cd62bda875fc73d68219e0036b7a0b37`)
+	NaClBoxTestMsg   = xtest.MustParseHexString(
+		`be075fc53c81f2d5cf141316ebeb0c7b5228c52a4c62cbd44b66849b64244ffce5ecbaaf33bd751a1ac728d45e
+		6c61296cdc3c01233561f41db66cce314adb310e3be8250c46f06dceea3a7fa1348057e2f6556ad6b1318a024a83
+		8f21af1fde048977eb48f59ffd4924ca1c60902e52f0a089bc76897040e082f937763848645e0705`)
+	NaClBoxTestCiphertext = xtest.MustParseHexString(
+		`f3ffc7703f9400e52a7dfb4b3d3305d98e993b9f48681273c29650ba32fc76ce48332ea7164d96a4476fb8c531
+		a1186ac0dfc17c98dce87b4da7f011ec48c97271d2c20f9b928fe2270d6fb863d51738b48eeee314a7cc8ab93216
+		4548e526ae90224368517acfeabd6bb3732bc0e9da99832b61ca01b6de56244a9e88d5f9b37973f622a43d14a659
+		9b1f654cb45a74e355a5`)
+)
+
+func TestGenKeyPairs(t *testing.T) {
+	Convey("GenKeyPairs should return a valid Curve25519xSalsa20Poly1305 key pair", t, func() {
+		rawPubkey, rawPrivkey, err := GenKeyPair(Curve25519xSalsa20Poly1305)
+		SoMsg("err", err, ShouldBeNil)
+		SoMsg("rawPubkey", len(rawPubkey), ShouldEqual, NaClBoxKeySize)
+		SoMsg("rawPrivkey", len(rawPrivkey), ShouldEqual, NaClBoxKeySize)
+		newPubkey, newPrivkey, err := GenKeyPair(Curve25519xSalsa20Poly1305)
+		SoMsg("err", err, ShouldBeNil)
+		SoMsg("rawPubkey", rawPubkey, ShouldNotResemble, newPubkey)
+		SoMsg("rawPrivkey", rawPrivkey, ShouldNotResemble, newPrivkey)
+	})
+
+	Convey("GenKeyPairs should return a valid Ed25519 key pair", t, func() {
+		rawPubkey, rawPrivkey, err := GenKeyPair(Ed25519)
+		SoMsg("err", err, ShouldBeNil)
+		SoMsg("rawPubkey", len(rawPubkey), ShouldEqual, ed25519.PublicKeySize)
+		SoMsg("rawPrivkey", len(rawPrivkey), ShouldEqual, ed25519.PrivateKeySize)
+		newPubkey, newPrivkey, err := GenKeyPair(Ed25519)
+		SoMsg("err", err, ShouldBeNil)
+		SoMsg("rawPubkey", rawPubkey, ShouldNotResemble, newPubkey)
+		SoMsg("rawPrivkey", rawPrivkey, ShouldNotResemble, newPrivkey)
+	})
+
+	Convey("GenKeyPairs should throw error for unknown algo", t, func() {
+		_, _, err := GenKeyPair("asdf")
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+}
+
+func TestSign(t *testing.T) {
+	// Note from: https://godoc.org/golang.org/x/crypto/ed25519
+	// "...this package's private key representation includes a public key suffix to make
+	// multiple signing operations with the same key more efficient...""
+	privKey := common.RawBytes(ed25519.NewKeyFromSeed(Ed25519TestPrivateKey))
+	Convey("Sign should sign message correctly", t, func() {
+		sig, err := Sign(Ed25519TestMsg, privKey, Ed25519)
+		SoMsg("err", err, ShouldBeNil)
+		SoMsg("sig", sig, ShouldResemble, Ed25519TestSignature)
+	})
+
+	Convey("Sign should throw error for invalid key size", t, func() {
+		_, err := Sign(Ed25519TestMsg, privKey[:63], Ed25519)
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+
+	Convey("Sign should throw error for unknown algo", t, func() {
+		_, err := Sign(Ed25519TestMsg, privKey, "asdf")
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+}
+
+func TestVerify(t *testing.T) {
+	Convey("Verify should verify signature correctly", t, func() {
+		err := Verify(Ed25519TestMsg, Ed25519TestSignature, Ed25519TestPublicKey, Ed25519)
+		SoMsg("err", err, ShouldBeNil)
+	})
+
+	Convey("Verify should throw an error for an invalid signature", t, func() {
+		err := Verify(Ed25519TestMsg, Ed25519TestSignature[:63], Ed25519TestPublicKey, Ed25519)
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+
+	Convey("Verify should throw an error for an invalid key size", t, func() {
+		err := Verify(Ed25519TestMsg, Ed25519TestSignature, Ed25519TestPublicKey[:31], Ed25519)
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+
+	Convey("Verify should throw an error for unknown algo", t, func() {
+		err := Verify(Ed25519TestMsg, Ed25519TestSignature, Ed25519TestPublicKey, "asdf")
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+}
+
+func TestEncrypt(t *testing.T) {
+	Convey("Encrypt should encrypt a plaintext correctly", t, func() {
+		rawCipher, err := Encrypt(NaClBoxTestMsg, NaClBoxTestNonce, NaClBoxTestPublicKey,
+			NaClBoxTestPrivateKey, Curve25519xSalsa20Poly1305)
+		SoMsg("err", err, ShouldBeNil)
+		SoMsg("rawCipher", rawCipher, ShouldResemble, NaClBoxTestCiphertext)
+	})
+
+	Convey("Encrypt should throw error for invalid nonce size", t, func() {
+		_, err := Encrypt(NaClBoxTestMsg, NaClBoxTestNonce[:23], NaClBoxTestPublicKey,
+			NaClBoxTestPrivateKey, Curve25519xSalsa20Poly1305)
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+
+	Convey("Encrypt should throw error for invalid public key size", t, func() {
+		_, err := Encrypt(NaClBoxTestMsg, NaClBoxTestNonce, NaClBoxTestPublicKey[:31],
+			NaClBoxTestPrivateKey, Curve25519xSalsa20Poly1305)
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+
+	Convey("Encrypt should throw error for invalid private key size", t, func() {
+		_, err := Encrypt(NaClBoxTestMsg, NaClBoxTestNonce, NaClBoxTestPublicKey,
+			NaClBoxTestPrivateKey[:31], Curve25519xSalsa20Poly1305)
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+
+	Convey("Encrypt should throw an error for unknown algo", t, func() {
+		_, err := Encrypt(NaClBoxTestMsg, NaClBoxTestNonce, NaClBoxTestPublicKey,
+			NaClBoxTestPrivateKey, "asdf")
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+}
+
+func TestDecrypt(t *testing.T) {
+	Convey("Decrypt should decrypt a ciphertex correctly", t, func() {
+		rawMsg, err := Decrypt(NaClBoxTestCiphertext, NaClBoxTestNonce, NaClBoxTestPublicKey,
+			NaClBoxTestPrivateKey, Curve25519xSalsa20Poly1305)
+		SoMsg("err", err, ShouldBeNil)
+		SoMsg("rawMsg", rawMsg, ShouldResemble, NaClBoxTestMsg)
+	})
+
+	Convey("Decrypt should throw error for invalid nonce size", t, func() {
+		_, err := Decrypt(NaClBoxTestCiphertext, NaClBoxTestNonce[:23], NaClBoxTestPublicKey,
+			NaClBoxTestPrivateKey, Curve25519xSalsa20Poly1305)
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+
+	Convey("Decrypt should throw error for invalid public key size", t, func() {
+		_, err := Decrypt(NaClBoxTestCiphertext, NaClBoxTestNonce, NaClBoxTestPublicKey[:31],
+			NaClBoxTestPrivateKey, Curve25519xSalsa20Poly1305)
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+
+	Convey("Decrypt should throw error for invalid private key size", t, func() {
+		_, err := Decrypt(NaClBoxTestCiphertext, NaClBoxTestNonce, NaClBoxTestPublicKey,
+			NaClBoxTestPrivateKey[:31], Curve25519xSalsa20Poly1305)
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+
+	Convey("Decrypt should throw an error for unknown algo", t, func() {
+		_, err := Decrypt(NaClBoxTestCiphertext, NaClBoxTestNonce, NaClBoxTestPublicKey,
+			NaClBoxTestPrivateKey, "asdf")
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+}

--- a/go/lib/scrypto/rand.go
+++ b/go/lib/scrypto/rand.go
@@ -16,10 +16,16 @@ package scrypto
 
 import (
 	"crypto/rand"
+	"io"
 	mrand "math/rand"
 	"sync"
 
 	"github.com/scionproto/scion/go/lib/common"
+)
+
+const (
+	InvalidNonceSize      = "Invalid nonce size"
+	UnableToGenerateNonce = "Unable to generate nonce"
 )
 
 func RandUint64() uint64 {
@@ -44,4 +50,17 @@ func MathRandSeed() {
 	mathSeedOnce.Do(func() {
 		mrand.Seed(RandInt64())
 	})
+}
+
+// Nonce takes an input length and returns a random nonce of the given length.
+func Nonce(l int) (common.RawBytes, error) {
+	if l <= 0 {
+		return nil, common.NewBasicError(InvalidNonceSize, nil)
+	}
+	nonce := make([]byte, l)
+	_, err := io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		return nil, common.NewBasicError(UnableToGenerateNonce, err)
+	}
+	return nonce, nil
 }

--- a/go/lib/scrypto/rand_test.go
+++ b/go/lib/scrypto/rand_test.go
@@ -1,0 +1,33 @@
+package scrypto
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestNonce(t *testing.T) {
+	Convey("Nonce should return a random byte sequence", t, func() {
+		rawNonce, err := Nonce(32)
+		SoMsg("err", err, ShouldBeNil)
+		newNonce, err := Nonce(32)
+		SoMsg("err", err, ShouldBeNil)
+		SoMsg("rawNonce", rawNonce, ShouldNotResemble, newNonce)
+	})
+
+	Convey("Nonce length is equal to input", t, func() {
+		rawNonce, err := Nonce(24)
+		SoMsg("err", err, ShouldBeNil)
+		SoMsg("rawNonce", len(rawNonce), ShouldResemble, 24)
+		rawNonce, err = Nonce(32)
+		SoMsg("err", err, ShouldBeNil)
+		SoMsg("rawNonce", len(rawNonce), ShouldResemble, 32)
+	})
+
+	Convey("Nonce should throw an error for an invalid length", t, func() {
+		_, err := Nonce(0)
+		SoMsg("err", err, ShouldNotBeNil)
+		_, err = Nonce(-1)
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+}

--- a/go/lib/xtest/helpers.go
+++ b/go/lib/xtest/helpers.go
@@ -157,7 +157,7 @@ func MustParseAS(s string) addr.AS {
 // It panics if the decoding fails.
 func MustParseHexString(s string) common.RawBytes {
 	// remove whitespace
-	reg, err := regexp.Compile(`[\s]+`)
+	reg, err := regexp.Compile(`\s+`)
 	if err != nil {
 		panic(err)
 	}

--- a/go/lib/xtest/helpers.go
+++ b/go/lib/xtest/helpers.go
@@ -16,12 +16,16 @@ package xtest
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
+
+	"github.com/scionproto/scion/go/lib/common"
 
 	"github.com/scionproto/scion/go/lib/addr"
 )
@@ -140,11 +144,28 @@ func MustParseIA(s string) addr.IA {
 }
 
 // MustParseAS parses s and returns the corresponding addr.AS object. It panics
-// if s is not valid AS representation
+// if s is not valid AS representation.
 func MustParseAS(s string) addr.AS {
 	ia, err := addr.ASFromString(s)
 	if err != nil {
 		panic(err)
 	}
 	return ia
+}
+
+// MustParseHexString parses s and returns the corresponding byte slice.
+// It panics if the decoding fails.
+func MustParseHexString(s string) common.RawBytes {
+	// remove whitespace
+	reg, err := regexp.Compile(`[\s]+`)
+	if err != nil {
+		panic(err)
+	}
+	s = reg.ReplaceAllString(s, "")
+
+	decoded, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return decoded
 }

--- a/go/tools/scion-pki/internal/keys/gen.go
+++ b/go/tools/scion-pki/internal/keys/gen.go
@@ -23,11 +23,11 @@ import (
 	"path/filepath"
 
 	"golang.org/x/crypto/ed25519"
-	"golang.org/x/crypto/nacl/box"
 
 	"github.com/scionproto/scion/go/lib/as_conf"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust"
+	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/conf"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
 )
@@ -116,19 +116,19 @@ func genKey(fname, outDir string, keyGenF keyGenFunc) error {
 }
 
 func genSignKey(rand io.Reader) ([]byte, error) {
-	_, private, err := ed25519.GenerateKey(rand)
+	_, private, err := scrypto.GenKeyPair(scrypto.Ed25519)
 	if err != nil {
 		return nil, err
 	}
-	return private.Seed(), nil
+	return ed25519.PrivateKey(private).Seed(), nil
 }
 
 func genEncKey(rand io.Reader) ([]byte, error) {
-	_, private, err := box.GenerateKey(rand)
+	_, private, err := scrypto.GenKeyPair(scrypto.Curve25519xSalsa20Poly1305)
 	if err != nil {
 		return nil, err
 	}
-	return (*private)[:], nil
+	return private, nil
 }
 
 func genMasterKey(rand io.Reader) ([]byte, error) {


### PR DESCRIPTION
This PR implements functionality for asymmetric encryption and decryption based on the currently used certificates. This will be required for the first order DRKey exchange.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1594)
<!-- Reviewable:end -->
