### PR TITLE
Fix writing of offsets in scion packets (go)

### DIFF
--- a/go/lib/hpkt/write.go
+++ b/go/lib/hpkt/write.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -76,7 +77,7 @@ func WriteScnPkt(s *spkt.ScnPkt, b common.RawBytes) (int, error) {
 	offset += addrPad
 
 	// Forwarding Path
-	if s.Path != nil {
+	if !s.Path.IsEmpty() {
 		cmnHdr.CurrInfoF = uint8((offset + s.Path.InfOff) / common.LineLen)
 		cmnHdr.CurrHopF = uint8((offset + s.Path.HopOff) / common.LineLen)
 		offset += copy(b[offset:], s.Path.Raw)

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -111,7 +111,7 @@ func (path *Path) InitOffsets() error {
 	path.InfOff = 0
 	path.HopOff = common.LineLen
 	// Cannot initialize an empty path
-	if path == nil || len(path.Raw) == 0 {
+	if path.IsEmpty() {
 		return common.NewBasicError("Unable to initialize empty path", nil)
 	}
 	// Skip Peer with Xover HF
@@ -151,6 +151,7 @@ func (path *Path) IncOffsets() error {
 	return path.incOffsets(hopF.Len())
 }
 
+// IsEmpty returns true if the path is nil or empty (no raw data).
 func (path *Path) IsEmpty() bool {
 	return path == nil || len(path.Raw) == 0
 }
@@ -189,6 +190,9 @@ func (path *Path) GetInfoField(offset int) (*InfoField, error) {
 	if offset < 0 {
 		return nil, common.NewBasicError("Negative InfoF offset", nil, "offset", offset)
 	}
+	if path.IsEmpty() {
+		return nil, common.NewBasicError("Unable to get infoField from empty path", nil)
+	}
 	infoF, err := InfoFFromRaw(path.Raw[offset:])
 	if err != nil {
 		return nil, common.NewBasicError("Unable to parse Info Field", err, "offset", offset)
@@ -199,6 +203,9 @@ func (path *Path) GetInfoField(offset int) (*InfoField, error) {
 func (path *Path) GetHopField(offset int) (*HopField, error) {
 	if offset < 0 {
 		return nil, common.NewBasicError("Negative HopF offset", nil, "offset", offset)
+	}
+	if path.IsEmpty() {
+		return nil, common.NewBasicError("Unable to get hopField from empty path", nil)
 	}
 	hopF, err := HopFFromRaw(path.Raw[offset:])
 	if err != nil {

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -1,4 +1,5 @@
 // Copyright 2016 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -148,6 +149,10 @@ func (path *Path) IncOffsets() error {
 		return common.NewBasicError("Hop Field parse error", err, "offset", path.HopOff)
 	}
 	return path.incOffsets(hopF.Len())
+}
+
+func (path *Path) IsEmpty() bool {
+	return path == nil || len(path.Raw) == 0
 }
 
 // incOffsets jumps ahead skip bytes, and searches for the first routing Hop


### PR DESCRIPTION
It could be that the s.Path is not nil but empty, then we should also not write CurreInfoF and CurrHopF
These fields will have the same value (0, i.e. offset / common.LineLen) which will lead to a parse error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1810)
<!-- Reviewable:end -->
