### PR TITLE
Enable dispatcher reconnection logic in Go infra

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -16,7 +16,7 @@ GOTAGS = assert
 MOCK_SRC_IN =\
     lib/infra/common.go \
     lib/pathdb/pathdb.go \
-    lib/snet/snetproxy/interface.go \
+    lib/snet/interface.go \
     lib/snet/snetproxy/reconnecter.go \
     lib/snet/snetproxy/io.go
 MOCK_SRC_OUT = $(foreach in,$(MOCK_SRC_IN),$(call mock_src_in_to_out,$(in)))

--- a/go/border/rctrl/ctrl.go
+++ b/go/border/rctrl/ctrl.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	dispPath string = reliable.DefaultDispPath
-	snetConn *snet.Conn
+	snetConn snet.Conn
 	ia       addr.IA
 	logger   log.Logger
 )

--- a/go/lib/env/env.go
+++ b/go/lib/env/env.go
@@ -65,6 +65,8 @@ type General struct {
 	TopologyPath string `toml:"Topology"`
 	// Topology is the loaded topology file.
 	Topology *topology.Topo `toml:"-"`
+	// ReconnectToDispatcher can be set to true to enable the snetproxy reconnecter.
+	ReconnectToDispatcher bool
 }
 
 // setFiles determines the values for extra config files (e.g., topology.json).

--- a/go/lib/env/env_test.go
+++ b/go/lib/env/env_test.go
@@ -32,6 +32,7 @@ type TestConfig struct {
 func TestLoadBase(t *testing.T) {
 	Convey("Load", t, func() {
 		var cfg TestConfig
+
 		_, err := toml.DecodeFile("testdata/ps.toml", &cfg)
 		SoMsg("err", err, ShouldBeNil)
 
@@ -42,5 +43,6 @@ func TestLoadBase(t *testing.T) {
 
 		SoMsg("specific topology is preferred", cfg.General.TopologyPath, ShouldEqual,
 			"testdata/dir/topology.json")
+		SoMsg("DispatcherReconnects", cfg.General.ReconnectToDispatcher, ShouldBeTrue)
 	})
 }

--- a/go/lib/env/testdata/ps.toml
+++ b/go/lib/env/testdata/ps.toml
@@ -10,6 +10,9 @@
   # directory.
   Topology = "testdata/dir/topology.json"
 
+  # ReconnectToDispatcher can be set to true to enable the snetproxy reconnecter.
+  ReconnectToDispatcher = true
+
 [logging]
   [logging.file]
     # Location of the logging file.

--- a/go/lib/infra/infraenv/infraenv.go
+++ b/go/lib/infra/infraenv/infraenv.go
@@ -1,0 +1,68 @@
+// Copyright 2018 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package infraenv contains convenience function common to SCION infra
+// services.
+package infraenv
+
+import (
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/disp"
+	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/infra/transport"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/snet/snetproxy"
+)
+
+const (
+	ErrAppUnableToInitMessenger = "Unable to initialize SCION Infra Messenger"
+)
+
+func InitMessenger(ia addr.IA, public, bind *snet.Addr, svc addr.HostSVC,
+	store infra.TrustStore) (infra.Messenger, error) {
+
+	conn, err := initNetworking(ia, public, bind, svc)
+	if err != nil {
+		return nil, err
+	}
+	msger := messenger.New(
+		ia,
+		disp.New(
+			transport.NewPacketTransport(conn),
+			messenger.DefaultAdapter,
+			log.Root(),
+		),
+		store,
+		log.Root(),
+		nil,
+	)
+	store.SetMessenger(msger)
+	return msger, nil
+}
+
+func initNetworking(ia addr.IA, public, bind *snet.Addr, svc addr.HostSVC) (snet.Conn, error) {
+	network, err := snet.NewNetwork(ia, "", "")
+	if err != nil {
+		return nil, common.NewBasicError("Unable to create network", err)
+	}
+	proxyNetwork := snetproxy.NewProxyNetwork(network)
+	conn, err := proxyNetwork.ListenSCIONWithBindSVC("udp4", public, bind, svc, 0)
+	if err != nil {
+		return nil, common.NewBasicError("Unable to listen on SCION", err)
+	}
+	return conn, nil
+}

--- a/go/lib/pktdisp/disp.go
+++ b/go/lib/pktdisp/disp.go
@@ -30,7 +30,7 @@ type DispatchFunc func(*DispPkt)
 // PktDispatcher listens on c, and calls f for every packet read.
 // N.B. the DispPkt passed to f is reused, so applications should make a copy if
 // this is a problem.
-func PktDispatcher(c *snet.Conn, f DispatchFunc) {
+func PktDispatcher(c snet.Conn, f DispatchFunc) {
 	defer log.LogPanicAndExit()
 	var err error
 	var n int

--- a/go/lib/snet/integration_test.go
+++ b/go/lib/snet/integration_test.go
@@ -203,8 +203,8 @@ func TestListen(t *testing.T) {
 					SoMsg("Error", err, ShouldNotBeNil)
 				} else {
 					SoMsg("Error", err, ShouldBeNil)
-					laddr := conn.LocalSnetAddr()
-					raddr := conn.RemoteSnetAddr()
+					laddr := conn.LocalAddr().(*Addr)
+					raddr := conn.RemoteAddr().(*Addr)
 					SoMsg("Local address", laddr.EqAddr(test.laddr), ShouldBeTrue)
 					SoMsg("Remote address", raddr, ShouldBeNil)
 				}

--- a/go/lib/snet/interface.go
+++ b/go/lib/snet/interface.go
@@ -12,36 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// FIXME(scrye): This file will go away once all its contents are baked into snet.
-
-package snetproxy
+package snet
 
 import (
 	"net"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/snet"
 )
 
-// FIXME(scrye): Temporary interface. This will be moved to snet when the
-// module is integrated.
 type Network interface {
 	ListenSCIONWithBindSVC(network string,
-		laddr, baddr *snet.Addr, svc addr.HostSVC, timeout time.Duration) (Conn, error)
+		laddr, baddr *Addr, svc addr.HostSVC, timeout time.Duration) (Conn, error)
 	DialSCIONWithBindSVC(network string,
-		laddr, raddr, baddr *snet.Addr, svc addr.HostSVC, timeout time.Duration) (Conn, error)
+		laddr, raddr, baddr *Addr, svc addr.HostSVC, timeout time.Duration) (Conn, error)
 }
 
-// FIXME(scrye): Temporary interface. This will be moved to snet when the
-// module is integrated.
 type Conn interface {
 	Read(b []byte) (int, error)
 	ReadFrom(b []byte) (int, net.Addr, error)
-	ReadFromSCION(b []byte) (int, *snet.Addr, error)
+	ReadFromSCION(b []byte) (int, *Addr, error)
 	Write(b []byte) (int, error)
 	WriteTo(b []byte, address net.Addr) (int, error)
-	WriteToSCION(b []byte, address *snet.Addr) (int, error)
+	WriteToSCION(b []byte, address *Addr) (int, error)
 	Close() error
 	LocalAddr() net.Addr
 	BindAddr() net.Addr

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -184,7 +184,9 @@ func (n *SCIONNetwork) DialSCIONWithBindSVC(network string, laddr, raddr, baddr 
 // Parameter network must be "udp4".
 //
 // A timeout of 0 means infinite timeout.
-func (n *SCIONNetwork) ListenSCION(network string, laddr *Addr, timeout time.Duration) (Conn, error) {
+func (n *SCIONNetwork) ListenSCION(network string, laddr *Addr,
+	timeout time.Duration) (Conn, error) {
+
 	return n.ListenSCIONWithBindSVC(network, laddr, nil, addr.SvcNone, timeout)
 }
 

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -60,7 +60,7 @@ import (
 
 var (
 	// Default SCION networking context for package-level Dial and Listen
-	DefNetwork *Network
+	DefNetwork *SCIONNetwork
 )
 
 // Init initializes the default SCION networking context.
@@ -73,7 +73,7 @@ func Init(ia addr.IA, sciondPath string, dispatcherPath string) error {
 }
 
 // InitWithNetwork initializes snet with the provided SCION networking context.
-func InitWithNetwork(network *Network) error {
+func InitWithNetwork(network *SCIONNetwork) error {
 	if DefNetwork != nil {
 		return common.NewBasicError("Cannot initialize global SCION network twice", nil)
 	}
@@ -89,9 +89,11 @@ func IA() addr.IA {
 	return DefNetwork.localIA
 }
 
+var _ Network = (*SCIONNetwork)(nil)
+
 // SCION networking context, containing local ISD-AS, SCIOND, Dispatcher and
 // Path resolver.
-type Network struct {
+type SCIONNetwork struct {
 	dispatcherPath string
 	// pathResolver references the default source of paths for a Network. This
 	// is set to nil when operating on a SCIOND-less Network.
@@ -101,11 +103,11 @@ type Network struct {
 
 // NewNetworkWithPR creates a new networking context with path resolver pr. A
 // nil path resolver means the Network will run without SCIOND.
-func NewNetworkWithPR(ia addr.IA, dispatcherPath string, pr *pathmgr.PR) *Network {
+func NewNetworkWithPR(ia addr.IA, dispatcherPath string, pr *pathmgr.PR) *SCIONNetwork {
 	if dispatcherPath == "" {
 		dispatcherPath = reliable.DefaultDispPath
 	}
-	return &Network{
+	return &SCIONNetwork{
 		dispatcherPath: dispatcherPath,
 		pathResolver:   pr,
 		localIA:        ia,
@@ -119,7 +121,7 @@ func NewNetworkWithPR(ia addr.IA, dispatcherPath string, pr *pathmgr.PR) *Networ
 // If sciondPath is the empty string, the network will run without SCIOND. In
 // this mode of operation, the app is fully responsible with supplying paths
 // for sent traffic.
-func NewNetwork(ia addr.IA, sciondPath string, dispatcherPath string) (*Network, error) {
+func NewNetwork(ia addr.IA, sciondPath string, dispatcherPath string) (*SCIONNetwork, error) {
 	var pathResolver *pathmgr.PR
 	if sciondPath != "" {
 		var err error
@@ -144,8 +146,8 @@ func NewNetwork(ia addr.IA, sciondPath string, dispatcherPath string) (*Network,
 // Read and Write methods can be used to receive and send SCION packets.
 //
 // A timeout of 0 means infinite timeout.
-func (n *Network) DialSCION(network string, laddr, raddr *Addr,
-	timeout time.Duration) (*Conn, error) {
+func (n *SCIONNetwork) DialSCION(network string, laddr, raddr *Addr,
+	timeout time.Duration) (Conn, error) {
 
 	return n.DialSCIONWithBindSVC(network, laddr, raddr, nil, addr.SvcNone, timeout)
 }
@@ -155,8 +157,8 @@ func (n *Network) DialSCION(network string, laddr, raddr *Addr,
 // Read and Write methods can be used to receive and send SCION packets.
 //
 // A timeout of 0 means infinite timeout.
-func (n *Network) DialSCIONWithBindSVC(network string, laddr, raddr, baddr *Addr,
-	svc addr.HostSVC, timeout time.Duration) (*Conn, error) {
+func (n *SCIONNetwork) DialSCIONWithBindSVC(network string, laddr, raddr, baddr *Addr,
+	svc addr.HostSVC, timeout time.Duration) (Conn, error) {
 
 	if raddr == nil {
 		return nil, common.NewBasicError("Unable to dial to nil remote", nil)
@@ -165,9 +167,10 @@ func (n *Network) DialSCIONWithBindSVC(network string, laddr, raddr, baddr *Addr
 	if err != nil {
 		return nil, err
 	}
-	conn.raddr = raddr.Copy()
+	snetConn := conn.(*SCIONConn)
+	snetConn.raddr = raddr.Copy()
 	if n.pathResolver != nil {
-		conn.sp, err = n.pathResolver.Watch(conn.laddr.IA, conn.raddr.IA)
+		snetConn.sp, err = n.pathResolver.Watch(snetConn.laddr.IA, snetConn.raddr.IA)
 		if err != nil {
 			return nil, common.NewBasicError("Unable to establish path", err)
 		}
@@ -181,7 +184,7 @@ func (n *Network) DialSCIONWithBindSVC(network string, laddr, raddr, baddr *Addr
 // Parameter network must be "udp4".
 //
 // A timeout of 0 means infinite timeout.
-func (n *Network) ListenSCION(network string, laddr *Addr, timeout time.Duration) (*Conn, error) {
+func (n *SCIONNetwork) ListenSCION(network string, laddr *Addr, timeout time.Duration) (Conn, error) {
 	return n.ListenSCIONWithBindSVC(network, laddr, nil, addr.SvcNone, timeout)
 }
 
@@ -191,8 +194,8 @@ func (n *Network) ListenSCION(network string, laddr *Addr, timeout time.Duration
 // Parameter network must be "udp4".
 //
 // A timeout of 0 means infinite timeout.
-func (n *Network) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr,
-	svc addr.HostSVC, timeout time.Duration) (*Conn, error) {
+func (n *SCIONNetwork) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr,
+	svc addr.HostSVC, timeout time.Duration) (Conn, error) {
 	// FIXME(scrye): If no local address is specified, we want to
 	// bind to the address of the outbound interface on a random
 	// free port. However, the current dispatcher version cannot
@@ -235,7 +238,7 @@ func (n *Network) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr,
 		return nil, common.NewBasicError("Supplied local address does not match network", nil,
 			"expected L4", l4Type, "actual L4", laddr.Host.L4.Type())
 	}
-	conn := &Conn{
+	conn := &SCIONConn{
 		net:        network,
 		scionNet:   n,
 		recvBuffer: make(common.RawBytes, BufSize),
@@ -282,12 +285,12 @@ func (n *Network) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr,
 }
 
 // PathResolver returns the pathmgr.PR that the network is using.
-func (n *Network) PathResolver() *pathmgr.PR {
+func (n *SCIONNetwork) PathResolver() *pathmgr.PR {
 	return n.pathResolver
 }
 
 // Sciond returns the sciond.Service that the network is using.
-func (n *Network) Sciond() sciond.Service {
+func (n *SCIONNetwork) Sciond() sciond.Service {
 	if n.pathResolver != nil {
 		return n.pathResolver.Sciond()
 	}
@@ -295,6 +298,6 @@ func (n *Network) Sciond() sciond.Service {
 }
 
 // IA returns the ISD-AS assigned to n
-func (n *Network) IA() addr.IA {
+func (n *SCIONNetwork) IA() addr.IA {
 	return n.localIA
 }

--- a/go/lib/snet/snetproxy/conn.go
+++ b/go/lib/snet/snetproxy/conn.go
@@ -25,13 +25,13 @@ import (
 	"github.com/scionproto/scion/go/lib/snet"
 )
 
-var _ Conn = (*ProxyConn)(nil)
+var _ snet.Conn = (*ProxyConn)(nil)
 
 type ProxyConn struct {
 	// connMtx protects read/write access to the snetConn pointer. connMtx must
 	// not be held when running methods on snetConn.
 	connMtx  sync.Mutex
-	snetConn Conn
+	snetConn snet.Conn
 
 	// ioMtx is used to ensure only one worker goroutine enters the main I/O
 	// loop.
@@ -54,7 +54,7 @@ type ProxyConn struct {
 	closeMtx sync.Mutex
 }
 
-func NewProxyConn(conn Conn, reconnecter Reconnecter) *ProxyConn {
+func NewProxyConn(conn snet.Conn, reconnecter Reconnecter) *ProxyConn {
 	return &ProxyConn{
 		snetConn:             conn,
 		dispatcherState:      NewState(),
@@ -163,7 +163,7 @@ func (conn *ProxyConn) asyncReconnectWrapper() {
 }
 
 // Reconnect is only used for testing purposes and should never be called.
-func (conn *ProxyConn) Reconnect() (Conn, error) {
+func (conn *ProxyConn) Reconnect() (snet.Conn, error) {
 	newConn, err := conn.reconnecter.Reconnect(0)
 	if err != nil {
 		return nil, err
@@ -271,14 +271,14 @@ func (conn *ProxyConn) getReadDeadline() time.Time {
 	return deadline
 }
 
-func (conn *ProxyConn) getConn() Conn {
+func (conn *ProxyConn) getConn() snet.Conn {
 	conn.connMtx.Lock()
 	c := conn.snetConn
 	conn.connMtx.Unlock()
 	return c
 }
 
-func (conn *ProxyConn) setConn(newConn Conn) {
+func (conn *ProxyConn) setConn(newConn snet.Conn) {
 	conn.connMtx.Lock()
 	conn.snetConn = newConn
 	conn.connMtx.Unlock()

--- a/go/lib/snet/snetproxy/conn_io_test.go
+++ b/go/lib/snet/snetproxy/conn_io_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/snet/mock_snet"
 	"github.com/scionproto/scion/go/lib/snet/snetproxy"
 	"github.com/scionproto/scion/go/lib/snet/snetproxy/mock_snetproxy"
 	"github.com/scionproto/scion/go/lib/xtest"
@@ -89,7 +90,7 @@ func TestProxyConnIO(t *testing.T) {
 			gomock.InOrder(
 				mockIO.EXPECT().Do(mockConn).Return(writeDispatcherError),
 				mockReconnecter.EXPECT().Reconnect(Any()).DoAndReturn(
-					func(_ time.Duration) (snetproxy.Conn, error) {
+					func(_ time.Duration) (snet.Conn, error) {
 						time.Sleep(tickerMultiplier(4))
 						return mockConn, nil
 					}),
@@ -104,7 +105,7 @@ func TestProxyConnIO(t *testing.T) {
 			gomock.InOrder(
 				mockIO.EXPECT().Do(mockConn).Return(writeDispatcherError),
 				mockReconnecter.EXPECT().Reconnect(Any()).DoAndReturn(
-					func(_ time.Duration) (snetproxy.Conn, error) {
+					func(_ time.Duration) (snet.Conn, error) {
 						time.Sleep(tickerMultiplier(6))
 						return mockConn, nil
 					}),
@@ -129,7 +130,7 @@ func TestProxyConnIO(t *testing.T) {
 			gomock.InOrder(
 				mockIO.EXPECT().Do(mockConn).Return(writeDispatcherError),
 				mockReconnecter.EXPECT().Reconnect(Any()).DoAndReturn(
-					func(_ time.Duration) (snetproxy.Conn, error) {
+					func(_ time.Duration) (snet.Conn, error) {
 						time.Sleep(tickerMultiplier(6))
 						return mockConn, nil
 					}),
@@ -167,7 +168,7 @@ func TestProxyConnAddrs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	Convey("Given a proxy conn running on an underlying connection with a reconnecter", t, func() {
-		mockConn := mock_snetproxy.NewMockConn(ctrl)
+		mockConn := mock_snet.NewMockConn(ctrl)
 		mockReconnecter := mock_snetproxy.NewMockReconnecter(ctrl)
 		proxyConn := snetproxy.NewProxyConn(mockConn, mockReconnecter)
 		Convey("Local address must call the same function on the underlying connection", func() {
@@ -278,7 +279,7 @@ func TestProxyConnClose(t *testing.T) {
 			mockIO := mock_snetproxy.NewMockIOOperation(ctrl)
 			mockIO.EXPECT().IsWrite().Return(true).AnyTimes()
 			mockIO.EXPECT().Do(mockConn).DoAndReturn(
-				func(_ snetproxy.Conn) error {
+				func(_ snet.Conn) error {
 					time.Sleep(tickerMultiplier(2))
 					return writeDispatcherError
 				})
@@ -296,7 +297,7 @@ func TestProxyConnClose(t *testing.T) {
 			mockReconnecter.EXPECT().Stop().AnyTimes()
 			mockReconnecter.EXPECT().
 				Reconnect(Any()).
-				DoAndReturn(func(_ time.Duration) (snetproxy.Conn, error) {
+				DoAndReturn(func(_ time.Duration) (snet.Conn, error) {
 					select {}
 				})
 			mockIO := mock_snetproxy.NewMockIOOperation(ctrl)

--- a/go/lib/snet/snetproxy/io.go
+++ b/go/lib/snet/snetproxy/io.go
@@ -24,7 +24,7 @@ import (
 // function without caring what it is.
 type IOOperation interface {
 	// Runs the I/O operation on conn
-	Do(conn Conn) error
+	Do(conn snet.Conn) error
 	// IsWrite returns true for types implementing write operations
 	IsWrite() bool
 }
@@ -38,7 +38,7 @@ type WriteOperation struct {
 	BaseOperation
 }
 
-func (op *WriteOperation) Do(conn Conn) error {
+func (op *WriteOperation) Do(conn snet.Conn) error {
 	n, err := conn.Write(op.buffer)
 	op.numBytes = n
 	return err
@@ -53,7 +53,7 @@ type WriteToOperation struct {
 	address *snet.Addr
 }
 
-func (op *WriteToOperation) Do(conn Conn) error {
+func (op *WriteToOperation) Do(conn snet.Conn) error {
 	n, err := conn.WriteTo(op.buffer, op.address)
 	op.numBytes = n
 	return err
@@ -63,7 +63,7 @@ type WriteToSCIONOperation struct {
 	WriteToOperation
 }
 
-func (op *WriteToSCIONOperation) Do(conn Conn) error {
+func (op *WriteToSCIONOperation) Do(conn snet.Conn) error {
 	n, err := conn.WriteToSCION(op.buffer, op.address)
 	op.numBytes = n
 	return err
@@ -73,7 +73,7 @@ type ReadOperation struct {
 	BaseOperation
 }
 
-func (op *ReadOperation) Do(conn Conn) error {
+func (op *ReadOperation) Do(conn snet.Conn) error {
 	n, err := conn.Read(op.buffer)
 	op.numBytes = n
 	return err
@@ -88,7 +88,7 @@ type ReadFromOperation struct {
 	address *snet.Addr
 }
 
-func (op *ReadFromOperation) Do(conn Conn) error {
+func (op *ReadFromOperation) Do(conn snet.Conn) error {
 	n, address, err := conn.ReadFrom(op.buffer)
 	op.numBytes = n
 	op.address = address.(*snet.Addr)
@@ -99,7 +99,7 @@ type ReadFromSCIONOperation struct {
 	ReadFromOperation
 }
 
-func (op *ReadFromSCIONOperation) Do(conn Conn) error {
+func (op *ReadFromSCIONOperation) Do(conn snet.Conn) error {
 	n, address, err := conn.ReadFromSCION(op.buffer)
 	op.numBytes = n
 	op.address = address

--- a/go/lib/snet/snetproxy/main_test.go
+++ b/go/lib/snet/snetproxy/main_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/snet/mock_snet"
 	"github.com/scionproto/scion/go/lib/snet/snetproxy"
-	"github.com/scionproto/scion/go/lib/snet/snetproxy/mock_snetproxy"
 )
 
 var (
@@ -54,9 +54,9 @@ var (
 )
 
 func NewMockConnWithAddrs(ctrl *gomock.Controller,
-	laddr, raddr, baddr net.Addr, svc addr.HostSVC) *mock_snetproxy.MockConn {
+	laddr, raddr, baddr net.Addr, svc addr.HostSVC) *mock_snet.MockConn {
 
-	address := mock_snetproxy.NewMockConn(ctrl)
+	address := mock_snet.NewMockConn(ctrl)
 	address.EXPECT().LocalAddr().Return(laddr).AnyTimes()
 	address.EXPECT().RemoteAddr().Return(raddr).AnyTimes()
 	address.EXPECT().BindAddr().Return(baddr).AnyTimes()

--- a/go/lib/snet/snetproxy/network_test.go
+++ b/go/lib/snet/snetproxy/network_test.go
@@ -25,15 +25,15 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/snet/mock_snet"
 	"github.com/scionproto/scion/go/lib/snet/snetproxy"
-	"github.com/scionproto/scion/go/lib/snet/snetproxy/mock_snetproxy"
 )
 
 func TestReconnect(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	Convey("Reconnections must conserve local and bind addresses", t, func() {
-		mockNetwork := mock_snetproxy.NewMockNetwork(ctrl)
+		mockNetwork := mock_snet.NewMockNetwork(ctrl)
 		Convey("Given a mocked underlying connection with local and bind", func() {
 			mockConn := NewMockConnWithAddrs(ctrl, localAddr, nil, bindAddr, svc)
 			Convey("If local address and bind address do not change", func() {
@@ -143,7 +143,7 @@ func TestNetworkFatalError(t *testing.T) {
 	defer ctrl.Finish()
 	Convey("Given a proxy network running over an underlying mocked network", t, func() {
 		err := common.NewBasicError("Not dispatcher dead error, e.g., malformed register msg", nil)
-		mockNetwork := mock_snetproxy.NewMockNetwork(ctrl)
+		mockNetwork := mock_snet.NewMockNetwork(ctrl)
 		proxyNetwork := snetproxy.NewProxyNetwork(mockNetwork)
 		Convey("The proxy network returns non-dispatcher dial errors from the mock", func() {
 			mockNetwork.EXPECT().
@@ -167,7 +167,7 @@ func TestNetworkDispatcherDeadError(t *testing.T) {
 	defer ctrl.Finish()
 	dispatcherError := &net.OpError{Err: os.NewSyscallError("connect", syscall.ECONNREFUSED)}
 	Convey("Listen and Dial should reattempt to connect on dispatcher down errors", t, func() {
-		mockNetwork := mock_snetproxy.NewMockNetwork(ctrl)
+		mockNetwork := mock_snet.NewMockNetwork(ctrl)
 		proxyNetwork := snetproxy.NewProxyNetwork(mockNetwork)
 		Convey("Dial tries to reconnect if no timeout set", func() {
 			mockConn := NewMockConnWithAddrs(ctrl, localAddr, remoteAddr, nil, addr.SvcNone)

--- a/go/lib/snet/snetproxy/reconnecter.go
+++ b/go/lib/snet/snetproxy/reconnecter.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/snet"
 )
 
 // Use a var here to allow tests to inject shorter intervals for fast testing.
@@ -27,7 +28,7 @@ var (
 )
 
 type Reconnecter interface {
-	Reconnect(timeout time.Duration) (Conn, error)
+	Reconnect(timeout time.Duration) (snet.Conn, error)
 	Stop()
 }
 
@@ -39,7 +40,7 @@ type TickingReconnecter struct {
 	// context-aware dials in reliable socket is tricky. This can make stopping
 	// the reconnecter take significant time, depending on the timeout of the
 	// reconnection function.
-	reconnectF func(timeout time.Duration) (Conn, error)
+	reconnectF func(timeout time.Duration) (snet.Conn, error)
 	state      *State
 	stopping   *AtomicBool
 }
@@ -47,7 +48,7 @@ type TickingReconnecter struct {
 // NewTickingReconnecter creates a new dispatcher reconnecter. Calling
 // Reconnect in turn calls f periodically to obtain a new connection to the
 // dispatcher,
-func NewTickingReconnecter(f func(timeout time.Duration) (Conn, error)) *TickingReconnecter {
+func NewTickingReconnecter(f func(timeout time.Duration) (snet.Conn, error)) *TickingReconnecter {
 	return &TickingReconnecter{
 		reconnectF: f,
 		stopping:   &AtomicBool{},
@@ -58,7 +59,7 @@ func NewTickingReconnecter(f func(timeout time.Duration) (Conn, error)) *Ticking
 // subject to timeout. Attempts that receive dispatcher connection errors are
 // followed by reattempts. Critical errors (e.g., port mismatches) return
 // immediately.
-func (r *TickingReconnecter) Reconnect(timeout time.Duration) (Conn, error) {
+func (r *TickingReconnecter) Reconnect(timeout time.Duration) (snet.Conn, error) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 	start := time.Now()

--- a/go/lib/snet/snetproxy/reconnecter_test.go
+++ b/go/lib/snet/snetproxy/reconnecter_test.go
@@ -21,13 +21,14 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/snet/snetproxy"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 // newErrorReconnF returns a dispatcher error after the duration elapses.
-func newErrorReconnF(sleep time.Duration) func(time.Duration) (snetproxy.Conn, error) {
-	return func(_ time.Duration) (snetproxy.Conn, error) {
+func newErrorReconnF(sleep time.Duration) func(time.Duration) (snet.Conn, error) {
+	return func(_ time.Duration) (snet.Conn, error) {
 		time.Sleep(sleep)
 		// return dispatcher error s.t. reconnecter reattempts
 		return nil, dispatcherError

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -51,11 +51,11 @@ func Init(keyPath, pemPath string) error {
 	return nil
 }
 
-func DialSCION(network *snet.Network, laddr, raddr *snet.Addr) (quic.Session, error) {
+func DialSCION(network *snet.SCIONNetwork, laddr, raddr *snet.Addr) (quic.Session, error) {
 	return DialSCIONWithBindSVC(network, laddr, raddr, nil, addr.SvcNone)
 }
 
-func DialSCIONWithBindSVC(network *snet.Network, laddr, raddr, baddr *snet.Addr,
+func DialSCIONWithBindSVC(network *snet.SCIONNetwork, laddr, raddr, baddr *snet.Addr,
 	svc addr.HostSVC) (quic.Session, error) {
 	sconn, err := sListen(network, laddr, baddr, svc)
 	if err != nil {
@@ -65,11 +65,11 @@ func DialSCIONWithBindSVC(network *snet.Network, laddr, raddr, baddr *snet.Addr,
 	return quic.Dial(sconn, raddr, "host:0", cliTlsCfg, nil)
 }
 
-func ListenSCION(network *snet.Network, laddr *snet.Addr) (quic.Listener, error) {
+func ListenSCION(network *snet.SCIONNetwork, laddr *snet.Addr) (quic.Listener, error) {
 	return ListenSCIONWithBindSVC(network, laddr, nil, addr.SvcNone)
 }
 
-func ListenSCIONWithBindSVC(network *snet.Network, laddr, baddr *snet.Addr,
+func ListenSCIONWithBindSVC(network *snet.SCIONNetwork, laddr, baddr *snet.Addr,
 	svc addr.HostSVC) (quic.Listener, error) {
 	if len(srvTlsCfg.Certificates) == 0 {
 		return nil, common.NewBasicError("squic: No server TLS certificate configured", nil)
@@ -81,8 +81,8 @@ func ListenSCIONWithBindSVC(network *snet.Network, laddr, baddr *snet.Addr,
 	return quic.Listen(sconn, srvTlsCfg, nil)
 }
 
-func sListen(network *snet.Network, laddr, baddr *snet.Addr,
-	svc addr.HostSVC) (*snet.Conn, error) {
+func sListen(network *snet.SCIONNetwork, laddr, baddr *snet.Addr,
+	svc addr.HostSVC) (snet.Conn, error) {
 	if network == nil {
 		network = snet.DefNetwork
 	}

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -112,6 +112,7 @@ func realMain() int {
 		env.GetPublicSnetAddress(topo.ISD_AS, topoAddress),
 		env.GetBindSnetAddress(topo.ISD_AS, topoAddress),
 		addr.SvcPS,
+		config.General.ReconnectToDispatcher,
 		trustStore,
 	)
 	if err != nil {

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -103,6 +103,10 @@ func realMain() int {
 		return 1
 	}
 	topoAddress := topo.PS.GetById(config.General.ID)
+	if topoAddress == nil {
+		log.Crit("Unable to find topo address")
+		return 1
+	}
 	msger, err := infraenv.InitMessenger(
 		topo.ISD_AS,
 		env.GetPublicSnetAddress(topo.ISD_AS, topoAddress),

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -29,11 +29,9 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/env"
 	"github.com/scionproto/scion/go/lib/infra"
-	"github.com/scionproto/scion/go/lib/infra/disp"
-	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/infra/infraenv"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
-	"github.com/scionproto/scion/go/lib/infra/transport"
 	"github.com/scionproto/scion/go/lib/log"
 	pathdbbe "github.com/scionproto/scion/go/lib/pathdb/sqlite"
 	"github.com/scionproto/scion/go/lib/revcache/memrevcache"
@@ -99,37 +97,23 @@ func realMain() int {
 		log.Crit("Unable to initialize trust store", "err", err)
 		return 1
 	}
-	err = snet.Init(topo.ISD_AS, "", "")
-	if err != nil {
-		log.Crit("Unable to initialize snet", "err", err)
-		return 1
-	}
-	topoAddress := topo.PS.GetById(config.General.ID)
-	publicAddr := env.GetPublicSnetAddress(topo.ISD_AS, topoAddress)
-	bindAddr := env.GetBindSnetAddress(topo.ISD_AS, topoAddress)
-	conn, err := snet.ListenSCIONWithBindSVC("udp4", publicAddr, bindAddr, addr.SvcPS)
-	if err != nil {
-		log.Crit("Unable to listen on SCION", "err", err)
-		return 1
-	}
 	err = trustStore.LoadAuthoritativeTRC(filepath.Join(config.General.ConfigDir, "certs"))
 	if err != nil {
 		log.Crit("TRC error", "err", err)
 		return 1
 	}
-	msger := messenger.New(
+	topoAddress := topo.PS.GetById(config.General.ID)
+	msger, err := infraenv.InitMessenger(
 		topo.ISD_AS,
-		disp.New(
-			transport.NewPacketTransport(conn),
-			messenger.DefaultAdapter,
-			log.Root(),
-		),
+		env.GetPublicSnetAddress(topo.ISD_AS, topoAddress),
+		env.GetBindSnetAddress(topo.ISD_AS, topoAddress),
+		addr.SvcPS,
 		trustStore,
-		log.Root(),
-		nil,
 	)
+	if err != nil {
+		log.Crit(infraenv.ErrAppUnableToInitMessenger, "err", err)
+	}
 	revCache := memrevcache.New(cache.NoExpiration, time.Second)
-	trustStore.SetMessenger(msger)
 	msger.AddHandler(infra.ChainRequest, trustStore.NewChainReqHandler(false))
 	// TOOD(lukedirtwalker): with the new CP-PKI design the PS should no longer need to handle TRC
 	// and cert requests.

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -36,7 +36,6 @@ import (
 	"github.com/scionproto/scion/go/lib/log"
 	pathdbbe "github.com/scionproto/scion/go/lib/pathdb/sqlite"
 	"github.com/scionproto/scion/go/lib/revcache/memrevcache"
-	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/proto"
 	"github.com/scionproto/scion/go/sciond/internal/fetcher"
 	"github.com/scionproto/scion/go/sciond/internal/sdconfig"
@@ -107,7 +106,9 @@ func realMain() int {
 		config.SD.Public,
 		config.SD.Bind,
 		addr.SvcNone,
-		trustStore)
+		config.General.ReconnectToDispatcher,
+		trustStore,
+	)
 	if err != nil {
 		log.Crit(infraenv.ErrAppUnableToInitMessenger, "err", err)
 		return 1

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -30,11 +30,9 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/env"
-	"github.com/scionproto/scion/go/lib/infra/disp"
-	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/infra/infraenv"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
-	"github.com/scionproto/scion/go/lib/infra/transport"
 	"github.com/scionproto/scion/go/lib/log"
 	pathdbbe "github.com/scionproto/scion/go/lib/pathdb/sqlite"
 	"github.com/scionproto/scion/go/lib/revcache/memrevcache"
@@ -99,35 +97,21 @@ func realMain() int {
 		log.Crit("Unable to initialize trust store", "err", err)
 		return 1
 	}
-	err = snet.Init(config.General.Topology.ISD_AS, "", "")
-	if err != nil {
-		log.Crit("Unable to initialize snet", "err", err)
-		return 1
-	}
-	conn, err := snet.ListenSCIONWithBindSVC("udp4", config.SD.Public,
-		config.SD.Bind, addr.SvcNone)
-	if err != nil {
-		log.Crit("Unable to listen on SCION", "err", err)
-		return 1
-	}
-
 	err = trustStore.LoadAuthoritativeTRC(filepath.Join(config.General.ConfigDir, "certs"))
 	if err != nil {
 		log.Crit("TRC error", "err", err)
 		return 1
 	}
-	msger := messenger.New(
+	msger, err := infraenv.InitMessenger(
 		config.General.Topology.ISD_AS,
-		disp.New(
-			transport.NewPacketTransport(conn),
-			messenger.DefaultAdapter,
-			log.Root(),
-		),
-		trustStore,
-		log.Root(),
-		nil,
-	)
-	trustStore.SetMessenger(msger)
+		config.SD.Public,
+		config.SD.Bind,
+		addr.SvcNone,
+		trustStore)
+	if err != nil {
+		log.Crit(infraenv.ErrAppUnableToInitMessenger, "err", err)
+		return 1
+	}
 	revCache := memrevcache.New(cache.NoExpiration, time.Second)
 	// Route messages to their correct handlers
 	handlers := servers.HandlerMap{

--- a/go/sig/disp/disp.go
+++ b/go/sig/disp/disp.go
@@ -27,7 +27,7 @@ import (
 	"github.com/scionproto/scion/go/sig/mgmt"
 )
 
-func Init(conn *snet.Conn) {
+func Init(conn snet.Conn) {
 	go pktdisp.PktDispatcher(conn, dispFunc)
 }
 

--- a/go/sig/egress/interface.go
+++ b/go/sig/egress/interface.go
@@ -55,7 +55,7 @@ type Session interface {
 	// ID returns the session's ID.
 	ID() mgmt.SessionType
 	// Conn returns the session's outbound snet Conn
-	Conn() *snet.Conn
+	Conn() snet.Conn
 	// Ring returns the session's ring buffer.
 	Ring() *ringbuf.Ring
 	// Remote returns the session's currently chosen SIG and path.

--- a/go/sig/egress/session/session.go
+++ b/go/sig/egress/session/session.go
@@ -53,7 +53,7 @@ type Session struct {
 	// bool
 	healthy        atomic.Value
 	ring           *ringbuf.Ring
-	conn           *snet.Conn
+	conn           snet.Conn
 	sessMonStop    chan struct{}
 	sessMonStopped chan struct{}
 	workerStopped  chan struct{}
@@ -117,7 +117,7 @@ func (s *Session) Ring() *ringbuf.Ring {
 	return s.ring
 }
 
-func (s *Session) Conn() *snet.Conn {
+func (s *Session) Conn() snet.Conn {
 	return s.conn
 }
 

--- a/go/sig/ingress/dispatcher.go
+++ b/go/sig/ingress/dispatcher.go
@@ -41,7 +41,7 @@ const (
 )
 
 var (
-	extConn            *snet.Conn
+	extConn            snet.Conn
 	tunIO              io.ReadWriteCloser
 	freeFrames         *ringbuf.Ring
 	framesRecvCounters map[metrics.CtrPairKey]metrics.CtrPair

--- a/go/sig/sigcmn/common.go
+++ b/go/sig/sigcmn/common.go
@@ -53,7 +53,7 @@ var (
 	IA       addr.IA
 	Host     addr.HostAddr
 	PathMgr  *pathmgr.PR
-	CtrlConn *snet.Conn
+	CtrlConn snet.Conn
 	MgmtAddr *mgmt.Addr
 )
 


### PR DESCRIPTION
Also:
  - move `snetproxy` networking-related interfaces into `snet`
  - refactor out of SD and PS common networking functionality and move it into a new package `infraenv`

Fixes #1474.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1854)
<!-- Reviewable:end -->
