### PR TITLE
Avoid leaking SyncPathData reference

### DIFF
--- a/go/lib/pathmgr/syncpaths.go
+++ b/go/lib/pathmgr/syncpaths.go
@@ -68,7 +68,7 @@ func NewSyncPaths() *SyncPaths {
 func (sp *SyncPaths) update(newAPS spathmeta.AppPathSet) {
 	sp.mutex.Lock()
 	defer sp.mutex.Unlock()
-	value := sp.value.Load().(*SyncPathsData)
+	value := sp.Load()
 	value.RefreshTime = time.Now()
 	toAdd := setSubtract(newAPS, value.APS)
 	toRemove := setSubtract(value.APS, newAPS)
@@ -81,7 +81,8 @@ func (sp *SyncPaths) update(newAPS spathmeta.AppPathSet) {
 
 // Load returns a SyncPathsData snapshot of the data within sp.
 func (sp *SyncPaths) Load() *SyncPathsData {
-	return sp.value.Load().(*SyncPathsData)
+	val := *sp.value.Load().(*SyncPathsData)
+	return &val
 }
 
 func setSubtract(x, y spathmeta.AppPathSet) spathmeta.AppPathSet {

--- a/go/lib/pathmgr/syncpaths_test.go
+++ b/go/lib/pathmgr/syncpaths_test.go
@@ -44,5 +44,31 @@ func TestSyncPathsTimestamp(t *testing.T) {
 				SoMsg("timestamp", data.RefreshTime, ShouldHappenOnOrBetween, beforeStore, afterStore)
 			})
 		})
+
+		Convey("Update must not modify snapshot", func() {
+			data := sp.Load()
+			snap := *data
+			sp.update(spathmeta.AppPathSet(nil))
+			Convey("Modify timestamp should not change", func() {
+				SoMsg("timestamp", data.ModifyTime, ShouldResemble, snap.ModifyTime)
+			})
+			Convey("Refresh timestamp should not change", func() {
+				SoMsg("timestamp", data.RefreshTime, ShouldResemble, snap.RefreshTime)
+			})
+		})
+
+		Convey("Modifying snapshot must not affect other snapshots", func() {
+			data := sp.Load()
+			snap := *data
+			other := sp.Load()
+			other.ModifyTime = time.Unix(0, 0)
+			other.RefreshTime = time.Unix(0, 0)
+			Convey("Modify timestamp should not change", func() {
+				SoMsg("timestamp", data.ModifyTime, ShouldResemble, snap.ModifyTime)
+			})
+			Convey("Refresh timestamp should not change", func() {
+				SoMsg("timestamp", data.RefreshTime, ShouldResemble, snap.RefreshTime)
+			})
+		})
 	})
 }


### PR DESCRIPTION
Return a snapshot instead of the reference to the actual `SyncPathData`.
Avoid modifying the `SyncPathData` object non-atomically.