### PR TITLE
More transparent DB setup

### DIFF
--- a/go/lib/pathstorage/pathstorage.go
+++ b/go/lib/pathstorage/pathstorage.go
@@ -20,6 +20,7 @@ import (
 	cache "github.com/patrickmn/go-cache"
 
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/pathdb"
 	sqlitepathdb "github.com/scionproto/scion/go/lib/pathdb/sqlite"
 	"github.com/scionproto/scion/go/lib/revcache"
@@ -47,6 +48,17 @@ func (c *PathDBConf) InitDefaults() {
 	}
 }
 
+// Validate validates the configuration, should be called after InitDefaults.
+func (c *PathDBConf) validate() error {
+	if c.Backend == BackendNone {
+		return common.NewBasicError("No backend set", nil)
+	}
+	if c.Connection == "" {
+		return common.NewBasicError("Empty connection not allowed", nil)
+	}
+	return nil
+}
+
 // RevCacheConf is the configuration for the connection to the revocation cache.
 type RevCacheConf struct {
 	Backend    Backend
@@ -60,10 +72,27 @@ func (c *RevCacheConf) InitDefaults() {
 	}
 }
 
+// Validate validates the configuration, should be called after InitDefaults.
+func (c *RevCacheConf) validate() error {
+	if c.Backend == BackendNone {
+		return common.NewBasicError("No backend set", nil)
+	}
+	if c.Backend != BackendMem && c.Connection == "" {
+		return common.NewBasicError("Empty connection not allowed", nil)
+	}
+	return nil
+}
+
 // NewPathStorage creates a PathStorage from the given configs.
 func NewPathStorage(pdbConf PathDBConf,
 	rcConf RevCacheConf) (pathdb.PathDB, revcache.RevCache, error) {
 
+	if err := pdbConf.validate(); err != nil {
+		return nil, nil, common.NewBasicError("Invalid pathdb config", err)
+	}
+	if err := rcConf.validate(); err != nil {
+		return nil, nil, common.NewBasicError("Invalid revcache config", err)
+	}
 	if sameBackend(pdbConf, rcConf) {
 		return newCombinedBackend(pdbConf, rcConf)
 	}
@@ -89,6 +118,7 @@ func newCombinedBackend(pdbConf PathDBConf,
 }
 
 func newPathDB(conf PathDBConf) (pathdb.PathDB, error) {
+	log.Info("Connecting PathDB", "backend", conf.Backend, "connection", conf.Connection)
 	switch conf.Backend {
 	case BackendSqlite:
 		return sqlitepathdb.New(conf.Connection)
@@ -100,6 +130,7 @@ func newPathDB(conf PathDBConf) (pathdb.PathDB, error) {
 }
 
 func newRevCache(conf RevCacheConf) (revcache.RevCache, error) {
+	log.Info("Connecting RevCache", "backend", conf.Backend, "connection", conf.Connection)
 	switch conf.Backend {
 	case BackendMem:
 		return memrevcache.New(cache.NoExpiration, time.Second), nil

--- a/go/lib/sqlite/sqlite.go
+++ b/go/lib/sqlite/sqlite.go
@@ -26,6 +26,9 @@ import (
 // stored database is different from schemaVersion, an error is returned.
 func New(path string, schema string, schemaVersion int) (*sql.DB, error) {
 	var err error
+	if path == "" {
+		return nil, common.NewBasicError("Empy path not allowed for sqlite", nil)
+	}
 	db, err := open(path)
 	if err != nil {
 		return nil, err
@@ -39,21 +42,23 @@ func New(path string, schema string, schemaVersion int) (*sql.DB, error) {
 	// prevent weird errors. (see https://stackoverflow.com/a/35805826)
 	db.SetMaxOpenConns(1)
 	if _, err = db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		return nil, common.NewBasicError("Unable to set WAL journal mode", err)
+		return nil, common.NewBasicError("Unable to set WAL journal mode", err,
+			"path", path)
 	}
 	// Check the schema version and set up new DB if necessary.
 	var existingVersion int
 	err = db.QueryRow("PRAGMA user_version;").Scan(&existingVersion)
 	if err != nil {
-		return nil, common.NewBasicError("Failed to check schema version", err)
+		return nil, common.NewBasicError("Failed to check schema version", err,
+			"path", path)
 	}
 	if existingVersion == 0 {
-		if err = setup(db, schema, schemaVersion); err != nil {
+		if err = setup(db, schema, schemaVersion, path); err != nil {
 			return nil, err
 		}
 	} else if existingVersion != schemaVersion {
 		return nil, common.NewBasicError("Database schema version mismatch", nil,
-			"expected", schemaVersion, "have", existingVersion)
+			"expected", schemaVersion, "have", existingVersion, "path", path)
 	}
 	return db, nil
 }
@@ -64,7 +69,7 @@ func open(path string) (*sql.DB, error) {
 	uri := fmt.Sprintf("%s?_foreign_keys=1", path)
 	db, err := sql.Open("sqlite3", uri)
 	if err != nil {
-		return nil, common.NewBasicError("Couldn't open SQLite database", err)
+		return nil, common.NewBasicError("Couldn't open SQLite database", err, "path", path)
 	}
 	// On future errors, close the sql database before exiting
 	defer func() {
@@ -74,36 +79,37 @@ func open(path string) (*sql.DB, error) {
 	}()
 	// Make sure DB is reachable
 	if err = db.Ping(); err != nil {
-		return nil, common.NewBasicError("Initial DB ping failed, connection broken?", err)
+		return nil, common.NewBasicError("Initial DB ping failed, connection broken?", err,
+			"path", path)
 	}
 	// Ensure foreign keys are supported and enabled.
 	var enabled bool
 	err = db.QueryRow("PRAGMA foreign_keys;").Scan(&enabled)
 	if err == sql.ErrNoRows {
-		return nil, common.NewBasicError("Foreign keys not supported", err)
+		return nil, common.NewBasicError("Foreign keys not supported", err,
+			"path", path)
 	}
 	if err != nil {
-		return nil, common.NewBasicError("Failed to check for foreign key support", err)
+		return nil, common.NewBasicError("Failed to check for foreign key support", err,
+			"path", path)
 	}
 	if !enabled {
 		db.Close()
-		return nil, common.NewBasicError("Failed to enable foreign key support", nil)
+		return nil, common.NewBasicError("Failed to enable foreign key support", nil,
+			"path", path)
 	}
 	return db, nil
 }
 
-func setup(db *sql.DB, schema string, schemaVersion int) error {
-	if db == nil {
-		return common.NewBasicError("No database open", nil)
-	}
+func setup(db *sql.DB, schema string, schemaVersion int, path string) error {
 	_, err := db.Exec(schema)
 	if err != nil {
-		return common.NewBasicError("Failed to set up SQLite database", err)
+		return common.NewBasicError("Failed to set up SQLite database", err, "path", path)
 	}
 	// Write schema version to database.
 	_, err = db.Exec(fmt.Sprintf("PRAGMA user_version = %d", schemaVersion))
 	if err != nil {
-		return common.NewBasicError("Failed to write schema version", err)
+		return common.NewBasicError("Failed to write schema version", err, "path", path)
 	}
 	return nil
 }

--- a/go/lib/sqlite/sqlite.go
+++ b/go/lib/sqlite/sqlite.go
@@ -27,7 +27,7 @@ import (
 func New(path string, schema string, schemaVersion int) (*sql.DB, error) {
 	var err error
 	if path == "" {
-		return nil, common.NewBasicError("Empy path not allowed for sqlite", nil)
+		return nil, common.NewBasicError("Empty path not allowed for sqlite", nil)
 	}
 	db, err := open(path)
 	if err != nil {

--- a/go/lib/sqlite/sqlite.go
+++ b/go/lib/sqlite/sqlite.go
@@ -72,6 +72,10 @@ func open(path string) (*sql.DB, error) {
 			db.Close()
 		}
 	}()
+	// Make sure DB is reachable
+	if err = db.Ping(); err != nil {
+		return nil, common.NewBasicError("Initial DB ping failed, connection broken?", err)
+	}
 	// Ensure foreign keys are supported and enabled.
 	var enabled bool
 	err = db.QueryRow("PRAGMA foreign_keys;").Scan(&enabled)

--- a/go/lib/truststorage/truststorage.go
+++ b/go/lib/truststorage/truststorage.go
@@ -21,6 +21,7 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb/trustdbsqlite"
+	"github.com/scionproto/scion/go/lib/log"
 )
 
 type Backend string
@@ -39,6 +40,7 @@ type TrustDBConf struct {
 
 // New creates a TrustDB from the config.
 func (c TrustDBConf) New() (trustdb.TrustDB, error) {
+	log.Info("Connecting TrustDB", "backend", c.Backend, "connection", c.Connection)
 	switch c.Backend {
 	case BackendSqlite:
 		return trustdbsqlite.New(c.Connection)


### PR DESCRIPTION
Fixes #2162 

Examples:
Clean setup:
```
2018-11-28 16:07:59.026287+0000 [INFO] Connecting PathDB backend=sqlite connection=gen-cache/ps1-ff00_0_110-1.path.db
2018-11-28 16:07:59.083183+0000 [INFO] Connecting RevCache backend=mem connection=""
2018-11-28 16:07:59.083246+0000 [INFO] Connecting TrustDB backend=sqlite connection=gen-cache/ps1-ff00_0_110-1.trust.db
```
Wrong config:
```
2018-11-28 16:09:13.184397+0000 [CRIT] Unable to initialize path storage err=
>  Invalid pathdb config
>      Empty connection not allowed
```
DB failure:
```
2018-11-28 16:15:42.959491+0000 [INFO] Connecting PathDB backend=sqlite connection=f
2018-11-28 16:15:42.959674+0000 [CRIT] Unable to initialize path storage err=
>  Initial DB ping failed, connection broken?
>      unable to open database file

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2178)
<!-- Reviewable:end -->
