### PR TITLE
Consistent timestamps

### DIFF
--- a/go/cert_srv/cert.go
+++ b/go/cert_srv/cert.go
@@ -46,7 +46,7 @@ func (h *ChainHandler) HandleReq(a *snet.Addr, req *cert_mgmt.ChainReq, config *
 	var chain *cert.Chain
 	if req.Version == cert_mgmt.NewestVersion {
 		chain = config.Store.GetNewestChain(req.IA())
-		if chain != nil && chain.Leaf.VerifyTime(uint64(time.Now().Unix())) != nil {
+		if chain != nil && chain.Leaf.VerifyTime(uint32(time.Now().Unix())) != nil {
 			chain = nil
 		}
 	} else {

--- a/go/cert_srv/reiss_handler.go
+++ b/go/cert_srv/reiss_handler.go
@@ -167,7 +167,7 @@ func (h *ReissHandler) issueChain(c *cert.Certificate, vKey common.RawBytes,
 	chain := &cert.Chain{Leaf: c.Copy(), Issuer: issCert}
 	chain.Leaf.CanIssue = false
 	chain.Leaf.TRCVersion = chain.Issuer.TRCVersion
-	chain.Leaf.IssuingTime = uint64(time.Now().Unix())
+	chain.Leaf.IssuingTime = uint32(time.Now().Unix())
 	chain.Leaf.ExpirationTime = chain.Leaf.IssuingTime + cert.DefaultLeafCertValidity
 	// Leaf certificate must expire before issuer certificate
 	if chain.Issuer.ExpirationTime < chain.Leaf.ExpirationTime {

--- a/go/cert_srv/reiss_tasks.go
+++ b/go/cert_srv/reiss_tasks.go
@@ -84,7 +84,7 @@ func (s *SelfIssuer) createLeafCert(leaf *cert.Certificate, config *conf.Conf) e
 	}
 	chain := &cert.Chain{Leaf: leaf.Copy(), Issuer: issCrt}
 	chain.Leaf.Version += 1
-	chain.Leaf.IssuingTime = uint64(time.Now().Unix())
+	chain.Leaf.IssuingTime = uint32(time.Now().Unix())
 	chain.Leaf.CanIssue = false
 	chain.Leaf.ExpirationTime = chain.Leaf.IssuingTime + cert.DefaultLeafCertValidity
 	if chain.Issuer.ExpirationTime < chain.Leaf.ExpirationTime {
@@ -115,7 +115,7 @@ func (s *SelfIssuer) createIssuerCert(config *conf.Conf) error {
 		return err
 	}
 	crt.Version += 1
-	crt.IssuingTime = uint64(time.Now().Unix())
+	crt.IssuingTime = uint32(time.Now().Unix())
 	crt.CanIssue = true
 	crt.ExpirationTime = crt.IssuingTime + cert.DefaultIssuerCertValidity
 	coreAS, err := s.getCoreASEntry(config)
@@ -222,7 +222,7 @@ func (r *ReissRequester) Run() {
 // currently active certificate chain.
 func (r *ReissRequester) sendReq(chain *cert.Chain, config *conf.Conf) error {
 	c := chain.Leaf.Copy()
-	c.IssuingTime = uint64(time.Now().Unix())
+	c.IssuingTime = uint32(time.Now().Unix())
 	c.ExpirationTime = c.IssuingTime + (chain.Leaf.ExpirationTime - chain.Leaf.IssuingTime)
 	c.Version += 1
 	if err := c.Sign(config.GetSigningKey(), chain.Leaf.SignAlgorithm); err != nil {

--- a/go/lib/crypto/cert/cert.go
+++ b/go/lib/crypto/cert/cert.go
@@ -46,11 +46,11 @@ type Certificate struct {
 	// EncAlgorithm is the algorithm associated with SubjectEncKey.
 	EncAlgorithm string
 	// ExpirationTime is the unix timestamp in seconds at which the certificate expires.
-	ExpirationTime uint64
+	ExpirationTime uint32
 	// Issuer is the certificate issuer. It can only be a issuing AS.
 	Issuer addr.IA
 	// IssuingTime is the unix timestamp in seconds at which the certificate was created.
-	IssuingTime uint64
+	IssuingTime uint32
 	// SignAlgorithm is the algorithm associated with SubjectSigKey.
 	SignAlgorithm string
 	// Signature is the certificate signature. It is computed over the rest of the certificate.
@@ -86,7 +86,7 @@ func (c *Certificate) Verify(subject addr.IA, verifyKey common.RawBytes, signAlg
 		return common.NewBasicError(InvalidSubject, nil,
 			"expected", c.Subject, "actual", subject)
 	}
-	if err := c.VerifyTime(uint64(time.Now().Unix())); err != nil {
+	if err := c.VerifyTime(uint32(time.Now().Unix())); err != nil {
 		return err
 	}
 	return c.VerifySignature(verifyKey, signAlgo)
@@ -94,7 +94,7 @@ func (c *Certificate) Verify(subject addr.IA, verifyKey common.RawBytes, signAlg
 
 // VerifyTime checks that the time ts is between issuing and expiration time. This function does
 // not check the validity of the signature.
-func (c *Certificate) VerifyTime(ts uint64) error {
+func (c *Certificate) VerifyTime(ts uint32) error {
 	if ts < c.IssuingTime {
 		return common.NewBasicError(EarlyUsage, nil,
 			"IssuingTime", util.TimeToString(util.USecsToTime(c.IssuingTime)),

--- a/go/lib/crypto/cert/cert_test.go
+++ b/go/lib/crypto/cert/cert_test.go
@@ -84,7 +84,7 @@ func Test_Certificate_Verify(t *testing.T) {
 		subject := addr.IA{I: 1, A: 0xff0000000311}
 		pubRaw, privRaw := []byte(pub), []byte(priv)
 
-		cert.IssuingTime = uint64(time.Now().Unix())
+		cert.IssuingTime = uint32(time.Now().Unix())
 		cert.ExpirationTime = cert.IssuingTime + 1<<20
 		cert.Sign(privRaw, crypto.Ed25519)
 
@@ -116,7 +116,7 @@ func Test_Certificate_Verify(t *testing.T) {
 		})
 
 		Convey("Early usage throws error", func() {
-			cert.IssuingTime = uint64(time.Now().Unix()) + 1<<20
+			cert.IssuingTime = uint32(time.Now().Unix()) + 1<<20
 			cert.ExpirationTime = cert.IssuingTime + 1<<20
 			cert.Sign(privRaw, crypto.Ed25519)
 			err := cert.Verify(subject, pubRaw, crypto.Ed25519)
@@ -124,8 +124,8 @@ func Test_Certificate_Verify(t *testing.T) {
 		})
 
 		Convey("Late usage throws error", func() {
-			cert.IssuingTime = uint64(time.Now().Unix()) - 1<<20
-			cert.ExpirationTime = uint64(time.Now().Unix()) - 1
+			cert.IssuingTime = uint32(time.Now().Unix()) - 1<<20
+			cert.ExpirationTime = uint32(time.Now().Unix()) - 1
 			cert.Sign(privRaw, crypto.Ed25519)
 			err := cert.Verify(subject, pubRaw, crypto.Ed25519)
 			SoMsg("err", err, ShouldNotBeNil)

--- a/go/lib/crypto/cert/chain_test.go
+++ b/go/lib/crypto/cert/chain_test.go
@@ -85,12 +85,12 @@ func Test_Chain_Verify(t *testing.T) {
 		pubTRCRaw, privTRCRaw := []byte(pub), []byte(priv)
 		trc_ := loadTRC(fnTRC, t)
 
-		chain.Leaf.IssuingTime = uint64(time.Now().Unix())
+		chain.Leaf.IssuingTime = uint32(time.Now().Unix())
 		chain.Leaf.ExpirationTime = chain.Leaf.IssuingTime + 1<<20
 		chain.Leaf.Sign(privCoreRaw, crypto.Ed25519)
 
 		chain.Issuer.SubjectSignKey = pubCoreRaw
-		chain.Issuer.IssuingTime = uint64(time.Now().Unix())
+		chain.Issuer.IssuingTime = uint32(time.Now().Unix())
 		chain.Issuer.ExpirationTime = chain.Leaf.IssuingTime + 1<<20
 		chain.Issuer.Sign(privTRCRaw, crypto.Ed25519)
 

--- a/go/lib/crypto/trc/trc.go
+++ b/go/lib/crypto/trc/trc.go
@@ -79,14 +79,14 @@ type TRC struct {
 	// CoreASes is a map from core ASes to their online and offline key.
 	CoreASes map[addr.IA]*CoreAS
 	// CreationTime is the unix timestamp in seconds at which the TRC was created.
-	CreationTime uint64
+	CreationTime uint32
 	// Description is an human-readable description of the ISD.
 	Description string
 	// ExpirationTime is the unix timestamp in seconds at which the TRC expires.
-	ExpirationTime uint64
+	ExpirationTime uint32
 	// GracePeriod is the period during which the TRC is valid after creation of a new TRC in
 	// seconds.
-	GracePeriod uint64
+	GracePeriod uint32
 	// ISD is the integer identifier from 1 to 4095.
 	ISD addr.ISD
 	// Quarantine describes if the TRC is an early announcement (true) or valid (false).
@@ -168,7 +168,7 @@ func (t *TRC) CheckActive(maxTRC *TRC) error {
 	if t.Quarantine {
 		return common.NewBasicError(EarlyAnnouncement, nil)
 	}
-	currTime := uint64(time.Now().Unix())
+	currTime := uint32(time.Now().Unix())
 	if currTime < t.CreationTime {
 		return common.NewBasicError(EarlyUsage, nil,
 			"now", timeToString(currTime), "creation", timeToString(t.CreationTime))
@@ -324,6 +324,6 @@ func (t *TRC) String() string {
 	return fmt.Sprintf("TRC %dv%d", t.ISD, t.Version)
 }
 
-func timeToString(t uint64) string {
+func timeToString(t uint32) string {
 	return util.TimeToString(util.USecsToTime(t))
 }

--- a/go/lib/crypto/trc/trc_test.go
+++ b/go/lib/crypto/trc/trc_test.go
@@ -190,9 +190,9 @@ func Test_TRC_CheckActive(t *testing.T) {
 		t2 := loadTRC(fnTRC, t)
 		t2.Version += 1
 
-		t1.CreationTime = uint64(time.Now().Unix())
+		t1.CreationTime = uint32(time.Now().Unix())
 		t1.ExpirationTime = t1.CreationTime + 1<<20
-		t2.CreationTime = uint64(time.Now().Unix())
+		t2.CreationTime = uint32(time.Now().Unix())
 		t2.ExpirationTime = t2.CreationTime + 1<<20
 
 		Convey("TRC is active", func() {
@@ -200,12 +200,12 @@ func Test_TRC_CheckActive(t *testing.T) {
 			SoMsg("err", err, ShouldBeNil)
 		})
 		Convey("Early usage", func() {
-			t1.CreationTime = uint64(time.Now().Unix()) + 1<<20
+			t1.CreationTime = uint32(time.Now().Unix()) + 1<<20
 			err := t1.CheckActive(t2)
 			SoMsg("err", err, ShouldNotBeNil)
 		})
 		Convey("Late usage", func() {
-			t1.ExpirationTime = uint64(time.Now().Unix()) - 1<<20
+			t1.ExpirationTime = uint32(time.Now().Unix()) - 1<<20
 			err := t1.CheckActive(t2)
 			SoMsg("err", err, ShouldNotBeNil)
 		})

--- a/go/lib/ctrl/path_mgmt/rev_info.go
+++ b/go/lib/ctrl/path_mgmt/rev_info.go
@@ -53,7 +53,7 @@ type RevInfo struct {
 	RawIsdas addr.IAInt `capnp:"isdas"`
 	// LinkType of revocation
 	LinkType     proto.LinkType
-	RawTimestamp uint64 `capnp:"timestamp"`
+	RawTimestamp uint32 `capnp:"timestamp"`
 	// RawTTL validity period of the revocation in seconds
 	RawTTL uint32 `capnp:"ttl"`
 }

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -199,7 +199,7 @@ func (fpm *FwdPathMeta) DstIA() addr.IA {
 }
 
 func (fpm *FwdPathMeta) Expiry() time.Time {
-	return util.USecsToTime(uint64(fpm.ExpTime))
+	return util.USecsToTime(uint32(fpm.ExpTime))
 }
 
 func (fpm *FwdPathMeta) String() string {

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -199,7 +199,7 @@ func (fpm *FwdPathMeta) DstIA() addr.IA {
 }
 
 func (fpm *FwdPathMeta) Expiry() time.Time {
-	return util.USecsToTime(uint32(fpm.ExpTime))
+	return util.USecsToTime(fpm.ExpTime)
 }
 
 func (fpm *FwdPathMeta) String() string {

--- a/go/lib/util/time.go
+++ b/go/lib/util/time.go
@@ -20,8 +20,8 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 )
 
-// USecsToTime takes seconds stored in a uint64.
-func USecsToTime(t uint64) time.Time {
+// USecsToTime takes seconds stored in a uint32.
+func USecsToTime(t uint32) time.Time {
 	return time.Unix(int64(t), 0)
 }
 

--- a/go/proto/sign.go
+++ b/go/proto/sign.go
@@ -26,7 +26,7 @@ import (
 var _ Cerealizable = (*SignS)(nil)
 
 type SignS struct {
-	Timestamp uint64
+	Timestamp uint32
 	Type      SignType
 	// Src holds the required metadata to verify the signature. The format is "STRING: METADATA".
 	// The prefix consists of "STRING: " and is required to match the regex "^\w+\: ".
@@ -63,7 +63,7 @@ func (s *SignS) Sign(key, message common.RawBytes) (common.RawBytes, error) {
 
 func (s *SignS) SignAndSet(key, message common.RawBytes) error {
 	var err error
-	s.Timestamp = uint64(time.Now().Unix())
+	s.Timestamp = uint32(time.Now().Unix())
 	s.Signature, err = s.Sign(key, message)
 	return err
 }
@@ -97,8 +97,8 @@ func (s *SignS) sigPack(msg common.RawBytes, inclSig bool) common.RawBytes {
 	if inclSig {
 		msg = append(msg, s.Signature...)
 	}
-	t := make(common.RawBytes, 8)
-	common.Order.PutUint64(t, s.Timestamp)
+	t := make(common.RawBytes, 4)
+	common.Order.PutUint32(t, s.Timestamp)
 	return append(msg, t...)
 }
 

--- a/go/tools/scion-pki/internal/certs/gen.go
+++ b/go/tools/scion-pki/internal/certs/gen.go
@@ -227,9 +227,9 @@ func genCertCommon(bc *conf.BaseCert, s addr.IA, signKeyFname string) (*cert.Cer
 	// Determine issuingTime and calculate expiration time from validity.
 	issuingTime := bc.IssuingTime
 	if issuingTime == 0 {
-		issuingTime = uint64(time.Now().Unix())
+		issuingTime = uint32(time.Now().Unix())
 	}
-	expirationTime := issuingTime + uint64(bc.Validity.Seconds())
+	expirationTime := issuingTime + uint32(bc.Validity.Seconds())
 	return &cert.Certificate{
 		Comment:        bc.Comment,
 		SubjectSignKey: signPub,

--- a/go/tools/scion-pki/internal/conf/as.go
+++ b/go/tools/scion-pki/internal/conf/as.go
@@ -153,7 +153,7 @@ type BaseCert struct {
 	Comment       string        `comment:"Description of the AS and certificate"`
 	EncAlgorithm  string        `comment:"Encryption algorithm used by AS, e.g., curve25519xsalsa20poly1305"`
 	SignAlgorithm string        `comment:"Signing algotirhm used by AS, e.g., ed25519"`
-	IssuingTime   uint64        `comment:"Time of issuance as UNIX epoch. If 0 will be set to now."`
+	IssuingTime   uint32        `comment:"Time of issuance as UNIX epoch. If 0 will be set to now."`
 	TRCVersion    uint64        `comment:"The version of the current TRC"`
 	Version       uint64        `comment:"The version of the certificate. Cannot be 0"`
 	Validity      time.Duration `ini:"-"`

--- a/go/tools/scion-pki/internal/conf/isd.go
+++ b/go/tools/scion-pki/internal/conf/isd.go
@@ -101,7 +101,7 @@ func (i *Isd) Write(path string, force bool) error {
 // Trc holds the parameters that are used to generate a Trc.
 type Trc struct {
 	Version        uint64        `comment:"The version of the TRC. Must not be 0."`
-	IssuingTime    uint64        `comment:"Time of issuance as UNIX epoch. If 0 will be set to now."`
+	IssuingTime    uint32        `comment:"Time of issuance as UNIX epoch. If 0 will be set to now."`
 	Validity       time.Duration `ini:"-"`
 	RawValidity    string        `ini:"Validity" comment:"The validity of the certificate as duration string, e.g., 180d or 36h"`
 	CoreIAs        []addr.IA     `ini:"-"`
@@ -113,7 +113,7 @@ type Trc struct {
 
 func (t *Trc) validate() error {
 	if t.IssuingTime == 0 {
-		t.IssuingTime = uint64(time.Now().Unix())
+		t.IssuingTime = uint32(time.Now().Unix())
 	}
 	if t.Version == 0 {
 		return common.NewBasicError(ErrTrcVersionNotSet, nil)

--- a/go/tools/scion-pki/internal/trc/gen.go
+++ b/go/tools/scion-pki/internal/trc/gen.go
@@ -79,13 +79,13 @@ func genTrc(isd addr.ISD) error {
 func newTrc(isd addr.ISD, iconf *conf.Isd, path string) (*trc.TRC, error) {
 	issuingTime := iconf.Trc.IssuingTime
 	if issuingTime == 0 {
-		issuingTime = uint64(time.Now().Unix())
+		issuingTime = uint32(time.Now().Unix())
 	}
 	t := &trc.TRC{
 		CreationTime:   iconf.Trc.IssuingTime,
 		Description:    iconf.Desc,
-		ExpirationTime: issuingTime + uint64(iconf.Trc.Validity.Seconds()),
-		GracePeriod:    uint64(iconf.Trc.GracePeriod),
+		ExpirationTime: issuingTime + uint32(iconf.Trc.Validity.Seconds()),
+		GracePeriod:    uint32(iconf.Trc.GracePeriod),
 		ISD:            isd,
 		QuorumTRC:      iconf.Trc.QuorumTRC,
 		Version:        iconf.Trc.Version,

--- a/go/tools/scion-pki/internal/trc/gen.go
+++ b/go/tools/scion-pki/internal/trc/gen.go
@@ -85,7 +85,7 @@ func newTrc(isd addr.ISD, iconf *conf.Isd, path string) (*trc.TRC, error) {
 		CreationTime:   iconf.Trc.IssuingTime,
 		Description:    iconf.Desc,
 		ExpirationTime: issuingTime + uint32(iconf.Trc.Validity.Seconds()),
-		GracePeriod:    uint32(iconf.Trc.GracePeriod),
+		GracePeriod:    uint32(iconf.Trc.GracePeriod.Seconds()),
 		ISD:            isd,
 		QuorumTRC:      iconf.Trc.QuorumTRC,
 		Version:        iconf.Trc.Version,

--- a/proto/drkey_mgmt.capnp
+++ b/proto/drkey_mgmt.capnp
@@ -6,7 +6,7 @@ $Go.import("github.com/scionproto/scion/go/proto");
 
 struct DRKeyReq {
     isdas @0 :UInt64;      # Src ISD-AS of the requested DRKey
-    timestamp @1 :UInt64;  # Timestamp
+    timestamp @1 :UInt32;  # Timestamp
     signature @2 :Data;    # Signature of (isdas, prefetch, timestamp)
     certVer @3 :UInt32;    # Version cert used to sign
     trcVer @4 :UInt32;     # Version of TRC, which signed cert
@@ -18,8 +18,8 @@ struct DRKeyReq {
 
 struct DRKeyRep {
     isdas @0 :UInt64;      # Src ISD-AS of the DRKey
-    timestamp @1 :UInt64;  # Timestamp
-    expTime @2 :UInt64;    # Expiration time of the DRKey
+    timestamp @1 :UInt32;  # Timestamp
+    expTime @2 :UInt32;    # Expiration time of the DRKey
     cipher @3 :Data;       # Encrypted DRKey
     signature @4 :Data;    # Signature (isdas, cipher, timestamp, expTime)
     certVerSrc @5 :UInt32; # Version of cert used to sign

--- a/proto/drkey_mgmt.capnp
+++ b/proto/drkey_mgmt.capnp
@@ -6,7 +6,7 @@ $Go.import("github.com/scionproto/scion/go/proto");
 
 struct DRKeyReq {
     isdas @0 :UInt64;      # Src ISD-AS of the requested DRKey
-    timestamp @1 :UInt32;  # Timestamp
+    timestamp @1 :UInt32;  # Timestamp, seconds since Unix Epoch
     signature @2 :Data;    # Signature of (isdas, prefetch, timestamp)
     certVer @3 :UInt32;    # Version cert used to sign
     trcVer @4 :UInt32;     # Version of TRC, which signed cert
@@ -18,8 +18,8 @@ struct DRKeyReq {
 
 struct DRKeyRep {
     isdas @0 :UInt64;      # Src ISD-AS of the DRKey
-    timestamp @1 :UInt32;  # Timestamp
-    expTime @2 :UInt32;    # Expiration time of the DRKey
+    timestamp @1 :UInt32;  # Timestamp, seconds since Unix Epoch
+    expTime @2 :UInt32;    # Expiration time of the DRKey, seconds since Unix Epoch
     cipher @3 :Data;       # Encrypted DRKey
     signature @4 :Data;    # Signature (isdas, cipher, timestamp, expTime)
     certVerSrc @5 :UInt32; # Version of cert used to sign

--- a/proto/rev_info.capnp
+++ b/proto/rev_info.capnp
@@ -6,9 +6,9 @@ $Go.import("github.com/scionproto/scion/go/proto");
 using Common = import "common.capnp";
 
 struct RevInfo {
-    ifID @0 :UInt64;  # ID of the interface to be revoked
-    isdas @1 :UInt64;  # ISD-AS of the revocation issuer.
+    ifID @0 :UInt64;               # ID of the interface to be revoked
+    isdas @1 :UInt64;              # ISD-AS of the revocation issuer.
     linkType @2 :Common.LinkType;  # Link type of the revoked interface
-    timestamp @3 :UInt64;  # Creation timestamp, seconds since Unix Epoch
-    ttl @4 :UInt32;  # The validity period of the revocation in seconds.
+    timestamp @3 :UInt32;          # Creation timestamp, seconds since Unix Epoch
+    ttl @4 :UInt32;                # The validity period of the revocation in seconds.
 }

--- a/proto/sciond.capnp
+++ b/proto/sciond.capnp
@@ -132,6 +132,6 @@ struct SegTypeHopReply {
 
 struct SegTypeHopReplyEntry {
     interfaces @0 :List(PathInterface);  # List of interfaces for the segment
-    timestamp @1 :UInt64;  # Creation timestamp, seconds since Unix Epoch
-    expTime @2 :UInt64;  # Expiration timestamp, seconds since Unix Epoch
+    timestamp @1 :UInt32;                # Creation timestamp, seconds since Unix Epoch
+    expTime @2 :UInt32;                  # Expiration timestamp, seconds since Unix Epoch
 }

--- a/proto/sign.capnp
+++ b/proto/sign.capnp
@@ -16,7 +16,7 @@ struct Sign {
     # Signature over blob, using signType, created by src. Unset if signType is `none`.
     signature @2 :Data;
     # Signature creation time. Seconds since Unix Epoch.
-    timestamp @3 :UInt64;
+    timestamp @3 :UInt32;
 }
 
 enum SignType {

--- a/python/lib/packet/proto_sign.py
+++ b/python/lib/packet/proto_sign.py
@@ -78,7 +78,7 @@ class ProtoSign(Cerealizable):
         b = [str(self.p.type).encode("utf-8"), self.p.src]
         if incl_sig:
             b.append(self.p.signature)
-        b.append(self.p.timestamp.to_bytes(8, 'big'))
+        b.append(self.p.timestamp.to_bytes(4, 'big'))
         return b"".join(b)
 
     def _sig_input(self, msg):


### PR DESCRIPTION
Fixes #1548.

Change `uin64` timestamp units to `uint32` in:
- DRKeyReq/Rep
- RevInfo
- SegTypeHopReplyEntry
- Sign
- TRC
- Certificate

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1634)
<!-- Reviewable:end -->
