### PR TITLE
Rename infra.MessageTypes to shorter names

### DIFF
--- a/go/lib/infra/common.go
+++ b/go/lib/infra/common.go
@@ -129,11 +129,11 @@ const (
 	TRCRequest
 	Chain
 	ChainRequest
-	PathSegmentRegistration
-	PathSegmentRequest
-	PathSegmentReply
-	PathSegmentRevocation
-	PathSegmentSynchronization
+	SegReg
+	SegRequest
+	SegReply
+	SegRev
+	SegSync
 	ChainIssueRequest
 	ChainIssueReply
 )
@@ -150,16 +150,16 @@ func (mt MessageType) String() string {
 		return "TRCRequest"
 	case TRC:
 		return "TRC"
-	case PathSegmentRegistration:
-		return "PathSegmentRegistration"
-	case PathSegmentRequest:
-		return "PathSegmentRequest"
-	case PathSegmentReply:
-		return "PathSegmentReply"
-	case PathSegmentRevocation:
-		return "PathSegmentRevocation"
-	case PathSegmentSynchronization:
-		return "PathSegmentSynchronization"
+	case SegReg:
+		return "SegReg"
+	case SegRequest:
+		return "SegRequest"
+	case SegReply:
+		return "SegReply"
+	case SegRev:
+		return "SegRev"
+	case SegSync:
+		return "SegSync"
 	case ChainIssueRequest:
 		return "ChainIssueRequest"
 	case ChainIssueReply:
@@ -176,7 +176,7 @@ type Messenger interface {
 	GetCertChain(ctx context.Context, msg *cert_mgmt.ChainReq, a net.Addr,
 		id uint64) (*cert_mgmt.Chain, error)
 	SendCertChain(ctx context.Context, msg *cert_mgmt.Chain, a net.Addr, id uint64) error
-	GetPathSegs(ctx context.Context, msg *path_mgmt.SegReq, a net.Addr,
+	GetSegs(ctx context.Context, msg *path_mgmt.SegReq, a net.Addr,
 		id uint64) (*path_mgmt.SegReply, error)
 	SendSegReply(ctx context.Context, msg *path_mgmt.SegReply, a net.Addr, id uint64) error
 	SendSegSync(ctx context.Context, msg *path_mgmt.SegSync, a net.Addr, id uint64) error

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -252,9 +252,9 @@ func (m *Messenger) SendCertChain(ctx context.Context, msg *cert_mgmt.Chain, a n
 	return m.getRequester(infra.Chain, infra.None).Notify(ctx, pld, a)
 }
 
-// GetPathSegs asks the server at the remote address for the path segments that
+// GetSegs asks the server at the remote address for the path segments that
 // satisfy msg, and returns a verified reply.
-func (m *Messenger) GetPathSegs(ctx context.Context, msg *path_mgmt.SegReq,
+func (m *Messenger) GetSegs(ctx context.Context, msg *path_mgmt.SegReq,
 	a net.Addr, id uint64) (*path_mgmt.SegReply, error) {
 
 	debug_id := util.GetDebugID()
@@ -263,10 +263,10 @@ func (m *Messenger) GetPathSegs(ctx context.Context, msg *path_mgmt.SegReq,
 	if err != nil {
 		return nil, err
 	}
-	logger.Debug("[Messenger] Sending request", "req_type", infra.PathSegmentRequest,
+	logger.Debug("[Messenger] Sending request", "req_type", infra.SegRequest,
 		"msg_id", id, "request", msg, "peer", a)
 	replyCtrlPld, _, err :=
-		m.getRequester(infra.PathSegmentRequest, infra.PathSegmentReply).Request(ctx, pld, a)
+		m.getRequester(infra.SegRequest, infra.SegReply).Request(ctx, pld, a)
 	if err != nil {
 		return nil, common.NewBasicError("[Messenger] Request error", err, "debug_id", debug_id)
 	}
@@ -297,8 +297,8 @@ func (m *Messenger) SendSegReply(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	m.log.Debug("[Messenger] Sending Notify", "type", infra.PathSegmentReply, "to", a, "id", id)
-	return m.getRequester(infra.PathSegmentReply, infra.None).Notify(ctx, pld, a)
+	m.log.Debug("[Messenger] Sending Notify", "type", infra.SegReply, "to", a, "id", id)
+	return m.getRequester(infra.SegReply, infra.None).Notify(ctx, pld, a)
 }
 
 // SendSegSync sends a reliable path_mgmt.SegSync to address a.
@@ -309,9 +309,8 @@ func (m *Messenger) SendSegSync(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	m.log.Debug("[Messenger] Sending Notify",
-		"type", infra.PathSegmentSynchronization, "to", a, "id", id)
-	return m.getRequester(infra.PathSegmentSynchronization, infra.None).Notify(ctx, pld, a)
+	m.log.Debug("[Messenger] Sending Notify", "type", infra.SegSync, "to", a, "id", id)
+	return m.getRequester(infra.SegSync, infra.None).Notify(ctx, pld, a)
 }
 
 func (m *Messenger) RequestChainIssue(ctx context.Context, msg *cert_mgmt.ChainIssReq, a net.Addr,
@@ -495,15 +494,15 @@ func (m *Messenger) validate(pld *ctrl.Pld) (infra.MessageType, proto.Cerealizab
 	case proto.CtrlPld_Which_pathMgmt:
 		switch pld.PathMgmt.Which {
 		case proto.PathMgmt_Which_segReq:
-			return infra.PathSegmentRequest, pld.PathMgmt.SegReq, nil
+			return infra.SegRequest, pld.PathMgmt.SegReq, nil
 		case proto.PathMgmt_Which_segReply:
-			return infra.PathSegmentReply, pld.PathMgmt.SegReply, nil
+			return infra.SegReply, pld.PathMgmt.SegReply, nil
 		case proto.PathMgmt_Which_segReg:
-			return infra.PathSegmentRegistration, pld.PathMgmt.SegReg, nil
+			return infra.SegReg, pld.PathMgmt.SegReg, nil
 		case proto.PathMgmt_Which_segSync:
-			return infra.PathSegmentSynchronization, pld.PathMgmt.SegSync, nil
+			return infra.SegSync, pld.PathMgmt.SegSync, nil
 		case proto.PathMgmt_Which_sRevInfo:
-			return infra.PathSegmentRevocation, pld.PathMgmt.SRevInfo, nil
+			return infra.SegRev, pld.PathMgmt.SRevInfo, nil
 		default:
 			return infra.None, nil,
 				common.NewBasicError("Unsupported SignedPld.CtrlPld.PathMgmt.Xxx message type",

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -19,8 +19,11 @@
 //  infra.Chain               -> ctrl.SignedPld/ctrl.Pld/cert_mgmt.Chain
 //  infra.TRCRequest          -> ctrl.SignedPld/ctrl.Pld/cert_mgmt.TRCReq
 //  infra.TRC                 -> ctrl.SignedPld/ctrl.Pld/cert_mgmt.TRC
-//  infra.PathSegmentRequest  -> ctrl.SignedPld/ctrl.Pld/path_mgmt.SegReq
-//  infra.PathSegmentReply    -> ctrl.SignedPld/ctrl.Pld/path_mgmt.SegReply
+//  infra.SegReq              -> ctrl.SignedPld/ctrl.Pld/path_mgmt.SegReg
+//  infra.SegRequest          -> ctrl.SignedPld/ctrl.Pld/path_mgmt.SegReq
+//  infra.SegReply            -> ctrl.SignedPld/ctrl.Pld/path_mgmt.SegReply
+//  infra.SegRev              -> ctrl.SignedPld/ctrl.Pld/path_mgmt.SRevInfo
+//  infra.SegSync             -> ctrl.SignedPld/ctrl.Pld/path_mgmt.SegSync
 //  infra.ChainIssueRequest   -> ctrl.SignedPld/ctrl.Pld/cert_mgmt.ChainIssReq
 //  infra.ChainIssueReply     -> ctrl.SignedPld/ctrl.Pld/cert_mgmt.ChainIssRep
 //

--- a/go/lib/infra/messenger/mock.go
+++ b/go/lib/infra/messenger/mock.go
@@ -88,7 +88,7 @@ func (m *MockMessenger) SendCertChain(ctx context.Context, msg *cert_mgmt.Chain,
 	panic("not implemented")
 }
 
-func (m *MockMessenger) GetPathSegs(ctx context.Context, msg *path_mgmt.SegReq, a net.Addr,
+func (m *MockMessenger) GetSegs(ctx context.Context, msg *path_mgmt.SegReq, a net.Addr,
 	id uint64) (*path_mgmt.SegReply, error) {
 
 	panic("not implemented")

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -102,7 +102,7 @@ func (h *segReqHandler) fetchAndSaveSegs(ctx context.Context, msger infra.Messen
 	src, dst addr.IA, cPSAddr net.Addr) error {
 
 	r := &path_mgmt.SegReq{RawSrcIA: src.IAInt(), RawDstIA: dst.IAInt()}
-	segs, err := msger.GetPathSegs(ctx, r, cPSAddr, requestID.Next())
+	segs, err := msger.GetSegs(ctx, r, cPSAddr, requestID.Next())
 	if err != nil {
 		return err
 	}

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -148,13 +148,12 @@ func realMain() int {
 	} else {
 		segReqHandler = handlers.NewSegReqNonCoreHandler(args)
 	}
-	msger.AddHandler(infra.PathSegmentRequest, segReqHandler)
-	msger.AddHandler(infra.PathSegmentRegistration,
-		handlers.NewSegRegHandler(args, config.PS.SegSync && core))
+	msger.AddHandler(infra.SegRequest, segReqHandler)
+	msger.AddHandler(infra.SegReg, handlers.NewSegRegHandler(args, config.PS.SegSync && core))
 	if config.PS.SegSync && core {
-		msger.AddHandler(infra.PathSegmentSynchronization, handlers.NewSyncHandler(args))
+		msger.AddHandler(infra.SegSync, handlers.NewSyncHandler(args))
 	}
-	msger.AddHandler(infra.PathSegmentRevocation, handlers.NewRevocHandler(args))
+	msger.AddHandler(infra.SegRev, handlers.NewRevocHandler(args))
 	// Create a channel where prometheus can signal fatal errors
 	fatalC := make(chan error, 1)
 	config.Metrics.StartPrometheus(fatalC)

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -440,7 +440,7 @@ func (f *Fetcher) getSegmentsFromNetwork(ctx context.Context,
 			CacheOnly: false,
 		},
 	}
-	reply, err := f.messenger.GetPathSegs(ctx, msg, ps, requestID.Next())
+	reply, err := f.messenger.GetSegs(ctx, msg, ps, requestID.Next())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Drop Path prefix for Seg* types. Also shorten some postfixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1826)
<!-- Reviewable:end -->
