### PR TITLE
Fix overlay port handling for BR in topology.

### DIFF
--- a/go/lib/topology/testdata/udpbr.json
+++ b/go/lib/topology/testdata/udpbr.json
@@ -1,0 +1,28 @@
+{
+    "ISD_AS": "6-ff00:0:362",
+    "Overlay": "UDP/IPv4+6",
+    "BorderRouters": {
+        "borderrouter6-ff00:0:362-1": {
+            "InternalAddr": {
+                  "Public": [
+                    {"Addr": "192.0.128.1", "L4Port": 30097},
+                    {"Addr": "2001:db8:a0b:12f0::1", "L4Port": 30098}
+                  ],
+                  "Bind": [
+                    {"Addr": "10.0.0.1", "L4Port": 30197},
+                    {"Addr": "fe80::", "L4Port": 30198}
+                  ]
+            },
+            "Interfaces": {
+                "101": {
+                    "Overlay": "UDP/IPv4",
+                    "Public": {"Addr": "192.0.2.1", "L4Port": 4997},
+                    "Remote": {"Addr": "192.0.2.2", "L4Port": 4998},
+                    "Bandwidth": 100000,
+                    "ISD_AS": "6-ff00:0:363",
+                    "LinkTo": "CORE"
+                }
+            }
+        }
+    }
+}

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -115,7 +115,18 @@ func (t *Topo) populateMeta(raw *RawTopo) error {
 func (t *Topo) populateBR(raw *RawTopo) error {
 	for name, rawBr := range raw.BorderRouters {
 		if rawBr.InternalAddr == nil {
-			return common.NewBasicError("Missing Internal Address", nil)
+			return common.NewBasicError("Missing Internal Address", nil, "br", name)
+		}
+		for i := range rawBr.InternalAddr.Public {
+			iAddr := &rawBr.InternalAddr.Public[i]
+			if iAddr.OverlayPort != 0 {
+				return common.NewBasicError("BR internal address may not have overlay port set",
+					nil, "br", name, "intAddr", iAddr)
+			}
+			if t.Overlay.IsUDP() {
+				// Set the overlay port to the L4 port as the BR does not run on top of the dispatcher.
+				iAddr.OverlayPort = iAddr.L4Port
+			}
 		}
 		intAddr, err := rawBr.InternalAddr.ToTopoAddr(t.Overlay)
 		if err != nil {

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -124,7 +124,8 @@ func (t *Topo) populateBR(raw *RawTopo) error {
 					nil, "br", name, "intAddr", iAddr)
 			}
 			if t.Overlay.IsUDP() {
-				// Set the overlay port to the L4 port as the BR does not run on top of the dispatcher.
+				// Set the overlay port to the L4 port as the BR does not run
+				// on top of the dispatcher.
 				iAddr.OverlayPort = iAddr.L4Port
 			}
 		}

--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -173,7 +173,8 @@ func Test_Service_Details(t *testing.T) {
 }
 
 func Test_Service_Count(t *testing.T) {
-	// This just checks the count of all the service types, actual population testing is done elsewhere
+	// This just checks the count of all the service types, actual population
+	// testing is done elsewhere
 	// The simple counting check for CS is done in the detailed population test as well
 	fn := "testdata/basic.json"
 	loadTopo(fn, t)
@@ -267,7 +268,6 @@ func Test_IFInfoMap(t *testing.T) {
 			So(c.IFInfoMap[id], ShouldResemble, ifm[id])
 		})
 	}
-
 }
 
 func Test_IFInfoMap_COREAS(t *testing.T) {
@@ -314,7 +314,23 @@ func Test_IFInfoMap_COREAS(t *testing.T) {
 			So(c.IFInfoMap[id], ShouldResemble, ifm[id])
 		})
 	}
+}
 
+func Test_IFInfo_InternalAddr(t *testing.T) {
+	ifm := make(map[common.IFIDType]*TopoAddr)
+	ifm[101] = &TopoAddr{
+		IPv4:    mkPBOv4("192.0.128.1", 30097, "10.0.0.1", 30197, 30097),
+		IPv6:    mkPBOv6("2001:db8:a0b:12f0::1", 30098, "fe80::", 30198, 30098),
+		Overlay: overlay.UDPIPv46,
+	}
+	fn := "testdata/udpbr.json"
+	loadTopo(fn, t)
+	for _, id := range []common.IFIDType{101} {
+		Convey(fmt.Sprintf("Checking IFInfoMap entry for Interface %d", id), t, func() {
+			c := testTopo
+			So(c.IFInfoMap[id].InternalAddr, ShouldResemble, ifm[id])
+		})
+	}
 }
 
 var br_cases = []struct {


### PR DESCRIPTION
It is (currently) illegal to specify `OverlayPort` in a BR entry, as the
BR doesn't run on top of the dispatcher. Additionally, calling
`OverlayAddr` on the internal address of a BR should set the overlay
port appropriately (assuming a UDP-based overlay).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1799)
<!-- Reviewable:end -->
