### PR TITLE
Support to build C code with debugging cflags

### DIFF
--- a/c/dispatcher/Makefile
+++ b/c/dispatcher/Makefile
@@ -4,6 +4,10 @@ CC = clang
 CFLAGS ?= -Wall -Werror -g -O2
 LDFLAGS ?= -lpthread -Wl,-Bstatic -lzlog -lfilter -lscion -Wl,-Bdynamic
 
+ifeq ($(D),1)
+CFLAGS += -gdwarf-2 -O0 -DZLOG_DEBUG
+endif
+
 LIB_DIR = ../lib
 INC = -I$(LIB_DIR)
 

--- a/c/dispatcher/dispatcher.c
+++ b/c/dispatcher/dispatcher.c
@@ -44,8 +44,10 @@
 FilterSocket *filter_socket = NULL;
 #endif
 
+#ifndef ZLOG_DEBUG
 #undef zlog_debug
 #define zlog_debug(...)
+#endif
 
 #define CMSG_CTRL_SIZE (CMSG_SPACE(sizeof(struct in6_pktinfo)) + CMSG_SPACE(sizeof(uint32_t)))
 #define DSTADDR(x) (((struct in_pktinfo *)CMSG_DATA(x))->ipi_addr)
@@ -212,7 +214,6 @@ int main(int argc, char **argv)
 void parse_cmdline(int argc, char **argv) {
     int c;
     bool delete_sock=false;
-
 
     while (1) {
         int option_index = 0;
@@ -953,8 +954,8 @@ void deliver_udp_svc(uint8_t *buf, int len, HostAddr *from, HostAddr *dst) {
             return;
         }
     }
-    //char dststr[MAX_HOST_ADDR_STR];
-    //char svcstr[MAX_HOST_ADDR_STR];
+    char dststr[MAX_HOST_ADDR_STR] __attribute__ ((unused));
+    char svcstr[MAX_HOST_ADDR_STR] __attribute__ ((unused));
     zlog_debug(zc, "deliver UDP packet to (%d-%" PRId64 "):%s SVC:%s",
             ISD(svc_key.isd_as), AS(svc_key.isd_as),
             addr_to_str(dst->addr, dst->addr_type, dststr),

--- a/c/lib/filter/Makefile
+++ b/c/lib/filter/Makefile
@@ -4,6 +4,10 @@ CC = clang
 CFLAGS ?= -Wall -Werror -g -fPIC
 LDFLAGS ?= -shared -Wl,-z,defs -lscion -lzlog
 
+ifeq ($(D),1)
+CFLAGS += -gdwarf-2 -O0
+endif
+
 LIB_DIR = ..
 INC = -I$(LIB_DIR)
 

--- a/c/lib/hsr/Makefile
+++ b/c/lib/hsr/Makefile
@@ -49,6 +49,10 @@ SRCS-y := hsr_dpdk.c
 CFLAGS += -O3 -I$(S)/.. -I$(S)/../scion -Wall -fno-strict-aliasing -g
 #CFLAGS += $(WERROR_FLAGS)
 
+ifeq ($(D),1)
+CFLAGS += -gdwarf-2 -O0
+endif
+
 EXTRA_LDFLAGS += -lscion -lrte_lpm
 
 include $(RTE_SDK)/mk/rte.extshared.mk

--- a/c/lib/scion/Makefile
+++ b/c/lib/scion/Makefile
@@ -4,6 +4,10 @@ CC = clang
 CFLAGS ?= -Wall -Werror -g -fPIC -O2
 LDFLAGS ?= -shared -Wl,-z,defs
 
+ifeq ($(D),1)
+CFLAGS += -gdwarf-2 -O0
+endif
+
 SRCS = $(filter-out $(BINARY).c, $(wildcard *.c))
 OBJS = $(SRCS:.c=.o)
 STATIC = libscion.a


### PR DESCRIPTION
This change adds the -D option to the Makefile such that the C code
would be built with '-gdwarf-2 -O0' cflags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1774)
<!-- Reviewable:end -->
