### PR TITLE
Fix buildkite build/push steps order

### DIFF
--- a/.buildkite/all_images
+++ b/.buildkite/all_images
@@ -20,7 +20,9 @@ fi
 if [ "$1" == "pull" ]; then
     # Pull images
     for app in $images; do
+        local_img="scion_$app"
         remote_img="$REGISTRY/$app"
         docker pull "$remote_img:$TAG"
+        docker tag "$remote_img:$TAG" "$local_img:latest"
     done
 fi

--- a/.buildkite/steps/build_all.yml
+++ b/.buildkite/steps/build_all.yml
@@ -1,10 +1,7 @@
-- label: Build perapp images
+- label: Build and push perapp images
   command:
   - docker pull $SCION_IMG
   - mkdir docker/_build && touch docker/_build/scion.stamp
   - make -C docker/perapp apps
-- wait
-- label: Push perapp images
-  command:
   - $BASE/all_images push
 - wait


### PR DESCRIPTION
Currently the push step might be run from a different agent than the build step. Also after pulling the images from the registry, they need to be tagged again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2183)
<!-- Reviewable:end -->
