### PR TITLE
br: fix panic when reprocessing a packet

### DIFF
--- a/go/border/rpkt/route.go
+++ b/go/border/rpkt/route.go
@@ -285,13 +285,15 @@ func (rp *RtrPkt) reprocess() (HookResult, error) {
 	// XXX We might need to reconsider keeping timeIn value due to effect on metrics.
 	timeIn := rp.TimeIn
 	raw := rp.Raw
+	refCnt := rp.refCnt
 	// reset
 	rp.Reset()
 	// restore
 	rp.Ctx = ctx
 	rp.Free = free
-	rp.Raw = raw
 	rp.TimeIn = timeIn
+	rp.Raw = raw
+	rp.refCnt = refCnt
 	// set as incoming from local interface
 	rp.DirFrom = rcmn.DirLocal
 	s := rp.Ctx.LocSockIn


### PR DESCRIPTION
Save/restore the refCnt when resetting the metadata of a packet to be
repreprocessed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1662)
<!-- Reviewable:end -->
