### PR TITLE
Try to ensure that addr.HostIPv4 is 4 bytes.

### DIFF
--- a/go/lib/addr/host.go
+++ b/go/lib/addr/host.go
@@ -123,7 +123,7 @@ func (h HostIPv4) Type() HostAddrType {
 }
 
 func (h HostIPv4) Pack() common.RawBytes {
-	return common.RawBytes(net.IP(h).To4())
+	return common.RawBytes(h.IP())
 }
 
 func (h HostIPv4) IP() net.IP {

--- a/go/lib/addr/host.go
+++ b/go/lib/addr/host.go
@@ -127,7 +127,8 @@ func (h HostIPv4) Pack() common.RawBytes {
 }
 
 func (h HostIPv4) IP() net.IP {
-	return net.IP(h)
+	// XXX(kormat): ensure the reply is the 4-byte representation.
+	return net.IP(h).To4()
 }
 
 func (h HostIPv4) Copy() HostAddr {
@@ -283,10 +284,18 @@ func HostFromRaw(b common.RawBytes, htype HostAddrType) (HostAddr, error) {
 }
 
 func HostFromIP(ip net.IP) HostAddr {
-	if ip.To4() != nil {
-		return HostIPv4(ip)
+	if ip4 := ip.To4(); ip4 != nil {
+		return HostIPv4(ip4)
 	}
 	return HostIPv6(ip)
+}
+
+func HostFromIPStr(s string) HostAddr {
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return nil
+	}
+	return HostFromIP(ip)
 }
 
 func HostLen(htype HostAddrType) (uint8, error) {

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -221,7 +221,7 @@ func topoAddrToIPv6AndPort(topoAddr topology.TopoAddr) (net.IP, uint16) {
 func topoBRAddrToIPv4AndPort(topoBRAddr topology.TopoBRAddr) (net.IP, uint16) {
 	if topoBRAddr.IPv4 != nil {
 		if v4Addr := topoBRAddr.IPv4.PublicOverlay; v4Addr != nil {
-			return v4Addr.L3().IP().To4(), v4Addr.L4().Port()
+			return v4Addr.L3().IP(), v4Addr.L4().Port()
 		}
 	}
 	return nil, 0
@@ -252,9 +252,7 @@ func buildHostInfo(ipv4, ipv6 net.IP, port4, port6 uint16) HostInfo {
 			Ipv4 []byte
 			Ipv6 []byte
 		}{
-			// XXX(scrye): Force 4-byte representation of IPv4 addresses
-			// because Python code doesn't understand Go's 16-byte format.
-			Ipv4: ipv4.To4(),
+			Ipv4: ipv4,
 			Ipv6: ipv6,
 		},
 		Port: port,

--- a/go/lib/snet/addr.go
+++ b/go/lib/snet/addr.go
@@ -121,11 +121,10 @@ func AddrFromString(s string) (*Addr, error) {
 	if hostSVC := addr.HostSVCFromString(parts["host"]); hostSVC != addr.SvcNone {
 		l3 = hostSVC
 	} else {
-		ip := net.ParseIP(parts["host"])
-		if ip == nil {
+		l3 = addr.HostFromIPStr(parts["host"])
+		if l3 == nil {
 			return nil, common.NewBasicError("Invalid IP address string", nil, "ip", parts["host"])
 		}
-		l3 = addr.HostFromIP(ip)
 	}
 	var l4 addr.L4Info
 	if parts["port"] != "" {

--- a/go/lib/snet/addr_test.go
+++ b/go/lib/snet/addr_test.go
@@ -31,7 +31,7 @@ func Test_Addr_String(t *testing.T) {
 		L4: addr.NewL4UDPInfo(10000),
 	}
 	host6 := &addr.AppAddr{
-		L3: addr.HostIPv6(net.ParseIP("2001::1")),
+		L3: addr.HostFromIPStr("2001::1"),
 		L4: addr.NewL4UDPInfo(20000),
 	}
 	tests := []struct {

--- a/go/lib/topology/addr.go
+++ b/go/lib/topology/addr.go
@@ -16,7 +16,6 @@ package topology
 
 import (
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/scionproto/scion/go/lib/addr"
@@ -182,12 +181,12 @@ type pubBindAddr struct {
 
 func (pbo *pubBindAddr) fromRaw(rpbo *RawPubBindOverlay, udpOverlay bool) error {
 	var err error
-	ip := net.ParseIP(rpbo.Public.Addr)
-	if ip == nil {
+	l3 := addr.HostFromIPStr(rpbo.Public.Addr)
+	if l3 == nil {
 		return common.NewBasicError(ErrInvalidPub, nil, "ip", rpbo.Public.Addr)
 	}
 	pbo.pub = &addr.AppAddr{
-		L3: addr.HostFromIP(ip),
+		L3: l3,
 		L4: addr.NewL4UDPInfo(uint16(rpbo.Public.L4Port)),
 	}
 	pbo.overlay, err = newOverlayAddr(udpOverlay, pbo.pub.L3, rpbo.Public.OverlayPort)
@@ -195,12 +194,12 @@ func (pbo *pubBindAddr) fromRaw(rpbo *RawPubBindOverlay, udpOverlay bool) error 
 		return err
 	}
 	if rpbo.Bind != nil {
-		ip := net.ParseIP(rpbo.Bind.Addr)
-		if ip == nil {
+		l3 := addr.HostFromIPStr(rpbo.Bind.Addr)
+		if l3 == nil {
 			return common.NewBasicError(ErrInvalidBind, nil, "ip", rpbo.Bind.Addr)
 		}
 		pbo.bind = &addr.AppAddr{
-			L3: addr.HostFromIP(ip),
+			L3: l3,
 			L4: addr.NewL4UDPInfo(uint16(rpbo.Bind.L4Port)),
 		}
 	}

--- a/go/lib/topology/addr_test.go
+++ b/go/lib/topology/addr_test.go
@@ -16,7 +16,6 @@ package topology
 
 import (
 	"fmt"
-	"net"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -194,7 +193,7 @@ func newPub(rapo *RawAddrPortOverlay) *addr.AppAddr {
 		return nil
 	}
 	return &addr.AppAddr{
-		L3: addr.HostFromIP(net.ParseIP(rapo.Addr)),
+		L3: addr.HostFromIPStr(rapo.Addr),
 		L4: addr.NewL4UDPInfo(uint16(rapo.L4Port)),
 	}
 }
@@ -204,7 +203,7 @@ func newBind(rap *RawAddrPort) *addr.AppAddr {
 		return nil
 	}
 	return &addr.AppAddr{
-		L3: addr.HostFromIP(net.ParseIP(rap.Addr)),
+		L3: addr.HostFromIPStr(rap.Addr),
 		L4: addr.NewL4UDPInfo(uint16(rap.L4Port)),
 	}
 }
@@ -217,7 +216,7 @@ func newOverlay(rapo *RawAddrPortOverlay) *overlay.OverlayAddr {
 	if rapo.OverlayPort != 0 {
 		l4 = addr.NewL4UDPInfo(uint16(rapo.OverlayPort))
 	}
-	o, _ := overlay.NewOverlayAddr(addr.HostFromIP(net.ParseIP(rapo.Addr)), l4)
+	o, _ := overlay.NewOverlayAddr(addr.HostFromIPStr(rapo.Addr), l4)
 	return o
 }
 

--- a/go/lib/topology/braddr.go
+++ b/go/lib/topology/braddr.go
@@ -16,7 +16,6 @@ package topology
 
 import (
 	"fmt"
-	"net"
 	"strings"
 
 	"github.com/scionproto/scion/go/lib/addr"
@@ -144,22 +143,20 @@ type overBindAddr struct {
 
 func (ob *overBindAddr) fromRaw(rob *RawOverlayBind, udpOverlay bool) error {
 	var err error
-	ip := net.ParseIP(rob.PublicOverlay.Addr)
-	if ip == nil {
+	l3 := addr.HostFromIPStr(rob.PublicOverlay.Addr)
+	if l3 == nil {
 		return common.NewBasicError(ErrInvalidPub, nil, "ip", rob.PublicOverlay.Addr)
 	}
-	ob.PublicOverlay, err = newOverlayAddr(udpOverlay, addr.HostFromIP(ip),
-		rob.PublicOverlay.OverlayPort)
+	ob.PublicOverlay, err = newOverlayAddr(udpOverlay, l3, rob.PublicOverlay.OverlayPort)
 	if err != nil {
 		return err
 	}
 	if rob.BindOverlay != nil {
-		ip := net.ParseIP(rob.BindOverlay.Addr)
-		if ip == nil {
+		l3 := addr.HostFromIPStr(rob.BindOverlay.Addr)
+		if l3 == nil {
 			return common.NewBasicError(ErrInvalidBind, nil, "ip", rob.BindOverlay.Addr)
 		}
-		ob.BindOverlay, err = newOverlayAddr(udpOverlay, addr.HostFromIP(ip),
-			rob.PublicOverlay.OverlayPort)
+		ob.BindOverlay, err = newOverlayAddr(udpOverlay, l3, rob.PublicOverlay.OverlayPort)
 		if err != nil {
 			return err
 		}

--- a/go/lib/topology/raw.go
+++ b/go/lib/topology/raw.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"strings"
 
 	"github.com/scionproto/scion/go/lib/addr"
@@ -179,8 +178,8 @@ func (b RawBRIntf) localTopoBRAddr(o overlay.Type) (*TopoBRAddr, error) {
 
 // make an OverlayAddr object from a BR interface Remote entry
 func (b RawBRIntf) remoteBRAddr(o overlay.Type) (*overlay.OverlayAddr, error) {
-	ip := net.ParseIP(b.RemoteOverlay.Addr)
-	if ip == nil {
+	l3 := addr.HostFromIPStr(b.RemoteOverlay.Addr)
+	if l3 == nil {
 		return nil, common.NewBasicError("Could not parse remote IP from string", nil,
 			"ip", b.RemoteOverlay.Addr)
 	}
@@ -191,7 +190,7 @@ func (b RawBRIntf) remoteBRAddr(o overlay.Type) (*overlay.OverlayAddr, error) {
 	if o.IsUDP() {
 		l4 = addr.NewL4UDPInfo(uint16(b.RemoteOverlay.OverlayPort))
 	}
-	return overlay.NewOverlayAddr(addr.HostFromIP(ip), l4)
+	return overlay.NewOverlayAddr(l3, l4)
 }
 
 type RawAddrOverlay struct {

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -18,7 +18,6 @@ package topology
 import (
 	"fmt"
 	"math/rand"
-	"net"
 	"sort"
 	"time"
 
@@ -303,12 +302,12 @@ func svcMapFromRaw(ras map[string]*RawSrvInfo, stype string, smap IDAddrMap,
 
 func (t *Topo) zkSvcFromRaw(zksvc map[int]*RawAddrPort) error {
 	for id, ap := range zksvc {
-		ip := net.ParseIP(ap.Addr)
-		if ip == nil {
+		l3 := addr.HostFromIPStr(ap.Addr)
+		if l3 == nil {
 			return common.NewBasicError("Parsing ZooKeeper address", nil, "addr", ap.Addr)
 		}
 		t.ZK[id] = &addr.AppAddr{
-			L3: addr.HostFromIP(ip),
+			L3: l3,
 			L4: addr.NewL4TCPInfo(uint16(ap.L4Port)),
 		}
 	}


### PR DESCRIPTION
- Add a new constructor, addr.HostFromIPStr, which takes a string, and
  return a addr.HostIPv4 or addr.HostIPv6 as appropriate.
- Convert unit tests to use/expect 4-byte IPv4 addresses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1885)
<!-- Reviewable:end -->
