### PR TITLE
messenger: Use path if we already have it

### DIFF
--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -735,6 +735,9 @@ func (pr *pathingRequester) getBlockingPath(ctx context.Context, a net.Addr) (ne
 	if snetAddress.IA == pr.local {
 		return snetAddress, nil
 	}
+	if snetAddress.Path != nil {
+		return snetAddress, nil
+	}
 	conn := snet.DefNetwork.PathResolver().Sciond()
 	paths, err := conn.Paths(ctx, snetAddress.IA, pr.local, 5, sciond.PathReqFlags{})
 	if err != nil {


### PR DESCRIPTION
If we need to get a path for a snet.Addr first check if there is already a path, if so use it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2267)
<!-- Reviewable:end -->
