### PR TITLE
Fix printing of AS number in scion.lua

### DIFF
--- a/tools/wireshark/scion.lua
+++ b/tools/wireshark/scion.lua
@@ -409,7 +409,7 @@ end
 function format_as(as)
     local asDec = as:uint64()
     if asDec > 1 and asDec <= 0xffffffff then
-        asStr = string.format("%d", asDec)
+        asStr = string.format("%s", asDec)
     else
         asStr = string.format("%x:%x:%x", as:bitfield(0, 16), as:bitfield(16, 16), as:bitfield(32, 16))
     end


### PR DESCRIPTION
ASes used to only ever contain ints, hence `%d` worked. However, the
newer shortened AS notation may have AS numbers like `9:5:6`, which `%d`
can't be used for. Switch to `%s` to fix this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2132)
<!-- Reviewable:end -->
