### PR TITLE
Process SCMP errors caused by SCMP packets

### DIFF
--- a/c/dispatcher/dispatcher.c
+++ b/c/dispatcher/dispatcher.c
@@ -1016,7 +1016,7 @@ void send_scmp_reply(uint8_t *buf, SCMPL4Header *scmp, HostAddr *from, uint16_t 
     reverse_packet(buf);
     scmp->type = htons(type);
     zlog_debug(zc, "send SCMP %s to %s:%d",
-            scmp_ct_to_str(strbuf, ntohs(scmp->class_), ntohs(scmp->type)),
+            scmp_ct_to_str(strbuf, scmp->class_, scmp->type),
             addr_to_str(from->addr, from->addr_type, NULL),
             ntohs(from->port));
     remove_hbh_scmp_extn(buf);
@@ -1057,33 +1057,52 @@ void deliver_scmp(uint8_t *buf, SCMPL4Header *scmp, int len, HostAddr *from)
         goto cleanup;
     }
 
+    int sock;
     Entry *e;
-    L4Key key;
+    L4Key key = { 0 };
     char isd_as_str[MAX_ISD_AS_STR];
-    memset(&key, 0, sizeof(key));
-    key.isd_as = be64toh(*(isdas_t *)(pld->addr + ISD_AS_LEN));
-    memcpy(key.host, get_src_addr((uint8_t * )pld->cmnhdr), get_src_len((uint8_t * )pld->cmnhdr));
+    PingEntry *pe;
+    uint64_t id;
+    char strbuf[MAX_SCMP_CLASS_TYPE_STR] = { 0 };
     switch (pld->meta->l4_proto) {
-        case L4_UDP:
-            /* Find src info in payload */
-            key.port = ntohs(*(uint16_t *)(pld->l4hdr));
-            HASH_FIND(hh, udp_port_list, &key, sizeof(key), e);
-            if (!e) {
-                format_isd_as(isd_as_str, MAX_ISD_AS_STR, key.isd_as);
-                zlog_info(zc, "SCMP entry for %s %s:%d not found", isd_as_str,
-                        addr_to_str(key.host, DST_TYPE((SCIONCommonHeader *)buf), NULL), key.port);
-                goto cleanup;
-            }
-            zlog_debug(zc, "SCMP entry for %s %s:%d found",
-                    format_isd_as(isd_as_str, MAX_ISD_AS_STR, key.isd_as),
+    case L4_UDP:
+        key.isd_as = be64toh(*(isdas_t *)(pld->addr + ISD_AS_LEN));
+        memcpy(key.host, get_src_addr((uint8_t * )pld->cmnhdr),
+                get_src_len((uint8_t * )pld->cmnhdr));
+        /* Find src info in payload */
+        key.port = ntohs(*(uint16_t *)(pld->l4hdr));
+        HASH_FIND(hh, udp_port_list, &key, sizeof(key), e);
+        if (!e) {
+            format_isd_as(isd_as_str, MAX_ISD_AS_STR, key.isd_as);
+            zlog_warn(zc, "SCMP entry for %s %s:%d not found", isd_as_str,
                     addr_to_str(key.host, DST_TYPE((SCIONCommonHeader *)buf), NULL), key.port);
-            break;
-        default:
-            zlog_error(zc, "SCMP not supported for protocol %d", pld->meta->l4_proto);
             goto cleanup;
+        }
+        zlog_debug(zc, "SCMP entry for %s %s:%d found",
+                format_isd_as(isd_as_str, MAX_ISD_AS_STR, key.isd_as),
+                addr_to_str(key.host, DST_TYPE((SCIONCommonHeader *)buf), NULL), key.port);
+        sock = e->sock;
+        break;
+    case L4_SCMP:
+        // XXX This is a special case where the L4 header quote also contains the Meta and Info
+        // fields of the original SCMP packet, where the ID is always the first 8B of the Info.
+        id = *((uint64_t *)(pld->l4hdr + sizeof(SCMPL4Header) + sizeof(SCMPMetaHeader)));
+        HASH_FIND(hh, ping_list, &id, sizeof(id), pe);
+        if (!pe) {
+            zlog_warn(zc, "SCMP %s reply (%" PRIx64 ") entry not found",
+                    scmp_ct_to_str(strbuf, scmp->class_, scmp->type), be64toh(id));
+            goto cleanup;
+        }
+        zlog_debug(zc, "SCMP %s reply (%" PRIx64 ") entry found",
+                scmp_ct_to_str(strbuf, scmp->class_, scmp->type), be64toh(id));
+        sock = pe->sock;
+        break;
+    default:
+        zlog_error(zc, "SCMP not supported for protocol %d", pld->meta->l4_proto);
+        goto cleanup;
     }
 
-    deliver_data(e->sock, from, buf, len);
+    deliver_data(sock, from, buf, len);
 cleanup:
     free(pld);
 }
@@ -1111,7 +1130,7 @@ void add_scmp_entry(SCMPL4Header *scmp, int sock)
         e->id = id;
         e->sock = sock;
         HASH_ADD(hh, ping_list, id, sizeof(id), e);
-        zlog_debug(zc, "SCMP entry added: sock=%d, id=%" PRIx64, sock, id);
+        zlog_debug(zc, "SCMP entry added: sock=%d, id=%" PRIx64, sock, be64toh(id));
     } else if (e->sock != sock) {
         zlog_error(zc, "failed adding SCMP echo mapping. ID %" PRIx64 " already in use.", be64toh(id));
     }

--- a/c/dispatcher/dispatcher.c
+++ b/c/dispatcher/dispatcher.c
@@ -1016,7 +1016,7 @@ void send_scmp_reply(uint8_t *buf, SCMPL4Header *scmp, HostAddr *from, uint16_t 
     reverse_packet(buf);
     scmp->type = htons(type);
     zlog_debug(zc, "send SCMP %s to %s:%d",
-            scmp_ct_to_str(strbuf, scmp->class_, scmp->type),
+            scmp_ct_to_str(strbuf, ntohs(scmp->class_), ntohs(scmp->type)),
             addr_to_str(from->addr, from->addr_type, NULL),
             ntohs(from->port));
     remove_hbh_scmp_extn(buf);
@@ -1034,11 +1034,11 @@ void deliver_scmp_reply(uint8_t *buf, SCMPL4Header *scmp, int len, HostAddr *fro
     HASH_FIND(hh, ping_list, &id, sizeof(id), e);
     if (e != NULL) {
         zlog_debug(zc, "SCMP %s reply (%" PRIx64 ") entry found",
-                scmp_ct_to_str(strbuf, scmp->class_, scmp->type), be64toh(id));
+                scmp_ct_to_str(strbuf, ntohs(scmp->class_), ntohs(scmp->type)), be64toh(id));
         deliver_data(e->sock, from, buf, len);
     } else {
         zlog_warn(zc, "SCMP %s reply (%" PRIx64 ") entry not found",
-                scmp_ct_to_str(strbuf, scmp->class_, scmp->type), be64toh(id));
+                scmp_ct_to_str(strbuf, ntohs(scmp->class_), ntohs(scmp->type)), be64toh(id));
     }
     free(pld);
 }
@@ -1090,11 +1090,11 @@ void deliver_scmp(uint8_t *buf, SCMPL4Header *scmp, int len, HostAddr *from)
         HASH_FIND(hh, ping_list, &id, sizeof(id), pe);
         if (!pe) {
             zlog_warn(zc, "SCMP %s reply (%" PRIx64 ") entry not found",
-                    scmp_ct_to_str(strbuf, scmp->class_, scmp->type), be64toh(id));
+                    scmp_ct_to_str(strbuf, ntohs(scmp->class_), ntohs(scmp->type)), be64toh(id));
             goto cleanup;
         }
         zlog_debug(zc, "SCMP %s reply (%" PRIx64 ") entry found",
-                scmp_ct_to_str(strbuf, scmp->class_, scmp->type), be64toh(id));
+                scmp_ct_to_str(strbuf, ntohs(scmp->class_), ntohs(scmp->type)), be64toh(id));
         sock = pe->sock;
         break;
     default:

--- a/c/lib/scion/scmp.c
+++ b/c/lib/scion/scmp.c
@@ -148,23 +148,25 @@ const char *scmp_ext_to_str(uint16_t index)
 const char *scmp_ct_to_str(char *buf, uint16_t class, uint16_t type)
 {
     const char *class_str = NULL, *type_str = NULL;
+    uint16_t c = ntohs(class);
+    uint16_t t = ntohs(type);
 
-    class_str = scmp_class_to_str(class);
-    switch (class) {
+    class_str = scmp_class_to_str(c);
+    switch (c) {
     case SCMP_CLASS_GENERAL:
-        type_str = scmp_general_to_str(type);
+        type_str = scmp_general_to_str(t);
         break;
     case SCMP_CLASS_ROUTING:
-        type_str = scmp_routing_to_str(type);
+        type_str = scmp_routing_to_str(t);
         break;
     case SCMP_CLASS_CMNHDR:
-        type_str = scmp_cmnhdr_to_str(type);
+        type_str = scmp_cmnhdr_to_str(t);
         break;
     case SCMP_CLASS_PATH:
-        type_str = scmp_path_to_str(type);
+        type_str = scmp_path_to_str(t);
         break;
     case SCMP_CLASS_EXT:
-        type_str = scmp_ext_to_str(type);
+        type_str = scmp_ext_to_str(t);
         break;
     default:
         class_str = "Unknown Class";

--- a/c/lib/scion/scmp.c
+++ b/c/lib/scion/scmp.c
@@ -148,25 +148,23 @@ const char *scmp_ext_to_str(uint16_t index)
 const char *scmp_ct_to_str(char *buf, uint16_t class, uint16_t type)
 {
     const char *class_str = NULL, *type_str = NULL;
-    uint16_t c = ntohs(class);
-    uint16_t t = ntohs(type);
 
-    class_str = scmp_class_to_str(c);
-    switch (c) {
+    class_str = scmp_class_to_str(class);
+    switch (class) {
     case SCMP_CLASS_GENERAL:
-        type_str = scmp_general_to_str(t);
+        type_str = scmp_general_to_str(type);
         break;
     case SCMP_CLASS_ROUTING:
-        type_str = scmp_routing_to_str(t);
+        type_str = scmp_routing_to_str(type);
         break;
     case SCMP_CLASS_CMNHDR:
-        type_str = scmp_cmnhdr_to_str(t);
+        type_str = scmp_cmnhdr_to_str(type);
         break;
     case SCMP_CLASS_PATH:
-        type_str = scmp_path_to_str(t);
+        type_str = scmp_path_to_str(type);
         break;
     case SCMP_CLASS_EXT:
-        type_str = scmp_ext_to_str(t);
+        type_str = scmp_ext_to_str(type);
         break;
     default:
         class_str = "Unknown Class";

--- a/go/lib/scmp/info.go
+++ b/go/lib/scmp/info.go
@@ -63,6 +63,10 @@ type InfoEcho struct {
 
 func InfoEchoFromRaw(b common.RawBytes) (*InfoEcho, error) {
 	e := &InfoEcho{}
+	if len(b) < e.Len() {
+		return nil, common.NewBasicError("Can't parse SCMP Info Echo, buffer is too short",
+			nil, "expected", e.Len(), "actual", len(b))
+	}
 	if err := restruct.Unpack(b, common.Order, e); err != nil {
 		return nil, common.NewBasicError("Failed to unpack SCMP ECHO info", err)
 	}

--- a/go/lib/scmp/meta.go
+++ b/go/lib/scmp/meta.go
@@ -38,6 +38,10 @@ const (
 )
 
 func MetaFromRaw(b []byte) (*Meta, error) {
+	if len(b) < MetaLen {
+		return nil, common.NewBasicError("Can't parse SCMP meta subheader, buffer is too short",
+			nil, "expected", MetaLen, "actual", len(b))
+	}
 	m := &Meta{}
 	if err := restruct.Unpack(b, binary.BigEndian, m); err != nil {
 		return nil, common.NewBasicError("Failed to unpack SCMP Metadata", err)

--- a/go/tools/scmp/cmn/common.go
+++ b/go/tools/scmp/cmn/common.go
@@ -190,7 +190,7 @@ func Validate(pkt *spkt.ScnPkt) (*scmp.Hdr, *scmp.Payload, error) {
 	if scmpHdr.Class != scmp.C_Path || scmpHdr.Type != scmp.T_P_RevokedIF {
 		return scmpHdr, scmpPld, nil
 	}
-	// Handle recovation
+	// Handle revocation
 	infoRev, ok := scmpPld.Info.(*scmp.InfoRevocation)
 	if !ok {
 		return scmpHdr, scmpPld,

--- a/go/tools/scmp/echo/echo.go
+++ b/go/tools/scmp/echo/echo.go
@@ -113,7 +113,7 @@ func recvPkts() {
 		now := time.Now()
 		err = hpkt.ParseScnPkt(pkt, b[:pktLen])
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: SCION packet parse error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "ERROR: SCION packet parse: %v\n", err)
 			continue
 		}
 		// Validate packet
@@ -121,7 +121,7 @@ func recvPkts() {
 		var info *scmp.InfoEcho
 		scmpHdr, info, err = validate(pkt)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: SCMP validation error: %v\n", err)
+			fmt.Fprintf(os.Stderr, "ERROR: SCMP validation: %v\n", err)
 			continue
 		}
 		cmn.Stats.Recv += 1
@@ -161,7 +161,7 @@ func validate(pkt *spkt.ScnPkt) (*scmp.Hdr, *scmp.InfoEcho, error) {
 			// XXX Special case where the L4Hdr quote contains the Meta and Info fields
 			info, e := scmp.InfoEchoFromRaw(scmpPld.L4Hdr[scmp.HdrLen+scmp.MetaLen:])
 			if e == nil {
-				return nil, nil, common.NewBasicError("Error received", nil, "scmp_seq", info.Seq)
+				return nil, nil, common.NewBasicError("", err, "scmp_seq", info.Seq)
 			}
 		}
 		return nil, nil, err

--- a/go/tools/scmp/echo/echo.go
+++ b/go/tools/scmp/echo/echo.go
@@ -161,7 +161,7 @@ func validate(pkt *spkt.ScnPkt) (*scmp.Hdr, *scmp.InfoEcho, error) {
 			// XXX Special case where the L4Hdr quote contains the Meta and Info fields
 			info, e := scmp.InfoEchoFromRaw(scmpPld.L4Hdr[scmp.HdrLen+scmp.MetaLen:])
 			if e == nil {
-				fmt.Printf("recovation received for scmp_seq=%d\n", info.Seq)
+				return nil, nil, common.NewBasicError("Error received", nil, "scmp_seq", info.Seq)
 			}
 		}
 		return nil, nil, err

--- a/go/tools/scmp/echo/echo.go
+++ b/go/tools/scmp/echo/echo.go
@@ -98,6 +98,7 @@ func recvPkts() {
 		pktLen, err := cmn.Conn.Read(b)
 		if err != nil {
 			if common.IsTimeoutErr(err) {
+				//fmt.Printf("Missed packet scmp_seq=%d\n", expectedSeq)
 				if expectedSeq > recvSeq {
 					expectedSeq += 1
 				} else {
@@ -114,7 +115,7 @@ func recvPkts() {
 		err = hpkt.ParseScnPkt(pkt, b[:pktLen])
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: SCION packet parse error: %v\n", err)
-			break
+			continue
 		}
 		// Validate packet
 		var scmpHdr *scmp.Hdr
@@ -122,7 +123,7 @@ func recvPkts() {
 		scmpHdr, info, err = validate(pkt)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: SCMP validation error: %v\n", err)
-			break
+			continue
 		}
 		cmn.Stats.Recv += 1
 		if info.Seq > recvSeq {
@@ -155,20 +156,21 @@ func summary() {
 }
 
 func validate(pkt *spkt.ScnPkt) (*scmp.Hdr, *scmp.InfoEcho, error) {
-	scmpHdr, ok := pkt.L4.(*scmp.Hdr)
-	if !ok {
-		return nil, nil,
-			common.NewBasicError("Not an SCMP header", nil, "type", common.TypeOf(pkt.L4))
-	}
-	scmpPld, ok := pkt.Pld.(*scmp.Payload)
-	if !ok {
-		return nil, nil,
-			common.NewBasicError("Not an SCMP payload", nil, "type", common.TypeOf(pkt.Pld))
+	scmpHdr, scmpPld, err := cmn.Validate(pkt)
+	if err != nil {
+		if len(scmpPld.L4Hdr) > 0 {
+			// XXX Special case where the L4Hdr quote contains the Meta and Info fields
+			info, e := scmp.InfoEchoFromRaw(scmpPld.L4Hdr[scmp.HdrLen+scmp.MetaLen:])
+			if e == nil {
+				fmt.Printf("recovation received for scmp_seq=%d\n", info.Seq)
+			}
+		}
+		return nil, nil, err
 	}
 	info, ok := scmpPld.Info.(*scmp.InfoEcho)
 	if !ok {
 		return nil, nil,
-			common.NewBasicError("Not an Info Echo", nil, "type", common.TypeOf(info))
+			common.NewBasicError("Not an Info Echo", nil, "type", common.TypeOf(scmpPld.Info))
 	}
 	if info.Id != id {
 		return nil, nil,

--- a/go/tools/scmp/echo/echo.go
+++ b/go/tools/scmp/echo/echo.go
@@ -98,7 +98,6 @@ func recvPkts() {
 		pktLen, err := cmn.Conn.Read(b)
 		if err != nil {
 			if common.IsTimeoutErr(err) {
-				//fmt.Printf("Missed packet scmp_seq=%d\n", expectedSeq)
 				if expectedSeq > recvSeq {
 					expectedSeq += 1
 				} else {
@@ -158,7 +157,7 @@ func summary() {
 func validate(pkt *spkt.ScnPkt) (*scmp.Hdr, *scmp.InfoEcho, error) {
 	scmpHdr, scmpPld, err := cmn.Validate(pkt)
 	if err != nil {
-		if len(scmpPld.L4Hdr) > 0 {
+		if scmpPld != nil && len(scmpPld.L4Hdr) > 0 {
 			// XXX Special case where the L4Hdr quote contains the Meta and Info fields
 			info, e := scmp.InfoEchoFromRaw(scmpPld.L4Hdr[scmp.HdrLen+scmp.MetaLen:])
 			if e == nil {

--- a/go/tools/scmp/main.go
+++ b/go/tools/scmp/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/pathmgr"
@@ -37,7 +38,9 @@ var (
 	sciondPath   = flag.String("sciond", "", "Path to sciond socket")
 	dispatcher   = flag.String("dispatcher", reliable.DefaultDispPath, "Path to dispatcher socket")
 	sciondFromIA = flag.Bool("sciondFromIA", false, "SCIOND socket path from IA address:ISD-AS")
+	refresh      = flag.Bool("refresh", false, "Set refresh flag for SCIOND path request")
 	pathRes      *pathmgr.PR
+	sdConn       sciond.Connector
 )
 
 func main() {
@@ -55,11 +58,20 @@ func main() {
 	} else if *sciondPath == "" {
 		*sciondPath = sciond.GetDefaultSCIONDPath(nil)
 	}
+
+	// Connect to sciond
+	sd := sciond.NewService(*sciondPath)
+	sdConn, err = sd.ConnectTimeout(1 * time.Second)
+	if err != nil {
+		cmn.Fatal("Failed to connect to SCIOND: %v\n", err)
+	}
+
 	pathRes, err = pathmgr.New(sciond.NewService(*sciondPath), &pathmgr.Timers{}, nil)
 	if err != nil {
 		cmn.Fatal("Unable to initialize pathmgr\nerr=%v", err)
 	}
-	// Connect directly to the dispatcher
+
+	// Connect to the dispatcher
 	cmn.Conn, _, err = reliable.Register(*dispatcher, cmn.Local.IA, cmn.Local.Host, cmn.Bind.Host,
 		addr.SvcNone)
 	if err != nil {
@@ -101,17 +113,19 @@ func doCommand(cmd string) int {
 	return 0
 }
 
-func choosePath() *sciond.PathReplyEntry {
-	var paths []*sciond.PathReplyEntry
-	var pathIndex uint64
-
-	pathSet := pathRes.Query(cmn.Local.IA, cmn.Remote.IA)
-
-	if len(pathSet) == 0 {
-		return nil
+func choosePath() sciond.PathReplyEntry {
+	reply, err := sdConn.Paths(cmn.Remote.IA, cmn.Local.IA, 0,
+		sciond.PathReqFlags{Refresh: *refresh})
+	if err != nil {
+		cmn.Fatal("Failed to retrieve paths from SCIOND: %v\n", err)
 	}
-	for _, p := range pathSet {
-		paths = append(paths, p.Entry)
+	if reply.ErrorCode != sciond.ErrorOk {
+		cmn.Fatal("SCIOND unable to retrieve paths: %s\n", reply.ErrorCode)
+	}
+	var pathIndex uint64
+	paths := reply.Entries
+	if len(paths) == 0 {
+		cmn.Fatal("No paths available to remote destination")
 	}
 	if cmn.Interactive {
 		fmt.Printf("Available paths to %v\n", cmn.Remote.IA)
@@ -135,10 +149,8 @@ func choosePath() *sciond.PathReplyEntry {
 }
 
 func setPathAndMtu() uint16 {
-	cmn.PathEntry = choosePath()
-	if cmn.PathEntry == nil {
-		cmn.Fatal("No paths available to remote destination")
-	}
+	path := choosePath()
+	cmn.PathEntry = &path
 	cmn.Remote.Path = spath.New(cmn.PathEntry.Path.FwdPath)
 	cmn.Remote.Path.InitOffsets()
 	cmn.Remote.NextHop, _ = cmn.PathEntry.HostInfo.Overlay()
@@ -147,12 +159,7 @@ func setPathAndMtu() uint16 {
 
 func setLocalMtu() uint16 {
 	// Use local AS MTU when we have no path
-	sd := pathRes.Sciond()
-	c, err := sd.Connect()
-	if err != nil {
-		cmn.Fatal("Unable to connect to sciond")
-	}
-	reply, err := c.ASInfo(addr.IA{})
+	reply, err := sdConn.ASInfo(addr.IA{})
 	if err != nil {
 		cmn.Fatal("Unable to request AS info to sciond")
 	}

--- a/go/tools/scmp/main.go
+++ b/go/tools/scmp/main.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/pathmgr"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/sock/reliable"
 	"github.com/scionproto/scion/go/lib/spath"
@@ -39,7 +38,6 @@ var (
 	dispatcher   = flag.String("dispatcher", reliable.DefaultDispPath, "Path to dispatcher socket")
 	sciondFromIA = flag.Bool("sciondFromIA", false, "SCIOND socket path from IA address:ISD-AS")
 	refresh      = flag.Bool("refresh", false, "Set refresh flag for SCIOND path request")
-	pathRes      *pathmgr.PR
 	sdConn       sciond.Connector
 )
 
@@ -58,19 +56,12 @@ func main() {
 	} else if *sciondPath == "" {
 		*sciondPath = sciond.GetDefaultSCIONDPath(nil)
 	}
-
 	// Connect to sciond
 	sd := sciond.NewService(*sciondPath)
 	sdConn, err = sd.ConnectTimeout(1 * time.Second)
 	if err != nil {
 		cmn.Fatal("Failed to connect to SCIOND: %v\n", err)
 	}
-
-	pathRes, err = pathmgr.New(sciond.NewService(*sciondPath), &pathmgr.Timers{}, nil)
-	if err != nil {
-		cmn.Fatal("Unable to initialize pathmgr\nerr=%v", err)
-	}
-
 	// Connect to the dispatcher
 	cmn.Conn, _, err = reliable.Register(*dispatcher, cmn.Local.IA, cmn.Local.Host, cmn.Bind.Host,
 		addr.SvcNone)

--- a/go/tools/scmp/recordpath/recordpath.go
+++ b/go/tools/scmp/recordpath/recordpath.go
@@ -104,20 +104,14 @@ func prettyPrint(pkt *spkt.ScnPkt, pktLen int, info *scmp.InfoRecordPath, rtt ti
 func validate(pkt *spkt.ScnPkt, pathEntry *sciond.PathReplyEntry) (*scmp.Hdr,
 	*scmp.InfoRecordPath, error) {
 
-	scmpHdr, ok := pkt.L4.(*scmp.Hdr)
-	if !ok {
-		return nil, nil,
-			common.NewBasicError("Not an SCMP header", nil, "type", common.TypeOf(pkt.L4))
-	}
-	scmpPld, ok := pkt.Pld.(*scmp.Payload)
-	if !ok {
-		return nil, nil,
-			common.NewBasicError("Not an SCMP payload", nil, "type", common.TypeOf(pkt.Pld))
+	scmpHdr, scmpPld, err := cmn.Validate(pkt)
+	if err != nil {
+		return nil, nil, err
 	}
 	info, ok := scmpPld.Info.(*scmp.InfoRecordPath)
 	if !ok {
 		return nil, nil,
-			common.NewBasicError("Not an Info RecordPath", nil, "type", common.TypeOf(info))
+			common.NewBasicError("Not an Info RecordPath", nil, "type", common.TypeOf(scmpPld.Info))
 	}
 	if info.Id != id {
 		return nil, nil,


### PR DESCRIPTION
There are a few issues when processing SCMP errors caused by SCMP packes,
like SCMP echo, by the border router and the dispatcher:
The border router fails to include the SCMP Info field, containing the
ID which is required to deliver the packet to the application.
The dispatcher does not process SCMP errors of SCMP packets.

This change adds the required support to the border router and the
dispatcher as well as modifying the SCMP tool to be able to deal with
SCMP revocations. It also adds a refresh flag to the scmp tool, which
now talks to sciond instead of the path manager.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2052)
<!-- Reviewable:end -->
