### PR TITLE
Switch from goimports to impi.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
                 command: ./tools/ci/docker_update
             - run:
                 name: Pull and tag scion_base image
-                command: ./tools/ci/prepare_image 2a63bff0424088146e6e7810d7ede484b66d6e91a7d2bf91ba0c21a67aac09c0
+                command: ./tools/ci/prepare_image 495a2d34450a5f584ad2032f0092e19d0563a8774d1f3dd1c1c64761adb54f7c
                 when: always
             - run:
                 name: Build scion:latest image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
                 command: ./tools/ci/docker_update
             - run:
                 name: Pull and tag scion_base image
-                command: ./tools/ci/prepare_image 98b38de3b70b91d9fd97b4b734e5461cea3a3a8b3777694c8c80c3981c6bf591
+                command: ./tools/ci/prepare_image 2a63bff0424088146e6e7810d7ede484b66d6e91a7d2bf91ba0c21a67aac09c0
                 when: always
             - run:
                 name: Build scion:latest image

--- a/go/Makefile
+++ b/go/Makefile
@@ -12,7 +12,6 @@ SHELL=/bin/bash
 LOCAL_DIRS = $(shell find * -maxdepth 0 -type d | grep -v '^vendor$$')
 LOCAL_PKGS = $(patsubst %, ./%/..., $(LOCAL_DIRS))
 LOCAL_GOBIN = $(shell realpath -s $$PWD/../bin)
-LOCAL_NONGEN = $(shell find ${LOCAL_DIRS} -type f -iname '*.go' -a '!' -iname '*.capnp.go' -a '!' -ipath '*/mock_*/*')
 GOTAGS = assert
 MOCK_SRC_IN =\
     lib/infra/common.go \

--- a/go/Makefile
+++ b/go/Makefile
@@ -45,8 +45,9 @@ coverage: deps_gen
 	@echo "Go coverage report here: file://$$PWD/gocover.html"
 
 lint:
-	@echo "======> goimports"
-	out=$$(goimports -d -local github.com/scionproto ${LOCAL_NONGEN}); if [ -n "$$out" ]; then echo "$$out"; exit 1; fi
+	@echo "======> impi"
+	@# Skip vendored, generated and CGO (https://github.com/pavius/impi/issues/5) files.
+	impi --local github.com/scionproto/scion --scheme stdThirdPartyLocal --skip '^vendor/' --skip '\.capnp\.go$$' --skip '/mock_[^/]*/' --skip '/c\.go$$' ./...
 	@echo "======> gofmt"
 	out=$$(gofmt -d -s ${LOCAL_DIRS}); if [ -n "$$out" ]; then echo "$$out"; exit 1; fi
 	@echo "======> go vet"

--- a/go/Makefile
+++ b/go/Makefile
@@ -44,7 +44,7 @@ coverage: deps_gen
 	@echo
 	@echo "Go coverage report here: file://$$PWD/gocover.html"
 
-lint:
+lint: vendor/.deps.stamp
 	@echo "======> impi"
 	@# Skip vendored, generated and CGO (https://github.com/pavius/impi/issues/5) files.
 	impi --local github.com/scionproto/scion --scheme stdThirdPartyLocal --skip '^vendor/' --skip '\.capnp\.go$$' --skip '/mock_[^/]*/' --skip '/c\.go$$' ./...

--- a/go/border/rpkt/rpkt_test.go
+++ b/go/border/rpkt/rpkt_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"

--- a/go/cert_srv/reiss_tasks.go
+++ b/go/cert_srv/reiss_tasks.go
@@ -20,7 +20,6 @@ import (
 	"net"
 	"time"
 
-	log "github.com/inconshreveable/log15"
 	"golang.org/x/crypto/ed25519"
 
 	"github.com/scionproto/scion/go/cert_srv/conf"
@@ -31,6 +30,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/messenger"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust"
+	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/scrypto/cert"
 	"github.com/scionproto/scion/go/lib/scrypto/trc"

--- a/go/cert_srv/reiss_tasks.go
+++ b/go/cert_srv/reiss_tasks.go
@@ -20,9 +20,8 @@ import (
 	"net"
 	"time"
 
-	"golang.org/x/crypto/ed25519"
-
 	log "github.com/inconshreveable/log15"
+	"golang.org/x/crypto/ed25519"
 
 	"github.com/scionproto/scion/go/cert_srv/conf"
 	"github.com/scionproto/scion/go/lib/addr"

--- a/go/lib/as_conf/master_keys.go
+++ b/go/lib/as_conf/master_keys.go
@@ -17,7 +17,6 @@ package as_conf
 import (
 	"encoding/base64"
 	"io/ioutil"
-
 	"path/filepath"
 
 	"github.com/scionproto/scion/go/lib/common"

--- a/go/lib/log/log.go
+++ b/go/lib/log/log.go
@@ -26,7 +26,8 @@ import (
 
 	"github.com/inconshreveable/log15"
 	logext "github.com/inconshreveable/log15/ext"
-	"github.com/kormat/fmt15" // Allows customization of timestamps and multi-line support
+	// Allows customization of timestamps and multi-line support
+	"github.com/kormat/fmt15"
 	"github.com/mattn/go-isatty"
 	"gopkg.in/natefinch/lumberjack.v2"
 

--- a/go/lib/pathmgr/resolver.go
+++ b/go/lib/pathmgr/resolver.go
@@ -17,11 +17,10 @@ package pathmgr
 import (
 	"time"
 
-	"github.com/scionproto/scion/go/lib/spath/spathmeta"
-
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/sciond"
+	"github.com/scionproto/scion/go/lib/spath/spathmeta"
 )
 
 // resolver receives requests from PR and answers them by contacting SCIOND.

--- a/go/lib/scrypto/cert/chain_test.go
+++ b/go/lib/scrypto/cert/chain_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
-
 	"golang.org/x/crypto/ed25519"
 
 	"github.com/scionproto/scion/go/lib/addr"

--- a/go/lib/xtest/helpers.go
+++ b/go/lib/xtest/helpers.go
@@ -26,9 +26,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/scionproto/scion/go/lib/common"
-
 	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
 )
 
 // TempFileName creates a temporary file in dir with the specified prefix, and

--- a/go/sig/ingress/dispatcher.go
+++ b/go/sig/ingress/dispatcher.go
@@ -19,10 +19,9 @@ import (
 	"io"
 	"time"
 
-	"github.com/scionproto/scion/go/lib/addr"
-
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/ringbuf"

--- a/go/tools/scmp/echo/echo.go
+++ b/go/tools/scmp/echo/echo.go
@@ -23,7 +23,6 @@ import (
 	"github.com/scionproto/scion/go/lib/hpkt"
 	"github.com/scionproto/scion/go/lib/scmp"
 	"github.com/scionproto/scion/go/lib/spkt"
-
 	"github.com/scionproto/scion/go/tools/scmp/cmn"
 )
 

--- a/go/tools/scmp/main.go
+++ b/go/tools/scmp/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/sock/reliable"
 	"github.com/scionproto/scion/go/lib/spath"
-
 	"github.com/scionproto/scion/go/tools/scmp/cmn"
 	"github.com/scionproto/scion/go/tools/scmp/echo"
 	"github.com/scionproto/scion/go/tools/scmp/recordpath"

--- a/go/tools/scmp/recordpath/recordpath.go
+++ b/go/tools/scmp/recordpath/recordpath.go
@@ -24,7 +24,6 @@ import (
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/scmp"
 	"github.com/scionproto/scion/go/lib/spkt"
-
 	"github.com/scionproto/scion/go/tools/scmp/cmn"
 )
 

--- a/go/tools/scmp/traceroute/traceroute.go
+++ b/go/tools/scmp/traceroute/traceroute.go
@@ -25,7 +25,6 @@ import (
 	"github.com/scionproto/scion/go/lib/scmp"
 	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/lib/spkt"
-
 	"github.com/scionproto/scion/go/tools/scmp/cmn"
 )
 

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -189,6 +189,18 @@
 			"revisionTime": "2016-01-05T22:08:40Z"
 		},
 		{
+			"checksumSHA1": "E3l/8pxiD5GkGqpS1DP9b+wFIog=",
+			"path": "github.com/kisielk/gotool",
+			"revision": "80517062f582ea3340cd4baf70e86d539ae7d84d",
+			"revisionTime": "2018-02-21T18:54:26Z"
+		},
+		{
+			"checksumSHA1": "9jyCVFMF5GDl15Vqp2ZxRmmNftE=",
+			"path": "github.com/kisielk/gotool/internal/load",
+			"revision": "80517062f582ea3340cd4baf70e86d539ae7d84d",
+			"revisionTime": "2018-02-21T18:54:26Z"
+		},
+		{
 			"checksumSHA1": "eiKZJz+wsoOmDZQ7xdpX+sqQte4=",
 			"license": "APL 2.0",
 			"path": "github.com/kormat/fmt15",
@@ -313,6 +325,12 @@
 			"path": "github.com/patrickmn/go-cache",
 			"revision": "7ac151875ffb48b9f3ccce9ea20f020b0c1596c8",
 			"revisionTime": "2017-04-18T23:29:47Z"
+		},
+		{
+			"checksumSHA1": "3sD1fLvjcNwB8JRpeSJWj8KsGL4=",
+			"path": "github.com/pavius/impi",
+			"revision": "c1cbdcb8df2b23af8530360d87ac9a7fabc48618",
+			"revisionTime": "2018-03-02T13:45:24Z"
 		},
 		{
 			"checksumSHA1": "FGg99nQ56Fo3radSCuU1AeEUJug=",

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -333,6 +333,12 @@
 			"revisionTime": "2018-03-02T13:45:24Z"
 		},
 		{
+			"checksumSHA1": "FptfsjsTRqvPxCAO8h+AuITYVpw=",
+			"path": "github.com/pavius/impi/cmd/impi",
+			"revision": "c1cbdcb8df2b23af8530360d87ac9a7fabc48618",
+			"revisionTime": "2018-03-02T13:45:24Z"
+		},
+		{
 			"checksumSHA1": "FGg99nQ56Fo3radSCuU1AeEUJug=",
 			"path": "github.com/pierrec/lz4",
 			"revision": "08c27939df1bd95e881e2c2367a749964ad1fceb",


### PR DESCRIPTION
impi allows us to lint for import grouping according to our style guide
(stdlib, then thirdparty, then local imports).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1861)
<!-- Reviewable:end -->
