### PR TITLE
SIG uses SvcSIG address to locate remote SIGs

### DIFF
--- a/go/lib/addr/host.go
+++ b/go/lib/addr/host.go
@@ -184,7 +184,7 @@ var _ HostAddr = (*HostSVC)(nil)
 type HostSVC uint16
 
 // HostSVCFromString returns the SVC address corresponding to str. For anycast
-// SVC addresses, use BS_A, PS_A, CS_A, and SB_A; shorthand versions without
+// SVC addresses, use BS_A, PS_A, CS_A etc.; shorthand versions without
 // the _A suffix (e.g., PS) also return anycast SVC addresses. For multicast,
 // use BS_M, PS_M, CS_M, and SB_M.
 func HostSVCFromString(str string) HostSVC {
@@ -205,6 +205,8 @@ func HostSVCFromString(str string) HostSVC {
 		return SvcCS | m
 	case "SB":
 		return SvcSB | m
+	case "SIG":
+		return SvcSIG | m
 	default:
 		return SvcNone
 	}


### PR DESCRIPTION
This patch leaves the old manually-configured SIGs in place
for failover purposes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2133)
<!-- Reviewable:end -->
