### PR TITLE
Init revs before testing resemblance

### DIFF
--- a/go/lib/revcache/revcachetest/revcachetest.go
+++ b/go/lib/revcache/revcachetest/revcachetest.go
@@ -66,6 +66,7 @@ func testInsertGet(t *testing.T, revCache revcache.RevCache) {
 	SoMsg("Insert should return true for a new entry", inserted, ShouldBeTrue)
 	SoMsg("Insert a new entry should not err", err, ShouldBeNil)
 	srCache, ok, err := revCache.Get(ctx, revcache.NewKey(ia110, ifId15))
+	initRevInfo(t, srCache)
 	SoMsg("Get should return ok for existing entry", ok, ShouldBeTrue)
 	SoMsg("Get should not err for existing entry", err, ShouldBeNil)
 	SoMsg("Get should return previously inserted value", srCache, ShouldResemble, sr)
@@ -98,6 +99,8 @@ func testGetAll(t *testing.T, revCache revcache.RevCache) {
 		*revcache.NewKey(ia110, ifId15): {},
 	})
 	SoMsg("GetAll should not err", err, ShouldBeNil)
+	SoMsg("Should contain one rev", 1, ShouldEqual, len(revs))
+	initRevInfo(t, revs[0])
 	SoMsg("GetAll should return revs for the given keys", revs, ShouldResemble,
 		[]*path_mgmt.SignedRevInfo{sr1})
 
@@ -153,6 +156,7 @@ func testInsertNewer(t *testing.T, revCache revcache.RevCache) {
 	SoMsg("Insert should return true for a new entry", inserted, ShouldBeTrue)
 	SoMsg("Insert a new entry should not err", err, ShouldBeNil)
 	srCache, ok, err := revCache.Get(ctx, revcache.NewKey(ia110, ifId15))
+	initRevInfo(t, srCache)
 	SoMsg("Get should return ok for existing entry", ok, ShouldBeTrue)
 	SoMsg("Get should not err for existing entry", err, ShouldBeNil)
 	SoMsg("Get should return previously inserted value", srCache, ShouldResemble, srNew)
@@ -172,4 +176,9 @@ func defaultRevInfo(ia addr.IA, ifId common.IFIDType) *path_mgmt.RevInfo {
 		RawTimestamp: util.TimeToSecs(time.Now()),
 		RawTTL:       uint32((time.Duration(10) * time.Second).Seconds()),
 	}
+}
+
+func initRevInfo(t *testing.T, sr *path_mgmt.SignedRevInfo) {
+	_, err := sr.RevInfo()
+	xtest.FailOnErr(t, err)
 }

--- a/go/lib/revcache/revcachetest/revcachetest.go
+++ b/go/lib/revcache/revcachetest/revcachetest.go
@@ -66,7 +66,7 @@ func testInsertGet(t *testing.T, revCache revcache.RevCache) {
 	SoMsg("Insert should return true for a new entry", inserted, ShouldBeTrue)
 	SoMsg("Insert a new entry should not err", err, ShouldBeNil)
 	srCache, ok, err := revCache.Get(ctx, revcache.NewKey(ia110, ifId15))
-	initRevInfo(t, srCache)
+	MustParseRevInfo(t, srCache)
 	SoMsg("Get should return ok for existing entry", ok, ShouldBeTrue)
 	SoMsg("Get should not err for existing entry", err, ShouldBeNil)
 	SoMsg("Get should return previously inserted value", srCache, ShouldResemble, sr)
@@ -100,7 +100,7 @@ func testGetAll(t *testing.T, revCache revcache.RevCache) {
 	})
 	SoMsg("GetAll should not err", err, ShouldBeNil)
 	SoMsg("Should contain one rev", 1, ShouldEqual, len(revs))
-	initRevInfo(t, revs[0])
+	MustParseRevInfo(t, revs[0])
 	SoMsg("GetAll should return revs for the given keys", revs, ShouldResemble,
 		[]*path_mgmt.SignedRevInfo{sr1})
 
@@ -156,7 +156,7 @@ func testInsertNewer(t *testing.T, revCache revcache.RevCache) {
 	SoMsg("Insert should return true for a new entry", inserted, ShouldBeTrue)
 	SoMsg("Insert a new entry should not err", err, ShouldBeNil)
 	srCache, ok, err := revCache.Get(ctx, revcache.NewKey(ia110, ifId15))
-	initRevInfo(t, srCache)
+	MustParseRevInfo(t, srCache)
 	SoMsg("Get should return ok for existing entry", ok, ShouldBeTrue)
 	SoMsg("Get should not err for existing entry", err, ShouldBeNil)
 	SoMsg("Get should return previously inserted value", srCache, ShouldResemble, srNew)
@@ -178,7 +178,7 @@ func defaultRevInfo(ia addr.IA, ifId common.IFIDType) *path_mgmt.RevInfo {
 	}
 }
 
-func initRevInfo(t *testing.T, sr *path_mgmt.SignedRevInfo) {
+func MustParseRevInfo(t *testing.T, sr *path_mgmt.SignedRevInfo) {
 	_, err := sr.RevInfo()
 	xtest.FailOnErr(t, err)
 }


### PR DESCRIPTION
Since we create the revocations with a method that initializes the revInfo
field in the test we should also make sure that the loaded one has this field initialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2033)
<!-- Reviewable:end -->
