### PR TITLE
FROZEN: BR: Enable discovery service querying

### DIFF
--- a/go/border/conf/conf.go
+++ b/go/border/conf/conf.go
@@ -55,55 +55,101 @@ type Conf struct {
 
 // Load sets up the configuration, loading it from the supplied config directory.
 func Load(id, confDir string) (*Conf, error) {
-	var err error
+	conf := &Conf{
+		Dir: confDir,
+	}
+	if err := conf.LoadTopo(id); err != nil {
+		return nil, err
+	}
+	if err := conf.LoadAsConf(); err != nil {
+		return nil, err
+	}
+	if err := conf.LoadMasterKeys(); err != nil {
+		return nil, err
+	}
+	if err := conf.InitMacPool(); err != nil {
+		return nil, err
+	}
+	if err := conf.InitNet(); err != nil {
+		return nil, err
+	}
+	return conf, nil
+}
 
-	// Declare a new Conf instance, and load the topology config.
-	conf := &Conf{}
-	conf.Dir = confDir
-	topoPath := filepath.Join(conf.Dir, topology.CfgName)
-	if conf.Topo, err = topology.LoadFromFile(topoPath); err != nil {
-		return nil, err
-	}
-	conf.IA = conf.Topo.ISD_AS
-	// Find the config for this router.
-	topoBR, ok := conf.Topo.BR[id]
-	if !ok {
-		return nil, common.NewBasicError("Unable to find element ID in topology", nil,
-			"id", id, "path", topoPath)
-	}
-	conf.BR = &topoBR
-	// Load AS configuration
-	asConfPath := filepath.Join(conf.Dir, as_conf.CfgName)
-	if err = as_conf.Load(asConfPath); err != nil {
-		return nil, err
-	}
-	conf.ASConf = as_conf.CurrConf
-	// Load master keys
-	conf.MasterKeys, err = keyconf.LoadMaster(filepath.Join(conf.Dir, "keys"))
+// LoadTopo loads the topology from the config directory and initializes the
+// entries related to topo in the config.
+func (c *Conf) LoadTopo(id string) error {
+	topoPath := filepath.Join(c.Dir, topology.CfgName)
+	topo, err := topology.LoadFromFile(topoPath)
 	if err != nil {
-		return nil, common.NewBasicError("Unable to load master keys", err)
+		return err
 	}
+	if err := c.InitTopo(id, topo); err != nil {
+		return common.NewBasicError("Unable to initialize topo", err, "path", topoPath)
+	}
+	return nil
+}
+
+// InitTopo initializesthe entries related to topo in the config.
+func (c *Conf) InitTopo(id string, topo *topology.Topo) error {
+	c.Topo = topo
+	c.IA = c.Topo.ISD_AS
+	// Find the config for this router.
+	topoBR, ok := c.Topo.BR[id]
+	if !ok {
+		return common.NewBasicError("Unable to find element ID in topology", nil,
+			"id", id)
+	}
+	c.BR = &topoBR
+	return nil
+}
+
+// LoadAsConf loads the as config from the config directory.
+func (c *Conf) LoadAsConf() error {
+	asConfPath := filepath.Join(c.Dir, as_conf.CfgName)
+	if err := as_conf.Load(asConfPath); err != nil {
+		return err
+	}
+	c.ASConf = as_conf.CurrConf
+	return nil
+}
+
+// LoadMasterKeys loads the master keys from the config directory.
+func (c *Conf) LoadMasterKeys() error {
+	var err error
+	c.MasterKeys, err = keyconf.LoadMaster(filepath.Join(c.Dir, "keys"))
+	if err != nil {
+		return common.NewBasicError("Unable to load master keys", err)
+	}
+	return nil
+}
+
+// InitMacPool initializes the hop field mac pool.
+func (c *Conf) InitMacPool() error {
 	// Generate keys
 	// This uses 16B keys with 1000 hash iterations, which is the same as the
 	// defaults used by pycrypto.
-	hfGenKey := pbkdf2.Key(conf.MasterKeys.Key0, []byte("Derive OF Key"), 1000, 16, sha256.New)
+	hfGenKey := pbkdf2.Key(c.MasterKeys.Key0, []byte("Derive OF Key"), 1000, 16, sha256.New)
 
 	// First check for MAC creation errors.
-	if _, err = scrypto.InitMac(hfGenKey); err != nil {
-		return nil, err
+	if _, err := scrypto.InitMac(hfGenKey); err != nil {
+		return err
 	}
 	// Create a pool of MAC instances.
-	conf.HFMacPool = sync.Pool{
+	c.HFMacPool = sync.Pool{
 		New: func() interface{} {
 			mac, _ := scrypto.InitMac(hfGenKey)
 			return mac
 		},
 	}
+	return nil
+}
 
-	// Create network configuration
-	if conf.Net, err = netconf.FromTopo(conf.BR.IFIDs, conf.Topo.IFInfoMap); err != nil {
-		return nil, err
+// InitNet initializes the network configuration.
+func (c *Conf) InitNet() error {
+	var err error
+	if c.Net, err = netconf.FromTopo(c.BR.IFIDs, c.Topo.IFInfoMap); err != nil {
+		return err
 	}
-	// Save config
-	return conf, nil
+	return nil
 }

--- a/go/border/main.go
+++ b/go/border/main.go
@@ -36,10 +36,11 @@ import (
 )
 
 var (
-	id       = flag.String("id", "", "Element ID (Required. E.g. 'br4-ff00:0:2f')")
-	confDir  = flag.String("confd", ".", "Configuration directory")
-	profFlag = flag.Bool("profile", false, "Enable cpu and memory profiling")
-	version  = flag.Bool("version", false, "Output version information and exit.")
+	id        = flag.String("id", "", "Element ID (Required. E.g. 'br4-ff00:0:2f')")
+	confDir   = flag.String("confd", ".", "Configuration directory")
+	profFlag  = flag.Bool("profile", false, "Enable cpu and memory profiling")
+	version   = flag.Bool("version", false, "Output version information and exit.")
+	fetchTopo = flag.Bool("discovery", false, "Enable fetching topology from discovery service")
 )
 
 func main() {

--- a/go/border/rctx/rctx.go
+++ b/go/border/rctx/rctx.go
@@ -19,6 +19,7 @@ package rctx
 
 import (
 	"math/rand"
+	"sync"
 	"sync/atomic"
 
 	"github.com/scionproto/scion/go/border/conf"
@@ -44,6 +45,9 @@ type Ctx struct {
 	// keyed by the interface ID of the relevant link.
 	ExtSockOut map[common.IFIDType]*Sock
 }
+
+// SetLock serializes updating the router context.
+var SetLock sync.Mutex
 
 // ctx is the current router context object.
 var ctx atomic.Value

--- a/go/border/rdiscovery/discovery.go
+++ b/go/border/rdiscovery/discovery.go
@@ -1,0 +1,187 @@
+// Copyright 2018 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rdiscovery
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/scionproto/scion/go/border/conf"
+	"github.com/scionproto/scion/go/border/rctx"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/discovery"
+	"github.com/scionproto/scion/go/lib/discovery/topofetcher"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/periodic"
+	"github.com/scionproto/scion/go/lib/topology"
+)
+
+var (
+	// Rate is the time between requests to the discovery service.
+	Rate = 5 * time.Second
+	// Timeout is the timeout for a request to the discovery service.
+	Timeout = 2 * time.Second
+)
+
+// FetchTopo periodically fetches a new topology file from the discovery service
+// and updates the config accordingly.
+func FetchTopo(id string, setCtx func(*rctx.Ctx) error, sig <-chan struct{}) {
+	t := &task{
+		Logger: log.New("Part", "Discovery"),
+		id:     id,
+		setCtx: setCtx,
+	}
+	t.Info("Starting periodic topology update")
+	periodic.StartPeriodicTask(t, periodic.NewTicker(Rate), Timeout)
+	// Update topology when a sighup is received.
+	for range sig {
+		if t.fetcher != nil {
+			t.fetcher.UpdateInstances(rctx.Get().Conf.Topo.DS)
+		}
+	}
+}
+
+var _ periodic.Task = (*task)(nil)
+
+type task struct {
+	log.Logger
+	// id is the router id.
+	id string
+	// setCtx is the callback to set the context for a router.
+	setCtx func(*rctx.Ctx) error
+	// fetcher is the discovery service fetcher
+	fetcher *topofetcher.Fetcher
+	// localAddr is the local control address. When changed, the fetcher
+	// http client is changed and runner needs to be restarted.
+	localAddr string
+}
+
+func (t *task) Run(ctx context.Context) {
+	if err := t.run(ctx); err != nil {
+		log.Error("Unable to fetch topology", "err", err)
+	}
+}
+
+func (t *task) run(ctx context.Context) error {
+	rCtx := rctx.Get()
+	if t.fetcher == nil {
+		var err error
+		t.fetcher, err = topofetcher.New(
+			rCtx.Conf.Topo.DS,
+			discovery.FetchParams{
+				Mode: discovery.Dynamic,
+				File: discovery.Full,
+			},
+			topofetcher.Callbacks{
+				Error:  t.handleErr,
+				Update: t.handleTopo,
+			},
+			nil,
+		)
+		if err != nil {
+			return common.NewBasicError("Unable to initialize fetcher", err)
+		}
+	}
+	localAddr, err := getLocalAddr(rCtx)
+	if err != nil {
+		return common.NewBasicError("Unable to get local address", err)
+	}
+	if t.localAddr != localAddr {
+		if t.fetcher.Client, err = client(localAddr); err != nil {
+			return common.NewBasicError("Unable to create client", err)
+		}
+	}
+	t.fetcher.Run(ctx)
+	return nil
+}
+
+// handleErr is the callback for the topology fetcher.
+func (t *task) handleErr(err error) {
+	t.Error("Unable to fetch new topology", "err", err)
+}
+
+// handleTopo is the callback for the topology fetcher.
+func (t *task) handleTopo(topo *topology.Topo) {
+	if err := t.handleTopoE(topo); err != nil {
+		log.Error("Unable to handle topology", "err", err)
+	}
+}
+
+func (t *task) handleTopoE(topo *topology.Topo) error {
+	// Make sure border router is still in the toplogy. Otherwise,
+	// the topology is rejected.
+	if _, ok := topo.BR[t.id]; !ok {
+		return common.NewBasicError("Unable to find element ID in topology", nil, "id", t.id)
+	}
+	// Avoid race with sighup reloading.
+	rctx.SetLock.Lock()
+	defer rctx.SetLock.Unlock()
+	oldCtx := rctx.Get()
+
+	cfg := &conf.Conf{
+		Dir:        oldCtx.Conf.Dir,
+		ASConf:     oldCtx.Conf.ASConf,
+		MasterKeys: oldCtx.Conf.MasterKeys,
+	}
+	if err := cfg.InitTopo(t.id, topo); err != nil {
+		return common.NewBasicError("Unable to initialize topology", err)
+	}
+	if err := cfg.InitNet(); err != nil {
+		return common.NewBasicError("Unable to initialize network config", err)
+	}
+	if err := cfg.InitMacPool(); err != nil {
+		return common.NewBasicError("Unable to initialize mac pool", err)
+	}
+	if err := t.setCtx(rctx.New(cfg)); err != nil {
+		return common.NewBasicError("Unable to set context", err)
+	}
+	return nil
+}
+
+func client(localAddr string) (*http.Client, error) {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", localAddr+":0")
+	if err != nil {
+		return nil, err
+	}
+	// The border router needs to use the correct source address to make sure
+	// it is on the ACL. The local address is set to ctrl address of the border router.
+	client := &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				LocalAddr: tcpAddr,
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+				DualStack: true,
+			}).DialContext,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+	return client, nil
+}
+
+// getLocalAddr gets the local control address.
+func getLocalAddr(ctx *rctx.Ctx) (string, error) {
+	if _, ok := ctx.Conf.Topo.IFInfoMap[ctx.Conf.BR.IFIDs[0]]; !ok {
+		return "", common.NewBasicError("Missing ifid info", nil, "ifid", ctx.Conf.BR.IFIDs[0])
+	}
+	ctrl := ctx.Conf.Topo.IFInfoMap[ctx.Conf.BR.IFIDs[0]].CtrlAddrs
+	return ctrl.PublicAddr(ctrl.Overlay).L3.String(), nil
+}

--- a/go/border/setup.go
+++ b/go/border/setup.go
@@ -79,7 +79,7 @@ func (r *Router) setup() error {
 		return err
 	}
 	// Setup new context.
-	if err = r.setupNewContext(config); err != nil {
+	if err = r.setupCtxFromConfig(config); err != nil {
 		return err
 	}
 	// Clear capabilities after setting up the network. Capabilities are currently
@@ -120,10 +120,16 @@ func (r *Router) loadNewConfig() (*conf.Conf, error) {
 	return config, nil
 }
 
-// setupNewContext sets up a new router context.
-func (r *Router) setupNewContext(config *conf.Conf) error {
+// setupCtxFromConfig sets up a new router context from the config.
+func (r *Router) setupCtxFromConfig(config *conf.Conf) error {
+	rctx.SetLock.Lock()
+	defer rctx.SetLock.Unlock()
+	return r.setupContext(rctx.New(config))
+}
+
+// setupContext sets up a new router context. The caller must hold rctx.SetLock.
+func (r *Router) setupContext(ctx *rctx.Ctx) error {
 	oldCtx := rctx.Get()
-	ctx := rctx.New(config)
 	if err := r.setupNet(ctx, oldCtx); err != nil {
 		return err
 	}


### PR DESCRIPTION
Enact changes in the topology file (fixes #2066)
Add `-discovery` flag to BR to enable periodic topology fetching.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2080)
<!-- Reviewable:end -->
