### PR TITLE
Improve time conversion consistency

### DIFF
--- a/go/cert_srv/reiss_handler.go
+++ b/go/cert_srv/reiss_handler.go
@@ -181,7 +181,7 @@ func (h *ReissHandler) issueChain(ctx context.Context, c *cert.Certificate, vKey
 	chain := &cert.Chain{Leaf: c.Copy(), Issuer: issCert}
 	chain.Leaf.CanIssue = false
 	chain.Leaf.TRCVersion = chain.Issuer.TRCVersion
-	chain.Leaf.IssuingTime = util.TimeToUSecs(time.Now())
+	chain.Leaf.IssuingTime = util.TimeToSecs(time.Now())
 	chain.Leaf.ExpirationTime = chain.Leaf.IssuingTime + cert.DefaultLeafCertValidity
 	// Leaf certificate must expire before issuer certificate
 	if chain.Issuer.ExpirationTime < chain.Leaf.ExpirationTime {

--- a/go/cert_srv/reiss_handler.go
+++ b/go/cert_srv/reiss_handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/scrypto/cert"
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/util"
 )
 
 const (
@@ -180,7 +181,7 @@ func (h *ReissHandler) issueChain(ctx context.Context, c *cert.Certificate, vKey
 	chain := &cert.Chain{Leaf: c.Copy(), Issuer: issCert}
 	chain.Leaf.CanIssue = false
 	chain.Leaf.TRCVersion = chain.Issuer.TRCVersion
-	chain.Leaf.IssuingTime = uint32(time.Now().Unix())
+	chain.Leaf.IssuingTime = util.TimeToUSecs(time.Now())
 	chain.Leaf.ExpirationTime = chain.Leaf.IssuingTime + cert.DefaultLeafCertValidity
 	// Leaf certificate must expire before issuer certificate
 	if chain.Issuer.ExpirationTime < chain.Leaf.ExpirationTime {

--- a/go/cert_srv/reiss_tasks.go
+++ b/go/cert_srv/reiss_tasks.go
@@ -113,7 +113,7 @@ func (s *SelfIssuer) createLeafCert(leaf *cert.Certificate, config *conf.Conf) e
 	}
 	chain := &cert.Chain{Leaf: leaf.Copy(), Issuer: issCrt}
 	chain.Leaf.Version += 1
-	chain.Leaf.IssuingTime = uint32(time.Now().Unix())
+	chain.Leaf.IssuingTime = util.TimeToUSecs(time.Now())
 	chain.Leaf.CanIssue = false
 	chain.Leaf.ExpirationTime = chain.Leaf.IssuingTime + cert.DefaultLeafCertValidity
 	if chain.Issuer.ExpirationTime < chain.Leaf.ExpirationTime {
@@ -146,7 +146,7 @@ func (s *SelfIssuer) createIssuerCert(config *conf.Conf) error {
 		return err
 	}
 	crt.Version += 1
-	crt.IssuingTime = uint32(time.Now().Unix())
+	crt.IssuingTime = util.TimeToUSecs(time.Now())
 	crt.CanIssue = true
 	crt.ExpirationTime = crt.IssuingTime + cert.DefaultIssuerCertValidity
 	coreAS, err := s.getCoreASEntry(config)
@@ -259,7 +259,7 @@ func (r *ReissRequester) sendReq(ctx context.Context, cancelF context.CancelFunc
 
 	defer cancelF()
 	c := chain.Leaf.Copy()
-	c.IssuingTime = uint32(time.Now().Unix())
+	c.IssuingTime = util.TimeToUSecs(time.Now())
 	c.ExpirationTime = c.IssuingTime + (chain.Leaf.ExpirationTime - chain.Leaf.IssuingTime)
 	c.Version += 1
 	if err := c.Sign(config.GetSigningKey(), chain.Leaf.SignAlgorithm); err != nil {

--- a/go/cert_srv/reiss_tasks.go
+++ b/go/cert_srv/reiss_tasks.go
@@ -113,7 +113,7 @@ func (s *SelfIssuer) createLeafCert(leaf *cert.Certificate, config *conf.Conf) e
 	}
 	chain := &cert.Chain{Leaf: leaf.Copy(), Issuer: issCrt}
 	chain.Leaf.Version += 1
-	chain.Leaf.IssuingTime = util.TimeToUSecs(time.Now())
+	chain.Leaf.IssuingTime = util.TimeToSecs(time.Now())
 	chain.Leaf.CanIssue = false
 	chain.Leaf.ExpirationTime = chain.Leaf.IssuingTime + cert.DefaultLeafCertValidity
 	if chain.Issuer.ExpirationTime < chain.Leaf.ExpirationTime {
@@ -146,7 +146,7 @@ func (s *SelfIssuer) createIssuerCert(config *conf.Conf) error {
 		return err
 	}
 	crt.Version += 1
-	crt.IssuingTime = util.TimeToUSecs(time.Now())
+	crt.IssuingTime = util.TimeToSecs(time.Now())
 	crt.CanIssue = true
 	crt.ExpirationTime = crt.IssuingTime + cert.DefaultIssuerCertValidity
 	coreAS, err := s.getCoreASEntry(config)
@@ -233,7 +233,7 @@ func (r *ReissRequester) Run() {
 				panic(err)
 			}
 			now := time.Now()
-			exp := util.USecsToTime(chain.Leaf.ExpirationTime)
+			exp := util.SecsToTime(chain.Leaf.ExpirationTime)
 			diff := exp.Sub(now)
 			if diff < 0 {
 				log.Error("[ReissRequester] Certificate expired without being reissued",
@@ -259,7 +259,7 @@ func (r *ReissRequester) sendReq(ctx context.Context, cancelF context.CancelFunc
 
 	defer cancelF()
 	c := chain.Leaf.Copy()
-	c.IssuingTime = util.TimeToUSecs(time.Now())
+	c.IssuingTime = util.TimeToSecs(time.Now())
 	c.ExpirationTime = c.IssuingTime + (chain.Leaf.ExpirationTime - chain.Leaf.IssuingTime)
 	c.Version += 1
 	if err := c.Sign(config.GetSigningKey(), chain.Leaf.SignAlgorithm); err != nil {

--- a/go/lib/ctrl/path_mgmt/rev_info.go
+++ b/go/lib/ctrl/path_mgmt/rev_info.go
@@ -68,7 +68,7 @@ func (r *RevInfo) IA() addr.IA {
 }
 
 func (r *RevInfo) Timestamp() time.Time {
-	return util.USecsToTime(r.RawTimestamp)
+	return util.SecsToTime(r.RawTimestamp)
 }
 
 func (r *RevInfo) TTL() time.Duration {

--- a/go/lib/sciond/mock.go
+++ b/go/lib/sciond/mock.go
@@ -23,6 +23,7 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/spath"
+	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/lib/xtest/graph"
 	"github.com/scionproto/scion/go/proto"
 )
@@ -99,7 +100,7 @@ func (m *MockConn) Paths(dst, src addr.IA, max uint16, f PathReqFlags) (*PathRep
 			PathReplyEntry{
 				Path: &FwdPathMeta{
 					Interfaces: pathInterfaces,
-					ExpTime:    uint32(time.Now().Add(spath.MaxTTL * time.Second).Unix()),
+					ExpTime:    util.TimeToUSecs(time.Now().Add(spath.MaxTTL * time.Second)),
 				},
 				HostInfo: HostInfo{
 				// TODO(scrye): leave nil for now since no tests use this

--- a/go/lib/sciond/mock.go
+++ b/go/lib/sciond/mock.go
@@ -100,7 +100,7 @@ func (m *MockConn) Paths(dst, src addr.IA, max uint16, f PathReqFlags) (*PathRep
 			PathReplyEntry{
 				Path: &FwdPathMeta{
 					Interfaces: pathInterfaces,
-					ExpTime:    util.TimeToUSecs(time.Now().Add(spath.MaxTTL * time.Second)),
+					ExpTime:    util.TimeToSecs(time.Now().Add(spath.MaxTTL * time.Second)),
 				},
 				HostInfo: HostInfo{
 				// TODO(scrye): leave nil for now since no tests use this

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -197,7 +197,7 @@ func (fpm *FwdPathMeta) DstIA() addr.IA {
 }
 
 func (fpm *FwdPathMeta) Expiry() time.Time {
-	return util.USecsToTime(fpm.ExpTime)
+	return util.SecsToTime(fpm.ExpTime)
 }
 
 func (fpm *FwdPathMeta) String() string {

--- a/go/lib/scrypto/cert/cert.go
+++ b/go/lib/scrypto/cert/cert.go
@@ -102,7 +102,7 @@ func (c *Certificate) Verify(subject addr.IA, verifyKey common.RawBytes, signAlg
 		return common.NewBasicError(InvalidSubject, nil,
 			"expected", c.Subject, "actual", subject)
 	}
-	if err := c.VerifyTime(uint32(time.Now().Unix())); err != nil {
+	if err := c.VerifyTime(util.TimeToUSecs(time.Now())); err != nil {
 		return err
 	}
 	return c.VerifySignature(verifyKey, signAlgo)

--- a/go/lib/scrypto/cert/cert.go
+++ b/go/lib/scrypto/cert/cert.go
@@ -102,7 +102,7 @@ func (c *Certificate) Verify(subject addr.IA, verifyKey common.RawBytes, signAlg
 		return common.NewBasicError(InvalidSubject, nil,
 			"expected", c.Subject, "actual", subject)
 	}
-	if err := c.VerifyTime(util.TimeToUSecs(time.Now())); err != nil {
+	if err := c.VerifyTime(util.TimeToSecs(time.Now())); err != nil {
 		return err
 	}
 	return c.VerifySignature(verifyKey, signAlgo)
@@ -113,13 +113,13 @@ func (c *Certificate) Verify(subject addr.IA, verifyKey common.RawBytes, signAlg
 func (c *Certificate) VerifyTime(ts uint32) error {
 	if ts < c.IssuingTime {
 		return common.NewBasicError(EarlyUsage, nil,
-			"IssuingTime", util.TimeToString(util.USecsToTime(c.IssuingTime)),
-			"current", util.TimeToString(util.USecsToTime(ts)))
+			"IssuingTime", util.TimeToString(util.SecsToTime(c.IssuingTime)),
+			"current", util.TimeToString(util.SecsToTime(ts)))
 	}
 	if ts > c.ExpirationTime {
 		return common.NewBasicError(Expired, nil,
-			"ExpirationTime", util.TimeToString(util.USecsToTime(c.ExpirationTime)),
-			"current", util.TimeToString(util.USecsToTime(ts)))
+			"ExpirationTime", util.TimeToString(util.SecsToTime(c.ExpirationTime)),
+			"current", util.TimeToString(util.SecsToTime(ts)))
 	}
 	return nil
 }

--- a/go/lib/scrypto/cert/cert_test.go
+++ b/go/lib/scrypto/cert/cert_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
@@ -107,7 +108,7 @@ func Test_Certificate_Verify(t *testing.T) {
 		subject := addr.IA{I: 1, A: 0xff0000000311}
 		pubRaw, privRaw := []byte(pub), []byte(priv)
 
-		cert.IssuingTime = uint32(time.Now().Unix())
+		cert.IssuingTime = util.TimeToUSecs(time.Now())
 		cert.ExpirationTime = cert.IssuingTime + 1<<20
 		cert.Sign(privRaw, scrypto.Ed25519)
 
@@ -139,7 +140,7 @@ func Test_Certificate_Verify(t *testing.T) {
 		})
 
 		Convey("Early usage throws error", func() {
-			cert.IssuingTime = uint32(time.Now().Unix()) + 1<<20
+			cert.IssuingTime = util.TimeToUSecs(time.Now()) + 1<<20
 			cert.ExpirationTime = cert.IssuingTime + 1<<20
 			cert.Sign(privRaw, scrypto.Ed25519)
 			err := cert.Verify(subject, pubRaw, scrypto.Ed25519)
@@ -147,8 +148,8 @@ func Test_Certificate_Verify(t *testing.T) {
 		})
 
 		Convey("Late usage throws error", func() {
-			cert.IssuingTime = uint32(time.Now().Unix()) - 1<<20
-			cert.ExpirationTime = uint32(time.Now().Unix()) - 1
+			cert.IssuingTime = util.TimeToUSecs(time.Now()) - 1<<20
+			cert.ExpirationTime = util.TimeToUSecs(time.Now()) - 1
 			cert.Sign(privRaw, scrypto.Ed25519)
 			err := cert.Verify(subject, pubRaw, scrypto.Ed25519)
 			SoMsg("err", err, ShouldNotBeNil)

--- a/go/lib/scrypto/cert/cert_test.go
+++ b/go/lib/scrypto/cert/cert_test.go
@@ -108,7 +108,7 @@ func Test_Certificate_Verify(t *testing.T) {
 		subject := addr.IA{I: 1, A: 0xff0000000311}
 		pubRaw, privRaw := []byte(pub), []byte(priv)
 
-		cert.IssuingTime = util.TimeToUSecs(time.Now())
+		cert.IssuingTime = util.TimeToSecs(time.Now())
 		cert.ExpirationTime = cert.IssuingTime + 1<<20
 		cert.Sign(privRaw, scrypto.Ed25519)
 
@@ -140,7 +140,7 @@ func Test_Certificate_Verify(t *testing.T) {
 		})
 
 		Convey("Early usage throws error", func() {
-			cert.IssuingTime = util.TimeToUSecs(time.Now()) + 1<<20
+			cert.IssuingTime = util.TimeToSecs(time.Now()) + 1<<20
 			cert.ExpirationTime = cert.IssuingTime + 1<<20
 			cert.Sign(privRaw, scrypto.Ed25519)
 			err := cert.Verify(subject, pubRaw, scrypto.Ed25519)
@@ -148,8 +148,8 @@ func Test_Certificate_Verify(t *testing.T) {
 		})
 
 		Convey("Late usage throws error", func() {
-			cert.IssuingTime = util.TimeToUSecs(time.Now()) - 1<<20
-			cert.ExpirationTime = util.TimeToUSecs(time.Now()) - 1
+			cert.IssuingTime = util.TimeToSecs(time.Now()) - 1<<20
+			cert.ExpirationTime = util.TimeToSecs(time.Now()) - 1
 			cert.Sign(privRaw, scrypto.Ed25519)
 			err := cert.Verify(subject, pubRaw, scrypto.Ed25519)
 			SoMsg("err", err, ShouldNotBeNil)

--- a/go/lib/scrypto/cert/chain.go
+++ b/go/lib/scrypto/cert/chain.go
@@ -157,13 +157,13 @@ func ChainFromSlice(certs []*Certificate) (*Chain, error) {
 func (c *Chain) Verify(subject addr.IA, t *trc.TRC) error {
 	if c.Leaf.IssuingTime < c.Issuer.IssuingTime {
 		return common.NewBasicError(LeafIssuedBefore, nil,
-			"leaf", util.TimeToString(util.USecsToTime(c.Leaf.IssuingTime)),
-			"issuer", util.TimeToString(util.USecsToTime(c.Issuer.IssuingTime)))
+			"leaf", util.TimeToString(util.SecsToTime(c.Leaf.IssuingTime)),
+			"issuer", util.TimeToString(util.SecsToTime(c.Issuer.IssuingTime)))
 	}
 	if c.Leaf.ExpirationTime > c.Issuer.ExpirationTime {
 		return common.NewBasicError(LeafExpiresAfter, nil,
-			"leaf", util.TimeToString(util.USecsToTime(c.Leaf.ExpirationTime)),
-			"issuer", util.TimeToString(util.USecsToTime(c.Issuer.ExpirationTime)))
+			"leaf", util.TimeToString(util.SecsToTime(c.Leaf.ExpirationTime)),
+			"issuer", util.TimeToString(util.SecsToTime(c.Issuer.ExpirationTime)))
 	}
 	if !c.Issuer.CanIssue {
 		return common.NewBasicError(IssCertInvalid, nil, "CanIssue", false)
@@ -173,8 +173,8 @@ func (c *Chain) Verify(subject addr.IA, t *trc.TRC) error {
 	}
 	if c.Issuer.ExpirationTime > t.ExpirationTime {
 		return common.NewBasicError(IssExpiresAfter, nil,
-			"issuer", util.TimeToString(util.USecsToTime(c.Issuer.ExpirationTime)),
-			"TRC", util.TimeToString(util.USecsToTime(t.ExpirationTime)))
+			"issuer", util.TimeToString(util.SecsToTime(c.Issuer.ExpirationTime)),
+			"TRC", util.TimeToString(util.SecsToTime(t.ExpirationTime)))
 	}
 	coreAS, ok := t.CoreASes[c.Issuer.Issuer]
 	if !ok {

--- a/go/lib/scrypto/cert/chain_test.go
+++ b/go/lib/scrypto/cert/chain_test.go
@@ -109,12 +109,12 @@ func Test_Chain_Verify(t *testing.T) {
 		pubTRCRaw, privTRCRaw := []byte(pub), []byte(priv)
 		trc_ := loadTRC(fnTRC, t)
 
-		chain.Leaf.IssuingTime = util.TimeToUSecs(time.Now())
+		chain.Leaf.IssuingTime = util.TimeToSecs(time.Now())
 		chain.Leaf.ExpirationTime = chain.Leaf.IssuingTime + 1<<20
 		chain.Leaf.Sign(privCoreRaw, scrypto.Ed25519)
 
 		chain.Issuer.SubjectSignKey = pubCoreRaw
-		chain.Issuer.IssuingTime = util.TimeToUSecs(time.Now())
+		chain.Issuer.IssuingTime = util.TimeToSecs(time.Now())
 		chain.Issuer.ExpirationTime = chain.Leaf.IssuingTime + 1<<20
 		chain.Issuer.Sign(privTRCRaw, scrypto.Ed25519)
 

--- a/go/lib/scrypto/cert/chain_test.go
+++ b/go/lib/scrypto/cert/chain_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/scrypto/trc"
+	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
@@ -108,12 +109,12 @@ func Test_Chain_Verify(t *testing.T) {
 		pubTRCRaw, privTRCRaw := []byte(pub), []byte(priv)
 		trc_ := loadTRC(fnTRC, t)
 
-		chain.Leaf.IssuingTime = uint32(time.Now().Unix())
+		chain.Leaf.IssuingTime = util.TimeToUSecs(time.Now())
 		chain.Leaf.ExpirationTime = chain.Leaf.IssuingTime + 1<<20
 		chain.Leaf.Sign(privCoreRaw, scrypto.Ed25519)
 
 		chain.Issuer.SubjectSignKey = pubCoreRaw
-		chain.Issuer.IssuingTime = uint32(time.Now().Unix())
+		chain.Issuer.IssuingTime = util.TimeToUSecs(time.Now())
 		chain.Issuer.ExpirationTime = chain.Leaf.IssuingTime + 1<<20
 		chain.Issuer.Sign(privTRCRaw, scrypto.Ed25519)
 

--- a/go/lib/scrypto/trc/trc.go
+++ b/go/lib/scrypto/trc/trc.go
@@ -229,7 +229,7 @@ func (t *TRC) IsActive(maxTRC *TRC) error {
 	if t.Quarantine {
 		return common.NewBasicError(EarlyAnnouncement, nil)
 	}
-	currTime := util.TimeToUSecs(time.Now())
+	currTime := util.TimeToSecs(time.Now())
 	if currTime < t.CreationTime {
 		return common.NewBasicError(EarlyUsage, nil,
 			"now", timeToString(currTime), "creation", timeToString(t.CreationTime))
@@ -416,5 +416,5 @@ func (t *TRC) String() string {
 }
 
 func timeToString(t uint32) string {
-	return util.TimeToString(util.USecsToTime(t))
+	return util.TimeToString(util.SecsToTime(t))
 }

--- a/go/lib/scrypto/trc/trc.go
+++ b/go/lib/scrypto/trc/trc.go
@@ -229,7 +229,7 @@ func (t *TRC) IsActive(maxTRC *TRC) error {
 	if t.Quarantine {
 		return common.NewBasicError(EarlyAnnouncement, nil)
 	}
-	currTime := uint32(time.Now().Unix())
+	currTime := util.TimeToUSecs(time.Now())
 	if currTime < t.CreationTime {
 		return common.NewBasicError(EarlyUsage, nil,
 			"now", timeToString(currTime), "creation", timeToString(t.CreationTime))

--- a/go/lib/scrypto/trc/trc_test.go
+++ b/go/lib/scrypto/trc/trc_test.go
@@ -239,9 +239,9 @@ func Test_TRC_CheckActive(t *testing.T) {
 		t2 := loadTRC(fnTRC, t)
 		t2.Version += 1
 
-		t1.CreationTime = util.TimeToUSecs(time.Now())
+		t1.CreationTime = util.TimeToSecs(time.Now())
 		t1.ExpirationTime = t1.CreationTime + 1<<20
-		t2.CreationTime = util.TimeToUSecs(time.Now())
+		t2.CreationTime = util.TimeToSecs(time.Now())
 		t2.ExpirationTime = t2.CreationTime + 1<<20
 
 		Convey("TRC is active", func() {
@@ -249,12 +249,12 @@ func Test_TRC_CheckActive(t *testing.T) {
 			SoMsg("err", err, ShouldBeNil)
 		})
 		Convey("Early usage", func() {
-			t1.CreationTime = util.TimeToUSecs(time.Now()) + 1<<20
+			t1.CreationTime = util.TimeToSecs(time.Now()) + 1<<20
 			err := t1.IsActive(t2)
 			SoMsg("err", err, ShouldNotBeNil)
 		})
 		Convey("Late usage", func() {
-			t1.ExpirationTime = util.TimeToUSecs(time.Now()) - 1<<20
+			t1.ExpirationTime = util.TimeToSecs(time.Now()) - 1<<20
 			err := t1.IsActive(t2)
 			SoMsg("err", err, ShouldNotBeNil)
 		})

--- a/go/lib/scrypto/trc/trc_test.go
+++ b/go/lib/scrypto/trc/trc_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
@@ -238,9 +239,9 @@ func Test_TRC_CheckActive(t *testing.T) {
 		t2 := loadTRC(fnTRC, t)
 		t2.Version += 1
 
-		t1.CreationTime = uint32(time.Now().Unix())
+		t1.CreationTime = util.TimeToUSecs(time.Now())
 		t1.ExpirationTime = t1.CreationTime + 1<<20
-		t2.CreationTime = uint32(time.Now().Unix())
+		t2.CreationTime = util.TimeToUSecs(time.Now())
 		t2.ExpirationTime = t2.CreationTime + 1<<20
 
 		Convey("TRC is active", func() {
@@ -248,12 +249,12 @@ func Test_TRC_CheckActive(t *testing.T) {
 			SoMsg("err", err, ShouldBeNil)
 		})
 		Convey("Early usage", func() {
-			t1.CreationTime = uint32(time.Now().Unix()) + 1<<20
+			t1.CreationTime = util.TimeToUSecs(time.Now()) + 1<<20
 			err := t1.IsActive(t2)
 			SoMsg("err", err, ShouldNotBeNil)
 		})
 		Convey("Late usage", func() {
-			t1.ExpirationTime = uint32(time.Now().Unix()) - 1<<20
+			t1.ExpirationTime = util.TimeToUSecs(time.Now()) - 1<<20
 			err := t1.IsActive(t2)
 			SoMsg("err", err, ShouldNotBeNil)
 		})

--- a/go/lib/util/time.go
+++ b/go/lib/util/time.go
@@ -20,13 +20,13 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 )
 
-// USecsToTime takes seconds stored in a uint32.
-func USecsToTime(t uint32) time.Time {
+// SecsToTime takes seconds stored in a uint32.
+func SecsToTime(t uint32) time.Time {
 	return time.Unix(int64(t), 0)
 }
 
-// TimeToUSecs returns seconds stored as uint32.
-func TimeToUSecs(t time.Time) uint32 {
+// TimeToSecs returns seconds stored as uint32.
+func TimeToSecs(t time.Time) uint32 {
 	return uint32(t.Unix())
 }
 

--- a/go/lib/util/time.go
+++ b/go/lib/util/time.go
@@ -25,9 +25,9 @@ func USecsToTime(t uint32) time.Time {
 	return time.Unix(int64(t), 0)
 }
 
-// SecsToTime takes seconds stored in a int64.
-func SecsToTime(t int64) time.Time {
-	return time.Unix(t, 0)
+// TimeToUSecs returns seconds stored as uint32.
+func TimeToUSecs(t time.Time) uint32 {
+	return uint32(t.Unix())
 }
 
 func TimeToString(t time.Time) string {

--- a/go/proto/sign.go
+++ b/go/proto/sign.go
@@ -63,7 +63,7 @@ func (s *SignS) Sign(key, message common.RawBytes) (common.RawBytes, error) {
 
 func (s *SignS) SignAndSet(key, message common.RawBytes) error {
 	var err error
-	s.Timestamp = util.TimeToUSecs(time.Now())
+	s.Timestamp = util.TimeToSecs(time.Now())
 	s.Signature, err = s.Sign(key, message)
 	return err
 }
@@ -71,7 +71,7 @@ func (s *SignS) SignAndSet(key, message common.RawBytes) error {
 // Time returns the timestamp. If the receiver is nil, the zero value is returned.
 func (s *SignS) Time() time.Time {
 	if s != nil {
-		return util.USecsToTime(s.Timestamp)
+		return util.SecsToTime(s.Timestamp)
 	}
 	return time.Time{}
 }

--- a/go/proto/sign.go
+++ b/go/proto/sign.go
@@ -63,7 +63,7 @@ func (s *SignS) Sign(key, message common.RawBytes) (common.RawBytes, error) {
 
 func (s *SignS) SignAndSet(key, message common.RawBytes) error {
 	var err error
-	s.Timestamp = uint32(time.Now().Unix())
+	s.Timestamp = util.TimeToUSecs(time.Now())
 	s.Signature, err = s.Sign(key, message)
 	return err
 }

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -207,7 +207,7 @@ func (f *Fetcher) buildSCIONDReplyEntries(paths []*combinator.Path) []sciond.Pat
 					FwdPath:    []byte{},
 					Mtu:        uint16(f.topology.MTU),
 					Interfaces: []sciond.PathInterface{},
-					ExpTime:    uint32(time.Now().Add(spath.MaxTTL * time.Second).Unix()),
+					ExpTime:    util.TimeToUSecs(time.Now().Add(spath.MaxTTL * time.Second)),
 				},
 			},
 		}
@@ -229,7 +229,7 @@ func (f *Fetcher) buildSCIONDReplyEntries(paths []*combinator.Path) []sciond.Pat
 				FwdPath:    x.Bytes(),
 				Mtu:        path.Mtu,
 				Interfaces: path.Interfaces,
-				ExpTime:    uint32(path.ExpTime.Unix()),
+				ExpTime:    util.TimeToUSecs(path.ExpTime),
 			},
 			HostInfo: sciond.HostInfo{
 				Addrs: struct {

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -207,7 +207,7 @@ func (f *Fetcher) buildSCIONDReplyEntries(paths []*combinator.Path) []sciond.Pat
 					FwdPath:    []byte{},
 					Mtu:        uint16(f.topology.MTU),
 					Interfaces: []sciond.PathInterface{},
-					ExpTime:    util.TimeToUSecs(time.Now().Add(spath.MaxTTL * time.Second)),
+					ExpTime:    util.TimeToSecs(time.Now().Add(spath.MaxTTL * time.Second)),
 				},
 			},
 		}
@@ -229,7 +229,7 @@ func (f *Fetcher) buildSCIONDReplyEntries(paths []*combinator.Path) []sciond.Pat
 				FwdPath:    x.Bytes(),
 				Mtu:        path.Mtu,
 				Interfaces: path.Interfaces,
-				ExpTime:    util.TimeToUSecs(path.ExpTime),
+				ExpTime:    util.TimeToSecs(path.ExpTime),
 			},
 			HostInfo: sciond.HostInfo{
 				Addrs: struct {

--- a/go/tools/scion-pki/internal/certs/gen.go
+++ b/go/tools/scion-pki/internal/certs/gen.go
@@ -228,7 +228,7 @@ func genCertCommon(bc *conf.BaseCert, s addr.IA, signKeyFname string) (*cert.Cer
 	// Determine issuingTime and calculate expiration time from validity.
 	issuingTime := bc.IssuingTime
 	if issuingTime == 0 {
-		issuingTime = util.TimeToUSecs(time.Now())
+		issuingTime = util.TimeToSecs(time.Now())
 	}
 	expirationTime := issuingTime + uint32(bc.Validity.Seconds())
 	return &cert.Certificate{

--- a/go/tools/scion-pki/internal/certs/gen.go
+++ b/go/tools/scion-pki/internal/certs/gen.go
@@ -29,6 +29,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/scrypto/cert"
 	"github.com/scionproto/scion/go/lib/scrypto/trc"
+	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/conf"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
 )
@@ -227,7 +228,7 @@ func genCertCommon(bc *conf.BaseCert, s addr.IA, signKeyFname string) (*cert.Cer
 	// Determine issuingTime and calculate expiration time from validity.
 	issuingTime := bc.IssuingTime
 	if issuingTime == 0 {
-		issuingTime = uint32(time.Now().Unix())
+		issuingTime = util.TimeToUSecs(time.Now())
 	}
 	expirationTime := issuingTime + uint32(bc.Validity.Seconds())
 	return &cert.Certificate{

--- a/go/tools/scion-pki/internal/conf/isd.go
+++ b/go/tools/scion-pki/internal/conf/isd.go
@@ -113,7 +113,7 @@ type Trc struct {
 
 func (t *Trc) validate() error {
 	if t.IssuingTime == 0 {
-		t.IssuingTime = uint32(time.Now().Unix())
+		t.IssuingTime = util.TimeToUSecs(time.Now())
 	}
 	if t.Version == 0 {
 		return common.NewBasicError(ErrTrcVersionNotSet, nil)

--- a/go/tools/scion-pki/internal/conf/isd.go
+++ b/go/tools/scion-pki/internal/conf/isd.go
@@ -113,7 +113,7 @@ type Trc struct {
 
 func (t *Trc) validate() error {
 	if t.IssuingTime == 0 {
-		t.IssuingTime = util.TimeToUSecs(time.Now())
+		t.IssuingTime = util.TimeToSecs(time.Now())
 	}
 	if t.Version == 0 {
 		return common.NewBasicError(ErrTrcVersionNotSet, nil)

--- a/go/tools/scion-pki/internal/trc/gen.go
+++ b/go/tools/scion-pki/internal/trc/gen.go
@@ -80,7 +80,7 @@ func genTrc(isd addr.ISD) error {
 func newTrc(isd addr.ISD, iconf *conf.Isd, path string) (*trc.TRC, error) {
 	issuingTime := iconf.Trc.IssuingTime
 	if issuingTime == 0 {
-		issuingTime = util.TimeToUSecs(time.Now())
+		issuingTime = util.TimeToSecs(time.Now())
 	}
 	t := &trc.TRC{
 		CreationTime:   iconf.Trc.IssuingTime,

--- a/go/tools/scion-pki/internal/trc/gen.go
+++ b/go/tools/scion-pki/internal/trc/gen.go
@@ -27,6 +27,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/scrypto/trc"
+	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/conf"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
 )
@@ -79,7 +80,7 @@ func genTrc(isd addr.ISD) error {
 func newTrc(isd addr.ISD, iconf *conf.Isd, path string) (*trc.TRC, error) {
 	issuingTime := iconf.Trc.IssuingTime
 	if issuingTime == 0 {
-		issuingTime = uint32(time.Now().Unix())
+		issuingTime = util.TimeToUSecs(time.Now())
 	}
 	t := &trc.TRC{
 		CreationTime:   iconf.Trc.IssuingTime,


### PR DESCRIPTION
- Make conversion from time.Time() to uint32 and vice versa more consistent
- Remove unused `SecsToTime`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1759)
<!-- Reviewable:end -->
