### PR TITLE
SIG: Avoid using path removed from path pool

### DIFF
--- a/go/sig/egress/session/sessmon.go
+++ b/go/sig/egress/session/sessmon.go
@@ -143,7 +143,10 @@ func (sm *sessMonitor) updateRemote() {
 			sm.Debug("Current path invalid", "remote", currRemote)
 			currSessPath = sm.getNewPath(nil)
 			sm.needUpdate = true
-			// Traffic must no longer be sent on the old path.
+			// Traffic must no longer be sent on the old path. This implies that the encap
+			// traffic is sent on a path that has not been tested by the session monitor yet.
+			// If the new path is unhealthy, it is changed quickly by the session monitor through
+			// the regular timeout mechanism above.
 			sm.sess.currRemote.Store(&egress.RemoteInfo{Sig: currSig, SessPath: currSessPath})
 		}
 	}

--- a/go/sig/egress/session/sessmon.go
+++ b/go/sig/egress/session/sessmon.go
@@ -143,6 +143,8 @@ func (sm *sessMonitor) updateRemote() {
 			sm.Debug("Current path invalid", "remote", currRemote)
 			currSessPath = sm.getNewPath(nil)
 			sm.needUpdate = true
+			// Traffic must no longer be sent on the old path.
+			sm.sess.currRemote.Store(&egress.RemoteInfo{Sig: currSig, SessPath: currSessPath})
 		}
 	}
 	sm.sess.healthy.Store(!sm.needUpdate)

--- a/go/sig/egress/worker/worker.go
+++ b/go/sig/egress/worker/worker.go
@@ -212,6 +212,8 @@ func (w *worker) resetFrame(f *frame) {
 		}
 		if remote.SessPath != nil {
 			w.currPathEntry = remote.SessPath.PathEntry()
+		} else {
+			w.currPathEntry = nil
 		}
 		if w.currPathEntry != nil {
 			mtu = w.currPathEntry.Path.Mtu

--- a/go/sig/egress/worker/worker.go
+++ b/go/sig/egress/worker/worker.go
@@ -210,10 +210,9 @@ func (w *worker) resetFrame(f *frame) {
 		if w.currSig != nil {
 			addrLen = uint16(spkt.AddrHdrLen(w.currSig.Host, sigcmn.Host))
 		}
+		w.currPathEntry = nil
 		if remote.SessPath != nil {
 			w.currPathEntry = remote.SessPath.PathEntry()
-		} else {
-			w.currPathEntry = nil
 		}
 		if w.currPathEntry != nil {
 			mtu = w.currPathEntry.Path.Mtu


### PR DESCRIPTION
Reset the path for the worker immediately if the current path is no longer part of the path set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1923)
<!-- Reviewable:end -->
