### PR TITLE
Move MasterASKey out of as_conf

### DIFF
--- a/go/border/conf/conf.go
+++ b/go/border/conf/conf.go
@@ -42,6 +42,8 @@ type Conf struct {
 	BR *topology.BRInfo
 	// ASConf is the local AS configuration.
 	ASConf *as_conf.ASConf
+	// MasterKeys holds the local AS master keys.
+	MasterKeys *as_conf.MasterKeys
 	// HFMacPool is the pool of Hop Field MAC generation instances.
 	HFMacPool sync.Pool
 	// Net is the network configuration of this router.
@@ -75,11 +77,14 @@ func Load(id, confDir string) (*Conf, error) {
 		return nil, err
 	}
 	conf.ASConf = as_conf.CurrConf
-
+	// Load master keys
+	if conf.MasterKeys, err = as_conf.LoadMasterKeys(conf.Dir); err != nil {
+		return nil, common.NewBasicError("Unable to load master keys", err)
+	}
 	// Generate keys
 	// This uses 16B keys with 1000 hash iterations, which is the same as the
 	// defaults used by pycrypto.
-	hfGenKey := pbkdf2.Key(conf.ASConf.MasterASKey, []byte("Derive OF Key"), 1000, 16, sha256.New)
+	hfGenKey := pbkdf2.Key(conf.MasterKeys.Key0, []byte("Derive OF Key"), 1000, 16, sha256.New)
 
 	// First check for MAC creation errors.
 	if _, err = scrypto.InitMac(hfGenKey); err != nil {

--- a/go/lib/as_conf/conf.go
+++ b/go/lib/as_conf/conf.go
@@ -21,16 +21,14 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/util"
 )
 
 type ASConf struct {
-	CertChainVersion int           `yaml:"CertChainVersion"`
-	MasterASKey      util.B64Bytes `yaml:"MasterASKey"`
-	PathSegmentTTL   int           `yaml:"PathSegmentTTL"`
-	PropagateTime    int           `yaml:"PropagateTime"`
-	RegisterPath     bool          `yaml:"RegisterPath"`
-	RegisterTime     int           `yaml:"RegisterTime"`
+	CertChainVersion int  `yaml:"CertChainVersion"`
+	PathSegmentTTL   int  `yaml:"PathSegmentTTL"`
+	PropagateTime    int  `yaml:"PropagateTime"`
+	RegisterPath     bool `yaml:"RegisterPath"`
+	RegisterTime     int  `yaml:"RegisterTime"`
 }
 
 const CfgName = "as.yml"

--- a/go/lib/as_conf/conf_test.go
+++ b/go/lib/as_conf/conf_test.go
@@ -18,8 +18,6 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
-
-	"github.com/scionproto/scion/go/lib/util"
 )
 
 func Test_ASConf(t *testing.T) {
@@ -29,7 +27,7 @@ func Test_ASConf(t *testing.T) {
 		}
 		c := CurrConf
 		So(c, ShouldResemble, &ASConf{
-			1, util.B64Bytes("VV?=tJ\xae\x85s\r8\x9d\xfc\xe5\x94\xa5"), 21600, 5, true, 60,
+			1, 21600, 5, true, 60,
 		})
 	})
 }

--- a/go/lib/as_conf/master_keys.go
+++ b/go/lib/as_conf/master_keys.go
@@ -1,0 +1,60 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package as_conf
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+
+	"path/filepath"
+
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+const (
+	MasterKey0 = "master0.key"
+	MasterKey1 = "master1.key"
+)
+
+type MasterKeys struct {
+	Key0 common.RawBytes
+	Key1 common.RawBytes
+}
+
+func LoadMasterKeys(confDir string) (*MasterKeys, error) {
+	var err error
+	keys := &MasterKeys{}
+	if keys.Key0, err = loadMasterKey(filepath.Join(confDir, "keys", MasterKey0)); err != nil {
+		return nil, err
+	}
+	if keys.Key1, err = loadMasterKey(filepath.Join(confDir, "keys", MasterKey1)); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+// loadMasterKey decodes a base64 encoded master key in file and returns the raw bytes.
+func loadMasterKey(file string) (common.RawBytes, error) {
+	b, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, common.NewBasicError(ErrorOpen, err)
+	}
+	dbuf := make([]byte, base64.StdEncoding.DecodedLen(len(b)))
+	n, err := base64.StdEncoding.Decode(dbuf, b)
+	if err != nil {
+		return nil, common.NewBasicError(ErrorParse, err)
+	}
+	return dbuf[:n], nil
+}

--- a/go/lib/as_conf/testdata/basic.yml
+++ b/go/lib/as_conf/testdata/basic.yml
@@ -1,5 +1,4 @@
 CertChainVersion: 1
-MasterASKey: VlY/PXRKroVzDTid/OWUpQ==
 PathSegmentTTL: 21600
 PropagateTime: 5
 RegisterPath: true

--- a/python/beacon_server/base.py
+++ b/python/beacon_server/base.py
@@ -31,6 +31,11 @@ from prometheus_client import Counter, Gauge
 from beacon_server.if_state import InterfaceState
 from lib.crypto.asymcrypto import get_sig_key
 from lib.crypto.symcrypto import kdf
+from lib.crypto.util import (
+    get_master_key,
+    MASTER_KEY_0,
+    MASTER_KEY_1
+)
 from lib.defines import (
     EXP_TIME_UNIT,
     GEN_CACHE_PATH,
@@ -134,11 +139,13 @@ class BeaconServer(SCIONElement, metaclass=ABCMeta):
         super().__init__(server_id, conf_dir, spki_cache_dir=spki_cache_dir,
                          prom_export=prom_export, sciond_path=sciond_path)
         self.config = self._load_as_conf()
+        self.master_key_0 = get_master_key(self.conf_dir, MASTER_KEY_0)
+        self.master_key_1 = get_master_key(self.conf_dir, MASTER_KEY_1)
         # TODO: add 2 policies
         self.path_policy = PathPolicy.from_file(
             os.path.join(conf_dir, PATH_POLICY_FILE))
         self.signing_key = get_sig_key(self.conf_dir)
-        self.of_gen_key = kdf(self.config.master_as_key, b"Derive OF Key")
+        self.of_gen_key = kdf(self.master_key_0, b"Derive OF Key")
         # Amount of time units a HOF is valid (time unit is EXP_TIME_UNIT).
         self.default_hof_exp_time = int(self.config.segment_ttl / EXP_TIME_UNIT)
         self.ifid_state = {}

--- a/python/cert_server/main.py
+++ b/python/cert_server/main.py
@@ -32,6 +32,7 @@ from lib.crypto.certificate_chain import CertificateChain, verify_sig_chain_trc
 from lib.crypto.trc import TRC
 from lib.crypto.symcrypto import crypto_hash
 from lib.crypto.symcrypto import kdf
+from lib.crypto.util import get_master_key, MASTER_KEY_0
 from lib.defines import GEN_CACHE_PATH
 from lib.drkey.drkey_mgmt import (
     DRKeyMgmt,
@@ -156,6 +157,7 @@ class CertServer(SCIONElement):
                                       self._cached_certs_handler)
         self.drkey_cache = ZkSharedCache(self.zk, self.ZK_DRKEY_PATH,
                                          self._cached_drkeys_handler)
+        self.master_key = get_master_key(self.conf_dir, MASTER_KEY_0)
         self.signing_key = get_sig_key(self.conf_dir)
         self.private_key = get_enc_key(self.conf_dir)
         self.drkey_secrets = ExpiringDict(DRKEY_MAX_SV, DRKEY_MAX_TTL)
@@ -572,7 +574,7 @@ class CertServer(SCIONElement):
         """
         sv = self.drkey_secrets.get(exp_time)
         if not sv:
-            sv = DRKeySecretValue(kdf(self.config.master_as_key, b"Derive DRKey Key"), exp_time)
+            sv = DRKeySecretValue(kdf(self.master_key, b"Derive DRKey Key"), exp_time)
             self.drkey_secrets[sv.exp_time] = sv
         return sv
 

--- a/python/lib/config.py
+++ b/python/lib/config.py
@@ -15,8 +15,6 @@
 :mod:`config` --- SCION configuration parser
 ============================================
 """
-# Stdlib
-import base64
 
 # SCION
 from lib.defines import DEFAULT_SEGMENT_TTL
@@ -28,7 +26,6 @@ class Config(object):
     The Config class parses the configuration file of an AS and stores such
     information for further use.
 
-    :ivar bytes master_as_key: AS certificate servers priv key.
     :ivar int propagation_time: the interval at which PCBs are propagated.
     :ivar int registration_time: the interval at which paths are registered.
     :ivar int registers_paths: whether or not the AS registers paths.
@@ -37,7 +34,6 @@ class Config(object):
     """
 
     def __init__(self):  # pragma: no cover
-        self.master_as_key = 0
         self.propagation_time = 0
         self.registration_time = 0
         self.registers_paths = 0
@@ -74,7 +70,6 @@ class Config(object):
 
         :param dict config: the name of the configuration file.
         """
-        self.master_as_key = base64.b64decode(config['MasterASKey'])
         self.propagation_time = config['PropagateTime']
         self.registration_time = config['RegisterTime']
         self.registers_paths = config['RegisterPath']

--- a/python/lib/crypto/util.py
+++ b/python/lib/crypto/util.py
@@ -18,10 +18,34 @@
 Various utilities for SCION functionality.
 """
 # Stdlib
+import base64
 import os
+
+# SCION
+from lib.util import read_file
 
 CERT_DIR = 'certs'
 KEYS_DIR = 'keys'
+
+MASTER_KEY_0 = "master0.key"
+MASTER_KEY_1 = "master1.key"
+
+
+def get_master_key_file_path(conf_dir, master_key):
+    """
+    Return the master key file path.
+    """
+    return os.path.join(conf_dir, KEYS_DIR, master_key)
+
+
+def get_master_key(conf_dir, master_key):
+    """
+    Return the raw master key.
+
+    :rtype: bytes
+    """
+    return base64.b64decode(
+        read_file(get_master_key_file_path(conf_dir, master_key)))
 
 
 def get_online_key_file_path(conf_dir):

--- a/python/test/lib/config_test.py
+++ b/python/test/lib/config_test.py
@@ -15,8 +15,6 @@
 :mod:`lib_config_test` --- lib.config unit tests
 ================================================
 """
-# Stdlib
-import base64
 
 # External packages
 import nose
@@ -31,7 +29,6 @@ class BaseLibConfig(object):
     Base class for lib.config unit tests
     """
     ATTRS_TO_KEYS = {
-        'master_as_key': 'MasterASKey',
         'propagation_time': 'PropagateTime',
         'registration_time': 'RegisterTime',
         'registers_paths': 'RegisterPath',
@@ -46,7 +43,6 @@ class TestConfigParseDict(BaseLibConfig):
     """
     config_dict = {
         "CertChainVersion": 0,
-        "MasterASKey": "Xf93o3Wz/4Gb0m6CXEaxag==",
         "PropagateTime": 5,
         "RegisterPath": 1,
         "RegisterTime": 5,
@@ -64,10 +60,7 @@ class TestConfigParseDict(BaseLibConfig):
                    "Unequal number of keys/attributes: is something missing?")
         for attr, key in self.ATTRS_TO_KEYS.items():
             value = getattr(config, attr)
-            if attr in ['master_of_gen_key', 'master_as_key']:
-                ntools.eq_(value, base64.b64decode(config_dict[key]))
-            else:
-                ntools.eq_(value, config_dict[key])
+            ntools.eq_(value, config_dict[key])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Remove MasterASKey from as_conf.yml.

The generator creates two keys in preparation for master key rollover (#1714 ) 
- `master0.key`
- `master1.key`

Fixes #1718 