### PR TITLE
Remove SCMP logging message from snet

### DIFF
--- a/go/lib/snet/reader.go
+++ b/go/lib/snet/reader.go
@@ -146,8 +146,6 @@ func (c *scionConnReader) handleSCMP(hdr *scmp.Hdr, pkt *spkt.ScnPkt) {
 	// Only handle revocations for now
 	if hdr.Class == scmp.C_Path && hdr.Type == scmp.T_P_RevokedIF {
 		c.handleSCMPRev(hdr, pkt)
-	} else {
-		log.Warn("Received unsupported SCMP message", "class", hdr.Class, "type", hdr.Type)
 	}
 }
 


### PR DESCRIPTION
The SCMP header is sent back to the app, and it can decide whether to
log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2206)
<!-- Reviewable:end -->
