### PR TITLE
PS: Change dedupe lifetime

### DIFF
--- a/go/path_srv/internal/handlers/psdedupe.go
+++ b/go/path_srv/internal/handlers/psdedupe.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
@@ -51,5 +52,5 @@ func NewGetSegsDeduper(msger infra.Messenger) dedupe.Deduper {
 		}
 		return dedupe.Response{Data: segs}
 	}
-	return dedupe.New(requestFunc, 0, 0)
+	return dedupe.New(requestFunc, 3*time.Second, 0)
 }

--- a/go/path_srv/internal/handlers/psdedupe.go
+++ b/go/path_srv/internal/handlers/psdedupe.go
@@ -52,5 +52,5 @@ func NewGetSegsDeduper(msger infra.Messenger) dedupe.Deduper {
 		}
 		return dedupe.Response{Data: segs}
 	}
-	return dedupe.New(requestFunc, 3*time.Second, 0)
+	return dedupe.New(requestFunc, time.Second, 0)
 }


### PR DESCRIPTION
The default interval of 5s is bad for integration tests, example: revoc test 131->212:
• 131 requests down segments at 130
• 130 hits a revocation
• 131 gets a new request but the request is deduplicated until the first one times out (after 5s).
• After the timeout the next request goes to 130 again.
• 130 selects another path to core in isd 2 but again hits a revocation
• 131 is again blocked for 5s
• After that 130 chooses the first path again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2285)
<!-- Reviewable:end -->
