### PR TITLE
snet: Fix bug in context monitor

### DIFF
--- a/go/lib/snet/internal/ctxmonitor/ctxmonitor.go
+++ b/go/lib/snet/internal/ctxmonitor/ctxmonitor.go
@@ -85,7 +85,7 @@ func (m *monitor) WithDeadline(ctx context.Context,
 	defer m.mtx.Unlock()
 
 	subCtx, cancelF := context.WithDeadline(ctx, deadline)
-	if m.deadlinePassed(deadline) {
+	if m.deadlinePassed(time.Now()) {
 		// Deadline has already passed, all new contexts are already Done
 		cancelF()
 		return subCtx, cancelF
@@ -94,8 +94,8 @@ func (m *monitor) WithDeadline(ctx context.Context,
 	return subCtx, m.createDeletionLocked(subCtx, cancelF)
 }
 
-func (m *monitor) deadlinePassed(ctxDeadline time.Time) bool {
-	return !m.deadline.Equal(time.Time{}) && m.deadline.Before(ctxDeadline)
+func (m *monitor) deadlinePassed(reference time.Time) bool {
+	return !m.deadline.Equal(time.Time{}) && m.deadline.Before(reference)
 }
 
 // createDeletionLocked returns a cancellation function that also deletes the

--- a/go/lib/snet/internal/ctxmonitor/ctxmonitor_test.go
+++ b/go/lib/snet/internal/ctxmonitor/ctxmonitor_test.go
@@ -93,6 +93,13 @@ func TestMonitor(t *testing.T) {
 			SoMsg("err", ctx.Err(), ShouldNotBeNil)
 			cancelF()
 		})
+		Convey("Set deadline in future, add context with deadline after, ctx is not Done", func() {
+			deadline := time.Now().Add(5 * time.Second)
+			m.SetDeadline(deadline)
+			ctx, cancelF := m.WithDeadline(context.Background(), deadline.Add(time.Second))
+			SoMsg("err", ctx.Err(), ShouldBeNil)
+			cancelF()
+		})
 	})
 }
 


### PR DESCRIPTION
Context monitor no longer immediately cancels new contexts created with
a deadline that is after the currently set deadline (if it hasn't
expired yet).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2176)
<!-- Reviewable:end -->
