### PR TITLE
Gracefully handle malformed dispatcher frames in SCIONElement

### DIFF
--- a/python/lib/socket.py
+++ b/python/lib/socket.py
@@ -283,8 +283,7 @@ class ReliableSocket(Socket):
             return None, None
         cookie, addr_type, packet_len = struct.unpack("!8sBI", buf)
         if cookie != self.COOKIE:
-            logging.critical("Dispatcher socket out of sync")
-            raise SCIONIOError
+            raise SCIONIOError("Dispatcher socket out of sync")
         port_len = 0
         if addr_type != AddrType.NONE:
             port_len = 2

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -1034,7 +1034,7 @@ class SCIONElement(object):
 
     def handle_recv(self, sock):
         """
-        Callback to handle a ready recving socket
+        Callback to handle a ready receiving socket
         """
         try:
             packet, addr = sock.recv()

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -44,6 +44,7 @@ from lib.defines import (
 from lib.errors import (
     SCIONBaseError,
     SCIONChecksumFailed,
+    SCIONIOError,
     SCIONServiceLookupError,
 )
 from lib.log import log_exception
@@ -1035,7 +1036,11 @@ class SCIONElement(object):
         """
         Callback to handle a ready recving socket
         """
-        packet, addr = sock.recv()
+        try:
+            packet, addr = sock.recv()
+        except SCIONIOError as e:
+            logging.error("Socket IO error: %s", e)
+            return
         if packet is None:
             self._socks.remove(sock)
             sock.close()


### PR DESCRIPTION
To test run infra with Python SCIOND. Then execute `echo "I expect this to crash the service" | socat STDIN UNIX-CONNECT:/run/shm/sciond/sd2-ff00_0_212.sock`

Fixes #2093

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2094)
<!-- Reviewable:end -->
