### PR TITLE
Don't use sudo -v

### DIFF
--- a/c/lib/filter/Makefile
+++ b/c/lib/filter/Makefile
@@ -38,13 +38,13 @@ $(DYNAMIC): $(OBJS)
 install: .installstamp
 
 .installstamp: $(TARGETS)
-	@sudo -vp "c/lib/filter:install [sudo] password for %p: "
+	@sudo -p "c/lib/filter:install [sudo] password for %p: " true
 	sudo cp $(TARGETS) $(PREFIX)/lib/
 	sudo ldconfig
 	touch .installstamp
 
 uninstall:
-	@sudo -vp "c/lib/filter:uninstall [sudo] password for %p: "
+	@sudo -p "c/lib/filter:uninstall [sudo] password for %p: " true
 	$(foreach var,$(TARGETS),sudo rm -f $(PREFIX)/lib/$(var);)
 	sudo ldconfig
 	rm -f .installstamp

--- a/c/lib/hsr/Makefile
+++ b/c/lib/hsr/Makefile
@@ -63,13 +63,13 @@ doinstall: .installstamp
 PREFIX ?= /usr/local
 build/$(SHARED): $(SHARED)
 .installstamp: build/$(SHARED)
-	@sudo -vp "c/lib/hsr:install [sudo] password for %p: "
+	@sudo -p "c/lib/hsr:install [sudo] password for %p: " true
 	sudo cp build/$(SHARED) $(PREFIX)/lib/
 	sudo ldconfig
 	touch .installstamp
 
 uninstall:
-	@sudo -vp "c/lib/hsr:uninstall [sudo] password for %p: "
+	@sudo -p "c/lib/hsr:uninstall [sudo] password for %p: " true
 	sudo rm -r $(PREFIX)/lib/$(SHARED)
 	sudo ldconfig
 	rm -f .installstamp

--- a/c/lib/scion/Makefile
+++ b/c/lib/scion/Makefile
@@ -39,13 +39,13 @@ checksum_bench: checksum_bench.c $(DYNAMIC)
 install: .installstamp
 
 .installstamp: $(TARGETS)
-	@sudo -vp "c/lib/scion:install [sudo] password for %p: "
+	@sudo -p "c/lib/scion:install [sudo] password for %p: " true
 	sudo cp $(TARGETS) $(PREFIX)/lib/
 	sudo ldconfig
 	touch .installstamp
 
 uninstall:
-	@sudo -vp "c/lib/scion:uninstall [sudo] password for %p: "
+	@sudo -p "c/lib/scion:uninstall [sudo] password for %p: " true
 	$(foreach var,$(TARGETS),sudo rm -f $(PREFIX)/lib/$(var);)
 	sudo ldconfig
 	rm -f .installstamp

--- a/go/Makefile
+++ b/go/Makefile
@@ -73,5 +73,5 @@ libs: deps_proto
 
 hsr: libs
 	GOBIN=${LOCAL_GOBIN} go install -v -tags "$(GOTAGS) hsr" ./border/...
-	sudo -vp "go:hsr [sudo] password for %p: "
+	@sudo -p "go:hsr [sudo] password for %p: " true
 	sudo setcap cap_dac_read_search,cap_dac_override,cap_sys_admin,cap_net_raw+ep ../bin/border


### PR DESCRIPTION
scionproto/scion#1787 used `sudo -v` as a way to ensure that sudo
credentials are cached before running the desired commands with sudo.
This, however, breaks in an environment where the user in question can
run any command without a password, as `sudo -v` will always prompt for
a password if no sudo credentials are present.

To work around this, this PR changes from using `sudo -vp <prompt>` to
`sudo -p <prompt> true`, which will actually run a (harmless) command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1807)
<!-- Reviewable:end -->
