### PR TITLE
Fix misleading snet error

### DIFF
--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -241,11 +241,7 @@ func (c *Conn) WriteToSCION(b []byte, raddr *Addr) (int, error) {
 	if c.conn == nil {
 		return 0, common.NewBasicError("Connection not initialized", nil)
 	}
-	n, err := c.write(b, raddr)
-	if err != nil {
-		return 0, common.NewBasicError("Dispatcher error", err)
-	}
-	return n, err
+	return c.write(b, raddr)
 }
 
 func (c *Conn) WriteTo(b []byte, raddr net.Addr) (int, error) {


### PR DESCRIPTION
No longer blame all possible errors in snet.Conn.write on the
dispatcher.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1748)
<!-- Reviewable:end -->
