### PR TITLE
Segverifier, PS, SD fixes/improvements

### DIFF
--- a/go/lib/infra/modules/segsaver/segsaver.go
+++ b/go/lib/infra/modules/segsaver/segsaver.go
@@ -17,14 +17,10 @@ package segsaver
 
 import (
 	"context"
-	"time"
 
-	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/pathdb"
-	"github.com/scionproto/scion/go/lib/revcache"
 	"github.com/scionproto/scion/go/proto"
 )
 
@@ -38,19 +34,4 @@ func StoreSeg(ctx context.Context, s *seg.Meta, pathDB pathdb.PathDB, log log.Lo
 		log.Debug("Inserted segment into path database", "segment", s.Segment)
 	}
 	return nil
-}
-
-// StoreRevocation stores a revocation in the revcache.
-// Revocation must be verified before calling this.
-func StoreRevocation(revocation *path_mgmt.SignedRevInfo, rcache revcache.RevCache) {
-	info, err := revocation.RevInfo()
-	if err != nil {
-		// This should be caught during network message sanitization
-		panic(err)
-	}
-	rcache.Set(
-		revcache.NewKey(info.IA(), common.IFIDType(info.IfID)),
-		revocation,
-		info.RelativeTTL(time.Now()),
-	)
 }

--- a/go/lib/infra/modules/segverifier/segverifier.go
+++ b/go/lib/infra/modules/segverifier/segverifier.go
@@ -71,11 +71,6 @@ Loop:
 	for numResults := 0; numResults < units; numResults++ {
 		select {
 		case result := <-unitResultsC:
-			if err := result.SegError(); err != nil {
-				segError(result.Unit.SegMeta, err)
-			} else {
-				verifiedSeg(ctx, result.Unit.SegMeta)
-			}
 			// Insert successfully verified revocations into the revcache
 			for index, revocation := range result.Unit.SRevInfos {
 				if err, ok := result.Errors[index]; ok {
@@ -83,6 +78,11 @@ Loop:
 				} else {
 					verifiedRev(ctx, revocation)
 				}
+			}
+			if err := result.SegError(); err != nil {
+				segError(result.Unit.SegMeta, err)
+			} else {
+				verifiedSeg(ctx, result.Unit.SegMeta)
 			}
 		case <-ctx.Done():
 			break Loop

--- a/go/path_srv/internal/handlers/common.go
+++ b/go/path_srv/internal/handlers/common.go
@@ -130,7 +130,7 @@ func (h *baseHandler) verifyAndStore(ctx context.Context, src net.Addr,
 		}
 	}
 	verifiedRev := func(ctx context.Context, rev *path_mgmt.SignedRevInfo) {
-		segsaver.StoreRevocation(rev, h.revCache)
+		h.revCache.Insert(rev)
 	}
 	segErr := func(s *seg.Meta, err error) {
 		h.logger.Warn("Segment verification failed", "segment", s.Segment, "err", err)

--- a/go/path_srv/internal/handlers/ifstateinfo.go
+++ b/go/path_srv/internal/handlers/ifstateinfo.go
@@ -20,7 +20,6 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
-	"github.com/scionproto/scion/go/lib/infra/modules/segsaver"
 	"github.com/scionproto/scion/go/lib/infra/modules/segverifier"
 )
 
@@ -62,5 +61,5 @@ func (h *ifStateInfoHandler) verifyAndStore(ctx context.Context, rev *path_mgmt.
 		h.logger.Error("[ifStateHandler] Failed to verify revInfo", "rev", rev, "err", err)
 		return
 	}
-	segsaver.StoreRevocation(rev, h.revCache)
+	h.revCache.Insert(rev)
 }

--- a/go/path_srv/internal/handlers/segrevoc.go
+++ b/go/path_srv/internal/handlers/segrevoc.go
@@ -20,7 +20,6 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
-	"github.com/scionproto/scion/go/lib/infra/modules/segsaver"
 	"github.com/scionproto/scion/go/lib/infra/modules/segverifier"
 )
 
@@ -57,5 +56,5 @@ func (h *revocHandler) verifyAndStore(ctx context.Context, revocation *path_mgmt
 		h.logger.Warn("[revocHandler] couldn't verify revocation", "err", err)
 		return
 	}
-	segsaver.StoreRevocation(revocation, h.revCache)
+	h.revCache.Insert(revocation)
 }

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -444,7 +444,7 @@ func (f *fetcherHandler) fetchAndVerify(ctx context.Context, cancelF context.Can
 		}
 	}
 	verifiedRev := func(ctx context.Context, rev *path_mgmt.SignedRevInfo) {
-		segsaver.StoreRevocation(rev, f.revocationCache)
+		f.revocationCache.Insert(rev)
 	}
 	segErr := func(s *seg.Meta, err error) {
 		f.logger.Warn("Segment verification failed", "segment", s.Segment, "err", err)
@@ -452,7 +452,8 @@ func (f *fetcherHandler) fetchAndVerify(ctx context.Context, cancelF context.Can
 	revErr := func(revocation *path_mgmt.SignedRevInfo, err error) {
 		f.logger.Warn("Revocation verification failed", "revocation", revocation, "err", err)
 	}
-	segverifier.Verify(ctx, f.trustStore, ps, reply.Recs.Recs, reply.Recs.SRevInfos,
+	revInfos := revcache.FilterNew(f.revocationCache, reply.Recs.SRevInfos)
+	segverifier.Verify(ctx, f.trustStore, ps, reply.Recs.Recs, revInfos,
 		verifiedSeg, verifiedRev, segErr, revErr)
 }
 

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -282,8 +282,7 @@ func (h *RevNotificationHandler) Handle(transport infra.Transport, src net.Addr,
 	revReply := sciond.RevReply{}
 	revInfo, err := h.verifySRevInfo(workCtx, revNotification.SRevInfo)
 	if err == nil {
-		h.RevCache.Set(revcache.NewKey(revInfo.RawIsdas.IA(), common.IFIDType(revInfo.IfID)),
-			revNotification.SRevInfo, revInfo.TTL())
+		h.RevCache.Insert(revNotification.SRevInfo)
 	}
 	switch {
 	case isValid(err):


### PR DESCRIPTION
* Make sure to call revocation callbacks first. Often they will be inserted in a DB, that should happen before the segments.
* Only verify revocations that are not yet in the cache (SD,PS) contributes #1884

Also in the PS makes sure to sanitize SegReply.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1887)
<!-- Reviewable:end -->
