### PR TITLE
border: check ifCurr before dereferencing it

### DIFF
--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -134,12 +134,13 @@ func (rp *RtrPkt) validateLocalIF(ifid *common.IFIDType) error {
 // mkInfoPathOffsets is a helper function to create an scmp.InfoPathOffsets
 // instance from the current packet.
 func (rp *RtrPkt) mkInfoPathOffsets() scmp.Info {
-	if curr, err := rp.IFCurr(); curr == nil || err != nil {
-		return nil
+	var ifid uint16
+	if curr, err := rp.IFCurr(); curr != nil && err == nil {
+		ifid = uint16(*curr)
 	}
 	return &scmp.InfoPathOffsets{
 		InfoF: uint16(rp.CmnHdr.CurrInfoF), HopF: uint16(rp.CmnHdr.CurrHopF),
-		IfID: uint16(*rp.ifCurr), Ingress: rp.DirFrom == rcmn.DirExternal,
+		IfID: ifid, Ingress: rp.DirFrom == rcmn.DirExternal,
 	}
 }
 

--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -134,6 +134,9 @@ func (rp *RtrPkt) validateLocalIF(ifid *common.IFIDType) error {
 // mkInfoPathOffsets is a helper function to create an scmp.InfoPathOffsets
 // instance from the current packet.
 func (rp *RtrPkt) mkInfoPathOffsets() scmp.Info {
+	if curr, err := rp.IFCurr(); curr == nil || err != nil {
+		return nil
+	}
 	return &scmp.InfoPathOffsets{
 		InfoF: uint16(rp.CmnHdr.CurrInfoF), HopF: uint16(rp.CmnHdr.CurrHopF),
 		IfID: uint16(*rp.ifCurr), Ingress: rp.DirFrom == rcmn.DirExternal,


### PR DESCRIPTION
There might be situations where ifCurr has not been set or cannot be
calculated because, ie. malformed headers.

Currently the border router panics in those situations when trying to
create SCMP path offsets information.

Safe check that ifCurr is set before use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1986)
<!-- Reviewable:end -->
