### PR TITLE
Testing: Write logs to separate files

### DIFF
--- a/acceptance/lib.sh
+++ b/acceptance/lib.sh
@@ -45,7 +45,7 @@ global_setup() {
     print_green "[>---------]" "Global test environment set-up"
     print_green "[->--------]" "Stopping infra"
     run_command stop_infra ${out_dir:+$out_dir/global_setup_pre_clean.out}
-    rm -f logs/*
+    find logs -mindepth 1 -maxdepth 1 -not -path '*/\.*' -exec rm -r {} +
     print_green "[-->-------]" "Building scion_base docker image"
     run_command build_docker_base ${out_dir:+$out_dir/global_setup_docker_base.out}
     print_green "[--->------]" "Building scion docker image"

--- a/go/examples/pingpong/pp_integration/main.go
+++ b/go/examples/pingpong/pp_integration/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	name = "pingpong"
+	name = "pp_integration"
 	cmd  = "./bin/pingpong"
 )
 

--- a/go/examples/pingpong/pp_integration/main.go
+++ b/go/examples/pingpong/pp_integration/main.go
@@ -46,7 +46,7 @@ func realMain() int {
 	clientArgs = append(clientArgs, cmnArgs...)
 	serverArgs := []string{"-mode", "server", "-local", integration.DstAddrPattern + ":0"}
 	serverArgs = append(serverArgs, cmnArgs...)
-	in := integration.NewBinaryIntegration(name, cmd, clientArgs, serverArgs, integration.StdLog)
+	in := integration.NewBinaryIntegration(name, cmd, clientArgs, serverArgs)
 	if err := runTests(in, integration.IAPairs()); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to run tests: %s\n", err)
 		return 1
@@ -71,7 +71,7 @@ func runTests(in integration.Integration, pairs []integration.IAPair) error {
 		for i, conn := range pairs {
 			log.Info(fmt.Sprintf("Test %v: %v -> %v (%v/%v)",
 				in.Name(), conn.Src.IA, conn.Dst.IA, i+1, len(pairs)))
-			if err := integration.RunClient(in, conn, 5*time.Second); err != nil {
+			if err := integration.RunClient(in, i+1, conn, 5*time.Second); err != nil {
 				log.Error("Error during client execution", "err", err)
 				return err
 			}

--- a/go/examples/pingpong/pp_integration/main.go
+++ b/go/examples/pingpong/pp_integration/main.go
@@ -71,7 +71,7 @@ func runTests(in integration.Integration, pairs []integration.IAPair) error {
 		for i, conn := range pairs {
 			log.Info(fmt.Sprintf("Test %v: %v -> %v (%v/%v)",
 				in.Name(), conn.Src.IA, conn.Dst.IA, i+1, len(pairs)))
-			if err := integration.RunClient(in, i+1, conn, 5*time.Second); err != nil {
+			if err := integration.RunClient(in, conn, 5*time.Second); err != nil {
 				log.Error("Error during client execution", "err", err)
 				return err
 			}

--- a/go/integration/cert_req_integration/main.go
+++ b/go/integration/cert_req_integration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/scionproto/scion/go/lib/integration"
 	"github.com/scionproto/scion/go/lib/log"
@@ -44,28 +43,10 @@ func realMain() int {
 	defer log.Flush()
 	clientArgs := []string{"-log.console", "debug", "-attempts", strconv.Itoa(*attempts),
 		"-local", integration.SrcAddrPattern, "-remoteIA", integration.DstIAReplace}
-	in := integration.NewBinaryIntegration(name, cmd, clientArgs, []string{}, integration.StdLog)
-	if err := runTests(in, integration.IAPairs()); err != nil {
+	in := integration.NewBinaryIntegration(name, cmd, clientArgs, []string{})
+	if err := integration.RunUnaryTests(in, integration.IAPairs()); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to run tests: %s\n", err)
 		return 1
 	}
 	return 0
-}
-
-// RunTests runs the client for each IAPair.
-// In case of an error the function is terminated immediately.
-func runTests(in integration.Integration, pairs []integration.IAPair) error {
-	return integration.ExecuteTimed(in.Name(), func() error {
-		// Start the clients for srcDest pair
-		for i, conn := range integration.IAPairs() {
-			log.Info(fmt.Sprintf("Test %v: %v -> %v (%v/%v)",
-				in.Name(), conn.Src.IA, conn.Dst.IA, i+1, len(integration.IAPairs())))
-			t := integration.DefaultRunTimeout + integration.RetryTimeout*time.Duration(*attempts)
-			if err := integration.RunClient(in, conn, t); err != nil {
-				log.Error("Error during client execution", "err", err)
-				return err
-			}
-		}
-		return nil
-	})
 }

--- a/go/integration/cert_req_integration/main.go
+++ b/go/integration/cert_req_integration/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/scionproto/scion/go/lib/integration"
 	"github.com/scionproto/scion/go/lib/log"
@@ -44,7 +45,8 @@ func realMain() int {
 	clientArgs := []string{"-log.console", "debug", "-attempts", strconv.Itoa(*attempts),
 		"-local", integration.SrcAddrPattern, "-remoteIA", integration.DstIAReplace}
 	in := integration.NewBinaryIntegration(name, cmd, clientArgs, []string{})
-	if err := integration.RunUnaryTests(in, integration.IAPairs()); err != nil {
+	timeout := integration.DefaultRunTimeout + integration.RetryTimeout*time.Duration(*attempts)
+	if err := integration.RunUnaryTests(in, integration.IAPairs(), timeout); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to run tests: %s\n", err)
 		return 1
 	}

--- a/go/integration/cli_srv_ext_pyintegration/main.go
+++ b/go/integration/cli_srv_ext_pyintegration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ func realMain() int {
 		integration.DstIAReplace}
 	serverArgs := []string{"--run_server", "-s", integration.DstHostReplace,
 		integration.DstIAReplace}
-	in := integration.NewBinaryIntegration(name, cmd, clientArgs, serverArgs, integration.StdLog)
+	in := integration.NewBinaryIntegration(name, cmd, clientArgs, serverArgs)
 	if err := integration.RunBinaryTests(in, integration.IAPairs()); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to run tests: %s\n", err)
 		return 1

--- a/go/integration/end2end_integration/main.go
+++ b/go/integration/end2end_integration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ func realMain() int {
 		"-remote", integration.DstAddrPattern + ":" + integration.ServerPortReplace}
 	serverArgs := []string{"-log.console", "debug", "-mode", "server",
 		"-local", integration.DstAddrPattern + ":0"}
-	in := integration.NewBinaryIntegration(name, cmd, clientArgs, serverArgs, integration.StdLog)
+	in := integration.NewBinaryIntegration(name, cmd, clientArgs, serverArgs)
 	if err := runTests(in, integration.IAPairs()); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to run tests: %s\n", err)
 		return 1
@@ -73,7 +73,7 @@ func runTests(in integration.Integration, pairs []integration.IAPair) error {
 			log.Info(fmt.Sprintf("Test %v: %v -> %v (%v/%v)",
 				in.Name(), conn.Src.IA, conn.Dst.IA, i+1, len(pairs)))
 			t := integration.DefaultRunTimeout + integration.CtxTimeout*time.Duration(*attempts)
-			if err := integration.RunClient(in, conn, t); err != nil {
+			if err := integration.RunClient(in, i+1, conn, t); err != nil {
 				log.Error("Error during client execution", "err", err)
 				return err
 			}

--- a/go/integration/end2end_integration/main.go
+++ b/go/integration/end2end_integration/main.go
@@ -73,7 +73,7 @@ func runTests(in integration.Integration, pairs []integration.IAPair) error {
 			log.Info(fmt.Sprintf("Test %v: %v -> %v (%v/%v)",
 				in.Name(), conn.Src.IA, conn.Dst.IA, i+1, len(pairs)))
 			t := integration.DefaultRunTimeout + integration.CtxTimeout*time.Duration(*attempts)
-			if err := integration.RunClient(in, i+1, conn, t); err != nil {
+			if err := integration.RunClient(in, conn, t); err != nil {
 				log.Error("Error during client execution", "err", err)
 				return err
 			}

--- a/go/integration/scmp_error_pyintegration/main.go
+++ b/go/integration/scmp_error_pyintegration/main.go
@@ -41,7 +41,8 @@ func realMain() int {
 	clientArgs := []string{"-c", integration.SrcHostReplace, "-s", integration.DstHostReplace,
 		integration.SrcIAReplace, integration.DstIAReplace}
 	in := integration.NewBinaryIntegration(name, cmd, clientArgs, []string{})
-	if err := integration.RunUnaryTests(in, integration.IAPairs(), 0); err != nil {
+	err := integration.RunUnaryTests(in, integration.IAPairs(), integration.DefaultRunTimeout)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to run tests: %s\n", err)
 		return 1
 	}

--- a/go/integration/scmp_error_pyintegration/main.go
+++ b/go/integration/scmp_error_pyintegration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ func realMain() int {
 	defer log.Flush()
 	clientArgs := []string{"-c", integration.SrcHostReplace, "-s", integration.DstHostReplace,
 		integration.SrcIAReplace, integration.DstIAReplace}
-	in := integration.NewBinaryIntegration(name, cmd, clientArgs, []string{}, integration.StdLog)
+	in := integration.NewBinaryIntegration(name, cmd, clientArgs, []string{})
 	if err := integration.RunUnaryTests(in, integration.IAPairs()); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to run tests: %s\n", err)
 		return 1

--- a/go/integration/scmp_error_pyintegration/main.go
+++ b/go/integration/scmp_error_pyintegration/main.go
@@ -41,7 +41,7 @@ func realMain() int {
 	clientArgs := []string{"-c", integration.SrcHostReplace, "-s", integration.DstHostReplace,
 		integration.SrcIAReplace, integration.DstIAReplace}
 	in := integration.NewBinaryIntegration(name, cmd, clientArgs, []string{})
-	if err := integration.RunUnaryTests(in, integration.IAPairs()); err != nil {
+	if err := integration.RunUnaryTests(in, integration.IAPairs(), 0); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to run tests: %s\n", err)
 		return 1
 	}

--- a/go/lib/integration/binary.go
+++ b/go/lib/integration/binary.go
@@ -154,7 +154,6 @@ func (bi *binaryIntegration) StartServer(ctx context.Context, dst snet.Addr) (Wa
 }
 
 func (bi *binaryIntegration) StartClient(ctx context.Context, src, dst snet.Addr) (Waiter, error) {
-
 	args := replacePattern(SrcIAReplace, src.IA.String(), bi.clientArgs)
 	args = replacePattern(SrcHostReplace, src.Host.L3.String(), args)
 	args = replacePattern(DstIAReplace, dst.IA.String(), args)
@@ -213,10 +212,6 @@ func (bi *binaryIntegration) writeLog(name, id, startInfo string, ep io.ReadClos
 	for scanner.Scan() {
 		w.WriteString(fmt.Sprintf("%s\n", scanner.Text()))
 	}
-}
-
-func (bi *binaryIntegration) logFile(name, id string) string {
-	return fmt.Sprintf("%s/%s_%s", bi.logDir, name, id)
 }
 
 func clientId(src, dst snet.Addr) string {

--- a/go/lib/integration/binary.go
+++ b/go/lib/integration/binary.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/log"
-	"github.com/scionproto/scion/go/lib/log/logparse"
 	"github.com/scionproto/scion/go/lib/snet"
 )
 
@@ -63,11 +62,11 @@ var (
 var _ Integration = (*binaryIntegration)(nil)
 
 type binaryIntegration struct {
-	name        string
-	cmd         string
-	clientArgs  []string
-	serverArgs  []string
-	logRedirect LogRedirect
+	name       string
+	cmd        string
+	clientArgs []string
+	serverArgs []string
+	logDir     string
 }
 
 // NewBinaryIntegration returns an implementation of the Integration interface.
@@ -75,15 +74,19 @@ type binaryIntegration struct {
 // Use SrcIAReplace and DstIAReplace in arguments as placeholder for the source and destination IAs.
 // When starting a client/server the placeholders will be replaced with the actual values.
 // The server should output the ReadySignal to Stdout once it is ready to accept clients.
-func NewBinaryIntegration(name string, cmd string, clientArgs, serverArgs []string,
-	logRedirect LogRedirect) Integration {
-
+func NewBinaryIntegration(name string, cmd string, clientArgs, serverArgs []string) Integration {
+	logDir := fmt.Sprintf("logs/%s", name)
+	err := os.Mkdir(logDir, os.ModePerm)
+	if err != nil && !os.IsExist(err) {
+		log.Error("Failed to create log folder for testrun", "dir", name, "err", err)
+		return nil
+	}
 	bi := &binaryIntegration{
-		name:        name,
-		cmd:         cmd,
-		clientArgs:  clientArgs,
-		serverArgs:  serverArgs,
-		logRedirect: logRedirect,
+		name:       name,
+		cmd:        cmd,
+		clientArgs: clientArgs,
+		serverArgs: serverArgs,
+		logDir:     logDir,
 	}
 	return dockerize(bi)
 }
@@ -133,7 +136,7 @@ func (bi *binaryIntegration) StartServer(ctx context.Context, dst snet.Addr) (Wa
 	}()
 	go func() {
 		defer log.LogPanicAndExit()
-		bi.logRedirect("Server", "ServerErr", dst.IA, ep)
+		bi.writeLog("Server", dst.IA.String(), ep)
 	}()
 	err = r.Start()
 	if err != nil {
@@ -147,7 +150,9 @@ func (bi *binaryIntegration) StartServer(ctx context.Context, dst snet.Addr) (Wa
 	}
 }
 
-func (bi *binaryIntegration) StartClient(ctx context.Context, src, dst snet.Addr) (Waiter, error) {
+func (bi *binaryIntegration) StartClient(ctx context.Context, id int,
+	src, dst snet.Addr) (Waiter, error) {
+
 	args := replacePattern(SrcIAReplace, src.IA.String(), bi.clientArgs)
 	args = replacePattern(SrcHostReplace, src.Host.L3.String(), args)
 	args = replacePattern(DstIAReplace, dst.IA.String(), args)
@@ -164,7 +169,7 @@ func (bi *binaryIntegration) StartClient(ctx context.Context, src, dst snet.Addr
 	}
 	go func() {
 		defer log.LogPanicAndExit()
-		bi.logRedirect("Client", "ClientErr", src.IA, ep)
+		bi.writeLog("Client", clientId(id, src.IA, dst.IA), ep)
 	}()
 	return r, r.Start()
 }
@@ -180,26 +185,28 @@ func replacePattern(pattern string, replacement string, args []string) []string 
 	return argsCopy
 }
 
-type LogRedirect func(name, pName string, local addr.IA, ep io.ReadCloser)
-
-// StdLog tries to parse any log line from the standard format and logs it with the same log level
-// as the original log entry to the log file.
-var StdLog LogRedirect = func(name, pName string, local addr.IA, ep io.ReadCloser) {
-	defer log.LogPanicAndExit()
+func (bi *binaryIntegration) writeLog(name, id string, ep io.ReadCloser) {
 	defer ep.Close()
-	logparse.ParseFrom(ep, pName, pName, func(e logparse.LogEntry) {
-		log.Log(e.Level, fmt.Sprintf("%s@%s: %s", name, local, strings.Join(e.Lines, "\n")))
-	})
-}
-
-// NonStdLog directly logs any lines as error to the log file
-var NonStdLog LogRedirect = func(name, pName string, local addr.IA, ep io.ReadCloser) {
-	defer log.LogPanicAndExit()
-	defer ep.Close()
+	var w *bufio.Writer
 	scanner := bufio.NewScanner(ep)
 	for scanner.Scan() {
-		log.Error(fmt.Sprintf("%s@%s: %s", name, local, scanner.Text()))
+		// Init the file lazily to not have a lot of empty files in the end.
+		if w == nil {
+			f, err := os.Create(fmt.Sprintf("%s/%s_%s", bi.logDir, name, id))
+			if err != nil {
+				log.Error("Failed to create log file for test run", "name", name, "id", id, "err", err)
+				return
+			}
+			defer f.Close()
+			w = bufio.NewWriter(f)
+			defer w.Flush()
+		}
+		w.WriteString(fmt.Sprintf("%s\n", scanner.Text()))
 	}
+}
+
+func clientId(id int, src, dst addr.IA) string {
+	return fmt.Sprintf("%d_%s->%s", id, src, dst)
 }
 
 var _ Waiter = (*binaryWaiter)(nil)

--- a/go/lib/integration/binary.go
+++ b/go/lib/integration/binary.go
@@ -194,7 +194,8 @@ func (bi *binaryIntegration) writeLog(name, id string, ep io.ReadCloser) {
 		if w == nil {
 			f, err := os.Create(fmt.Sprintf("%s/%s_%s", bi.logDir, name, id))
 			if err != nil {
-				log.Error("Failed to create log file for test run", "name", name, "id", id, "err", err)
+				log.Error("Failed to create log file for test run",
+					"name", name, "id", id, "err", err)
 				return
 			}
 			defer f.Close()

--- a/go/lib/integration/binary.go
+++ b/go/lib/integration/binary.go
@@ -139,7 +139,7 @@ func (bi *binaryIntegration) StartServer(ctx context.Context, dst snet.Addr) (Wa
 	}()
 	go func() {
 		defer log.LogPanicAndExit()
-		bi.writeLog("server", dst.IA.FileFmt(false), "", ep)
+		bi.writeLog("server", dst.IA.FileFmt(false), dst.IA.FileFmt(false), ep)
 	}()
 	err = r.Start()
 	if err != nil {
@@ -153,8 +153,7 @@ func (bi *binaryIntegration) StartServer(ctx context.Context, dst snet.Addr) (Wa
 	}
 }
 
-func (bi *binaryIntegration) StartClient(ctx context.Context, id int,
-	src, dst snet.Addr) (Waiter, error) {
+func (bi *binaryIntegration) StartClient(ctx context.Context, src, dst snet.Addr) (Waiter, error) {
 
 	args := replacePattern(SrcIAReplace, src.IA.String(), bi.clientArgs)
 	args = replacePattern(SrcHostReplace, src.Host.L3.String(), args)
@@ -206,10 +205,10 @@ func (bi *binaryIntegration) writeLog(name, id, startInfo string, ep io.ReadClos
 	}
 	w := bufio.NewWriter(f)
 	defer w.Flush()
-	w.WriteString(fmt.Sprintf("%v Starting %s %s %s\n",
-		time.Now().Format(fmt15.TimeFmt), name, id, startInfo))
-	defer w.WriteString(fmt.Sprintf("%v Finished %s %s %s\n",
-		time.Now().Format(fmt15.TimeFmt), name, id, startInfo))
+	w.WriteString(fmt.Sprintf("%v Starting %s %s\n",
+		time.Now().Format(fmt15.TimeFmt), name, startInfo))
+	defer w.WriteString(fmt.Sprintf("%v Finished %s %s\n",
+		time.Now().Format(fmt15.TimeFmt), name, startInfo))
 	scanner := bufio.NewScanner(ep)
 	for scanner.Scan() {
 		w.WriteString(fmt.Sprintf("%s\n", scanner.Text()))

--- a/go/lib/integration/docker.go
+++ b/go/lib/integration/docker.go
@@ -59,10 +59,12 @@ func (di *dockerIntegration) StartServer(ctx context.Context, dst snet.Addr) (Wa
 	return bi.StartServer(ctx, dst)
 }
 
-func (di *dockerIntegration) StartClient(ctx context.Context, src, dst snet.Addr) (Waiter, error) {
+func (di *dockerIntegration) StartClient(ctx context.Context, id int,
+	src, dst snet.Addr) (Waiter, error) {
+
 	bi := *di.binaryIntegration
 	bi.clientArgs = append([]string{dockerArg, src.IA.FileFmt(false), bi.cmd}, bi.clientArgs...)
 	bi.cmd = dockerCmd
 	log.Debug(fmt.Sprintf("Starting client for %s in a docker container", dst.IA.FileFmt(false)))
-	return bi.StartClient(ctx, src, dst)
+	return bi.StartClient(ctx, id, src, dst)
 }

--- a/go/lib/integration/docker.go
+++ b/go/lib/integration/docker.go
@@ -60,7 +60,6 @@ func (di *dockerIntegration) StartServer(ctx context.Context, dst snet.Addr) (Wa
 }
 
 func (di *dockerIntegration) StartClient(ctx context.Context, src, dst snet.Addr) (Waiter, error) {
-
 	bi := *di.binaryIntegration
 	bi.clientArgs = append([]string{dockerArg, src.IA.FileFmt(false), bi.cmd}, bi.clientArgs...)
 	bi.cmd = dockerCmd

--- a/go/lib/integration/docker.go
+++ b/go/lib/integration/docker.go
@@ -59,12 +59,11 @@ func (di *dockerIntegration) StartServer(ctx context.Context, dst snet.Addr) (Wa
 	return bi.StartServer(ctx, dst)
 }
 
-func (di *dockerIntegration) StartClient(ctx context.Context, id int,
-	src, dst snet.Addr) (Waiter, error) {
+func (di *dockerIntegration) StartClient(ctx context.Context, src, dst snet.Addr) (Waiter, error) {
 
 	bi := *di.binaryIntegration
 	bi.clientArgs = append([]string{dockerArg, src.IA.FileFmt(false), bi.cmd}, bi.clientArgs...)
 	bi.cmd = dockerCmd
 	log.Debug(fmt.Sprintf("Starting client for %s in a docker container", dst.IA.FileFmt(false)))
-	return bi.StartClient(ctx, id, src, dst)
+	return bi.StartClient(ctx, src, dst)
 }

--- a/go/lib/integration/integration.go
+++ b/go/lib/integration/integration.go
@@ -83,7 +83,7 @@ type Integration interface {
 	// StartClient should start the client on the src address connecting to the dst address.
 	// StartClient should return immediately.
 	// The context should be used to make the client cancellable.
-	StartClient(ctx context.Context, id int, src, dst snet.Addr) (Waiter, error)
+	StartClient(ctx context.Context, src, dst snet.Addr) (Waiter, error)
 }
 
 // Waiter is a descriptor of a process running in the integration test.
@@ -212,10 +212,10 @@ func StartServer(in Integration, dst snet.Addr) (io.Closer, error) {
 
 // RunClient runs a client on the given IAPair.
 // If the client does not finish until timeout it is killed.
-func RunClient(in Integration, id int, pair IAPair, timeout time.Duration) error {
+func RunClient(in Integration, pair IAPair, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	c, err := in.StartClient(ctx, id, pair.Src, pair.Dst)
+	c, err := in.StartClient(ctx, pair.Src, pair.Dst)
 	if err != nil {
 		return err
 	}
@@ -264,7 +264,7 @@ func RunBinaryTests(in Integration, pairs []IAPair) error {
 		// Start client
 		log.Info(fmt.Sprintf("Test %v: %v -> %v (%v/%v)", in.Name(), pair.Src.IA, pair.Dst.IA,
 			idx+1, len(pairs)))
-		if err := RunClient(in, idx+1, pair, DefaultRunTimeout); err != nil {
+		if err := RunClient(in, pair, DefaultRunTimeout); err != nil {
 			fmt.Fprintf(os.Stderr, "Error during client execution: %s\n", err)
 			return err
 		}
@@ -282,7 +282,7 @@ func RunUnaryTests(in Integration, pairs []IAPair, timeout time.Duration) error 
 		log.Info(fmt.Sprintf("Test %v: %v -> %v (%v/%v)",
 			in.Name(), pair.Src.IA, pair.Dst.IA, idx+1, len(pairs)))
 		// Start client
-		if err := RunClient(in, idx+1, pair, timeout); err != nil {
+		if err := RunClient(in, pair, timeout); err != nil {
 			fmt.Fprintf(os.Stderr, "Error during client execution: %s\n", err)
 			return err
 		}

--- a/go/lib/integration/integration.go
+++ b/go/lib/integration/integration.go
@@ -274,12 +274,15 @@ func RunBinaryTests(in Integration, pairs []IAPair) error {
 
 // RunUnaryTests runs the client for each IAPair.
 // In case of an error the function is terminated immediately.
-func RunUnaryTests(in Integration, pairs []IAPair) error {
+func RunUnaryTests(in Integration, pairs []IAPair, timeout time.Duration) error {
+	if timeout == 0 {
+		timeout = DefaultRunTimeout
+	}
 	return runTests(in, pairs, 2, func(idx int, pair IAPair) error {
 		log.Info(fmt.Sprintf("Test %v: %v -> %v (%v/%v)",
 			in.Name(), pair.Src.IA, pair.Dst.IA, idx+1, len(pairs)))
 		// Start client
-		if err := RunClient(in, idx+1, pair, DefaultRunTimeout); err != nil {
+		if err := RunClient(in, idx+1, pair, timeout); err != nil {
 			fmt.Fprintf(os.Stderr, "Error during client execution: %s\n", err)
 			return err
 		}

--- a/go/lib/integration/integration.go
+++ b/go/lib/integration/integration.go
@@ -83,7 +83,7 @@ type Integration interface {
 	// StartClient should start the client on the src address connecting to the dst address.
 	// StartClient should return immediately.
 	// The context should be used to make the client cancellable.
-	StartClient(ctx context.Context, src, dst snet.Addr) (Waiter, error)
+	StartClient(ctx context.Context, id int, src, dst snet.Addr) (Waiter, error)
 }
 
 // Waiter is a descriptor of a process running in the integration test.
@@ -212,10 +212,10 @@ func StartServer(in Integration, dst snet.Addr) (io.Closer, error) {
 
 // RunClient runs a client on the given IAPair.
 // If the client does not finish until timeout it is killed.
-func RunClient(in Integration, pair IAPair, timeout time.Duration) error {
+func RunClient(in Integration, id int, pair IAPair, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	c, err := in.StartClient(ctx, pair.Src, pair.Dst)
+	c, err := in.StartClient(ctx, id, pair.Src, pair.Dst)
 	if err != nil {
 		return err
 	}
@@ -264,7 +264,7 @@ func RunBinaryTests(in Integration, pairs []IAPair) error {
 		// Start client
 		log.Info(fmt.Sprintf("Test %v: %v -> %v (%v/%v)", in.Name(), pair.Src.IA, pair.Dst.IA,
 			idx+1, len(pairs)))
-		if err := RunClient(in, pair, DefaultRunTimeout); err != nil {
+		if err := RunClient(in, idx+1, pair, DefaultRunTimeout); err != nil {
 			fmt.Fprintf(os.Stderr, "Error during client execution: %s\n", err)
 			return err
 		}
@@ -279,7 +279,7 @@ func RunUnaryTests(in Integration, pairs []IAPair) error {
 		log.Info(fmt.Sprintf("Test %v: %v -> %v (%v/%v)",
 			in.Name(), pair.Src.IA, pair.Dst.IA, idx+1, len(pairs)))
 		// Start client
-		if err := RunClient(in, pair, DefaultRunTimeout); err != nil {
+		if err := RunClient(in, idx+1, pair, DefaultRunTimeout); err != nil {
 			fmt.Fprintf(os.Stderr, "Error during client execution: %s\n", err)
 			return err
 		}

--- a/go/tools/scmp/scmp_integration/main.go
+++ b/go/tools/scmp/scmp_integration/main.go
@@ -57,8 +57,10 @@ func realMain() int {
 
 	for _, tc := range testCases {
 		log.Info(fmt.Sprintf("Run scmp-%s-tests:", tc.Name))
-		in := integration.NewBinaryIntegration(tc.Name, "./bin/scmp", tc.Args, nil)
-		if err := integration.RunUnaryTests(in, integration.IAPairs(), 0); err != nil {
+		in := integration.NewBinaryIntegration(tc.Name, "./integration/bin_wrapper.sh",
+			append([]string{"./bin/scmp"}, tc.Args...), nil)
+		err := integration.RunUnaryTests(in, integration.IAPairs(), integration.DefaultRunTimeout)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to run scmp-%s-tests: %s\n", tc.Name, err)
 			return 1
 		}

--- a/go/tools/scmp/scmp_integration/main.go
+++ b/go/tools/scmp/scmp_integration/main.go
@@ -58,7 +58,7 @@ func realMain() int {
 	for _, tc := range testCases {
 		log.Info(fmt.Sprintf("Run scmp-%s-tests:", tc.Name))
 		in := integration.NewBinaryIntegration(tc.Name, "./bin/scmp", tc.Args, nil)
-		if err := integration.RunUnaryTests(in, integration.IAPairs()); err != nil {
+		if err := integration.RunUnaryTests(in, integration.IAPairs(), 0); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to run scmp-%s-tests: %s\n", tc.Name, err)
 			return 1
 		}

--- a/go/tools/scmp/scmp_integration/main.go
+++ b/go/tools/scmp/scmp_integration/main.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,29 +57,11 @@ func realMain() int {
 
 	for _, tc := range testCases {
 		log.Info(fmt.Sprintf("Run scmp-%s-tests:", tc.Name))
-		in := integration.NewBinaryIntegration(tc.Name, "./bin/scmp", tc.Args, nil,
-			integration.NonStdLog)
-		if err := runTests(in, integration.IAPairs()); err != nil {
+		in := integration.NewBinaryIntegration(tc.Name, "./bin/scmp", tc.Args, nil)
+		if err := integration.RunUnaryTests(in, integration.IAPairs()); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to run scmp-%s-tests: %s\n", tc.Name, err)
 			return 1
 		}
 	}
 	return 0
-}
-
-// RunTests runs the scmp tool for each IAPair.
-// In case of an error the function is terminated immediately.
-func runTests(in integration.Integration, pairs []integration.IAPair) error {
-	return integration.ExecuteTimed(in.Name(), func() error {
-		// Run for all srcDest pair
-		for i, conn := range pairs {
-			log.Info(fmt.Sprintf("Test %v: %v -> %v (%v/%v)",
-				in.Name(), conn.Src.IA, conn.Dst.IA, i+1, len(pairs)))
-			if err := integration.RunClient(in, conn, integration.DefaultRunTimeout); err != nil {
-				fmt.Fprintf(os.Stderr, "Error during client execution: %s\n", err)
-				return err
-			}
-		}
-		return nil
-	})
 }

--- a/integration/bin_wrapper.sh
+++ b/integration/bin_wrapper.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Wrapper to run integration binaries.
+
+PROG=$1
+shift
+
+log() {
+    echo "$(date -u --rfc-3339=ns) $@" 1>&2
+}
+
+set -o pipefail
+
+"$PROG" "$@" |& while read line; do log $line; done

--- a/integration/bin_wrapper.sh
+++ b/integration/bin_wrapper.sh
@@ -6,7 +6,7 @@ PROG=$1
 shift
 
 log() {
-    echo "$(date -u --rfc-3339=ns) $@" 1>&2
+    echo "$(date -u +"%F %T.%6N%z") $@" 1>&2
 }
 
 set -o pipefail


### PR DESCRIPTION
In integration tests write logs of child processes in to separate files.
This way we can run clients in parallel and still see what happens.
Also this fixes #2105

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2161)
<!-- Reviewable:end -->
