### PR TITLE
Remove shadowing of original error with connection

### DIFF
--- a/go/lib/infra/transport/packet_transport.go
+++ b/go/lib/infra/transport/packet_transport.go
@@ -70,7 +70,7 @@ func (u *PacketTransport) SendUnreliableMsgTo(ctx context.Context, b common.RawB
 	}
 	n, err := u.conn.WriteTo(b, address)
 	if n != len(b) {
-		return common.NewBasicError("Wrote incomplete message", nil, "wrote", n, "expected", len(b))
+		return common.NewBasicError("Wrote incomplete message", err, "wrote", n, "expected", len(b))
 	}
 	return err
 }


### PR DESCRIPTION
If err != nil then return the actual error, that helps a lot while debugging

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1615)
<!-- Reviewable:end -->
