### PR TITLE
Make protos consistent between go and python

### DIFF
--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -191,8 +191,7 @@ func (ps *PathSegment) VerifyASEntry(key common.RawBytes, idx int) error {
 }
 
 func (ps *PathSegment) sigPack(idx int) (common.RawBytes, error) {
-	err := ps.validateIdx(idx)
-	if err != nil {
+	if err := ps.validateIdx(idx); err != nil {
 		return nil, err
 	}
 	data := append(common.RawBytes(nil), ps.RawSData...)

--- a/python/lib/packet/pcb.py
+++ b/python/lib/packet/pcb.py
@@ -171,11 +171,12 @@ class PathSegment(Cerealizable):
         if idx is None:
             idx = len(self.p.asEntries) - 1
         b = [self.p.sdata]
-        for i in range(idx+1):
+        for i in range(idx):
             sblob = self.p.asEntries[i]
             b.append(sblob.blob)
             ssign = ProtoSign(sblob.sign)
-            b.append(ssign.sig_pack(i != idx))
+            b.append(ssign.sig_pack())
+        b.append(self.p.asEntries[idx].blob)
         return b"".join(b)
 
     def add_asm(self, asm, sig_type=ProtoSignType.NONE, sig_src=b""):  # pragma: no cover

--- a/python/lib/packet/proto_sign.py
+++ b/python/lib/packet/proto_sign.py
@@ -75,14 +75,14 @@ class ProtoSign(Cerealizable):
             raise ProtoSignError("Unsupported proto signature type (verify): %s" % self.p.type)
 
     def sig_pack(self, incl_sig=True):
-        # FIXME(worxli) #1524
         b = [str(self.p.type).encode("utf-8"), self.p.src]
         if incl_sig:
             b.append(self.p.signature)
+        b.append(self.p.timestamp.to_bytes(8, 'big'))
         return b"".join(b)
 
     def _sig_input(self, msg):
-        return b"".join([self.sig_pack(False), msg])
+        return b"".join([msg, self.sig_pack(incl_sig=False)])
 
     def __str__(self):
         return "%s: type: %s src: %s ts: %s" % (self.NAME, self.p.type,

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -464,7 +464,7 @@ class SCIONElement(object):
         try:
             self._verify_path_seg(seg_meta)
         except SCIONVerificationError as e:
-            logging.error("Signature verification failed for %s: %s" %
+            logging.error("Signature verification of segment failed for %s: %s" %
                           (seg_meta.seg.short_id(), e))
             return
         with self.unv_segs_lock:


### PR DESCRIPTION
Make proto signature equal in go and python

- Add timestamp to sign in python
- Add non-signature fields into signature in go
- Make signature fields order consistent
- Fix ASEntry sign method in python

Fixes #1524. Fixes #1617.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1618)
<!-- Reviewable:end -->
