### PR TITLE
sciond-API: Wrap errors

### DIFF
--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -188,7 +188,7 @@ func (c *connector) Paths(ctx context.Context, dst, src addr.IA, max uint16,
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, common.NewBasicError("[sciond-API] Failed to get Paths", err)
 	}
 	return reply.(*Pld).PathReply, nil
 }
@@ -214,7 +214,7 @@ func (c *connector) ASInfo(ctx context.Context, ia addr.IA) (*ASInfoReply, error
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, common.NewBasicError("[sciond-API] Failed to get ASInfo", err)
 	}
 	asInfoReply := pld.(*Pld).AsInfoReply
 	c.asInfos.SetDefault(key, asInfoReply)
@@ -242,7 +242,7 @@ func (c *connector) IFInfo(ctx context.Context, ifs []common.IFIDType) (*IFInfoR
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, common.NewBasicError("[sciond-API] Failed to get IFInfo", err)
 	}
 	ifInfoReply := pld.(*Pld).IfInfoReply
 	// Add new information to cache
@@ -293,7 +293,7 @@ func (c *connector) SVCInfo(ctx context.Context,
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, common.NewBasicError("[sciond-API] Failed to get SVCInfo", err)
 	}
 	serviceInfoReply := pld.(*Pld).ServiceInfoReply
 	// Add new information to cache
@@ -348,7 +348,7 @@ func (c *connector) RevNotification(ctx context.Context,
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, common.NewBasicError("[sciond-API] Failed to send RevNotification", err)
 	}
 	return reply.(*Pld).RevReply, nil
 }


### PR DESCRIPTION
Otherwise it might not be obvious that they come from the sciond API.
For example if an app uses a dispatcher as well it is not clear if the dispatcher error message is from the app or the sciond API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2269)
<!-- Reviewable:end -->
