### PR TITLE
Sync newest CertChain/TRC handling in Python with Go

### DIFF
--- a/python/cert_server/main.py
+++ b/python/cert_server/main.py
@@ -275,7 +275,6 @@ class CertServer(SCIONElement):
 
     def _check_cc(self, key):
         isd_as, ver = key
-        ver = None if ver == CertChainRequest.NEWEST_VERSION else ver
         cert_chain = self.trust_store.get_cert(isd_as, ver)
         if cert_chain:
             return True
@@ -304,7 +303,6 @@ class CertServer(SCIONElement):
 
     def _reply_cc(self, key, req_info):
         isd_as, ver = key
-        ver = None if ver == CertChainRequest.NEWEST_VERSION else ver
         meta = req_info[0]
         req_id = req_info[2]
         cert_chain = self.trust_store.get_cert(isd_as, ver)

--- a/python/lib/trust_store.py
+++ b/python/lib/trust_store.py
@@ -85,7 +85,7 @@ class TrustStore(object):
         with self._trcs_lock:
             if not self._trcs[isd]:
                 return None
-            if version is None:
+            if version is None or version == 0:
                 # Return the most recent TRC.
                 _, trc = max(self._trcs[isd])
                 return trc
@@ -106,7 +106,7 @@ class TrustStore(object):
         with self._certs_lock:
             if not self._certs[isd_as]:
                 return None
-            if version is None:
+            if version is None or version == 0:
                 # Return the most recent cert.
                 _, cert = max(self._certs[isd_as])
                 return cert


### PR DESCRIPTION
The Go implementation treats a version of `0` as "give me the newest version". The Python code base was never updated to those semantics. Historically, version `0` was the first version of a cert/chain/TRC. This PR fixes this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1691)
<!-- Reviewable:end -->
