### PR TITLE
Allow per-app docker images to be built in parallel.

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -21,6 +21,7 @@ cmd_base() {
     copy_tree
     docker_build "base"
     docker tag scion_base:latest "$ORG/scion_base:pending"
+    touch docker/_build/scion_base.stamp
 }
 
 cmd_build() {
@@ -64,6 +65,7 @@ docker_build() {
     echo
     docker build $DOCKER_ARGS -f "$conf" -t "$tag" "$build_dir/scion.git" | tee "$log"
     docker tag "$tag" "$image_name:latest"
+    touch docker/_build/scion.stamp
 }
 
 cmd_clean() {

--- a/docker/perapp/Makefile
+++ b/docker/perapp/Makefile
@@ -6,9 +6,8 @@ endif
 ALL_TARGETS = base apps debug
 .PHONY: $(ALL_TARGETS)
 all: $(ALL_TARGETS)
-$(ALL_TARGETS): | scion_hash
-scion_hash:
-	@./docker_hash scion
+hashes/scion: ../_build/scion.stamp
+	./docker_hash scion
 
 .PHONY: clean
 clean:
@@ -22,7 +21,6 @@ clean:
 BASE_TARGETS = app_builder app_base python_base debug_base
 .PHONY: $(BASE_TARGETS)
 base: $(BASE_TARGETS)
-$(BASE_TARGETS): | scion_hash
 
 app_builder: hashes/app_builder
 hashes/app_builder: base/Dockerfile.builder hashes/scion
@@ -44,7 +42,6 @@ hashes/debug_base: base/Dockerfile.debug hashes/scion
 APP_TARGETS = border dispatcher sig path_py path beacon_py cert_py sciond_py sciond
 .PHONY: $(APP_TARGETS)
 apps: $(APP_TARGETS)
-$(APP_TARGETS): | scion_hash
 
 border: hashes/border
 hashes/border: app/Dockerfile.border hashes/app_base hashes/app_builder
@@ -86,7 +83,6 @@ hashes/sciond: app/Dockerfile.sciond hashes/app_base hashes/app_builder
 DEBUG_TARGETS = border_debug dispatcher_debug sig_debug path_debug_py path_debug beacon_py_debug cert_py_debug sciond_py_debug sciond_debug
 .PHONY: $(DEBUG_TARGETS)
 debug: $(DEBUG_TARGETS)
-$(DEBUG_TARGETS): | scion_hash
 
 border_debug: hashes/border_debug
 hashes/border_debug: debug/Dockerfile.border hashes/debug_base hashes/border


### PR DESCRIPTION
This PR adds build .stamp files in docker.sh, so docker/perapp/Makefile
can depend on them. This removes the need for the order-only scion_hash
target hack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1913)
<!-- Reviewable:end -->
