### PR TITLE
Make snet.Addr implement JSONUnmarshaler.

### DIFF
--- a/go/lib/snet/addr.go
+++ b/go/lib/snet/addr.go
@@ -15,6 +15,7 @@
 package snet
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"net"
@@ -99,6 +100,20 @@ func (a *Addr) UnmarshalText(text []byte) error {
 		return err
 	}
 	*a = *other
+	return nil
+}
+
+// UnmarshalJSON impleemnts json.Unmarshaler.
+func (a *Addr) UnmarshalJSON(b []byte) error {
+	var astr string
+	if err := json.Unmarshal(b, &astr); err != nil {
+		return err
+	}
+	addr, err := AddrFromString(astr)
+	if err != nil {
+		return err
+	}
+	*a = *addr
 	return nil
 }
 


### PR DESCRIPTION
In the RAINS configuration file we wanted to be able to pass in a SCION
address as a string instead of having the full expansion of this struct.
Since this configuration is automagically parsed by `encoding/json`, it
was not possible to pass a string in to the configuration file. Hence I
propose adding a JSONUnmarshaler method which calls AddrFromString.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2253)
<!-- Reviewable:end -->
