### PR TITLE
Fix reconnecting acceptance test

### DIFF
--- a/acceptance/reconnecting_acceptance/test
+++ b/acceptance/reconnecting_acceptance/test
@@ -15,10 +15,11 @@ test_setup() {
 
 test_run() {
     set -e
-    bin/end2end_integration -src 1-ff00:0:112 -dst 1-ff00:0:110
+    bin/end2end_integration -src 1-ff00:0:112 -dst 1-ff00:0:110 -attempts 5
     docker restart dispatcher
     sqlite3 gen-cache/sd1-ff00_0_112.path.db "delete from segments;"
-    bin/end2end_integration -src 1-ff00:0:112 -dst 1-ff00:0:110
+    sleep 5
+    bin/end2end_integration -src 1-ff00:0:112 -dst 1-ff00:0:110 -attempts 5
 }
 
 test_teardown() {


### PR DESCRIPTION
The processes involved in the end to end test were racing against SD's
reconnector for dispatcher ports, which meant sometimes collisions would
prevent SD from reconnecting. Also returns the behavior to the older
Python end to end, with multiple attempts per reconnection.