### PR TITLE
Extract common topology-related ops from Go SD and PS

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -18,7 +18,8 @@ MOCK_SRC_IN =\
     lib/pathdb/pathdb.go \
     lib/snet/interface.go \
     lib/snet/snetproxy/reconnecter.go \
-    lib/snet/snetproxy/io.go
+    lib/snet/snetproxy/io.go \
+    lib/infra/modules/itopo/itopo.go
 MOCK_SRC_OUT = $(foreach in,$(MOCK_SRC_IN),$(call mock_src_in_to_out,$(in)))
 # This uses the format <stdlib package>/<interface>:
 MOCK_STD_IN = net/Addr

--- a/go/Makefile
+++ b/go/Makefile
@@ -18,8 +18,7 @@ MOCK_SRC_IN =\
     lib/pathdb/pathdb.go \
     lib/snet/interface.go \
     lib/snet/snetproxy/reconnecter.go \
-    lib/snet/snetproxy/io.go \
-    lib/infra/modules/itopo/itopo.go
+    lib/snet/snetproxy/io.go
 MOCK_SRC_OUT = $(foreach in,$(MOCK_SRC_IN),$(call mock_src_in_to_out,$(in)))
 # This uses the format <stdlib package>/<interface>:
 MOCK_STD_IN = net/Addr

--- a/go/lib/infra/modules/itopo/itopo.go
+++ b/go/lib/infra/modules/itopo/itopo.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich, Anapaya Systems
+// Copyright 2018 ETH Zurich
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,56 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package itopo implements convenience functions for topology-related operations.
+// Package itopo stores a singleton topology for reloading. Client packages
+// that grab a reference with GetCurrentTopology are guaranteed to receive a
+// stable snapshot of the topology.
 //
-// Additionally, it maintains a pointer to the current configuration (once one
-// is set). The package level topology setters and getters can be safely called
-// from multiple goroutines.
+// To change the pointer for future GetCurrentTopology calls, use
+// SetCurrentTopology whenever topology information changes.
 package itopo
 
 import (
 	"sync"
 
-	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/topology"
-	"github.com/scionproto/scion/go/proto"
-)
-
-const (
-	ErrAddressNotFound = "Address not found"
 )
 
 var (
 	topologyMtx     sync.RWMutex
-	currentTopology Topology = nil
+	currentTopology *topology.Topo = nil
 )
 
-type Topology interface {
-	IA() addr.IA
-	MTU() uint16
-	Core() bool
-	// FIXME(scrye): Give apps the possibility to choose the overlay; see
-	// https://github.com/scionproto/scion/issues/1855
-	GetAnyAppAddr(svc proto.ServiceType) (*addr.AppAddr, *overlay.OverlayAddr, error)
-	GetAnyTopoAddr(svc proto.ServiceType) (*topology.TopoAddr, error)
-	GetTopoAddrById(svc proto.ServiceType, id string) (*topology.TopoAddr, error)
-	GetAllTopoAddrs(svc proto.ServiceType) ([]topology.TopoAddr, error)
-	GetBROverlayAddrByIfid(ifid common.IFIDType) *overlay.OverlayAddr
-	GetTopoBRAddrByIfid(ifid common.IFIDType) *topology.TopoBRAddr
-	GetAllTopoBRAddrs() map[common.IFIDType]*topology.TopoBRAddr
-}
-
-// SetCurrentTopologyFromBase atomically sets the package-wide default topology to
+// SetCurrentTopology atomically sets the package-wide default topology to
 // topo.
-func SetCurrentTopologyFromBase(topo *topology.Topo) {
-	topologyMtx.Lock()
-	currentTopology = NewTopology(topo)
-	topologyMtx.Unlock()
-}
-
-func SetCurrentTopology(topo Topology) {
+func SetCurrentTopology(topo *topology.Topo) {
 	topologyMtx.Lock()
 	currentTopology = topo
 	topologyMtx.Unlock()
@@ -69,148 +41,9 @@ func SetCurrentTopology(topo Topology) {
 
 // GetCurrentTopology atomically returns a pointer to the package-wide
 // default topology.
-func GetCurrentTopology() Topology {
+func GetCurrentTopology() *topology.Topo {
 	topologyMtx.RLock()
 	t := currentTopology
 	topologyMtx.RUnlock()
 	return t
-}
-
-type topologyS struct {
-	*topology.Topo
-}
-
-func NewTopology(topo *topology.Topo) Topology {
-	return &topologyS{Topo: topo}
-}
-
-func (topo *topologyS) IA() addr.IA {
-	return topo.ISD_AS
-}
-
-func (topo *topologyS) MTU() uint16 {
-	return uint16(topo.Topo.MTU)
-}
-
-func (topo *topologyS) Core() bool {
-	return topo.Topo.Core
-}
-
-func (topo *topologyS) GetAnyAppAddr(
-	svc proto.ServiceType) (*addr.AppAddr, *overlay.OverlayAddr, error) {
-
-	svcInfo, err := topo.getSvcInfo(svc)
-	if err != nil {
-		return nil, nil, err
-	}
-	topoAddr := svcInfo.getAnyTopoAddr()
-	if topoAddr == nil {
-		return nil, nil, common.NewBasicError(ErrAddressNotFound, nil)
-	}
-	return topoAddr.PublicAddr(topo.Overlay), topoAddr.OverlayAddr(topo.Overlay), nil
-}
-
-func (topo *topologyS) GetAnyTopoAddr(svc proto.ServiceType) (*topology.TopoAddr, error) {
-	svcInfo, err := topo.getSvcInfo(svc)
-	if err != nil {
-		return nil, err
-	}
-	topoAddr := svcInfo.getAnyTopoAddr()
-	if topoAddr == nil {
-		return nil, common.NewBasicError(ErrAddressNotFound, nil)
-	}
-	return topoAddr, nil
-}
-
-func (topo *topologyS) GetTopoAddrById(svc proto.ServiceType,
-	id string) (*topology.TopoAddr, error) {
-
-	svcInfo, err := topo.getSvcInfo(svc)
-	if err != nil {
-		return nil, err
-	}
-	topoAddr := svcInfo.getTopoAddrById(id)
-	if topoAddr == nil {
-		return nil, common.NewBasicError(ErrAddressNotFound, nil)
-	}
-	return topoAddr, nil
-}
-
-func (topo *topologyS) GetAllTopoAddrs(svc proto.ServiceType) ([]topology.TopoAddr, error) {
-	svcInfo, err := topo.getSvcInfo(svc)
-	if err != nil {
-		return nil, err
-	}
-	topoAddrs := svcInfo.getAllTopoAddrs()
-	if topoAddrs == nil {
-		return nil, common.NewBasicError(ErrAddressNotFound, nil)
-	}
-	return topoAddrs, nil
-}
-
-func (topo *topologyS) getSvcInfo(svc proto.ServiceType) (*svcInfo, error) {
-	switch svc {
-	case proto.ServiceType_unset:
-		return nil, common.NewBasicError("Service type unset", nil)
-	case proto.ServiceType_bs:
-		return &svcInfo{overlay: topo.Overlay, names: topo.BSNames, idTopoAddrMap: topo.BS}, nil
-	case proto.ServiceType_ps:
-		return &svcInfo{overlay: topo.Overlay, names: topo.PSNames, idTopoAddrMap: topo.PS}, nil
-	case proto.ServiceType_cs:
-		return &svcInfo{overlay: topo.Overlay, names: topo.CSNames, idTopoAddrMap: topo.CS}, nil
-	case proto.ServiceType_sb:
-		return &svcInfo{overlay: topo.Overlay, names: topo.SBNames, idTopoAddrMap: topo.SB}, nil
-	default:
-		return nil, common.NewBasicError("Unsupported service type", nil, "type", svc)
-	}
-}
-
-func (topo *topologyS) GetBROverlayAddrByIfid(ifid common.IFIDType) *overlay.OverlayAddr {
-	topoBRAddr := topo.GetTopoBRAddrByIfid(ifid)
-	if topoBRAddr == nil {
-		return nil
-	}
-	return topoBRAddr.PublicOverlay(topo.Overlay)
-}
-
-func (topo *topologyS) GetTopoBRAddrByIfid(ifid common.IFIDType) *topology.TopoBRAddr {
-	if ifInfo, ok := topo.IFInfoMap[ifid]; ok {
-		return ifInfo.InternalAddrs
-	}
-	return nil
-}
-
-func (topo *topologyS) GetAllTopoBRAddrs() map[common.IFIDType]*topology.TopoBRAddr {
-	m := make(map[common.IFIDType]*topology.TopoBRAddr)
-	for ifid, ifInfo := range topo.IFInfoMap {
-		m[ifid] = ifInfo.InternalAddrs
-	}
-	return m
-}
-
-// svcInfo contains topology information for a single SCION service
-type svcInfo struct {
-	overlay       overlay.Type
-	names         topology.ServiceNames
-	idTopoAddrMap topology.IDAddrMap
-}
-
-func (svc *svcInfo) getAnyTopoAddr() *topology.TopoAddr {
-	id, err := svc.names.GetRandom()
-	if err != nil {
-		return nil
-	}
-	return svc.idTopoAddrMap.GetById(id)
-}
-
-func (svc *svcInfo) getTopoAddrById(id string) *topology.TopoAddr {
-	return svc.idTopoAddrMap.GetById(id)
-}
-
-func (svc *svcInfo) getAllTopoAddrs() []topology.TopoAddr {
-	var topoAddrs []topology.TopoAddr
-	for _, topoAddr := range svc.idTopoAddrMap {
-		topoAddrs = append(topoAddrs, topoAddr)
-	}
-	return topoAddrs
 }

--- a/go/lib/infra/modules/itopo/itopo.go
+++ b/go/lib/infra/modules/itopo/itopo.go
@@ -1,0 +1,196 @@
+// Copyright 2018 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package itopo
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/overlay"
+	"github.com/scionproto/scion/go/lib/topology"
+	"github.com/scionproto/scion/go/proto"
+)
+
+var (
+	topologyMtx     sync.Mutex
+	currentTopology Topology = nil
+)
+
+type Topology interface {
+	IA() addr.IA
+	MTU() uint16
+	Core() bool
+	GetAnyAppAddr(svc proto.ServiceType) *addr.AppAddr
+	GetAnyTopoAddr(svc proto.ServiceType) *topology.TopoAddr
+	GetTopoAddrById(svc proto.ServiceType, id string) *topology.TopoAddr
+	GetAllTopoAddrs(svc proto.ServiceType) []topology.TopoAddr
+	GetBROverlayAddrByIfid(ifid common.IFIDType) *overlay.OverlayAddr
+	GetBRTopoAddrByIfid(ifid common.IFIDType) *topology.TopoAddr
+	GetAllBRTopoAddrs() map[common.IFIDType]*topology.TopoAddr
+}
+
+// SetCurrentTopologyFromBase atomically sets the package-wide default topology to
+// topo.
+func SetCurrentTopologyFromBase(topo *topology.Topo) {
+	topologyMtx.Lock()
+	currentTopology = NewTopology(topo)
+	topologyMtx.Unlock()
+}
+
+func SetCurrentTopology(topo Topology) {
+	topologyMtx.Lock()
+	currentTopology = topo
+	topologyMtx.Unlock()
+}
+
+// GetCurrentTopology atomically returns a pointer to the package-wide
+// default topology.
+func GetCurrentTopology() Topology {
+	topologyMtx.Lock()
+	t := currentTopology
+	topologyMtx.Unlock()
+	return t
+}
+
+type topologyS struct {
+	*topology.Topo
+}
+
+func NewTopology(topo *topology.Topo) Topology {
+	return &topologyS{Topo: topo}
+}
+
+func (topo *topologyS) IA() addr.IA {
+	return topo.ISD_AS
+}
+
+func (topo *topologyS) MTU() uint16 {
+	return uint16(topo.Topo.MTU)
+}
+
+func (topo *topologyS) Core() bool {
+	return topo.Topo.Core
+}
+
+func (topo *topologyS) GetAnyAppAddr(svc proto.ServiceType) *addr.AppAddr {
+	svcInfo := topo.getSvcInfo(svc)
+	if svcInfo == nil {
+		return nil
+	}
+	return svcInfo.getAnyAppAddr()
+}
+
+func (topo *topologyS) GetAnyTopoAddr(svc proto.ServiceType) *topology.TopoAddr {
+	svcInfo := topo.getSvcInfo(svc)
+	if svcInfo == nil {
+		return nil
+	}
+	return svcInfo.getAnyTopoAddr()
+}
+
+func (topo *topologyS) GetTopoAddrById(svc proto.ServiceType, id string) *topology.TopoAddr {
+	svcInfo := topo.getSvcInfo(svc)
+	if svcInfo == nil {
+		return nil
+	}
+	return svcInfo.getTopoAddrById(id)
+}
+
+func (topo *topologyS) GetAllTopoAddrs(svc proto.ServiceType) []topology.TopoAddr {
+	svcInfo := topo.getSvcInfo(svc)
+	if svcInfo == nil {
+		return nil
+	}
+	return svcInfo.getAllTopoAddrs()
+}
+
+func (topo *topologyS) getSvcInfo(svc proto.ServiceType) *svcInfo {
+	switch svc {
+	case proto.ServiceType_unset:
+		// FIXME(lukedirtwalker): inform client about this:
+		// see https://github.com/scionproto/scion/issues/1673
+		return nil
+	case proto.ServiceType_bs:
+		return &svcInfo{overlay: topo.Overlay, names: topo.BSNames, idTopoAddrMap: topo.BS}
+	case proto.ServiceType_ps:
+		return &svcInfo{overlay: topo.Overlay, names: topo.PSNames, idTopoAddrMap: topo.PS}
+	case proto.ServiceType_cs:
+		return &svcInfo{overlay: topo.Overlay, names: topo.CSNames, idTopoAddrMap: topo.CS}
+	case proto.ServiceType_sb:
+		return &svcInfo{overlay: topo.Overlay, names: topo.SBNames, idTopoAddrMap: topo.SB}
+	default:
+		panic(fmt.Sprintf("unknown svc type %v", svc))
+	}
+}
+
+func (topo *topologyS) GetBROverlayAddrByIfid(ifid common.IFIDType) *overlay.OverlayAddr {
+	topoAddr := topo.GetBRTopoAddrByIfid(ifid)
+	if topoAddr == nil {
+		return nil
+	}
+	return topoAddr.PublicOverlay(topo.Overlay)
+}
+
+func (topo *topologyS) GetBRTopoAddrByIfid(ifid common.IFIDType) *topology.TopoAddr {
+	if ifInfo, ok := topo.IFInfoMap[ifid]; ok {
+		return ifInfo.InternalAddrs
+	}
+	return nil
+}
+
+func (topo *topologyS) GetAllBRTopoAddrs() map[common.IFIDType]*topology.TopoAddr {
+	m := make(map[common.IFIDType]*topology.TopoAddr)
+	for ifid, ifInfo := range topo.IFInfoMap {
+		m[ifid] = ifInfo.InternalAddrs
+	}
+	return m
+}
+
+// svcInfo contains topology information for a single SCION service
+type svcInfo struct {
+	overlay       overlay.Type
+	names         topology.ServiceNames
+	idTopoAddrMap topology.IDAddrMap
+}
+
+func (svc *svcInfo) getAnyAppAddr() *addr.AppAddr {
+	topoAddr := svc.getAnyTopoAddr()
+	if topoAddr == nil {
+		return nil
+	}
+	return topoAddr.PublicAddr(svc.overlay)
+}
+
+func (svc *svcInfo) getAnyTopoAddr() *topology.TopoAddr {
+	id, err := svc.names.GetRandom()
+	if err != nil {
+		return nil
+	}
+	return svc.idTopoAddrMap.GetById(id)
+}
+
+func (svc *svcInfo) getTopoAddrById(id string) *topology.TopoAddr {
+	return svc.idTopoAddrMap.GetById(id)
+}
+
+func (svc *svcInfo) getAllTopoAddrs() []topology.TopoAddr {
+	var topoAddrs []topology.TopoAddr
+	for _, topoAddr := range svc.idTopoAddrMap {
+		topoAddrs = append(topoAddrs, topoAddr)
+	}
+	return topoAddrs
+}

--- a/go/lib/infra/modules/trust/config.go
+++ b/go/lib/infra/modules/trust/config.go
@@ -14,8 +14,6 @@
 
 package trust
 
-import "net"
-
 // FIXME(scrye): When reloading support gets added again, Options should include
 // all the reloadable aspects of the trust store. Instead of direct access,
 // accessors should be preferred to ensure concurrency-safe reads.
@@ -25,7 +23,6 @@ type Config struct {
 	// IA must always return a valid chain. This is set to true on CSes and to
 	// false on others.
 	MustHaveLocalChain bool
-	// LocalCSes must have a length of 0 on CS nodes. On others, a random entry
-	// is queried for TRCs and Chains.
-	LocalCSes []net.Addr
+	// IsCS is set to true on CSes and false on others.
+	IsCS bool
 }

--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -570,12 +570,12 @@ func (store *Store) isLocal(address net.Addr) error {
 // destination AS.
 func (store *Store) ChooseServer(destination addr.IA) (net.Addr, error) {
 	topo := itopo.GetCurrentTopology()
-	if store.config.IsCS == false {
-		csAddr := topo.GetAnyAppAddr(proto.ServiceType_cs)
-		if csAddr == nil {
-			return nil, common.NewBasicError("Need CS, but none found", nil)
+	if !store.config.IsCS {
+		csAddr, csOverlayAddr, err := topo.GetAnyAppAddr(proto.ServiceType_cs)
+		if err != nil {
+			return nil, common.NewBasicError("Need CS, but none found", err)
 		}
-		return &snet.Addr{IA: store.ia, Host: csAddr}, nil
+		return &snet.Addr{IA: store.ia, Host: csAddr, NextHop: csOverlayAddr}, nil
 	}
 	if destination.A == 0 {
 		pathSet := snet.DefNetwork.PathResolver().Query(store.ia, addr.IA{I: destination.I})

--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -573,7 +573,7 @@ func (store *Store) ChooseServer(destination addr.IA) (net.Addr, error) {
 	if !store.config.IsCS {
 		csAddr, csOverlayAddr, err := topo.GetAnyAppAddr(proto.ServiceType_cs)
 		if err != nil {
-			return nil, common.NewBasicError("Need CS, but none found", err)
+			return nil, common.NewBasicError("Failed to look up CS in topology", err)
 		}
 		return &snet.Addr{IA: store.ia, Host: csAddr, NextHop: csOverlayAddr}, nil
 	}

--- a/go/lib/infra/modules/trust/trust_test.go
+++ b/go/lib/infra/modules/trust/trust_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/disp"
 	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/infra/mock_infra"
 	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
 	"github.com/scionproto/scion/go/lib/infra/modules/itopo/mock_itopo"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
@@ -747,10 +748,8 @@ func initStore(t *testing.T, ctrl *gomock.Controller,
 	t.Helper()
 	db, err := trustdb.New(":memory:")
 	xtest.FailOnErr(t, err)
-	ctrl := gomock.NewController(t)
-	// defer ctrl.Finish()
 	mockTopology := mock_itopo.NewMockTopology(ctrl)
-	mockTopology.EXPECT().GetAnyAppAddr(gomock.Any()).Return(&addr.AppAddr{}).AnyTimes()
+	mockTopology.EXPECT().GetAnyAppAddr(gomock.Any()).Return(&addr.AppAddr{}, nil, nil).AnyTimes()
 	itopo.SetCurrentTopology(mockTopology)
 	// FIXME(scrye): to correctly test this, the Config should specify that
 	// snet is used to determine an AS in the remote core. However, for now we

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -23,6 +23,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/lib/util"
@@ -246,7 +247,7 @@ func buildHostInfo(ipv4, ipv6 []byte, port4, port6 uint16) HostInfo {
 	if port4 != 0 && port6 != 0 && port4 != port6 {
 		// NOTE: https://github.com/scionproto/scion/issues/1842 will change
 		// the behavior of this.
-		panic(fmt.Sprintf("port mismatch %v %v", port4, port6))
+		log.Warn("port mismatch", "port4", port4, "port6", port6)
 	}
 	// XXX This assumes that Ipv4 and IPv6 use the same port!
 	port := port4

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -171,7 +171,13 @@ func HostInfoFromTopoAddr(topoAddr topology.TopoAddr) HostInfo {
 	ipv4, port4 := topoAddrToIPAndPort(overlay.IPv4, topoAddr)
 	ipv6, port6 := topoAddrToIPAndPort(overlay.IPv6, topoAddr)
 	if port4 != 0 && port6 != 0 && port4 != port6 {
+		// NOTE: https://github.com/scionproto/scion/issues/1842 will change
+		// the behavior of this.
 		panic(fmt.Sprintf("port mismatch %v %v", port4, port6))
+	}
+	port := port4
+	if port == 0 {
+		port = port6
 	}
 	// XXX This assumes that Ipv4 and IPv6 use the same port!
 	return HostInfo{
@@ -182,7 +188,7 @@ func HostInfoFromTopoAddr(topoAddr topology.TopoAddr) HostInfo {
 			Ipv4: ipv4,
 			Ipv6: ipv6,
 		},
-		Port: port4,
+		Port: port,
 	}
 }
 

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -208,11 +208,6 @@ func topoAddrToIPv4AndPort(topoAddr topology.TopoAddr) (net.IP, uint16) {
 		ip = pubAddr.L3.IP()
 		port = pubAddr.L4.Port()
 	}
-	// XXX(scrye): Force 4-byte representation of IPv4 addresses
-	// because Python code doesn't understand Go's 16-byte format.
-	if ip != nil {
-		ip = ip.To4()
-	}
 	return ip, port
 }
 
@@ -225,8 +220,7 @@ func topoAddrToIPv6AndPort(topoAddr topology.TopoAddr) (net.IP, uint16) {
 
 func topoBRAddrToIPv4AndPort(topoBRAddr topology.TopoBRAddr) (net.IP, uint16) {
 	if topoBRAddr.IPv4 != nil {
-		v4Addr := topoBRAddr.IPv4.PublicOverlay
-		if v4Addr != nil {
+		if v4Addr := topoBRAddr.IPv4.PublicOverlay; v4Addr != nil {
 			return v4Addr.L3().IP().To4(), v4Addr.L4().Port()
 		}
 	}
@@ -235,15 +229,14 @@ func topoBRAddrToIPv4AndPort(topoBRAddr topology.TopoBRAddr) (net.IP, uint16) {
 
 func topoBRAddrToIPv6AndPort(topoBRAddr topology.TopoBRAddr) (net.IP, uint16) {
 	if topoBRAddr.IPv6 != nil {
-		v6Addr := topoBRAddr.IPv6.PublicOverlay
-		if v6Addr != nil {
+		if v6Addr := topoBRAddr.IPv6.PublicOverlay; v6Addr != nil {
 			return v6Addr.L3().IP(), v6Addr.L4().Port()
 		}
 	}
 	return nil, 0
 }
 
-func buildHostInfo(ipv4, ipv6 []byte, port4, port6 uint16) HostInfo {
+func buildHostInfo(ipv4, ipv6 net.IP, port4, port6 uint16) HostInfo {
 	if port4 != 0 && port6 != 0 && port4 != port6 {
 		// NOTE: https://github.com/scionproto/scion/issues/1842 will change
 		// the behavior of this.
@@ -259,7 +252,9 @@ func buildHostInfo(ipv4, ipv6 []byte, port4, port6 uint16) HostInfo {
 			Ipv4 []byte
 			Ipv6 []byte
 		}{
-			Ipv4: ipv4,
+			// XXX(scrye): Force 4-byte representation of IPv4 addresses
+			// because Python code doesn't understand Go's 16-byte format.
+			Ipv4: ipv4.To4(),
 			Ipv6: ipv6,
 		},
 		Port: port,

--- a/go/lib/topology/addr.go
+++ b/go/lib/topology/addr.go
@@ -190,14 +190,23 @@ func (pbo *pubBindAddr) fromRaw(rpbo *RawPubBindOverlay, udpOverlay bool) error 
 }
 
 func (t *pubBindAddr) PublicAddr() *addr.AppAddr {
+	if t == nil {
+		return nil
+	}
 	return t.pub
 }
 
 func (t *pubBindAddr) BindAddr() *addr.AppAddr {
+	if t == nil {
+		return nil
+	}
 	return t.bind
 }
 
 func (t *pubBindAddr) OverlayAddr() *overlay.OverlayAddr {
+	if t == nil {
+		return nil
+	}
 	return t.overlay
 }
 

--- a/go/lib/topology/addr.go
+++ b/go/lib/topology/addr.go
@@ -45,6 +45,24 @@ type TopoAddr struct {
 	Overlay overlay.Type
 }
 
+// TestTopoAddr creates a new TopoAddr. This is only for testing and should
+// never be used by apps.
+func TestTopoAddr(v4AppAddr, v6AppAddr *addr.AppAddr,
+	v4OverlayAddr, v6OverlayAddr *overlay.OverlayAddr) TopoAddr {
+
+	return TopoAddr{
+		IPv4: &pubBindAddr{
+			pub:     v4AppAddr,
+			overlay: v4OverlayAddr,
+		},
+		IPv6: &pubBindAddr{
+			pub:     v6AppAddr,
+			overlay: v6OverlayAddr,
+		},
+		Overlay: overlay.IPv46,
+	}
+}
+
 // Create TopoAddr from RawAddrMap, depending on supplied Overlay type
 func topoAddrFromRAM(s RawAddrMap, ot overlay.Type) (*TopoAddr, error) {
 	if err := overlayCheck(ot); err != nil {

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -273,10 +273,6 @@ func (svc *SVCInfo) GetAnyTopoAddr() *TopoAddr {
 	return svc.idTopoAddrMap.GetById(id)
 }
 
-func (svc *SVCInfo) GetTopoAddrById(id string) *TopoAddr {
-	return svc.idTopoAddrMap.GetById(id)
-}
-
 func (svc *SVCInfo) GetAllTopoAddrs() []TopoAddr {
 	var topoAddrs []TopoAddr
 	for _, topoAddr := range svc.idTopoAddrMap {

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -229,6 +229,62 @@ func (t *Topo) populateServices(raw *RawTopo) error {
 	return nil
 }
 
+func (t *Topo) GetAllTopoAddrs(svc proto.ServiceType) ([]TopoAddr, error) {
+	svcInfo, err := t.GetSvcInfo(svc)
+	if err != nil {
+		return nil, err
+	}
+	topoAddrs := svcInfo.GetAllTopoAddrs()
+	if topoAddrs == nil {
+		return nil, common.NewBasicError("Address not found", nil)
+	}
+	return topoAddrs, nil
+}
+
+func (t *Topo) GetSvcInfo(svc proto.ServiceType) (*SVCInfo, error) {
+	switch svc {
+	case proto.ServiceType_unset:
+		return nil, common.NewBasicError("Service type unset", nil)
+	case proto.ServiceType_bs:
+		return &SVCInfo{overlay: t.Overlay, names: t.BSNames, idTopoAddrMap: t.BS}, nil
+	case proto.ServiceType_ps:
+		return &SVCInfo{overlay: t.Overlay, names: t.PSNames, idTopoAddrMap: t.PS}, nil
+	case proto.ServiceType_cs:
+		return &SVCInfo{overlay: t.Overlay, names: t.CSNames, idTopoAddrMap: t.CS}, nil
+	case proto.ServiceType_sb:
+		return &SVCInfo{overlay: t.Overlay, names: t.SBNames, idTopoAddrMap: t.SB}, nil
+	default:
+		return nil, common.NewBasicError("Unsupported service type", nil, "type", svc)
+	}
+}
+
+// SVCInfo contains topology information for a single SCION service
+type SVCInfo struct {
+	overlay       overlay.Type
+	names         ServiceNames
+	idTopoAddrMap IDAddrMap
+}
+
+func (svc *SVCInfo) GetAnyTopoAddr() *TopoAddr {
+	id, err := svc.names.GetRandom()
+	if err != nil {
+		return nil
+	}
+	return svc.idTopoAddrMap.GetById(id)
+}
+
+func (svc *SVCInfo) GetTopoAddrById(id string) *TopoAddr {
+	return svc.idTopoAddrMap.GetById(id)
+}
+
+func (svc *SVCInfo) GetAllTopoAddrs() []TopoAddr {
+	var topoAddrs []TopoAddr
+	for _, topoAddr := range svc.idTopoAddrMap {
+		topoAddrs = append(topoAddrs, topoAddr)
+	}
+	return topoAddrs
+}
+
 // Convert map of Name->RawSrvInfo into map of Name->TopoAddr and sorted slice of Names
 // stype is only used for error reporting
 func svcMapFromRaw(ras map[string]*RawSrvInfo, stype string, smap IDAddrMap,

--- a/go/lib/topology/topotestutil/topotestutil.go
+++ b/go/lib/topology/topotestutil/topotestutil.go
@@ -1,0 +1,43 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topotestutil
+
+import (
+	"fmt"
+
+	"github.com/scionproto/scion/go/lib/topology"
+	"github.com/scionproto/scion/go/proto"
+)
+
+func AddServer(topo *topology.Topo, svc proto.ServiceType, name string,
+	topoAddr topology.TopoAddr) {
+
+	switch svc {
+	case proto.ServiceType_bs:
+		topo.BSNames = append(topo.BSNames, name)
+		topo.BS[name] = topoAddr
+	case proto.ServiceType_ps:
+		topo.PSNames = append(topo.PSNames, name)
+		topo.PS[name] = topoAddr
+	case proto.ServiceType_cs:
+		topo.CSNames = append(topo.CSNames, name)
+		topo.CS[name] = topoAddr
+	case proto.ServiceType_sb:
+		topo.SBNames = append(topo.SBNames, name)
+		topo.SB[name] = topoAddr
+	default:
+		panic(fmt.Sprintf("service type error %v", svc))
+	}
+}

--- a/go/path_srv/internal/addrutil/addrutil.go
+++ b/go/path_srv/internal/addrutil/addrutil.go
@@ -50,11 +50,10 @@ func GetPath(svc addr.HostSVC, ps *seg.PathSegment,
 	if !ok {
 		return nil, common.NewBasicError("Unable to find first-hop BR for path", nil, "ifId", ifId)
 	}
-	nextHop := ifInfo.InternalAddrs.PublicOverlay(topo.Overlay)
 	return &snet.Addr{
 		IA:      dst,
 		Host:    addr.NewSVCUDPAppAddr(svc),
 		Path:    p,
-		NextHop: nextHop,
+		NextHop: ifInfo.InternalAddrs.PublicOverlay(topo.Overlay),
 	}, nil
 }

--- a/go/path_srv/internal/addrutil/addrutil.go
+++ b/go/path_srv/internal/addrutil/addrutil.go
@@ -21,14 +21,14 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
-	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/spath"
+	"github.com/scionproto/scion/go/lib/topology"
 )
 
 // GetPath creates a path from the given segment and then creates a snet.Addr to the given dst.
 func GetPath(svc addr.HostSVC, ps *seg.PathSegment,
-	dst addr.IA, topo itopo.Topology) (net.Addr, error) {
+	dst addr.IA, topo *topology.Topo) (net.Addr, error) {
 
 	x := &bytes.Buffer{}
 	if _, err := ps.RawWriteTo(x); err != nil {
@@ -46,10 +46,11 @@ func GetPath(svc addr.HostSVC, ps *seg.PathSegment,
 		return nil, common.NewBasicError("Failed to extract first HopField", err, "p", p)
 	}
 	ifId := hopF.ConsIngress
-	nextHop := topo.GetBROverlayAddrByIfid(ifId)
-	if nextHop == nil {
+	ifInfo, ok := topo.IFInfoMap[ifId]
+	if !ok {
 		return nil, common.NewBasicError("Unable to find first-hop BR for path", nil, "ifId", ifId)
 	}
+	nextHop := ifInfo.InternalAddrs.PublicOverlay(topo.Overlay)
 	return &snet.Addr{
 		IA:      dst,
 		Host:    addr.NewSVCUDPAppAddr(svc),

--- a/go/path_srv/internal/handlers/common.go
+++ b/go/path_srv/internal/handlers/common.go
@@ -19,16 +19,17 @@ import (
 	"net"
 	"time"
 
+	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
 	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
 	"github.com/scionproto/scion/go/lib/infra/modules/segsaver"
 	"github.com/scionproto/scion/go/lib/infra/modules/segverifier"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/pathdb"
 	"github.com/scionproto/scion/go/lib/pathdb/query"
 	"github.com/scionproto/scion/go/lib/revcache"
-	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/path_srv/internal/psconfig"
 	"github.com/scionproto/scion/go/path_srv/internal/segutil"
 )
@@ -42,8 +43,8 @@ type HandlerArgs struct {
 	PathDB     pathdb.PathDB
 	RevCache   revcache.RevCache
 	TrustStore infra.TrustStore
-	Topology   *topology.Topo
 	Config     psconfig.Config
+	IA         addr.IA
 }
 
 type baseHandler struct {
@@ -51,7 +52,7 @@ type baseHandler struct {
 	pathDB     pathdb.PathDB
 	revCache   revcache.RevCache
 	trustStore infra.TrustStore
-	topology   *topology.Topo
+	topology   itopo.Topology
 	retryInt   time.Duration
 	config     psconfig.Config
 	logger     log.Logger
@@ -63,9 +64,9 @@ func newBaseHandler(request *infra.Request, args HandlerArgs) *baseHandler {
 		pathDB:     args.PathDB,
 		revCache:   args.RevCache,
 		trustStore: args.TrustStore,
-		topology:   args.Topology,
 		retryInt:   time.Second,
 		config:     args.Config,
+		topology:   itopo.GetCurrentTopology(),
 		logger:     request.Logger,
 	}
 }

--- a/go/path_srv/internal/handlers/common.go
+++ b/go/path_srv/internal/handlers/common.go
@@ -30,6 +30,7 @@ import (
 	"github.com/scionproto/scion/go/lib/pathdb"
 	"github.com/scionproto/scion/go/lib/pathdb/query"
 	"github.com/scionproto/scion/go/lib/revcache"
+	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/path_srv/internal/psconfig"
 	"github.com/scionproto/scion/go/path_srv/internal/segutil"
 )
@@ -52,7 +53,7 @@ type baseHandler struct {
 	pathDB     pathdb.PathDB
 	revCache   revcache.RevCache
 	trustStore infra.TrustStore
-	topology   itopo.Topology
+	topology   *topology.Topo
 	retryInt   time.Duration
 	config     psconfig.Config
 	logger     log.Logger

--- a/go/path_srv/internal/handlers/segreg.go
+++ b/go/path_srv/internal/handlers/segreg.go
@@ -17,6 +17,7 @@ package handlers
 import (
 	"context"
 
+	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
@@ -24,12 +25,14 @@ import (
 
 type segRegHandler struct {
 	*baseHandler
+	localIA addr.IA
 }
 
 func NewSegRegHandler(args HandlerArgs) infra.Handler {
 	f := func(r *infra.Request) {
 		handler := &segRegHandler{
 			baseHandler: newBaseHandler(r, args),
+			localIA:     args.IA,
 		}
 		handler.Handle()
 	}

--- a/go/path_srv/internal/handlers/segreqcore.go
+++ b/go/path_srv/internal/handlers/segreqcore.go
@@ -38,7 +38,7 @@ func NewSegReqCoreHandler(args HandlerArgs) infra.Handler {
 		handler := &segReqCoreHandler{
 			segReqHandler: segReqHandler{
 				baseHandler: newBaseHandler(r, args),
-				localIA:     args.Topology.ISD_AS,
+				localIA:     args.IA,
 			},
 		}
 		handler.Handle()

--- a/go/path_srv/internal/handlers/segreqnoncore.go
+++ b/go/path_srv/internal/handlers/segreqnoncore.go
@@ -44,7 +44,7 @@ func NewSegReqNonCoreHandler(args HandlerArgs) infra.Handler {
 		handler := &segReqNonCoreHandler{
 			segReqHandler: segReqHandler{
 				baseHandler: newBaseHandler(r, args),
-				localIA:     args.Topology.ISD_AS,
+				localIA:     args.IA,
 			},
 		}
 		handler.Handle()

--- a/go/path_srv/internal/handlers/segreqnoncore_test.go
+++ b/go/path_srv/internal/handlers/segreqnoncore_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/mock_infra"
+	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/pathdb"
 	pathdbbe "github.com/scionproto/scion/go/lib/pathdb/sqlite"
@@ -179,14 +180,14 @@ func expectedSegs(ups, cores, downs []*seg.PathSegment) []*seg.Meta {
 	return e
 }
 
-func loadTopo(t *testing.T, ia addr.IA) *topology.Topo {
+func loadTopo(t *testing.T, ia addr.IA) itopo.Topology {
 	fileName, ok := topoFiles[ia]
 	if !ok {
 		t.Fatalf("Missing %v in topoFile maps", ia)
 	}
 	topo, err := topology.LoadFromFile(filepath.Join("testdata", fileName))
 	xtest.FailOnErr(t, err)
-	return topo
+	return itopo.NewTopology(topo)
 }
 
 func TestSegReqLocal(t *testing.T) {

--- a/go/path_srv/internal/handlers/segreqnoncore_test.go
+++ b/go/path_srv/internal/handlers/segreqnoncore_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/mock_infra"
-	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/pathdb"
 	pathdbbe "github.com/scionproto/scion/go/lib/pathdb/sqlite"
@@ -180,14 +179,14 @@ func expectedSegs(ups, cores, downs []*seg.PathSegment) []*seg.Meta {
 	return e
 }
 
-func loadTopo(t *testing.T, ia addr.IA) itopo.Topology {
+func loadTopo(t *testing.T, ia addr.IA) *topology.Topo {
 	fileName, ok := topoFiles[ia]
 	if !ok {
 		t.Fatalf("Missing %v in topoFile maps", ia)
 	}
 	topo, err := topology.LoadFromFile(filepath.Join("testdata", fileName))
 	xtest.FailOnErr(t, err)
-	return itopo.NewTopology(topo)
+	return topo
 }
 
 func TestSegReqLocal(t *testing.T) {

--- a/go/path_srv/internal/handlers/segsync.go
+++ b/go/path_srv/internal/handlers/segsync.go
@@ -17,6 +17,7 @@ package handlers
 import (
 	"context"
 
+	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
@@ -24,12 +25,14 @@ import (
 
 type syncHandler struct {
 	*baseHandler
+	localIA addr.IA
 }
 
 func NewSyncHandler(args HandlerArgs) infra.Handler {
 	f := func(r *infra.Request) {
 		handler := &syncHandler{
 			baseHandler: newBaseHandler(r, args),
+			localIA:     args.IA,
 		}
 		handler.Handle()
 	}

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -87,7 +87,7 @@ func realMain() int {
 	}
 	topo := itopo.GetCurrentTopology()
 	trustConf := &trust.Config{}
-	trustStore, err := trust.NewStore(trustDB, topo.IA(),
+	trustStore, err := trust.NewStore(trustDB, topo.ISD_AS,
 		rand.Uint64(), trustConf, log.Root())
 	if err != nil {
 		log.Crit("Unable to initialize trust store", "err", err)
@@ -124,9 +124,9 @@ func realMain() int {
 		RevCache:   revCache,
 		TrustStore: trustStore,
 		Config:     config.PS,
-		IA:         topo.IA(),
+		IA:         topo.ISD_AS,
 	}
-	core := topo.Core()
+	core := topo.Core
 	var segReqHandler infra.Handler
 	if core {
 		segReqHandler = handlers.NewSegReqCoreHandler(args)
@@ -178,7 +178,7 @@ func setup(configName string) error {
 	if err := env.InitGeneral(&config.General); err != nil {
 		return err
 	}
-	itopo.SetCurrentTopologyFromBase(config.General.Topology)
+	itopo.SetCurrentTopology(config.General.Topology)
 	if err := env.InitLogging(&config.Logging); err != nil {
 		return err
 	}

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -112,7 +112,7 @@ func (f *fetcherHandler) GetPaths(ctx context.Context, req *sciond.PathReq,
 	// Commit to a path server, and use it for path and crypto queries
 	psAddr, psOverlayAddr, err := f.topology.GetAnyAppAddr(proto.ServiceType_ps)
 	if err != nil {
-		return nil, common.NewBasicError("PS not found in topology", err)
+		return nil, common.NewBasicError("Failed to look up PS in topology", err)
 	}
 	ps := &snet.Addr{IA: f.topology.IA(), Host: psAddr, NextHop: psOverlayAddr}
 
@@ -269,7 +269,7 @@ func (f *fetcherHandler) buildSCIONDReplyEntries(paths []*combinator.Path) []sci
 			// In-memory write should never fail
 			panic(err)
 		}
-		nextHop := f.topology.GetBRTopoAddrByIfid(path.Interfaces[0].IfID)
+		nextHop := f.topology.GetTopoBRAddrByIfid(path.Interfaces[0].IfID)
 		if nextHop == nil {
 			f.logger.Warn("Unable to find first-hop BR for path", "ifid", path.Interfaces[0].IfID)
 			continue
@@ -281,7 +281,7 @@ func (f *fetcherHandler) buildSCIONDReplyEntries(paths []*combinator.Path) []sci
 				Interfaces: path.Interfaces,
 				ExpTime:    util.TimeToSecs(path.ExpTime),
 			},
-			HostInfo: sciond.HostInfoFromTopoAddr(*nextHop),
+			HostInfo: sciond.HostInfoFromTopoBRAddr(*nextHop),
 		})
 	}
 	return entries

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -409,7 +409,9 @@ func (f *fetcherHandler) filterRevokedPaths(paths []*combinator.Path) []*combina
 	return newPaths
 }
 
-func (f *Fetcher) shouldRefetchSegs(ctx context.Context, req *sciond.PathReq) (bool, error) {
+func (f *fetcherHandler) shouldRefetchSegs(ctx context.Context,
+	req *sciond.PathReq) (bool, error) {
+
 	nq, err := f.pathDB.GetNextQuery(ctx, req.Dst.IA())
 	if err != nil || nq == nil {
 		return true, err
@@ -470,7 +472,7 @@ func (f *fetcherHandler) getSegmentsFromNetwork(ctx context.Context,
 	return reply.Sanitize(f.logger), nil
 }
 
-func (f *Fetcher) flushSegmentsWithFirstHopInterfaces(ctx context.Context) error {
+func (f *fetcherHandler) flushSegmentsWithFirstHopInterfaces(ctx context.Context) error {
 	intfs := make([]*query.IntfSpec, 0, len(f.topology.IFInfoMap))
 	for ifid := range f.topology.IFInfoMap {
 		intfs = append(intfs, &query.IntfSpec{

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -250,7 +250,13 @@ func (h *SVCInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, 
 
 func makeHostInfos(topo itopo.Topology, t proto.ServiceType) []sciond.HostInfo {
 	var hostInfos []sciond.HostInfo
-	for _, a := range topo.GetAllTopoAddrs(t) {
+	addresses, err := topo.GetAllTopoAddrs(t)
+	if err != nil {
+		// FIXME(lukedirtwalker): inform client about this:
+		// see https://github.com/scionproto/scion/issues/1673
+		return hostInfos
+	}
+	for _, a := range addresses {
 		hostInfos = append(hostInfos, sciond.HostInfoFromTopoAddr(a))
 	}
 	return hostInfos

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -169,7 +169,7 @@ func (h *IFInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, p
 	topo := itopo.GetCurrentTopology()
 	if len(ifInfoRequest.IfIDs) == 0 {
 		// Reply with all the IFIDs we know
-		for ifid, topoAddr := range topo.GetAllBRTopoAddrs() {
+		for ifid, topoAddr := range topo.GetAllTopoBRAddrs() {
 			ifInfoReply.RawEntries = append(ifInfoReply.RawEntries, sciond.IFInfoReplyEntry{
 				IfID:     ifid,
 				HostInfo: sciond.HostInfoFromTopoBRAddr(*topoAddr),
@@ -178,7 +178,7 @@ func (h *IFInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, p
 	} else {
 		// Reply with only the IFIDs the client requested
 		for _, ifid := range ifInfoRequest.IfIDs {
-			topoAddr := topo.GetBRTopoAddrByIfid(ifid)
+			topoAddr := topo.GetTopoBRAddrByIfid(ifid)
 			if topoAddr == nil {
 				logger.Info("Received IF Info Request, but IFID not found", "ifid", ifid)
 				continue

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -23,12 +23,11 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
 	"github.com/scionproto/scion/go/lib/infra/modules/segverifier"
 	"github.com/scionproto/scion/go/lib/log"
-	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/revcache"
 	"github.com/scionproto/scion/go/lib/sciond"
-	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/proto"
 	"github.com/scionproto/scion/go/sciond/internal/fetcher"
 )
@@ -94,7 +93,6 @@ func (h *PathRequestHandler) Handle(transport infra.Transport, src net.Addr, pld
 // for each ASInfoRequest it receives.
 type ASInfoRequestHandler struct {
 	TrustStore infra.TrustStore
-	Topology   *topology.Topo
 }
 
 func (h *ASInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, pld *sciond.Pld,
@@ -107,8 +105,9 @@ func (h *ASInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, p
 	// NOTE(scrye): Only support single-homed SCIONDs for now (returned slice
 	// will at most contain one element).
 	reqIA := pld.AsInfoReq.Isdas.IA()
+	topo := itopo.GetCurrentTopology()
 	if reqIA.IsZero() {
-		reqIA = h.Topology.ISD_AS
+		reqIA = topo.IA()
 	}
 	asInfoReply := sciond.ASInfoReply{}
 	trcObj, err := h.TrustStore.GetValidTRC(workCtx, reqIA.I, nil)
@@ -118,13 +117,13 @@ func (h *ASInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, p
 		// the future.
 		asInfoReply.Entries = []sciond.ASInfoReplyEntry{}
 	}
-	if reqIA.IsZero() || reqIA.Eq(h.Topology.ISD_AS) {
+	if reqIA.IsZero() || reqIA.Eq(topo.IA()) {
 		// Requested AS is us
 		asInfoReply.Entries = []sciond.ASInfoReplyEntry{
 			{
-				RawIsdas: h.Topology.ISD_AS.IAInt(),
-				Mtu:      uint16(h.Topology.MTU),
-				IsCore:   trcObj.CoreASes.Contains(h.Topology.ISD_AS),
+				RawIsdas: topo.IA().IAInt(),
+				Mtu:      topo.MTU(),
+				IsCore:   trcObj.CoreASes.Contains(topo.IA()),
 			},
 		}
 	} else {
@@ -158,9 +157,7 @@ func (h *ASInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, p
 // IFInfoRequestHandler represents the shared global state for the handling of all
 // IFInfoRequest queries. The SCIOND API spawns a goroutine with method Handle
 // for each IFInfoRequest it receives.
-type IFInfoRequestHandler struct {
-	Topology *topology.Topo
-}
+type IFInfoRequestHandler struct{}
 
 func (h *IFInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, pld *sciond.Pld,
 	logger log.Logger) {
@@ -169,25 +166,26 @@ func (h *IFInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, p
 	logger.Debug("[SCIOND:IFInfoRequestHandler] Received request", "request", &pld.IfInfoRequest)
 	ifInfoRequest := pld.IfInfoRequest
 	ifInfoReply := sciond.IFInfoReply{}
+	topo := itopo.GetCurrentTopology()
 	if len(ifInfoRequest.IfIDs) == 0 {
 		// Reply with all the IFIDs we know
-		for ifid, ifInfo := range h.Topology.IFInfoMap {
+		for ifid, topoAddr := range topo.GetAllBRTopoAddrs() {
 			ifInfoReply.RawEntries = append(ifInfoReply.RawEntries, sciond.IFInfoReplyEntry{
 				IfID:     ifid,
-				HostInfo: TopoBRAddrToHostInfo(h.Topology.Overlay, *ifInfo.InternalAddrs),
+				HostInfo: sciond.HostInfoFromTopoBRAddr(*topoAddr),
 			})
 		}
 	} else {
 		// Reply with only the IFIDs the client requested
 		for _, ifid := range ifInfoRequest.IfIDs {
-			ifInfo, ok := h.Topology.IFInfoMap[ifid]
-			if !ok {
+			topoAddr := topo.GetBRTopoAddrByIfid(ifid)
+			if topoAddr == nil {
 				logger.Info("Received IF Info Request, but IFID not found", "ifid", ifid)
 				continue
 			}
 			ifInfoReply.RawEntries = append(ifInfoReply.RawEntries, sciond.IFInfoReplyEntry{
 				IfID:     ifid,
-				HostInfo: TopoBRAddrToHostInfo(h.Topology.Overlay, *ifInfo.InternalAddrs),
+				HostInfo: sciond.HostInfoFromTopoBRAddr(*topoAddr),
 			})
 		}
 	}
@@ -212,9 +210,7 @@ func (h *IFInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, p
 // SVCInfoRequestHandler represents the shared global state for the handling of all
 // SVCInfoRequest queries. The SCIOND API spawns a goroutine with method Handle
 // for each SVCInfoRequest it receives.
-type SVCInfoRequestHandler struct {
-	Topology *topology.Topo
-}
+type SVCInfoRequestHandler struct{}
 
 func (h *SVCInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, pld *sciond.Pld,
 	logger log.Logger) {
@@ -223,22 +219,10 @@ func (h *SVCInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, 
 	logger.Debug("[SCIOND:SVCInfoRequestHandler] Received request")
 	svcInfoRequest := pld.ServiceInfoRequest
 	svcInfoReply := sciond.ServiceInfoReply{}
+	topo := itopo.GetCurrentTopology()
 	for _, t := range svcInfoRequest.ServiceTypes {
 		var hostInfos []sciond.HostInfo
-		switch t {
-		case proto.ServiceType_unset:
-			// FIXME(lukedirtwalker): inform client about this:
-			// see https://github.com/scionproto/scion/issues/1673
-			continue
-		case proto.ServiceType_bs:
-			hostInfos = makeHostInfos(h.Topology.Overlay, h.Topology.BS)
-		case proto.ServiceType_ps:
-			hostInfos = makeHostInfos(h.Topology.Overlay, h.Topology.PS)
-		case proto.ServiceType_cs:
-			hostInfos = makeHostInfos(h.Topology.Overlay, h.Topology.CS)
-		case proto.ServiceType_sb:
-			hostInfos = makeHostInfos(h.Topology.Overlay, h.Topology.SB)
-		}
+		hostInfos = makeHostInfos(topo, t)
 		replyEntry := sciond.ServiceInfoReplyEntry{
 			ServiceType: t,
 			Ttl:         DefaultServiceTTL,
@@ -264,76 +248,12 @@ func (h *SVCInfoRequestHandler) Handle(transport infra.Transport, src net.Addr, 
 	logger.Debug("[SCIOND:SVCInfoRequestHandler] Sent reply", "svcInfo", svcInfoReply)
 }
 
-func makeHostInfos(ot overlay.Type, addrMap map[string]topology.TopoAddr) []sciond.HostInfo {
-	hostInfos := make([]sciond.HostInfo, 0, len(addrMap))
-	for _, a := range addrMap {
-		hostInfos = append(hostInfos, TopoAddrToHostInfo(ot, a))
+func makeHostInfos(topo itopo.Topology, t proto.ServiceType) []sciond.HostInfo {
+	var hostInfos []sciond.HostInfo
+	for _, a := range topo.GetAllTopoAddrs(t) {
+		hostInfos = append(hostInfos, sciond.HostInfoFromTopoAddr(a))
 	}
 	return hostInfos
-}
-
-func TopoAddrToHostInfo(ot overlay.Type, topoAddr topology.TopoAddr) sciond.HostInfo {
-	var ipv4, ipv6 net.IP
-	var port uint16
-	if ot.IsIPv4() {
-		v4Addr := topoAddr.IPv4.PublicAddr()
-		if v4Addr != nil {
-			// XXX(scrye): Force 4-byte representation of IPv4 addresses
-			// because Python code doesn't understand Go's 16-byte format.
-			ipv4 = v4Addr.L3.IP().To4()
-			port = v4Addr.L4.Port()
-		}
-	}
-	if ot.IsIPv6() {
-		v6Addr := topoAddr.IPv6.PublicAddr()
-		if v6Addr != nil {
-			ipv6 = v6Addr.L3.IP()
-			port = v6Addr.L4.Port()
-		}
-	}
-	// XXX This assumes that Ipv4 and IPv6 use the same port!
-	return sciond.HostInfo{
-		Addrs: struct {
-			Ipv4 []byte
-			Ipv6 []byte
-		}{
-			Ipv4: ipv4,
-			Ipv6: ipv6,
-		},
-		Port: port,
-	}
-}
-
-func TopoBRAddrToHostInfo(ot overlay.Type, topoAddr topology.TopoBRAddr) sciond.HostInfo {
-	var ipv4, ipv6 net.IP
-	var port uint16
-	if ot.IsIPv4() {
-		v4Addr := topoAddr.IPv4.PublicOverlay
-		if v4Addr != nil {
-			// XXX(scrye): Force 4-byte representation of IPv4 addresses
-			// because Python code doesn't understand Go's 16-byte format.
-			ipv4 = v4Addr.L3().IP().To4()
-			port = v4Addr.L4().Port()
-		}
-	}
-	if ot.IsIPv6() {
-		v6Addr := topoAddr.IPv6.PublicOverlay
-		if v6Addr != nil {
-			ipv6 = v6Addr.L3().IP()
-			port = v6Addr.L4().Port()
-		}
-	}
-	// XXX This assumes that Ipv4 and IPv6 use the same port!
-	return sciond.HostInfo{
-		Addrs: struct {
-			Ipv4 []byte
-			Ipv6 []byte
-		}{
-			Ipv4: ipv4,
-			Ipv6: ipv6,
-		},
-		Port: port,
-	}
 }
 
 // RevNotificationHandler represents the shared global state for the handling of all

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -119,10 +119,6 @@ func realMain() int {
 	handlers := servers.HandlerMap{
 		proto.SCIONDMsg_Which_pathReq: &servers.PathRequestHandler{
 			Fetcher: fetcher.NewFetcher(
-				// FIXME(scrye): This doesn't allow for topology updates. When
-				// reloading support is implemented, fresh topology information
-				// should be loaded from file.
-				config.General.Topology,
 				msger,
 				pathDB,
 				trustStore,

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -169,7 +169,7 @@ func Init(configName string) error {
 	if err != nil {
 		return err
 	}
-	itopo.SetCurrentTopologyFromBase(config.General.Topology)
+	itopo.SetCurrentTopology(config.General.Topology)
 	environment = env.SetupEnv(nil)
 	err = env.InitLogging(&config.Logging)
 	if err != nil {

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/env"
 	"github.com/scionproto/scion/go/lib/infra/infraenv"
+	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
 	"github.com/scionproto/scion/go/lib/log"
@@ -132,14 +133,9 @@ func realMain() int {
 		},
 		proto.SCIONDMsg_Which_asInfoReq: &servers.ASInfoRequestHandler{
 			TrustStore: trustStore,
-			Topology:   config.General.Topology,
 		},
-		proto.SCIONDMsg_Which_ifInfoRequest: &servers.IFInfoRequestHandler{
-			Topology: config.General.Topology,
-		},
-		proto.SCIONDMsg_Which_serviceInfoRequest: &servers.SVCInfoRequestHandler{
-			Topology: config.General.Topology,
-		},
+		proto.SCIONDMsg_Which_ifInfoRequest:      &servers.IFInfoRequestHandler{},
+		proto.SCIONDMsg_Which_serviceInfoRequest: &servers.SVCInfoRequestHandler{},
 		proto.SCIONDMsg_Which_revNotification: &servers.RevNotificationHandler{
 			RevCache:   revCache,
 			TrustStore: trustStore,
@@ -177,6 +173,7 @@ func Init(configName string) error {
 	if err != nil {
 		return err
 	}
+	itopo.SetCurrentTopologyFromBase(config.General.Topology)
 	environment = env.SetupEnv(nil)
 	err = env.InitLogging(&config.Logging)
 	if err != nil {

--- a/go/sciond/server_test.go
+++ b/go/sciond/server_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
 	"github.com/scionproto/scion/go/lib/log"
-	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/scrypto/trc"
 	"github.com/scionproto/scion/go/lib/topology"
@@ -160,7 +159,7 @@ func TestIFInfo(t *testing.T) {
 				RawEntries: []sciond.IFInfoReplyEntry{
 					{
 						IfID: ifids[0],
-						HostInfo: servers.TopoAddrToHostInfo(topo.Overlay,
+						HostInfo: sciond.HostInfoFromTopoBRAddr(
 							*topo.IFInfoMap[ifids[0]].InternalAddrs),
 					},
 				},
@@ -173,12 +172,12 @@ func TestIFInfo(t *testing.T) {
 				RawEntries: []sciond.IFInfoReplyEntry{
 					{
 						IfID: ifids[0],
-						HostInfo: servers.TopoAddrToHostInfo(topo.Overlay,
+						HostInfo: sciond.HostInfoFromTopoBRAddr(
 							*topo.IFInfoMap[ifids[0]].InternalAddrs),
 					},
 					{
 						IfID: ifids[1],
-						HostInfo: servers.TopoAddrToHostInfo(topo.Overlay,
+						HostInfo: sciond.HostInfoFromTopoBRAddr(
 							*topo.IFInfoMap[ifids[1]].InternalAddrs),
 					},
 				},
@@ -349,17 +348,4 @@ func TestMain(m *testing.M) {
 		log.Root().SetHandler(log.DiscardHandler())
 	}
 	os.Exit(m.Run())
-}
-
-func MakeBRHostInfos(ot overlay.Type, brMap map[string]topology.BRInfo,
-	ifInfoMap map[common.IFIDType]topology.IFInfo) []sciond.HostInfo {
-
-	hostInfos := make([]sciond.HostInfo, 0, len(brMap))
-	for _, brInfo := range brMap {
-		// One IFID is enough to find the unique internal address. Panic if no
-		// IFIDs exist.
-		ifid := brInfo.IFIDs[0]
-		hostInfos = append(hostInfos, sciond.HostInfoFromTopoAddr(*ifInfoMap[ifid].InternalAddrs))
-	}
-	return hostInfos
 }


### PR DESCRIPTION
This is a stepping stone towards implementing topology reloading in Go (see https://github.com/scionproto/scion/issues/1836).

This PR aggregates bits and pieces of topology-related code that were scattered throughout SD and PS.

It also defines a topology interface that can be used together with `gomock` to cleanly integrate the topology in tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1850)
<!-- Reviewable:end -->
