### PR TITLE
Provide context to sudo password prompts.

### DIFF
--- a/c/lib/filter/Makefile
+++ b/c/lib/filter/Makefile
@@ -38,11 +38,13 @@ $(DYNAMIC): $(OBJS)
 install: .installstamp
 
 .installstamp: $(TARGETS)
+	@sudo -vp "c/lib/filter:install [sudo] password for %p: "
 	sudo cp $(TARGETS) $(PREFIX)/lib/
 	sudo ldconfig
 	touch .installstamp
 
 uninstall:
+	@sudo -vp "c/lib/filter:uninstall [sudo] password for %p: "
 	$(foreach var,$(TARGETS),sudo rm -f $(PREFIX)/lib/$(var);)
 	sudo ldconfig
 	rm -f .installstamp

--- a/c/lib/hsr/Makefile
+++ b/c/lib/hsr/Makefile
@@ -63,11 +63,13 @@ doinstall: .installstamp
 PREFIX ?= /usr/local
 build/$(SHARED): $(SHARED)
 .installstamp: build/$(SHARED)
+	@sudo -vp "c/lib/hsr:install [sudo] password for %p: "
 	sudo cp build/$(SHARED) $(PREFIX)/lib/
 	sudo ldconfig
 	touch .installstamp
 
 uninstall:
+	@sudo -vp "c/lib/hsr:uninstall [sudo] password for %p: "
 	sudo rm -r $(PREFIX)/lib/$(SHARED)
 	sudo ldconfig
 	rm -f .installstamp

--- a/c/lib/scion/Makefile
+++ b/c/lib/scion/Makefile
@@ -39,11 +39,13 @@ checksum_bench: checksum_bench.c $(DYNAMIC)
 install: .installstamp
 
 .installstamp: $(TARGETS)
+	@sudo -vp "c/lib/scion:install [sudo] password for %p: "
 	sudo cp $(TARGETS) $(PREFIX)/lib/
 	sudo ldconfig
 	touch .installstamp
 
 uninstall:
+	@sudo -vp "c/lib/scion:uninstall [sudo] password for %p: "
 	$(foreach var,$(TARGETS),sudo rm -f $(PREFIX)/lib/$(var);)
 	sudo ldconfig
 	rm -f .installstamp

--- a/go/Makefile
+++ b/go/Makefile
@@ -73,4 +73,5 @@ libs: deps_proto
 
 hsr: libs
 	GOBIN=${LOCAL_GOBIN} go install -v -tags "$(GOTAGS) hsr" ./border/...
+	sudo -vp "go:hsr [sudo] password for %p: "
 	sudo setcap cap_dac_read_search,cap_dac_override,cap_sys_admin,cap_net_raw+ep ../bin/border

--- a/scion.sh
+++ b/scion.sh
@@ -86,10 +86,10 @@ run_setup() {
      # Create dispatcher and sciond dirs or change owner
     local disp_dir="/run/shm/dispatcher"
     [ -d "$disp_dir" ] || mkdir "$disp_dir"
-    [ $(stat -c "%U" "$disp_dir") == "$LOGNAME" ] || sudo chown $LOGNAME: "$disp_dir"
+    [ $(stat -c "%U" "$disp_dir") == "$LOGNAME" ] || { echo "Fix ownership of $disp_dir"; sudo chown $LOGNAME: "$disp_dir"; }
     local sciond_dir="/run/shm/sciond"
     [ -d "$sciond_dir" ] || mkdir "$sciond_dir"
-    [ $(stat -c "%U" "$sciond_dir") == "$LOGNAME" ] || sudo chown $LOGNAME: "$sciond_dir"
+    [ $(stat -c "%U" "$sciond_dir") == "$LOGNAME" ] || { echo "Fix ownership of $sciond_dir"; sudo chown $LOGNAME: "$sciond_dir"; }
 }
 
 cmd_stop() {


### PR DESCRIPTION
This means that if you run `make -s`, you'll know what you're entering
your password for. If your sudo credentials are already current, then
you won't see the prompt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1787)
<!-- Reviewable:end -->
