### PR TITLE
BR: Fix topo reloading

### DIFF
--- a/go/border/setup.go
+++ b/go/border/setup.go
@@ -277,14 +277,14 @@ func setupPosixAddExt(r *Router, ctx *rctx.Ctx, intf *netconf.Interface,
 		}
 	} else if interfaceChanged(intf, oldIntf) {
 		log.Debug("Existing interface changed.", "old", oldIntf, "new", intf)
-		// An existing interface has changed.
-		// Stop old input goroutine.
-		oldCtx.ExtSockIn[intf.Id].Stop()
-		oldCtx.ExtSockOut[intf.Id].Stop()
 		// Configure new Posix I/O.
 		if err := addPosixIntf(r, ctx, intf, labels); err != nil {
 			return rpkt.HookError, err
 		}
+		// An existing interface has changed.
+		// Stop old input goroutine.
+		oldCtx.ExtSockIn[intf.Id].Stop()
+		oldCtx.ExtSockOut[intf.Id].Stop()
 	} else {
 		log.Debug("No change detected for external socket.", "conn",
 			intf.IFAddr.BindOrPublicOverlay(ctx.Conf.Topo.Overlay))


### PR DESCRIPTION
The old sockets should not be closed before the new ones are started successfully.

(partially addresses #2254)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2252)
<!-- Reviewable:end -->
