### PR TITLE
Add SvcSIG service address

### DIFF
--- a/c/lib/scion/address.h
+++ b/c/lib/scion/address.h
@@ -71,6 +71,7 @@ static const uint32_t ADDR_LENS[] = {
 #define SVC_PATH_MGMT 1
 #define SVC_CERT_MGMT 2
 #define SVC_SIBRA 3
+#define SVC_SIG 4
 
 #define SVC_MULTICAST 0x8000
 

--- a/go/border/rctx/rctx.go
+++ b/go/border/rctx/rctx.go
@@ -123,6 +123,8 @@ func (ctx *Ctx) GetSVCNamesMap(svc addr.HostSVC) ([]string,
 		names, elemMap = t.CSNames, t.CS
 	case addr.SvcSB:
 		names, elemMap = t.SBNames, t.SB
+	case addr.SvcSIG:
+		names, elemMap = t.SIGNames, t.SIG
 	default:
 		return nil, nil, common.NewBasicError("Unsupported SVC address",
 			scmp.NewError(scmp.C_Routing, scmp.T_R_BadHost, nil, nil), "svc", svc)

--- a/go/lib/addr/host.go
+++ b/go/lib/addr/host.go
@@ -64,6 +64,7 @@ const (
 	SvcPS   HostSVC = 0x0001
 	SvcCS   HostSVC = 0x0002
 	SvcSB   HostSVC = 0x0003
+	SvcSIG  HostSVC = 0x0004
 	SvcNone HostSVC = 0xffff
 )
 

--- a/go/lib/common/defs.go
+++ b/go/lib/common/defs.go
@@ -28,13 +28,14 @@ const (
 )
 
 const (
-	BR = "BR"
-	BS = "BS"
-	PS = "PS"
-	CS = "CS"
-	SB = "SB"
-	RS = "RS"
-	DS = "DS"
+	BR  = "BR"
+	BS  = "BS"
+	PS  = "PS"
+	CS  = "CS"
+	SB  = "SB"
+	RS  = "RS"
+	SIG = "SIG"
+	DS  = "DS"
 )
 
 // Interface ID

--- a/go/lib/topology/raw.go
+++ b/go/lib/topology/raw.go
@@ -51,6 +51,7 @@ type RawTopo struct {
 	PathService        map[string]*RawSrvInfo `json:",omitempty"`
 	SibraService       map[string]*RawSrvInfo `json:",omitempty"`
 	RainsService       map[string]*RawSrvInfo `json:",omitempty"`
+	SIG                map[string]*RawSrvInfo `json:",omitempty"`
 	DiscoveryService   map[string]*RawSrvInfo `json:",omitempty"`
 }
 

--- a/go/lib/topology/testdata/basic.json
+++ b/go/lib/topology/testdata/basic.json
@@ -93,6 +93,12 @@
         "rs1-ff00:0:311-2": {"Addrs": {
             "IPv6": {"Public": {"Addr": "2001:db8:f00:b43::78", "L4Port": 30098}}}}
     },
+    "SIG": {
+        "sig1-ff00:0:311-1": {"Addrs": {
+            "IPv4": {"Public": {"Addr": "127.0.0.82", "L4Port": 30100}}}},
+        "sig1-ff00:0:311-2": {"Addrs": {
+            "IPv6": {"Public": {"Addr": "2001:db8:f00:b43::82", "L4Port": 30100}}}}
+    },
     "DiscoveryService": {
         "ds1-ff00:0:311-1": {"Addrs": {
             "IPv4": {"Public": {"Addr": "127.0.0.99", "L4Port": 53535}}}},

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -79,18 +79,20 @@ type Topo struct {
 	// if they want to use a given interface.
 	IFInfoMap map[common.IFIDType]IFInfo
 
-	BS      IDAddrMap
-	BSNames ServiceNames
-	CS      IDAddrMap
-	CSNames ServiceNames
-	PS      IDAddrMap
-	PSNames ServiceNames
-	SB      IDAddrMap
-	SBNames ServiceNames
-	RS      IDAddrMap
-	RSNames ServiceNames
-	DS      IDAddrMap
-	DSNames ServiceNames
+	BS       IDAddrMap
+	BSNames  ServiceNames
+	CS       IDAddrMap
+	CSNames  ServiceNames
+	PS       IDAddrMap
+	PSNames  ServiceNames
+	SB       IDAddrMap
+	SBNames  ServiceNames
+	RS       IDAddrMap
+	RSNames  ServiceNames
+	DS       IDAddrMap
+	DSNames  ServiceNames
+	SIG      IDAddrMap
+	SIGNames ServiceNames
 
 	ZK map[int]*addr.AppAddr
 }
@@ -104,6 +106,7 @@ func NewTopo() *Topo {
 		PS:        make(IDAddrMap),
 		SB:        make(IDAddrMap),
 		RS:        make(IDAddrMap),
+		SIG:       make(IDAddrMap),
 		DS:        make(IDAddrMap),
 		ZK:        make(map[int]*addr.AppAddr),
 		IFInfoMap: make(map[common.IFIDType]IFInfo),
@@ -211,7 +214,7 @@ func (t *Topo) populateBR(raw *RawTopo) error {
 }
 
 func (t *Topo) populateServices(raw *RawTopo) error {
-	// Populate BS, CS, PS, SB, RS and DS maps
+	// Populate BS, CS, PS, SB, RS, SIG and DS maps
 	var err error
 	t.BSNames, err = svcMapFromRaw(raw.BeaconService, common.BS, t.BS, t.Overlay)
 	if err != nil {
@@ -230,6 +233,10 @@ func (t *Topo) populateServices(raw *RawTopo) error {
 		return err
 	}
 	t.RSNames, err = svcMapFromRaw(raw.RainsService, common.RS, t.RS, t.Overlay)
+	if err != nil {
+		return err
+	}
+	t.SIGNames, err = svcMapFromRaw(raw.SIG, common.SIG, t.SIG, t.Overlay)
 	if err != nil {
 		return err
 	}
@@ -264,6 +271,8 @@ func (t *Topo) GetSvcInfo(svc proto.ServiceType) (*SVCInfo, error) {
 		return &SVCInfo{overlay: t.Overlay, names: t.CSNames, idTopoAddrMap: t.CS}, nil
 	case proto.ServiceType_sb:
 		return &SVCInfo{overlay: t.Overlay, names: t.SBNames, idTopoAddrMap: t.SB}, nil
+	case proto.ServiceType_sig:
+		return &SVCInfo{overlay: t.Overlay, names: t.SIGNames, idTopoAddrMap: t.SIG}, nil
 	case proto.ServiceType_ds:
 		return &SVCInfo{overlay: t.Overlay, names: t.DSNames, idTopoAddrMap: t.DS}, nil
 	default:

--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -176,6 +176,7 @@ func Test_Service_Count(t *testing.T) {
 		SoMsg("Checking PS", len(c.PS), ShouldEqual, 2)
 		SoMsg("Checking SB", len(c.SB), ShouldEqual, 2)
 		SoMsg("Checking RS", len(c.RS), ShouldEqual, 2)
+		SoMsg("Checking RS", len(c.SIG), ShouldEqual, 2)
 		SoMsg("Checking DS", len(c.DS), ShouldEqual, 2)
 	})
 

--- a/go/sig/sigcmn/common.go
+++ b/go/sig/sigcmn/common.go
@@ -83,6 +83,8 @@ func Init(ia addr.IA, ip net.IP) error {
 	l4 := addr.NewL4UDPInfo(uint16(*CtrlPort))
 	CtrlConn, err = snet.ListenSCION(
 		"udp4", &snet.Addr{IA: IA, Host: &addr.AppAddr{L3: Host, L4: l4}})
+	CtrlConn, err = snet.ListenSCIONWithBindSVC("udp4",
+		&snet.Addr{IA: IA, Host: &addr.AppAddr{L3: Host, L4: l4}}, nil, addr.SvcSIG)
 	if err != nil {
 		return common.NewBasicError("Error creating ctrl socket", err)
 	}

--- a/proto/common.capnp
+++ b/proto/common.capnp
@@ -13,10 +13,11 @@ enum LinkType {
 
 enum ServiceType {
     unset @0; # Not set
-    bs @1;  # Beacon service
-    ps @2;  # Path service
-    cs @3;  # Certificate service
-    sb @4;  # SIBRA service
-    ds @5;  # Discovery service
-    br @6;  # Border router
+    bs  @1;  # Beacon service
+    ps  @2;  # Path service
+    cs  @3;  # Certificate service
+    sb  @4;  # SIBRA service
+    ds  @5;  # Discovery service
+    br  @6;  # Border router
+    sig @7;  # SCION-IP gateway
 }

--- a/python/lib/packet/svc.py
+++ b/python/lib/packet/svc.py
@@ -38,20 +38,24 @@ class SVCType(object):
     CS_A = HostAddrSVC(2, raw=False)
     # SIBRA service
     SB_A = HostAddrSVC(3, raw=False)
+    # SIG service
+    SIG_A = HostAddrSVC(4, raw=False)
     # No service, used e.g., in TCP socket.
     NONE = HostAddrSVC(0xffff, raw=False)
 
 SVC_TO_SERVICE = {
-    SVCType.BS_A.addr: ServiceType.BS,
-    SVCType.BS_M.addr: ServiceType.BS,
-    SVCType.PS_A.addr: ServiceType.PS,
-    SVCType.CS_A.addr: ServiceType.CS,
-    SVCType.SB_A.addr: ServiceType.SIBRA,
+    SVCType.BS_A.addr:  ServiceType.BS,
+    SVCType.BS_M.addr:  ServiceType.BS,
+    SVCType.PS_A.addr:  ServiceType.PS,
+    SVCType.CS_A.addr:  ServiceType.CS,
+    SVCType.SIG_A.addr: ServiceType.SIG,
+    SVCType.SB_A.addr:  ServiceType.SIBRA,
 }
 
 SERVICE_TO_SVC_A = {
-    ServiceType.BS: SVCType.BS_A,
-    ServiceType.CS: SVCType.CS_A,
-    ServiceType.PS: SVCType.PS_A,
+    ServiceType.BS:    SVCType.BS_A,
+    ServiceType.CS:    SVCType.CS_A,
+    ServiceType.PS:    SVCType.PS_A,
     ServiceType.SIBRA: SVCType.SB_A,
+    ServiceType.SIG:   SVCType.SIG_A,
 }

--- a/python/lib/topology.py
+++ b/python/lib/topology.py
@@ -199,6 +199,7 @@ class Topology(object):
     :ivar list beacon_servers: beacons servers in the AS.
     :ivar list certificate_servers: certificate servers in the AS.
     :ivar list path_servers: path servers in the AS.
+    :ivar list sigs: SIGs in the as.
     :ivar list discovery_servers: discovery servers in the AS.
     :ivar list border_routers: border routers in the AS.
     :ivar list parent_interfaces: BR interfaces linking to upstream ASes.
@@ -215,6 +216,7 @@ class Topology(object):
         self.certificate_servers = []
         self.path_servers = []
         self.sibra_servers = []
+        self.sigs = []
         self.discovery_servers = []
         self.border_routers = []
         self.parent_interfaces = []
@@ -265,6 +267,7 @@ class Topology(object):
             ("CertificateService", self.certificate_servers),
             ("PathService", self.path_servers),
             ("SibraService", self.sibra_servers),
+            ("SIG", self.sigs),
             ("DiscoveryService", self.discovery_servers),
         ):
             for k, v in topology.get(type_, {}).items():
@@ -309,6 +312,7 @@ class Topology(object):
             ServiceType.CS: self.certificate_servers,
             ServiceType.PS: self.path_servers,
             ServiceType.SIBRA: self.sibra_servers,
+            ServiceType.SIG: self.sigs,
             ServiceType.DS: self.discovery_servers,
         }
         try:

--- a/python/lib/types.py
+++ b/python/lib/types.py
@@ -66,6 +66,8 @@ class ServiceType(TypeBase):
     DS = "ds"
     #: Border router
     BR = "br"
+    #: SCION-IP gateway
+    SIG = "sig"
 
 
 class ExtensionClass(TypeBase):

--- a/python/test/lib/topology_test.py
+++ b/python/test/lib/topology_test.py
@@ -165,6 +165,7 @@ class TestTopologyParseSrvDicts(object):
             'CertificateService': {"cs1": "cs1 val"},
             'PathService': {"ps1": "ps1 val", "ps2": "ps2 val"},
             'SibraService': {"sb1": "sb1 val"},
+            'SIG': {"sig1": "sig1 val"},
             'DiscoveryService': {"ds1": "ds1 val"},
         }
         inst = Topology()
@@ -173,9 +174,13 @@ class TestTopologyParseSrvDicts(object):
         inst._parse_srv_dicts(topo_dict)
         # Tests
         assert_these_calls(server, [
-            call("bs1 val", "bs1"), call("cs1 val", "cs1"),
-            call("ps1 val", "ps1"), call("ps2 val", "ps2"),
-            call("sb1 val", "sb1"), call("ds1 val", "ds1"),
+            call("bs1 val", "bs1"),
+            call("cs1 val", "cs1"),
+            call("ps1 val", "ps1"),
+            call("ps2 val", "ps2"),
+            call("sb1 val", "sb1"),
+            call("sig1 val", "sig1"),
+            call("ds1 val", "ds1"),
         ], any_order=True)
         ntools.eq_(inst.beacon_servers, ["bs1-bs1 val"])
         ntools.eq_(inst.certificate_servers, ["cs1-cs1 val"])


### PR DESCRIPTION
- Add the new service type
- Register SIG with the appropriate address
- Make topology parsers aware of the new service type
- This patch doesn't add SIGs to the topology generator