### PR TITLE
border: best effort approach for scmp error quotes

### DIFF
--- a/go/border/rpkt/l4.go
+++ b/go/border/rpkt/l4.go
@@ -71,6 +71,10 @@ func (rp *RtrPkt) findL4() (bool, error) {
 	nextHdr := rp.idxs.nextHdrIdx.Type
 	offset := rp.idxs.nextHdrIdx.Index
 	for nextHdr == common.HopByHopClass || nextHdr == common.End2EndClass {
+		if len(rp.Raw[offset:]) < common.LineLen {
+			return false, common.NewBasicError("Bad header length", nil,
+				"min", common.LineLen, "actual", len(rp.Raw[offset:]))
+		}
 		currHdr := nextHdr
 		currExtn := common.ExtnType{Class: currHdr, Type: rp.Raw[offset+2]}
 		if currHdr == common.HopByHopClass {

--- a/go/border/rpkt/l4.go
+++ b/go/border/rpkt/l4.go
@@ -65,39 +65,39 @@ func (rp *RtrPkt) L4Hdr(verify bool) (l4.L4Header, error) {
 	return rp.l4, nil
 }
 
-// findL4 finds the layer 4 header, if any.
+// findL4 tries to find the layer 4 header, if any.
 func (rp *RtrPkt) findL4() (bool, error) {
 	// Start from the next unparsed header, if any.
 	nextHdr := rp.idxs.nextHdrIdx.Type
 	offset := rp.idxs.nextHdrIdx.Index
-	for offset < len(rp.Raw) {
+	for nextHdr == common.HopByHopClass || nextHdr == common.End2EndClass {
 		currHdr := nextHdr
-		if _, ok := common.L4Protocols[currHdr]; ok {
-			// Reached L4 protocol
-			rp.L4Type = nextHdr
-			rp.idxs.l4 = offset
-			break
-		}
-		// TODO(kormat): handle detecting unknown L4 protocols.
 		currExtn := common.ExtnType{Class: currHdr, Type: rp.Raw[offset+2]}
-		hdrLen := int(rp.Raw[offset+1]) * common.LineLen
-		rp.idxs.e2eExt = append(rp.idxs.e2eExt, extnIdx{currExtn, offset})
+		if currHdr == common.HopByHopClass {
+			rp.idxs.hbhExt = append(rp.idxs.hbhExt, extnIdx{currExtn, offset})
+		} else {
+			rp.idxs.e2eExt = append(rp.idxs.e2eExt, extnIdx{currExtn, offset})
+		}
 		nextHdr = common.L4ProtocolType(rp.Raw[offset])
-		offset += hdrLen
+		hdrLen := int(rp.Raw[offset+1]) * common.LineLen
 		if hdrLen == 0 {
 			// FIXME(kormat): Can't return an SCMP error as we can't parse the headers
 			return false, common.NewBasicError("0-length header", nil,
-				"nextHdr", nextHdr, "offset", offset)
+				"currHdr", currHdr, "nextHdr", nextHdr, "offset", offset)
 		}
+		offset += hdrLen
+		if offset > len(rp.Raw) {
+			// FIXME(kormat): Can't generally return an SCMP error as parsing the
+			// headers has failed.
+			return false, common.NewBasicError(ErrExtChainTooLong, nil,
+				"curr", offset, "max", len(rp.Raw))
+		}
+		rp.idxs.nextHdrIdx.Type = nextHdr
+		rp.idxs.nextHdrIdx.Index = offset
 	}
-	if offset > len(rp.Raw) {
-		// FIXME(kormat): Can't generally return an SCMP error as parsing the
-		// headers has failed.
-		return false, common.NewBasicError(ErrExtChainTooLong, nil,
-			"curr", offset, "max", len(rp.Raw))
-	}
-	rp.idxs.nextHdrIdx.Type = nextHdr
-	rp.idxs.nextHdrIdx.Index = offset
+	// Reached L4 Protocol
+	rp.L4Type = nextHdr
+	rp.idxs.l4 = offset
 	return true, nil
 }
 

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -287,12 +287,9 @@ func (rp *RtrPkt) ToScnPkt(verify bool) (*spkt.ScnPkt, error) {
 		}
 		sp.E2EExt = append(sp.E2EExt, se)
 	}
-	if sp.L4, err = rp.L4Hdr(verify); err != nil {
-		return nil, err
-	}
-	if sp.Pld, err = rp.Payload(verify); err != nil {
-		return nil, err
-	}
+	// Try to parse L4 and Payload, but we might fail to do so, ie. unsupported L4 protocol
+	sp.L4, _ = rp.L4Hdr(verify)
+	sp.Pld, _ = rp.Payload(verify)
 	return sp, nil
 }
 
@@ -300,6 +297,17 @@ func (rp *RtrPkt) ToScnPkt(verify bool) (*spkt.ScnPkt, error) {
 // packet identified by the blk argument. This is used, for example, by SCMP to
 // quote parts of the packet in an error response.
 func (rp *RtrPkt) GetRaw(blk scmp.RawBlock) common.RawBytes {
+	pldOff := rp.idxs.pld
+	if pldOff == 0 {
+		// Either we failed to find the L4 header or the L4 header is an unknown protocol.
+		pldOff = len(rp.Raw)
+	}
+	l4Off := rp.idxs.l4
+	if l4Off == 0 {
+		// L4 header not found, likely failed to parse extensions.
+		// Use the last parsed header as L4 offset
+		l4Off = rp.idxs.nextHdrIdx.Index
+	}
 	switch blk {
 	case scmp.RawCmnHdr:
 		return rp.Raw[:spkt.CmnHdrLen]
@@ -308,9 +316,9 @@ func (rp *RtrPkt) GetRaw(blk scmp.RawBlock) common.RawBytes {
 	case scmp.RawPathHdr:
 		return rp.Raw[rp.idxs.path:rp.CmnHdr.HdrLenBytes()]
 	case scmp.RawExtHdrs:
-		return rp.Raw[rp.CmnHdr.HdrLenBytes():rp.idxs.l4]
+		return rp.Raw[rp.CmnHdr.HdrLenBytes():l4Off]
 	case scmp.RawL4Hdr:
-		return rp.Raw[rp.idxs.l4:rp.idxs.pld]
+		return rp.Raw[l4Off:pldOff]
 	}
 	rp.Crit("Invalid raw block requested", "blk", blk)
 	return nil

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -288,8 +288,19 @@ func (rp *RtrPkt) ToScnPkt(verify bool) (*spkt.ScnPkt, error) {
 		sp.E2EExt = append(sp.E2EExt, se)
 	}
 	// Try to parse L4 and Payload, but we might fail to do so, ie. unsupported L4 protocol
-	sp.L4, _ = rp.L4Hdr(verify)
-	sp.Pld, _ = rp.Payload(verify)
+	if sp.L4, err = rp.L4Hdr(verify); err != nil {
+		if common.GetErrorMsg(err) != UnsupportedL4 {
+			return nil, err
+		}
+	}
+	if err == nil {
+		// L4 header was parsed without error, then parse payload
+		if sp.Pld, err = rp.Payload(verify); err != nil {
+			if common.GetErrorMsg(err) != UnsupportedL4 {
+				return nil, err
+			}
+		}
+	}
 	return sp, nil
 }
 

--- a/go/lib/scmp/pld.go
+++ b/go/lib/scmp/pld.go
@@ -98,6 +98,10 @@ func (p *Payload) Copy() (common.Payload, error) {
 }
 
 func (p *Payload) WritePld(b common.RawBytes) (int, error) {
+	if p.Len() > len(b) {
+		return 0, common.NewBasicError("Not engough space in buffer", nil,
+			"actual", len(b), "expected", p.Len())
+	}
 	offset := 0
 	if err := p.Meta.Write(b[offset:]); err != nil {
 		return 0, err


### PR DESCRIPTION
The border router findL4() method keeps track of the last parsed
header/eextension.

With this approach when generating SCMP quotes, it includes as much
relevant data as possible.

If the border router failed to parse the extensions, thus could not find
the L4 offset, it quotes everything after the last parsed extension as
the L4 quote.

If it found the L4 header but it is an unknown/unsupported protocol,
then it quotes everything from the L4 offset as the L4 quote.

With a best effort approach, if the buffer where the Payload is written
to does not have enough space, it will fail and it is up to the caller
to modify the SCMP quotes to fit in the buffer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/1994)
<!-- Reviewable:end -->
