### PR TITLE
Delete double enabling of dispatcher reconnect

### DIFF
--- a/acceptance/reconnecting_acceptance/test
+++ b/acceptance/reconnecting_acceptance/test
@@ -11,12 +11,6 @@ test_setup() {
     set -e
     ./scion.sh topology zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
     # Enable automatic dispatcher reconnects in SCIOND and PS
-    for sd in gen/ISD1/*/endhost/sciond.toml; do
-        sed -i '/\[general\]/a ReconnectToDispatcher = true' "$sd"
-    done
-    for ps in gen/ISD1/*/ps*/psconfig.toml; do
-        sed -i '/\[general\]/a ReconnectToDispatcher = true' "$ps"
-    done
     ./scion.sh run
 }
 

--- a/acceptance/reconnecting_acceptance/test
+++ b/acceptance/reconnecting_acceptance/test
@@ -10,7 +10,6 @@ TEST_TOPOLOGY="topology/Tiny.topo"
 test_setup() {
     set -e
     ./scion.sh topology zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
-    # Enable automatic dispatcher reconnects in SCIOND and PS
     ./scion.sh run
 }
 


### PR DESCRIPTION
Test reconnecting_acceptance was failing due to dispatcher reconnects being enabled twice (now that it is a generator default).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2061)
<!-- Reviewable:end -->
