### PR TITLE
pathmgr: fix flaky unit test

### DIFF
--- a/go/lib/pathmgr/pathmgr_test.go
+++ b/go/lib/pathmgr/pathmgr_test.go
@@ -35,27 +35,35 @@ import (
 	"github.com/scionproto/scion/go/lib/xtest/graph"
 )
 
+const (
+	// BaseDurationUnit is used to compute relative timeouts between events in
+	// tests. If tests are flaky, increase this.
+	BaseDurationUnit = 5 * time.Millisecond
+)
+
+func getDuration(multiplier time.Duration) time.Duration {
+	return multiplier * BaseDurationUnit
+}
+
 func TestQuery(t *testing.T) {
 	Convey("Query, we have 0 paths and SCIOND is asked again, receive 1 path", t, func() {
 		g := graph.NewDefaultGraph()
-		pm := NewPR(t, g, 250, 250, 100)
+		pm := NewPR(t, g, 0, 0)
 		srcIA := xtest.MustParseIA("1-ff00:0:133")
 		dstIA := xtest.MustParseIA("1-ff00:0:131")
 
 		aps := pm.Query(context.Background(), srcIA, dstIA)
 		SoMsg("aps len", len(aps), ShouldEqual, 1)
-		Convey("Query immediately, same path is read from cache", func() {
+		Convey("Query immediately, get paths", func() {
 			aps := pm.Query(context.Background(), srcIA, dstIA)
 			SoMsg("aps len", len(aps), ShouldEqual, 1)
 			SoMsg("path", getPathStrings(aps), ShouldContain,
 				"[1-ff00:0:133#1019 1-ff00:0:132#1910 "+
 					"1-ff00:0:132#1916 1-ff00:0:131#1619]")
 		})
-		Convey("Wait 200ms for paths to expire, then query and get new paths", func() {
+		Convey("Then query again and get new paths", func() {
 			// Add new path between 1-ff00:0:133 and 1-ff00:0:131
 			g.AddLink("1-ff00:0:133", 101902, "1-ff00:0:132", 191002, false)
-			// Wait for two seconds to guarantee that the pathmgr refreshes the paths
-			<-time.After(200 * time.Millisecond)
 			aps := pm.Query(context.Background(), srcIA, dstIA)
 			SoMsg("aps len", len(aps), ShouldEqual, 2)
 			SoMsg("path #1", getPathStrings(aps), ShouldContain,
@@ -73,7 +81,7 @@ var denyEntry = &pathpol.ACLEntry{Action: pathpol.Deny, Rule: pathpol.NewHopPred
 
 func TestQueryFilter(t *testing.T) {
 	g := graph.NewDefaultGraph()
-	pm := NewPR(t, g, 0, 0, 0)
+	pm := NewPR(t, g, 0, 0)
 	srcIA := xtest.MustParseIA("1-ff00:0:133")
 	dstIA := xtest.MustParseIA("1-ff00:0:131")
 	Convey("Query with policy filter, only one path should remain, default deny", t, func() {
@@ -117,7 +125,7 @@ func TestQueryFilter(t *testing.T) {
 func TestACLPolicyFilter(t *testing.T) {
 	Convey("Query with ACL policy filter", t, func() {
 		g := graph.NewDefaultGraph()
-		pm := NewPR(t, g, 0, 0, 0)
+		pm := NewPR(t, g, 0, 0)
 		srcIA := xtest.MustParseIA("2-ff00:0:222")
 		dstIA := xtest.MustParseIA("1-ff00:0:131")
 		pp, _ := pathpol.HopPredicateFromString("1-ff00:0:121#0")
@@ -133,7 +141,7 @@ func TestACLPolicyFilter(t *testing.T) {
 	})
 	Convey("Query with longer ACL policy filter", t, func() {
 		g := graph.NewDefaultGraph()
-		pm := NewPR(t, g, 0, 0, 0)
+		pm := NewPR(t, g, 0, 0)
 		srcIA := xtest.MustParseIA("2-ff00:0:222")
 		dstIA := xtest.MustParseIA("1-ff00:0:131")
 		pp, _ := pathpol.HopPredicateFromString("1-ff00:0:121#0")
@@ -198,14 +206,14 @@ func TestWatchPolling(t *testing.T) {
 				), nil,
 			).MinTimes(1),
 		)
-		pr := New(sd, Timers{ErrorRefire: time.Millisecond}, nil)
+		pr := New(sd, Timers{ErrorRefire: getDuration(1)}, nil)
 		Convey("and adding a watch that retrieves zero paths", func() {
 			sp, err := pr.Watch(context.Background(), src, dst)
 			xtest.FailOnErr(t, err)
 			Convey("there are 0 paths currently available", func() {
 				So(len(sp.Load().APS), ShouldEqual, 0)
-				Convey("and waiting for 10ms grabs new paths", func() {
-					time.Sleep(10 * time.Millisecond)
+				Convey("and waiting for 4 time units grabs new paths", func() {
+					time.Sleep(getDuration(4))
 					So(len(sp.Load().APS), ShouldEqual, 1)
 				})
 			})
@@ -233,7 +241,7 @@ func TestWatchFilter(t *testing.T) {
 				), nil,
 			).AnyTimes(),
 		)
-		pr := New(sd, Timers{ErrorRefire: time.Millisecond}, nil)
+		pr := New(sd, Timers{ErrorRefire: getDuration(1)}, nil)
 		Convey("and adding a watch that should retrieve 1 path", func() {
 			pp, err := spathmeta.NewPathPredicate("1-ff00:0:111#105")
 			xtest.FailOnErr(t, err)
@@ -244,8 +252,8 @@ func TestWatchFilter(t *testing.T) {
 			xtest.FailOnErr(t, err)
 			Convey("there are 0 paths due to filtering", func() {
 				So(len(sp.Load().APS), ShouldEqual, 0)
-				Convey("and waiting for 10ms grabs 1 path that is not filtered", func() {
-					time.Sleep(10 * time.Millisecond)
+				Convey("and waiting for 4 time units grabs 1 path that is not filtered", func() {
+					time.Sleep(getDuration(4))
 					So(len(sp.Load().APS), ShouldEqual, 1)
 				})
 			})
@@ -357,7 +365,8 @@ func newTestRev(t *testing.T, rev string) *path_mgmt.SignedRevInfo {
 	return signedRevInfo
 }
 
-func NewPR(t *testing.T, g *graph.Graph, normalRefire, errorRefire, maxAge int) Resolver {
+func NewPR(t *testing.T, g *graph.Graph, normalRefire, errorRefire time.Duration) Resolver {
+
 	t.Helper()
 
 	mockConn, err := sciond.NewMockService(g).Connect()
@@ -366,8 +375,8 @@ func NewPR(t *testing.T, g *graph.Graph, normalRefire, errorRefire, maxAge int) 
 	return New(
 		mockConn,
 		Timers{
-			NormalRefire: time.Duration(normalRefire) * time.Millisecond,
-			ErrorRefire:  time.Duration(errorRefire) * time.Millisecond,
+			NormalRefire: normalRefire,
+			ErrorRefire:  errorRefire,
 		},
 		log.Root(),
 	)


### PR DESCRIPTION
Also make test run faster by deleting deprecated sleeps.