### PR TITLE
border: unblock reader when closing a socket

### DIFF
--- a/go/border/rctx/io.go
+++ b/go/border/rctx/io.go
@@ -15,6 +15,8 @@
 package rctx
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/scionproto/scion/go/border/rcmn"
@@ -99,6 +101,9 @@ func (s *Sock) Stop() {
 		// The order of the sequence below is important:
 		// Close the Sock, which effectively only signals the Reader to finish.
 		close(s.stop)
+		// If there is no traffic, the Reader might be blocked reading from the socket, so
+		// unblock the reader with deadline
+		s.Conn.SetReadDeadline(time.Now())
 		if s.Reader != nil {
 			<-s.readerStopped
 		}

--- a/go/lib/overlay/conn/conn.go
+++ b/go/lib/overlay/conn/conn.go
@@ -49,6 +49,7 @@ type Conn interface {
 	WriteBatch([]ipv4.Message) (int, error)
 	LocalAddr() *overlay.OverlayAddr
 	RemoteAddr() *overlay.OverlayAddr
+	SetReadDeadline(time.Time) error
 	Close() error
 }
 
@@ -112,6 +113,11 @@ func (c *connUDPIPv4) WriteBatch(msgs []ipv4.Message) (int, error) {
 	return c.pconn.WriteBatch(msgs, 0)
 }
 
+// SetReadDeadline sets the read deadline associated with the endpoint.
+func (c *connUDPIPv4) SetReadDeadline(t time.Time) error {
+	return c.pconn.SetReadDeadline(t)
+}
+
 type connUDPIPv6 struct {
 	connUDPBase
 	pconn *ipv6.PacketConn
@@ -153,6 +159,11 @@ func (c *connUDPIPv6) ReadBatch(msgs []ipv4.Message, metas []ReadMeta) (int, err
 
 func (c *connUDPIPv6) WriteBatch(msgs []ipv4.Message) (int, error) {
 	return c.pconn.WriteBatch(msgs, 0)
+}
+
+// SetReadDeadline sets the read deadline associated with the endpoint.
+func (c *connUDPIPv6) SetReadDeadline(t time.Time) error {
+	return c.pconn.SetReadDeadline(t)
 }
 
 type connUDPBase struct {


### PR DESCRIPTION
When closing a socket, ie. interface change during config reload, with
no traffic, the reader will block forever waiting for packets.

Because we apparently want to flush any in-flight packet in the border
router, although we might already lose packets received by the nic but
not deliver to the application yet, we cannot close the socket at the
start. Thus, we need SetReadDeadline funcitonality to unblock the reader
and allow the proper socket cleanup steps.

Fixes #2078

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2088)
<!-- Reviewable:end -->
