### PR TITLE
Add timeout support for custom network snet

### DIFF
--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -86,37 +86,41 @@ type Conn struct {
 	prefPathKey spathmeta.PathKey
 }
 
-// DialSCION calls DialSCION on the default networking context.
+// DialSCION calls DialSCION with infinite timeout on the default networking
+// context.
 func DialSCION(network string, laddr, raddr *Addr) (*Conn, error) {
 	if DefNetwork == nil {
 		return nil, common.NewBasicError("SCION network not initialized", nil)
 	}
-	return DefNetwork.DialSCION(network, laddr, raddr)
+	return DefNetwork.DialSCION(network, laddr, raddr, -1)
 }
 
-// DialSCIONWithBindSVC calls DialSCIONWithBindSVC on the default networking context.
+// DialSCIONWithBindSVC calls DialSCIONWithBindSVC with infinite timeout on the
+// default networking context.
 func DialSCIONWithBindSVC(network string, laddr, raddr, baddr *Addr,
 	svc addr.HostSVC) (*Conn, error) {
 	if DefNetwork == nil {
 		return nil, common.NewBasicError("SCION network not initialized", nil)
 	}
-	return DefNetwork.DialSCIONWithBindSVC(network, laddr, raddr, baddr, svc)
+	return DefNetwork.DialSCIONWithBindSVC(network, laddr, raddr, baddr, svc, -1)
 }
 
-// ListenSCION calls ListenSCION on the default networking context.
+// ListenSCION calls ListenSCION with infinite timeout on the default
+// networking context.
 func ListenSCION(network string, laddr *Addr) (*Conn, error) {
 	if DefNetwork == nil {
 		return nil, common.NewBasicError("SCION network not initialized", nil)
 	}
-	return DefNetwork.ListenSCION(network, laddr)
+	return DefNetwork.ListenSCION(network, laddr, -1)
 }
 
-// ListenSCIONWithBindSVC calls ListenSCIONWithBindSVC on the default networking context.
+// ListenSCIONWithBindSVC calls ListenSCIONWithBindSVC with infinite timeout on
+// the default networking context.
 func ListenSCIONWithBindSVC(network string, laddr, baddr *Addr, svc addr.HostSVC) (*Conn, error) {
 	if DefNetwork == nil {
 		return nil, common.NewBasicError("SCION network not initialized", nil)
 	}
-	return DefNetwork.ListenSCIONWithBindSVC(network, laddr, baddr, svc)
+	return DefNetwork.ListenSCIONWithBindSVC(network, laddr, baddr, svc, -1)
 }
 
 // ReadFromSCION reads data into b, returning the length of copied data and the

--- a/go/lib/snet/integration_test.go
+++ b/go/lib/snet/integration_test.go
@@ -139,13 +139,13 @@ func ClientServer(haveSciond bool, idx int, tc TestCase) {
 			fmt.Sprintf("%v,[%v]:%d", tc.dstIA, tc.dstLocal, tc.dstPort))
 		SoMsg("Server address error", err, ShouldBeNil)
 
-		sconn, err := serverNet.ListenSCION("udp4", serverAddr)
+		sconn, err := serverNet.ListenSCION("udp4", serverAddr, -1)
 		SoMsg("Listen error", err, ShouldBeNil)
 
 		err = sconn.SetDeadline(time.Now().Add(5 * time.Second))
 		SoMsg("Server deadline error", err, ShouldBeNil)
 
-		cconn, err := clientNet.DialSCION("udp4", clientAddr, serverAddr)
+		cconn, err := clientNet.DialSCION("udp4", clientAddr, serverAddr, -1)
 		SoMsg("Client dial error", err, ShouldBeNil)
 		cconn.SetDeadline(time.Now().Add(5 * time.Second))
 		SoMsg("Client deadline error", err, ShouldBeNil)

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -142,19 +142,26 @@ func NewNetwork(ia addr.IA, sciondPath string, dispatcherPath string) (*Network,
 // DialSCION returns a SCION connection to raddr. Nil values for laddr are not
 // supported yet.  Parameter network must be "udp4". The returned connection's
 // Read and Write methods can be used to receive and send SCION packets.
-func (n *Network) DialSCION(network string, laddr *Addr, raddr *Addr) (*Conn, error) {
-	return n.DialSCIONWithBindSVC(network, laddr, raddr, nil, addr.SvcNone)
+//
+// A negative timeout means infinite timeout.
+func (n *Network) DialSCION(network string, laddr, raddr *Addr,
+	timeout time.Duration) (*Conn, error) {
+
+	return n.DialSCIONWithBindSVC(network, laddr, raddr, nil, addr.SvcNone, timeout)
 }
 
 // DialSCIONWithBindSVC returns a SCION connection to raddr. Nil values for laddr are not
 // supported yet.  Parameter network must be "udp4". The returned connection's
 // Read and Write methods can be used to receive and send SCION packets.
+//
+// A negative timeout means infinite timeout.
 func (n *Network) DialSCIONWithBindSVC(network string, laddr, raddr, baddr *Addr,
-	svc addr.HostSVC) (*Conn, error) {
+	svc addr.HostSVC, timeout time.Duration) (*Conn, error) {
+
 	if raddr == nil {
 		return nil, common.NewBasicError("Unable to dial to nil remote", nil)
 	}
-	conn, err := n.ListenSCIONWithBindSVC(network, laddr, baddr, svc)
+	conn, err := n.ListenSCIONWithBindSVC(network, laddr, baddr, svc, timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -172,16 +179,20 @@ func (n *Network) DialSCIONWithBindSVC(network string, laddr, raddr, baddr *Addr
 // not supported yet. The returned connection's ReadFrom and WriteTo methods
 // can be used to receive and send SCION packets with per-packet addressing.
 // Parameter network must be "udp4".
-func (n *Network) ListenSCION(network string, laddr *Addr) (*Conn, error) {
-	return n.ListenSCIONWithBindSVC(network, laddr, nil, addr.SvcNone)
+//
+// A negative timeout means infinite timeout.
+func (n *Network) ListenSCION(network string, laddr *Addr, timeout time.Duration) (*Conn, error) {
+	return n.ListenSCIONWithBindSVC(network, laddr, nil, addr.SvcNone, timeout)
 }
 
 // ListenSCIONWithBindSVC registers laddr with the dispatcher. Nil values for laddr are
 // not supported yet. The returned connection's ReadFrom and WriteTo methods
 // can be used to receive and send SCION packets with per-packet addressing.
 // Parameter network must be "udp4".
+//
+// A negative timeout means infinite timeout.
 func (n *Network) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr,
-	svc addr.HostSVC) (*Conn, error) {
+	svc addr.HostSVC, timeout time.Duration) (*Conn, error) {
 	if network != "udp4" {
 		return nil, common.NewBasicError("Network not implemented", nil, "net", network)
 	}
@@ -235,8 +246,8 @@ func (n *Network) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr,
 				"expected", conn.scionNet.localIA, "actual", conn.baddr.IA, "type", "bind")
 		}
 	}
-	rconn, port, err := reliable.Register(conn.scionNet.dispatcherPath,
-		conn.laddr.IA, conn.laddr.Host, bindAddr, svc)
+	rconn, port, err := reliable.RegisterTimeout(conn.scionNet.dispatcherPath,
+		conn.laddr.IA, conn.laddr.Host, bindAddr, svc, timeout)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to register with dispatcher", err)
 	}

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -86,5 +86,5 @@ func sListen(network *snet.Network, laddr, baddr *snet.Addr,
 	if network == nil {
 		network = snet.DefNetwork
 	}
-	return network.ListenSCIONWithBindSVC("udp4", laddr, baddr, svc)
+	return network.ListenSCIONWithBindSVC("udp4", laddr, baddr, svc, -1)
 }

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -168,14 +168,14 @@ func RegisterTimeout(dispatcher string, ia addr.IA, public, bind *addr.AppAddr, 
 			"public", public, "bind", bind)
 	}
 
-	deadline := time.Now().Add(timeout)
 	conn, err := DialTimeout(dispatcher, timeout)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	// If a timeout was specified, make reads and writes return if deadline exceeded
-	if timeout != 0 {
+	if timeout >= 0 {
+		deadline := time.Now().Add(timeout)
 		conn.SetDeadline(deadline)
 	}
 	reqSize := regBaseHeaderLen + public.L3.Size()


### PR DESCRIPTION
Support is only added to `Network` objects, because most callers don't care about setting a timeout and will be using the default `Dial`/`Listen` calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1804)
<!-- Reviewable:end -->
