### PR TITLE
Various build/ci fixes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,4 @@ RUN tar xf ~/python_local.tar.gz -C ~
 RUN docker/deps_check
 
 # Syncing should be a no-op, just need installation to run
-RUN make -C go deps
-
-# Build topology files
-RUN ./scion.sh topology
+RUN make -sC go deps

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o pipefail
+
 . integration/common.sh
 
 # Get docker flag and container name
@@ -28,7 +30,7 @@ shutdown() {
 }
 
 log "Starting scion (without building)"
-./scion.sh run nobuild | grep -v "started"
+./scion.sh run nobuild | grep -v "started" || exit 1
 log "Scion status:"
 ./scion.sh status || exit 1
 

--- a/tools/ci/integration
+++ b/tools/ci/integration
@@ -3,8 +3,23 @@
 . tools/ci/common.sh
 set -eo pipefail
 
+cntr="${1:-scion_ci}"
+
+docker container exec $cntr bash -c "set -x; ./scion.sh topology ${DOCKER:+-d}"
+
 if [ -n "$DOCKER" ]; then
-    ./integration/integration_test.sh -d "${1:-scion_ci}" |& tee logs/integration.run
+    # Make sure stale configs/state on the host are removed.
+    for i in gen gen-certs; do
+        [ -e "$i" ] && rm -r "$i"
+    done
+    rm -f ./logs/* ./gen-cache/*
+    mkdir -p gen-cache
+    # Copy out new topology
+    docker cp "$cntr:/home/scion/go/src/github.com/scionproto/scion/gen" .
+    docker cp "$cntr:/home/scion/go/src/github.com/scionproto/scion/gen-certs" .
+    # Run tests from host.
+    ./integration/integration_test.sh -d "$cntr" |& tee logs/integration.run
 else
-    docker container exec ${1:-scion_ci} bash -c "set -eo pipefail; sudo service zookeeper start; ./integration/integration_test.sh |& tee logs/integration.run"
+    # Run tests inside the CI container.
+    docker container exec "$cntr" bash -c "set -eo pipefail; sudo service zookeeper start; ./integration/integration_test.sh |& tee logs/integration.run"
 fi

--- a/tools/ci/integration
+++ b/tools/ci/integration
@@ -1,14 +1,10 @@
 #!/bin/bash
 
 . tools/ci/common.sh
-set -exo pipefail
+set -eo pipefail
 
-if [ "$DOCKER" = true ]; then
-    ctnr=${1:-scion_ci}
-    docker container exec $ctnr bash -c "./scion.sh topology -d"
-    docker cp $ctnr:/home/scion/go/src/github.com/scionproto/scion/gen .
-    docker cp $ctnr:/home/scion/go/src/github.com/scionproto/scion/gen-certs .
-    ./integration/integration_test.sh -d $ctnr |& tee logs/integration.run
+if [ -n "$DOCKER" ]; then
+    ./integration/integration_test.sh -d "${1:-scion_ci}" |& tee logs/integration.run
 else
     docker container exec ${1:-scion_ci} bash -c "set -eo pipefail; sudo service zookeeper start; ./integration/integration_test.sh |& tee logs/integration.run"
 fi

--- a/tools/ci/local
+++ b/tools/ci/local
@@ -10,11 +10,6 @@ if [ -n "$DOCKER" ]; then
     ./scion.sh stop
     echo "Stop local zookeeper"
     systemctl is-active --quiet zookeeper && { sudo service zookeeper stop || exit 1; }
-    for i in gen gen-certs; do
-        [ -e "$i" ] && rm -r "$i"
-    done
-    rm -f ./logs/* ./gen-cache/*
-    mkdir -p gen-cache
 fi
 
 ./docker.sh build || exit 1
@@ -33,11 +28,6 @@ result=$((result+$?))
 ./tools/ci/sphinx "$cntr"
 result=$((result+$?))
 
-docker container exec $cntr bash -c "set -x; ./scion.sh topology ${DOCKER:+-d}"
-if [ -n "$DOCKER" ]; then
-    docker cp $cntr:/home/scion/go/src/github.com/scionproto/scion/gen .
-    docker cp $cntr:/home/scion/go/src/github.com/scionproto/scion/gen-certs .
-fi
 ./tools/ci/integration $args "$cntr"
 result=$((result+$?))
 

--- a/tools/ci/local
+++ b/tools/ci/local
@@ -1,41 +1,51 @@
 #!/bin/bash
 
-CONTAINER="scion_ci"
-
 . tools/ci/common.sh
-if [ "$DOCKER" = true ]; then
-    args="-d $CONTAINER"
+
+cntr="${1:-scion_ci}"
+
+if [ -n "$DOCKER" ]; then
+    args="-d $cntr"
     # Stop a local scion run because we don't want to interfere
     ./scion.sh stop
     echo "Stop local zookeeper"
     systemctl is-active --quiet zookeeper && { sudo service zookeeper stop || exit 1; }
+    for i in gen gen-certs; do
+        [ -e "$i" ] && rm -r "$i"
+    done
+    rm -f ./logs/* ./gen-cache/*
+    mkdir -p gen-cache
 fi
 
-docker inspect "$CONTAINER" &>/dev/null && docker rm -f "$CONTAINER"
 ./docker.sh build || exit 1
+[ -n "$DOCKER" ] && { make -sC docker/perapp || exit 1; }
+
+docker inspect "$cntr" &>/dev/null && { echo "Removing stale container"; docker rm -f "$cntr"; }
 ./tools/ci/setup_container $args || exit 1
+
 result=0
-./tools/ci/build "$CONTAINER"
+./tools/ci/build "$cntr"
 result=$((result+$?))
-./tools/ci/lint "$CONTAINER"
+./tools/ci/lint "$cntr"
 result=$((result+$?))
-./tools/ci/unittest "$CONTAINER"
+./tools/ci/unittest "$cntr"
 result=$((result+$?))
-./tools/ci/sphinx "$CONTAINER"
+./tools/ci/sphinx "$cntr"
 result=$((result+$?))
 
-if [ "$DOCKER" = true ]; then
-    make -sC docker/perapp || exit 1
-    rm -r gen/* gen-cache/* gen-certs/* logs/*
+docker container exec $cntr bash -c "set -x; ./scion.sh topology ${DOCKER:+-d}"
+if [ -n "$DOCKER" ]; then
+    docker cp $cntr:/home/scion/go/src/github.com/scionproto/scion/gen .
+    docker cp $cntr:/home/scion/go/src/github.com/scionproto/scion/gen-certs .
 fi
-./tools/ci/integration $args "$CONTAINER"
+./tools/ci/integration $args "$cntr"
 result=$((result+$?))
 
 tmpdir=$(mktemp -d /tmp/artifacts.XXXXXXX)
-./tools/ci/clean_up "$tmpdir" "$CONTAINER" || exit 1
+./tools/ci/clean_up "$tmpdir" "$cntr" || exit 1
 echo "Artifacts dir: $tmpdir"
 
-docker rm -f "$CONTAINER"
+[ $result -eq 0 ] && docker rm -f "$cntr"
 ./scion.sh stop
 
 if [ $result -eq 0 ]; then

--- a/tools/ci/setup_container
+++ b/tools/ci/setup_container
@@ -1,9 +1,12 @@
 #!/bin/bash
 
 . tools/ci/common.sh
-set -ex
 
-[ "$DOCKER" = true ] && mount="-v "/run/shm/dispatcher:/run/shm/dispatcher:rw" -v "/run/shm/sciond:/run/shm/sciond:rw""
+cntr=${1:-scion_ci}
 
-docker create --name=${1:-scion_ci} --entrypoint= $mount scion:latest tail -f /dev/null
-docker container start ${1:-scion_ci}
+set -e
+
+[ -n "$DOCKER" ] && mount="-v /run/shm/dispatcher:/run/shm/dispatcher:rw -v /run/shm/sciond:/run/shm/sciond:rw"
+
+docker create --name=$cntr --entrypoint= $mount scion:latest tail -f /dev/null
+docker container start $cntr

--- a/tools/quiet
+++ b/tools/quiet
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+tf=$(mktemp --tmpdir scion-quiet.XXXXXXX)
+"$@" &>"$tf"
+result=$?
+[ $result -eq 0 ] || cat "$tf"
+rm "$tf"
+exit $result


### PR DESCRIPTION
- Don't run ./scion.sh topology in docker/Dockerfile - without knowing
  the backend to use it doesn't make much sense. Instead it's run by
  tools/ci/local
- integration_test stops if ./scion.sh run fails.
- Always run supervisor.sh shutdown in ./scion.sh topology - it's
  idempotent, and avoids failure if gen/ is missing.
- Add tools/quiet to run commands and only show the output if it exits
  non-zero.
- Use tools/quiet to shut up supervisor & docker-compose start/stop
  messages.
- Don't print errors when /run/shm/{dispatcher,sciond} don't exist on
  scion.sh stop.
- Removed unnecessary `set -x`'s.
- Only remove local ci container on success.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1775)
<!-- Reviewable:end -->
