### PR TITLE
pathdb: Store next query instead of LastQuery

### DIFF
--- a/go/lib/pathdb/pathdb.go
+++ b/go/lib/pathdb/pathdb.go
@@ -46,9 +46,9 @@ type PathDB interface {
 	DeleteExpired(ctx context.Context, now time.Time) (int, error)
 	// Get returns all path segment(s) matching the parameters specified.
 	Get(context.Context, *query.Params) ([]*query.Result, error)
-	// InsertLastQueried inserts or updates the timestamp lastQuery for the given dst.
-	InsertLastQueried(ctx context.Context, dst addr.IA, lastQuery time.Time) (bool, error)
-	// GetLastQueried returns the lastQuery timestamp for the given dst,
+	// InsertNextQuery inserts or updates the timestamp nextQuery for the given dst.
+	InsertNextQuery(ctx context.Context, dst addr.IA, nextQuery time.Time) (bool, error)
+	// GetNextQuery returns the nextQuery timestamp for the given dst,
 	// or nil if it hasn't been queried.
-	GetLastQueried(ctx context.Context, dst addr.IA) (*time.Time, error)
+	GetNextQuery(ctx context.Context, dst addr.IA) (*time.Time, error)
 }

--- a/go/lib/pathdb/sqlite/schema.go
+++ b/go/lib/pathdb/sqlite/schema.go
@@ -21,7 +21,7 @@ const (
 	// SchemaVersion is the version of the SQLite schema understood by this backend.
 	// Whenever changes to the schema are made, this version number should be increased
 	// to prevent data corruption between incompatible database schemas.
-	SchemaVersion = 3
+	SchemaVersion = 4
 	// Schema is the SQLite database layout.
 	Schema = `CREATE TABLE Segments(
 		RowID INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -63,10 +63,10 @@ const (
 		PRIMARY KEY (SegRowID, IsdID, AsID, CfgID) ON CONFLICT IGNORE,
 		FOREIGN KEY (SegRowID) REFERENCES Segments(RowID) ON DELETE CASCADE
 	);
-	CREATE TABLE LastQuery(
+	CREATE TABLE NextQuery(
 		IsdID INTEGER NOT NULL,
 		AsID INTEGER NOT NULL,
-		LastQuery INTEGER NOT NULL,
+		NextQuery INTEGER NOT NULL,
 		PRIMARY KEY (IsdID, AsID) ON CONFLICT REPLACE
 	);`
 	SegmentsTable  = "Segments"
@@ -75,5 +75,5 @@ const (
 	EndsAtTable    = "EndsAt"
 	SegTypesTable  = "SegTypes"
 	HpCfgIdsTable  = "HpCfgIds"
-	LastQueryTable = "LastQuery"
+	NextQueryTable = "NextQuery"
 )

--- a/go/lib/pathdb/sqlite/sqlite_test.go
+++ b/go/lib/pathdb/sqlite/sqlite_test.go
@@ -601,7 +601,7 @@ func TestGetModifiedIDs(t *testing.T) {
 	})
 }
 
-func Test_LastQuery(t *testing.T) {
+func TestNextQuery(t *testing.T) {
 	Convey("LastQuery", t, func() {
 		// Setup
 		b, tmpF := setupDB(t)
@@ -611,26 +611,26 @@ func Test_LastQuery(t *testing.T) {
 		defer cancelF()
 		dst := xtest.MustParseIA("1-ff00:0:133")
 		oldT := time.Now().Add(-10 * time.Second)
-		updated, err := b.InsertLastQueried(ctx, dst, oldT)
+		updated, err := b.InsertNextQuery(ctx, dst, oldT)
 		xtest.FailOnErr(t, err)
 		SoMsg("Should Insert new", updated, ShouldBeTrue)
-		dbT, err := b.GetLastQueried(ctx, dst)
+		dbT, err := b.GetNextQuery(ctx, dst)
 		xtest.FailOnErr(t, err)
 		SoMsg("Should return inserted time", dbT.Unix(), ShouldEqual, oldT.Unix())
 		newT := time.Now()
-		updated, err = b.InsertLastQueried(ctx, dst, newT)
+		updated, err = b.InsertNextQuery(ctx, dst, newT)
 		xtest.FailOnErr(t, err)
 		SoMsg("Should Update existing", updated, ShouldBeTrue)
-		dbT, err = b.GetLastQueried(ctx, dst)
+		dbT, err = b.GetNextQuery(ctx, dst)
 		xtest.FailOnErr(t, err)
 		SoMsg("Should return updated time", dbT.Unix(), ShouldEqual, newT.Unix())
-		updated, err = b.InsertLastQueried(ctx, dst, oldT)
+		updated, err = b.InsertNextQuery(ctx, dst, oldT)
 		xtest.FailOnErr(t, err)
 		SoMsg("Should not update to older", updated, ShouldBeFalse)
-		dbT, err = b.GetLastQueried(ctx, dst)
+		dbT, err = b.GetNextQuery(ctx, dst)
 		xtest.FailOnErr(t, err)
 		SoMsg("Should return updated time", dbT.Unix(), ShouldEqual, newT.Unix())
-		dbT, err = b.GetLastQueried(ctx, xtest.MustParseIA("1-ff00:0:122"))
+		dbT, err = b.GetNextQuery(ctx, xtest.MustParseIA("1-ff00:0:122"))
 		SoMsg("Should be nil", dbT, ShouldBeNil)
 	})
 }

--- a/go/path_srv/internal/psconfig/psconfig.go
+++ b/go/path_srv/internal/psconfig/psconfig.go
@@ -32,15 +32,19 @@ type Config struct {
 	// using SegSync messages.
 	SegSync bool
 	PathDB  string
-	// QueryInterval specifies after how much time segments
+	// queryInterval specifies after how much time segments
 	// for a destination should be refetched.
-	QueryInterval duration
+	queryInterval duration `toml:"QueryInterval"`
 }
 
 func (c *Config) InitDefaults() {
-	if c.QueryInterval.Duration == 0 {
-		c.QueryInterval.Duration = DefaultQueryInterval
+	if c.queryInterval.Duration == 0 {
+		c.queryInterval.Duration = DefaultQueryInterval
 	}
+}
+
+func (c *Config) QueryInterval() time.Duration {
+	return c.queryInterval.Duration
 }
 
 var _ (toml.TextUnmarshaler) = (*duration)(nil)


### PR DESCRIPTION
NextQuery is more flexible.
We can implement different strategies, for example:
* backoff if we repeatedly get no segs
* Use smaller interval if we receive less than k segs
etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1869)
<!-- Reviewable:end -->
