### PR TITLE
SD client API can now tolerate SD restarts

### DIFF
--- a/go/integration/cert_req/main.go
+++ b/go/integration/cert_req/main.go
@@ -170,7 +170,8 @@ func getSVCAddress() (*sciond.HostInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	reply, err := connector.SVCInfo([]proto.ServiceType{proto.ServiceType_cs})
+	reply, err := connector.SVCInfo(context.Background(),
+		[]proto.ServiceType{proto.ServiceType_cs})
 	if err != nil {
 		return nil, err
 	}

--- a/go/integration/cert_req/main.go
+++ b/go/integration/cert_req/main.go
@@ -170,8 +170,9 @@ func getSVCAddress() (*sciond.HostInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	reply, err := connector.SVCInfo(context.Background(),
-		[]proto.ServiceType{proto.ServiceType_cs})
+	ctx, cancelF := context.WithTimeout(context.Background(), integration.DefaultIOTimeout)
+	defer cancelF()
+	reply, err := connector.SVCInfo(ctx, []proto.ServiceType{proto.ServiceType_cs})
 	if err != nil {
 		return nil, err
 	}

--- a/go/integration/end2end/main.go
+++ b/go/integration/end2end/main.go
@@ -162,7 +162,7 @@ func (c client) getRemote(n int) error {
 	// Get paths from sciond
 	ctx, cancelF := context.WithTimeout(context.Background(), libint.CtxTimeout)
 	defer cancelF()
-	paths, err := c.sdConn.PathsCtx(ctx, remote.IA, integration.Local.IA, 1,
+	paths, err := c.sdConn.Paths(ctx, remote.IA, integration.Local.IA, 1,
 		sciond.PathReqFlags{Refresh: n != 0})
 	if err != nil {
 		return err

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -740,7 +740,8 @@ func (pr *pathingRequester) getBlockingPath(a net.Addr) (net.Addr, error) {
 	if err != nil {
 		return nil, err
 	}
-	paths, err := conn.Paths(snetAddress.IA, pr.local, 5, sciond.PathReqFlags{})
+	paths, err := conn.Paths(context.Background(), snetAddress.IA, pr.local, 5,
+		sciond.PathReqFlags{})
 	if err != nil {
 		return nil, err
 	}

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -703,7 +703,7 @@ func NewPathingRequester(signer ctrl.Signer, sigv ctrl.SigVerifier, d *disp.Disp
 func (pr *pathingRequester) Request(ctx context.Context, pld *ctrl.Pld,
 	a net.Addr) (*ctrl.Pld, *proto.SignS, error) {
 
-	newAddr, err := pr.getBlockingPath(a)
+	newAddr, err := pr.getBlockingPath(ctx, a)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -711,7 +711,7 @@ func (pr *pathingRequester) Request(ctx context.Context, pld *ctrl.Pld,
 }
 
 func (pr *pathingRequester) Notify(ctx context.Context, pld *ctrl.Pld, a net.Addr) error {
-	newAddr, err := pr.getBlockingPath(a)
+	newAddr, err := pr.getBlockingPath(ctx, a)
 	if err != nil {
 		return err
 	}
@@ -719,14 +719,14 @@ func (pr *pathingRequester) Notify(ctx context.Context, pld *ctrl.Pld, a net.Add
 }
 
 func (pr *pathingRequester) NotifyUnreliable(ctx context.Context, pld *ctrl.Pld, a net.Addr) error {
-	newAddr, err := pr.getBlockingPath(a)
+	newAddr, err := pr.getBlockingPath(ctx, a)
 	if err != nil {
 		return err
 	}
 	return pr.requester.NotifyUnreliable(ctx, pld, newAddr)
 }
 
-func (pr *pathingRequester) getBlockingPath(a net.Addr) (net.Addr, error) {
+func (pr *pathingRequester) getBlockingPath(ctx context.Context, a net.Addr) (net.Addr, error) {
 	// for SCIOND-less operation do not try to resolve paths
 	if snet.DefNetwork == nil || snet.DefNetwork.PathResolver() == nil {
 		return a, nil
@@ -740,8 +740,7 @@ func (pr *pathingRequester) getBlockingPath(a net.Addr) (net.Addr, error) {
 	if err != nil {
 		return nil, err
 	}
-	paths, err := conn.Paths(context.Background(), snetAddress.IA, pr.local, 5,
-		sciond.PathReqFlags{})
+	paths, err := conn.Paths(ctx, snetAddress.IA, pr.local, 5, sciond.PathReqFlags{})
 	if err != nil {
 		return nil, err
 	}

--- a/go/lib/pathmgr/infra_test.go
+++ b/go/lib/pathmgr/infra_test.go
@@ -45,7 +45,7 @@ func ExamplePR() {
 	}
 	// Initialize path resolver
 	sciondPath := sciond.GetDefaultSCIONDPath(&src)
-	sciondService := sciond.NewService(sciondPath)
+	sciondService := sciond.NewService(sciondPath, true)
 	pr, err := New(sciondService, nil, log.Root())
 	if err != nil {
 		fmt.Println("Failed to connect to SCIOND", "err", err)

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -40,6 +40,7 @@ package pathmgr
 // resolver operate over a thread-safe cache which contains path information.
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -247,12 +248,12 @@ func (r *PR) revoke(b common.RawBytes) {
 		log.Error("Revocation failed, unable to connect to SCIOND", "err", err)
 		return
 	}
-	reply, err := conn.RevNotification(sRevInfo)
+	reply, err := conn.RevNotification(context.Background(), sRevInfo)
 	if err != nil {
 		log.Error("Revocation failed, unable to inform SCIOND about revocation", "err", err)
 		return
 	}
-	err = conn.Close()
+	err = conn.Close(context.Background())
 	if err != nil {
 		log.Error("Revocation error, unable to close SCIOND connection", "err", err)
 		// Continue with revocation

--- a/go/lib/pathmgr/resolver.go
+++ b/go/lib/pathmgr/resolver.go
@@ -16,6 +16,7 @@
 package pathmgr
 
 import (
+	"context"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
@@ -79,7 +80,8 @@ func (r *resolver) run() {
 
 // lookup queries SCIOND, blocking while waiting for the response.
 func (r *resolver) lookup(src, dst addr.IA) spathmeta.AppPathSet {
-	reply, err := r.sciondConn.Paths(dst, src, numReqPaths, sciond.PathReqFlags{})
+	reply, err := r.sciondConn.Paths(context.Background(), dst, src, numReqPaths,
+		sciond.PathReqFlags{})
 	if err != nil {
 		log.Error("SCIOND network error", "err", err)
 		r.reconnect()

--- a/go/lib/pathpol/policy_test.go
+++ b/go/lib/pathpol/policy_test.go
@@ -15,6 +15,7 @@
 package pathpol
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -48,7 +49,8 @@ func TestBasicPolicy(t *testing.T) {
 	Convey("TestPolicy", t, func() {
 		for _, tc := range testCases {
 			Convey(tc.Name, func() {
-				paths, err := conn.Paths(tc.Dst, tc.Src, 5, sciond.PathReqFlags{})
+				paths, err := conn.Paths(context.Background(), tc.Dst, tc.Src, 5,
+					sciond.PathReqFlags{})
 				SoMsg("sciond err", err, ShouldBeNil)
 
 				inAPS := spathmeta.NewAppPathSet(paths)
@@ -184,7 +186,8 @@ func TestSequenceEval(t *testing.T) {
 	Convey("TestList", t, func() {
 		for _, tc := range testCases {
 			Convey(tc.Name, func() {
-				paths, err := conn.Paths(tc.Dst, tc.Src, 5, sciond.PathReqFlags{})
+				paths, err := conn.Paths(context.Background(), tc.Dst, tc.Src, 5,
+					sciond.PathReqFlags{})
 				SoMsg("sciond err", err, ShouldBeNil)
 
 				inAPS := spathmeta.NewAppPathSet(paths)
@@ -292,7 +295,8 @@ func TestACLEval(t *testing.T) {
 	Convey("TestPolicy", t, func() {
 		for _, tc := range testCases {
 			Convey(tc.Name, func() {
-				paths, err := conn.Paths(tc.Dst, tc.Src, 5, sciond.PathReqFlags{})
+				paths, err := conn.Paths(context.Background(), tc.Dst, tc.Src, 5,
+					sciond.PathReqFlags{})
 				SoMsg("sciond err", err, ShouldBeNil)
 
 				inAPS := spathmeta.NewAppPathSet(paths)
@@ -310,7 +314,7 @@ func TestACLPanic(t *testing.T) {
 
 	conn := testGetSCIONDConn(t)
 	Convey("TestACLPanic", t, func() {
-		paths, err := conn.Paths(xtest.MustParseIA("2-ff00:0:211"),
+		paths, err := conn.Paths(context.Background(), xtest.MustParseIA("2-ff00:0:211"),
 			xtest.MustParseIA("2-ff00:0:212"), 5, sciond.PathReqFlags{})
 		SoMsg("sciond err", err, ShouldBeNil)
 
@@ -455,7 +459,8 @@ func TestOptionsEval(t *testing.T) {
 	Convey("TestPolicy", t, func() {
 		for _, tc := range testCases {
 			Convey(tc.Name, func() {
-				paths, err := conn.Paths(tc.Dst, tc.Src, 5, sciond.PathReqFlags{})
+				paths, err := conn.Paths(context.Background(), tc.Dst, tc.Src, 5,
+					sciond.PathReqFlags{})
 				SoMsg("sciond err", err, ShouldBeNil)
 
 				inAPS := spathmeta.NewAppPathSet(paths)

--- a/go/lib/pktcls/action_test.go
+++ b/go/lib/pktcls/action_test.go
@@ -16,6 +16,7 @@
 package pktcls
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -330,7 +331,8 @@ func TestActionAct(t *testing.T) {
 			Convey(tc.Name, func() {
 				for _, stc := range tc.SubTestCases {
 					Convey(stc.Name, func() {
-						paths, err := conn.Paths(stc.Dst, stc.Src, 5, sciond.PathReqFlags{})
+						paths, err := conn.Paths(context.Background(), stc.Dst, stc.Src, 5,
+							sciond.PathReqFlags{})
 						SoMsg("sciond err", err, ShouldBeNil)
 
 						inAPS := spathmeta.NewAppPathSet(paths)

--- a/go/lib/sciond/mock.go
+++ b/go/lib/sciond/mock.go
@@ -80,7 +80,9 @@ type MockConn struct {
 //
 // Paths does not guarantee to represent a consistent snapshot of the SCION
 // network if the backing multigraph is modified while Paths is running.
-func (m *MockConn) Paths(dst, src addr.IA, max uint16, f PathReqFlags) (*PathReply, error) {
+func (m *MockConn) Paths(ctx context.Context, dst, src addr.IA, max uint16,
+	f PathReqFlags) (*PathReply, error) {
+
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -120,58 +122,33 @@ func (m *MockConn) Paths(dst, src addr.IA, max uint16, f PathReqFlags) (*PathRep
 	}, nil
 }
 
-// PathsCtx is not implemented.
-func (m *MockConn) PathsCtx(ctx context.Context, dst, src addr.IA, max uint16,
-	f PathReqFlags) (*PathReply, error) {
-
-	panic("not implemented")
-}
-
 // ASInfo is not implemented.
-func (m *MockConn) ASInfo(ia addr.IA) (*ASInfoReply, error) {
-	panic("not implemented")
-}
-
-// ASInfoCtx is not implemented.
-func (m *MockConn) ASInfoCtx(ctx context.Context, ia addr.IA) (*ASInfoReply, error) {
+func (m *MockConn) ASInfo(ctx context.Context, ia addr.IA) (*ASInfoReply, error) {
 	panic("not implemented")
 }
 
 // IFInfo is not implemented.
-func (m *MockConn) IFInfo(ifs []common.IFIDType) (*IFInfoReply, error) {
-	panic("not implemented")
-}
-
-// IFInfoCtx is not implemented.
-func (m *MockConn) IFInfoCtx(ctx context.Context, ifs []common.IFIDType) (*IFInfoReply, error) {
+func (m *MockConn) IFInfo(ctx context.Context, ifs []common.IFIDType) (*IFInfoReply, error) {
 	panic("not implemented")
 }
 
 // SVCInfo is not implemented.
-func (m *MockConn) SVCInfo(svcTypes []proto.ServiceType) (*ServiceInfoReply, error) {
-	panic("not implemented")
-}
-
-// SVCInfoCtx is not implemented.
-func (m *MockConn) SVCInfoCtx(ctx context.Context,
+func (m *MockConn) SVCInfo(ctx context.Context,
 	svcTypes []proto.ServiceType) (*ServiceInfoReply, error) {
 
 	panic("not implemented")
 }
 
 // RevNotificationFromRaw is not implemented.
-func (m *MockConn) RevNotificationFromRaw(b []byte) (*RevReply, error) {
-	panic("not implemented")
-}
-
-// RevNotificationFromRawCtx is not implemented.
-func (m *MockConn) RevNotificationFromRawCtx(ctx context.Context, b []byte) (*RevReply, error) {
+func (m *MockConn) RevNotificationFromRaw(ctx context.Context, b []byte) (*RevReply, error) {
 	panic("not implemented")
 }
 
 // RevNotification deletes the edge containing revInfo.IfID from the
 // multigraph. RevNotification does not perform any validation of revInfo.
-func (m *MockConn) RevNotification(sRevInfo *path_mgmt.SignedRevInfo) (*RevReply, error) {
+func (m *MockConn) RevNotification(ctx context.Context,
+	sRevInfo *path_mgmt.SignedRevInfo) (*RevReply, error) {
+
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -182,20 +159,8 @@ func (m *MockConn) RevNotification(sRevInfo *path_mgmt.SignedRevInfo) (*RevReply
 	}, nil
 }
 
-// RevNotificationCtx is not implemented.
-func (m *MockConn) RevNotificationCtx(ctx context.Context,
-	sRevInfo *path_mgmt.SignedRevInfo) (*RevReply, error) {
-
-	panic("not implemented")
-}
-
 // Close is a no-op.
-func (m *MockConn) Close() error {
-	return nil
-}
-
-// CloseCtx is a no-op.
-func (m *MockConn) CloseCtx(ctx context.Context) error {
+func (m *MockConn) Close(ctx context.Context) error {
 	return nil
 }
 

--- a/go/lib/sciond/reconn.go
+++ b/go/lib/sciond/reconn.go
@@ -1,0 +1,154 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sciond
+
+import (
+	"context"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/proto"
+)
+
+const (
+	testConnectTimeout = time.Second
+)
+
+// reconnector is a SCIOND API implementation that is resilient to SCIOND going
+// down and up.
+//
+// It achieves the above property by establishing a connection for each API
+// call.
+type reconnector struct {
+	srvc Service
+}
+
+func newReconnector(srvc Service, initialCheckTimeout time.Duration) (*reconnector, error) {
+	// Test during initialization that SCIOND is alive; this helps catch some
+	// unfixable issues (like bad socket name) while apps are still
+	// initializing their networking.
+	c := &reconnector{srvc: srvc}
+	if err := c.checkForSciond(initialCheckTimeout); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *reconnector) checkForSciond(initialCheckTimeout time.Duration) error {
+	sciondConn, err := c.srvc.ConnectTimeout(initialCheckTimeout)
+	if err != nil {
+		return common.NewBasicError("Unable to connect to SCIOND", err)
+	}
+	if err := sciondConn.Close(context.Background()); err != nil {
+		return common.NewBasicError("Error when closing test SCIOND conn", err)
+	}
+	return nil
+}
+
+func (c *reconnector) Paths(ctx context.Context, dst, src addr.IA, max uint16,
+	f PathReqFlags) (*PathReply, error) {
+
+	conn, err := c.ctxAwareConnect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close(ctx)
+	return conn.Paths(ctx, dst, src, max, f)
+}
+
+func (c *reconnector) ASInfo(ctx context.Context, ia addr.IA) (*ASInfoReply, error) {
+	conn, err := c.ctxAwareConnect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close(ctx)
+	return conn.ASInfo(ctx, ia)
+}
+
+func (c *reconnector) IFInfo(ctx context.Context, ifs []common.IFIDType) (*IFInfoReply, error) {
+	conn, err := c.ctxAwareConnect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close(ctx)
+	return conn.IFInfo(ctx, ifs)
+}
+
+func (c *reconnector) SVCInfo(ctx context.Context,
+	svcTypes []proto.ServiceType) (*ServiceInfoReply, error) {
+
+	conn, err := c.ctxAwareConnect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close(ctx)
+	return conn.SVCInfo(ctx, svcTypes)
+}
+
+func (c *reconnector) RevNotificationFromRaw(ctx context.Context, b []byte) (*RevReply, error) {
+	conn, err := c.ctxAwareConnect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close(ctx)
+	return conn.RevNotificationFromRaw(ctx, b)
+}
+
+func (c *reconnector) RevNotification(ctx context.Context,
+	sRevInfo *path_mgmt.SignedRevInfo) (*RevReply, error) {
+
+	conn, err := c.ctxAwareConnect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close(ctx)
+	return conn.RevNotification(ctx, sRevInfo)
+}
+
+func (c *reconnector) Close(ctx context.Context) error {
+	return nil
+}
+
+func (c *reconnector) ctxAwareConnect(ctx context.Context) (Connector, error) {
+	var timeout time.Duration
+	if deadline, ok := ctx.Deadline(); ok {
+		timeout = deadline.Sub(time.Now())
+		if timeout < 0 {
+			timeout = 0
+		}
+	}
+
+	type returnValue struct {
+		conn Connector
+		err  error
+	}
+	barrier := make(chan returnValue, 1)
+	go func() {
+		conn, err := c.srvc.ConnectTimeout(timeout)
+		barrier <- returnValue{conn: conn, err: err}
+	}()
+
+	select {
+	case rValue := <-barrier:
+		return rValue.conn, rValue.err
+	case <-ctx.Done():
+		// This will leak a goroutine permanently, if ctx doesn't have a
+		// deadline, or for a long amount of time, if the deadline is very far
+		// into the future.
+		return nil, ctx.Err()
+	}
+}

--- a/go/lib/sciond/reconn.go
+++ b/go/lib/sciond/reconn.go
@@ -31,6 +31,13 @@ var _ Connector = (*reconnector)(nil)
 //
 // It achieves the above property by establishing a connection for each API
 // call.
+//
+// XXX(scrye): The underlying one-shot SCIOND API connection has an infra
+// dispatcher layered on top of the unix transport communication with sciond.
+// This is not necessary for request-response matching, but is useful for
+// context.Context support. If performance becomes an issue, an improvement
+// might be to have a lightweight implementation that just ensures context
+// suport.
 type reconnector struct {
 	path string
 }

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -67,7 +67,7 @@ type Service interface {
 	Connect() (Connector, error)
 	// ConnectTimeout acts like Connect but takes a timeout.
 	//
-	// A negative timeout means infinite timeout.
+	// A timeout of 0 means infinite timeout.
 	//
 	// To check for timeout errors, type assert the returned error to
 	// *net.OpError and call method Timeout().
@@ -92,12 +92,15 @@ func NewService(name string, reconnects bool) Service {
 
 func (s *service) Connect() (Connector, error) {
 	if s.reconnects {
-		return newReconnector(s, testConnectTimeout)
+		return newReconnector(s.path, testConnectTimeout)
 	}
 	return connect(s.path)
 }
 
 func (s *service) ConnectTimeout(timeout time.Duration) (Connector, error) {
+	if s.reconnects {
+		return newReconnector(s.path, timeout)
+	}
 	return connectTimeout(s.path, timeout)
 }
 

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -75,16 +75,25 @@ type Service interface {
 }
 
 type service struct {
-	path string
+	path       string
+	reconnects bool
 }
 
-func NewService(name string) Service {
+// NewService returns a SCIOND API connection factory.
+//
+// If reconnects is true, connections created from the factory will tolerate
+// SCIOND restarts.
+func NewService(name string, reconnects bool) Service {
 	return &service{
-		path: name,
+		path:       name,
+		reconnects: reconnects,
 	}
 }
 
 func (s *service) Connect() (Connector, error) {
+	if s.reconnects {
+		return newReconnector(s, testConnectTimeout)
+	}
 	return connect(s.path)
 }
 
@@ -98,32 +107,25 @@ func (s *service) ConnectTimeout(timeout time.Duration) (Connector, error) {
 type Connector interface {
 	// Paths requests from SCIOND a set of end to end paths between src and
 	// dst. max specifices the maximum number of paths returned.
-	Paths(dst, src addr.IA, max uint16, f PathReqFlags) (*PathReply, error)
-	PathsCtx(ctx context.Context, dst, src addr.IA, max uint16, f PathReqFlags) (*PathReply, error)
+	Paths(ctx context.Context, dst, src addr.IA, max uint16, f PathReqFlags) (*PathReply, error)
 	// ASInfo requests from SCIOND information about AS ia.
-	ASInfo(ia addr.IA) (*ASInfoReply, error)
-	ASInfoCtx(ctx context.Context, ia addr.IA) (*ASInfoReply, error)
+	ASInfo(ctx context.Context, ia addr.IA) (*ASInfoReply, error)
 	// IFInfo requests from SCIOND addresses and ports of interfaces.  Slice
 	// ifs contains interface IDs of BRs. If empty, a fresh (i.e., uncached)
 	// answer containing all interfaces is returned.
-	IFInfo(ifs []common.IFIDType) (*IFInfoReply, error)
-	IFInfoCtx(ctx context.Context, ifs []common.IFIDType) (*IFInfoReply, error)
+	IFInfo(ctx context.Context, ifs []common.IFIDType) (*IFInfoReply, error)
 	// SVCInfo requests from SCIOND information about addresses and ports of
 	// infrastructure services.  Slice svcTypes contains a list of desired
 	// service types. If unset, a fresh (i.e., uncached) answer containing all
 	// service types is returned.
-	SVCInfo(svcTypes []proto.ServiceType) (*ServiceInfoReply, error)
-	SVCInfoCtx(ctx context.Context, svcTypes []proto.ServiceType) (*ServiceInfoReply, error)
+	SVCInfo(ctx context.Context, svcTypes []proto.ServiceType) (*ServiceInfoReply, error)
 	// RevNotification sends a raw revocation to SCIOND, as contained in an
 	// SCMP message.
-	RevNotificationFromRaw(b []byte) (*RevReply, error)
-	RevNotificationFromRawCtx(ctx context.Context, b []byte) (*RevReply, error)
+	RevNotificationFromRaw(ctx context.Context, b []byte) (*RevReply, error)
 	// RevNotification sends a RevocationInfo message to SCIOND.
-	RevNotification(sRevInfo *path_mgmt.SignedRevInfo) (*RevReply, error)
-	RevNotificationCtx(ctx context.Context, sRevInfo *path_mgmt.SignedRevInfo) (*RevReply, error)
+	RevNotification(ctx context.Context, sRevInfo *path_mgmt.SignedRevInfo) (*RevReply, error)
 	// Close shuts down the connection to a SCIOND server.
-	Close() error
-	CloseCtx(ctx context.Context) error
+	Close(ctx context.Context) error
 }
 
 type connector struct {
@@ -163,11 +165,7 @@ func (c *connector) nextID() uint64 {
 	return atomic.AddUint64(&c.requestID, 1)
 }
 
-func (c *connector) Paths(dst, src addr.IA, max uint16, f PathReqFlags) (*PathReply, error) {
-	return c.PathsCtx(context.Background(), dst, src, max, f)
-}
-
-func (c *connector) PathsCtx(ctx context.Context, dst, src addr.IA, max uint16,
+func (c *connector) Paths(ctx context.Context, dst, src addr.IA, max uint16,
 	f PathReqFlags) (*PathReply, error) {
 
 	c.Lock()
@@ -192,11 +190,7 @@ func (c *connector) PathsCtx(ctx context.Context, dst, src addr.IA, max uint16,
 	return reply.(*Pld).PathReply, nil
 }
 
-func (c *connector) ASInfo(ia addr.IA) (*ASInfoReply, error) {
-	return c.ASInfoCtx(context.Background(), ia)
-}
-
-func (c *connector) ASInfoCtx(ctx context.Context, ia addr.IA) (*ASInfoReply, error) {
+func (c *connector) ASInfo(ctx context.Context, ia addr.IA) (*ASInfoReply, error) {
 	c.Lock()
 	defer c.Unlock()
 	// Check if information for this ISD-AS is cached
@@ -224,11 +218,7 @@ func (c *connector) ASInfoCtx(ctx context.Context, ia addr.IA) (*ASInfoReply, er
 	return asInfoReply, nil
 }
 
-func (c *connector) IFInfo(ifs []common.IFIDType) (*IFInfoReply, error) {
-	return c.IFInfoCtx(context.Background(), ifs)
-}
-
-func (c *connector) IFInfoCtx(ctx context.Context, ifs []common.IFIDType) (*IFInfoReply, error) {
+func (c *connector) IFInfo(ctx context.Context, ifs []common.IFIDType) (*IFInfoReply, error) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -278,11 +268,7 @@ func (c *connector) getIFEntriesFromCache(
 	return foundEntries, remainingIfs
 }
 
-func (c *connector) SVCInfo(svcTypes []proto.ServiceType) (*ServiceInfoReply, error) {
-	return c.SVCInfoCtx(context.Background(), svcTypes)
-}
-
-func (c *connector) SVCInfoCtx(ctx context.Context,
+func (c *connector) SVCInfo(ctx context.Context,
 	svcTypes []proto.ServiceType) (*ServiceInfoReply, error) {
 
 	c.Lock()
@@ -332,24 +318,16 @@ func (c *connector) getSVCEntriesFromCache(
 	return foundEntries, remainingSVCs
 }
 
-func (c *connector) RevNotificationFromRaw(b []byte) (*RevReply, error) {
-	return c.RevNotificationFromRawCtx(context.Background(), b)
-}
-
-func (c *connector) RevNotificationFromRawCtx(ctx context.Context, b []byte) (*RevReply, error) {
+func (c *connector) RevNotificationFromRaw(ctx context.Context, b []byte) (*RevReply, error) {
 	// Extract information from notification
 	sRevInfo, err := path_mgmt.NewSignedRevInfoFromRaw(b)
 	if err != nil {
 		return nil, err
 	}
-	return c.RevNotificationCtx(ctx, sRevInfo)
+	return c.RevNotification(ctx, sRevInfo)
 }
 
-func (c *connector) RevNotification(sRevInfo *path_mgmt.SignedRevInfo) (*RevReply, error) {
-	return c.RevNotificationCtx(context.Background(), sRevInfo)
-}
-
-func (c *connector) RevNotificationCtx(ctx context.Context,
+func (c *connector) RevNotification(ctx context.Context,
 	sRevInfo *path_mgmt.SignedRevInfo) (*RevReply, error) {
 
 	c.Lock()
@@ -372,11 +350,7 @@ func (c *connector) RevNotificationCtx(ctx context.Context,
 	return reply.(*Pld).RevReply, nil
 }
 
-func (c *connector) Close() error {
-	return c.CloseCtx(context.Background())
-}
-
-func (c *connector) CloseCtx(ctx context.Context) error {
+func (c *connector) Close(ctx context.Context) error {
 	return c.dispatcher.Close(ctx)
 }
 

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -92,7 +92,7 @@ func NewService(name string, reconnects bool) Service {
 
 func (s *service) Connect() (Connector, error) {
 	if s.reconnects {
-		return newReconnector(s.path, testConnectTimeout)
+		return newReconnector(s.path, 0)
 	}
 	return connect(s.path)
 }

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -126,7 +126,7 @@ func NewNetwork(ia addr.IA, sciondPath string, dispatcherPath string) (*SCIONNet
 	if sciondPath != "" {
 		var err error
 		pathResolver, err = pathmgr.New(
-			sciond.NewService(sciondPath),
+			sciond.NewService(sciondPath, true),
 			&pathmgr.Timers{
 				NormalRefire: time.Minute,
 				ErrorRefire:  3 * time.Second,

--- a/go/lib/spath/spathmeta/pred_test.go
+++ b/go/lib/spath/spathmeta/pred_test.go
@@ -16,6 +16,7 @@
 package spathmeta
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -110,8 +111,8 @@ func TestPathPredicates(t *testing.T) {
 				SoMsg("err", err, ShouldBeNil)
 				SoMsg("pp", pp, ShouldNotBeNil)
 
-				reply, err := conn.Paths(MustParseIA(tc.dst), MustParseIA(tc.src),
-					5, sciond.PathReqFlags{})
+				reply, err := conn.Paths(context.Background(), MustParseIA(tc.dst),
+					MustParseIA(tc.src), 5, sciond.PathReqFlags{})
 				SoMsg("paths err", err, ShouldBeNil)
 				SoMsg("one path only", len(reply.Entries), ShouldEqual, 1)
 

--- a/go/tools/scmp/main.go
+++ b/go/tools/scmp/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -57,7 +58,7 @@ func main() {
 		*sciondPath = sciond.GetDefaultSCIONDPath(nil)
 	}
 	// Connect to sciond
-	sd := sciond.NewService(*sciondPath)
+	sd := sciond.NewService(*sciondPath, false)
 	sdConn, err = sd.ConnectTimeout(1 * time.Second)
 	if err != nil {
 		cmn.Fatal("Failed to connect to SCIOND: %v\n", err)
@@ -105,7 +106,7 @@ func doCommand(cmd string) int {
 }
 
 func choosePath() sciond.PathReplyEntry {
-	reply, err := sdConn.Paths(cmn.Remote.IA, cmn.Local.IA, 0,
+	reply, err := sdConn.Paths(context.Background(), cmn.Remote.IA, cmn.Local.IA, 0,
 		sciond.PathReqFlags{Refresh: *refresh})
 	if err != nil {
 		cmn.Fatal("Failed to retrieve paths from SCIOND: %v\n", err)
@@ -150,7 +151,7 @@ func setPathAndMtu() uint16 {
 
 func setLocalMtu() uint16 {
 	// Use local AS MTU when we have no path
-	reply, err := sdConn.ASInfo(addr.IA{})
+	reply, err := sdConn.ASInfo(context.Background(), addr.IA{})
 	if err != nil {
 		cmn.Fatal("Unable to request AS info to sciond")
 	}

--- a/go/tools/showpaths/paths.go
+++ b/go/tools/showpaths/paths.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net"
@@ -58,12 +59,12 @@ func main() {
 	log.AddLogConsFlags()
 	validateFlags()
 
-	sd := sciond.NewService(*sciondPath)
+	sd := sciond.NewService(*sciondPath, false)
 	sdConn, err := sd.ConnectTimeout(*timeout)
 	if err != nil {
 		LogFatal("Failed to connect to SCIOND: %v\n", err)
 	}
-	reply, err := sdConn.Paths(dstIA, srcIA, uint16(*maxPaths),
+	reply, err := sdConn.Paths(context.Background(), dstIA, srcIA, uint16(*maxPaths),
 		sciond.PathReqFlags{Refresh: *refresh})
 	if err != nil {
 		LogFatal("Failed to retrieve paths from SCIOND: %v\n", err)


### PR DESCRIPTION
The API establishes and tears down the connection to SD for each API call. It is more expensive than the shared connection we had, but it is resilient to SD restarts since there is no persistent connection.

Also in this PR:
  - simplified the SCIOND API to no longer have non-context/context variants;
  - cleaned up logging during infra dispatcher shutdown;

Known issues:
  - an infra dispatcher is initialized over the unix transport to SD; it is not strictly needed as only one message exchange happens on the transport, but it provides context-friendly primitives for talking on the connection. We can optimize in the future and delete it.

This is a prerequisite of the concurrency-friendly path manager.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2127)
<!-- Reviewable:end -->
