### PR TITLE
Use fatal library in path_srv, cert_srv and sciond

### DIFF
--- a/go/lib/env/env.go
+++ b/go/lib/env/env.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/fatal"
 	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/overlay"
@@ -204,14 +205,15 @@ type Metrics struct {
 	Prometheus string
 }
 
-func (cfg *Metrics) StartPrometheus(fatalC chan error) {
+func (cfg *Metrics) StartPrometheus() {
+	fatal.Check()
 	if cfg.Prometheus != "" {
 		http.Handle("/metrics", promhttp.Handler())
 		log.Info("Exporting prometheus metrics", "addr", cfg.Prometheus)
 		go func() {
 			defer log.LogPanicAndExit()
 			if err := http.ListenAndServe(cfg.Prometheus, nil); err != nil {
-				fatalC <- common.NewBasicError("HTTP ListenAndServe error", err)
+				fatal.Fatal(common.NewBasicError("HTTP ListenAndServe error", err))
 			}
 		}()
 	}

--- a/go/lib/pktdisp/disp.go
+++ b/go/lib/pktdisp/disp.go
@@ -34,6 +34,7 @@ type DispatchFunc func(*DispPkt)
 // N.B. the DispPkt passed to f is reused, so applications should make a copy if
 // this is a problem.
 func PktDispatcher(c snet.Conn, f DispatchFunc, pktDispStop chan struct{}) {
+	fatal.Check()
 	var err error
 	var n int
 	dp := &DispPkt{Raw: make(common.RawBytes, common.MaxMTU)}

--- a/go/sig/main.go
+++ b/go/sig/main.go
@@ -64,6 +64,7 @@ func main() {
 }
 
 func realMain() int {
+	fatal.Init()
 	env.AddFlags()
 	flag.Parse()
 	if v, ok := env.CheckFlags(sigconfig.Sample); !ok {
@@ -106,13 +107,11 @@ func realMain() int {
 		reader.NewReader(tunIO).Run()
 	}()
 	spawnIngressDispatcher(tunIO)
-	cfg.Metrics.StartPrometheus(fatal.Chan())
+	cfg.Metrics.StartPrometheus()
 	select {
 	case <-environment.AppShutdownSignal:
 		return 0
-	case err := <-fatal.Chan():
-		// Prometheus or the ingress dispatcher encountered a fatal error, thus we exit.
-		log.Crit("Fatal error during execution", "err", err)
+	case <-fatal.Chan():
 		return 1
 	}
 }


### PR DESCRIPTION
This patch also moves logging the fatal condition into the failing
goroutine and makes servers wait for 1 second before exiting. This
way we can collect multiple fatal errors in the log in case the
first one is not the most informative one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2208)
<!-- Reviewable:end -->
