### PR TITLE
log.LogPanicAndExit is callers responsibility

### DIFF
--- a/go/border/error.go
+++ b/go/border/error.go
@@ -1,4 +1,5 @@
 // Copyright 2016 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,7 +49,6 @@ func (r *Router) handlePktError(rp *rpkt.RtrPkt, perr error, desc string) {
 
 // PackeError creates an SCMP error for the given packet and sends it to its source.
 func (r *Router) PacketError() {
-	defer log.LogPanicAndExit()
 	// Run forever.
 	for args := range r.pktErrorQ {
 		r.doPktError(args.rp, args.perr)

--- a/go/border/io-hsr.go
+++ b/go/border/io-hsr.go
@@ -1,4 +1,5 @@
 // Copyright 2016 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +44,10 @@ type HSRInput struct {
 
 func (hi *HSRInput) Start() {
 	if !hi.running {
-		go hi.Func(hi.Router, hi.StopChan, hi.StoppedChan)
+		go func() {
+			defer log.LogPanicAndExit()
+			hi.Func(hi.Router, hi.StopChan, hi.StoppedChan)
+		}()
 		hi.running = true
 	}
 }

--- a/go/border/main.go
+++ b/go/border/main.go
@@ -1,4 +1,5 @@
 // Copyright 2016 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -89,6 +90,7 @@ func setupSignals() {
 	signal.Notify(sig, os.Interrupt)
 	signal.Notify(sig, syscall.SIGTERM)
 	go func() {
+		defer log.LogPanicAndExit()
 		<-sig
 		log.Info("Exiting")
 		profile.Stop()

--- a/go/border/metrics/metrics.go
+++ b/go/border/metrics/metrics.go
@@ -1,4 +1,5 @@
 // Copyright 2016 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -144,6 +145,9 @@ func Start() error {
 		return common.NewBasicError("Unable to bind prometheus metrics port", err)
 	}
 	log.Info("Exporting prometheus metrics", "addr", *promAddr)
-	go http.Serve(ln, nil)
+	go func() {
+		defer log.LogPanicAndExit()
+		http.Serve(ln, nil)
+	}()
 	return nil
 }

--- a/go/border/rctrl/ctrl.go
+++ b/go/border/rctrl/ctrl.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,7 +41,6 @@ var (
 )
 
 func Control(sRevInfoQ chan rpkt.RawSRevCallbackArgs) {
-	defer log.LogPanicAndExit()
 	var err error
 	logger = log.New("Part", "Control")
 	ctx := rctx.Get()
@@ -61,8 +60,14 @@ func Control(sRevInfoQ chan rpkt.RawSRevCallbackArgs) {
 		logger.Error("Listening on address", "addr", ctrlAddr, "err", err)
 		return
 	}
-	go ifStateUpdate()
-	go revInfoFwd(sRevInfoQ)
+	go func() {
+		defer log.LogPanicAndExit()
+		ifStateUpdate()
+	}()
+	go func() {
+		defer log.LogPanicAndExit()
+		revInfoFwd(sRevInfoQ)
+	}()
 	processCtrl()
 }
 

--- a/go/border/rctrl/ifstate.go
+++ b/go/border/rctrl/ifstate.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
-	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
 )
 
@@ -39,7 +38,6 @@ const (
 // interface state changes, so this is only needed as a fail-safe after
 // startup.
 func ifStateUpdate() {
-	defer log.LogPanicAndExit()
 	genIFStateReq()
 	for range time.Tick(ifStateFreq) {
 		genIFStateReq()

--- a/go/border/rctrl/revinfo.go
+++ b/go/border/rctrl/revinfo.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import (
 // RevInfoFwd takes RevInfos, and forwards them to the local Beacon Service
 // (BS) and Path Service (PS).
 func revInfoFwd(revInfoQ chan rpkt.RawSRevCallbackArgs) {
-	defer log.LogPanicAndExit()
 	// Run forever.
 	for args := range revInfoQ {
 		revInfo, err := args.SignedRevInfo.RevInfo()

--- a/go/border/rctx/io.go
+++ b/go/border/rctx/io.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,10 +75,16 @@ func NewSock(ring *ringbuf.Ring, conn conn.Conn, dir rcmn.Dir,
 func (s *Sock) Start() {
 	if !s.running {
 		if s.Reader != nil {
-			go s.Reader(s, s.stop, s.readerStopped)
+			go func() {
+				defer log.LogPanicAndExit()
+				s.Reader(s, s.stop, s.readerStopped)
+			}()
 		}
 		if s.Writer != nil {
-			go s.Writer(s, s.stop, s.writerStopped)
+			go func() {
+				defer log.LogPanicAndExit()
+				s.Writer(s, s.stop, s.writerStopped)
+			}()
 		}
 		s.running = true
 		log.Info("Sock routines started", "addr", s.Conn.LocalAddr())

--- a/go/border/router.go
+++ b/go/border/router.go
@@ -71,9 +71,18 @@ func NewRouter(id, confDir string) (*Router, error) {
 // Run sets up networking, and starts go routines for handling the main packet
 // processing as well as various other router functions.
 func (r *Router) Run() error {
-	go r.PacketError()
-	go r.confSig()
-	go rctrl.Control(r.sRevInfoQ)
+	go func() {
+		defer log.LogPanicAndExit()
+		r.PacketError()
+	}()
+	go func() {
+		defer log.LogPanicAndExit()
+		r.confSig()
+	}()
+	go func() {
+		defer log.LogPanicAndExit()
+		rctrl.Control(r.sRevInfoQ)
+	}()
 	// TODO(shitz): Here should be some code to periodically check the discovery
 	// service for updated info.
 	var wait chan struct{}
@@ -83,7 +92,6 @@ func (r *Router) Run() error {
 
 // confSig handles reloading the configuration when SIGHUP is received.
 func (r *Router) confSig() {
-	defer log.LogPanicAndExit()
 	for range sighup {
 		var err error
 		var config *conf.Conf

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -105,16 +105,19 @@ func setupSignals() {
 	signal.Notify(sig, os.Interrupt)
 	signal.Notify(sig, syscall.SIGTERM)
 	go func() {
+		defer log.LogPanicAndExit()
 		s := <-sig
 		log.Info("Received signal, exiting...", "signal", s)
 		log.Flush()
 		os.Exit(1)
 	}()
-	go configSig()
+	go func() {
+		defer log.LogPanicAndExit()
+		configSig()
+	}()
 }
 
 func configSig() {
-	defer log.LogPanicAndExit()
 	for range sighup {
 		log.Info("Reloading is not supported")
 	}

--- a/go/cert_srv/reiss_tasks.go
+++ b/go/cert_srv/reiss_tasks.go
@@ -250,7 +250,10 @@ func (r *ReissRequester) Run() {
 			}
 
 			ctx, cancelF := context.WithTimeout(context.Background(), DefaultReissTimeout)
-			go r.sendReq(ctx, cancelF, chain, config)
+			go func() {
+				defer log.LogPanicAndExit()
+				r.sendReq(ctx, cancelF, chain, config)
+			}()
 			time.Sleep(config.ReissRate)
 		}
 	}

--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -246,7 +247,10 @@ func (c *client) run() {
 	}
 	c.quicStream = newQuicStream(qstream)
 	log.Debug("Quic stream opened", "local", &local, "remote", &remote)
-	go c.send()
+	go func() {
+		defer log.LogPanicAndExit()
+		c.send()
+	}()
 	c.read()
 }
 
@@ -359,7 +363,10 @@ func (s server) run() {
 			break
 		}
 		log.Info("Quic session accepted", "src", qsess.RemoteAddr())
-		go s.handleClient(qsess)
+		go func() {
+			defer log.LogPanicAndExit()
+			s.handleClient(qsess)
+		}()
 	}
 }
 

--- a/go/lib/infra/example/main.go
+++ b/go/lib/infra/example/main.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,7 +46,10 @@ func main() {
 		serverApp.trustStore.NewChainReqHandler(false))
 	serverApp.messenger.AddHandler(infra.TRCRequest,
 		serverApp.trustStore.NewTRCReqHandler(false))
-	go serverApp.messenger.ListenAndServe()
+	go func() {
+		defer log.LogPanicAndExit()
+		serverApp.messenger.ListenAndServe()
+	}()
 	// Do work
 	select {}
 }

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -557,8 +557,8 @@ func (m *Messenger) serve(ctx context.Context, cancelF context.CancelFunc, pld *
 		return
 	}
 	go func() {
-		defer cancelF()
 		defer log.LogPanicAndExit()
+		defer cancelF()
 		handler.Handle(infra.NewRequest(ctx, msg, signedPld, address, pld.ReqId, logger))
 	}()
 }

--- a/go/lib/infra/modules/trust/trust_test.go
+++ b/go/lib/infra/modules/trust/trust_test.go
@@ -567,7 +567,10 @@ func TestTRCReqHandler(t *testing.T) {
 			Convey(tc.Name, func() {
 				handler := store.NewTRCReqHandler(tc.RecursionEnabled)
 				serverMessenger.AddHandler(infra.TRCRequest, handler)
-				go serverMessenger.ListenAndServe()
+				go func() {
+					defer log.LogPanicAndExit()
+					serverMessenger.ListenAndServe()
+				}()
 				defer serverMessenger.CloseServer()
 
 				ctx, cancelF := context.WithTimeout(context.Background(), testCtxTimeout)
@@ -685,7 +688,10 @@ func TestChainReqHandler(t *testing.T) {
 			Convey(tc.Name, func() {
 				handler := store.NewChainReqHandler(tc.RecursionEnabled)
 				serverMessenger.AddHandler(infra.ChainRequest, handler)
-				go serverMessenger.ListenAndServe()
+				go func() {
+					defer log.LogPanicAndExit()
+					serverMessenger.ListenAndServe()
+				}()
 				defer serverMessenger.CloseServer()
 
 				ctx, cancelF := context.WithTimeout(context.Background(), testCtxTimeout)

--- a/go/lib/log/log.go
+++ b/go/lib/log/log.go
@@ -86,6 +86,7 @@ func SetupLogFile(name string, logDir string, logLevel string, logSize int, logA
 
 	if logFlush > 0 {
 		go func() {
+			defer LogPanicAndExit()
 			for range time.Tick(time.Duration(logFlush) * time.Second) {
 				Flush()
 			}

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -129,7 +130,10 @@ func New(srvc sciond.Service, timers *Timers, logger log.Logger) (*PR, error) {
 		normalRefire:  timers.NormalRefire,
 		errorRefire:   timers.ErrorRefire,
 	}
-	go r.run()
+	go func() {
+		defer log.LogPanicAndExit()
+		r.run()
+	}()
 	return pr, nil
 }
 

--- a/go/lib/pathmgr/resolver.go
+++ b/go/lib/pathmgr/resolver.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,7 +42,6 @@ type resolver struct {
 // updates the path cache with the result. Periodic requests are readded to the
 // channel.
 func (r *resolver) run() {
-	defer log.LogPanicAndExit()
 	for request := range r.requestQueue {
 		aps := r.lookup(request.src, request.dst)
 		switch request.reqType {

--- a/go/lib/periodic/periodic.go
+++ b/go/lib/periodic/periodic.go
@@ -48,7 +48,10 @@ func StartPeriodicTask(task Task, ticker *time.Ticker, timeout time.Duration) *R
 		stop:    make(chan struct{}),
 		stopped: make(chan struct{}),
 	}
-	go runner.runLoop()
+	go func() {
+		defer log.LogPanicAndExit()
+		runner.runLoop()
+	}()
 	return runner
 }
 
@@ -61,7 +64,6 @@ func (r *Runner) Stop() {
 }
 
 func (r *Runner) runLoop() {
-	defer log.LogPanicAndExit()
 	defer close(r.stopped)
 	for {
 		select {

--- a/go/lib/pktdisp/disp.go
+++ b/go/lib/pktdisp/disp.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +32,6 @@ type DispatchFunc func(*DispPkt)
 // N.B. the DispPkt passed to f is reused, so applications should make a copy if
 // this is a problem.
 func PktDispatcher(c snet.Conn, f DispatchFunc) {
-	defer log.LogPanicAndExit()
 	var err error
 	var n int
 	dp := &DispPkt{Raw: make(common.RawBytes, common.MaxMTU)}

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -167,7 +167,10 @@ func (f *fetcherHandler) GetPaths(ctx context.Context, req *sciond.PathReq,
 	// and revocation cache.
 	subCtx, cancelF := NewExtendedContext(ctx, DefaultMinWorkerLifetime)
 	earlyTrigger := util.NewTrigger(earlyReplyInterval)
-	go f.fetchAndVerify(subCtx, cancelF, req, earlyTrigger, ps)
+	go func() {
+		defer log.LogPanicAndExit()
+		f.fetchAndVerify(subCtx, cancelF, req, earlyTrigger, ps)
+	}()
 	// Wait for deadlines while also waiting for the early reply.
 	select {
 	case <-earlyTrigger.Done():

--- a/go/sig/base/pollhdlr.go
+++ b/go/sig/base/pollhdlr.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +27,6 @@ import (
 )
 
 func PollReqHdlr() {
-	defer log.LogPanicAndExit()
 	log.Info("PollReqHdlr: starting")
 	for rpld := range disp.Dispatcher.PollReqC {
 		req, ok := rpld.P.(*mgmt.PollReq)

--- a/go/sig/disp/disp.go
+++ b/go/sig/disp/disp.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +29,10 @@ import (
 )
 
 func Init(conn snet.Conn) {
-	go pktdisp.PktDispatcher(conn, dispFunc)
+	go func() {
+		defer log.LogPanicAndExit()
+		pktdisp.PktDispatcher(conn, dispFunc)
+	}()
 }
 
 type RegType int

--- a/go/sig/egress/dispatcher/dispatcher.go
+++ b/go/sig/egress/dispatcher/dispatcher.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,7 +47,6 @@ func NewDispatcher(ia addr.IA, ring *ringbuf.Ring, ss egress.SessionSelector) *e
 }
 
 func (ed *egressDispatcher) Run() {
-	defer log.LogPanicAndExit()
 	ed.Info("EgressDispatcher: starting")
 	bufs := make(ringbuf.EntryList, egress.EgressBufPkts)
 	for {

--- a/go/sig/egress/reader/reader.go
+++ b/go/sig/egress/reader/reader.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,7 +49,6 @@ func NewReader(tunIO io.ReadWriteCloser) *Reader {
 }
 
 func (r *Reader) Run() {
-	defer log.LogPanicAndExit()
 	r.log.Info("EgressReader: starting")
 	bufs := make(ringbuf.EntryList, egress.EgressBufPkts)
 BatchLoop:

--- a/go/sig/egress/session/sessmon.go
+++ b/go/sig/egress/session/sessmon.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,7 +68,6 @@ func newSessMonitor(sess *Session) *sessMonitor {
 }
 
 func (sm *sessMonitor) run() {
-	defer log.LogPanicAndExit()
 	defer close(sm.sess.sessMonStopped)
 	// Setup timers
 	reqTick := time.NewTicker(tickLen)

--- a/go/sig/ingress/worker.go
+++ b/go/sig/ingress/worker.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -73,12 +74,10 @@ func NewWorker(remote *snet.Addr, sessId mgmt.SessionType) *Worker {
 }
 
 func (w *Worker) Stop() {
-	defer log.LogPanicAndExit()
 	w.Ring.Close()
 }
 
 func (w *Worker) Run() {
-	defer log.LogPanicAndExit()
 	w.Info("IngressWorker starting")
 	frames := make(ringbuf.EntryList, 64)
 	lastCleanup := time.Now()
@@ -143,7 +142,10 @@ func (w *Worker) cleanup() {
 			// Remove the reassembly list from the map and then release all frames
 			// back to the bufpool.
 			delete(w.rlists, epoch)
-			go rlist.removeAll()
+			go func() {
+				defer log.LogPanicAndExit()
+				rlist.removeAll()
+			}()
 		} else {
 			// Mark the reassembly list for deletion. If it is not accessed between now
 			// and the next cleanup interval, it will be removed.

--- a/go/sig/main.go
+++ b/go/sig/main.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -100,14 +101,23 @@ func main() {
 	}
 	egress.Init()
 	disp.Init(sigcmn.CtrlConn)
-	go base.PollReqHdlr()
+	go func() {
+		defer log.LogPanicAndExit()
+		base.PollReqHdlr()
+	}()
 	// Parse config
 	if loadConfig(*cfgPath) != true {
 		fatal("Unable to load config on startup")
 	}
-	go reloadOnSIGHUP(*cfgPath)
+	go func() {
+		defer log.LogPanicAndExit()
+		reloadOnSIGHUP(*cfgPath)
+	}()
 	// Spawn egress reader
-	go reader.NewReader(tunIO).Run()
+	go func() {
+		defer log.LogPanicAndExit()
+		reader.NewReader(tunIO).Run()
+	}()
 	// Spawn ingress Dispatcher.
 	if err := ingress.Init(tunIO); err != nil {
 		fatal("Unable to spawn ingress dispatcher", "err", err)
@@ -169,7 +179,6 @@ func setupTun() (io.ReadWriteCloser, error) {
 }
 
 func reloadOnSIGHUP(path string) {
-	defer log.LogPanicAndExit()
 	log.Info("reloadOnSIGHUP: started")
 	for range sighup {
 		log.Info("reloadOnSIGHUP: reloading...")

--- a/go/sig/metrics/metrics.go
+++ b/go/sig/metrics/metrics.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -108,7 +109,10 @@ func Start() error {
 	http.HandleFunc("/configversion", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintln(w, atomic.LoadUint64(&ConfigVersion))
 	})
-	go http.Serve(ln, nil)
+	go func() {
+		defer log.LogPanicAndExit()
+		http.Serve(ln, nil)
+	}()
 	return nil
 }
 


### PR DESCRIPTION
By using the same pattern everywhere we can easily check for go routines that do not call log.LogPanicAndExit.

Also this commit adds a few missing calls in fetcher and deduper and possibly more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2060)
<!-- Reviewable:end -->
