### PR TITLE
sciond: Increase timeout for PathReply processing

### DIFF
--- a/python/sciond/req.py
+++ b/python/sciond/req.py
@@ -1,4 +1,5 @@
 # Copyright 2017 ETH Zurich
+# Copyright 2018 ETH Zurich, Anapaya Systems
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +18,7 @@ import logging
 import threading
 
 # How long to wait (at most) after segments are received before considering the request done.
-_WAIT_TIME = 0.2
+_WAIT_TIME = 0.5
 
 
 class RequestState:  # pragma: no cover


### PR DESCRIPTION
On a CI env we have seen that processing 7 segments can take more than 200ms.
Since the last PCB was the missing piece for the path,
sciond wrongly answered with 0 path, even though
there would have been one if it waited longer.

Increasing the timeout is a temporary fix for this.
We expect the go-sciond to be better in this regard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1808)
<!-- Reviewable:end -->
