### PR TITLE
Seed math/rand's PRNG on start

### DIFF
--- a/go/border/router.go
+++ b/go/border/router.go
@@ -27,6 +27,7 @@ import (
 	"github.com/scionproto/scion/go/border/rctx"
 	"github.com/scionproto/scion/go/border/rpkt"
 	"github.com/scionproto/scion/go/lib/assert"
+	"github.com/scionproto/scion/go/lib/crypto"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/ringbuf"
 )
@@ -41,6 +42,7 @@ func init() {
 	// used by confSig below.
 	sighup = make(chan os.Signal, 1)
 	signal.Notify(sighup, syscall.SIGHUP)
+	crypto.MathRandSeed()
 }
 
 type Router struct {

--- a/go/lib/common/rand.go
+++ b/go/lib/common/rand.go
@@ -1,0 +1,39 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"crypto/rand"
+	mrand "math/rand"
+)
+
+func RandUint64() uint64 {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		// If this happens, there's some serious problem with the runtime or
+		// OS, and there's nothing we can do about it.
+		panic("No random numbers available")
+	}
+	return NativeOrder.Uint64(b)
+}
+
+func RandInt64() int64 {
+	return int64(RandUint64())
+}
+
+func init() {
+	// Make sure math/rand's default generator is seeded with a random value on start.
+	mrand.Seed(RandInt64())
+}

--- a/go/lib/crypto/rand.go
+++ b/go/lib/crypto/rand.go
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package crypto
 
 import (
 	"crypto/rand"
 	mrand "math/rand"
+	"sync"
+
+	"github.com/scionproto/scion/go/lib/common"
 )
 
 func RandUint64() uint64 {
@@ -26,14 +29,18 @@ func RandUint64() uint64 {
 		// OS, and there's nothing we can do about it.
 		panic("No random numbers available")
 	}
-	return NativeOrder.Uint64(b)
+	return common.NativeOrder.Uint64(b)
 }
 
 func RandInt64() int64 {
 	return int64(RandUint64())
 }
 
-func init() {
-	// Make sure math/rand's default generator is seeded with a random value on start.
-	mrand.Seed(RandInt64())
+var mathSeedOnce sync.Once
+
+// Seed math/rand's default generator with a random value, once.
+func MathRandSeed() {
+	mathSeedOnce.Do(func() {
+		mrand.Seed(RandInt64())
+	})
 }

--- a/go/lib/env/env.go
+++ b/go/lib/env/env.go
@@ -27,12 +27,10 @@ package env
 import (
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
@@ -70,8 +68,6 @@ type General struct {
 	TopologyPath string `toml:"Topology"`
 	// Topology is the loaded topology file.
 	Topology *topology.Topo `toml:"-"`
-	// Seed for the PRNG. A value of 0 means use current UNIX time as seed.
-	Seed int64
 }
 
 // setFiles determines the values for extra config files (e.g., topology.json).
@@ -101,12 +97,6 @@ func InitGeneral(cfg *General) error {
 		return err
 	}
 	cfg.Topology = topo
-	// Initialize default PRNG
-	if cfg.Seed == 0 {
-		rand.Seed(time.Now().Unix())
-	} else {
-		rand.Seed(cfg.Seed)
-	}
 	return nil
 }
 

--- a/go/lib/env/env.go
+++ b/go/lib/env/env.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/crypto"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/snet"
@@ -56,6 +57,7 @@ func init() {
 	os.Setenv("TZ", "UTC")
 	sighupC = make(chan os.Signal, 1)
 	signal.Notify(sighupC, syscall.SIGHUP)
+	crypto.MathRandSeed()
 }
 
 type General struct {

--- a/go/lib/env/testdata/ps.toml
+++ b/go/lib/env/testdata/ps.toml
@@ -10,9 +10,6 @@
   # directory.
   Topology = "testdata/dir/topology.json"
 
-  # Seed for the PRNG. A value of 0 means use current UNIX time as seed.
-  Seed = 0
-
 [logging]
   [logging.file]
     # Location of the logging file.

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -29,7 +29,6 @@ package sciond
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -139,8 +138,6 @@ func connectTimeout(socketName string, timeout time.Duration) (*connector, error
 	if err != nil {
 		return nil, err
 	}
-	rand.Seed(time.Now().UnixNano())
-
 	return &connector{
 		dispatcher: disp.New(
 			transport.NewPacketTransport(conn),

--- a/go/lib/snet/integration_test.go
+++ b/go/lib/snet/integration_test.go
@@ -27,7 +27,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	_ "github.com/scionproto/scion/go/lib/common" // Ensure math/rand is seeded.
+	"github.com/scionproto/scion/go/lib/crypto"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/util"
@@ -219,7 +219,7 @@ func TestListen(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	var err error
-
+	crypto.MathRandSeed()
 	// Load topology information
 	asStruct, err := util.LoadASList("../../../gen/as_list.yml")
 	if err != nil {

--- a/go/lib/snet/integration_test.go
+++ b/go/lib/snet/integration_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/scionproto/scion/go/lib/addr"
+	_ "github.com/scionproto/scion/go/lib/common" // Ensure math/rand is seeded.
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/util"
@@ -61,7 +62,6 @@ type TestCase struct {
 }
 
 func generateTests(asList []addr.IA, count int, haveSciond bool) []TestCase {
-	rand.Seed(time.Now().UnixNano())
 	tests := make([]TestCase, 0, 0)
 	var cIndex, sIndex int32
 	for i := 0; i < count; i++ {

--- a/go/lib/snet/rpt/rpt.go
+++ b/go/lib/snet/rpt/rpt.go
@@ -63,11 +63,6 @@ const (
 	maxReadEvents = 1 << 8
 )
 
-var (
-	// Used to initialize the first packet ID
-	generator = rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
-)
-
 var _ infra.Transport = (*RPT)(nil)
 
 // RPT (Reliable Packet Transport) implements a simple packet-oriented protocol
@@ -117,7 +112,7 @@ type RPT struct {
 func New(conn net.PacketConn, logger log.Logger) *RPT {
 	t := &RPT{
 		conn:       conn,
-		nextPktID:  uint56(generator.Int63n(maxUint56 + 1)),
+		nextPktID:  uint56(rand.Int63n(maxUint56 + 1)),
 		readEvents: make(chan *readEventDesc, maxReadEvents),
 		closedChan: make(chan struct{}),
 		doneChan:   make(chan struct{}),

--- a/go/lib/sock/reliable/bench_test.go
+++ b/go/lib/sock/reliable/bench_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
+
+	_ "github.com/scionproto/scion/go/lib/common" // Ensure math/rand is seeded.
 )
 
 type SetupFunc func() interface{}
@@ -144,7 +146,6 @@ func benchmark(b *testing.B, setup SetupFunc, client EndpointFunc, server Endpoi
 }
 
 func setupTestNFunc() interface{} {
-	rand.Seed(time.Now().UnixNano())
 	msgs := make([]Msg, 1000)
 	for i := 0; i < len(msgs); i++ {
 		msgs[i].Buffer = make([]byte, rand.Intn(1280))

--- a/go/lib/sock/reliable/bench_test.go
+++ b/go/lib/sock/reliable/bench_test.go
@@ -22,8 +22,12 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	_ "github.com/scionproto/scion/go/lib/common" // Ensure math/rand is seeded.
+	"github.com/scionproto/scion/go/lib/crypto"
 )
+
+func init() {
+	crypto.MathRandSeed()
+}
 
 type SetupFunc func() interface{}
 type EndpointFunc func(*Conn, interface{})

--- a/go/tools/scmp/cmn/common.go
+++ b/go/tools/scmp/cmn/common.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/crypto"
 	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/scmp"
@@ -63,6 +64,7 @@ func init() {
 	flag.Usage = scmpUsage
 	Stats = &ScmpStats{}
 	Start = time.Now()
+	crypto.MathRandSeed()
 }
 
 func scmpUsage() {

--- a/go/tools/scmp/cmn/common.go
+++ b/go/tools/scmp/cmn/common.go
@@ -47,7 +47,6 @@ var (
 	Conn      *reliable.Conn
 	Mtu       uint16
 	PathEntry *sciond.PathReplyEntry
-	rnd       *rand.Rand
 	Stats     *ScmpStats
 	Start     time.Time
 )
@@ -62,9 +61,6 @@ func init() {
 	flag.Var((*snet.Addr)(&Remote), "remote", "(Mandatory for clients) address to connect to")
 	flag.Var((*snet.Addr)(&Bind), "bind", "address to bind to, if running behind NAT")
 	flag.Usage = scmpUsage
-	// Initialize random
-	seed := rand.NewSource(time.Now().UnixNano())
-	rnd = rand.New(seed)
 	Stats = &ScmpStats{}
 	Start = time.Now()
 }
@@ -161,7 +157,7 @@ func NextHopAddr() net.Addr {
 }
 
 func Rand() uint64 {
-	return rnd.Uint64()
+	return rand.Uint64()
 }
 
 func UpdatePktTS(pkt *spkt.ScnPkt, ts time.Time) {


### PR DESCRIPTION
This ensures that all uses of math/rand have a reasonably secure seed.
This fixes, e.g.:
- go/border/rpkt/route.go that didn't use a seeded math/rand
- Use of non-goroutine-safe rand.Source's in snet/rpt and scmp/cmn.
- potential for multiple libraries to call rand.Seed().

Also:
- Add 2 convenience functions to get crypto/rand 64-bit integers.
- Drop the "Seed" field from the env.General struct, as it no longer
  makes sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1715)
<!-- Reviewable:end -->
