### PR TITLE
Add -fail parameter to sig_ping_acceptance utility

### DIFF
--- a/acceptance/sig_reload_acceptance/test
+++ b/acceptance/sig_reload_acceptance/test
@@ -19,7 +19,7 @@ test_run() {
     jq "del(.ASes.\"$DST_IA\")" $SIG_JSON | sponge $SIG_JSON
     reload_sig "$SRC_IA_FILE"
     # Must fail
-    ./bin/sig_ping_acceptance -d -src $SRC_IA -dst $DST_IA || [ $? -eq 1 ]
+    ./bin/sig_ping_acceptance -d -fail -src $SRC_IA -dst $DST_IA
     # Add $DST_IA again to sig.json
     jq ".ASes.\"$DST_IA\" = $HOP_JSON" $SIG_JSON | sponge $SIG_JSON
     reload_sig "$SRC_IA_FILE"

--- a/go/acceptance/sig_ping_acceptance/main.go
+++ b/go/acceptance/sig_ping_acceptance/main.go
@@ -33,6 +33,7 @@ var (
 	name     = "sig_ping_acceptance"
 	cmd      = "ping"
 	attempts = flag.Int("attempts", 5, "Number of ping attempts.")
+	fail     = flag.Bool("fail", false, "Succeed if the pings don't make it through.")
 )
 
 func main() {
@@ -58,9 +59,14 @@ func realMain() int {
 	in := integration.NewBinaryIntegration(name, integration.WrapperCmd, args, nil)
 	err := integration.RunUnaryTests(in, integration.UniqueIAPairs(acceptance.SigAddr),
 		time.Duration(*attempts)*time.Second+integration.DefaultRunTimeout)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to run tests: %s\n", err)
-		return 1
+	if !*fail && err == nil {
+		// The test is supposed to succeed and it did indeed succeeded.
+		return 0
 	}
-	return 0
+	if *fail && err != nil {
+		// The test is supposed to fail it did indeed fail.
+		return 0
+	}
+	fmt.Fprintf(os.Stderr, "Failed to run tests: %s\n", err)
+	return 1
 }


### PR DESCRIPTION
This allows us to be more specific about which errors
count as "pings not going through".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2299)
<!-- Reviewable:end -->
