### PR TITLE
Simplify some network errors

### DIFF
--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -275,7 +275,7 @@ func (n *SCIONNetwork) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr
 	rconn, port, err := reliable.RegisterTimeout(conn.scionNet.dispatcherPath,
 		conn.laddr.IA, conn.laddr.Host, bindAddr, svc, timeout)
 	if err != nil {
-		return nil, common.NewBasicError("Unable to register with dispatcher", err)
+		return nil, err
 	}
 	if port != conn.laddr.Host.L4.Port() {
 		// Update port

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -455,7 +455,7 @@ func (conn *Conn) writeN(bufs []Msg) (int, error) {
 	for copied < index {
 		n, err := conn.UnixConn.Write(conn.sendBuf[copied:index])
 		if err != nil {
-			return 0, common.NewBasicError("Error writing to UNIX socket", err)
+			return 0, err
 		}
 		copied += n
 	}


### PR DESCRIPTION
The simplified errors are more similar to network errors returned by the standard library, and easier to act on in calling code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1906)
<!-- Reviewable:end -->
