### PR TITLE
Add a QuicConfig to squic Dial/Listen methods

### DIFF
--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -237,7 +237,7 @@ func (c *client) run() {
 	// IP address needs to be supplied explicitly. When supplied a local
 	// port of 0, DialSCION will assign a random free local port.
 	var err error
-	c.qsess, err = squic.DialSCION(nil, &local, &remote)
+	c.qsess, err = squic.DialSCION(nil, &local, &remote, nil)
 	if err != nil {
 		LogFatal("Unable to dial", "err", err)
 	}
@@ -347,7 +347,7 @@ type server struct {
 // On any error, the server exits.
 func (s server) run() {
 	// Listen on SCION address
-	qsock, err := squic.ListenSCION(nil, &local)
+	qsock, err := squic.ListenSCION(nil, &local, nil)
 	if err != nil {
 		LogFatal("Unable to listen", "err", err)
 	}

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -51,26 +51,26 @@ func Init(keyPath, pemPath string) error {
 	return nil
 }
 
-func DialSCION(network *snet.SCIONNetwork, laddr, raddr *snet.Addr) (quic.Session, error) {
-	return DialSCIONWithBindSVC(network, laddr, raddr, nil, addr.SvcNone)
+func DialSCION(network *snet.SCIONNetwork, laddr, raddr *snet.Addr, quicConfig *quic.Config) (quic.Session, error) {
+	return DialSCIONWithBindSVC(network, laddr, raddr, nil, addr.SvcNone, quicConfig)
 }
 
 func DialSCIONWithBindSVC(network *snet.SCIONNetwork, laddr, raddr, baddr *snet.Addr,
-	svc addr.HostSVC) (quic.Session, error) {
+	svc addr.HostSVC, quicConfig *quic.Config) (quic.Session, error) {
 	sconn, err := sListen(network, laddr, baddr, svc)
 	if err != nil {
 		return nil, err
 	}
 	// Use dummy hostname, as it's used for SNI, and we're not doing cert verification.
-	return quic.Dial(sconn, raddr, "host:0", cliTlsCfg, nil)
+	return quic.Dial(sconn, raddr, "host:0", cliTlsCfg, quicConfig)
 }
 
-func ListenSCION(network *snet.SCIONNetwork, laddr *snet.Addr) (quic.Listener, error) {
-	return ListenSCIONWithBindSVC(network, laddr, nil, addr.SvcNone)
+func ListenSCION(network *snet.SCIONNetwork, laddr *snet.Addr, quicConfig *quic.Config) (quic.Listener, error) {
+	return ListenSCIONWithBindSVC(network, laddr, nil, addr.SvcNone, quicConfig)
 }
 
 func ListenSCIONWithBindSVC(network *snet.SCIONNetwork, laddr, baddr *snet.Addr,
-	svc addr.HostSVC) (quic.Listener, error) {
+	svc addr.HostSVC, quicConfig *quic.Config) (quic.Listener, error) {
 	if len(srvTlsCfg.Certificates) == 0 {
 		return nil, common.NewBasicError("squic: No server TLS certificate configured", nil)
 	}
@@ -78,7 +78,7 @@ func ListenSCIONWithBindSVC(network *snet.SCIONNetwork, laddr, baddr *snet.Addr,
 	if err != nil {
 		return nil, err
 	}
-	return quic.Listen(sconn, srvTlsCfg, nil)
+	return quic.Listen(sconn, srvTlsCfg, quicConfig)
 }
 
 func sListen(network *snet.SCIONNetwork, laddr, baddr *snet.Addr,

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -53,11 +53,13 @@ func Init(keyPath, pemPath string) error {
 
 func DialSCION(network *snet.SCIONNetwork, laddr, raddr *snet.Addr,
 	quicConfig *quic.Config) (quic.Session, error) {
+
 	return DialSCIONWithBindSVC(network, laddr, raddr, nil, addr.SvcNone, quicConfig)
 }
 
 func DialSCIONWithBindSVC(network *snet.SCIONNetwork, laddr, raddr, baddr *snet.Addr,
 	svc addr.HostSVC, quicConfig *quic.Config) (quic.Session, error) {
+
 	sconn, err := sListen(network, laddr, baddr, svc)
 	if err != nil {
 		return nil, err
@@ -68,11 +70,13 @@ func DialSCIONWithBindSVC(network *snet.SCIONNetwork, laddr, raddr, baddr *snet.
 
 func ListenSCION(network *snet.SCIONNetwork, laddr *snet.Addr,
 	quicConfig *quic.Config) (quic.Listener, error) {
+
 	return ListenSCIONWithBindSVC(network, laddr, nil, addr.SvcNone, quicConfig)
 }
 
 func ListenSCIONWithBindSVC(network *snet.SCIONNetwork, laddr, baddr *snet.Addr,
 	svc addr.HostSVC, quicConfig *quic.Config) (quic.Listener, error) {
+
 	if len(srvTlsCfg.Certificates) == 0 {
 		return nil, common.NewBasicError("squic: No server TLS certificate configured", nil)
 	}
@@ -85,6 +89,7 @@ func ListenSCIONWithBindSVC(network *snet.SCIONNetwork, laddr, baddr *snet.Addr,
 
 func sListen(network *snet.SCIONNetwork, laddr, baddr *snet.Addr,
 	svc addr.HostSVC) (snet.Conn, error) {
+		
 	if network == nil {
 		network = snet.DefNetwork
 	}

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -89,7 +89,7 @@ func ListenSCIONWithBindSVC(network *snet.SCIONNetwork, laddr, baddr *snet.Addr,
 
 func sListen(network *snet.SCIONNetwork, laddr, baddr *snet.Addr,
 	svc addr.HostSVC) (snet.Conn, error) {
-		
+
 	if network == nil {
 		network = snet.DefNetwork
 	}

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -51,7 +51,8 @@ func Init(keyPath, pemPath string) error {
 	return nil
 }
 
-func DialSCION(network *snet.SCIONNetwork, laddr, raddr *snet.Addr, quicConfig *quic.Config) (quic.Session, error) {
+func DialSCION(network *snet.SCIONNetwork, laddr, raddr *snet.Addr,
+	quicConfig *quic.Config) (quic.Session, error) {
 	return DialSCIONWithBindSVC(network, laddr, raddr, nil, addr.SvcNone, quicConfig)
 }
 
@@ -65,7 +66,8 @@ func DialSCIONWithBindSVC(network *snet.SCIONNetwork, laddr, raddr, baddr *snet.
 	return quic.Dial(sconn, raddr, "host:0", cliTlsCfg, quicConfig)
 }
 
-func ListenSCION(network *snet.SCIONNetwork, laddr *snet.Addr, quicConfig *quic.Config) (quic.Listener, error) {
+func ListenSCION(network *snet.SCIONNetwork, laddr *snet.Addr,
+	quicConfig *quic.Config) (quic.Listener, error) {
 	return ListenSCIONWithBindSVC(network, laddr, nil, addr.SvcNone, quicConfig)
 }
 


### PR DESCRIPTION
This PR enables clients to pass a QuicConfig to Dial/Listen methods in the squic package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2180)
<!-- Reviewable:end -->
