### PR TITLE
Remove crypto handlers from non-core PSes

### DIFF
--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -122,10 +122,13 @@ func realMain() int {
 		log.Crit(infraenv.ErrAppUnableToInitMessenger, "err", err)
 		return 1
 	}
-	msger.AddHandler(infra.ChainRequest, trustStore.NewChainReqHandler(false))
-	// TOOD(lukedirtwalker): with the new CP-PKI design the PS should no longer need to handle TRC
-	// and cert requests.
-	msger.AddHandler(infra.TRCRequest, trustStore.NewTRCReqHandler(false))
+	core := topo.Core
+	if core {
+		// TOOD(lukedirtwalker): with the new CP-PKI design the PS should no longer need to handle
+		// TRC and cert requests.
+		msger.AddHandler(infra.ChainRequest, trustStore.NewChainReqHandler(false))
+		msger.AddHandler(infra.TRCRequest, trustStore.NewTRCReqHandler(false))
+	}
 	args := handlers.HandlerArgs{
 		PathDB:     pathDB,
 		RevCache:   revCache,
@@ -133,7 +136,6 @@ func realMain() int {
 		Config:     config.PS,
 		IA:         topo.ISD_AS,
 	}
-	core := topo.Core
 	var segReqHandler infra.Handler
 	deduper := handlers.NewGetSegsDeduper(msger)
 	if core {


### PR DESCRIPTION
Non-core PSes should never receive TRC or Chain requests.
PSes always request crypto material from the sender:
Core PS asks BS or other core PSes.
Non-core PS asks BS or core PS.

All other processes should go through sciond or the CS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2198)
<!-- Reviewable:end -->
