### PR TITLE
Add scion_path arg for python docker services

### DIFF
--- a/python/topology/generator.py
+++ b/python/topology/generator.py
@@ -1266,6 +1266,8 @@ class DockerGenerator(object):
             entry['container_name'] = k
             entry['volumes'].append('${PWD}/%s:/share/conf:ro' % os.path.join(base, k))
             entry['command'].append('--prom=%s' % _prom_addr_infra(v))
+            entry['command'].append('--sciond_path=%s' %  
+                get_default_sciond_path(ISD_AS(topo["ISD_AS"])))
             entry['command'].append(k)
             entry['command'].append('conf')
             self.dc_conf['services'][k] = entry
@@ -1299,6 +1301,8 @@ class DockerGenerator(object):
             entry['container_name'] = k
             entry['volumes'].append('${PWD}/%s:/share/conf:ro' % os.path.join(base, k))
             entry['command'].append('--prom=%s' % _prom_addr_infra(v))
+            entry['command'].append('--sciond_path=%s' %  
+                get_default_sciond_path(ISD_AS(topo["ISD_AS"])))
             entry['command'].append(k)
             entry['command'].append('conf')
             self.dc_conf['services'][k] = entry
@@ -1333,6 +1337,8 @@ class DockerGenerator(object):
             if self.ps == 'py':
                 entry['command'].append('--spki_cache_dir=cache')
                 entry['command'].append('--prom=%s' % _prom_addr_infra(v))
+                entry['command'].append('--sciond_path=%s' %  
+                    get_default_sciond_path(ISD_AS(topo["ISD_AS"])))
                 entry['command'].append(k)
                 entry['command'].append('conf')
             self.dc_conf['services'][k] = entry

--- a/python/topology/generator.py
+++ b/python/topology/generator.py
@@ -1267,7 +1267,7 @@ class DockerGenerator(object):
             entry['volumes'].append('${PWD}/%s:/share/conf:ro' % os.path.join(base, k))
             entry['command'].append('--prom=%s' % _prom_addr_infra(v))
             entry['command'].append('--sciond_path=%s' %
-                get_default_sciond_path(ISD_AS(topo["ISD_AS"])))
+                                    get_default_sciond_path(ISD_AS(topo["ISD_AS"])))
             entry['command'].append(k)
             entry['command'].append('conf')
             self.dc_conf['services'][k] = entry
@@ -1302,7 +1302,7 @@ class DockerGenerator(object):
             entry['volumes'].append('${PWD}/%s:/share/conf:ro' % os.path.join(base, k))
             entry['command'].append('--prom=%s' % _prom_addr_infra(v))
             entry['command'].append('--sciond_path=%s' %
-                get_default_sciond_path(ISD_AS(topo["ISD_AS"])))
+                                    get_default_sciond_path(ISD_AS(topo["ISD_AS"])))
             entry['command'].append(k)
             entry['command'].append('conf')
             self.dc_conf['services'][k] = entry
@@ -1338,7 +1338,7 @@ class DockerGenerator(object):
                 entry['command'].append('--spki_cache_dir=cache')
                 entry['command'].append('--prom=%s' % _prom_addr_infra(v))
                 entry['command'].append('--sciond_path=%s' %
-                    get_default_sciond_path(ISD_AS(topo["ISD_AS"])))
+                                        get_default_sciond_path(ISD_AS(topo["ISD_AS"])))
                 entry['command'].append(k)
                 entry['command'].append('conf')
             self.dc_conf['services'][k] = entry

--- a/python/topology/generator.py
+++ b/python/topology/generator.py
@@ -1266,7 +1266,7 @@ class DockerGenerator(object):
             entry['container_name'] = k
             entry['volumes'].append('${PWD}/%s:/share/conf:ro' % os.path.join(base, k))
             entry['command'].append('--prom=%s' % _prom_addr_infra(v))
-            entry['command'].append('--sciond_path=%s' %  
+            entry['command'].append('--sciond_path=%s' %
                 get_default_sciond_path(ISD_AS(topo["ISD_AS"])))
             entry['command'].append(k)
             entry['command'].append('conf')
@@ -1301,7 +1301,7 @@ class DockerGenerator(object):
             entry['container_name'] = k
             entry['volumes'].append('${PWD}/%s:/share/conf:ro' % os.path.join(base, k))
             entry['command'].append('--prom=%s' % _prom_addr_infra(v))
-            entry['command'].append('--sciond_path=%s' %  
+            entry['command'].append('--sciond_path=%s' %
                 get_default_sciond_path(ISD_AS(topo["ISD_AS"])))
             entry['command'].append(k)
             entry['command'].append('conf')
@@ -1337,7 +1337,7 @@ class DockerGenerator(object):
             if self.ps == 'py':
                 entry['command'].append('--spki_cache_dir=cache')
                 entry['command'].append('--prom=%s' % _prom_addr_infra(v))
-                entry['command'].append('--sciond_path=%s' %  
+                entry['command'].append('--sciond_path=%s' %
                     get_default_sciond_path(ISD_AS(topo["ISD_AS"])))
                 entry['command'].append(k)
                 entry['command'].append('conf')


### PR DESCRIPTION
Otherwise they cannot connect to sciond, since they'll try default.sock.
Running only end2end test with Python infra this problem didn't appear.
When running cert_req_test the problem appeared with Python infra.
When running Go-SD and Go-PS the problem also occured with the end2end test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1975)
<!-- Reviewable:end -->
