### PR TITLE
Drop AUTOINCREMENT from pathdb schema

### DIFF
--- a/go/lib/pathdb/sqlite/schema.go
+++ b/go/lib/pathdb/sqlite/schema.go
@@ -21,10 +21,10 @@ const (
 	// SchemaVersion is the version of the SQLite schema understood by this backend.
 	// Whenever changes to the schema are made, this version number should be increased
 	// to prevent data corruption between incompatible database schemas.
-	SchemaVersion = 4
+	SchemaVersion = 5
 	// Schema is the SQLite database layout.
 	Schema = `CREATE TABLE Segments(
-		RowID INTEGER PRIMARY KEY AUTOINCREMENT,
+		RowID INTEGER PRIMARY KEY,
 		SegID DATA UNIQUE NOT NULL,
 		LastUpdated INTEGER NOT NULL,
 		Segment DATA NOT NULL,


### PR DESCRIPTION
We don't need it, and it isn't recommended to use it if it's not required.
See https://www.sqlite.org/autoinc.html for a more detailed explanation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1930)
<!-- Reviewable:end -->
