### PR TITLE
Fix some integration test issues

### DIFF
--- a/.buildkite/deploy.yml
+++ b/.buildkite/deploy.yml
@@ -1,8 +1,8 @@
 - wait
 - label: Build app images
   command:
-    - make -C docker/perapp
     - mkdir docker/_build && touch docker/_build/scion.stamp
+    - make -C docker/perapp
   branches: "v*.*.*"
 - wait
 - label: Docker login

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -35,8 +35,8 @@ if [ "$BUILDKITE_BRANCH" == "master" ]; then
     "$BASE/acceptance.sh"
 fi
 
-# deploy
-cat "$BASE/deploy.yml"
-
 # Stop docker.sh
 cat "$BASE/teardown.yml"
+
+# deploy
+cat "$BASE/deploy.yml"

--- a/go/integration/end2end_integration/main.go
+++ b/go/integration/end2end_integration/main.go
@@ -26,10 +26,9 @@ import (
 )
 
 var (
-	name       = "end2end_integration"
-	cmd        = "./bin/end2end"
-	dockerArgs = []string{"tester", cmd}
-	attempts   = flag.Int("attempts", 1, "Number of attempts before giving up.")
+	name     = "end2end_integration"
+	cmd      = "./bin/end2end"
+	attempts = flag.Int("attempts", 1, "Number of attempts before giving up.")
 )
 
 func main() {

--- a/go/lib/infra/disp/disp.go
+++ b/go/lib/infra/disp/disp.go
@@ -171,8 +171,8 @@ func (d *Dispatcher) RecvFrom(ctx context.Context) (proto.Cerealizable, net.Addr
 func (d *Dispatcher) goBackgroundReceiver() {
 	go func() {
 		defer log.LogPanicAndExit()
-		d.log.Info("Started")
-		defer d.log.Info("Stopped")
+		d.log.Debug("Started")
+		defer d.log.Debug("Stopped")
 		defer close(d.stoppedChan)
 	Loop:
 		for {

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -281,7 +281,7 @@ func (n *SCIONNetwork) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr
 		// Update port
 		conn.laddr.Host.L4 = addr.NewL4UDPInfo(port)
 	}
-	log.Info("Registered with dispatcher", "addr", conn.laddr)
+	log.Debug("Registered with dispatcher", "addr", conn.laddr)
 	conn.conn = rconn
 	return conn, nil
 }

--- a/go/tools/scmp/cmn/common.go
+++ b/go/tools/scmp/cmn/common.go
@@ -185,7 +185,7 @@ func UpdatePktTS(pkt *spkt.ScnPkt, ts time.Time) {
 }
 
 func Fatal(msg string, a ...interface{}) {
-	fmt.Printf("CRIT: "+msg+"\n", a...)
+	fmt.Fprintf(os.Stderr, "CRIT: "+msg+"\n", a...)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
- Less `Info` logging from `snet`, less clutter in integration tests
- Fix deploy pipeline, stop CI container before deploy step
- Remove unused variable in `end2end` integration test
- Log scmp errors to Stderr, so the integration tests also log the error

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2111)
<!-- Reviewable:end -->
