### PR TITLE
Topo: Add TTL

### DIFF
--- a/go/border/brconf/conf.go
+++ b/go/border/brconf/conf.go
@@ -101,7 +101,7 @@ func Load(id, confDir string) (*Conf, error) {
 	}
 
 	// Create network configuration
-	if conf.Net, err = netconf.FromTopo(conf.BR.IFIDs, conf.Topo.IFInfoMap); err != nil {
+	if conf.Net, err = netconf.FromTopo(conf.BR, conf.Topo.IFInfoMap); err != nil {
 		return nil, err
 	}
 	// Save config

--- a/go/border/netconf/interface.go
+++ b/go/border/netconf/interface.go
@@ -46,21 +46,20 @@ type NetConf struct {
 }
 
 // FromTopo creates a NetConf instance from the topology.
-func FromTopo(intfs []common.IFIDType, infomap map[common.IFIDType]topology.IFInfo) (
+func FromTopo(br *topology.BRInfo, infomap map[common.IFIDType]topology.IFInfo) (
 	*NetConf, error) {
-	n := &NetConf{}
+	n := &NetConf{
+		LocAddr:  br.InternalAddrs,
+		CtrlAddr: br.CtrlAddrs,
+	}
 	n.IFs = make(map[common.IFIDType]*Interface)
-	for _, ifid := range intfs {
+	for _, ifid := range br.IFIDs {
 		ifinfo := infomap[ifid]
-		if n.LocAddr == nil {
-			n.LocAddr = ifinfo.InternalAddrs
-		} else if assert.On {
+		if assert.On {
 			assert.Must(n.LocAddr == ifinfo.InternalAddrs,
 				"Cannot have multiple local data-plane addresses")
 		}
-		if n.CtrlAddr == nil {
-			n.CtrlAddr = ifinfo.CtrlAddrs
-		} else if assert.On {
+		if assert.On {
 			assert.Must(n.CtrlAddr == ifinfo.CtrlAddrs,
 				"Cannot have multiple local control-plane addresses")
 		}

--- a/go/border/netconf/interface.go
+++ b/go/border/netconf/interface.go
@@ -48,13 +48,17 @@ type NetConf struct {
 // FromTopo creates a NetConf instance from the topology.
 func FromTopo(br *topology.BRInfo, infomap map[common.IFIDType]topology.IFInfo) (
 	*NetConf, error) {
+
 	n := &NetConf{
 		LocAddr:  br.InternalAddrs,
 		CtrlAddr: br.CtrlAddrs,
 	}
 	n.IFs = make(map[common.IFIDType]*Interface)
 	for _, ifid := range br.IFIDs {
-		ifinfo := infomap[ifid]
+		ifinfo, ok := infomap[ifid]
+		if assert.On {
+			assert.Must(ok, "Interface must exist")
+		}
 		if assert.On {
 			assert.Must(n.LocAddr == ifinfo.InternalAddrs,
 				"Cannot have multiple local data-plane addresses")

--- a/go/lib/topology/raw.go
+++ b/go/lib/topology/raw.go
@@ -41,6 +41,7 @@ const (
 type RawTopo struct {
 	Timestamp          int64
 	TimestampHuman     string
+	TTL                uint32
 	ISD_AS             string
 	Overlay            string
 	MTU                int

--- a/go/lib/topology/testdata/basic.json
+++ b/go/lib/topology/testdata/basic.json
@@ -1,6 +1,7 @@
 {
     "Timestamp": 168570123,
     "TimestampHuman": "1975-05-06 01:02:03.000000+0000",
+    "TTL": 3600,
     "ISD_AS": "1-ff00:0:311",
     "MTU": 1472,
     "Overlay": "IPv4+6",

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -51,7 +51,9 @@ func (s ServiceNames) GetRandom() (string, error) {
 
 // Topo is the main struct encompassing topology information for use in Go code.
 // The first section contains metadata about the topology. All of these fields
-// should be self-explanatory.
+// should be self-explanatory. The unit of TTL is seconds, with the zero value
+// indicating an infinite TTL.
+//
 // The second section concerns the Border routers. BRNames is just a sorted slice
 // of the names of the BRs in this topolgy. Its contents is exactly the same as
 // the keys in the BR map.
@@ -67,7 +69,7 @@ func (s ServiceNames) GetRandom() (string, error) {
 type Topo struct {
 	Timestamp      time.Time
 	TimestampHuman string // This can vary wildly in format and is only for informational purposes.
-	TTL            uint32
+	TTL            time.Duration
 	ISD_AS         addr.IA
 	Overlay        overlay.Type
 	MTU            int
@@ -139,7 +141,7 @@ func (t *Topo) populateMeta(raw *RawTopo) error {
 	var err error
 	t.Timestamp = time.Unix(raw.Timestamp, 0)
 	t.TimestampHuman = raw.TimestampHuman
-	t.TTL = raw.TTL
+	t.TTL = time.Duration(raw.TTL) * time.Second
 
 	if t.ISD_AS, err = addr.IAFromString(raw.ISD_AS); err != nil {
 		return err
@@ -254,7 +256,7 @@ func (t *Topo) populateServices(raw *RawTopo) error {
 
 func (t *Topo) Active(now time.Time) bool {
 	return !now.Before(t.Timestamp) && (t.TTL == 0 ||
-		now.Before(t.Timestamp.Add(time.Duration(t.TTL)*time.Second)))
+		now.Before(t.Timestamp.Add(t.TTL)))
 }
 
 func (t *Topo) GetAllTopoAddrs(svc proto.ServiceType) ([]TopoAddr, error) {

--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -117,18 +117,17 @@ func Test_Active(t *testing.T) {
 	Convey("Checking Active", t, func() {
 		loadTopo(fn, t)
 		c := testTopo
-		start := time.Unix(168570123, 0)
 		Convey("Given a positive TTL", func() {
-			SoMsg("Before TS inactive", c.Active(start.Add(-time.Second)), ShouldBeFalse)
-			SoMsg("TS in active range", c.Active(start), ShouldBeTrue)
-			SoMsg("End of active range", c.Active(start.Add(3599*time.Second)), ShouldBeTrue)
-			SoMsg("Expired inactive", c.Active(start.Add(time.Hour)), ShouldBeFalse)
+			SoMsg("Before TS inactive", c.Active(c.Timestamp.Add(-time.Second)), ShouldBeFalse)
+			SoMsg("TS in active range", c.Active(c.Timestamp), ShouldBeTrue)
+			SoMsg("End of active range", c.Active(c.Timestamp.Add(c.TTL-1)), ShouldBeTrue)
+			SoMsg("Expired inactive", c.Active(c.Timestamp.Add(time.Hour)), ShouldBeFalse)
 		})
 		Convey("Given a zero TTL", func() {
 			c.TTL = 0
-			SoMsg("Before TS inactive", c.Active(start.Add(-time.Second)), ShouldBeFalse)
-			SoMsg("TS in active range", c.Active(start), ShouldBeTrue)
-			SoMsg("Distant time active", c.Active(start.Add(100*time.Hour)), ShouldBeTrue)
+			SoMsg("Before TS inactive", c.Active(c.Timestamp.Add(-time.Second)), ShouldBeFalse)
+			SoMsg("TS in active range", c.Active(c.Timestamp), ShouldBeTrue)
+			SoMsg("Distant time active", c.Active(c.Timestamp.Add(100*time.Hour)), ShouldBeTrue)
 		})
 	})
 }

--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -103,7 +103,7 @@ func Test_Meta(t *testing.T) {
 		// Is testing this piece of data really useful?
 		SoMsg("Checking field 'TimestampHuman", c.TimestampHuman,
 			ShouldContainSubstring, "1975-05-06 01:02:03.000000+0000")
-		SoMsg("Checking field 'TTL'", c.TTL, ShouldEqual, 3600)
+		SoMsg("Checking field 'TTL'", c.TTL, ShouldEqual, time.Hour)
 		SoMsg("Checking field 'ISD_AS'", c.ISD_AS, ShouldResemble, addr.IA{I: 1, A: 0xff0000000311})
 		SoMsg("Checking field 'Overlay'", c.Overlay, ShouldEqual, overlay.IPv46)
 		SoMsg("Checking field 'MTU'", c.MTU, ShouldEqual, 1472)


### PR DESCRIPTION
Add TTL field to topology file.
TTL indicates for how long the topology is valid in seconds since the timestamp.

Additionally, add CtrlAddrs and InternalAddrs to BRInfo.
(Otherwise this information is lost for border routers without any interfaces)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2287)
<!-- Reviewable:end -->
