### PR TITLE
Implement verification in SCIOND

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
                 command: ./tools/ci/docker_update
             - run:
                 name: Pull and tag scion_base image
-                command: ./tools/ci/prepare_image fc1d63f0870b97f9b2a2aeef3c8051bf371b8f5767434157d50f3742fe76e2c6
+                command: ./tools/ci/prepare_image 732c53f9528850fa4db503c43d35b96da357bdbb184dec1d4d08bf69e77fadf6
                 when: always
             - run:
                 name: Build scion:latest image

--- a/env/pip3/requirements.txt
+++ b/env/pip3/requirements.txt
@@ -31,4 +31,4 @@ prometheus-client==0.0.19 --hash=sha256:ce4ddcb89a870ee771ca5427df123029bf5344ea
 # pypacker: licenses/GPLv2
 pypacker==4.1 --hash=sha256:05bc5c873cfef620ce8b07df4aa286ea199e328b5b1eabd0b10aa0bb699c464f # Direct dependency
 # toml: licenses/MIT
-toml==0.9.4 --hash=sha256:8e86bd6ce8cc11b9620cb637466453d94f5d57ad86f17e98a98d1f73e3baab2d
+toml==0.9.4 --hash=sha256:8e86bd6ce8cc11b9620cb637466453d94f5d57ad86f17e98a98d1f73e3baab2d # Direct dependency

--- a/env/pip3/requirements.txt
+++ b/env/pip3/requirements.txt
@@ -30,3 +30,5 @@ pycparser==2.17 --hash=sha256:0aac31e917c24cb3357f5a4d5566f2cc91a19ca41862f6c3c2
 prometheus-client==0.0.19 --hash=sha256:ce4ddcb89a870ee771ca5427df123029bf5344ea84f535ded4a1787e29a22a3f # Direct dependency
 # pypacker: licenses/GPLv2
 pypacker==4.1 --hash=sha256:05bc5c873cfef620ce8b07df4aa286ea199e328b5b1eabd0b10aa0bb699c464f # Direct dependency
+# toml: licenses/MIT
+toml==0.9.4 --hash=sha256:8e86bd6ce8cc11b9620cb637466453d94f5d57ad86f17e98a98d1f73e3baab2d

--- a/go/cert_srv/conf/conf.go
+++ b/go/cert_srv/conf/conf.go
@@ -278,7 +278,7 @@ func (c *Conf) loadLeafReissTime() error {
 
 // checkIssCert checks that the trust store contains the issuer certificate.
 func (c *Conf) checkIssCert() error {
-	chain, err := c.Store.GetValidChain(context.Background(), c.PublicAddr.IA, c.PublicAddr.IA.I)
+	chain, err := c.Store.GetValidChain(context.Background(), nil, c.PublicAddr.IA)
 	if err != nil {
 		return err
 	}

--- a/go/cert_srv/conf/conf.go
+++ b/go/cert_srv/conf/conf.go
@@ -278,7 +278,7 @@ func (c *Conf) loadLeafReissTime() error {
 
 // checkIssCert checks that the trust store contains the issuer certificate.
 func (c *Conf) checkIssCert() error {
-	chain, err := c.Store.GetValidChain(context.Background(), nil, c.PublicAddr.IA)
+	chain, err := c.Store.GetValidChain(context.Background(), c.PublicAddr.IA, nil)
 	if err != nil {
 		return err
 	}

--- a/go/cert_srv/setup.go
+++ b/go/cert_srv/setup.go
@@ -74,6 +74,7 @@ func setupNewConf(newConf *conf.Conf) error {
 		return err
 	}
 	msger := messenger.New(
+		newConf.Topo.ISD_AS,
 		disp.New(
 			transport.NewPacketTransport(conn),
 			messenger.DefaultAdapter,

--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -261,3 +261,7 @@ type IAInt uint64
 func (iaI IAInt) IA() IA {
 	return IA{I: ISD(iaI >> ASBits), A: AS(iaI & MaxAS)}
 }
+
+func (iaI IAInt) String() string {
+	return iaI.IA().String()
+}

--- a/go/lib/ctrl/signed_util.go
+++ b/go/lib/ctrl/signed_util.go
@@ -162,7 +162,7 @@ func GetChainForSign(ctx context.Context, s *SignSrcDef,
 	if err != nil {
 		return nil, common.NewBasicError("Unable to get certificate chain", err)
 	}
-	maxTRC, err := tStore.GetValidTRC(ctx, t.ISD, t.ISD)
+	maxTRC, err := tStore.GetValidTRC(ctx, nil, t.ISD)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to get maxTRC", err)
 	}

--- a/go/lib/ctrl/signed_util.go
+++ b/go/lib/ctrl/signed_util.go
@@ -162,7 +162,7 @@ func GetChainForSign(ctx context.Context, s *SignSrcDef,
 	if err != nil {
 		return nil, common.NewBasicError("Unable to get certificate chain", err)
 	}
-	maxTRC, err := tStore.GetValidTRC(ctx, nil, t.ISD)
+	maxTRC, err := tStore.GetValidTRC(ctx, t.ISD, nil)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to get maxTRC", err)
 	}

--- a/go/lib/infra/common.go
+++ b/go/lib/infra/common.go
@@ -23,6 +23,7 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/scrypto/cert"
 	"github.com/scionproto/scion/go/lib/scrypto/trc"
 	"github.com/scionproto/scion/go/proto"
@@ -74,15 +75,18 @@ type Request struct {
 	FullMessage proto.Cerealizable
 	// Peer is the node that sent this request
 	Peer net.Addr
-
+	// ID is the CtrlPld top-level ID.
 	ID uint64
+	// Logger can be used to write handler-scope messages in a way that can be
+	// easily correlated with server request/responses.
+	Logger log.Logger
 	// ctx is a server context, used in handlers when receiving messages from
 	// the network.
 	ctx context.Context
 }
 
 func NewRequest(ctx context.Context, msg, fullMsg proto.Cerealizable, peer net.Addr,
-	id uint64) *Request {
+	id uint64, logger log.Logger) *Request {
 
 	return &Request{
 		Message:     msg,
@@ -90,6 +94,7 @@ func NewRequest(ctx context.Context, msg, fullMsg proto.Cerealizable, peer net.A
 		Peer:        peer,
 		ctx:         ctx,
 		ID:          id,
+		Logger:      logger,
 	}
 }
 
@@ -179,8 +184,9 @@ func MessengerFromContext(ctx context.Context) (Messenger, bool) {
 }
 
 type TrustStore interface {
-	GetValidChain(ctx context.Context, ia addr.IA, trail ...addr.ISD) (*cert.Chain, error)
-	GetValidTRC(ctx context.Context, isd addr.ISD, trail ...addr.ISD) (*trc.TRC, error)
+	GetValidChain(ctx context.Context, source net.Addr, ia addr.IA) (*cert.Chain, error)
+	GetValidTRC(ctx context.Context, source net.Addr, isd addr.ISD) (*trc.TRC, error)
+	GetValidCachedTRC(ctx context.Context, isd addr.ISD) (*trc.TRC, error)
 	GetChain(ctx context.Context, ia addr.IA, version uint64) (*cert.Chain, error)
 	GetTRC(ctx context.Context, isd addr.ISD, version uint64) (*trc.TRC, error)
 	NewTRCReqHandler(recurseAllowed bool) Handler

--- a/go/lib/infra/common.go
+++ b/go/lib/infra/common.go
@@ -184,8 +184,8 @@ func MessengerFromContext(ctx context.Context) (Messenger, bool) {
 }
 
 type TrustStore interface {
-	GetValidChain(ctx context.Context, source net.Addr, ia addr.IA) (*cert.Chain, error)
-	GetValidTRC(ctx context.Context, source net.Addr, isd addr.ISD) (*trc.TRC, error)
+	GetValidChain(ctx context.Context, ia addr.IA, source net.Addr) (*cert.Chain, error)
+	GetValidTRC(ctx context.Context, isd addr.ISD, source net.Addr) (*trc.TRC, error)
 	GetValidCachedTRC(ctx context.Context, isd addr.ISD) (*trc.TRC, error)
 	GetChain(ctx context.Context, ia addr.IA, version uint64) (*cert.Chain, error)
 	GetTRC(ctx context.Context, isd addr.ISD, version uint64) (*trc.TRC, error)

--- a/go/lib/infra/example/main.go
+++ b/go/lib/infra/example/main.go
@@ -78,6 +78,7 @@ func InitDefaultNetworking(conn net.PacketConn) *ExampleServerApp {
 	}
 	// Initialize messenger with verification capabilities (trustStore-backed)
 	server.messenger = messenger.New(
+		xtest.MustParseIA("1-ff00:0:1"),
 		dispatcherLayer,
 		server.trustStore,
 		log.Root(),

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -64,6 +64,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
@@ -72,7 +73,10 @@ import (
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/disp"
 	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/spath"
+	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/proto"
 )
 
@@ -128,12 +132,13 @@ type Messenger struct {
 	ctx     context.Context
 	cancelF context.CancelFunc
 
+	ia  addr.IA
 	log log.Logger
 }
 
 // New creates a new Messenger that uses dispatcher for sending and receiving
 // messages, and trustStore as crypto information database.
-func New(dispatcher *disp.Dispatcher, store infra.TrustStore, logger log.Logger,
+func New(ia addr.IA, dispatcher *disp.Dispatcher, store infra.TrustStore, logger log.Logger,
 	config *Config) *Messenger {
 
 	if config == nil {
@@ -147,6 +152,7 @@ func New(dispatcher *disp.Dispatcher, store infra.TrustStore, logger log.Logger,
 	// trustStore.
 	ctx, cancelF := context.WithCancel(context.Background())
 	return &Messenger{
+		ia:         ia,
 		config:     config,
 		dispatcher: dispatcher,
 		signer:     ctrl.NullSigner,
@@ -165,23 +171,29 @@ func New(dispatcher *disp.Dispatcher, store infra.TrustStore, logger log.Logger,
 func (m *Messenger) GetTRC(ctx context.Context, msg *cert_mgmt.TRCReq,
 	a net.Addr, id uint64) (*cert_mgmt.TRC, error) {
 
+	logger := m.log.New("trace_id", util.GetTraceID())
 	pld, err := ctrl.NewCertMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
 	if err != nil {
 		return nil, err
 	}
-	m.log.Debug("[Messenger] Sending Request", "type", infra.TRCRequest, "to", a, "id", id)
+	logger.Debug("[Messenger] Sending request", "req_type", infra.TRCRequest,
+		"msg_id", id, "request", msg, "peer", a)
 	replyCtrlPld, _, err := m.getRequester(infra.TRCRequest, infra.TRC).Request(ctx, pld, a)
 	if err != nil {
+		logger.Info("[Messenger] Request error", "err", err)
 		return nil, err
 	}
 	_, replyMsg, err := m.validate(replyCtrlPld)
 	if err != nil {
+		logger.Info("[Messenger] Reply validation failed", "err", err)
 		return nil, err
 	}
 	reply, ok := replyMsg.(*cert_mgmt.TRC)
 	if !ok {
+		logger.Info("[Messenger] type assertion failed", "err", err)
 		return nil, newTypeAssertErr("*cert_mgmt.TRC", replyMsg)
 	}
+	logger.Debug("[Messenger] Received reply", "reply", reply)
 	return reply, nil
 }
 
@@ -200,23 +212,29 @@ func (m *Messenger) SendTRC(ctx context.Context, msg *cert_mgmt.TRC, a net.Addr,
 func (m *Messenger) GetCertChain(ctx context.Context, msg *cert_mgmt.ChainReq,
 	a net.Addr, id uint64) (*cert_mgmt.Chain, error) {
 
+	logger := m.log.New("trace_id", util.GetTraceID())
 	pld, err := ctrl.NewCertMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
 	if err != nil {
 		return nil, err
 	}
-	m.log.Debug("[Messenger] Sending Request", "type", infra.ChainRequest, "to", a, "id", id)
+	logger.Debug("[Messenger] Sending request", "req_type", infra.ChainRequest,
+		"msg_id", id, "request", msg, "peer", a)
 	replyCtrlPld, _, err := m.getRequester(infra.ChainRequest, infra.Chain).Request(ctx, pld, a)
 	if err != nil {
+		logger.Info("[Messenger] Request error", "err", err)
 		return nil, err
 	}
 	_, replyMsg, err := m.validate(replyCtrlPld)
 	if err != nil {
+		logger.Info("[Messenger] Reply validation error", "err", err)
 		return nil, err
 	}
 	reply, ok := replyMsg.(*cert_mgmt.Chain)
 	if !ok {
+		logger.Info("[Messenger] Type assertion failed")
 		return nil, newTypeAssertErr("*cert_mgmt.Chain", replyMsg)
 	}
+	logger.Debug("[Messenger] Received reply", "reply", reply)
 	return reply, nil
 }
 
@@ -237,51 +255,64 @@ func (m *Messenger) SendCertChain(ctx context.Context, msg *cert_mgmt.Chain, a n
 func (m *Messenger) GetPathSegs(ctx context.Context, msg *path_mgmt.SegReq,
 	a net.Addr, id uint64) (*path_mgmt.SegReply, error) {
 
+	logger := m.log.New("trace_id", util.GetTraceID())
 	pld, err := ctrl.NewPathMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
 	if err != nil {
 		return nil, err
 	}
-	m.log.Debug("[Messenger] Sending Request", "type", infra.PathSegmentRequest, "to", a, "id", id)
+	logger.Debug("[Messenger] Sending request", "req_type", infra.PathSegmentRequest,
+		"msg_id", id, "request", msg, "peer", a)
 	replyCtrlPld, _, err :=
 		m.getRequester(infra.PathSegmentRequest, infra.PathSegmentReply).Request(ctx, pld, a)
 	if err != nil {
+		logger.Info("[Messenger] Request error", "err", err)
 		return nil, err
 	}
 	_, replyMsg, err := m.validate(replyCtrlPld)
 	if err != nil {
+		logger.Info("[Messenger] Reply validation error", "err", err)
 		return nil, err
 	}
 	reply, ok := replyMsg.(*path_mgmt.SegReply)
 	if !ok {
+		logger.Info("[Messenger] Type assertion failed")
 		return nil, newTypeAssertErr("*path_mgmt.SegReply", replyMsg)
 	}
 	if err := reply.ParseRaw(); err != nil {
+		logger.Info("[Messneger] Reply parse error")
 		return nil, err
 	}
+	logger.Debug("[Messenger] Received reply")
 	return reply, nil
 }
 
 func (m *Messenger) RequestChainIssue(ctx context.Context, msg *cert_mgmt.ChainIssReq, a net.Addr,
 	id uint64) (*cert_mgmt.ChainIssRep, error) {
 
+	logger := m.log.New("trace_id", util.GetTraceID())
 	pld, err := ctrl.NewCertMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
 	if err != nil {
 		return nil, err
 	}
-	m.log.Debug("[Messenger] Sending Request", "type", infra.ChainIssueRequest, "to", a, "id", id)
+	logger.Debug("[Messenger] Sending request", "req_type", infra.ChainIssueRequest,
+		"msg_id", id, "request", msg, "peer", a)
 	replyCtrlPld, _, err :=
 		m.getRequester(infra.ChainIssueRequest, infra.ChainIssueReply).Request(ctx, pld, a)
 	if err != nil {
+		logger.Info("[Messenger] Request error", "err", err)
 		return nil, err
 	}
 	_, replyMsg, err := m.validate(replyCtrlPld)
 	if err != nil {
+		logger.Info("[Messenger] Reply validation error", "err", err)
 		return nil, err
 	}
 	reply, ok := replyMsg.(*cert_mgmt.ChainIssRep)
 	if !ok {
+		logger.Info("[Messenger] Type assertion failed")
 		return nil, newTypeAssertErr("*cert_mgmt.ChainIssReply", replyMsg)
 	}
+	logger.Debug("[Messenger] Received reply")
 	return reply, nil
 }
 
@@ -326,10 +357,11 @@ func (m *Messenger) ListenAndServe() {
 			}
 			continue
 		}
+		logger := m.log.New("trace_id", util.GetTraceID())
 
 		signedPld, ok := genericMsg.(*ctrl.SignedPld)
 		if !ok {
-			m.log.Error("Type assertion failure", "from", address, "expected", "*ctrl.SignedPld",
+			logger.Error("Type assertion failure", "from", address, "expected", "*ctrl.SignedPld",
 				"actual", common.TypeOf(genericMsg))
 			continue
 		}
@@ -341,7 +373,7 @@ func (m *Messenger) ListenAndServe() {
 			// functionality in the main ctrl libraries is still missing.
 			err = m.verifySignedPld(serveCtx, signedPld, m.verifier, address.(*snet.Addr))
 			if err != nil {
-				m.log.Error("Verification error", "from", address, "err", err)
+				logger.Error("Verification error", "from", address, "err", err)
 				serveCancelF()
 				continue
 			}
@@ -349,11 +381,11 @@ func (m *Messenger) ListenAndServe() {
 
 		pld, err := signedPld.Pld()
 		if err != nil {
-			m.log.Error("Unable to extract Pld from CtrlPld", "from", address, "err", err)
+			logger.Error("Unable to extract Pld from CtrlPld", "from", address, "err", err)
 			serveCancelF()
 			continue
 		}
-		m.serve(serveCtx, serveCancelF, pld, signedPld, address)
+		m.serve(serveCtx, serveCancelF, pld, signedPld, address, logger)
 	}
 }
 
@@ -378,29 +410,29 @@ func (m *Messenger) verifySignedPld(ctx context.Context, signedPld *ctrl.SignedP
 }
 
 func (m *Messenger) serve(ctx context.Context, cancelF context.CancelFunc, pld *ctrl.Pld,
-	signedPld *ctrl.SignedPld, address net.Addr) {
+	signedPld *ctrl.SignedPld, address net.Addr, logger log.Logger) {
 
 	// Validate that the message is of acceptable type, and that its top-level
 	// signature is correct.
 	msgType, msg, err := m.validate(pld)
 	if err != nil {
-		m.log.Error("Received message, but unable to validate message", "from", address, "err", err)
+		logger.Error("Received message, but unable to validate message", "from", address, "err", err)
 		return
 	}
-	m.log.Debug("[Messenger] Received Message", "type", msgType, "from", address, "id", pld.ReqId)
+	logger.Debug("[Messenger] Received message", "type", msgType, "from", address, "id", pld.ReqId)
 
 	m.handlersLock.RLock()
 	handler := m.handlers[msgType]
 	m.handlersLock.RUnlock()
 	if handler == nil {
-		m.log.Error("Received message, but handler not found", "from", address,
+		logger.Error("Received message, but handler not found", "from", address,
 			"msgType", msgType)
 		return
 	}
 	go func() {
 		defer cancelF()
 		defer log.LogPanicAndExit()
-		handler.Handle(infra.NewRequest(ctx, msg, signedPld, address, pld.ReqId))
+		handler.Handle(infra.NewRequest(ctx, msg, signedPld, address, pld.ReqId, logger))
 	}()
 }
 
@@ -498,17 +530,92 @@ func (m *Messenger) UpdateVerifier(verifier ctrl.SigVerifier) {
 //
 // If message type respT is to be verified, the key is initialized from
 // m.verifier. Otherwise, it is set to a null verifier.
-func (m *Messenger) getRequester(reqT, respT infra.MessageType) *ctrl_msg.Requester {
+func (m *Messenger) getRequester(reqT, respT infra.MessageType) *PathingRequester {
 	m.cryptoLock.RLock()
 	defer m.cryptoLock.RUnlock()
 	signer := ctrl.NullSigner
 	if _, ok := m.signMask[reqT]; ok {
 		signer = m.signer
 	}
-	return ctrl_msg.NewRequester(signer, m.verifier, m.dispatcher)
+	return NewPathingRequester(signer, m.verifier, m.dispatcher, m.ia)
 }
 
 func newTypeAssertErr(typeStr string, msg interface{}) error {
 	errStr := fmt.Sprintf("Unable to type assert disp.Message to %s", typeStr)
 	return common.NewBasicError(errStr, nil, "msg", msg)
+}
+
+// PathingRequester is a requester with an attached local IA. It resolves the
+// SCION path to construct complete snet addresses that rarely block on writes.
+//
+// FIXME(scrye): This is just a hack to improve performance in the default
+// topology, by allowing each goroutine to issue a request to SCIOND in
+// parallel (as opposed of one goroutine waiting for another if the Path
+// Resolver were to be used). This logic should be moved to snet internals
+// once the path resolver has support for concurrent queries and context
+// awareness.
+type PathingRequester struct {
+	requester *ctrl_msg.Requester
+	local     addr.IA
+}
+
+func NewPathingRequester(signer ctrl.Signer, sigv ctrl.SigVerifier, d *disp.Dispatcher,
+	local addr.IA) *PathingRequester {
+
+	return &PathingRequester{
+		requester: ctrl_msg.NewRequester(signer, sigv, d),
+		local:     local,
+	}
+}
+
+func (pr *PathingRequester) Request(ctx context.Context, pld *ctrl.Pld,
+	a net.Addr) (*ctrl.Pld, *proto.SignS, error) {
+
+	newAddr, err := pr.getBlockingPath(a)
+	if err != nil {
+		return nil, nil, err
+	}
+	return pr.requester.Request(ctx, pld, newAddr)
+}
+
+func (pr *PathingRequester) Notify(ctx context.Context, pld *ctrl.Pld, a net.Addr) error {
+	newAddr, err := pr.getBlockingPath(a)
+	if err != nil {
+		return err
+	}
+	return pr.requester.Notify(ctx, pld, newAddr)
+}
+
+func (pr *PathingRequester) NotifyUnreliable(ctx context.Context, pld *ctrl.Pld, a net.Addr) error {
+	newAddr, err := pr.getBlockingPath(a)
+	if err != nil {
+		return err
+	}
+	return pr.requester.NotifyUnreliable(ctx, pld, newAddr)
+}
+
+func (pr *PathingRequester) getBlockingPath(a net.Addr) (net.Addr, error) {
+	// for SCIOND-less operation do not try to resolve paths
+	if snet.DefNetwork == nil || snet.DefNetwork.PathResolver() == nil {
+		return a, nil
+	}
+	snetAddress := a.(*snet.Addr).Copy()
+	sdService := snet.DefNetwork.PathResolver().Sciond()
+	conn, err := sdService.Connect()
+	if err != nil {
+		return nil, err
+	}
+	paths, err := conn.Paths(snetAddress.IA, pr.local, 5, sciond.PathReqFlags{})
+	if err != nil {
+		return nil, err
+	}
+	if len(paths.Entries) == 0 {
+		return nil, common.NewBasicError("unable to find path", nil)
+	}
+	snetAddress.Path = spath.New(paths.Entries[0].Path.FwdPath)
+	snetAddress.NextHop, err = paths.Entries[0].HostInfo.Overlay()
+	if err != nil {
+		return nil, common.NewBasicError("unable to build next hop", err)
+	}
+	return snetAddress, nil
 }

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -171,7 +171,8 @@ func New(ia addr.IA, dispatcher *disp.Dispatcher, store infra.TrustStore, logger
 func (m *Messenger) GetTRC(ctx context.Context, msg *cert_mgmt.TRCReq,
 	a net.Addr, id uint64) (*cert_mgmt.TRC, error) {
 
-	logger := m.log.New("debug_id", util.GetDebugID())
+	debug_id := util.GetDebugID()
+	logger := m.log.New("debug_id", debug_id)
 	pld, err := ctrl.NewCertMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
 	if err != nil {
 		return nil, err
@@ -180,19 +181,18 @@ func (m *Messenger) GetTRC(ctx context.Context, msg *cert_mgmt.TRCReq,
 		"msg_id", id, "request", msg, "peer", a)
 	replyCtrlPld, _, err := m.getRequester(infra.TRCRequest, infra.TRC).Request(ctx, pld, a)
 	if err != nil {
-		logger.Info("[Messenger] Request error", "err", err)
-		return nil, err
+		return nil, common.NewBasicError("[Messenger] Request error", err, "debug_id", debug_id)
 	}
 	_, replyMsg, err := m.validate(replyCtrlPld)
 	if err != nil {
-		logger.Info("[Messenger] Reply validation failed", "err", err)
-		return nil, err
+		return nil, common.NewBasicError("[Messenger] Reply validation failed", err,
+			"debug_id", debug_id)
 	}
 	reply, ok := replyMsg.(*cert_mgmt.TRC)
 	if !ok {
 		err := newTypeAssertErr("*cert_mgmt.TRC", replyMsg)
-		logger.Info("[Messenger] type assertion failed", "err", err)
-		return nil, err
+		return nil, common.NewBasicError("[Messenger] Type assertion failed", err,
+			"debug_id", debug_id)
 	}
 	logger.Debug("[Messenger] Received reply", "reply", reply)
 	return reply, nil
@@ -213,7 +213,8 @@ func (m *Messenger) SendTRC(ctx context.Context, msg *cert_mgmt.TRC, a net.Addr,
 func (m *Messenger) GetCertChain(ctx context.Context, msg *cert_mgmt.ChainReq,
 	a net.Addr, id uint64) (*cert_mgmt.Chain, error) {
 
-	logger := m.log.New("debug_id", util.GetDebugID())
+	debug_id := util.GetDebugID()
+	logger := m.log.New("debug_id", debug_id)
 	pld, err := ctrl.NewCertMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
 	if err != nil {
 		return nil, err
@@ -222,18 +223,18 @@ func (m *Messenger) GetCertChain(ctx context.Context, msg *cert_mgmt.ChainReq,
 		"msg_id", id, "request", msg, "peer", a)
 	replyCtrlPld, _, err := m.getRequester(infra.ChainRequest, infra.Chain).Request(ctx, pld, a)
 	if err != nil {
-		logger.Info("[Messenger] Request error", "err", err)
-		return nil, err
+		return nil, common.NewBasicError("[Messenger] Request error", err, "debug_id", debug_id)
 	}
 	_, replyMsg, err := m.validate(replyCtrlPld)
 	if err != nil {
-		logger.Info("[Messenger] Reply validation error", "err", err)
-		return nil, err
+		return nil, common.NewBasicError("[Messenger] Reply validation failed", err,
+			"debug_id", debug_id)
 	}
 	reply, ok := replyMsg.(*cert_mgmt.Chain)
 	if !ok {
-		logger.Info("[Messenger] Type assertion failed")
-		return nil, newTypeAssertErr("*cert_mgmt.Chain", replyMsg)
+		err := newTypeAssertErr("*cert_mgmt.TRC", replyMsg)
+		return nil, common.NewBasicError("[Messenger] Type assertion failed", err,
+			"debug_id", debug_id)
 	}
 	logger.Debug("[Messenger] Received reply", "reply", reply)
 	return reply, nil
@@ -256,7 +257,8 @@ func (m *Messenger) SendCertChain(ctx context.Context, msg *cert_mgmt.Chain, a n
 func (m *Messenger) GetPathSegs(ctx context.Context, msg *path_mgmt.SegReq,
 	a net.Addr, id uint64) (*path_mgmt.SegReply, error) {
 
-	logger := m.log.New("debug_id", util.GetDebugID())
+	debug_id := util.GetDebugID()
+	logger := m.log.New("debug_id", debug_id)
 	pld, err := ctrl.NewPathMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
 	if err != nil {
 		return nil, err
@@ -266,18 +268,18 @@ func (m *Messenger) GetPathSegs(ctx context.Context, msg *path_mgmt.SegReq,
 	replyCtrlPld, _, err :=
 		m.getRequester(infra.PathSegmentRequest, infra.PathSegmentReply).Request(ctx, pld, a)
 	if err != nil {
-		logger.Info("[Messenger] Request error", "err", err)
-		return nil, err
+		return nil, common.NewBasicError("[Messenger] Request error", err, "debug_id", debug_id)
 	}
 	_, replyMsg, err := m.validate(replyCtrlPld)
 	if err != nil {
-		logger.Info("[Messenger] Reply validation error", "err", err)
-		return nil, err
+		return nil, common.NewBasicError("[Messenger] Reply validation failed", err,
+			"debug_id", debug_id)
 	}
 	reply, ok := replyMsg.(*path_mgmt.SegReply)
 	if !ok {
-		logger.Info("[Messenger] Type assertion failed")
-		return nil, newTypeAssertErr("*path_mgmt.SegReply", replyMsg)
+		err := newTypeAssertErr("*cert_mgmt.TRC", replyMsg)
+		return nil, common.NewBasicError("[Messenger] Type assertion failed", err,
+			"debug_id", debug_id)
 	}
 	if err := reply.ParseRaw(); err != nil {
 		logger.Info("[Messneger] Reply parse error")
@@ -290,7 +292,8 @@ func (m *Messenger) GetPathSegs(ctx context.Context, msg *path_mgmt.SegReq,
 func (m *Messenger) RequestChainIssue(ctx context.Context, msg *cert_mgmt.ChainIssReq, a net.Addr,
 	id uint64) (*cert_mgmt.ChainIssRep, error) {
 
-	logger := m.log.New("debug_id", util.GetDebugID())
+	debug_id := util.GetDebugID()
+	logger := m.log.New("debug_id", debug_id)
 	pld, err := ctrl.NewCertMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
 	if err != nil {
 		return nil, err
@@ -300,18 +303,18 @@ func (m *Messenger) RequestChainIssue(ctx context.Context, msg *cert_mgmt.ChainI
 	replyCtrlPld, _, err :=
 		m.getRequester(infra.ChainIssueRequest, infra.ChainIssueReply).Request(ctx, pld, a)
 	if err != nil {
-		logger.Info("[Messenger] Request error", "err", err)
-		return nil, err
+		return nil, common.NewBasicError("[Messenger] Request error", err, "debug_id", debug_id)
 	}
 	_, replyMsg, err := m.validate(replyCtrlPld)
 	if err != nil {
-		logger.Info("[Messenger] Reply validation error", "err", err)
-		return nil, err
+		return nil, common.NewBasicError("[Messenger] Reply validation failed", err,
+			"debug_id", debug_id)
 	}
 	reply, ok := replyMsg.(*cert_mgmt.ChainIssRep)
 	if !ok {
-		logger.Info("[Messenger] Type assertion failed")
-		return nil, newTypeAssertErr("*cert_mgmt.ChainIssReply", replyMsg)
+		err := newTypeAssertErr("*cert_mgmt.TRC", replyMsg)
+		return nil, common.NewBasicError("[Messenger] Type assertion failed", err,
+			"debug_id", debug_id)
 	}
 	logger.Debug("[Messenger] Received reply")
 	return reply, nil

--- a/go/lib/infra/messenger/messenger_test.go
+++ b/go/lib/infra/messenger/messenger_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
+	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
@@ -59,8 +60,8 @@ func MockTRCHandler(request *infra.Request) {
 func TestTRCExchange(t *testing.T) {
 	Convey("Setup", t, func() {
 		c2s, s2c := p2p.New()
-		clientMessenger := setupMessenger(c2s, "client")
-		serverMessenger := setupMessenger(s2c, "server")
+		clientMessenger := setupMessenger(xtest.MustParseIA("1-ff00:0:1"), c2s, "client")
+		serverMessenger := setupMessenger(xtest.MustParseIA("2-ff00:0:1"), s2c, "server")
 
 		Convey("Client/server", xtest.Parallel(func(sc *xtest.SC) {
 			// The client sends a TRC request to the server, and receives the
@@ -84,11 +85,11 @@ func TestTRCExchange(t *testing.T) {
 	})
 }
 
-func setupMessenger(conn net.PacketConn, name string) *Messenger {
+func setupMessenger(ia addr.IA, conn net.PacketConn, name string) *Messenger {
 	transport := rpt.New(conn, log.New("name", name))
 	dispatcher := disp.New(transport, DefaultAdapter, log.New("name", name))
 	config := &Config{DisableSignatureVerification: true}
-	return New(dispatcher, nil, log.Root().New("name", name), config)
+	return New(ia, dispatcher, nil, log.Root().New("name", name), config)
 }
 
 func TestMain(m *testing.M) {

--- a/go/lib/infra/modules/combinator/graph.go
+++ b/go/lib/infra/modules/combinator/graph.go
@@ -319,9 +319,18 @@ func (solution *PathSolution) GetFwdPathMetadata() *Path {
 				}
 
 				if solEdge.edge.Shortcut != 0 {
+					// XXX(scrye): Path reversal doesn't build valid reverse
+					// paths (both in Python and in Go) if the X-flag isn't
+					// included after the Verify-only flag HF in the
+					// down-segment (see the common upstream test for an
+					// example).
+					if solEdge.segment.IsDownSeg() && edgeIdx == 1 {
+						newHF.Xover = true
+					}
+
 					if solEdge.edge.Peer != 0 {
-						// We're crossing a peering shortcut. Always set Xover flag
-						// for the current hop field, even if on last segment.
+						// Always set Xover flag for the current hop field,
+						// even if on last segment.
 						newHF.Xover = true
 						// Add a new hop field for the peering entry, and set Xover.
 						pHF := currentSeg.appendHopFieldFrom(asEntry.HopEntries[solEdge.edge.Peer])

--- a/go/lib/infra/modules/combinator/graph.go
+++ b/go/lib/infra/modules/combinator/graph.go
@@ -319,11 +319,6 @@ func (solution *PathSolution) GetFwdPathMetadata() *Path {
 				}
 
 				if solEdge.edge.Shortcut != 0 {
-					// XXX(scrye): Path reversal doesn't build valid reverse
-					// paths (both in Python and in Go) if the X-flag isn't
-					// included after the Verify-only flag HF in the
-					// down-segment (see the common upstream test for an
-					// example).
 					if solEdge.segment.IsDownSeg() && edgeIdx == 1 {
 						newHF.Xover = true
 					}

--- a/go/lib/infra/modules/combinator/testdata/14_compute_path.txt
+++ b/go/lib/infra/modules/combinator/testdata/14_compute_path.txt
@@ -7,7 +7,7 @@ Path #0:
       HF .V InIF=0 OutIF=2123
     IF CS. ISD=2
       HF .V InIF=0 OutIF=2123
-      HF .. InIF=2321 OutIF=2326
+      HF X. InIF=2321 OutIF=2326
       HF .. InIF=2623 OutIF=0
   Interfaces:
     2-ff00:0:212#2523

--- a/go/lib/infra/modules/trust/helpers.go
+++ b/go/lib/infra/modules/trust/helpers.go
@@ -34,11 +34,11 @@ import (
 // forever.
 
 func CreateSign(ia addr.IA, store infra.TrustStore) (*proto.SignS, error) {
-	c, err := store.GetValidChain(context.TODO(), ia, ia.I)
+	c, err := store.GetValidChain(context.TODO(), nil, ia)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to find local certificate chain", err)
 	}
-	t, err := store.GetValidTRC(context.TODO(), ia.I, ia.I)
+	t, err := store.GetValidTRC(context.TODO(), nil, ia.I)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to find local TRC", err)
 	}
@@ -59,7 +59,7 @@ func CreateSign(ia addr.IA, store infra.TrustStore) (*proto.SignS, error) {
 
 // VerifyChain verifies the chain based on the TRCs present in the store.
 func VerifyChain(subject addr.IA, chain *cert.Chain, store infra.TrustStore) error {
-	maxTrc, err := store.GetValidTRC(context.TODO(), chain.Issuer.Issuer.I, chain.Issuer.Issuer.I)
+	maxTrc, err := store.GetValidTRC(context.TODO(), nil, chain.Issuer.Issuer.I)
 	if err != nil {
 		return common.NewBasicError("Unable to find TRC", nil, "isd", chain.Issuer.Issuer.I)
 	}

--- a/go/lib/infra/modules/trust/helpers.go
+++ b/go/lib/infra/modules/trust/helpers.go
@@ -34,11 +34,11 @@ import (
 // forever.
 
 func CreateSign(ia addr.IA, store infra.TrustStore) (*proto.SignS, error) {
-	c, err := store.GetValidChain(context.TODO(), nil, ia)
+	c, err := store.GetValidChain(context.TODO(), ia, nil)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to find local certificate chain", err)
 	}
-	t, err := store.GetValidTRC(context.TODO(), nil, ia.I)
+	t, err := store.GetValidTRC(context.TODO(), ia.I, nil)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to find local TRC", err)
 	}
@@ -59,7 +59,7 @@ func CreateSign(ia addr.IA, store infra.TrustStore) (*proto.SignS, error) {
 
 // VerifyChain verifies the chain based on the TRCs present in the store.
 func VerifyChain(subject addr.IA, chain *cert.Chain, store infra.TrustStore) error {
-	maxTrc, err := store.GetValidTRC(context.TODO(), nil, chain.Issuer.Issuer.I)
+	maxTrc, err := store.GetValidTRC(context.TODO(), chain.Issuer.Issuer.I, nil)
 	if err != nil {
 		return common.NewBasicError("Unable to find TRC", nil, "isd", chain.Issuer.Issuer.I)
 	}

--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -18,7 +18,6 @@ package trust
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"net"
 	"sync"
@@ -43,9 +42,11 @@ const (
 )
 
 var (
-	ErrEndOfTrail           = "Reached end of trail, but no trusted TRC found"
+	ErrNotFoundLocally      = "Chain/TRC not found locally"
 	ErrMissingAuthoritative = "Trust store is authoritative for requested object, and object was not found"
 )
+
+var _ infra.TrustStore = (*Store)(nil)
 
 // Store manages requests for TRC and Certificate Chain objects.
 //
@@ -163,69 +164,25 @@ func (store *Store) chainRequestFunc(ctx context.Context, request dedupe.Request
 	return dedupe.Response{Data: chain}
 }
 
-// GetValidTRC asks the trust store to return a valid TRC for isd. Trail should
-// contain a sequence of cross-signing ISDs to be used during validation, with
-// the requested TRC being the first one.
-func (store *Store) GetValidTRC(ctx context.Context, isd addr.ISD,
-	trail ...addr.ISD) (*trc.TRC, error) {
+// GetValidTRC asks the trust store to return a valid TRC for isd. Server is
+// queried over the network if the TRC is not available locally. Otherwise, the
+// default server is queried.
+func (store *Store) GetValidTRC(ctx context.Context, server net.Addr,
+	isd addr.ISD) (*trc.TRC, error) {
 
-	if len(trail) > 0 && trail[0] != isd {
-		return nil, common.NewBasicError(fmt.Sprintf("bad trail, should start with ISD=%d\n", isd),
-			nil, "trail", trail)
-	}
-	// FIXME(scrye): This needs support for anycasting to remote core ISDs
-	return store.getValidTRC(ctx, trail, true,
-		&snet.Addr{IA: addr.IA{I: isd}, Host: &addr.AppAddr{L3: addr.SvcCS}})
+	// FIXME(scrye): fall back to getTRC for now, although getValidTRC should
+	// perform additional validations in the future.
+	return store.getTRC(ctx, isd, 0, true, nil, server)
 }
 
-// getValidTRC recursively follows trail to create a fully validated trust
-// chain leading up to trail[0].  Given a trail composed of:
-//   [ISD1, ISD2, ISD3, ISD4]
-// getValidTRC first tries to see if the TRC for ISD1 is in trustdb. If it's
-// not, it recursively calls getValidTRC on new trail:
-//   [ISD2, ISD3, ISD4]
-// and eventually:
-//   [ISD3, ISD4]
-// Suppose the TRC for ISD3 is in the database. The function returns the TRC
-// and nil. The caller now has access to the TRC for ISD3, and needs to obtain
-// the TRC for ISD2. It issues a call to the backend passing the TRC of ISD3 as
-// the validator. Once it gets the TRC for ISD2, it returns it. The TRC for
-// ISD2 is then used to download the TRC for ISD1.
-func (store *Store) getValidTRC(ctx context.Context, trail []addr.ISD,
-	recurse bool, server net.Addr) (*trc.TRC, error) {
-
-	if len(trail) == 0 {
-		// We've reached the end of the trail and did not find a trust anchor,
-		// propagate this information to the caller.
-		return nil, common.NewBasicError(ErrEndOfTrail, nil)
-	}
-
-	if trail[0] == 0 {
-		return nil, common.NewBasicError("value 0 is not a valid ISD number", nil)
-	}
-
-	trcObj, err := store.trustdb.GetTRCVersionCtx(ctx, trail[0], 0)
-	if err != nil || trcObj != nil {
-		return trcObj, err
-	}
-
-	// The TRC needed to perform verification is not in trustdb; advance the
-	// trail and recursively try to get the next TRC.
-	nextTRC, err := store.getValidTRC(ctx, trail[1:], recurse, server)
+// GetValidCachedTRC asks the trust store to return a valid TRC for isd without
+// accessing the network.
+func (store *Store) GetValidCachedTRC(ctx context.Context, isd addr.ISD) (*trc.TRC, error) {
+	trcObj, err := store.getTRC(ctx, isd, 0, false, nil, nil)
 	if err != nil {
-		return nil, err
+		return nil, common.NewBasicError(ErrNotFoundLocally, err)
 	}
-	if recurse == false {
-		return nil, common.NewBasicError("TRC not found in DB (valid requested), "+
-			"and recursion disabled", nil, "isd", trail[0])
-	}
-	return store.getTRCFromNetwork(ctx, &trcRequest{
-		isd:      trail[0],
-		version:  0,
-		id:       store.nextID(),
-		server:   server,
-		postHook: store.newTRCValidator(nextTRC),
-	})
+	return trcObj, nil
 }
 
 // GetTRC asks the trust store to return a TRC of the requested
@@ -234,29 +191,31 @@ func (store *Store) getValidTRC(ctx context.Context, trail []addr.ISD,
 func (store *Store) GetTRC(ctx context.Context,
 	isd addr.ISD, version uint64) (*trc.TRC, error) {
 
-	return store.getTRC(ctx, isd, version, true, nil)
+	return store.getTRC(ctx, isd, version, true, nil, nil)
 }
 
 // getTRC attempts to grab the TRC from the database; if the TRC is not found,
 // it follows up with a network request (if allowed).  Parameter recurse
 // specifies whether this function is allowed to create new network requests.
-// Parameter requester contains the node that caused the function to be called,
+// Parameter client contains the node that caused the function to be called,
 // or nil if the function was called due to a local feature.
 func (store *Store) getTRC(ctx context.Context, isd addr.ISD, version uint64,
-	recurse bool, requester net.Addr) (*trc.TRC, error) {
+	recurse bool, client, server net.Addr) (*trc.TRC, error) {
 
 	trcObj, err := store.trustdb.GetTRCVersionCtx(ctx, isd, version)
 	if err != nil || trcObj != nil {
 		return trcObj, err
 	}
 	if recurse == false {
-		return nil, common.NewBasicError("TRC not found in DB, and recursion disabled", nil,
-			"isd", isd, "version", version, "requester", requester)
+		return nil, common.NewBasicError(ErrNotFoundLocally, nil, "isd", isd, "version", version,
+			"client", client)
 	}
-	if err := store.isLocal(requester); err != nil {
+	if err := store.isLocal(client); err != nil {
 		return nil, err
 	}
-	server, err := store.ChooseServer(addr.IA{I: isd})
+	if server == nil {
+		server, err = store.ChooseServer(addr.IA{I: isd})
+	}
 	if err != nil {
 		return nil, common.NewBasicError("Error determining server to query", err,
 			"requested_isd", isd, "requested_version", version)
@@ -266,7 +225,7 @@ func (store *Store) getTRC(ctx context.Context, isd addr.ISD, version uint64,
 		version:  version,
 		id:       store.nextID(),
 		server:   server,
-		postHook: nil, // Disable verification / database insertion
+		postHook: store.newInsertTRCHook(),
 	})
 }
 
@@ -285,19 +244,12 @@ func (store *Store) getTRCFromNetwork(ctx context.Context, req *trcRequest) (*tr
 	}
 }
 
-// newTRCValidator returns a TRC validation callback with validator as
-// trust anchor. If validation succeeds, the validated TRC is also inserted in
-// the trust database.
-func (store *Store) newTRCValidator(validator *trc.TRC) ValidateTRCF {
+// newInsertTRCHook returns a TRC validation callback which always inserts the
+// TRC into the database.
+func (store *Store) newInsertTRCHook() ValidateTRCF {
 	return func(ctx context.Context, trcObj *trc.TRC) error {
-		if validator == nil {
-			return common.NewBasicError("TRC verification error, nil verifier", nil,
-				"target", trcObj)
-		}
-		if _, err := trcObj.Verify(validator); err != nil {
-			return common.NewBasicError("TRC verification error", err)
-		}
-		if _, err := store.trustdb.InsertTRCCtx(ctx, trcObj); err != nil {
+		_, err := store.trustdb.InsertTRCCtx(ctx, trcObj)
+		if err != nil {
 			return common.NewBasicError("Unable to store TRC in database", err)
 		}
 		return nil
@@ -307,22 +259,18 @@ func (store *Store) newTRCValidator(validator *trc.TRC) ValidateTRCF {
 // GetValidChain asks the trust store to return a valid certificate chain for ia.
 // Trail should contain a sequence of cross-signing ISDs to be used during
 // validation, with the ISD of the certificate chain being the first one.
-func (store *Store) GetValidChain(ctx context.Context, ia addr.IA,
-	trail ...addr.ISD) (*cert.Chain, error) {
+// Server is queried over the network if the chain is not available locally.
+func (store *Store) GetValidChain(ctx context.Context, server net.Addr,
+	ia addr.IA) (*cert.Chain, error) {
 
-	if len(trail) > 0 && trail[0] != ia.I {
-		return nil, common.NewBasicError(fmt.Sprintf("bad trail, should start with ISD=%d\n", ia.I),
-			nil, "trail", trail)
+	if server == nil {
+		server = &snet.Addr{IA: ia, Host: &addr.AppAddr{L3: addr.SvcCS}}
 	}
-
-	// FIXME(scrye): Currently send message to CS in remote AS, but this should
-	// change once server hints can be passed to the trust store.
-	return store.getValidChain(ctx, ia, trail, true,
-		&snet.Addr{IA: ia, Host: &addr.AppAddr{L3: addr.SvcCS}})
+	return store.getValidChain(ctx, ia, true, nil, server)
 }
 
-func (store *Store) getValidChain(ctx context.Context, ia addr.IA, trail []addr.ISD,
-	recurse bool, server net.Addr) (*cert.Chain, error) {
+func (store *Store) getValidChain(ctx context.Context, ia addr.IA, recurse bool,
+	client, server net.Addr) (*cert.Chain, error) {
 
 	chain, err := store.trustdb.GetChainVersionCtx(ctx, ia, 0)
 	if err != nil || chain != nil {
@@ -334,14 +282,13 @@ func (store *Store) getValidChain(ctx context.Context, ia addr.IA, trail []addr.
 	}
 	// Chain not found, so we'll need to fetch one. First, fetch the TRC we'll
 	// need during certificate chain validation.
-	trcObj, err := store.getValidTRC(ctx, trail, recurse, server)
+	trcObj, err := store.getTRC(ctx, ia.I, 0, recurse, client, server)
 	if err != nil {
 		return nil, err
 	}
 
 	if recurse == false {
-		return nil, common.NewBasicError("Chain not found in DB (valid chain requested), and "+
-			"recursion disabled", nil, "ia", ia)
+		return nil, common.NewBasicError(ErrNotFoundLocally, nil, "ia", ia)
 	}
 	return store.getChainFromNetwork(ctx, &chainRequest{
 		ia:       ia,
@@ -454,15 +401,15 @@ func (store *Store) LoadAuthoritativeTRC(dir string) error {
 	}
 
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
-	dbTRC, err := store.GetValidTRC(ctx, store.ia.I, store.ia.I)
+	dbTRC, err := store.getTRC(ctx, store.ia.I, 0, false, nil, nil)
 	cancelF()
 	switch {
-	case err != nil && common.GetErrorMsg(err) != ErrEndOfTrail:
+	case err != nil && common.GetErrorMsg(err) != ErrNotFoundLocally:
 		// Unexpected error in trust store
 		return err
-	case common.GetErrorMsg(err) == ErrEndOfTrail && fileTRC == nil:
+	case common.GetErrorMsg(err) == ErrNotFoundLocally && fileTRC == nil:
 		return common.NewBasicError("No TRC found on disk or in trustdb", nil)
-	case common.GetErrorMsg(err) == ErrEndOfTrail && fileTRC != nil:
+	case common.GetErrorMsg(err) == ErrNotFoundLocally && fileTRC != nil:
 		_, err := store.trustdb.InsertTRC(fileTRC)
 		return err
 	case err == nil && fileTRC == nil:
@@ -504,7 +451,7 @@ func (store *Store) LoadAuthoritativeChain(dir string) error {
 	}
 
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
-	dbChain, err := store.GetValidChain(ctx, store.ia, store.ia.I)
+	dbChain, err := store.getValidChain(ctx, store.ia, false, nil, nil)
 	cancelF()
 	switch {
 	case err != nil && common.GetErrorMsg(err) != ErrMissingAuthoritative:
@@ -547,7 +494,6 @@ func (store *Store) NewTRCReqHandler(recurse bool) infra.Handler {
 		handler := &trcReqHandler{
 			request: r,
 			store:   store,
-			log:     store.log,
 			recurse: recurse,
 		}
 		handler.Handle()
@@ -565,7 +511,6 @@ func (store *Store) NewChainReqHandler(recurse bool) infra.Handler {
 		handler := chainReqHandler{
 			request: r,
 			store:   store,
-			log:     store.log,
 			recurse: recurse,
 		}
 		handler.Handle()
@@ -581,7 +526,6 @@ func (store *Store) NewTRCPushHandler() infra.Handler {
 		handler := trcPushHandler{
 			request: r,
 			store:   store,
-			log:     store.log,
 		}
 		handler.Handle()
 	}
@@ -597,7 +541,6 @@ func (store *Store) NewChainPushHandler() infra.Handler {
 		handler := chainPushHandler{
 			request: r,
 			store:   store,
-			log:     store.log,
 		}
 		handler.Handle()
 	}

--- a/go/lib/infra/modules/trust/trust_test.go
+++ b/go/lib/infra/modules/trust/trust_test.go
@@ -108,62 +108,18 @@ func TestGetValidTRC(t *testing.T) {
 	testCases := []struct {
 		Name          string
 		ISD           addr.ISD
-		Trail         []addr.ISD
 		ExpData       *trc.TRC
 		ExpError      bool
 		DBTRCInChecks []*trc.TRC // Check that these objects were saved to persistent storage
 	}{
 		{
-			Name: "bad ISD=0",
-			ISD:  0, Trail: []addr.ISD{0},
-			ExpData: nil, ExpError: true,
+			Name: "bad ISD=0", ISD: 0, ExpData: nil, ExpError: true,
 		},
 		{
-			Name: "local ISD=1",
-			ISD:  1, Trail: []addr.ISD{1},
-			ExpData: trcs[1], ExpError: false,
+			Name: "local ISD=1", ISD: 1, ExpData: trcs[1], ExpError: false,
 		},
 		{
-			Name: "unknown ISD=2, nil trail",
-			ISD:  2, Trail: nil,
-			ExpData: nil, ExpError: true,
-		},
-		{
-			Name: "unknown ISD=2, empty trail",
-			ISD:  2, Trail: []addr.ISD{},
-			ExpData: nil, ExpError: true,
-		},
-		{
-			Name: "unknown ISD=5, bad trail",
-			ISD:  5, Trail: []addr.ISD{1, 2, 3},
-			ExpData: nil, ExpError: true,
-		},
-		{
-			Name: "unknown ISD=2, 2-length trail, no trust root in trail",
-			ISD:  2, Trail: []addr.ISD{2, 3},
-			ExpData: nil, ExpError: true,
-		},
-		{
-			Name: "unknown ISD=2, 2-length trail, trust root in trail",
-			ISD:  2, Trail: []addr.ISD{2, 1},
-			ExpData: trcs[2], ExpError: false,
-		},
-		{
-			Name: "unknown ISD=2, 3-length trail, trust root mid-trail ",
-			ISD:  2, Trail: []addr.ISD{2, 1, 3},
-			ExpData: trcs[2], ExpError: false,
-			DBTRCInChecks: []*trc.TRC{trcs[2]},
-		},
-		{
-			Name: "unknown ISD=2, 3-length trail, trust root at end of trail",
-			ISD:  2, Trail: []addr.ISD{2, 3, 1},
-			ExpData: trcs[2], ExpError: false,
-			DBTRCInChecks: []*trc.TRC{trcs[2], trcs[3]},
-		},
-		{
-			Name: "bogus ISD=42, 2-length trail",
-			ISD:  42, Trail: []addr.ISD{42, 1},
-			ExpData: nil, ExpError: true,
+			Name: "unknown ISD=6", ISD: 6, ExpData: nil, ExpError: true,
 		},
 	}
 
@@ -182,7 +138,7 @@ func TestGetValidTRC(t *testing.T) {
 				ctx, cancelF := context.WithTimeout(context.Background(), testCtxTimeout)
 				defer cancelF()
 
-				trcObj, err := store.GetValidTRC(ctx, tc.ISD, tc.Trail...)
+				trcObj, err := store.GetValidTRC(ctx, nil, tc.ISD)
 				xtest.SoMsgError("err", err, tc.ExpError)
 				SoMsg("trc", trcObj, ShouldResemble, tc.ExpData)
 
@@ -206,8 +162,6 @@ func TestGetTRC(t *testing.T) {
 		Version  uint64
 		ExpData  *trc.TRC
 		ExpError bool
-
-		DBTRCNotInChecks []*trc.TRC // Explicitly check that these objects where not saved to DB
 	}{
 		{
 			Name: "bad ISD=0",
@@ -233,7 +187,6 @@ func TestGetTRC(t *testing.T) {
 			Name: "unknown ISD=2, version 1",
 			ISD:  2, Version: 1,
 			ExpData: trcs[2], ExpError: false,
-			DBTRCNotInChecks: []*trc.TRC{trcs[2]},
 		},
 		{
 			Name: "unknown ISD=2, max version",
@@ -277,17 +230,9 @@ func TestGetTRC(t *testing.T) {
 			Convey(tc.Name, func() {
 				ctx, cancelF := context.WithTimeout(context.Background(), testCtxTimeout)
 				defer cancelF()
-
 				trcObj, err := store.GetTRC(ctx, tc.ISD, tc.Version)
 				xtest.SoMsgError("err", err, tc.ExpError)
 				SoMsg("trc", trcObj, ShouldResemble, tc.ExpData)
-
-				// Post-check DB state to verify that unverified objects were not inserted
-				for _, trcObj := range tc.DBTRCNotInChecks {
-					get, err := store.trustdb.GetTRCVersion(trcObj.ISD, trcObj.Version)
-					SoMsg("db err", err, ShouldBeNil)
-					SoMsg("db trc", get, ShouldBeNil)
-				}
 			})
 		}
 	})
@@ -300,29 +245,28 @@ func TestGetValidChain(t *testing.T) {
 	testCases := []struct {
 		Name            string
 		IA              addr.IA
-		Trail           []addr.ISD
 		ExpData         *cert.Chain
 		ExpError        bool
 		DBChainInChecks []*cert.Chain // Check that these objects were saved to persistent storage
 	}{
 		{
-			Name: "bad IA=0-1",
-			IA:   xtest.MustParseIA("0-ff00:0:1"), Trail: []addr.ISD{0},
+			Name:    "bad IA=0-1",
+			IA:      xtest.MustParseIA("0-ff00:0:1"),
 			ExpData: nil, ExpError: true,
 		},
 		{
-			Name: "bad IA=1-0",
-			IA:   addr.IA{I: 1, A: 0}, Trail: []addr.ISD{0},
+			Name:    "bad IA=1-0",
+			IA:      addr.IA{I: 1, A: 0},
 			ExpData: nil, ExpError: true,
 		},
 		{
-			Name: "local IA=1-1",
-			IA:   xtest.MustParseIA("1-ff00:0:1"), Trail: []addr.ISD{1},
+			Name:    "local IA=1-1",
+			IA:      xtest.MustParseIA("1-ff00:0:1"),
 			ExpData: chains[xtest.MustParseIA("1-ff00:0:1")], ExpError: false,
 		},
 		{
-			Name: "remote IA=2-4",
-			IA:   xtest.MustParseIA("2-ff00:0:4"), Trail: []addr.ISD{2, 1},
+			Name:    "remote IA=2-4",
+			IA:      xtest.MustParseIA("2-ff00:0:4"),
 			ExpData: chains[xtest.MustParseIA("2-ff00:0:4")], ExpError: false,
 			DBChainInChecks: []*cert.Chain{chains[xtest.MustParseIA("2-ff00:0:4")]},
 		},
@@ -335,15 +279,13 @@ func TestGetValidChain(t *testing.T) {
 		}
 		store, cleanF := initStore(t, xtest.MustParseIA("1-ff00:0:1"), msger)
 		defer cleanF()
-
 		insertTRC(t, store, trcs[1])
-
-		for _, tc := range testCases {
+		for _, tc := range testCases[3:4] {
 			Convey(tc.Name, func() {
 				ctx, cancelF := context.WithTimeout(context.Background(), testCtxTimeout)
 				defer cancelF()
 
-				chain, err := store.GetValidChain(ctx, tc.IA, tc.Trail...)
+				chain, err := store.GetValidChain(ctx, nil, tc.IA)
 				xtest.SoMsgError("err", err, tc.ExpError)
 				SoMsg("trc", chain, ShouldResemble, tc.ExpData)
 
@@ -366,7 +308,6 @@ func TestGetChain(t *testing.T) {
 		Name               string
 		IA                 addr.IA
 		Version            uint64
-		Trail              []addr.ISD
 		ExpData            *cert.Chain
 		ExpError           bool
 		DBChainNotInChecks []*cert.Chain // Check that these objects were not saved to DB
@@ -566,9 +507,9 @@ func TestTRCReqHandler(t *testing.T) {
 
 		c2s, s2c := p2p.New()
 		// each test initiates a request from the client messenger
-		clientMessenger := setupMessenger(c2s, nil, "client")
+		clientMessenger := setupMessenger(xtest.MustParseIA("2-ff00:0:1"), c2s, nil, "client")
 		// the server messenger runs ListenAndServe, backed by the trust store
-		serverMessenger := setupMessenger(s2c, store, "server")
+		serverMessenger := setupMessenger(xtest.MustParseIA("1-ff00:0:1"), s2c, store, "server")
 
 		for _, tc := range testCases {
 			Convey(tc.Name, func() {
@@ -685,9 +626,9 @@ func TestChainReqHandler(t *testing.T) {
 
 		c2s, s2c := p2p.New()
 		// each test initiates a request from the client messenger
-		clientMessenger := setupMessenger(c2s, nil, "client")
+		clientMessenger := setupMessenger(xtest.MustParseIA("2-ff00:0:1"), c2s, nil, "client")
 		// the server messenger runs ListenAndServe, backed by the trust store
-		serverMessenger := setupMessenger(s2c, store, "server")
+		serverMessenger := setupMessenger(xtest.MustParseIA("1-ff00:0:1"), s2c, store, "server")
 
 		for _, tc := range testCases {
 			Convey(tc.Name, func() {
@@ -716,11 +657,11 @@ func TestChainReqHandler(t *testing.T) {
 	})
 }
 
-func setupMessenger(conn net.PacketConn, store *Store, name string) infra.Messenger {
+func setupMessenger(ia addr.IA, conn net.PacketConn, store *Store, name string) infra.Messenger {
 	transport := rpt.New(conn, log.New("name", name))
 	dispatcher := disp.New(transport, messenger.DefaultAdapter, log.New("name", name))
 	config := &messenger.Config{DisableSignatureVerification: true}
-	return messenger.New(dispatcher, store, log.Root().New("name", name), config)
+	return messenger.New(ia, dispatcher, store, log.Root().New("name", name), config)
 }
 
 func loadCrypto(t *testing.T, isds []addr.ISD,

--- a/go/lib/infra/modules/trust/trust_test.go
+++ b/go/lib/infra/modules/trust/trust_test.go
@@ -138,7 +138,7 @@ func TestGetValidTRC(t *testing.T) {
 				ctx, cancelF := context.WithTimeout(context.Background(), testCtxTimeout)
 				defer cancelF()
 
-				trcObj, err := store.GetValidTRC(ctx, nil, tc.ISD)
+				trcObj, err := store.GetValidTRC(ctx, tc.ISD, nil)
 				xtest.SoMsgError("err", err, tc.ExpError)
 				SoMsg("trc", trcObj, ShouldResemble, tc.ExpData)
 
@@ -285,7 +285,7 @@ func TestGetValidChain(t *testing.T) {
 				ctx, cancelF := context.WithTimeout(context.Background(), testCtxTimeout)
 				defer cancelF()
 
-				chain, err := store.GetValidChain(ctx, nil, tc.IA)
+				chain, err := store.GetValidChain(ctx, tc.IA, nil)
 				xtest.SoMsgError("err", err, tc.ExpError)
 				SoMsg("trc", chain, ShouldResemble, tc.ExpData)
 

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -207,34 +207,34 @@ func (t *Topo) GetTopoAddr(nodeType string, id string) *TopoAddr {
 	return nil
 }
 
-// GetRandomPS returns the IA, Host and L4 Port for a random PS, with
-// randomness taken from the default source.
-func (t *Topo) GetRandomPS() *addr.AppAddr {
-	numPSServers := len(t.PSNames)
-	if numPSServers == 0 {
+// GetRandomServer returns the application address for a random service of type
+// t; BS, PS, and CS are currently supported.. Randomness is taken from the
+// default source. If no server is found, the returned address is nil.
+func (t *Topo) GetRandomServer(serviceTypeStr string) *addr.AppAddr {
+	names := t.extractServerNames(serviceTypeStr)
+	numServers := len(names)
+	if numServers == 0 {
 		return nil
 	}
-	psName := t.PSNames[rand.Intn(numPSServers)]
-	topoAddr := t.GetTopoAddr("PS", psName)
+	topoAddr := t.GetTopoAddr(serviceTypeStr, names[rand.Intn(numServers)])
 	if topoAddr == nil {
 		return nil
 	}
 	return topoAddr.PublicAddr(t.Overlay)
+
 }
 
-// GetRandomCS returns the IA, Host and L4 Port for a random CS, with
-// randomness taken from the default source.
-func (t *Topo) GetRandomCS() *addr.AppAddr {
-	numCSServers := len(t.CSNames)
-	if numCSServers == 0 {
+func (t *Topo) extractServerNames(serviceTypeStr string) []string {
+	switch serviceTypeStr {
+	case common.BS:
+		return t.BSNames
+	case common.CS:
+		return t.CSNames
+	case common.PS:
+		return t.PSNames
+	default:
 		return nil
 	}
-	csName := t.CSNames[rand.Intn(numCSServers)]
-	topoAddr := t.GetTopoAddr("CS", csName)
-	if topoAddr == nil {
-		return nil
-	}
-	return topoAddr.PublicAddr(t.Overlay)
 }
 
 // Convert map of Name->RawAddrInfo into map of Name->TopoAddr and sorted slice of Names

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -16,6 +16,7 @@ package topology
 
 import (
 	"fmt"
+	"math/rand"
 	"sort"
 	"time"
 
@@ -204,6 +205,36 @@ func (t *Topo) GetTopoAddr(nodeType string, id string) *TopoAddr {
 		return &cp
 	}
 	return nil
+}
+
+// GetRandomPS returns the IA, Host and L4 Port for a random PS, with
+// randomness taken from the default source.
+func (t *Topo) GetRandomPS() *addr.AppAddr {
+	numPSServers := len(t.PSNames)
+	if numPSServers == 0 {
+		return nil
+	}
+	psName := t.PSNames[rand.Intn(numPSServers)]
+	topoAddr := t.GetTopoAddr("PS", psName)
+	if topoAddr == nil {
+		return nil
+	}
+	return topoAddr.PublicAddr(t.Overlay)
+}
+
+// GetRandomCS returns the IA, Host and L4 Port for a random CS, with
+// randomness taken from the default source.
+func (t *Topo) GetRandomCS() *addr.AppAddr {
+	numCSServers := len(t.CSNames)
+	if numCSServers == 0 {
+		return nil
+	}
+	csName := t.CSNames[rand.Intn(numCSServers)]
+	topoAddr := t.GetTopoAddr("CS", csName)
+	if topoAddr == nil {
+		return nil
+	}
+	return topoAddr.PublicAddr(t.Overlay)
 }
 
 // Convert map of Name->RawAddrInfo into map of Name->TopoAddr and sorted slice of Names

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -184,7 +184,7 @@ func (t *Topo) populateServices(raw *RawTopo) error {
 }
 
 // GetTopoAddr is a helper method that returns the TopoAddress for a specific
-// element ID of type t. nodeType must be one of BS, CS or CP. If the ID is not
+// element ID of type t. nodeType must be one of BS, CS or PS. If the ID is not
 // found, nil is returned.
 func (t *Topo) GetTopoAddr(serviceType proto.ServiceType, id string) *TopoAddr {
 	var addressMap map[string]TopoAddr

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
@@ -185,21 +184,17 @@ func (t *Topo) populateServices(raw *RawTopo) error {
 }
 
 // GetTopoAddr is a helper method that returns the TopoAddress for a specific
-// element ID of type t. nodeType must be one of BS, PS, CS, RS or DS. If the
-// ID is not found, nil is returned.
-func (t *Topo) GetTopoAddr(nodeType string, id string) *TopoAddr {
+// element ID of type t. nodeType must be one of BS, CS or CP. If the ID is not
+// found, nil is returned.
+func (t *Topo) GetTopoAddr(serviceType proto.ServiceType, id string) *TopoAddr {
 	var addressMap map[string]TopoAddr
-	switch nodeType {
-	case common.BS:
+	switch serviceType {
+	case proto.ServiceType_bs:
 		addressMap = t.BS
-	case common.CS:
+	case proto.ServiceType_cs:
 		addressMap = t.CS
-	case common.PS:
+	case proto.ServiceType_ps:
 		addressMap = t.PS
-	case common.RS:
-		addressMap = t.RS
-	case common.DS:
-		addressMap = t.DS
 	}
 	if _, ok := addressMap[id]; ok {
 		cp := addressMap[id]
@@ -221,12 +216,7 @@ func (t *Topo) GetRandomServer(serviceType proto.ServiceType) (*addr.AppAddr, er
 		return nil, common.NewBasicError("Found no servers of requested type", nil,
 			"type", serviceType)
 	}
-	topoAddr := t.GetTopoAddr(
-		// FIXME(scrye): remove this once the wire format is tested for
-		// uppercase service names
-		strings.ToUpper(serviceType.String()),
-		names[rand.Intn(numServers)],
-	)
+	topoAddr := t.GetTopoAddr(serviceType, names[rand.Intn(numServers)])
 	return topoAddr.PublicAddr(t.Overlay), nil
 
 }

--- a/go/lib/util/debugid.go
+++ b/go/lib/util/debugid.go
@@ -19,15 +19,15 @@ import (
 	"math/rand"
 )
 
-// TraceID is used to correlate behavior in logs. A TraceID is allocated
+// DebugID is used to correlate behavior in logs. A DebugID is allocated
 // for each outgoing request/response or notify message exchange, and for each
 // handler executed during ListenAndServe.
-type TraceID uint32
+type DebugID uint32
 
-func GetTraceID() TraceID {
-	return TraceID(rand.Uint32())
+func GetDebugID() DebugID {
+	return DebugID(rand.Uint32())
 }
 
-func (id TraceID) String() string {
+func (id DebugID) String() string {
 	return fmt.Sprintf("%08x", uint32(id))
 }

--- a/go/lib/util/trace.go
+++ b/go/lib/util/trace.go
@@ -1,0 +1,33 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+// TraceID is used to correlate behavior in logs. A TraceID is allocated
+// for each outgoing request/response or notify message exchange, and for each
+// handler executed during ListenAndServe.
+type TraceID uint32
+
+func GetTraceID() TraceID {
+	return TraceID(rand.Uint32())
+}
+
+func (id TraceID) String() string {
+	return fmt.Sprintf("%08x", uint32(id))
+}

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -41,6 +41,7 @@ import (
 	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/proto"
 )
 
 const (
@@ -94,9 +95,9 @@ func (f *Fetcher) GetPaths(ctx context.Context, req *sciond.PathReq,
 	}
 
 	// Commit to a path server, and use it for path and crypto queries
-	psAppAddr := f.topology.GetRandomServer(common.PS)
-	if psAppAddr == nil {
-		return nil, common.NewBasicError("PS not found in topology", nil)
+	psAppAddr, err := f.topology.GetRandomServer(proto.ServiceType_ps)
+	if err != nil {
+		return nil, common.NewBasicError("PS not found in topology", err)
 	}
 	ps := &snet.Addr{IA: f.topology.ISD_AS, Host: psAppAddr}
 

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -31,6 +31,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra/modules/combinator"
 	"github.com/scionproto/scion/go/lib/infra/modules/segsaver"
 	"github.com/scionproto/scion/go/lib/infra/modules/segverifier"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/pathdb"
 	"github.com/scionproto/scion/go/lib/pathdb/query"
@@ -90,24 +91,44 @@ func (f *Fetcher) GetPaths(ctx context.Context, req *sciond.PathReq,
 		return f.buildSCIONDReply(nil, sciond.ErrorBadSrcIA),
 			common.NewBasicError("Bad source AS", nil, "ia", req.Src.IA())
 	}
+
+	// Commit to a path server, and use it for path and crypto queries
+	psAppAddr := f.topology.GetRandomPS()
+	if psAppAddr == nil {
+		return nil, common.NewBasicError("PS not found in topology", nil)
+	}
+	ps := &snet.Addr{IA: f.topology.ISD_AS, Host: psAppAddr}
+
 	// Check destination
-	// FIXME(scrye): disallow remote AS = 0 for now, although we should add
-	// support for this eventually
-	if req.Dst.IA().I == 0 || req.Dst.IA().A == 0 {
+	if req.Dst.IA().I == 0 {
 		return f.buildSCIONDReply(nil, sciond.ErrorBadDstIA),
 			common.NewBasicError("Bad destination AS", nil, "ia", req.Dst.IA())
+	}
+	if req.Dst.IA().A == 0 {
+		remoteTRC, err := f.trustStore.GetValidTRC(ctx, ps, req.Dst.IA().I)
+		if err != nil {
+			return f.buildSCIONDReply(nil, sciond.ErrorInternal),
+				common.NewBasicError("Unable to select from remote core", err)
+		}
+		coreASes := remoteTRC.CoreASes.ASList()
+		if len(coreASes) == 0 {
+			return f.buildSCIONDReply(nil, sciond.ErrorInternal),
+				common.NewBasicError("No remote core AS found", nil)
+		}
+		req.Dst = coreASes[rand.Intn(len(coreASes))].IAInt()
 	}
 	if req.Dst.IA().Eq(f.topology.ISD_AS) {
 		return f.buildSCIONDReply(nil, sciond.ErrorOk), nil
 	}
-
+	// Try to build paths from local information first, if we don't have to
+	// get fresh segments.
 	if !req.Flags.Refresh {
-		// Try to build paths from local information first, if we don't have to
-		// get fresh segments.
-		paths, err := f.buildPathsFromDB(ctx, req)
+		paths, err := f.buildPathsFromDB(ctx, req, ps)
 		switch {
 		case ctx.Err() != nil:
 			return f.buildSCIONDReply(nil, sciond.ErrorNoPaths), nil
+		case err != nil && common.GetErrorMsg(err) == trust.ErrNotFoundLocally:
+			break
 		case err != nil:
 			return f.buildSCIONDReply(nil, sciond.ErrorInternal), err
 		case err == nil && len(paths) > 0:
@@ -119,14 +140,14 @@ func (f *Fetcher) GetPaths(ctx context.Context, req *sciond.PathReq,
 	// and revocation cache.
 	subCtx, cancelF := NewExtendedContext(ctx, DefaultMinWorkerLifetime)
 	earlyTrigger := util.NewTrigger(earlyReplyInterval)
-	go f.fetchAndVerify(subCtx, cancelF, req, earlyTrigger)
+	go f.fetchAndVerify(subCtx, cancelF, req, earlyTrigger, ps)
 	// Wait for deadlines while also waiting for the early reply.
 	select {
 	case <-earlyTrigger.Done():
 	case <-subCtx.Done():
 	case <-ctx.Done():
 	}
-	paths, err := f.buildPathsFromDB(ctx, req)
+	paths, err := f.buildPathsFromDB(ctx, req, ps)
 	switch {
 	case ctx.Err() != nil:
 		return f.buildSCIONDReply(nil, sciond.ErrorNoPaths), nil
@@ -143,7 +164,7 @@ func (f *Fetcher) GetPaths(ctx context.Context, req *sciond.PathReq,
 		case <-subCtx.Done():
 		case <-ctx.Done():
 		}
-		paths, err := f.buildPathsFromDB(ctx, req)
+		paths, err := f.buildPathsFromDB(ctx, req, ps)
 		switch {
 		case ctx.Err() != nil:
 			return f.buildSCIONDReply(nil, sciond.ErrorNoPaths), nil
@@ -236,7 +257,7 @@ func (f *Fetcher) buildSCIONDReplyEntries(paths []*combinator.Path) []sciond.Pat
 					Ipv4 []byte
 					Ipv6 []byte
 				}{
-					Ipv4: nextHop.InternalAddr.IPv4.PublicAddr().L3.IP(),
+					Ipv4: nextHop.InternalAddr.IPv4.PublicAddr().L3.IP().To4(),
 					// FIXME(scrye): also add support for IPv6
 				},
 				Port: nextHop.InternalAddr.IPv4.PublicAddr().L4.Port(),
@@ -249,27 +270,20 @@ func (f *Fetcher) buildSCIONDReplyEntries(paths []*combinator.Path) []sciond.Pat
 // buildPathsFromDB attempts to build paths only from information contained in the
 // local path database, taking the revocation cache into account.
 func (f *Fetcher) buildPathsFromDB(ctx context.Context,
-	req *sciond.PathReq) ([]*combinator.Path, error) {
+	req *sciond.PathReq, ps *snet.Addr) ([]*combinator.Path, error) {
 
 	// Try to determine whether the destination AS is core or not
-	// FIXME(scrye): The trail below is incorrect. The tests are written with
-	// this in mind, and they populate the database s.t. the trust store is
-	// guaranteed to not create network traffic here. This will be fixed when
-	// the trust store adds support for address hints and trailless local
-	// queries.
-	dstTrc, err := f.trustStore.GetValidTRC(ctx, req.Dst.IA().I, req.Dst.IA().I)
+	subCtx, subCancelF := context.WithTimeout(ctx, time.Second)
+	defer subCancelF()
+	dstTrc, err := f.trustStore.GetValidCachedTRC(subCtx, req.Dst.IA().I)
 	if err != nil {
 		// There are situations where we cannot tell if the remote is core. In
 		// these cases we just error out, and calling code will try to get path
 		// segments. When buildPaths is called again, err should be nil and the
 		// function will proceed to the next part.
-		// FIXME(scrye): We want to differentiate between critical errors and
-		// "I didn't find what you're looking for in the DB" errors. We want to
-		// mask out the latter, s.t. calling code doesn't halt execution when
-		// it sees an error.
 		return nil, err
 	}
-	localTrc, err := f.trustStore.GetValidTRC(ctx, f.topology.ISD_AS.I, f.topology.ISD_AS.I)
+	localTrc, err := f.trustStore.GetValidTRC(ctx, nil, f.topology.ISD_AS.I)
 	if err != nil {
 		return nil, err
 	}
@@ -366,10 +380,10 @@ func (f *Fetcher) filterRevokedPaths(paths []*combinator.Path) []*combinator.Pat
 // successfully verified are added to the pathDB. Revocations that are
 // successfully verified are added to the revocation cache.
 func (f *Fetcher) fetchAndVerify(ctx context.Context, cancelF context.CancelFunc,
-	req *sciond.PathReq, earlyTrigger *util.Trigger) {
+	req *sciond.PathReq, earlyTrigger *util.Trigger, ps *snet.Addr) {
 
 	defer cancelF()
-	reply, err := f.getSegmentsFromNetwork(ctx, req)
+	reply, err := f.getSegmentsFromNetwork(ctx, req, ps)
 	if err != nil {
 		log.Warn("Unable to retrieve paths from network", "err", err)
 		return
@@ -400,23 +414,8 @@ func (f *Fetcher) fetchAndVerify(ctx context.Context, cancelF context.CancelFunc
 }
 
 func (f *Fetcher) getSegmentsFromNetwork(ctx context.Context,
-	req *sciond.PathReq) (*path_mgmt.SegReply, error) {
+	req *sciond.PathReq, ps *snet.Addr) (*path_mgmt.SegReply, error) {
 
-	// Randomly choose a path server
-	numPSServers := len(f.topology.PSNames)
-	if numPSServers == 0 {
-		return nil, common.NewBasicError("Need PS for segments, but none found in topology", nil)
-	}
-	psName := f.topology.PSNames[rand.Intn(numPSServers)]
-	topoAddr := f.topology.PS[psName]
-	ps := &snet.Addr{
-		IA:   f.topology.ISD_AS,
-		Host: topoAddr.PublicAddr(f.topology.Overlay),
-	}
-	if ps.Host == nil {
-		return nil, common.NewBasicError("PS address not found", nil, "name", psName,
-			"overlay", f.topology.Overlay)
-	}
 	// Get segments from path server
 	msg := &path_mgmt.SegReq{
 		RawSrcIA: req.Src,

--- a/go/sciond/internal/servers/api.go
+++ b/go/sciond/internal/servers/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/sciond"
+	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/proto"
 )
 
@@ -73,7 +74,7 @@ func (srv *TransportHandler) Handle(b common.RawBytes, address net.Addr) {
 		log.Error("handler not found for capnp message", "which", p.Which)
 		return
 	}
-	handler.Handle(srv.Transport, address, p, srv.Logger.New("id", p.Id))
+	handler.Handle(srv.Transport, address, p, srv.Logger.New("trace_id", util.GetTraceID()))
 }
 
 func (srv *TransportHandler) Close() error {

--- a/go/sciond/internal/servers/api.go
+++ b/go/sciond/internal/servers/api.go
@@ -74,7 +74,7 @@ func (srv *TransportHandler) Handle(b common.RawBytes, address net.Addr) {
 		log.Error("handler not found for capnp message", "which", p.Which)
 		return
 	}
-	handler.Handle(srv.Transport, address, p, srv.Logger.New("trace_id", util.GetTraceID()))
+	handler.Handle(srv.Transport, address, p, srv.Logger.New("debug_id", util.GetDebugID()))
 }
 
 func (srv *TransportHandler) Close() error {

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -112,7 +112,7 @@ func (h *ASInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, p
 		reqIA = h.Topology.ISD_AS
 	}
 	asInfoReply := sciond.ASInfoReply{}
-	trcObj, err := h.TrustStore.GetValidTRC(workCtx, nil, reqIA.I)
+	trcObj, err := h.TrustStore.GetValidTRC(workCtx, reqIA.I, nil)
 	if err != nil {
 		// FIXME(scrye): return a zero AS because the protocol doesn't
 		// support errors, but we probably want to return an error here in
@@ -397,13 +397,4 @@ func isInvalid(err error) bool {
 // verification ended with an outcome of unknown.
 func isUnknown(err error) bool {
 	return err != nil
-}
-
-func iaInSlice(ia addr.IA, s []addr.IA) bool {
-	for _, otherIA := range s {
-		if otherIA.Eq(ia) {
-			return true
-		}
-	}
-	return false
 }

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -35,8 +35,12 @@ import (
 )
 
 const (
-	DefaultHandlerLifetime = 10 * time.Second
-	DefaultEarlyReply      = 200 * time.Millisecond
+	// DefaultReplyTimeout is allocated to SCIOND handlers to reply back to the client.
+	DefaultReplyTimeout = 2 * time.Second
+	// DefaultWorkTimeout is allocated to SCIOND handlers work (e.g., network
+	// traffic and crypto operations)
+	DefaultWorkTimeout = 10 * time.Second
+	DefaultEarlyReply  = 200 * time.Millisecond
 	// DefaultServiceTTL is the TTL value for ServiceInfoReply objects,
 	// expressed in seconds.
 	DefaultServiceTTL uint32 = 300
@@ -56,11 +60,13 @@ type PathRequestHandler struct {
 func (h *PathRequestHandler) Handle(transport infra.Transport, src net.Addr, pld *sciond.Pld,
 	logger log.Logger) {
 
-	ctx, cancelF := context.WithTimeout(context.Background(), DefaultHandlerLifetime)
-	defer cancelF()
-	getPathsReply, err := h.Fetcher.GetPaths(ctx, &pld.PathReq, DefaultEarlyReply)
+	logger = logger.New("pathReq", &pld.PathReq)
+	logger.Debug("[SCIOND:PathRequestHandler] Received request")
+	workCtx, workCancelF := context.WithTimeout(context.Background(), DefaultWorkTimeout)
+	defer workCancelF()
+	getPathsReply, err := h.Fetcher.GetPaths(workCtx, &pld.PathReq, DefaultEarlyReply)
 	if err != nil {
-		logger.Warn("Unable to get paths", "err", err)
+		logger.Warn("[SCIOND:PathRequestHandler] Unable to get paths", "err", err)
 	}
 	// Always reply, as the Fetcher will fill in the relevant error bits of the reply
 	reply := &sciond.Pld{
@@ -74,9 +80,14 @@ func (h *PathRequestHandler) Handle(transport infra.Transport, src net.Addr, pld
 		// it is a bug.
 		panic(err)
 	}
+	ctx, cancelF := context.WithTimeout(context.Background(), DefaultReplyTimeout)
+	defer cancelF()
 	if err := transport.SendMsgTo(ctx, b, src); err != nil {
-		logger.Warn("Unable to reply to client", "client", src, "err", err)
+		logger.Warn("[SCIOND:PathRequestHandler] Unable to reply to client",
+			"client", src, "err", err)
+		return
 	}
+	logger.Debug("[SCIOND:PathRequestHandler] Replied to path request", "paths", getPathsReply)
 }
 
 // ASInfoRequestHandler represents the shared global state for the handling of all
@@ -84,45 +95,47 @@ func (h *PathRequestHandler) Handle(transport infra.Transport, src net.Addr, pld
 // for each ASInfoRequest it receives.
 type ASInfoRequestHandler struct {
 	TrustStore infra.TrustStore
-	CoreASes   []addr.IA
-	Messenger  infra.Messenger
 	Topology   *topology.Topo
 }
 
 func (h *ASInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, pld *sciond.Pld,
 	logger log.Logger) {
 
-	ctx, cancelF := context.WithTimeout(context.Background(), DefaultHandlerLifetime)
-	defer cancelF()
-	// FIXME(scrye): Only support single-homed SCIONDs for now (returned slice
+	logger = logger.New("asInfoReq", &pld.AsInfoReq)
+	logger.Debug("[SCIOND:ASInfoRequestHandler] Received request")
+	workCtx, workCancelF := context.WithTimeout(context.Background(), DefaultWorkTimeout)
+	defer workCancelF()
+	// NOTE(scrye): Only support single-homed SCIONDs for now (returned slice
 	// will at most contain one element).
 	reqIA := pld.AsInfoReq.Isdas.IA()
+	if reqIA.IsZero() {
+		reqIA = h.Topology.ISD_AS
+	}
 	asInfoReply := sciond.ASInfoReply{}
+	trcObj, err := h.TrustStore.GetValidTRC(workCtx, nil, reqIA.I)
+	if err != nil {
+		// FIXME(scrye): return a zero AS because the protocol doesn't
+		// support errors, but we probably want to return an error here in
+		// the future.
+		asInfoReply.Entries = []sciond.ASInfoReplyEntry{}
+	}
 	if reqIA.IsZero() || reqIA.Eq(h.Topology.ISD_AS) {
 		// Requested AS is us
 		asInfoReply.Entries = []sciond.ASInfoReplyEntry{
 			{
 				RawIsdas: h.Topology.ISD_AS.IAInt(),
 				Mtu:      uint16(h.Topology.MTU),
-				IsCore:   iaInSlice(h.Topology.ISD_AS, h.CoreASes),
+				IsCore:   trcObj.CoreASes.Contains(h.Topology.ISD_AS),
 			},
 		}
 	} else {
 		// Requested AS is not us
-		trcObj, err := h.TrustStore.GetValidTRC(ctx, reqIA.I, reqIA.I)
-		if err != nil {
-			// FIXME(scrye): return a zero AS because the protocol doesn't
-			// support errors, but we probably want to return an error here in
-			// the future.
-			asInfoReply.Entries = []sciond.ASInfoReplyEntry{}
-		} else {
-			asInfoReply.Entries = []sciond.ASInfoReplyEntry{
-				{
-					RawIsdas: reqIA.IAInt(),
-					Mtu:      0,
-					IsCore:   trcObj.CoreASes.Contains(reqIA),
-				},
-			}
+		asInfoReply.Entries = []sciond.ASInfoReplyEntry{
+			{
+				RawIsdas: reqIA.IAInt(),
+				Mtu:      0,
+				IsCore:   trcObj.CoreASes.Contains(reqIA),
+			},
 		}
 	}
 	reply := &sciond.Pld{
@@ -134,9 +147,13 @@ func (h *ASInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, p
 	if err != nil {
 		panic(err)
 	}
+	ctx, cancelF := context.WithTimeout(context.Background(), DefaultReplyTimeout)
+	defer cancelF()
 	if err := transport.SendMsgTo(ctx, b, src); err != nil {
 		logger.Warn("Unable to reply to client", "client", src, "err", err)
+		return
 	}
+	logger.Debug("[SCIOND:ASInfoRequestHandler] Sent reply", "asInfo", asInfoReply)
 }
 
 // IFInfoRequestHandler represents the shared global state for the handling of all
@@ -149,8 +166,8 @@ type IFInfoRequestHandler struct {
 func (h *IFInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, pld *sciond.Pld,
 	logger log.Logger) {
 
-	ctx, cancelF := context.WithTimeout(context.Background(), DefaultHandlerLifetime)
-	defer cancelF()
+	logger = logger.New("ifInfoReq", &pld.IfInfoRequest)
+	logger.Debug("[SCIOND:IFInfoRequestHandler] Received request", "request", &pld.IfInfoRequest)
 	ifInfoRequest := pld.IfInfoRequest
 	ifInfoReply := sciond.IFInfoReply{}
 	if len(ifInfoRequest.IfIDs) == 0 {
@@ -184,9 +201,13 @@ func (h *IFInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, p
 	if err != nil {
 		panic(err)
 	}
+	ctx, cancelF := context.WithTimeout(context.Background(), DefaultReplyTimeout)
+	defer cancelF()
 	if err := transport.SendMsgTo(ctx, b, src); err != nil {
 		logger.Warn("Unable to reply to client", "client", src, "err", err)
+		return
 	}
+	logger.Debug("[SCIOND:IFInfoRequestHandler] Sent reply", "ifInfo", ifInfoReply)
 }
 
 // SVCInfoRequestHandler represents the shared global state for the handling of all
@@ -199,8 +220,8 @@ type SVCInfoRequestHandler struct {
 func (h *SVCInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, pld *sciond.Pld,
 	logger log.Logger) {
 
-	ctx, cancelF := context.WithTimeout(context.Background(), DefaultHandlerLifetime)
-	defer cancelF()
+	logger = logger.New("svcInfoReq", &pld.ServiceInfoRequest)
+	logger.Debug("[SCIOND:SVCInfoRequestHandler] Received request")
 	svcInfoRequest := pld.ServiceInfoRequest
 	svcInfoReply := sciond.ServiceInfoReply{}
 	for _, t := range svcInfoRequest.ServiceTypes {
@@ -235,9 +256,13 @@ func (h *SVCInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, 
 	if err != nil {
 		panic(err)
 	}
+	ctx, cancelF := context.WithTimeout(context.Background(), DefaultReplyTimeout)
+	defer cancelF()
 	if err := transport.SendMsgTo(ctx, b, src); err != nil {
 		logger.Warn("Unable to reply to client", "client", src, "err", err)
+		return
 	}
+	logger.Debug("[SCIOND:SVCInfoRequestHandler] Sent reply", "svcInfo", svcInfoReply)
 }
 
 func makeHostInfos(ot overlay.Type, addrMap map[string]topology.TopoAddr) []sciond.HostInfo {
@@ -255,7 +280,9 @@ func TopoAddrToHostInfo(ot overlay.Type, topoAddr topology.TopoAddr) sciond.Host
 	if ot.IsIPv4() {
 		v4Addr = topoAddr.IPv4.PublicAddr()
 		if v4Addr != nil {
-			ipv4 = v4Addr.L3.IP()
+			// XXX(scrye): Force 4-byte representation of IPv4 addresses
+			// because Python code doesn't understand Go's 16-byte format.
+			ipv4 = v4Addr.L3.IP().To4()
 			port = v4Addr.L4.Port()
 		}
 	}
@@ -283,17 +310,20 @@ func TopoAddrToHostInfo(ot overlay.Type, topoAddr topology.TopoAddr) sciond.Host
 // RevNotification announcements. The SCIOND API spawns a goroutine with method Handle
 // for each RevNotification it receives.
 type RevNotificationHandler struct {
-	RevCache revcache.RevCache
+	RevCache   revcache.RevCache
+	TrustStore infra.TrustStore
 }
 
 func (h *RevNotificationHandler) Handle(transport infra.Transport, src net.Addr, pld *sciond.Pld,
 	logger log.Logger) {
 
-	ctx, cancelF := context.WithTimeout(context.Background(), DefaultHandlerLifetime)
-	defer cancelF()
+	logger = logger.New("revNotification", &pld.RevNotification)
+	logger.Debug("[SCIOND:RevNotificationHandler] Received request")
+	workCtx, workCancelF := context.WithTimeout(context.Background(), DefaultWorkTimeout)
+	defer workCancelF()
 	revNotification := pld.RevNotification
 	revReply := sciond.RevReply{}
-	revInfo, err := h.verifySRevInfo(ctx, revNotification.SRevInfo)
+	revInfo, err := h.verifySRevInfo(workCtx, revNotification.SRevInfo)
 	if err == nil {
 		h.RevCache.Set(revcache.NewKey(revInfo.RawIsdas.IA(), common.IFIDType(revInfo.IfID)),
 			revNotification.SRevInfo, revInfo.TTL())
@@ -319,9 +349,13 @@ func (h *RevNotificationHandler) Handle(transport infra.Transport, src net.Addr,
 	if err != nil {
 		panic(err)
 	}
+	ctx, cancelF := context.WithTimeout(context.Background(), DefaultReplyTimeout)
+	defer cancelF()
 	if err := transport.SendMsgTo(ctx, b, src); err != nil {
 		logger.Warn("Unable to reply to client", "client", src, "err", err)
+		return
 	}
+	logger.Debug("[SCIOND:RevNotificationHandler] Sent reply", "revInfo", revInfo)
 }
 
 // verifySRevInfo first checks if the RevInfo can be extracted from sRevInfo,
@@ -335,15 +369,13 @@ func (h *RevNotificationHandler) verifySRevInfo(ctx context.Context,
 	if err != nil {
 		return nil, common.NewBasicError("Unable to extract RevInfo", nil)
 	}
-	// FIXME(scrye): pass in trail here
-	err = segverifier.VerifyRevInfo(ctx, sRevInfo, []addr.ISD{})
+	err = segverifier.VerifyRevInfo(ctx, h.TrustStore, nil, sRevInfo)
 	return info, err
 }
 
 // isValid is a placeholder. It should return true if and only if revocation
 // verification ended with an outcome of valid.
 func isValid(err error) bool {
-	// FIXME(scrye): implement this once we have verification
 	return err == nil
 }
 
@@ -364,7 +396,6 @@ func isInvalid(err error) bool {
 // isUnknown is a placeholder. It should return true if and only if revocation
 // verification ended with an outcome of unknown.
 func isUnknown(err error) bool {
-	// FIXME(scrye): implement this once we have verification
 	return err != nil
 }
 

--- a/go/sciond/internal/servers/server.go
+++ b/go/sciond/internal/servers/server.go
@@ -16,6 +16,7 @@ package servers
 
 import (
 	"context"
+	"io"
 	"net"
 	"sync"
 
@@ -81,7 +82,7 @@ func (srv *Server) ListenAndServe() error {
 			defer log.LogPanicAndExit()
 			pconn := conn.(net.PacketConn)
 			hdl := NewTransportHandler(transport.NewPacketTransport(pconn), srv.handlers, srv.log)
-			if err := hdl.Serve(); err != nil {
+			if err := hdl.Serve(); err != nil && err != io.EOF {
 				srv.log.Error("Transport handler error", "err", err)
 			}
 		}()

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -158,6 +158,7 @@ func realMain() int {
 				pathDB,
 				trustStore,
 				revCache,
+				log.Root(),
 			),
 		},
 		proto.SCIONDMsg_Which_asInfoReq: &servers.ASInfoRequestHandler{

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -134,6 +134,7 @@ func realMain() int {
 		return 1
 	}
 	msger := messenger.New(
+		config.General.Topology.ISD_AS,
 		disp.New(
 			transport.NewPacketTransport(conn),
 			messenger.DefaultAdapter,
@@ -161,7 +162,6 @@ func realMain() int {
 		},
 		proto.SCIONDMsg_Which_asInfoReq: &servers.ASInfoRequestHandler{
 			TrustStore: trustStore,
-			Messenger:  msger,
 			Topology:   config.General.Topology,
 		},
 		proto.SCIONDMsg_Which_ifInfoRequest: &servers.IFInfoRequestHandler{
@@ -171,7 +171,8 @@ func realMain() int {
 			Topology: config.General.Topology,
 		},
 		proto.SCIONDMsg_Which_revNotification: &servers.RevNotificationHandler{
-			RevCache: revCache,
+			RevCache:   revCache,
+			TrustStore: trustStore,
 		},
 	}
 	// Create a channel where server goroutines can signal fatal errors

--- a/go/sciond/server_test.go
+++ b/go/sciond/server_test.go
@@ -328,6 +328,9 @@ func Setup(t *testing.T, configTmpl string) (sciond.Connector, *topology.Topo, f
 }
 
 func TestMain(m *testing.M) {
+	// FIXME(scrye): Logging to stdout/stderr is messy in tests because logging
+	// gets mixed with normal test output. Integration tests should log to
+	// files instead.
 	log.AddLogConsFlags()
 	flag.Parse()
 	if err := log.SetupFromFlags(""); err != nil {

--- a/go/sciond/server_test.go
+++ b/go/sciond/server_test.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"html/template"
 	"os"
@@ -327,6 +328,11 @@ func Setup(t *testing.T, configTmpl string) (sciond.Connector, *topology.Topo, f
 }
 
 func TestMain(m *testing.M) {
+	log.AddLogConsFlags()
+	flag.Parse()
+	if err := log.SetupFromFlags(""); err != nil {
+		panic(err)
+	}
 	if !testing.Verbose() {
 		log.Root().SetHandler(log.DiscardHandler())
 	}

--- a/python/topology/generator.py
+++ b/python/topology/generator.py
@@ -28,6 +28,7 @@ import math
 import os
 import random
 import sys
+import toml
 from collections import defaultdict
 from io import StringIO
 from string import Template
@@ -116,6 +117,7 @@ DEFAULT_LINK_BW = 1000
 
 DEFAULT_BEACON_SERVERS = 1
 DEFAULT_CERTIFICATE_SERVER = "py"
+DEFAULT_SCIOND = "py"
 DEFAULT_GRACE_PERIOD = 18000
 DEFAULT_CERTIFICATE_SERVERS = 1
 DEFAULT_PATH_SERVERS = 1
@@ -158,7 +160,8 @@ class ConfigGenerator(object):
                  path_policy_file=DEFAULT_PATH_POLICY_FILE,
                  zk_config_file=DEFAULT_ZK_CONFIG, network=None,
                  use_mininet=False, use_docker=False, bind_addr=GENERATE_BIND_ADDRESS,
-                 pseg_ttl=DEFAULT_SEGMENT_TTL, cs=DEFAULT_CERTIFICATE_SERVER):
+                 pseg_ttl=DEFAULT_SEGMENT_TTL, cs=DEFAULT_CERTIFICATE_SERVER,
+                 sd=DEFAULT_SCIOND):
         """
         Initialize an instance of the class ConfigGenerator.
 
@@ -188,8 +191,12 @@ class ConfigGenerator(object):
         self.pseg_ttl = pseg_ttl
         self._read_defaults(network)
         self.cs = cs
+        self.sd = sd
         if self.docker and self.cs is not DEFAULT_CERTIFICATE_SERVER:
             logging.critical("Cannot use non-default CS with docker!")
+            sys.exit(1)
+        if self.docker and self.sd is not DEFAULT_SCIOND:
+            logging.critical("Cannot use non-default SCIOND with docker!")
             sys.exit(1)
 
     def _read_defaults(self, network):
@@ -227,6 +234,7 @@ class ConfigGenerator(object):
         ca_private_key_files, ca_cert_files, ca_certs = self._generate_cas()
         cert_files, trc_files, cust_files = self._generate_certs_trcs(ca_certs)
         topo_dicts, zookeepers, networks, prv_networks = self._generate_topology()
+        self._generate_go(topo_dicts)
         if self.docker:
             self._generate_docker(topo_dicts)
         else:
@@ -270,9 +278,13 @@ class ConfigGenerator(object):
             self.default_mtu, self.gen_bind_addr, self.docker, overlay)
         return topo_gen.generate()
 
+    def _generate_go(self, topo_dicts):
+        go_gen = GoGenerator(self.out_dir, topo_dicts)
+        go_gen.generate()
+
     def _generate_supervisor(self, topo_dicts):
         super_gen = SupervisorGenerator(
-            self.out_dir, topo_dicts, self.mininet, self.cs)
+            self.out_dir, topo_dicts, self.mininet, self.cs, self.sd)
         super_gen.generate()
 
     def _generate_docker(self, topo_dicts):
@@ -865,11 +877,12 @@ class PrometheusGenerator(object):
 
 
 class SupervisorGenerator(object):
-    def __init__(self, out_dir, topo_dicts, mininet, cs):
+    def __init__(self, out_dir, topo_dicts, mininet, cs, sd):
         self.out_dir = out_dir
         self.topo_dicts = topo_dicts
         self.mininet = mininet
         self.cs = cs
+        self.sd = sd
 
     def generate(self):
         self._write_dispatcher_conf()
@@ -919,8 +932,11 @@ class SupervisorGenerator(object):
 
     def _sciond_entry(self, name, conf_dir):
         path = self._sciond_path(name)
+        if self.sd == "py":
+            return self._common_entry(
+                name, ["python/bin/sciond", "--api-addr", path, name, conf_dir])
         return self._common_entry(
-            name, ["python/bin/sciond", "--api-addr", path, name, conf_dir])
+                name, ["bin/sciond", "-config", os.path.join(conf_dir, "config.toml")])
 
     def _sciond_path(self, name):
         return os.path.join(SCIOND_API_SOCKDIR, "%s.sock" % name)
@@ -1019,6 +1035,50 @@ class SupervisorGenerator(object):
     def _mk_cmd(self, name, cmd_args):
         return "bash -c 'exec %s &>logs/%s.OUT'" % (
             " ".join(['"%s"' % arg for arg in cmd_args]), name)
+
+
+class GoGenerator(object):
+    def __init__(self, out_dir, topo_dicts):
+        self.out_dir = out_dir
+        self.topo_dicts = topo_dicts
+
+    def generate(self):
+        for topo_id, topo in self.topo_dicts.items():
+            base = topo_id.base_dir(self.out_dir)
+            sciond_conf = self._build_sciond_conf(topo_id, topo["ISD_AS"], base)
+            write_file(os.path.join(base, "endhost", "config.toml"), toml.dumps(sciond_conf))
+
+    def _build_sciond_conf(self, topo_id, ia, base):
+        name = self._sciond_name(topo_id)
+        raw_entry = {
+            'general': {
+                'ID': name,
+                'Topology': os.path.join(base, "endhost", 'topology.json'),
+                'ConfigDir': os.path.join(base, "endhost"),
+            },
+            'logging': {
+                'file': {
+                    'Path': os.path.join('logs', "%s.log" % name),
+                    'Level': 'debug',
+                },
+                'console': {
+                    'Level': 'crit',
+                },
+            },
+            'trust': {
+                'TrustDB': os.path.join('gen-cache', '%s.trust.db' % name),
+            },
+            'sd': {
+                'Reliable': os.path.join(SCIOND_API_SOCKDIR, "%s.sock" % name),
+                'Unix': os.path.join(SCIOND_API_SOCKDIR, "%s.unix" % name),
+                'Public': '%s,[127.0.0.1]:0' % ia,
+                'PathDB': os.path.join('gen-cache', '%s.path.db' % name),
+            },
+        }
+        return raw_entry
+
+    def _sciond_name(self, topo_id):
+        return 'sd' + topo_id.file_fmt()
 
 
 class DockerGenerator(object):


### PR DESCRIPTION
Fixes #1709 and #1494.

Also:
  - Allows switching between the Go and Python versions of the CS and SCIOND
  - Strips trust trail support from a lot of places
  - Provides cleaner logging for handlers and network messaging

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1731)
<!-- Reviewable:end -->
