### PR TITLE
Some prep work for per-app docker containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
 
     build:
         docker:
-            - image: scionproto/scion_base@sha256:b07539c503ebcb24b81da93daddb237763d604fef1d3fc0c6d6112362cf4edd7
+            - image: scionproto/scion_base@sha256:62261e1528f28c28e76f95b69be50002006af4fa9fad6d4931f317bfbab1043c
         <<: *job
         steps:
             - checkout

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 SRC_DIRS = c/lib/scion c/lib/filter sub/lwip-contrib c/lib/tcp c/dispatcher
 
-all: clibs dispatcher go
+all: tags clibs dispatcher go
 
 clean:
 	$(foreach var,$(SRC_DIRS),$(MAKE) -C $(var) clean || exit 1;)
@@ -42,4 +42,4 @@ uninstall:
 	$(foreach var,$(SRC_DIRS),$(MAKE) -C $(var) uninstall || exit 1;)
 
 tags:
-	{ git ls-files; git submodule --quiet foreach 'git ls-files | sed "s|^|$$path/|"'; } | ctags -L -
+	which ctags >/dev/null 2>&1 || exit 0; { git ls-files; git submodule --quiet foreach 'git ls-files | sed "s|^|$$path/|"'; } | ctags -L -

--- a/c/dispatcher/Makefile
+++ b/c/dispatcher/Makefile
@@ -2,7 +2,7 @@
 
 CC = clang
 CFLAGS ?= -Wall -Werror -g -O2
-LDFLAGS ?= -lpthread -lzlog -Wl,-Bstatic -ltcpmw -llwip -lfilter -lscion -Wl,-Bdynamic
+LDFLAGS ?= -lpthread -Wl,-Bstatic -lzlog -ltcpmw -llwip -lfilter -lscion -Wl,-Bdynamic
 
 LIB_DIR = ../lib
 LWIPDIR = ../../sub/lwip/src/include

--- a/c/dispatcher/dispatcher.c
+++ b/c/dispatcher/dispatcher.c
@@ -176,7 +176,7 @@ int main(int argc, char **argv)
     if (!zlog_cfg)
         zlog_cfg = "c/dispatcher/dispatcher.conf";
     if (zlog_init(zlog_cfg) < 0) {
-        fprintf(stderr, "failed to init zlog (cfg: %s)\n", zlog_cfg);
+        fprintf(stderr, "failed to init zlog (cfg: %s): %s\n", zlog_cfg, strerror(errno));
         return -1;
     }
     zc = zlog_get_category("dispatcher");

--- a/docker.sh
+++ b/docker.sh
@@ -31,6 +31,12 @@ cmd_build() {
     docker_build
 }
 
+cmd_app() {
+    set -e
+    set -o pipefail
+    docker build $DOCKER_ARGS -t "scion_app" - < docker/Dockerfile.app
+}
+
 
 copy_tree() {
     set -e
@@ -137,7 +143,9 @@ del_imgs() {
 cmd_help() {
 	cat <<-_EOF
 	Usage:
+	    $PROGRAM base
 	    $PROGRAM build
+	    $PROGRAM app
 	    $PROGRAM run
 	        Run the Docker image.
 	    $PROGRAM clean
@@ -165,6 +173,7 @@ fi
 case $COMMAND in
     base)               cmd_base ;;
     build)              cmd_build ;;
+    app)                cmd_app ;;
     clean)              shift; cmd_clean "$@" ;;
     run)                shift; cmd_run "$@" ;;
     help)               cmd_help ;;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,9 @@ RUN sudo chown -R scion: $BASE
 # Restore the go dependency cache from scion_base
 RUN tar xf ~/go_vendor.tar.gz -C go/vendor/
 
+# Restore the python dependency cache from scion_base
+RUN tar xf ~/python_local.tar.gz -C ~
+
 # Make sure dependencies haven't been changed since scion_base was rebuilt
 RUN docker/deps_check
 

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -1,3 +1,5 @@
 FROM scion:latest
 
+RUN sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y strace
+
 RUN make -s

--- a/docker/Dockerfile.app
+++ b/docker/Dockerfile.app
@@ -1,0 +1,3 @@
+FROM scion:latest
+
+RUN make -s

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -6,10 +6,13 @@ ENV PATH /usr/local/go/bin:$GOPATH/bin:$HOME/.local/bin:$PATH
 
 WORKDIR $BASE
 
+# Use eatmydata to speed up a lot of the building
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y eatmydata sudo && apt-get clean
-# eatmydata to speed up a lot of the building
-RUN ln -s /usr/bin/eatmydata /usr/local/bin/apt-get
-RUN ln -s /usr/bin/eatmydata /usr/local/bin/dpkg
+RUN set -ex; \
+    ln -s /usr/bin/eatmydata /usr/local/bin/apt-get; \
+    ln -s /usr/bin/eatmydata /usr/local/bin/dpkg; \
+    ln -s /usr/bin/eatmydata /usr/local/bin/pip; \
+    ln -s /usr/bin/eatmydata /usr/local/bin/pip3
 
 RUN useradd -s /bin/bash scion
 RUN echo "scion ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/scion
@@ -30,9 +33,14 @@ COPY env/common.sh env/
 COPY env/debian env/debian
 RUN sudo apt-get update && APTARGS=-y env/debian/deps && sudo apt-get clean
 
-# Pip3 packages
+# Pip packages
 COPY env/pip3 env/pip3
-RUN env/pip3/deps && rm -r ~/.cache/pip
+COPY env/pip2 env/pip2
+RUN set -ex; \
+    env/pip2/deps; \
+    env/pip3/deps; \
+    tar czf ~/python_local.tar.gz --owner=scion -C ~ .local; \
+    rm -r ~/.cache/pip ~/.local
 
 # Pip2 packages
 COPY env/pip2 env/pip2
@@ -40,11 +48,11 @@ RUN env/pip2/deps && rm -r ~/.cache/pip
 
 # zlog packages
 COPY env/zlog env/zlog
-RUN env/zlog/deps
+RUN eatmydata env/zlog/deps
 
 # Go version check, and govendor
 COPY env/go env/go
-RUN GO_INSTALL=y env/go/deps
+RUN GO_INSTALL=y eatmydata env/go/deps && rm -r ~/go/pkg/
 
 # Cleanup
 RUN sudo rm -r env
@@ -52,10 +60,14 @@ RUN sudo rm -r env
 # Vendored go packages
 COPY go/vendor/ go/vendor
 RUN sudo chown -R scion .
-RUN \
-    set -ex; cd go; govendor sync -v; govendor install ./vendor/...; \
-    cd vendor; tar caf ~/go_vendor.tar.gz --owner=scion $(find * -maxdepth 0 -type d); \
-    cd ../../; rm -r go ~/go/.cache
+RUN set -ex; \
+    cd go; \
+    eatmydata govendor sync -v; \
+    eatmydata govendor install ./vendor/...; \
+    cd vendor; \
+    tar caf ~/go_vendor.tar.gz --owner=scion $(find * -maxdepth 0 -type d); \
+    cd ../../; \
+    rm -r go ~/go/.cache ~/go/pkg/
 
 #################################################################################
 ## Dependencies are now installed, carry on with the rest.

--- a/env/common.sh
+++ b/env/common.sh
@@ -32,6 +32,10 @@ pip_install() {
     "$pip" --disable-pip-version-check install --user --require-hashes -r "$req"
 }
 
+sudo_preload() {
+    LD_PRELOAD= sudo LD_PRELOAD="$LD_PRELOAD" "$@"
+}
+
 if [ -t 1 ]; then
     CURL_PARAM="-#"
 else

--- a/env/go/deps
+++ b/env/go/deps
@@ -18,7 +18,7 @@ go_check_install() {
         go_ver_check && return
         go_ver_msg
     fi
-    [ -d /usr/local/go ] && sudo rm -r /usr/local/go
+    [ -d /usr/local/go ] && sudo_preload rm -r /usr/local/go
     go_install
 }
 
@@ -61,7 +61,7 @@ go_install() {
     curl -L $CURL_PARAM "$src" -o "$file"
     echo "$sum $file" | sha256sum -c -
     echo "Installing to /usr/local/go. Ensure that /usr/local/go/bin is in your \$PATH"
-    sudo tar -C /usr/local -xf "$file"
+    sudo_preload tar -C /usr/local -xf "$file"
     rm -r "${tmpdir:?}"
 }
 

--- a/env/zlog/deps
+++ b/env/zlog/deps
@@ -13,7 +13,7 @@ curl -L $CURL_PARAM https://github.com/HardySimpson/zlog/archive/1.2.12.tar.gz |
 make -sj6
 echo "ldconfig" >> postinstall-pak
 echo "ldconfig" >> postremove-pak
-sudo checkinstall -D --pkgname zlog --nodoc -y --deldoc --deldesc --strip=no --stripso=no --pkgversion 1.2.12 &> checkinstall.log || cat checkinstall.log
-sudo rm *deb
+sudo_preload checkinstall -D --pkgname zlog --nodoc -y --deldoc --deldesc --strip=no --stripso=no --pkgversion 1.2.12 &> checkinstall.log || cat checkinstall.log
+sudo_preload rm *deb
 cd -
 rm -r "${tmpdir:?}"

--- a/tools/ci/build_prep
+++ b/tools/ci/build_prep
@@ -6,6 +6,8 @@ git submodule sync --recursive
 git submodule update --init --recursive
 # Restore the go dependency cache from scion_base
 tar xf ~/go_vendor.tar.gz -C go/vendor/
+# Restore the python dependency cache from scion_base
+tar xf ~/python_local.tar.gz -C ~
 # Ensure none of the dependency information has changed since scion_base was
 # last built. If any has, exit non-zero at the end of this step.
 ./docker/deps_check || rt=1


### PR DESCRIPTION
docker:
- Use eatmydata more liberally to speed things up.
- Make a tarball of the pip3/pip2 installation in base for later use.
- Clean up some formatting.
- Add a new Dockerfile (docker/Dockerfile.app) that is based on the
  normal docker image, but compiles all the code.
dispatcher:
- Statically link dispatcher against libzlog to ease dockerizing.
- Include the strerror in the output of zlog_init fails.

Also:
- Run ctags by default if it's installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1605)
<!-- Reviewable:end -->
