### PR TITLE
spkt: correct some common header fields units

### DIFF
--- a/go/lib/spkt/cmnhdr.go
+++ b/go/lib/spkt/cmnhdr.go
@@ -121,7 +121,7 @@ func (c *CmnHdr) HopFOffBytes() int {
 
 func (c CmnHdr) String() string {
 	return fmt.Sprintf(
-		"Ver:%d Dst:%s Src:%s TotalLen:%dB HdrLen: %dB CurrInfoF:%dB CurrHopF:%dB NextHdr:%s",
+		"Ver:%d Dst:%s Src:%s TotalLen:%dB HdrLen: %d CurrInfoF:%d CurrHopF:%d NextHdr:%s",
 		c.Ver, c.DstType, c.SrcType, c.TotalLen, c.HdrLen, c.CurrInfoF, c.CurrHopF, c.NextHdr,
 	)
 }


### PR DESCRIPTION
The following fields are not Bytes:
- header length
- current Info Field offset
- current Hop Field offset

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1985)
<!-- Reviewable:end -->
