### PR TITLE
WatchFilter uses pathpol.Policy instead of ActionFilterPaths

### DIFF
--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -42,7 +42,6 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/pathpol"
-	"github.com/scionproto/scion/go/lib/pktcls"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/spath/spathmeta"
 )
@@ -97,8 +96,7 @@ type Resolver interface {
 	// refreshed automatically.
 	//
 	// A nil filter will not delete any paths.
-	WatchFilter(ctx context.Context, src, dst addr.IA,
-		filter *pktcls.ActionFilterPaths) (*SyncPaths, error)
+	WatchFilter(ctx context.Context, src, dst addr.IA, filter *pathpol.Policy) (*SyncPaths, error)
 	// WatchCount returns the number of active watchers.
 	WatchCount() int
 	// RevokeRaw informs SCIOND of a revocation.
@@ -156,7 +154,7 @@ func (r *resolver) QueryFilter(ctx context.Context, src, dst addr.IA,
 }
 
 func (r *resolver) WatchFilter(ctx context.Context, src, dst addr.IA,
-	filter *pktcls.ActionFilterPaths) (*SyncPaths, error) {
+	filter *pathpol.Policy) (*SyncPaths, error) {
 
 	aps := r.Query(ctx, src, dst)
 	if filter != nil {

--- a/go/lib/pathmgr/pathmgr_test.go
+++ b/go/lib/pathmgr/pathmgr_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/pathpol"
-	"github.com/scionproto/scion/go/lib/pktcls"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/sciond/mock_sciond"
 	"github.com/scionproto/scion/go/lib/spath/spathmeta"
@@ -239,10 +238,9 @@ func TestWatchFilter(t *testing.T) {
 		)
 		pr := New(sd, Timers{ErrorRefire: getDuration(1)}, nil)
 		Convey("and adding a watch that should retrieve 1 path", func() {
-			pp, err := spathmeta.NewPathPredicate("1-ff00:0:111#105")
+			seq, err := pathpol.NewSequence([]string{"1-ff00:0:111#105", "0", "0"})
 			xtest.FailOnErr(t, err)
-			filter := pktcls.NewActionFilterPaths("test-1-ff00:0:131#1619",
-				pktcls.NewCondPathPredicate(pp))
+			filter := pathpol.NewPolicy("test-1-ff00:0:131#1619", nil, seq, nil)
 
 			sp, err := pr.WatchFilter(context.Background(), src, dst, filter)
 			xtest.FailOnErr(t, err)

--- a/go/lib/pathpol/policy.go
+++ b/go/lib/pathpol/policy.go
@@ -29,18 +29,18 @@ import (
 
 // ExtPolicy is an extending policy, it may have a list of policies it extends
 type ExtPolicy struct {
-	Extends []string
+	Extends []string `json:",omitempty"`
 	*Policy
 }
 
 // PolicyMap is a container for Policies, keyed by their unique name. PolicyMap
 // can be used to marshal Policies to JSON. Unmarshaling back to PolicyMap is
 // guaranteed to yield an object that is identical to the initial one.
-type PolicyMap map[string]*Policy
+type PolicyMap map[string]*ExtPolicy
 
 // Policy is a compiled path policy object, all extended policies have been merged.
 type Policy struct {
-	Name     string
+	Name     string   `json:"-"`
 	ACL      *ACL     `json:",omitempty"`
 	Sequence Sequence `json:",omitempty"`
 	Options  []Option `json:",omitempty"`


### PR DESCRIPTION
Addtionally, serialization of Policy is changed slightly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2289)
<!-- Reviewable:end -->
