### PR TITLE
Fix AppAddr.Copy

### DIFF
--- a/go/lib/addr/appaddr.go
+++ b/go/lib/addr/appaddr.go
@@ -24,6 +24,9 @@ type AppAddr struct {
 }
 
 func (a *AppAddr) Copy() *AppAddr {
+	if a == nil {
+		return nil
+	}
 	return &AppAddr{L3: a.L3.Copy(), L4: a.L4.Copy()}
 }
 

--- a/go/lib/addr/l4info.go
+++ b/go/lib/addr/l4info.go
@@ -59,6 +59,9 @@ func (l *l4AddrInfo) Port() uint16 {
 }
 
 func (l *l4AddrInfo) Copy() L4Info {
+	if l == nil {
+		return nil
+	}
 	return &l4AddrInfo{pType: l.pType, port: l.port}
 }
 


### PR DESCRIPTION
Avoid panic when copying `snet.Addr` with empty host address.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1929)
<!-- Reviewable:end -->
