### PR TITLE
SIG dies immediately when if disconnects from dispatcher

### DIFF
--- a/go/lib/snet/snetproxy/conn.go
+++ b/go/lib/snet/snetproxy/conn.go
@@ -23,6 +23,7 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/sock/reliable"
 )
 
 var _ snet.Conn = (*ProxyConn)(nil)
@@ -127,7 +128,8 @@ Loop:
 		case <-conn.dispatcherState.Up():
 			err = op.Do(conn.getConn())
 			if err != nil {
-				if isDispatcherError(err) && !conn.isClosing() {
+				if reliable.IsDispatcherError(err) &&
+					!conn.isClosing() {
 					conn.spawnAsyncReconnecterOnce()
 					continue
 				} else {

--- a/go/lib/snet/snetproxy/errors.go
+++ b/go/lib/snet/snetproxy/errors.go
@@ -14,15 +14,6 @@
 
 package snetproxy
 
-import (
-	"io"
-	"net"
-	"os"
-	"syscall"
-
-	"github.com/scionproto/scion/go/lib/common"
-)
-
 const (
 	ErrDispatcherDead            = "dispatcher dead"
 	ErrLocalAddressChanged       = "local address changed on reconnect"
@@ -31,55 +22,3 @@ const (
 	ErrReconnecterStopped        = "Stop method was called"
 	ErrClosed                    = "closed"
 )
-
-func isDispatcherError(err error) bool {
-	err = extractNestedError(err)
-	// On Linux, the following errors should prompt a reconnect:
-	//   - An EOF, when a Read happens to a connection that was closed at the
-	//   other end, and there is no outstanding outgoing data.
-	//   - An EPIPE, when a Write happens to a connection that was closed at
-	//   the other end.
-	//   - An ECONNRESET, when a Read happens to a connection that was
-	//   closed at the other end, and there is outstanding outgoing data. An
-	//   ECONNRESET may be followed by EOF on repeated attempts.
-	if err == io.EOF ||
-		isSpecificSysError(err, syscall.EPIPE) ||
-		isSpecificSysError(err, syscall.ECONNRESET) {
-		return true
-	}
-	// All other errors can be immediately propagated back to the application.
-	return false
-}
-
-// extractNestedError returns the innermost error of err.
-func extractNestedError(err error) error {
-	if nestedError := common.GetNestedError(err); nestedError != nil {
-		return nestedError
-	}
-	return err
-}
-
-func isSpecificSysError(err error, errno syscall.Errno) bool {
-	serr, ok := getSysError(err)
-	if !ok {
-		return false
-	}
-	return serr.Err == errno
-}
-
-func isSysError(err error) bool {
-	_, ok := getSysError(err)
-	return ok
-}
-
-func getSysError(err error) (*os.SyscallError, bool) {
-	nerr, ok := err.(*net.OpError)
-	if !ok {
-		return nil, false
-	}
-	serr, ok := nerr.Err.(*os.SyscallError)
-	if !ok {
-		return nil, false
-	}
-	return serr, true
-}

--- a/go/lib/snet/snetproxy/reconnecter.go
+++ b/go/lib/snet/snetproxy/reconnecter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/sock/reliable"
 )
 
 // Use a var here to allow tests to inject shorter intervals for fast testing.
@@ -75,7 +76,7 @@ func (r *TickingReconnecter) Reconnect(timeout time.Duration) (snet.Conn, error)
 		}
 		conn, err := r.reconnectF(newTimeout)
 		switch {
-		case isSysError(err):
+		case reliable.IsSysError(err):
 			// Wait until next tick to retry. If the overall timeout expires
 			// before the next tick, return immediately with an error.
 			// time.Ticker will ensure that no more than one attempt is made

--- a/go/lib/sock/reliable/errors.go
+++ b/go/lib/sock/reliable/errors.go
@@ -1,0 +1,76 @@
+// Copyright 2018 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reliable
+
+import (
+	"io"
+	"net"
+	"os"
+	"syscall"
+
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+func IsDispatcherError(err error) bool {
+	err = extractNestedError(err)
+	// On Linux, the following errors should prompt a reconnect:
+	//   - An EOF, when a Read happens to a connection that was closed at the
+	//   other end, and there is no outstanding outgoing data.
+	//   - An EPIPE, when a Write happens to a connection that was closed at
+	//   the other end.
+	//   - An ECONNRESET, when a Read happens to a connection that was
+	//   closed at the other end, and there is outstanding outgoing data. An
+	//   ECONNRESET may be followed by EOF on repeated attempts.
+	if err == io.EOF ||
+		IsSpecificSysError(err, syscall.EPIPE) ||
+		IsSpecificSysError(err, syscall.ECONNRESET) {
+		return true
+	}
+	// All other errors can be immediately propagated back to the application.
+	return false
+}
+
+// extractNestedError returns the innermost error of err.
+func extractNestedError(err error) error {
+	if nestedError := common.GetNestedError(err); nestedError != nil {
+		return nestedError
+	}
+	return err
+}
+
+func IsSpecificSysError(err error, errno syscall.Errno) bool {
+	serr, ok := getSysError(err)
+	if !ok {
+		return false
+	}
+	return serr.Err == errno
+}
+
+func IsSysError(err error) bool {
+	_, ok := getSysError(err)
+	return ok
+}
+
+func getSysError(err error) (*os.SyscallError, bool) {
+	nerr, ok := err.(*net.OpError)
+	if !ok {
+		return nil, false
+	}
+	serr, ok := nerr.Err.(*os.SyscallError)
+	if !ok {
+		return nil, false
+	}
+	return serr, true
+}

--- a/go/sig/main.go
+++ b/go/sig/main.go
@@ -120,7 +120,7 @@ func main() {
 	}()
 	// Spawn ingress Dispatcher.
 	if err := ingress.Init(tunIO); err != nil {
-		fatal("Unable to spawn ingress dispatcher", "err", err)
+		fatal("Ingress dispatcher error", "err", err)
 	}
 }
 


### PR DESCRIPTION
This is a intermediate measure. Eventually, we want to have
proper reconnect functionality but until then it's better
to kill the process instead of keeping it alive and malfunctioning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2131)
<!-- Reviewable:end -->
