### PR TITLE
Update PathSegment string representation.

### DIFF
--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -317,11 +317,14 @@ func (ps *PathSegment) ProtoId() proto.ProtoIdType {
 }
 
 func (ps *PathSegment) String() string {
+	if ps == nil {
+		return "<nil>"
+	}
 	desc := []string{}
 	if id, err := ps.ID(); err != nil {
 		desc = append(desc, fmt.Sprintf("ID error: %s", err))
 	} else {
-		desc = append(desc, id.String())
+		desc = append(desc, id.String()[:12])
 	}
 	info, _ := ps.InfoF()
 	desc = append(desc, util.TimeToString(info.Timestamp()))

--- a/go/lib/ctrl/seg/segs.go
+++ b/go/lib/ctrl/seg/segs.go
@@ -22,8 +22,9 @@ import (
 type Segments []*PathSegment
 
 // FilterSegs filters the given segs and only keeps the segments for which keep returns true.
-// Modifies segs in-place.
-func (segs *Segments) FilterSegs(keep func(*PathSegment) bool) {
+// Modifies segs in-place. Returns the number of segments filtered out.
+func (segs *Segments) FilterSegs(keep func(*PathSegment) bool) int {
+	full := len(*segs)
 	filtered := (*segs)[:0]
 	for _, s := range *segs {
 		if keep(s) {
@@ -31,6 +32,7 @@ func (segs *Segments) FilterSegs(keep func(*PathSegment) bool) {
 		}
 	}
 	*segs = filtered
+	return full - len(*segs)
 }
 
 // FirstIAs returns the slice of FirstIAs in the given segments. Each FirstIA appears just once.


### PR DESCRIPTION
- If a *seg.PathSegment is nil, just return "<nil">.
- Use a shorter version of seg id in the string output (using 12B, same
  as python). This improves log readability a lot.

Also:
- Change segs.FilterSegs to return how many segments were filtered out.
  It's useful for debugging if nothing else.