### PR TITLE
Make SIG IDs in the topology canonical

### DIFF
--- a/python/topology/docker_utils.py
+++ b/python/topology/docker_utils.py
@@ -94,7 +94,7 @@ class DockerUtilsGenerator(object):
             # If the tester container needs to communicate to the SIG, it needs the SIG_IP and
             # REMOTE_NETS which are the remote subnets that need to be routed through the SIG.
             # net information for the connected SIG
-            sig_net = self.args.networks['sig_%s' % topo_id.file_fmt()][0]
+            sig_net = self.args.networks['sig%s' % topo_id.file_fmt()][0]
             net = self.args.networks[name][0]
             bridge = self.args.bridges[net['net']]
             entry['networks'][bridge] = {'ipv4_address': str(net['ipv4'])}
@@ -105,7 +105,7 @@ class DockerUtilsGenerator(object):
     def _sig_testing_conf(self):
         text = ''
         for topo_id in self.args.topo_dicts:
-            ip = self.args.networks['sig_%s' % topo_id.file_fmt()][0]['ipv4']
+            ip = self.args.networks['sig%s' % topo_id.file_fmt()][0]['ipv4']
             text += str(topo_id) + ' ' + str(ip) + '\n'
             conf_path = os.path.join(self.args.output_dir, 'sig-testing.conf')
             write_file(conf_path, text)

--- a/python/topology/sig.py
+++ b/python/topology/sig.py
@@ -84,7 +84,7 @@ class SIGGenerator(object):
             ]
         }
 
-        net = self.args.networks['sig_%s' % topo_id.file_fmt()][0]
+        net = self.args.networks['sig%s' % topo_id.file_fmt()][0]
         entry['networks'][self.args.bridges[net['net']]] = {'ipv4_address': str(net['ipv4'])}
         self.dc_conf['services']['scion_disp_sig_%s' % topo_id.file_fmt()] = entry
         vol_name = 'vol_scion_%sdisp_sig_%s' % (self.prefix, topo_id.file_fmt())
@@ -125,7 +125,7 @@ class SIGGenerator(object):
             if topo_id == t_id:
                 continue
             sig_cfg['ASes'][str(t_id)] = {"Nets": [], "Sigs": {}}
-            net = self.args.networks['sig_%s' % t_id.file_fmt()][0]
+            net = self.args.networks['sig%s' % t_id.file_fmt()][0]
             sig_cfg['ASes'][str(t_id)]['Nets'].append(net['net'])
             sig_cfg['ASes'][str(t_id)]['Sigs']['sig'] = {"Addr": str(net['ipv4'])}
 
@@ -134,7 +134,7 @@ class SIGGenerator(object):
         write_file(cfg, contents_json + '\n')
 
     def _sig_toml(self, topo_id, topo, base):
-        name = 'sig_%s' % topo_id.file_fmt()
+        name = 'sig%s' % topo_id.file_fmt()
         net = self.args.networks[name][0]
         base = topo_id.base_dir(self.args.output_dir)
         log_level = 'trace' if self.args.trace else 'debug'

--- a/python/topology/topo.py
+++ b/python/topology/topo.py
@@ -133,7 +133,7 @@ class TopoGenerator(object):
     def _register_sigs(self):
         for isd_as, _ in self.args.topo_config_dict["ASes"].items():
             topo_id = TopoID(isd_as)
-            self._reg_addr(topo_id, "sig_" + topo_id.file_fmt())
+            self._reg_addr(topo_id, "sig" + topo_id.file_fmt())
             self._reg_addr(topo_id, "tester_" + topo_id.file_fmt())
 
     def _br_name(self, ep, assigned_br_id, br_ids, if_ids):


### PR DESCRIPTION
All other services are named something like br1-ff00_0_222.
SIG is nmaed sig_1-ff00_0_222. This patch makes the naming consistent.