### PR TITLE
BR: Add acceptance test for context reload rollback

### DIFF
--- a/acceptance/topo_br_reload_rollback_acceptance/test
+++ b/acceptance/topo_br_reload_rollback_acceptance/test
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Whenever a BR's addresses in the topology file are changed to invalid values,
+# and the BR's process receives a SIGHUP, it will try to reload the topology and
+# handle the errors correctly. In code, this is done by rolling back changes.
+# This acceptance tests checks that the rollback works as expected.
+#
+# This test checks the following:
+# 1. Invalid internal address -> ignore changes; expect traffic to pass
+# 2. Invalid interface address (local) -> ignore changes; expect traffic to pass
+
+TEST_NAME="topo_br_reload_rollback"
+TEST_TOPOLOGY="acceptance/topo_br_reload_util/Tinier.topo"
+
+. acceptance/topo_br_reload_util/util.sh
+
+test_setup() {
+    base_setup
+}
+
+test_run() {
+    set -e
+    cp $SRC_TOPO "${SRC_TOPO}.tmp"
+    local orig_int=$(jq '.BorderRouters[].InternalAddrs.IPv4.PublicOverlay' $SRC_TOPO)
+    local orig_src=$(jq '.BorderRouters[].Interfaces[].PublicOverlay' $SRC_TOPO)
+    local orig_dst=$(jq '.BorderRouters[].Interfaces[].PublicOverlay' $DST_TOPO)
+
+    check_internal_fail
+    cp "${SRC_TOPO}.tmp" $SRC_TOPO
+    check_if_local_fail
+}
+
+check_internal_fail() {
+    check_connectivity "Start check_internal_fail"
+    jq '.BorderRouters[].InternalAddrs.IPv4.PublicOverlay.Addr = "172.220.42.42"' $SRC_TOPO | sponge $SRC_TOPO
+    ./tools/dc dc kill -s HUP scion_br"$SRC_IA_FILE"-1
+    check_connectivity "End check_internal_fail"
+}
+
+check_if_local_fail() {
+    check_connectivity "Start check_if_local_fail"
+    jq '.BorderRouters[].InternalAddrs.IPv4.PublicOverlay.OverlayPort = 42424' $SRC_TOPO | sponge $SRC_TOPO
+    jq '.BorderRouters[].Interfaces[].PublicOverlay.Addr = "172.220.42.42"' $SRC_TOPO | sponge $SRC_TOPO
+    ./tools/dc dc kill -s HUP scion_br"$SRC_IA_FILE"-1
+    check_connectivity "End check_if_local_fail"
+}
+
+test_teardown() {
+    base_teardown
+    rm "${SRC_TOPO}.tmp"
+}
+
+PROGRAM=`basename "$0"`
+COMMAND="$1"
+
+case "$COMMAND" in
+    name)
+        echo $TEST_NAME ;;
+    setup|run|teardown)
+        "test_$COMMAND" ;;
+    *) print_help; exit 1 ;;
+esac
+

--- a/acceptance/topo_br_reload_rollback_acceptance/test
+++ b/acceptance/topo_br_reload_rollback_acceptance/test
@@ -12,6 +12,8 @@
 TEST_NAME="topo_br_reload_rollback"
 TEST_TOPOLOGY="acceptance/topo_br_reload_util/Tinier.topo"
 
+TMP_TOPO=$TMP_TOPO
+
 . acceptance/topo_br_reload_util/util.sh
 
 test_setup() {
@@ -20,13 +22,9 @@ test_setup() {
 
 test_run() {
     set -e
-    cp $SRC_TOPO "${SRC_TOPO}.tmp"
-    local orig_int=$(jq '.BorderRouters[].InternalAddrs.IPv4.PublicOverlay' $SRC_TOPO)
-    local orig_src=$(jq '.BorderRouters[].Interfaces[].PublicOverlay' $SRC_TOPO)
-    local orig_dst=$(jq '.BorderRouters[].Interfaces[].PublicOverlay' $DST_TOPO)
-
+    cp $SRC_TOPO $TMP_TOPO
     check_internal_fail
-    cp "${SRC_TOPO}.tmp" $SRC_TOPO
+    cp $TMP_TOPO $SRC_TOPO
     check_if_local_fail
 }
 
@@ -47,7 +45,7 @@ check_if_local_fail() {
 
 test_teardown() {
     base_teardown
-    rm "${SRC_TOPO}.tmp"
+    rm $TMP_TOPO
 }
 
 PROGRAM=`basename "$0"`

--- a/acceptance/topo_br_reload_rollback_acceptance/test
+++ b/acceptance/topo_br_reload_rollback_acceptance/test
@@ -12,7 +12,7 @@
 TEST_NAME="topo_br_reload_rollback"
 TEST_TOPOLOGY="acceptance/topo_br_reload_util/Tinier.topo"
 
-TMP_TOPO=$TMP_TOPO
+TMP_TOPO="${SRC_TOPO}.tmp"
 
 . acceptance/topo_br_reload_util/util.sh
 

--- a/acceptance/topo_br_reload_rollback_acceptance/test
+++ b/acceptance/topo_br_reload_rollback_acceptance/test
@@ -31,7 +31,7 @@ test_run() {
 check_internal_fail() {
     check_connectivity "Start check_internal_fail"
     jq '.BorderRouters[].InternalAddrs.IPv4.PublicOverlay.Addr = "172.220.42.42"' $SRC_TOPO | sponge $SRC_TOPO
-    ./tools/dc dc kill -s HUP scion_br"$SRC_IA_FILE"-1
+    ./tools/dc scion kill -s HUP scion_br"$SRC_IA_FILE"-1
     check_connectivity "End check_internal_fail"
 }
 
@@ -39,7 +39,7 @@ check_if_local_fail() {
     check_connectivity "Start check_if_local_fail"
     jq '.BorderRouters[].InternalAddrs.IPv4.PublicOverlay.OverlayPort = 42424' $SRC_TOPO | sponge $SRC_TOPO
     jq '.BorderRouters[].Interfaces[].PublicOverlay.Addr = "172.220.42.42"' $SRC_TOPO | sponge $SRC_TOPO
-    ./tools/dc dc kill -s HUP scion_br"$SRC_IA_FILE"-1
+    ./tools/dc scion kill -s HUP scion_br"$SRC_IA_FILE"-1
     check_connectivity "End check_if_local_fail"
 }
 

--- a/acceptance/topo_br_reload_util/util.sh
+++ b/acceptance/topo_br_reload_util/util.sh
@@ -17,7 +17,7 @@ check_logs() {
 }
 
 check_connectivity() {
-    bin/end2end_integration -src $SRC_IA -dst $DST_IA -attempts 5 -d || { echo "FAIL: Traffic does not pass. $1" ; return 1; }
+    bin/end2end_integration -src $SRC_IA -dst $DST_IA -attempts 5 -d || { echo "FAIL: Traffic does not pass. step=( $1 )" ; return 1; }
 }
 
 unqoute() {


### PR DESCRIPTION
Add acceptance test to check failed sighup topology reloads are recovered correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2277)
<!-- Reviewable:end -->
