### PR TITLE
border: check errors before updating metadata

### DIFF
--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -360,13 +360,7 @@ func (rp *RtrPkt) IncPath() (bool, error) {
 	rp.infoF = infoF
 	rp.hopF = hopF
 	rp.IncrementedPath = true
-	if segChgd {
-		// Extract new ConsDir flag.
-		rp.consDirFlag = nil
-		if _, err = rp.ConsDirFlag(); err != nil {
-			return segChgd, err
-		}
-	}
+	rp.consDirFlag = &infoF.ConsDir
 	// Extract the next interface ID.
 	rp.ifNext = nil
 	if _, err = rp.IFNext(); err != nil {

--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -351,7 +351,7 @@ func (rp *RtrPkt) IncPath() (bool, error) {
 			scmp.NewError(scmp.C_Path, scmp.T_P_BadHopField, rp.mkInfoPathOffsets(), nil))
 	}
 	// Check that the segment didn't change from a down-segment to an up-segment.
-	if origConsDir && !*rp.consDirFlag {
+	if origConsDir && !infoF.ConsDir {
 		return segChgd, common.NewBasicError("Switched from down-segment to up-segment",
 			scmp.NewError(scmp.C_Path, scmp.T_P_BadSegment, rp.mkInfoPathOffsets(), nil))
 	}


### PR DESCRIPTION
Check for possible errors when incrementing the path before updating the
packet metadata, which can result in an invalid state.

The issue showed up when the border router processes a BadSegment
packet. Because the metadata is updated, when we create the scmp reply
and reverse the packet, we fail to increment the reversed path, not
being able to send the error back.

With this change, the packet metadata is only updated once we have
verified that there are no errors when incrementing the path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1988)
<!-- Reviewable:end -->
