### PR TITLE
Fix pathdbtest and other small improvements

### DIFF
--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -38,9 +38,11 @@ type PathSegment struct {
 	RawSData     common.RawBytes        `capnp:"sdata"`
 	SData        *PathSegmentSignedData `capnp:"-"`
 	RawASEntries []*proto.SignedBlobS   `capnp:"asEntries"`
-	ASEntries    []*ASEntry             `capnp:"-"`
-	id           common.RawBytes
-	fullId       common.RawBytes
+	// ASEntries contains the AS entries.
+	// WARNING: Should never be modified! Use AddASEntry or create a new Segment instead.
+	ASEntries []*ASEntry `capnp:"-"`
+	id        common.RawBytes
+	fullId    common.RawBytes
 }
 
 func NewSeg(infoF *spath.InfoField) (*PathSegment, error) {
@@ -256,8 +258,13 @@ func (ps *PathSegment) AddASEntry(ase *ASEntry, signType proto.SignType,
 		Sign: proto.NewSignS(signType, signSrc),
 	})
 	ps.ASEntries = append(ps.ASEntries, ase)
-	ps.id = nil
+	ps.invalidateIds()
 	return nil
+}
+
+func (ps *PathSegment) invalidateIds() {
+	ps.id = nil
+	ps.fullId = nil
 }
 
 func (ps *PathSegment) SignLastASEntry(key common.RawBytes) error {

--- a/go/lib/infra/dedupe/notification.go
+++ b/go/lib/infra/dedupe/notification.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ func newNotificationTable() *notificationTable {
 }
 
 // Add registers ch with the dedupe and broadcast key maps. If a network
-// request needs to be issued, the returneed context is non-nil.
+// request needs to be issued, the returned context is non-nil.
 func (table *notificationTable) Add(req Request, ch ResponseChannel,
 	dedupeLifetime time.Duration) context.Context {
 
@@ -95,9 +95,8 @@ func (table *notificationTable) Add(req Request, ch ResponseChannel,
 		if expiry.After(time.Now()) {
 			ch <- response
 			return nil
-		} else {
-			table.cache.Delete(bkey)
 		}
+		table.cache.Delete(bkey)
 	}
 
 	// We need to chain ch to the notification lists, and start a handler

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -553,7 +553,7 @@ func (m *Messenger) serve(ctx context.Context, cancelF context.CancelFunc, pld *
 	m.handlersLock.RUnlock()
 	if handler == nil {
 		logger.Error("Received message, but handler not found", "from", address,
-			"msgType", msgType)
+			"msgType", msgType, "id", pld.ReqId)
 		return
 	}
 	go func() {

--- a/go/lib/pathdb/query/query.go
+++ b/go/lib/pathdb/query/query.go
@@ -68,3 +68,10 @@ func (r Results) Segs() seg.Segments {
 	}
 	return segs
 }
+
+// ByLastUpdate implements the sort.Interface to sort results by LastUpdate time stamp.
+type ByLastUpdate Results
+
+func (r ByLastUpdate) Len() int           { return len(r) }
+func (r ByLastUpdate) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+func (r ByLastUpdate) Less(i, j int) bool { return r[i].LastUpdate.Before(r[j].LastUpdate) }


### PR DESCRIPTION
Since IDs are cached we shouldn't modify ASEntries directly.

Also introduce some other helper methods and small fixes.