### PR TITLE
CS/trustdb: make sure context is used everywhere

### DIFF
--- a/go/cert_srv/internal/reiss/handler.go
+++ b/go/cert_srv/internal/reiss/handler.go
@@ -164,7 +164,7 @@ func (h *Handler) validateReq(c *cert.Certificate, vKey common.RawBytes,
 func (h *Handler) issueChain(ctx context.Context, c *cert.Certificate,
 	vKey common.RawBytes) (*cert.Chain, error) {
 
-	issCert, err := h.getIssuerCert()
+	issCert, err := h.getIssuerCert(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (h *Handler) issueChain(ctx context.Context, c *cert.Certificate,
 	if err != nil {
 		return nil, err
 	}
-	if _, err = h.State.TrustDB.InsertChain(chain); err != nil {
+	if _, err = h.State.TrustDB.InsertChain(ctx, chain); err != nil {
 		log.Error("[ReissHandler] Unable to write reissued certificate chain to disk", "err", err)
 		return nil, err
 	}
@@ -212,8 +212,8 @@ func (h *Handler) sendRep(ctx context.Context, addr net.Addr, chain *cert.Chain,
 	return msger.SendChainIssueReply(ctx, &cert_mgmt.ChainIssRep{RawChain: raw}, addr, id)
 }
 
-func (h *Handler) getIssuerCert() (*cert.Certificate, error) {
-	issCrt, err := h.State.TrustDB.GetIssCertMaxVersion(h.IA)
+func (h *Handler) getIssuerCert(ctx context.Context) (*cert.Certificate, error) {
+	issCrt, err := h.State.TrustDB.GetIssCertMaxVersion(ctx, h.IA)
 	if err != nil {
 		return nil, err
 	}

--- a/go/cert_srv/internal/reiss/requester.go
+++ b/go/cert_srv/internal/reiss/requester.go
@@ -111,7 +111,7 @@ func (r *Requester) handleRep(ctx context.Context, rep *cert_mgmt.ChainIssRep) (
 	if err = r.validateRep(ctx, chain); err != nil {
 		return true, common.NewBasicError("Unable to validate chain", err, "chain", chain)
 	}
-	if _, err = r.State.TrustDB.InsertChain(chain); err != nil {
+	if _, err = r.State.TrustDB.InsertChain(ctx, chain); err != nil {
 		return true, common.NewBasicError("Unable to insert reissued certificate chain in TrustDB",
 			err, "chain", chain)
 	}

--- a/go/lib/infra/modules/trust/handlers.go
+++ b/go/lib/infra/modules/trust/handlers.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -161,7 +161,7 @@ func (h *trcPushHandler) Handle() {
 	}
 	subCtx, cancelF := context.WithTimeout(h.request.Context(), HandlerTimeout)
 	defer cancelF()
-	n, err := h.store.trustdb.InsertTRCCtx(subCtx, trcObj)
+	n, err := h.store.trustdb.InsertTRC(subCtx, trcObj)
 	if err != nil {
 		logger.Error("[TrustStore:trcPushHandler] Unable to insert TRC into DB", "err", err)
 		return
@@ -195,7 +195,7 @@ func (h *chainPushHandler) Handle() {
 	}
 	subCtx, cancelF := context.WithTimeout(h.request.Context(), HandlerTimeout)
 	defer cancelF()
-	n, err := h.store.trustdb.InsertChainCtx(subCtx, chain)
+	n, err := h.store.trustdb.InsertChain(subCtx, chain)
 	if err != nil {
 		logger.Error("[TrustStore:chainPushHandler] Unable to insert chain into DB", "err", err)
 		return

--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -199,7 +199,7 @@ func (store *Store) GetTRC(ctx context.Context,
 func (store *Store) getTRC(ctx context.Context, isd addr.ISD, version uint64,
 	recurse bool, client, server net.Addr) (*trc.TRC, error) {
 
-	trcObj, err := store.trustdb.GetTRCVersionCtx(ctx, isd, version)
+	trcObj, err := store.trustdb.GetTRCVersion(ctx, isd, version)
 	if err != nil || trcObj != nil {
 		return trcObj, err
 	}
@@ -250,7 +250,7 @@ func (store *Store) insertTRCHook() ValidateTRCFunc {
 
 // insertTRCHookLocal always inserts the TRC into the database.
 func (store *Store) insertTRCHookLocal(ctx context.Context, trcObj *trc.TRC) error {
-	if _, err := store.trustdb.InsertTRCCtx(ctx, trcObj); err != nil {
+	if _, err := store.trustdb.InsertTRC(ctx, trcObj); err != nil {
 		return common.NewBasicError("Unable to store TRC in database", err)
 	}
 	return nil
@@ -297,7 +297,7 @@ func (store *Store) GetValidChain(ctx context.Context, ia addr.IA,
 func (store *Store) getValidChain(ctx context.Context, ia addr.IA, recurse bool,
 	client, server net.Addr) (*cert.Chain, error) {
 
-	chain, err := store.trustdb.GetChainMaxVersionCtx(ctx, ia)
+	chain, err := store.trustdb.GetChainMaxVersion(ctx, ia)
 	if err != nil || chain != nil {
 		return chain, err
 	}
@@ -342,7 +342,7 @@ func (store *Store) GetChain(ctx context.Context, ia addr.IA,
 func (store *Store) getChain(ctx context.Context, ia addr.IA, version uint64,
 	recurse bool, client net.Addr) (*cert.Chain, error) {
 
-	chain, err := store.trustdb.GetChainVersionCtx(ctx, ia, version)
+	chain, err := store.trustdb.GetChainVersion(ctx, ia, version)
 	if err != nil || chain != nil {
 		return chain, err
 	}
@@ -386,7 +386,7 @@ func (store *Store) newChainValidatorForwarding(validator *trc.TRC) ValidateChai
 		if err := verifyChain(validator, chain); err != nil {
 			return err
 		}
-		_, err := store.trustdb.InsertChainCtx(ctx, chain)
+		_, err := store.trustdb.InsertChain(ctx, chain)
 		if err != nil {
 			return common.NewBasicError("Unable to store CertChain in database", err)
 		}
@@ -422,7 +422,7 @@ func (store *Store) newChainValidatorLocal(validator *trc.TRC) ValidateChainFunc
 		if err := verifyChain(validator, chain); err != nil {
 			return err
 		}
-		_, err := store.trustdb.InsertChainCtx(ctx, chain)
+		_, err := store.trustdb.InsertChain(ctx, chain)
 		if err != nil {
 			return common.NewBasicError("Unable to store CertChain in database", err)
 		}
@@ -480,7 +480,7 @@ func (store *Store) LoadAuthoritativeTRC(dir string) error {
 	case common.GetErrorMsg(err) == ErrNotFoundLocally && fileTRC == nil:
 		return common.NewBasicError("No TRC found on disk or in trustdb", nil)
 	case common.GetErrorMsg(err) == ErrNotFoundLocally && fileTRC != nil:
-		_, err := store.trustdb.InsertTRC(fileTRC)
+		_, err := store.trustdb.InsertTRC(ctx, fileTRC)
 		return err
 	case err == nil && fileTRC == nil:
 		// Nothing to do, no TRC to load from file but we already have one in the DB
@@ -489,7 +489,7 @@ func (store *Store) LoadAuthoritativeTRC(dir string) error {
 		// Found a TRC file on disk, and found a TRC in the DB. Check versions.
 		switch {
 		case fileTRC.Version > dbTRC.Version:
-			_, err := store.trustdb.InsertTRC(fileTRC)
+			_, err := store.trustdb.InsertTRC(ctx, fileTRC)
 			return err
 		case fileTRC.Version == dbTRC.Version:
 			// Because it is the same version, check if the TRCs match
@@ -530,7 +530,7 @@ func (store *Store) LoadAuthoritativeChain(dir string) error {
 	case common.GetErrorMsg(err) == ErrMissingAuthoritative && fileChain == nil:
 		return common.NewBasicError("No chain found on disk or in trustdb", nil)
 	case common.GetErrorMsg(err) == ErrMissingAuthoritative && fileChain != nil:
-		_, err := store.trustdb.InsertChain(fileChain)
+		_, err := store.trustdb.InsertChain(ctx, fileChain)
 		return err
 	case err == nil && fileChain == nil:
 		// Nothing to do, no chain to load from file but we already have one in the DB
@@ -539,7 +539,7 @@ func (store *Store) LoadAuthoritativeChain(dir string) error {
 		// Found a chain file on disk, and found a chain in the DB. Check versions.
 		switch {
 		case fileChain.Leaf.Version > dbChain.Leaf.Version:
-			_, err := store.trustdb.InsertChain(fileChain)
+			_, err := store.trustdb.InsertChain(ctx, fileChain)
 			return err
 		case fileChain.Leaf.Version == dbChain.Leaf.Version:
 			// Because it is the same version, check if the chains match

--- a/go/lib/infra/modules/trust/trust_test.go
+++ b/go/lib/infra/modules/trust/trust_test.go
@@ -200,7 +200,7 @@ func TestGetValidTRC(t *testing.T) {
 
 				// Post-check DB state to verify insertion
 				for _, trcObj := range tc.DBTRCInChecks {
-					get, err := store.trustdb.GetTRCVersion(trcObj.ISD, trcObj.Version)
+					get, err := store.trustdb.GetTRCVersion(ctx, trcObj.ISD, trcObj.Version)
 					SoMsg("db err", err, ShouldBeNil)
 					SoMsg("db trc", get, ShouldResemble, trcObj)
 				}
@@ -345,7 +345,7 @@ func TestGetValidChain(t *testing.T) {
 
 				// Post-check DB state to verify insertion
 				for _, chain := range tc.DBChainInChecks {
-					get, err := store.trustdb.GetChainVersion(chain.Leaf.Subject,
+					get, err := store.trustdb.GetChainVersion(ctx, chain.Leaf.Subject,
 						chain.Leaf.Version)
 					SoMsg("db err", err, ShouldBeNil)
 					SoMsg("db chain", get, ShouldResemble, chain)
@@ -441,7 +441,7 @@ func TestGetChain(t *testing.T) {
 
 				// Post-check DB state to verify that unverified objects were not inserted
 				for _, chain := range tc.DBChainNotInChecks {
-					get, err := store.trustdb.GetChainVersion(chain.Leaf.Subject,
+					get, err := store.trustdb.GetChainVersion(ctx, chain.Leaf.Subject,
 						chain.Leaf.Version)
 					SoMsg("db err", err, ShouldBeNil)
 					SoMsg("db chain", get, ShouldBeNil)
@@ -770,13 +770,13 @@ func initStore(t *testing.T, ctrl *gomock.Controller,
 func insertTRC(t *testing.T, store *Store, trcObj *trc.TRC) {
 	t.Helper()
 
-	_, err := store.trustdb.InsertTRC(trcObj)
+	_, err := store.trustdb.InsertTRC(context.Background(), trcObj)
 	xtest.FailOnErr(t, err)
 }
 
 func insertChain(t *testing.T, store *Store, chain *cert.Chain) {
 	t.Helper()
 
-	_, err := store.trustdb.InsertChain(chain)
+	_, err := store.trustdb.InsertChain(context.Background(), chain)
 	xtest.FailOnErr(t, err)
 }

--- a/go/lib/infra/modules/trust/trustdb/db.go
+++ b/go/lib/infra/modules/trust/trustdb/db.go
@@ -225,16 +225,11 @@ func (db *DB) Close() error {
 
 // GetIssCertVersion returns the specified version of the issuer certificate for
 // ia. If version is scrypto.LatestVer, this is equivalent to GetCertMaxVersion.
-func (db *DB) GetIssCertVersion(ia addr.IA, version uint64) (*cert.Certificate, error) {
-	return db.GetIssCertVersionCtx(context.Background(), ia, version)
-}
-
-// GetIssCertVersionCtx is the context-aware version of GetIssCertVersion.
-func (db *DB) GetIssCertVersionCtx(ctx context.Context, ia addr.IA,
+func (db *DB) GetIssCertVersion(ctx context.Context, ia addr.IA,
 	version uint64) (*cert.Certificate, error) {
 
 	if version == scrypto.LatestVer {
-		return db.GetIssCertMaxVersionCtx(ctx, ia)
+		return db.GetIssCertMaxVersion(ctx, ia)
 	}
 	db.RLock()
 	defer db.RUnlock()
@@ -244,12 +239,7 @@ func (db *DB) GetIssCertVersionCtx(ctx context.Context, ia addr.IA,
 }
 
 // GetIssCertMaxVersion returns the max version of the issuer certificate for ia.
-func (db *DB) GetIssCertMaxVersion(ia addr.IA) (*cert.Certificate, error) {
-	return db.GetIssCertMaxVersionCtx(context.Background(), ia)
-}
-
-// GetIssCertMaxVersionCtx is the context-aware version of GetIssCertMaxVersion.
-func (db *DB) GetIssCertMaxVersionCtx(ctx context.Context, ia addr.IA) (*cert.Certificate, error) {
+func (db *DB) GetIssCertMaxVersion(ctx context.Context, ia addr.IA) (*cert.Certificate, error) {
 	db.RLock()
 	defer db.RUnlock()
 	var raw common.RawBytes
@@ -258,11 +248,7 @@ func (db *DB) GetIssCertMaxVersionCtx(ctx context.Context, ia addr.IA) (*cert.Ce
 }
 
 // InsertIssCert inserts the issuer certificate.
-func (db *DB) InsertIssCert(c *cert.Certificate) (int64, error) {
-	return db.InsertIssCertCtx(context.Background(), c)
-}
-
-func (db *DB) InsertIssCertCtx(ctx context.Context, crt *cert.Certificate) (int64, error) {
+func (db *DB) InsertIssCert(ctx context.Context, crt *cert.Certificate) (int64, error) {
 	raw, err := crt.JSON(false)
 	if err != nil {
 		return 0, common.NewBasicError("Unable to convert to JSON", err)
@@ -279,16 +265,11 @@ func (db *DB) InsertIssCertCtx(ctx context.Context, crt *cert.Certificate) (int6
 
 // GetLeafCertVersion returns the specified version of the issuer certificate for
 // ia. If version is scrypto.LatestVer, this is equivalent to GetCertMaxVersion.
-func (db *DB) GetLeafCertVersion(ia addr.IA, version uint64) (*cert.Certificate, error) {
-	return db.GetLeafCertVersionCtx(context.Background(), ia, version)
-}
-
-// GetLeafCertVersionCtx is the context-aware version of GetLeafCertVersion.
-func (db *DB) GetLeafCertVersionCtx(ctx context.Context, ia addr.IA,
+func (db *DB) GetLeafCertVersion(ctx context.Context, ia addr.IA,
 	version uint64) (*cert.Certificate, error) {
 
 	if version == scrypto.LatestVer {
-		return db.GetLeafCertMaxVersionCtx(ctx, ia)
+		return db.GetLeafCertMaxVersion(ctx, ia)
 	}
 	db.RLock()
 	defer db.RUnlock()
@@ -298,12 +279,7 @@ func (db *DB) GetLeafCertVersionCtx(ctx context.Context, ia addr.IA,
 }
 
 // GetLeafCertMaxVersion returns the max version of the issuer certificate for ia.
-func (db *DB) GetLeafCertMaxVersion(ia addr.IA) (*cert.Certificate, error) {
-	return db.GetLeafCertMaxVersionCtx(context.Background(), ia)
-}
-
-// GetLeafCertMaxVersionCtx is the context-aware version of GetLeafCertMaxVersion.
-func (db *DB) GetLeafCertMaxVersionCtx(ctx context.Context, ia addr.IA) (*cert.Certificate, error) {
+func (db *DB) GetLeafCertMaxVersion(ctx context.Context, ia addr.IA) (*cert.Certificate, error) {
 	db.RLock()
 	defer db.RUnlock()
 	var raw common.RawBytes
@@ -330,11 +306,7 @@ func parseCert(raw common.RawBytes, ia addr.IA, v uint64, err error) (*cert.Cert
 }
 
 // InsertLeafCert inserts the issuer certificate.
-func (db *DB) InsertLeafCert(c *cert.Certificate) (int64, error) {
-	return db.InsertLeafCertCtx(context.Background(), c)
-}
-
-func (db *DB) InsertLeafCertCtx(ctx context.Context, crt *cert.Certificate) (int64, error) {
+func (db *DB) InsertLeafCert(ctx context.Context, crt *cert.Certificate) (int64, error) {
 	raw, err := crt.JSON(false)
 	if err != nil {
 		return 0, common.NewBasicError("Unable to convert to JSON", err)
@@ -351,16 +323,11 @@ func (db *DB) InsertLeafCertCtx(ctx context.Context, crt *cert.Certificate) (int
 
 // GetChainVersion returns the specified version of the certificate chain for
 // ia. If version is scrypto.LatestVer, this is equivalent to GetChainMaxVersion.
-func (db *DB) GetChainVersion(ia addr.IA, version uint64) (*cert.Chain, error) {
-	return db.GetChainVersionCtx(context.Background(), ia, version)
-}
-
-// GetChainVersionCtx is the context-aware version of GetChainVersion.
-func (db *DB) GetChainVersionCtx(ctx context.Context, ia addr.IA,
+func (db *DB) GetChainVersion(ctx context.Context, ia addr.IA,
 	version uint64) (*cert.Chain, error) {
 
 	if version == scrypto.LatestVer {
-		return db.GetChainMaxVersionCtx(ctx, ia)
+		return db.GetChainMaxVersion(ctx, ia)
 	}
 	db.RLock()
 	defer db.RUnlock()
@@ -372,11 +339,7 @@ func (db *DB) GetChainVersionCtx(ctx context.Context, ia addr.IA,
 	return parseChain(rows, err)
 }
 
-func (db *DB) GetChainMaxVersion(ia addr.IA) (*cert.Chain, error) {
-	return db.GetChainMaxVersionCtx(context.Background(), ia)
-}
-
-func (db *DB) GetChainMaxVersionCtx(ctx context.Context, ia addr.IA) (*cert.Chain, error) {
+func (db *DB) GetChainMaxVersion(ctx context.Context, ia addr.IA) (*cert.Chain, error) {
 	db.RLock()
 	defer db.RUnlock()
 	rows, err := db.getChainMaxVersionStmt.QueryContext(ctx, ia.I, ia.A, ia.I, ia.A, ia.I, ia.A,
@@ -416,16 +379,11 @@ func parseChain(rows *sql.Rows, err error) (*cert.Chain, error) {
 
 // InsertChain inserts chain into the database. The first return value is the
 // number of rows affected.
-func (db *DB) InsertChain(chain *cert.Chain) (int64, error) {
-	return db.InsertChainCtx(context.Background(), chain)
-}
-
-// InsertChainCtx is the context aware version of InsertChain.
-func (db *DB) InsertChainCtx(ctx context.Context, chain *cert.Chain) (int64, error) {
-	if _, err := db.InsertLeafCertCtx(ctx, chain.Leaf); err != nil {
+func (db *DB) InsertChain(ctx context.Context, chain *cert.Chain) (int64, error) {
+	if _, err := db.InsertLeafCert(ctx, chain.Leaf); err != nil {
 		return 0, err
 	}
-	if _, err := db.InsertIssCertCtx(ctx, chain.Issuer); err != nil {
+	if _, err := db.InsertIssCert(ctx, chain.Issuer); err != nil {
 		return 0, err
 	}
 	db.Lock()
@@ -458,16 +416,11 @@ func (db *DB) getIssCertRowIDCtx(ctx context.Context, ia addr.IA, ver uint64) (i
 
 // GetTRCVersion returns the specified version of the TRC for
 // isd. If version is scrypto.LatestVer, this is equivalent to GetTRCMaxVersion.
-func (db *DB) GetTRCVersion(isd addr.ISD, version uint64) (*trc.TRC, error) {
-	return db.GetTRCVersionCtx(context.Background(), isd, version)
-}
-
-// GetTRCVersionCtx is the context aware version of GetTRCVersion.
-func (db *DB) GetTRCVersionCtx(ctx context.Context,
+func (db *DB) GetTRCVersion(ctx context.Context,
 	isd addr.ISD, version uint64) (*trc.TRC, error) {
 
 	if version == scrypto.LatestVer {
-		return db.GetTRCMaxVersionCtx(ctx, isd)
+		return db.GetTRCMaxVersion(ctx, isd)
 	}
 	db.RLock()
 	defer db.RUnlock()
@@ -486,11 +439,7 @@ func (db *DB) GetTRCVersionCtx(ctx context.Context,
 	return trcobj, nil
 }
 
-func (db *DB) GetTRCMaxVersion(isd addr.ISD) (*trc.TRC, error) {
-	return db.GetTRCMaxVersionCtx(context.Background(), isd)
-}
-
-func (db *DB) GetTRCMaxVersionCtx(ctx context.Context, isd addr.ISD) (*trc.TRC, error) {
+func (db *DB) GetTRCMaxVersion(ctx context.Context, isd addr.ISD) (*trc.TRC, error) {
 	db.RLock()
 	defer db.RUnlock()
 	var raw common.RawBytes
@@ -510,12 +459,7 @@ func (db *DB) GetTRCMaxVersionCtx(ctx context.Context, isd addr.ISD) (*trc.TRC, 
 
 // InsertTRC inserts trcobj into the database. The first return value is the
 // number of rows affected.
-func (db *DB) InsertTRC(trcobj *trc.TRC) (int64, error) {
-	return db.InsertTRCCtx(context.Background(), trcobj)
-}
-
-// InsertTRCCtx is the context aware version of InsertTRC.
-func (db *DB) InsertTRCCtx(ctx context.Context, trcobj *trc.TRC) (int64, error) {
+func (db *DB) InsertTRC(ctx context.Context, trcobj *trc.TRC) (int64, error) {
 	raw, err := trcobj.JSON(false)
 	if err != nil {
 		return 0, common.NewBasicError("Unable to convert to JSON", err)


### PR DESCRIPTION
-Remove trustdb methods without context.
-Make sure that the context is properly passed on to called methods.

Fixes #2069