### PR TITLE
SCIOND no longer returns expired paths

### DIFF
--- a/go/lib/infra/modules/combinator/expiry_test.go
+++ b/go/lib/infra/modules/combinator/expiry_test.go
@@ -71,8 +71,7 @@ func TestComputeSegmentExpTime(t *testing.T) {
 		for _, tc := range testCases {
 			Convey(tc.Name, func() {
 				computedExpiration := tc.Segment.ComputeExpTime()
-				expectedExpiration := tc.ExpectedExpiration
-				So(computedExpiration.Unix(), ShouldEqual, expectedExpiration)
+				So(computedExpiration.Unix(), ShouldEqual, tc.ExpectedExpiration)
 			})
 		}
 	})

--- a/go/lib/infra/modules/combinator/expiry_test.go
+++ b/go/lib/infra/modules/combinator/expiry_test.go
@@ -1,0 +1,96 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package combinator
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/spath"
+)
+
+// FIXME(scrye): when more unit tests get added to spath, these should probably
+// move there
+
+func TestComputeSegmentExpTime(t *testing.T) {
+	testCases := []struct {
+		Name               string
+		Segment            *Segment
+		ExpectedExpiration uint64
+	}{
+		{
+			Name:               "smallest possible expiration value",
+			Segment:            buildTestSegment(0, 0),
+			ExpectedExpiration: 337,
+		},
+		{
+			Name:               "non-zero hop ttl field value",
+			Segment:            buildTestSegment(0, 1),
+			ExpectedExpiration: 675,
+		},
+		{
+			Name:               "two hop fields, min should be taken",
+			Segment:            buildTestSegment(0, 4, 0),
+			ExpectedExpiration: 337,
+		},
+		{
+			Name:               "maximum ttl selected",
+			Segment:            buildTestSegment(0, 255),
+			ExpectedExpiration: 24 * 60 * 60,
+		},
+		{
+			Name:               "ttl relative to info field timestamp",
+			Segment:            buildTestSegment(100, 1),
+			ExpectedExpiration: 775,
+		},
+		{
+			Name:               "ttl relative to maximum info field timestamp",
+			Segment:            buildTestSegment(4294967295, 1),
+			ExpectedExpiration: 4294967970,
+		},
+		{
+			Name:               "maximum possible value",
+			Segment:            buildTestSegment(4294967295, 255),
+			ExpectedExpiration: 4295053695,
+		},
+	}
+	Convey("Expiration values should be correct", t, func() {
+		for _, tc := range testCases {
+			Convey(tc.Name, func() {
+				So(tc.Segment.ComputeExpTime(), ShouldEqual, tc.ExpectedExpiration)
+			})
+		}
+	})
+}
+
+func buildTestSegment(timestamp uint32, ttls ...uint8) *Segment {
+	segment := &Segment{}
+	segment.InfoField = &InfoField{
+		InfoField: &spath.InfoField{
+			TsInt: timestamp,
+		},
+	}
+	for _, ttl := range ttls {
+		segment.HopFields = append(segment.HopFields,
+			&HopField{
+				HopField: &spath.HopField{
+					ExpTime: spath.ExpTimeType(ttl),
+				},
+			},
+		)
+	}
+	return segment
+}

--- a/go/lib/infra/modules/combinator/expiry_test.go
+++ b/go/lib/infra/modules/combinator/expiry_test.go
@@ -16,7 +16,6 @@ package combinator
 
 import (
 	"testing"
-	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -72,8 +71,8 @@ func TestComputeSegmentExpTime(t *testing.T) {
 		for _, tc := range testCases {
 			Convey(tc.Name, func() {
 				computedExpiration := tc.Segment.ComputeExpTime()
-				expectedExpiration := time.Unix(tc.ExpectedExpiration, 0)
-				So(computedExpiration.Unix(), ShouldEqual, expectedExpiration.Unix())
+				expectedExpiration := tc.ExpectedExpiration
+				So(computedExpiration.Unix(), ShouldEqual, expectedExpiration)
 			})
 		}
 	})

--- a/go/lib/infra/modules/combinator/graph.go
+++ b/go/lib/infra/modules/combinator/graph.go
@@ -23,7 +23,6 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
 	"github.com/scionproto/scion/go/lib/sciond"
-	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/proto"
 )
 
@@ -280,8 +279,7 @@ func (solution *PathSolution) GetFwdPathMetadata() *Path {
 	}
 	for edgeIdx, solEdge := range solution.edges {
 		currentSeg := &Segment{
-			Type:    solEdge.segment.Type,
-			ExpTime: spath.MaxTimestamp,
+			Type: solEdge.segment.Type,
 		}
 		currentSeg.initInfoFieldFrom(solEdge.segment.PathSegment)
 		currentSeg.InfoField.ConsDir = solEdge.segment.IsDownSeg()
@@ -299,8 +297,6 @@ func (solution *PathSolution) GetFwdPathMetadata() *Path {
 
 			// Normal hop field.
 			newHF := currentSeg.appendHopFieldFrom(asEntry.HopEntries[0])
-			currentSeg.ExpTime = minUint32(currentSeg.ExpTime,
-				uint32(newHF.ExpTime.ToDuration().Seconds()))
 			inIFID, outIFID = newHF.ConsEgress, newHF.ConsIngress
 
 			// If we've transitioned from a previous segment, set Xover flag.
@@ -338,8 +334,6 @@ func (solution *PathSolution) GetFwdPathMetadata() *Path {
 						// Add a new hop field for the peering entry, and set Xover.
 						pHF := currentSeg.appendHopFieldFrom(asEntry.HopEntries[solEdge.edge.Peer])
 						pHF.Xover = true
-						currentSeg.ExpTime = minUint32(currentSeg.ExpTime,
-							uint32(pHF.ExpTime.ToDuration().Seconds()))
 						inIFID, outIFID = pHF.ConsEgress, pHF.ConsIngress
 					} else {
 						// Normal shortcut, so only half of this HF is traversed by the packet
@@ -357,7 +351,6 @@ func (solution *PathSolution) GetFwdPathMetadata() *Path {
 	}
 	path.reverseDownSegment()
 	path.aggregateInterfaces()
-	path.computeExpTime()
 	return path
 }
 

--- a/go/lib/spath/hop.go
+++ b/go/lib/spath/hop.go
@@ -36,6 +36,7 @@ const (
 	VerifyOnlyMask    = 0x02
 	RecurseMask       = 0x04
 	MaxTTL            = 24 * 60 * 60 // One day in seconds
+	ExpTimeUnit       = MaxTTL / 256 // ~5m38s
 	MaxTTLField       = ExpTimeType(255)
 	macInputLen       = 16
 )
@@ -171,5 +172,5 @@ type ExpTimeType uint8
 // ToDuration calculates the relative expiration time in seconds.
 // Note that for a 0 value ExpTime, the minimal duration is ExpTimeUnit.
 func (e ExpTimeType) ToDuration() time.Duration {
-	return ((time.Duration(e) + time.Duration(1)) * time.Duration(MaxTTL)) / 256 * time.Second
+	return (time.Duration(e) + 1) * time.Duration(ExpTimeUnit) * time.Second
 }

--- a/go/lib/spath/hop.go
+++ b/go/lib/spath/hop.go
@@ -36,7 +36,7 @@ const (
 	VerifyOnlyMask    = 0x02
 	RecurseMask       = 0x04
 	MaxTTL            = 24 * 60 * 60 // One day in seconds
-	ExpTimeUnit       = MaxTTL / 256 // ~5m38s
+	MaxTTLField       = ExpTimeType(255)
 	macInputLen       = 16
 )
 
@@ -171,5 +171,5 @@ type ExpTimeType uint8
 // ToDuration calculates the relative expiration time in seconds.
 // Note that for a 0 value ExpTime, the minimal duration is ExpTimeUnit.
 func (e ExpTimeType) ToDuration() time.Duration {
-	return time.Duration(e+1) * time.Duration(ExpTimeUnit) * time.Second
+	return ((time.Duration(e) + time.Duration(1)) * time.Duration(MaxTTL)) / 256 * time.Second
 }

--- a/go/lib/spath/hop.go
+++ b/go/lib/spath/hop.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"math"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/common"
@@ -37,7 +38,7 @@ const (
 	RecurseMask       = 0x04
 	MaxTTL            = 24 * 60 * 60 // One day in seconds
 	ExpTimeUnit       = MaxTTL / 256 // ~5m38s
-	MaxTTLField       = ExpTimeType(255)
+	MaxTTLField       = ExpTimeType(math.MaxUint8)
 	macInputLen       = 16
 )
 

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -15,12 +15,16 @@
 
 package spath
 
-import (
-	"github.com/scionproto/scion/go/lib/common"
-)
+import "github.com/scionproto/scion/go/lib/common"
 
 const (
 	MaxTimestamp = ^uint32(0)
+)
+
+var (
+	// MaxExpirationTime is the maximum absolute expiration time of SCION hop
+	// fields.
+	MaxExpirationTime = uint64(MaxTimestamp) * uint64(MaxTTLField.ToDuration().Seconds())
 )
 
 type Path struct {

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -15,16 +15,21 @@
 
 package spath
 
-import "github.com/scionproto/scion/go/lib/common"
+import (
+	"math"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/common"
+)
 
 const (
-	MaxTimestamp = ^uint32(0)
+	MaxTimestamp = math.MaxUint32
 )
 
 var (
 	// MaxExpirationTime is the maximum absolute expiration time of SCION hop
 	// fields.
-	MaxExpirationTime = uint64(MaxTimestamp) * uint64(MaxTTLField.ToDuration().Seconds())
+	MaxExpirationTime = time.Unix(MaxTimestamp, 0).Add(MaxTTLField.ToDuration())
 )
 
 type Path struct {

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -284,7 +284,7 @@ func (f *fetcherHandler) buildSCIONDReplyEntries(paths []*combinator.Path) []sci
 				FwdPath:    x.Bytes(),
 				Mtu:        path.Mtu,
 				Interfaces: path.Interfaces,
-				ExpTime:    uint32(path.ComputeExpTime()),
+				ExpTime:    uint32(path.ComputeExpTime().Unix()),
 			},
 			HostInfo: sciond.HostInfoFromTopoBRAddr(*ifInfo.InternalAddrs),
 		})
@@ -504,9 +504,9 @@ func buildPathsToAllDsts(req *sciond.PathReq,
 
 func filterExpiredPaths(paths []*combinator.Path) []*combinator.Path {
 	var validPaths []*combinator.Path
-	now := uint64(time.Now().Unix())
+	now := time.Now()
 	for _, path := range paths {
-		if path.ComputeExpTime() >= now {
+		if path.ComputeExpTime().After(now) {
 			validPaths = append(validPaths, path)
 		}
 	}

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -284,7 +284,7 @@ func (f *fetcherHandler) buildSCIONDReplyEntries(paths []*combinator.Path) []sci
 				FwdPath:    x.Bytes(),
 				Mtu:        path.Mtu,
 				Interfaces: path.Interfaces,
-				ExpTime:    util.TimeToSecs(path.ExpTime),
+				ExpTime:    uint32(path.ComputeExpTime()),
 			},
 			HostInfo: sciond.HostInfoFromTopoBRAddr(*ifInfo.InternalAddrs),
 		})
@@ -499,7 +499,18 @@ func buildPathsToAllDsts(req *sciond.PathReq,
 	for _, dst := range dsts {
 		paths = append(paths, combinator.Combine(req.Src.IA(), dst, ups, cores, downs)...)
 	}
-	return paths
+	return filterExpiredPaths(paths)
+}
+
+func filterExpiredPaths(paths []*combinator.Path) []*combinator.Path {
+	var validPaths []*combinator.Path
+	now := uint64(time.Now().Unix())
+	for _, path := range paths {
+		if path.ComputeExpTime() >= now {
+			validPaths = append(validPaths, path)
+		}
+	}
+	return validPaths
 }
 
 // NewExtendedContext returns a new _independent_ context that can extend past


### PR DESCRIPTION
Also:
  - added unit tests for expiry calculation;
  - fixed a bug in spath (max value for hop ttl field caused computed ttl to be 0);
  - changed ttl computation to reduce rounding errors, and have max ttl be exactly equal to a day;
  - cleaned up path combinator a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1944)
<!-- Reviewable:end -->
