### PR TITLE
Update gopacket version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
                 command: ./tools/ci/docker_update
             - run:
                 name: Pull and tag scion_base image
-                command: ./tools/ci/prepare_image 89ee7e0b01200680f8620439bba7df9b8e825a04b57258c5ee6758a274443430
+                command: ./tools/ci/prepare_image 9a3e4dc16519ff8b1bffb623474d695dcc1dd4f9c5232daa55ecee07490a0db7
                 when: always
             - run:
                 name: Build scion:latest image

--- a/docker.sh
+++ b/docker.sh
@@ -79,7 +79,7 @@ cmd_clean() {
 
 common_args() {
     # Limit to 6G of ram, don't allow swapping.
-    local args="-h scion -m 6GB --memory-swap=6GB --shm-size=1024M $DOCKER_ARGS"
+    local args="-h scion -m 4GB --memory-swap=4GB --shm-size=1024M $DOCKER_ARGS"
     args+=" -v /var/run/docker.sock:/var/run/docker.sock"
     args+=" -v $SCION_MOUNT/gen:/home/scion/go/src/github.com/scionproto/scion/gen"
     args+=" -v $SCION_MOUNT/logs:/home/scion/go/src/github.com/scionproto/scion/logs"

--- a/docker.sh
+++ b/docker.sh
@@ -78,7 +78,7 @@ cmd_clean() {
 }
 
 common_args() {
-    # Limit to 6G of ram, don't allow swapping.
+    # Limit to 4G of ram, don't allow swapping.
     local args="-h scion -m 4GB --memory-swap=4GB --shm-size=1024M $DOCKER_ARGS"
     args+=" -v /var/run/docker.sock:/var/run/docker.sock"
     args+=" -v $SCION_MOUNT/gen:/home/scion/go/src/github.com/scionproto/scion/gen"

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -136,16 +136,16 @@
 			"revisionTime": "2016-10-12T20:53:35Z"
 		},
 		{
-			"checksumSHA1": "zYWRs1ulJNrF3bmnRQAEA2WnPQs=",
+			"checksumSHA1": "bBQats+Oofu1ynsNBZcZEfldr8U=",
 			"path": "github.com/google/gopacket",
-			"revision": "e20408befa7dcef61c3c35f53df06d3f8a194e60",
-			"revisionTime": "2017-06-05T10:28:22Z"
+			"revision": "a35e09f9f224786863ce609de910bc82fc4d4faf",
+			"revisionTime": "2018-10-23T10:10:25Z"
 		},
 		{
-			"checksumSHA1": "GV4QgbWjIWIAIhOlNAJDt8+MtE4=",
+			"checksumSHA1": "um5piGuv1mDW1MSN2W2MOk9I+lc=",
 			"path": "github.com/google/gopacket/layers",
-			"revision": "e20408befa7dcef61c3c35f53df06d3f8a194e60",
-			"revisionTime": "2017-06-05T10:28:22Z"
+			"revision": "a35e09f9f224786863ce609de910bc82fc4d4faf",
+			"revisionTime": "2018-10-23T10:10:25Z"
 		},
 		{
 			"checksumSHA1": "P3zGmsNjW8m15a+nks4FdVpFKwE=",


### PR DESCRIPTION
Update to a more recent version of gopacket, which includes the
following commit:
    Attempt to reduce memory usage caused by enums.go strings.
    commit-id: 8c5cfc5ae25c08c58287b22231251f3f9c155ec6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2035)
<!-- Reviewable:end -->
