### PR TITLE
border: fix error replies for unsupported L4 protocols

### DIFF
--- a/go/border/error.go
+++ b/go/border/error.go
@@ -133,12 +133,7 @@ func (r *Router) createSCMPErrorReply(rp *rpkt.RtrPkt, ct scmp.ClassType,
 			sp.HBHExt = append(sp.HBHExt, e)
 		}
 	}
-	// Add SCMP l4 header and payload
-	var l4Type common.L4ProtocolType
-	if sp.L4 != nil {
-		l4Type = sp.L4.L4Type()
-	}
-	sp.Pld = scmp.PldFromQuotes(ct, info, l4Type, rp.GetRaw)
+	sp.Pld = scmp.PldFromQuotes(ct, info, rp.L4Type, rp.GetRaw)
 	sp.L4 = scmp.NewHdr(ct, sp.Pld.Len())
 	return rp.CreateReply(sp)
 }


### PR DESCRIPTION
When generating SCMP errors replies for bad packets, the border router
quotes different parts of the bad packet, this quotes also depend on how
much the border router is able to parse of it.

The issue shows with unsupported procotols, ie. TCP, where the border
router generates an SCMP error reply with Meta L4Type value 0, meaning
None/HopByHop, which is obviously wrong.

The problem arise because we try to retrieve the L4 Type from the parsed
L4 header, which we do not parsed as it is unsupported.

The solution is simple as rpkt already has the L4Type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2170)
<!-- Reviewable:end -->
