### PR TITLE
braccept: revocation test and rework segment generation

### DIFF
--- a/acceptance/brutil/common.sh
+++ b/acceptance/brutil/common.sh
@@ -11,6 +11,11 @@ DEVINFO_FN=${TEST_ARTIFACTS_DIR}/devinfo.txt
 # Each test should have its own set_veths function for specific setup
 test_setup() {
     set -e
+
+    local disp_dir="/run/shm/dispatcher"
+    [ -d "$disp_dir" ] || mkdir "$disp_dir"
+    [ $(stat -c "%U" "$disp_dir") == "$LOGNAME" ] || { sudo -p "Fixing ownership of $disp_dir - [sudo] password for %p: " chown $LOGNAME: "$disp_dir"; }
+
     sudo -p "Setup docker containers and virtual interfaces - [sudo] password for %p: " true
     # Bring up the dispatcher container and add new veth interfaces
     # This approach currently works because the dispatcher binds to 0.0.0.0 address.

--- a/acceptance/brutil/docker-compose.yml
+++ b/acceptance/brutil/docker-compose.yml
@@ -1,15 +1,4 @@
 version: "3.4"
-x-core-br: &core-br
-  environment:
-    SU_EXEC_USERSPEC: "$LOGNAME"
-  image: scion_border
-  network_mode: "service:dispatcher"
-  volumes:
-    - "/etc/passwd:/etc/passwd:ro"
-    - "/etc/group:/etc/group:ro"
-    - "/run/shm/dispatcher:/run/shm/dispatcher"
-    - "../../logs:/share/logs"
-    - "${TEST_ARTIFACTS_DIR}/conf:/share/conf"
 x-br: &br
   environment:
     SU_EXEC_USERSPEC: "$LOGNAME"
@@ -34,11 +23,11 @@ services:
       - "../../logs:/share/logs"
       - "./dispatcher-conf:/share/conf"
   core-brA:
-    <<: *core-br
+    <<: *br
   core-brB:
-    <<: *core-br
+    <<: *br
   core-brC:
-    <<: *core-br
+    <<: *br
   brA:
     <<: *br
   brB:

--- a/go/border/braccept/brA.go
+++ b/go/border/braccept/brA.go
@@ -19,28 +19,34 @@ import (
 
 	"github.com/scionproto/scion/go/border/braccept/tpkt"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/l4"
+	"github.com/scionproto/scion/go/lib/scmp"
 )
+
+var brACtrlScionHdr = tpkt.NewGenCmnHdr(
+	"1-ff00:0:1", "192.168.0.101", "1-ff00:0:1", "BS_M", nil, common.L4UDP)
 
 var IgnoredPacketsBrA = []*tpkt.ExpPkt{
 	{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
 		tpkt.GenOverlayIP4UDP("192.168.0.11", 30041, "192.168.0.61", 30041),
-		tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.101", "1-ff00:0:1", "BS_M", nil, common.L4UDP),
-		tpkt.NewUDP(20001, 0, ifStateReq),
+		brACtrlScionHdr,
+		tpkt.NewUDP(20001, 0, &brACtrlScionHdr.ScionLayer, ifStateReq),
 		ifStateReq,
 	}}}
 
 func genTestsBrA(hMac hash.Hash) []*BRTest {
-	return []*BRTest{
+	tests := []*BRTest{
 		{
-			Desc: "Single IFID - external - Xover Peer - local destination",
+			Desc: "Single IFID peer - Xover peer/local",
 			In: &tpkt.Pkt{
 				Dev: "ifid_121", Layers: []tpkt.LayerBuilder{
 					tpkt.GenOverlayIP4UDP("192.168.12.3", 40000, "192.168.12.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:2", "172.16.2.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revsegP_2C0X_2A0X_06C,
-							seg_06A_1A0X_1C0X.Macs(hMac, 1)},
+							segment("(__P)[X_.261.0][X_.211.0][0.621]", nil),
+							segment("(C__)[0.611][X_.121.0][X_.161.0]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -49,23 +55,24 @@ func genTestsBrA(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.11", 30001, "192.168.0.51", 30041),
 					tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revsegP_2C0X_2A0X_06C,
-							seg_06A_1A0X_1C0X.Macs(hMac, 1)},
+							segment("(__P)[X_.261.0][X_.211.0][0.621]", nil),
+							segment("(C__)[0.611][X_.121.0][X_.161.0]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
+			Ignore: IgnoredPacketsBrA,
 		},
 		// XXX should we check both segments have Peer flag set? currently not required
 		{
-			Desc: "Single IFID - internal - Xover Peer - remote destination",
+			Desc: "Single IFID peer - Xover local/peer",
 			In: &tpkt.Pkt{
 				Dev: "ifid_local", Layers: []tpkt.LayerBuilder{
 					tpkt.GenOverlayIP4UDP("192.168.0.51", 30041, "192.168.0.11", 30001),
 					tpkt.NewValidScion("1-ff00:0:1", "192.168.0.51", "1-ff00:0:2", "172.16.2.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revsegSP_1C0X_1A0X_06AV.Macs(hMac, 0, 1),
-							seg_06CV_2A0X_2C0X},
+							segment("(_SP)[X_.161.0][X_.121.0][_V.0.611]", hMac, 0, 1),
+							segment("(C__)[_V.0.621][X_.211.0][X_.261.0]", nil)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -74,22 +81,23 @@ func genTestsBrA(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.12.2", 50000, "192.168.12.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.51", "1-ff00:0:2", "172.16.2.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revsegSP_1C0X_1A0X_06AV.Macs(hMac, 0, 1),
-							seg_06CV_2A0X_2C0X},
+							segment("(_SP)[X_.161.0][X_.121.0][_V.0.611]", hMac, 0, 1),
+							segment("(C__)[_V.0.621][X_.211.0][X_.261.0]", nil)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
+			Ignore: IgnoredPacketsBrA,
 		},
 		{
-			Desc: "Single IFID - external - Xover peer/child",
+			Desc: "Single IFID peer - Xover peer/child",
 			In: &tpkt.Pkt{
 				Dev: "ifid_121", Layers: []tpkt.LayerBuilder{
 					tpkt.GenOverlayIP4UDP("192.168.12.3", 40000, "192.168.12.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:2", "172.16.2.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revsegP_2C0X_2A0X_06C,
-							segSP_06B_1A1DX_1D1DX_5A0.Macs(hMac, 1, 2)},
+							segment("(__P)[X_.261.0][X_.211.0][0.621]", nil),
+							segment("(CSP)[0.612][X_.121.151][X_.162.151][511.0]", hMac, 1, 2)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -98,22 +106,23 @@ func genTestsBrA(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.11", 30001, "192.168.0.14", 30004),
 					tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(1, 2, tpkt.Segments{
-							revsegP_2C0X_2A0X_06C,
-							segSP_06B_1A1DX_1D1DX_5A0.Macs(hMac, 1, 2)},
+							segment("(__P)[X_.261.0][X_.211.0][0.621]", nil),
+							segment("(CSP)[0.612][X_.121.151][X_.162.151][511.0]", hMac, 1, 2)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
+			Ignore: IgnoredPacketsBrA,
 		},
 		{
-			Desc: "Single IFID - internal - Xover child/peer",
+			Desc: "Single IFID peer - Xover child/peer",
 			In: &tpkt.Pkt{
 				Dev: "ifid_local", Layers: []tpkt.LayerBuilder{
 					tpkt.GenOverlayIP4UDP("192.168.0.13", 30003, "192.168.0.11", 30001),
 					tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "1-ff00:0:2", "172.16.2.1",
 						tpkt.GenPath(0, 2, tpkt.Segments{
-							revsegSP_5A0_1D1DX_1A1DX_06BV.Macs(hMac, 1, 2),
-							seg_06CV_2A0X_2C0X},
+							segment("(_SP)[511.0][X_.162.151][X_.121.151][_V.0.612]", hMac, 1, 2),
+							segment("(C__)[_V.0.621][X_.211.0][X_.261.0]", nil)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -122,12 +131,85 @@ func genTestsBrA(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.12.2", 50000, "192.168.12.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:5", "172.16.5.1", "1-ff00:0:2", "172.16.2.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revsegSP_5A0_1D1DX_1A1DX_06BV.Macs(hMac, 1, 2),
-							seg_06CV_2A0X_2C0X},
+							segment("(_SP)[511.0][X_.162.151][X_.121.151][_V.0.612]", hMac, 1, 2),
+							segment("(C__)[_V.0.621][X_.211.0][X_.261.0]", nil)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
+			Ignore: IgnoredPacketsBrA,
 		},
 	}
+
+	pktTriggerRev := tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "1-ff00:0:2", "172.16.2.1",
+		tpkt.GenPath(0, 2, tpkt.Segments{
+			segment("(_SP)[511.0][X_.162.151][X_.121.151][_V.0.612]", hMac, 1, 2),
+			segment("(C__)[_V.0.621][X_.211.0][X_.261.0]", nil)},
+		), nil,
+		&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil)
+
+	revScmpScionHdr := tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.11", "1-ff00:0:5", "172.16.5.1",
+		tpkt.GenPath(1, 2, tpkt.Segments{
+			segment("(___)[X_.261.0][X_.211.0][_V.0.621]", nil),
+			segment("(CSP)[_V.0.612][X_.121.151][X_.162.151][511.0]", hMac, 1, 2)},
+		),
+		common.HopByHopClass)
+
+	brCtrlScionHdr := tpkt.NewGenCmnHdr(
+		"1-ff00:0:1", "192.168.0.61", "1-ff00:0:1", "192.168.0.101", nil, common.L4UDP)
+
+	signedRevInfo := tpkt.MustSRevInfo(121, "1-ff00:0:1", "peer", tsNow32, 60)
+
+	ifStateInfoDown := &tpkt.PathMgmtPld{
+		Signer:      ctrl.NullSigner,
+		SigVerifier: ctrl.NullSigVerifier,
+		Instance: &path_mgmt.IFStateInfos{Infos: []*path_mgmt.IFStateInfo{
+			{IfID: 121, Active: false, SRevInfo: signedRevInfo},
+		}},
+	}
+	ifStateInfoUp := &tpkt.PathMgmtPld{
+		Signer:      ctrl.NullSigner,
+		SigVerifier: ctrl.NullSigVerifier,
+		Instance: &path_mgmt.IFStateInfos{Infos: []*path_mgmt.IFStateInfo{
+			{IfID: 121, Active: true, SRevInfo: nil},
+		}},
+	}
+	revTest := &BRTest{
+		Desc: "Single IFID peer - Revocation on interface owned",
+		Pre: &tpkt.Pkt{
+			Dev: "ifid_local", Layers: []tpkt.LayerBuilder{
+				tpkt.GenOverlayIP4UDP("192.168.0.61", 20006, "192.168.0.11", 30041),
+				brCtrlScionHdr,
+				tpkt.NewUDP(20006, 20001, &brCtrlScionHdr.ScionLayer, ifStateInfoDown),
+				ifStateInfoDown,
+			}},
+		In: &tpkt.Pkt{
+			Dev: "ifid_local", Layers: []tpkt.LayerBuilder{
+				tpkt.GenOverlayIP4UDP("192.168.0.13", 30003, "192.168.0.11", 30001),
+				pktTriggerRev,
+			}},
+		Out: []*tpkt.ExpPkt{
+			{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.0.11", 30001, "192.168.0.13", 30003),
+				revScmpScionHdr,
+				&tpkt.ScionSCMPExtn{Extn: scmp.Extn{Error: true, HopByHop: true}},
+				tpkt.NewSCMP(scmp.C_Path, scmp.T_P_RevokedIF, noTime,
+					&revScmpScionHdr.ScionLayer,
+					[]tpkt.LayerBuilder{
+						pktTriggerRev,
+					},
+					tpkt.NewRevocation(0, 2, 121, false, signedRevInfo),
+					common.L4UDP),
+			}}},
+		Post: &tpkt.Pkt{
+			Dev: "ifid_local", Layers: []tpkt.LayerBuilder{
+				tpkt.GenOverlayIP4UDP("192.168.0.61", 20006, "192.168.0.11", 30041),
+				brCtrlScionHdr,
+				tpkt.NewUDP(20006, 20001, &brCtrlScionHdr.ScionLayer, ifStateInfoUp),
+				ifStateInfoUp,
+			}},
+		Ignore: IgnoredPacketsBrA,
+	}
+	tests = append(tests, revTest)
+	return tests
 }

--- a/go/border/braccept/brB.go
+++ b/go/border/braccept/brB.go
@@ -22,11 +22,14 @@ import (
 	"github.com/scionproto/scion/go/lib/l4"
 )
 
+var brBCtrlScionHdr = tpkt.NewGenCmnHdr(
+	"1-ff00:0:1", "192.168.0.102", "1-ff00:0:1", "BS_M", nil, common.L4UDP)
+
 var IgnoredPacketsBrB = []*tpkt.ExpPkt{
 	{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
 		tpkt.GenOverlayIP4UDP("192.1680.12", 30041, "192.168.0.61", 30041),
-		tpkt.NewGenCmnHdr("1-ff00:0:1", "192.1680.102", "1-ff00:0:1", "BS_M", nil, common.L4UDP),
-		tpkt.NewUDP(20002, 0, ifStateReq),
+		brBCtrlScionHdr,
+		tpkt.NewUDP(20002, 0, &brBCtrlScionHdr.ScionLayer, ifStateReq),
 		ifStateReq,
 	}}}
 
@@ -39,7 +42,7 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.3", 40000, "192.168.14.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:4", "172.16.4.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_4A0_01B.Macs(hMac, 1)},
+							segment("(___)[411.0][0.141]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -48,10 +51,10 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.12", 30002, "192.168.0.51", 30041),
 					tpkt.NewGenCmnHdr("1-ff00:0:4", "172.16.4.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_4A0_01B.Macs(hMac, 1)},
+							segment("(___)[411.0][0.141]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrB,
 		},
@@ -62,7 +65,7 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.51", 30041, "192.168.0.12", 30002),
 					tpkt.NewValidScion("1-ff00:0:1", "192.168.0.51", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(0, 0, tpkt.Segments{
-							seg_01B_4A0.Macs(hMac, 0)},
+							segment("(C__)[0.141][411.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -71,10 +74,10 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.2", 50000, "192.168.14.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.51", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_01B_4A0.Macs(hMac, 0)},
+							segment("(C__)[0.141][411.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrB,
 		},
@@ -85,7 +88,7 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.3", 40000, "192.168.14.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:4", "172.16.4.1", "1-ff00:0:6", "172.16.6.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_4A0_1D1B_06B.Macs(hMac, 1)},
+							segment("(___)[411.0][162.141][0.612]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -94,10 +97,10 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.12", 30002, "192.168.0.14", 30004),
 					tpkt.NewGenCmnHdr("1-ff00:0:4", "172.16.4.1", "1-ff00:0:6", "172.16.6.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_4A0_1D1B_06B.Macs(hMac, 1)},
+							segment("(___)[411.0][162.141][0.612]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrB,
 		},
@@ -108,7 +111,7 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.14", 30004, "192.168.0.12", 30002),
 					tpkt.NewValidScion("1-ff00:0:6", "172.16.6.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_06B_1D1B_4A0.Macs(hMac, 1)},
+							segment("(C__)[0.612][162.141][411.0]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -117,10 +120,10 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.2", 50000, "192.168.14.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:6", "172.16.6.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(0, 2, tpkt.Segments{
-							seg_06B_1D1B_4A0.Macs(hMac, 1)},
+							segment("(C__)[0.612][162.141][411.0]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrB,
 		},
@@ -131,8 +134,8 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.3", 40000, "192.168.14.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:4", "172.16.4.1", "1-ff00:0:2", "172.16.2.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revsegSP_4A0_1C1BX_1A1BX_06AV.Macs(hMac, 1, 2),
-							seg_06CV_2A0X_2C0X},
+							segment("(_SP)[411.0][X_.161.141][X_.121.141][_V.0.611]", hMac, 1, 2),
+							segment("(C__)[_V.0.621][X_.211.0][X_.261.0]", nil)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -141,11 +144,11 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.12", 30002, "192.168.0.11", 30001),
 					tpkt.NewGenCmnHdr("1-ff00:0:4", "172.16.4.1", "1-ff00:0:2", "172.16.2.1",
 						tpkt.GenPath(0, 2, tpkt.Segments{
-							revsegSP_4A0_1C1BX_1A1BX_06AV.Macs(hMac, 1, 2),
-							seg_06CV_2A0X_2C0X},
+							segment("(_SP)[411.0][X_.161.141][X_.121.141][_V.0.611]", hMac, 1, 2),
+							segment("(C__)[_V.0.621][X_.211.0][X_.261.0]", nil)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrB,
 		},
@@ -156,8 +159,8 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.11", 30001, "192.168.0.12", 30002),
 					tpkt.NewValidScion("1-ff00:0:2", "172.16.2.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(1, 2, tpkt.Segments{
-							revsegP_2C0X_2A0X_06C,
-							segSP_06A_1A1BX_1C1BX_4A0.Macs(hMac, 1, 2)},
+							segment("(__P)[X_.261.0][X_.211.0][0.621]", nil),
+							segment("(CSP)[0.611][X_.121.141][X_.161.141][411.0]", hMac, 1, 2)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -166,11 +169,11 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.2", 50000, "192.168.14.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(1, 3, tpkt.Segments{
-							revsegP_2C0X_2A0X_06C,
-							segSP_06A_1A1BX_1C1BX_4A0.Macs(hMac, 1, 2)},
+							segment("(__P)[X_.261.0][X_.211.0][0.621]", nil),
+							segment("(CSP)[0.611][X_.121.141][X_.161.141][411.0]", hMac, 1, 2)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrB,
 		},
@@ -181,8 +184,8 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.3", 40000, "192.168.14.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:4", "172.16.4.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revsegS_4A0_1D1BX_06BV.Macs(hMac, 1),
-							segS_06BV_1D1DX_5A0.Macs(hMac, 1)},
+							segment("(_S_)[411.0][X_.162.141][_V.0.612]", hMac, 1),
+							segment("(CS_)[_V.0.612][X_.162.151][511.0]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -191,11 +194,11 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.12", 30002, "192.168.0.14", 30004),
 					tpkt.NewGenCmnHdr("1-ff00:0:4", "172.16.4.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revsegS_4A0_1D1BX_06BV.Macs(hMac, 1),
-							segS_06BV_1D1DX_5A0.Macs(hMac, 1)},
+							segment("(_S_)[411.0][X_.162.141][_V.0.612]", hMac, 1),
+							segment("(CS_)[_V.0.612][X_.162.151][511.0]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrB,
 		},
@@ -206,8 +209,8 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.14", 30004, "192.168.0.12", 30002),
 					tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revsegS_5A0_1D1DX_06BV.Macs(hMac, 1),
-							segS_06BV_1D1BX_4A0.Macs(hMac, 1)},
+							segment("(_S_)[511.0][X_.162.151][_V.0.612]", hMac, 1),
+							segment("(CS_)[_V.0.612][X_.162.141][411.0]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -216,11 +219,11 @@ func genTestsBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.2", 50000, "192.168.14.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:5", "172.16.5.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(1, 2, tpkt.Segments{
-							revsegS_5A0_1D1DX_06BV.Macs(hMac, 1),
-							segS_06BV_1D1BX_4A0.Macs(hMac, 1)},
+							segment("(_S_)[511.0][X_.162.151][_V.0.612]", hMac, 1),
+							segment("(CS_)[_V.0.612][X_.162.141][411.0]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrB,
 		},

--- a/go/border/braccept/brC.go
+++ b/go/border/braccept/brC.go
@@ -22,11 +22,14 @@ import (
 	"github.com/scionproto/scion/go/lib/l4"
 )
 
+var brCCtrlScionHdr = tpkt.NewGenCmnHdr(
+	"1-ff00:0:1", "192.168.0.103", "1-ff00:0:1", "BS_M", nil, common.L4UDP)
+
 var IgnoredPacketsBrC = []*tpkt.ExpPkt{
 	{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
 		tpkt.GenOverlayIP4UDP("192.168.0.13", 30041, "192.168.0.61", 30041),
-		tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.103", "1-ff00:0:1", "BS_M", nil, common.L4UDP),
-		tpkt.NewUDP(20003, 0, ifStateReq),
+		brCCtrlScionHdr,
+		tpkt.NewUDP(20003, 0, &brCCtrlScionHdr.ScionLayer, ifStateReq),
 		ifStateReq,
 	}}}
 
@@ -39,7 +42,7 @@ func genTestsBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.16.3", 40000, "192.168.16.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:6", "172.16.6.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_6A0_01B.Macs(hMac, 1)},
+							segment("(___)[611.0][0.161]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -48,10 +51,10 @@ func genTestsBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.13", 30003, "192.168.0.51", 30041),
 					tpkt.NewGenCmnHdr("1-ff00:0:6", "172.16.6.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_6A0_01B.Macs(hMac, 1)},
+							segment("(___)[611.0][0.161]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrB,
 		},
@@ -62,7 +65,7 @@ func genTestsBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.51", 30041, "192.168.0.13", 30003),
 					tpkt.NewValidScion("1-ff00:0:1", "192.168.0.51", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(0, 0, tpkt.Segments{
-							seg_01B_6A0.Macs(hMac, 0)},
+							segment("(C__)[0.161][611.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -71,10 +74,10 @@ func genTestsBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.16.2", 50000, "192.168.16.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.51", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_01B_6A0.Macs(hMac, 0)},
+							segment("(C__)[0.161][611.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrB,
 		},
@@ -85,7 +88,7 @@ func genTestsBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.16.3", 40000, "192.168.16.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:4", "172.16.4.1", "1-ff00:0:6", "172.16.6.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_06A_1C1B_4A0.Macs(hMac, 1)},
+							segment("(C__)[0.611][161.141][411.0]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -94,10 +97,10 @@ func genTestsBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.13", 30003, "192.168.0.12", 30002),
 					tpkt.NewGenCmnHdr("1-ff00:0:4", "172.16.4.1", "1-ff00:0:6", "172.16.6.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_06A_1C1B_4A0.Macs(hMac, 1)},
+							segment("(C__)[0.611][161.141][411.0]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrB,
 		},
@@ -108,7 +111,7 @@ func genTestsBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.12", 30002, "192.168.0.13", 30003),
 					tpkt.NewValidScion("1-ff00:0:6", "172.16.6.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_4A0_1C1B_06A.Macs(hMac, 1)},
+							segment("(___)[411.0][161.141][0.611]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -117,10 +120,10 @@ func genTestsBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.16.2", 50000, "192.168.16.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:6", "172.16.6.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(0, 2, tpkt.Segments{
-							revseg_4A0_1C1B_06A.Macs(hMac, 1)},
+							segment("(___)[411.0][161.141][0.611]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrB,
 		},

--- a/go/border/braccept/brD.go
+++ b/go/border/braccept/brD.go
@@ -19,19 +19,25 @@ import (
 
 	"github.com/scionproto/scion/go/border/braccept/tpkt"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/l4"
+	"github.com/scionproto/scion/go/lib/scmp"
 )
+
+var brDCtrlScionHdr = tpkt.NewGenCmnHdr(
+	"1-ff00:0:1", "192.168.0.104", "1-ff00:0:1", "BS_M", nil, common.L4UDP)
 
 var IgnoredPacketsBrD = []*tpkt.ExpPkt{
 	{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
 		tpkt.GenOverlayIP4UDP("192.168.0.14", 30041, "192.168.0.61", 30041),
-		tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.104", "1-ff00:0:1", "BS_M", nil, common.L4UDP),
-		tpkt.NewUDP(20004, 0, ifStateReq),
+		brDCtrlScionHdr,
+		tpkt.NewUDP(20004, 0, &brDCtrlScionHdr.ScionLayer, ifStateReq),
 		ifStateReq,
 	}}}
 
 func genTestsBrD(hMac hash.Hash) []*BRTest {
-	return []*BRTest{
+	tests := []*BRTest{
 		{
 			Desc: "Multiple IFIDs - child/local",
 			In: &tpkt.Pkt{
@@ -39,7 +45,7 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.15.3", 40000, "192.168.15.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:5", "172.16.4.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_5A0_01C.Macs(hMac, 1)},
+							segment("(___)[511.0][0.151]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -48,10 +54,10 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.14", 30004, "192.168.0.51", 30041),
 					tpkt.NewGenCmnHdr("1-ff00:0:5", "172.16.4.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_5A0_01C.Macs(hMac, 1)},
+							segment("(___)[511.0][0.151]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrD,
 		},
@@ -62,7 +68,7 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.51", 30041, "192.168.0.14", 30004),
 					tpkt.NewValidScion("1-ff00:0:1", "192.168.0.51", "1-ff00:0:5", "172.16.4.1",
 						tpkt.GenPath(0, 0, tpkt.Segments{
-							seg_01C_5A0.Macs(hMac, 0)},
+							segment("(C__)[0.151][511.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -71,10 +77,10 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.15.2", 50000, "192.168.15.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.51", "1-ff00:0:5", "172.16.4.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_01C_5A0.Macs(hMac, 0)},
+							segment("(C__)[0.151][511.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrD,
 		},
@@ -85,7 +91,7 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.15.3", 40000, "192.168.15.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:5", "172.16.4.1", "1-ff00:0:6", "172.16.6.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_5A0_1D1D_06B.Macs(hMac, 1)},
+							segment("(___)[511.0][162.151][0.612]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -94,10 +100,10 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.16.4", 50000, "192.168.16.5", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:5", "172.16.4.1", "1-ff00:0:6", "172.16.6.1",
 						tpkt.GenPath(0, 2, tpkt.Segments{
-							revseg_5A0_1D1D_06B.Macs(hMac, 1)},
+							segment("(___)[511.0][162.151][0.612]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrD,
 		},
@@ -108,7 +114,7 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.16.5", 40000, "192.168.16.4", 50000),
 					tpkt.NewValidScion("1-ff00:0:6", "172.16.6.1", "1-ff00:0:5", "172.16.4.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_06B_1D1D_5A0.Macs(hMac, 1)},
+							segment("(C__)[0.612][162.151][511.0]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -117,10 +123,10 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.15.2", 50000, "192.168.15.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:6", "172.16.6.1", "1-ff00:0:5", "172.16.4.1",
 						tpkt.GenPath(0, 2, tpkt.Segments{
-							seg_06B_1D1D_5A0.Macs(hMac, 1)},
+							segment("(C__)[0.612][162.151][511.0]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrD,
 		},
@@ -131,8 +137,8 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.15.3", 40000, "192.168.15.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "1-ff00:0:3", "172.16.3.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revsegSP_5A0_1D1DX_1D1DX_06BV.Macs(hMac, 1, 2),
-							seg_08AV_3A0X_3C0X},
+							segment("(_SP)[511.0][X_.162.151][X_.131.151][_V.0.612]", hMac, 1, 2),
+							segment("(C__)[_V.0.831][X_.311.0][X_.381.0]", nil)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -141,11 +147,11 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.13.2", 50000, "192.168.13.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:5", "172.16.5.1", "1-ff00:0:3", "172.16.3.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revsegSP_5A0_1D1DX_1D1DX_06BV.Macs(hMac, 1, 2),
-							seg_08AV_3A0X_3C0X},
+							segment("(_SP)[511.0][X_.162.151][X_.131.151][_V.0.612]", hMac, 1, 2),
+							segment("(C__)[_V.0.831][X_.311.0][X_.381.0]", nil)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrD,
 		},
@@ -156,8 +162,8 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.13.3", 40000, "192.168.13.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:3", "173.16.3.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revsegSP_3C0X_3A0X_08AV,
-							segSP_06BV_1D1DX_1D1DX_5A0.Macs(hMac, 1, 2)},
+							segment("(_SP)[X_.381.0][X_.311.0][_V.0.831]", nil),
+							segment("(CSP)[_V.0.612][X_.131.151][X_.162.151][511.0]", hMac, 1, 2)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -166,11 +172,11 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.15.2", 50000, "192.168.15.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:3", "173.16.3.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(1, 3, tpkt.Segments{
-							revsegSP_3C0X_3A0X_08AV,
-							segSP_06BV_1D1DX_1D1DX_5A0.Macs(hMac, 1, 2)},
+							segment("(_SP)[X_.381.0][X_.311.0][_V.0.831]", nil),
+							segment("(CSP)[_V.0.612][X_.131.151][X_.162.151][511.0]", hMac, 1, 2)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrD,
 		},
@@ -181,8 +187,8 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.5", 40000, "192.168.14.4", 50000),
 					tpkt.NewValidScion("1-ff00:0:4", "172.16.4.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revsegS_4B0_1D1DX_06BV.Macs(hMac, 1),
-							segS_06BV_1D1DX_5A0.Macs(hMac, 1)},
+							segment("(_S_)[412.0][X_.162.142][_V.0.612]", hMac, 1),
+							segment("(CS_)[_V.0.612][X_.162.151][511.0]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -191,13 +197,241 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.15.2", 50000, "192.168.15.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:4", "172.16.4.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(1, 2, tpkt.Segments{
-							revsegS_4B0_1D1DX_06BV.Macs(hMac, 1),
-							segS_06BV_1D1DX_5A0.Macs(hMac, 1)},
+							segment("(_S_)[412.0][X_.162.142][_V.0.612]", hMac, 1),
+							segment("(CS_)[_V.0.612][X_.162.151][511.0]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsBrD,
 		},
 	}
+	// We use a known IP ie. CS, so we already have ARP entry for it
+	revScionHdr := tpkt.NewGenCmnHdr("1-ff00:0:5", "172.16.5.1", "1-ff00:0:1", "192.168.0.71",
+		tpkt.GenPath(0, 2, tpkt.Segments{
+			segment("(___)[999.0][511.512][0.151]", hMac, 2)},
+		),
+		common.HopByHopClass)
+
+	sRevInfo := tpkt.MustSRevInfo(512, "1-ff00:0:5", "child", tsNow32, 60)
+	rev := tpkt.NewRevocation(0, 1, 512, false, sRevInfo)
+
+	revScmpHdrPld := tpkt.NewSCMP(scmp.C_Path, scmp.T_P_RevokedIF, now,
+		&revScionHdr.ScionLayer, []tpkt.LayerBuilder{
+			tpkt.NewValidScion("1-ff00:0:1", "192.168.0.71", "1-ff00:0:9", "172.16.9.1",
+				tpkt.GenPath(0, 1, tpkt.Segments{
+					segment("(C__)[0.151][511.512][999.0]", hMac, 0)},
+				), nil,
+				&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil)},
+		rev,
+		common.L4UDP)
+
+	revPsScionHdr := tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.104", "1-ff00:0:1", "PS",
+		nil, common.L4UDP)
+	revPsPld := &tpkt.PathMgmtPld{
+		Signer:      ctrl.NullSigner,
+		SigVerifier: ctrl.NullSigVerifier,
+		Instance:    sRevInfo,
+	}
+
+	revLocalFork := &BRTest{
+		Desc: "Multiple IFIDs - Revocation to local destination, fork to PS",
+		In: &tpkt.Pkt{
+			Dev: "ifid_151", Layers: []tpkt.LayerBuilder{
+				tpkt.GenOverlayIP4UDP("192.168.15.3", 40000, "192.168.15.2", 50000),
+				revScionHdr,
+				tpkt.NewSCMPExtn(common.L4SCMP, scmp.Extn{Error: true, HopByHop: true}),
+				revScmpHdrPld,
+			}},
+		Out: []*tpkt.ExpPkt{
+			{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.0.14", 30004, "192.168.0.71", 30041),
+				revScionHdr,
+				&tpkt.ScionSCMPExtn{Extn: scmp.Extn{Error: true, HopByHop: true}},
+				revScmpHdrPld,
+			}},
+			{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.0.14", 30041, "192.168.0.51", 30041),
+				revPsScionHdr,
+				tpkt.NewUDP(20004, 0, &revPsScionHdr.ScionLayer, revPsPld),
+				revPsPld,
+			}}},
+		Ignore: IgnoredPacketsBrD,
+	}
+	tests = append(tests, revLocalFork)
+	// We use a known IP ie. CS, so we already have ARP entry for it
+	revScionHdr = tpkt.NewGenCmnHdr("1-ff00:0:7", "172.16.7.1", "1-ff00:0:5", "172.16.5.1",
+		tpkt.GenPath(0, 1, tpkt.Segments{
+			segment("(C__)[0.711][171.151][511.0]", hMac, 1)},
+		),
+		common.HopByHopClass)
+
+	sRevInfo = tpkt.MustSRevInfo(777, "1-ff00:0:7", "child", tsNow32, 10)
+	rev = tpkt.NewRevocation(0, 1, 777, false, sRevInfo)
+
+	revScmpHdrPld = tpkt.NewSCMP(scmp.C_Path, scmp.T_P_RevokedIF, now,
+		&revScionHdr.ScionLayer, []tpkt.LayerBuilder{
+			tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "1-ff00:0:9", "172.16.9.1",
+				tpkt.GenPath(0, 1, tpkt.Segments{
+					segment("(___)[511.0][171.151][0.711]", hMac, 1)},
+				), nil,
+				&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil)},
+		rev,
+		common.L4UDP)
+
+	revPsScionHdr = tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.104", "1-ff00:0:1", "PS",
+		nil, common.L4UDP)
+	revBsScionHdr := tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.104", "1-ff00:0:1", "BS",
+		nil, common.L4UDP)
+	revPsPld = &tpkt.PathMgmtPld{
+		Signer:      ctrl.NullSigner,
+		SigVerifier: ctrl.NullSigVerifier,
+		Instance:    sRevInfo,
+	}
+
+	revLocalFork = &BRTest{
+		Desc: "Multiple IFIDs - Revocation received on parent ifid, fork to PS",
+		In: &tpkt.Pkt{
+			Dev: "ifid_171", Layers: []tpkt.LayerBuilder{
+				tpkt.GenOverlayIP4UDP("192.168.17.3", 40000, "192.168.17.2", 50000),
+				revScionHdr,
+				tpkt.NewSCMPExtn(common.L4SCMP, scmp.Extn{Error: true, HopByHop: true}),
+				revScmpHdrPld,
+			}},
+		Out: []*tpkt.ExpPkt{
+			{Dev: "ifid_151", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.15.2", 50000, "192.168.15.3", 40000),
+				tpkt.NewGenCmnHdr("1-ff00:0:7", "172.16.7.1", "1-ff00:0:5", "172.16.5.1",
+					tpkt.GenPath(0, 2, tpkt.Segments{
+						segment("(C__)[0.711][171.151][511.0]", hMac, 1)},
+					),
+					common.HopByHopClass),
+				&tpkt.ScionSCMPExtn{Extn: scmp.Extn{Error: true, HopByHop: true}},
+				revScmpHdrPld,
+			}},
+			{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.0.14", 30041, "192.168.0.51", 30041),
+				revPsScionHdr,
+				tpkt.NewUDP(20004, 0, &revPsScionHdr.ScionLayer, revPsPld),
+				revPsPld,
+			}},
+			{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.0.14", 30041, "192.168.0.61", 30041),
+				revBsScionHdr,
+				tpkt.NewUDP(20004, 0, &revBsScionHdr.ScionLayer, revPsPld),
+				revPsPld,
+			}}},
+		Ignore: IgnoredPacketsBrD,
+	}
+	tests = append(tests, revLocalFork)
+	// We use a known IP ie. CS, so we already have ARP entry for it
+	revScionHdr = tpkt.NewGenCmnHdr("2-ff00:0:7", "172.16.7.1", "1-ff00:0:5", "172.16.5.1",
+		tpkt.GenPath(0, 1, tpkt.Segments{
+			segment("(C__)[0.711][171.151][511.0]", hMac, 1)},
+		),
+		common.HopByHopClass)
+
+	revScmpHdrPld = tpkt.NewSCMP(scmp.C_Path, scmp.T_P_RevokedIF, now,
+		&revScionHdr.ScionLayer, []tpkt.LayerBuilder{
+			tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "2-ff00:0:9", "172.16.9.1",
+				tpkt.GenPath(0, 1, tpkt.Segments{
+					segment("(___)[511.0][171.151][0.711]", hMac, 1)},
+				), nil,
+				&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil)},
+		tpkt.NewRevocation(0, 1, 777, false,
+			tpkt.MustSRevInfo(777, "2-ff00:0:7", "child", tsNow32, 10)),
+		common.L4UDP)
+
+	revLocalFork = &BRTest{
+		Desc: "Multiple IFIDs - Revocation from remote ISD, just forward",
+		In: &tpkt.Pkt{
+			Dev: "ifid_171", Layers: []tpkt.LayerBuilder{
+				tpkt.GenOverlayIP4UDP("192.168.17.3", 40000, "192.168.17.2", 50000),
+				revScionHdr,
+				tpkt.NewSCMPExtn(common.L4SCMP, scmp.Extn{Error: true, HopByHop: true}),
+				revScmpHdrPld,
+			}},
+		Out: []*tpkt.ExpPkt{
+			{Dev: "ifid_151", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.15.2", 50000, "192.168.15.3", 40000),
+				tpkt.NewGenCmnHdr("2-ff00:0:7", "172.16.7.1", "1-ff00:0:5", "172.16.5.1",
+					tpkt.GenPath(0, 2, tpkt.Segments{
+						segment("(C__)[0.711][171.151][511.0]", hMac, 1)},
+					),
+					common.HopByHopClass),
+				&tpkt.ScionSCMPExtn{Extn: scmp.Extn{Error: true, HopByHop: true}},
+				revScmpHdrPld,
+			}}},
+		Ignore: IgnoredPacketsBrD,
+	}
+	tests = append(tests, revLocalFork)
+	pktTriggerRev := tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "1-ff00:0:6", "172.16.6.1",
+		tpkt.GenPath(0, 1, tpkt.Segments{
+			segment("(___)[511.0][161.151][0.611]", hMac, 1)},
+		), nil,
+		&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil)
+
+	revScmpScionHdr := tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.14", "1-ff00:0:5", "172.16.5.1",
+		tpkt.GenPath(0, 2, tpkt.Segments{
+			segment("(C__)[0.611][161.151][511.0]", hMac, 1)},
+		),
+		common.HopByHopClass)
+
+	brCtrlScionHdr := tpkt.NewGenCmnHdr(
+		"1-ff00:0:1", "192.168.0.61", "1-ff00:0:1", "192.168.0.104", nil, common.L4UDP)
+
+	signedRevInfo := tpkt.MustSRevInfo(161, "1-ff00:0:1", "parent", tsNow32, 60)
+
+	ifStateInfoDown := &tpkt.PathMgmtPld{
+		Signer:      ctrl.NullSigner,
+		SigVerifier: ctrl.NullSigVerifier,
+		Instance: &path_mgmt.IFStateInfos{Infos: []*path_mgmt.IFStateInfo{
+			{IfID: 161, Active: false, SRevInfo: signedRevInfo},
+		}},
+	}
+	ifStateInfoUp := &tpkt.PathMgmtPld{
+		Signer:      ctrl.NullSigner,
+		SigVerifier: ctrl.NullSigVerifier,
+		Instance: &path_mgmt.IFStateInfos{Infos: []*path_mgmt.IFStateInfo{
+			{IfID: 161, Active: true, SRevInfo: nil},
+		}},
+	}
+	revTest := &BRTest{
+		Desc: "Multiple IFIDs - Revocation on interface not owned",
+		Pre: &tpkt.Pkt{
+			Dev: "ifid_local", Layers: []tpkt.LayerBuilder{
+				tpkt.GenOverlayIP4UDP("192.168.0.61", 20006, "192.168.0.14", 30041),
+				brCtrlScionHdr,
+				tpkt.NewUDP(20006, 20004, &brCtrlScionHdr.ScionLayer, ifStateInfoDown),
+				ifStateInfoDown,
+			}},
+		In: &tpkt.Pkt{
+			Dev: "ifid_151", Layers: []tpkt.LayerBuilder{
+				tpkt.GenOverlayIP4UDP("192.168.15.3", 40000, "192.168.15.2", 50000),
+				pktTriggerRev,
+			}},
+		Out: []*tpkt.ExpPkt{
+			{Dev: "ifid_151", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.15.2", 50000, "192.168.15.3", 40000),
+				revScmpScionHdr,
+				&tpkt.ScionSCMPExtn{Extn: scmp.Extn{Error: true, HopByHop: true}},
+				tpkt.NewSCMP(scmp.C_Path, scmp.T_P_RevokedIF, noTime,
+					&revScmpScionHdr.ScionLayer,
+					[]tpkt.LayerBuilder{
+						pktTriggerRev,
+					},
+					tpkt.NewRevocation(0, 1, 161, true, signedRevInfo),
+					common.L4UDP),
+			}}},
+		Post: &tpkt.Pkt{
+			Dev: "ifid_local", Layers: []tpkt.LayerBuilder{
+				tpkt.GenOverlayIP4UDP("192.168.0.61", 20006, "192.168.0.14", 30041),
+				brCtrlScionHdr,
+				tpkt.NewUDP(20006, 20004, &brCtrlScionHdr.ScionLayer, ifStateInfoUp),
+				ifStateInfoUp,
+			}},
+		Ignore: IgnoredPacketsBrD,
+	}
+	tests = append(tests, revTest)
+	return tests
 }

--- a/go/border/braccept/brtest.go
+++ b/go/border/braccept/brtest.go
@@ -27,11 +27,19 @@ import (
 // BRTest defines a single test
 type BRTest struct {
 	Desc string
+	// Pre is the packet to be sent before the actual test packets.
+	// An example of this packet would be an IFState to deactivate the interface when testing
+	// for a revoked interface.
+	Pre *tpkt.Pkt
 	// In is the packet being sent to the border router
 	In *tpkt.Pkt
 	// Out is the list of expected packets. No expected packets means that the packet
 	// should be dropped by the border router, and nothing is expected.
 	Out []*tpkt.ExpPkt
+	// Post is the packet to be sent to the border router once the test has been completed.
+	// An example for this post packet would be an IFStateInfo to activate the interface and keep
+	// the border router in a known state.
+	Post *tpkt.Pkt
 	// Ignore is the list of packets that should be ignored.
 	Ignore []*tpkt.ExpPkt
 }

--- a/go/border/braccept/common_tests.go
+++ b/go/border/braccept/common_tests.go
@@ -54,7 +54,11 @@ var (
 	if_831 = common.IFIDType(831)
 )
 
-var tsNow = uint32(time.Now().Unix())
+var (
+	now     = time.Now()
+	tsNow32 = uint32(now.Unix())
+	noTime  = time.Time{}
+)
 
 var ifStateReq = &tpkt.PathMgmtPld{
 	Signer:      ctrl.NullSigner,

--- a/go/border/braccept/core_brA.go
+++ b/go/border/braccept/core_brA.go
@@ -19,20 +19,24 @@ import (
 
 	"github.com/scionproto/scion/go/border/braccept/tpkt"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/l4"
 	"github.com/scionproto/scion/go/lib/scmp"
 )
 
+var coreBrACtrlScionHdr = tpkt.NewGenCmnHdr(
+	"1-ff00:0:1", "192.168.0.101", "1-ff00:0:1", "BS_M", nil, common.L4UDP)
+
 var IgnoredPacketsCoreBrA = []*tpkt.ExpPkt{
 	{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
 		tpkt.GenOverlayIP4UDP("192.168.0.11", 30041, "192.168.0.61", 30041),
-		tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.101", "1-ff00:0:1", "BS_M", nil, common.L4UDP),
-		tpkt.NewUDP(20001, 0, ifStateReq),
+		coreBrACtrlScionHdr,
+		tpkt.NewUDP(20001, 0, &coreBrACtrlScionHdr.ScionLayer, ifStateReq),
 		ifStateReq,
 	}}}
 
 func genTestsCoreBrA(hMac hash.Hash) []*BRTest {
-	return []*BRTest{
+	tests := []*BRTest{
 		{
 			Desc: "Single IFID core - external - local destination",
 			In: &tpkt.Pkt{
@@ -40,7 +44,7 @@ func genTestsCoreBrA(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.12.3", 40000, "192.168.12.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:2", "172.16.2.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_02A_1A0.Macs(hMac, 1)},
+							segment("(C__)[0.211][121.0]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -49,10 +53,10 @@ func genTestsCoreBrA(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.11", 30001, "192.168.0.51", 30041),
 					tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_02A_1A0.Macs(hMac, 1)},
+							segment("(C__)[0.211][121.0]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrA,
 		},
@@ -63,7 +67,7 @@ func genTestsCoreBrA(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.51", 30041, "192.168.0.11", 30001),
 					tpkt.NewValidScion("1-ff00:0:1", "192.168.0.51", "1-ff00:0:2", "172.16.2.1",
 						tpkt.GenPath(0, 0, tpkt.Segments{
-							seg_01A_2A0.Macs(hMac, 0)},
+							segment("(C__)[0.121][211.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -72,22 +76,22 @@ func genTestsCoreBrA(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.12.2", 50000, "192.168.12.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.51", "1-ff00:0:2", "172.16.2.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_01A_2A0.Macs(hMac, 0)},
+							segment("(C__)[0.121][211.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrA,
 		},
 		{
-			Desc: "Single IFID core - external - Xover core/child",
+			Desc: "Single IFID core - Xover core/child",
 			In: &tpkt.Pkt{
 				Dev: "ifid_121", Layers: []tpkt.LayerBuilder{
 					tpkt.GenOverlayIP4UDP("192.168.12.3", 40000, "192.168.12.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:2", "172.16.2.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_02A_1A0X.Macs(hMac, 1),
-							seg_01B_4A0.Macs(hMac, 0)},
+							segment("(C__)[0.211][X_.121.0]", hMac, 1),
+							segment("(C__)[0.141][411.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -96,23 +100,23 @@ func genTestsCoreBrA(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.11", 30001, "192.168.0.12", 30002),
 					tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(1, 0, tpkt.Segments{
-							seg_02A_1A0X.Macs(hMac, 1),
-							seg_01B_4A0.Macs(hMac, 0)},
+							segment("(C__)[0.211][X_.121.0]", hMac, 1),
+							segment("(C__)[0.141][411.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrA,
 		},
 		{
-			Desc: "Single IFID core - internal - Xover child/core",
+			Desc: "Single IFID core - Xover child/core",
 			In: &tpkt.Pkt{
 				Dev: "ifid_local", Layers: []tpkt.LayerBuilder{
 					tpkt.GenOverlayIP4UDP("192.168.0.13", 30003, "192.168.0.11", 30001),
 					tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "1-ff00:0:2", "172.16.2.1",
 						tpkt.GenPath(1, 0, tpkt.Segments{
-							revseg_4A0_01BX.Macs(hMac, 1),
-							revseg_1A0_02A.Macs(hMac, 0)},
+							segment("(___)[411.0][X_.0.141]", hMac, 1),
+							segment("(___)[121.0][0.211]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -121,86 +125,16 @@ func genTestsCoreBrA(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.12.2", 50000, "192.168.12.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:5", "172.16.5.1", "1-ff00:0:2", "172.16.2.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revseg_4A0_01BX.Macs(hMac, 1),
-							revseg_1A0_02A.Macs(hMac, 0)},
+							segment("(___)[411.0][X_.0.141]", hMac, 1),
+							segment("(___)[121.0][0.211]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrA,
 		},
 		{
-			Desc: "Single IFID - external - bad path - Xover core-core",
-			In: &tpkt.Pkt{
-				Dev: "ifid_121", Layers: []tpkt.LayerBuilder{
-					tpkt.GenOverlayIP4UDP("192.168.12.3", 40000, "192.168.12.2", 50000),
-					tpkt.NewValidScion("1-ff00:0:2", "172.16.2.1", "1-ff00:0:3", "172.16.3.1",
-						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_02A_1A0X.Macs(hMac, 1),
-							seg_01C_3A0.Macs(hMac, 0)},
-						), nil,
-						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
-				}},
-			Out: []*tpkt.ExpPkt{
-				{Dev: "ifid_121", Layers: []tpkt.LayerMatcher{
-					tpkt.GenOverlayIP4UDP("192.168.12.2", 50000, "192.168.12.3", 40000),
-					tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.11", "1-ff00:0:2", "172.16.2.1",
-						tpkt.GenPath(1, 0, tpkt.Segments{
-							revseg_3A0_01C.Macs(hMac, 1),
-							revseg_1A0X_02A.Macs(hMac, 0)},
-						),
-						common.HopByHopClass),
-					&tpkt.ScionSCMPExtn{Extn: scmp.Extn{Error: true}},
-					tpkt.NewSCMP(scmp.C_Path, scmp.T_P_BadSegment, []tpkt.LayerBuilder{
-						tpkt.NewValidScion("1-ff00:0:2", "172.16.2.1", "1-ff00:0:3", "172.16.3.1",
-							tpkt.GenPath(1, 0, tpkt.Segments{
-								seg_02A_1A0X.Macs(hMac, 1),
-								seg_01C_3A0.Macs(hMac, 0)},
-							), nil,
-							&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil)},
-						&scmp.InfoPathOffsets{InfoF: 1, HopF: 0, IfID: if_121, Ingress: true},
-						common.L4UDP),
-				}}},
-			Ignore: IgnoredPacketsCoreBrA,
-		},
-		{
-			Desc: "Single IFID - external - bad path - Xover core-core unsupported l4",
-			In: &tpkt.Pkt{
-				Dev: "ifid_121", Layers: []tpkt.LayerBuilder{
-					tpkt.GenOverlayIP4UDP("192.168.12.3", 40000, "192.168.12.2", 50000),
-					tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:3", "172.16.3.1",
-						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_02A_1A0X.Macs(hMac, 1),
-							seg_01C_3A0.Macs(hMac, 0)},
-						),
-						common.L4TCP),
-					tpkt.NewPld([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
-				}},
-			Out: []*tpkt.ExpPkt{
-				{Dev: "ifid_121", Layers: []tpkt.LayerMatcher{
-					tpkt.GenOverlayIP4UDP("192.168.12.2", 50000, "192.168.12.3", 40000),
-					tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.11", "1-ff00:0:2", "172.16.2.1",
-						tpkt.GenPath(1, 0, tpkt.Segments{
-							revseg_3A0_01C.Macs(hMac, 1),
-							revseg_1A0X_02A.Macs(hMac, 0)},
-						),
-						common.HopByHopClass),
-					&tpkt.ScionSCMPExtn{Extn: scmp.Extn{Error: true}},
-					tpkt.NewSCMP(scmp.C_Path, scmp.T_P_BadSegment, []tpkt.LayerBuilder{
-						tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:3", "172.16.3.1",
-							tpkt.GenPath(1, 0, tpkt.Segments{
-								seg_02A_1A0X.Macs(hMac, 1),
-								seg_01C_3A0.Macs(hMac, 0)},
-							),
-							common.L4TCP),
-						tpkt.NewPld([]byte{1, 2, 3, 4, 5, 6, 7, 8})},
-						&scmp.InfoPathOffsets{InfoF: 1, HopF: 0, IfID: if_121, Ingress: true},
-						common.L4TCP),
-				}}},
-			Ignore: IgnoredPacketsCoreBrA,
-		},
-		{
-			Desc: "Single IFID - external - empty overlay packet",
+			Desc: "Single IFID core - Empty overlay packet",
 			In: &tpkt.Pkt{
 				Dev: "ifid_121", Layers: []tpkt.LayerBuilder{
 					tpkt.GenOverlayIP4UDP("192.168.12.3", 40000, "192.168.12.2", 50000),
@@ -209,7 +143,7 @@ func genTestsCoreBrA(hMac hash.Hash) []*BRTest {
 			Ignore: IgnoredPacketsCoreBrA,
 		},
 		{
-			Desc: "Single IFID - external - bad packet 7 Bytes",
+			Desc: "Single IFID core - Bad packet 7 Bytes",
 			In: &tpkt.Pkt{
 				Dev: "ifid_121", Layers: []tpkt.LayerBuilder{
 					tpkt.GenOverlayIP4UDP("192.168.12.3", 40000, "192.168.12.2", 50000),
@@ -219,4 +153,156 @@ func genTestsCoreBrA(hMac hash.Hash) []*BRTest {
 			Ignore: IgnoredPacketsCoreBrA,
 		},
 	}
+	expScionHdr := tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.11", "1-ff00:0:2", "172.16.2.1",
+		tpkt.GenPath(1, 0, tpkt.Segments{
+			segment("(___)[311.0][0.131]", hMac, 1),
+			segment("(___)[X_.121.0][0.211]", hMac, 0)},
+		),
+		common.HopByHopClass)
+
+	expScmpHdrPld := tpkt.NewSCMP(scmp.C_Path, scmp.T_P_BadSegment, noTime,
+		&expScionHdr.ScionLayer, []tpkt.LayerBuilder{
+			tpkt.NewValidScion("1-ff00:0:2", "172.16.2.1", "1-ff00:0:3", "172.16.3.1",
+				tpkt.GenPath(1, 0, tpkt.Segments{
+					segment("(C__)[0.211][X_.121.0]", hMac, 1),
+					segment("(C__)[0.131][311.0]", hMac, 0)},
+				), nil,
+				&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil)},
+		&scmp.InfoPathOffsets{InfoF: 1, HopF: 0, IfID: if_121, Ingress: true},
+		common.L4UDP)
+
+	test := &BRTest{
+		Desc: "Single IFID core - Xover core-core - Bad Path",
+		In: &tpkt.Pkt{
+			Dev: "ifid_121", Layers: []tpkt.LayerBuilder{
+				tpkt.GenOverlayIP4UDP("192.168.12.3", 40000, "192.168.12.2", 50000),
+				tpkt.NewValidScion("1-ff00:0:2", "172.16.2.1", "1-ff00:0:3", "172.16.3.1",
+					tpkt.GenPath(0, 1, tpkt.Segments{
+						segment("(C__)[0.211][X_.121.0]", hMac, 1),
+						segment("(C__)[0.131][311.0]", hMac, 0)},
+					), nil,
+					&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
+			}},
+		Out: []*tpkt.ExpPkt{
+			{Dev: "ifid_121", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.12.2", 50000, "192.168.12.3", 40000),
+				expScionHdr,
+				&tpkt.ScionSCMPExtn{Extn: scmp.Extn{Error: true}},
+				expScmpHdrPld,
+			}}},
+		Ignore: IgnoredPacketsCoreBrA,
+	}
+	tests = append(tests, test)
+
+	expScionHdr = tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.11", "1-ff00:0:2", "172.16.2.1",
+		tpkt.GenPath(1, 0, tpkt.Segments{
+			segment("(___)[311.0][0.131]", hMac, 1),
+			segment("(___)[X_.121.0][0.211]", hMac, 0)},
+		),
+		common.HopByHopClass)
+
+	expScmpHdrPld = tpkt.NewSCMP(scmp.C_Path, scmp.T_P_BadSegment, noTime,
+		&expScionHdr.ScionLayer, []tpkt.LayerBuilder{
+			tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:3", "172.16.3.1",
+				tpkt.GenPath(1, 0, tpkt.Segments{
+					segment("(C__)[0.211][X_.121.0]", hMac, 1),
+					segment("(C__)[0.131][311.0]", hMac, 0)},
+				),
+				common.L4TCP),
+			tpkt.NewPld([]byte{1, 2, 3, 4, 5, 6, 7, 8})},
+		&scmp.InfoPathOffsets{InfoF: 1, HopF: 0, IfID: if_121, Ingress: true},
+		common.L4TCP)
+
+	test = &BRTest{
+		Desc: "Single IFID core - Xover core-core - Bad Path Unsupported L4",
+		In: &tpkt.Pkt{
+			Dev: "ifid_121", Layers: []tpkt.LayerBuilder{
+				tpkt.GenOverlayIP4UDP("192.168.12.3", 40000, "192.168.12.2", 50000),
+				tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:3", "172.16.3.1",
+					tpkt.GenPath(0, 1, tpkt.Segments{
+						segment("(C__)[0.211][X_.121.0]", hMac, 1),
+						segment("(C__)[0.131][311.0]", hMac, 0)},
+					),
+					common.L4TCP),
+				tpkt.NewPld([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+			}},
+		Out: []*tpkt.ExpPkt{
+			{Dev: "ifid_121", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.12.2", 50000, "192.168.12.3", 40000),
+				expScionHdr,
+				&tpkt.ScionSCMPExtn{Extn: scmp.Extn{Error: true}},
+				expScmpHdrPld,
+			}}},
+		Ignore: IgnoredPacketsCoreBrA,
+	}
+	tests = append(tests, test)
+	// We use a known IP ie. CS, so we already have ARP entry for it
+	revScionHdr := tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:4", "172.16.4.1",
+		tpkt.GenPath(0, 1, tpkt.Segments{
+			segment("(___)[211.0][X_.0.121]", hMac, 1),
+			segment("(C__)[X_.0.141][411.0]", hMac, 0)},
+		),
+		common.HopByHopClass)
+
+	sRevInfo := tpkt.MustSRevInfo(222, "1-ff00:0:2", "child", tsNow32, 60)
+	rev := tpkt.NewRevocation(0, 1, 222, false, sRevInfo)
+
+	revScmpHdrPld := tpkt.NewSCMP(scmp.C_Path, scmp.T_P_RevokedIF, now,
+		&revScionHdr.ScionLayer, []tpkt.LayerBuilder{
+			tpkt.NewValidScion("1-ff00:0:4", "172.16.4.1", "1-ff00:0:9", "172.16.9.1",
+				tpkt.GenPath(1, 1, tpkt.Segments{
+					segment("(___)[411.0][X_.0.141]", hMac, 1),
+					segment("(C__)[X_.0.121][211.0]", hMac, 0)},
+				), nil,
+				&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil)},
+		rev,
+		common.L4UDP)
+
+	revPsScionHdr := tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.101", "1-ff00:0:1", "PS",
+		nil, common.L4UDP)
+	revBsScionHdr := tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.101", "1-ff00:0:1", "BS",
+		nil, common.L4UDP)
+	revPld := &tpkt.PathMgmtPld{
+		Signer:      ctrl.NullSigner,
+		SigVerifier: ctrl.NullSigVerifier,
+		Instance:    sRevInfo,
+	}
+
+	revLocalFork := &BRTest{
+		Desc: "Single IFID core - Revocation to local destination, fork to PS and BS",
+		In: &tpkt.Pkt{
+			Dev: "ifid_121", Layers: []tpkt.LayerBuilder{
+				tpkt.GenOverlayIP4UDP("192.168.12.3", 40000, "192.168.12.2", 50000),
+				revScionHdr,
+				tpkt.NewSCMPExtn(common.L4SCMP, scmp.Extn{Error: true, HopByHop: true}),
+				revScmpHdrPld,
+			}},
+		Out: []*tpkt.ExpPkt{
+			{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.0.11", 30001, "192.168.0.12", 30002),
+				tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:4", "172.16.4.1",
+					tpkt.GenPath(1, 0, tpkt.Segments{
+						segment("(___)[211.0][X_.0.121]", hMac, 1),
+						segment("(C__)[X_.0.141][411.0]", hMac, 0)},
+					),
+					common.HopByHopClass),
+				&tpkt.ScionSCMPExtn{Extn: scmp.Extn{Error: true, HopByHop: true}},
+				revScmpHdrPld,
+			}},
+			{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.0.11", 30041, "192.168.0.51", 30041),
+				revPsScionHdr,
+				tpkt.NewUDP(20001, 0, &revPsScionHdr.ScionLayer, revPld),
+				revPld,
+			}},
+			{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
+				tpkt.GenOverlayIP4UDP("192.168.0.11", 30041, "192.168.0.61", 30041),
+				revBsScionHdr,
+				tpkt.NewUDP(20001, 0, &revBsScionHdr.ScionLayer, revPld),
+				revPld,
+			}}},
+		Ignore: IgnoredPacketsCoreBrA,
+	}
+	tests = append(tests, revLocalFork)
+	return tests
 }

--- a/go/border/braccept/core_brB.go
+++ b/go/border/braccept/core_brB.go
@@ -22,11 +22,14 @@ import (
 	"github.com/scionproto/scion/go/lib/l4"
 )
 
+var coreBrBCtrlScionHdr = tpkt.NewGenCmnHdr(
+	"1-ff00:0:1", "192.168.0.102", "1-ff00:0:1", "BS_M", nil, common.L4UDP)
+
 var IgnoredPacketsCoreBrB = []*tpkt.ExpPkt{
 	{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
 		tpkt.GenOverlayIP4UDP("192.168.0.12", 30041, "192.168.0.61", 30041),
-		tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.102", "1-ff00:0:1", "BS_M", nil, common.L4UDP),
-		tpkt.NewUDP(20002, 0, ifStateReq),
+		coreBrBCtrlScionHdr,
+		tpkt.NewUDP(20002, 0, &coreBrBCtrlScionHdr.ScionLayer, ifStateReq),
 		ifStateReq,
 	}}}
 
@@ -39,7 +42,7 @@ func genTestsCoreBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.3", 40000, "192.168.14.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:4", "172.16.4.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_4A0_01B.Macs(hMac, 1)},
+							segment("(___)[411.0][0.141]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -48,10 +51,10 @@ func genTestsCoreBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.12", 30002, "192.168.0.51", 30041),
 					tpkt.NewGenCmnHdr("1-ff00:0:4", "172.16.4.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_4A0_01B.Macs(hMac, 1)},
+							segment("(___)[411.0][0.141]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrB,
 		},
@@ -62,7 +65,7 @@ func genTestsCoreBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.51", 30041, "192.168.0.12", 30002),
 					tpkt.NewValidScion("1-ff00:0:1", "192.168.0.51", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(0, 0, tpkt.Segments{
-							seg_01B_4A0.Macs(hMac, 0)},
+							segment("(C__)[0.141][411.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -71,10 +74,10 @@ func genTestsCoreBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.2", 50000, "192.168.14.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.51", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_01B_4A0.Macs(hMac, 0)},
+							segment("(C__)[0.141][411.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrB,
 		},
@@ -85,8 +88,8 @@ func genTestsCoreBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.3", 40000, "192.168.14.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:4", "172.16.4.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_4A0_01BX.Macs(hMac, 1),
-							seg_01C_5A0.Macs(hMac, 0)},
+							segment("(___)[411.0][X_.0.141]", hMac, 1),
+							segment("(C__)[0.151][511.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -95,11 +98,11 @@ func genTestsCoreBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.12", 30002, "192.168.0.13", 30003),
 					tpkt.NewGenCmnHdr("1-ff00:0:4", "172.16.4.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(1, 0, tpkt.Segments{
-							revseg_4A0_01BX.Macs(hMac, 1),
-							seg_01C_5A0.Macs(hMac, 0)},
+							segment("(___)[411.0][X_.0.141]", hMac, 1),
+							segment("(C__)[0.151][511.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrB,
 		},
@@ -110,8 +113,8 @@ func genTestsCoreBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.13", 30003, "192.168.0.12", 30002),
 					tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(1, 0, tpkt.Segments{
-							revseg_5A0_01C.Macs(hMac, 1),
-							seg_01B_4A0.Macs(hMac, 0)},
+							segment("(___)[511.0][0.151]", hMac, 1),
+							segment("(C__)[0.141][411.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -120,11 +123,11 @@ func genTestsCoreBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.2", 50000, "192.168.14.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:5", "172.16.5.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revseg_5A0_01C.Macs(hMac, 1),
-							seg_01B_4A0.Macs(hMac, 0)},
+							segment("(___)[511.0][0.151]", hMac, 1),
+							segment("(C__)[0.141][411.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrB,
 		},
@@ -135,8 +138,8 @@ func genTestsCoreBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.3", 40000, "192.168.14.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:4", "172.16.4.1", "1-ff00:0:2", "172.16.2.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_4A0_01BX.Macs(hMac, 1),
-							seg_01A_2A0.Macs(hMac, 0)},
+							segment("(___)[411.0][X_.0.141]", hMac, 1),
+							segment("(C__)[0.121][211.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -145,11 +148,11 @@ func genTestsCoreBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.12", 30002, "192.168.0.11", 30001),
 					tpkt.NewGenCmnHdr("1-ff00:0:4", "172.16.4.1", "1-ff00:0:2", "172.16.2.1",
 						tpkt.GenPath(1, 0, tpkt.Segments{
-							revseg_4A0_01BX.Macs(hMac, 1),
-							seg_01A_2A0.Macs(hMac, 0)},
+							segment("(___)[411.0][X_.0.141]", hMac, 1),
+							segment("(C__)[0.121][211.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrB,
 		},
@@ -160,8 +163,8 @@ func genTestsCoreBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.11", 30001, "192.168.0.12", 30002),
 					tpkt.NewValidScion("1-ff00:0:2", "172.16.2.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(1, 0, tpkt.Segments{
-							revseg_2A0_01A.Macs(hMac, 1),
-							seg_01B_4A0.Macs(hMac, 0)},
+							segment("(___)[211.0][0.121]", hMac, 1),
+							segment("(C__)[0.141][411.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -170,11 +173,11 @@ func genTestsCoreBrB(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.2", 50000, "192.168.14.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revseg_2A0_01A.Macs(hMac, 1),
-							seg_01B_4A0.Macs(hMac, 0)},
+							segment("(___)[211.0][0.121]", hMac, 1),
+							segment("(C__)[0.141][411.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrB,
 		},

--- a/go/border/braccept/core_brC.go
+++ b/go/border/braccept/core_brC.go
@@ -22,11 +22,14 @@ import (
 	"github.com/scionproto/scion/go/lib/l4"
 )
 
+var coreBrCCtrlScionHdr = tpkt.NewGenCmnHdr(
+	"1-ff00:0:1", "192.168.0.103", "1-ff00:0:1", "BS_M", nil, common.L4UDP)
+
 var IgnoredPacketsCoreBrC = []*tpkt.ExpPkt{
 	{Dev: "ifid_local", Layers: []tpkt.LayerMatcher{
 		tpkt.GenOverlayIP4UDP("192.168.0.13", 30041, "192.168.0.61", 30041),
-		tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.103", "1-ff00:0:1", "BS_M", nil, common.L4UDP),
-		tpkt.NewUDP(20003, 0, ifStateReq),
+		coreBrCCtrlScionHdr,
+		tpkt.NewUDP(20003, 0, &coreBrCCtrlScionHdr.ScionLayer, ifStateReq),
 		ifStateReq,
 	}}}
 
@@ -39,7 +42,7 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.13.3", 40000, "192.168.13.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:3", "172.16.3.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_03A_1C0.Macs(hMac, 1)},
+							segment("(C__)[0.311][131.0]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -48,10 +51,10 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.13", 30003, "192.168.0.51", 30041),
 					tpkt.NewGenCmnHdr("1-ff00:0:3", "172.16.3.1", "1-ff00:0:1", "192.168.0.51",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							seg_03A_1C0.Macs(hMac, 1)},
+							segment("(C__)[0.311][131.0]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrC,
 		},
@@ -62,7 +65,7 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.51", 30041, "192.168.0.13", 30003),
 					tpkt.NewValidScion("1-ff00:0:1", "192.168.0.51", "1-ff00:0:3", "172.16.3.1",
 						tpkt.GenPath(0, 0, tpkt.Segments{
-							revseg_1C0_03A.Macs(hMac, 0)},
+							segment("(___)[131.0][0.311]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -71,10 +74,10 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.13.2", 50000, "192.168.13.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.51", "1-ff00:0:3", "172.16.3.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_1C0_03A.Macs(hMac, 0)},
+							segment("(___)[131.0][0.311]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrC,
 		},
@@ -85,7 +88,7 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.12.5", 40000, "192.168.12.4", 50000),
 					tpkt.NewValidScion("1-ff00:0:2", "172.16.2.1", "1-ff00:0:3", "172.16.3.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_2B0_1C1C_03A.Macs(hMac, 1)},
+							segment("(___)[212.0][131.122][0.311]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -94,10 +97,10 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.13.2", 50000, "192.168.13.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:3", "172.16.3.1",
 						tpkt.GenPath(0, 2, tpkt.Segments{
-							revseg_2B0_1C1C_03A.Macs(hMac, 1)},
+							segment("(___)[212.0][131.122][0.311]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrC,
 		},
@@ -108,7 +111,7 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.0.11", 30003, "192.168.0.13", 30003),
 					tpkt.NewValidScion("1-ff00:0:2", "172.16.2.1", "1-ff00:0:3", "172.16.3.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_2A0_1C1A_03A.Macs(hMac, 1)},
+							segment("(___)[211.0][131.121][0.311]", hMac, 1)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -117,10 +120,10 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.13.2", 50000, "192.168.13.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:2", "172.16.2.1", "1-ff00:0:3", "172.16.3.1",
 						tpkt.GenPath(0, 2, tpkt.Segments{
-							revseg_2A0_1C1A_03A.Macs(hMac, 1)},
+							segment("(___)[211.0][131.121][0.311]", hMac, 1)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrC,
 		},
@@ -131,8 +134,8 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.13.3", 40000, "192.168.13.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:3", "172.16.3.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_3A0_01CX.Macs(hMac, 1),
-							seg_01C_5A0.Macs(hMac, 0)},
+							segment("(___)[311.0][X_.0.131]", hMac, 1),
+							segment("(C__)[0.151][511.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -141,11 +144,11 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.15.2", 50000, "192.168.15.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:3", "172.16.3.1", "1-ff00:0:5", "172.16.5.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revseg_3A0_01CX.Macs(hMac, 1),
-							seg_01C_5A0.Macs(hMac, 0)},
+							segment("(___)[311.0][X_.0.131]", hMac, 1),
+							segment("(C__)[0.151][511.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrC,
 		},
@@ -156,8 +159,8 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.15.3", 40000, "192.168.15.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "1-ff00:0:3", "172.16.3.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_5A0_01CX.Macs(hMac, 1),
-							seg_01C_3A0.Macs(hMac, 0)},
+							segment("(___)[511.0][X_.0.151]", hMac, 1),
+							segment("(C__)[0.131][311.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -166,11 +169,11 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.13.2", 50000, "192.168.13.3", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:5", "172.16.5.1", "1-ff00:0:3", "172.16.3.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revseg_5A0_01CX.Macs(hMac, 1),
-							seg_01C_3A0.Macs(hMac, 0)},
+							segment("(___)[511.0][X_.0.151]", hMac, 1),
+							segment("(C__)[0.131][311.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrC,
 		},
@@ -181,8 +184,8 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.15.3", 40000, "192.168.15.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(0, 1, tpkt.Segments{
-							revseg_5A0_01CX.Macs(hMac, 1),
-							seg_01C_4B0.Macs(hMac, 0)},
+							segment("(___)[511.0][X_.0.151]", hMac, 1),
+							segment("(C__)[0.142][412.0]", hMac, 0)},
 						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
@@ -191,11 +194,11 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 					tpkt.GenOverlayIP4UDP("192.168.14.4", 50000, "192.168.14.5", 40000),
 					tpkt.NewGenCmnHdr("1-ff00:0:5", "172.16.5.1", "1-ff00:0:4", "172.16.4.1",
 						tpkt.GenPath(1, 1, tpkt.Segments{
-							revseg_5A0_01CX.Macs(hMac, 1),
-							seg_01C_4B0.Macs(hMac, 0)},
+							segment("(___)[511.0][X_.0.151]", hMac, 1),
+							segment("(C__)[0.142][412.0]", hMac, 0)},
 						),
 						common.L4UDP),
-					tpkt.NewUDP(40111, 40222, nil),
+					tpkt.NewUDP(40111, 40222, nil, nil),
 				}}},
 			Ignore: IgnoredPacketsCoreBrC,
 		},
@@ -206,8 +209,10 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 				Dev: "ifid_151", Layers: []tpkt.LayerBuilder{
 					tpkt.GenOverlayIP4UDP("192.168.15.3", 40000, "192.168.15.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "1-ff00:0:5", "172.16.5.2",
-						tpkt.GenPath(0, 1,
-						path_1C_5A_rev_X_1C_5A.SetMac(0, 1, hMac).SetMac(1, 0, hMac)), nil,
+						tpkt.GenPath(0, 1, tpkt.Segments{
+							segment("(___)[511.0][X_.0.151]", hMac, 1),
+							segment("(C__)[0.151][511.0]", hMac, 0)},
+						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
 			Out: []*tpkt.ExpPkt{},
@@ -220,8 +225,10 @@ func genTestsCoreBrC(hMac hash.Hash) []*BRTest {
 				Dev: "ifid_151", Layers: []tpkt.LayerBuilder{
 					tpkt.GenOverlayIP4UDP("192.168.15.3", 40000, "192.168.15.2", 50000),
 					tpkt.NewValidScion("1-ff00:0:5", "172.16.5.1", "1-ff00:0:5", "172.16.5.2",
-						tpkt.GenPath(0, 1,
-						path_1C_5A_rev_X_1C_5B.SetMac(0, 1, hMac).SetMac(1, 0, hMac)), nil,
+						tpkt.GenPath(0, 1, tpkt.Segments{
+							segment("(___)[511.0][X_.0.151]", hMac, 1),
+							segment("(C__)[0.152][512.0]", hMac, 0)},
+						), nil,
 						&l4.UDP{SrcPort: 40111, DstPort: 40222}, nil),
 				}},
 			Out: []*tpkt.ExpPkt{},

--- a/go/border/braccept/main.go
+++ b/go/border/braccept/main.go
@@ -47,9 +47,10 @@ type ifInfo struct {
 }
 
 const (
-	snapshot_len int32         = 1024
-	promiscuous  bool          = true
-	timeout      time.Duration = 1 * time.Second
+	snapshot_len int32 = 1024
+	promiscuous  bool  = true
+	//timeout      time.Duration = 1 * time.Second
+	timeout time.Duration = 60 * time.Second
 )
 
 var (
@@ -230,19 +231,43 @@ func registerScionPorts() {
 // It returns true if the test was successful, ie. all expected packets and no others were received,
 // otherwise it returns false.
 func doTest(t *BRTest, cases []reflect.SelectCase) error {
-	devInfo, ok := devByName[t.In.Dev]
+	var errStr []string
+	var err error
+	if err = sendPkt(t.Pre, true); err != nil {
+		errStr = append(errStr, err.Error())
+	}
+	if err = sendPkt(t.In, false); err == nil {
+		err = checkRecvPkts(t, cases)
+	}
+	if err != nil {
+		errStr = append(errStr, err.Error())
+	}
+	err = sendPkt(t.Post, true)
+	if err != nil {
+		errStr = append(errStr, err.Error())
+	}
+	if len(errStr) > 0 {
+		return fmt.Errorf(strings.Join(errStr, "\n"))
+	}
+	return nil
+}
+
+func sendPkt(pkt *tpkt.Pkt, to bool) error {
+	if pkt == nil {
+		return nil
+	}
+	devInfo, ok := devByName[pkt.Dev]
 	if !ok {
-		return fmt.Errorf("No device information for: %s\n", t.In.Dev)
+		return fmt.Errorf("No device information for: %s\n", pkt.Dev)
 	}
-	raw, err := t.In.Pack(devInfo.mac)
+	raw, err := pkt.Pack(devInfo.mac)
 	if err != nil {
 		return err
 	}
-	err = devInfo.handle.WritePacketData(raw)
-	if err != nil {
-		return err
+	if to {
+		defer time.Sleep(timeout)
 	}
-	return checkRecvPkts(t, cases)
+	return devInfo.handle.WritePacketData(raw)
 }
 
 // checkRecvPkts compares packets received in any interface against the expected packets

--- a/go/border/braccept/segments.go
+++ b/go/border/braccept/segments.go
@@ -15,396 +15,87 @@
 package main
 
 import (
+	"fmt"
+	"hash"
+	"regexp"
+	"strconv"
+
 	"github.com/scionproto/scion/go/border/braccept/tpkt"
+	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/spath"
 )
 
-var (
-	// Segments between ff00:0:1 <-> ff00:0:2
-	seg_02A_1A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsEgress: if_211},
-			{ConsIngress: if_121},
-		})
-	revseg_1A0_02A = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsIngress: if_121},
-			{ConsEgress: if_211},
-		})
-	seg_02A_1A0X = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsEgress: if_211},
-			{ConsIngress: if_121, Xover: true},
-		})
-	revseg_1A0X_02A = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsIngress: if_121, Xover: true},
-			{ConsEgress: if_211},
-		})
-	seg_01A_2A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsEgress: if_121},
-			{ConsIngress: if_211},
-		})
-	revseg_2A0_01A = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsIngress: if_211},
-			{ConsEgress: if_121},
-		})
-	// Segments between ff00:0:1 <-> ff00:0:3
-	seg_03A_1C0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsEgress: if_311},
-			{ConsIngress: if_131},
-		})
-	revseg_1C0_03A = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsIngress: if_131},
-			{ConsEgress: if_311},
-		})
-	seg_01C_3A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsEgress: if_131},
-			{ConsIngress: if_311},
-		})
-	revseg_3A0_01C = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsIngress: if_311},
-			{ConsEgress: if_131},
-		})
-	revseg_3A0_01CX = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsIngress: if_311},
-			{ConsEgress: if_131, Xover: true},
-		})
-	// Segments between ff00:0:2 <-> ff00:0:3
-	seg_02A_1A1C_3A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsEgress: if_211},
-			{ConsIngress: if_121, ConsEgress: if_131},
-			{ConsIngress: if_311},
-		})
-	revseg_3A0_1A1C_02A = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsIngress: if_311},
-			{ConsIngress: if_121, ConsEgress: if_131},
-			{ConsEgress: if_211},
-		})
-	seg_03A_1C1A_2A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsEgress: if_311},
-			{ConsIngress: if_131, ConsEgress: if_121},
-			{ConsIngress: if_211},
-		})
-	revseg_2A0_1C1A_03A = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsIngress: if_211},
-			{ConsIngress: if_131, ConsEgress: if_121},
-			{ConsEgress: if_311},
-		})
-	revseg_2B0_1C1C_03A = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsIngress: if_212},
-			{ConsIngress: if_131, ConsEgress: if_122},
-			{ConsEgress: if_311},
-		})
-	// Segments between ff00:0:1 <-> ff00:0:4
-	seg_01B_4A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsEgress: if_141},
-			{ConsIngress: if_411},
-		})
-	revseg_4A0_01B = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsIngress: if_411},
-			{ConsEgress: if_141},
-		})
-	seg_01C_4B0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsEgress: if_142},
-			{ConsIngress: if_412},
-		})
-	revseg_4B0_01C = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsIngress: if_412},
-			{ConsEgress: if_142},
-		})
-	revseg_4A0_01BX = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsIngress: if_411},
-			{ConsEgress: if_141, Xover: true},
-		})
-	// Segments between ff00:0:1 <-> ff00:0:5
-	seg_01C_5A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsEgress: if_151},
-			{ConsIngress: if_511},
-		})
-	revseg_5A0_01C = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsIngress: if_511},
-			{ConsEgress: if_151},
-		})
-	seg_01CX_5A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsEgress: if_151, Xover: true},
-			{ConsIngress: if_511},
-		})
-	revseg_5A0_01CX = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsIngress: if_511},
-			{ConsEgress: if_151, Xover: true},
-		})
-	// Segments between ff00:0:1 <-> ff00:0:6
-	seg_01B_6A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsEgress: if_161},
-			{ConsIngress: if_611},
-		})
-	revseg_6A0_01B = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 2},
-		[]*spath.HopField{
-			{ConsIngress: if_611},
-			{ConsEgress: if_161},
-		})
-	// Segments between ff00:0:6 <-> ff00:0:4
-	seg_06B_1D1B_4A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsEgress: if_612},
-			{ConsIngress: if_162, ConsEgress: if_141},
-			{ConsIngress: if_411},
-		})
-	revseg_4A0_1D1B_06B = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsIngress: if_411},
-			{ConsIngress: if_162, ConsEgress: if_141},
-			{ConsEgress: if_612},
-		})
-	seg_06A_1C1B_4A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsEgress: if_611},
-			{ConsIngress: if_161, ConsEgress: if_141},
-			{ConsIngress: if_411},
-		})
-	revseg_4A0_1C1B_06A = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsIngress: if_411},
-			{ConsIngress: if_161, ConsEgress: if_141},
-			{ConsEgress: if_611},
-		})
-	segS_06BV_1D1BX_4A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3, Shortcut: true},
-		[]*spath.HopField{
-			{ConsEgress: if_612, VerifyOnly: true},
-			{ConsIngress: if_162, ConsEgress: if_141, Xover: true},
-			{ConsIngress: if_411},
-		})
-	revsegS_4A0_1D1BX_06BV = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3, Shortcut: true},
-		[]*spath.HopField{
-			{ConsIngress: if_411},
-			{ConsIngress: if_162, ConsEgress: if_141, Xover: true},
-			{ConsEgress: if_612, VerifyOnly: true},
-		})
-	segS_06BV_1D1DX_4B0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3, Shortcut: true},
-		[]*spath.HopField{
-			{ConsEgress: if_612, VerifyOnly: true},
-			{ConsIngress: if_162, ConsEgress: if_142, Xover: true},
-			{ConsIngress: if_412},
-		})
-	revsegS_4B0_1D1DX_06BV = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3, Shortcut: true},
-		[]*spath.HopField{
-			{ConsIngress: if_412},
-			{ConsIngress: if_162, ConsEgress: if_142, Xover: true},
-			{ConsEgress: if_612, VerifyOnly: true},
-		})
-	segSP_06A_1A1BX_1C1BX_4A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 4, Peer: true, Shortcut: true},
-		[]*spath.HopField{
-			{ConsEgress: if_611},
-			{ConsIngress: if_121, ConsEgress: if_141, Xover: true},
-			{ConsIngress: if_161, ConsEgress: if_141, Xover: true},
-			{ConsIngress: if_411},
-		})
-	revsegSP_4A0_1C1BX_1A1BX_06AV = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 4, Peer: true, Shortcut: true},
-		[]*spath.HopField{
-			{ConsIngress: if_411},
-			{ConsIngress: if_161, ConsEgress: if_141, Xover: true},
-			{ConsIngress: if_121, ConsEgress: if_141, Xover: true},
-			{ConsEgress: if_611, VerifyOnly: true},
-		})
-	// Segments between ff00:0:6 <-> ff00:0:5
-	seg_06B_1D1D_5A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsEgress: if_612},
-			{ConsIngress: if_162, ConsEgress: if_151},
-			{ConsIngress: if_511},
-		})
-	revseg_5A0_1D1D_06B = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsIngress: if_511},
-			{ConsIngress: if_162, ConsEgress: if_151},
-			{ConsEgress: if_612},
-		})
-	segS_06BV_1D1DX_5A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3, Shortcut: true},
-		[]*spath.HopField{
-			{ConsEgress: if_612, VerifyOnly: true},
-			{ConsIngress: if_162, ConsEgress: if_151, Xover: true},
-			{ConsIngress: if_511},
-		})
-	revsegS_5A0_1D1DX_06BV = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3, Shortcut: true},
-		[]*spath.HopField{
-			{ConsIngress: if_511},
-			{ConsIngress: if_162, ConsEgress: if_151, Xover: true},
-			{ConsEgress: if_612, VerifyOnly: true},
-		})
-	segSP_06B_1A1DX_1D1DX_5A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 4, Peer: true, Shortcut: true},
-		[]*spath.HopField{
-			{ConsEgress: if_612},
-			{ConsIngress: if_121, ConsEgress: if_151, Xover: true},
-			{ConsIngress: if_162, ConsEgress: if_151, Xover: true},
-			{ConsIngress: if_511},
-		})
-	revsegSP_5A0_1D1DX_1A1DX_06BV = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 4, Peer: true, Shortcut: true},
-		[]*spath.HopField{
-			{ConsIngress: if_511},
-			{ConsIngress: if_162, ConsEgress: if_151, Xover: true},
-			{ConsIngress: if_121, ConsEgress: if_151, Xover: true},
-			{ConsEgress: if_612, VerifyOnly: true},
-		})
-	segSP_06BV_1D1DX_1D1DX_5A0 = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 4, Peer: true, Shortcut: true},
-		[]*spath.HopField{
-			{ConsEgress: if_612, VerifyOnly: true},
-			{ConsIngress: if_131, ConsEgress: if_151, Xover: true},
-			{ConsIngress: if_162, ConsEgress: if_151, Xover: true},
-			{ConsIngress: if_511},
-		})
-	revsegSP_5A0_1D1DX_1D1DX_06BV = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 4, Peer: true, Shortcut: true},
-		[]*spath.HopField{
-			{ConsIngress: if_511},
-			{ConsIngress: if_162, ConsEgress: if_151, Xover: true},
-			{ConsIngress: if_131, ConsEgress: if_151, Xover: true},
-			{ConsEgress: if_612, VerifyOnly: true},
-		})
-	// Segments between ff00:0:6 <-> ff00:0:2 with peer to ff00:0:1
-	seg_06C_2A0X_2C0X = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsEgress: if_621},
-			{ConsIngress: if_211, Xover: true},
-			{ConsIngress: if_261, Xover: true},
-		})
-	seg_06CV_2A0X_2C0X = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsEgress: if_621, VerifyOnly: true},
-			{ConsIngress: if_211, Xover: true},
-			{ConsIngress: if_261, Xover: true},
-		})
-	revseg_2C0X_2A0X_06C = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsIngress: if_261, Xover: true},
-			{ConsIngress: if_211, Xover: true},
-			{ConsEgress: if_621},
-		})
-	revsegP_2C0X_2A0X_06C = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3, Peer: true},
-		[]*spath.HopField{
-			{ConsIngress: if_261, Xover: true},
-			{ConsIngress: if_211, Xover: true},
-			{ConsEgress: if_621},
-		})
-	// Segments between ff00:0:6 <-> ff00:0:1 with peer to ff00:0:2
-	seg_06A_1A0X_1C0X = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsEgress: if_611},
-			{ConsIngress: if_121, Xover: true},
-			{ConsIngress: if_161, Xover: true},
-		})
-	revseg_1C0X_1A0X_06A = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsIngress: if_161, Xover: true},
-			{ConsIngress: if_121, Xover: true},
-			{ConsEgress: if_611},
-		})
-	revsegSP_1C0X_1A0X_06AV = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3, Peer: true, Shortcut: true},
-		[]*spath.HopField{
-			{ConsIngress: if_161, Xover: true},
-			{ConsIngress: if_121, Xover: true},
-			{ConsEgress: if_611, VerifyOnly: true},
-		})
-	// Segments between ff00:0:8 <-> ff00:0:3 with peer to ff00:0:1
-	seg_08A_3A0X_3C0X = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsEgress: if_831},
-			{ConsIngress: if_311, Xover: true},
-			{ConsIngress: if_381, Xover: true},
-		})
-	seg_08AV_3A0X_3C0X = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: true, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsEgress: if_831, VerifyOnly: true},
-			{ConsIngress: if_311, Xover: true},
-			{ConsIngress: if_381, Xover: true},
-		})
-	revseg_3C0X_3A0X_08A = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3},
-		[]*spath.HopField{
-			{ConsIngress: if_381, Xover: true},
-			{ConsIngress: if_311, Xover: true},
-			{ConsEgress: if_831},
-		})
-	revsegSP_3C0X_3A0X_08AV = tpkt.NewSegment(
-		&spath.InfoField{ConsDir: false, ISD: 1, TsInt: tsNow, Hops: 3, Peer: true, Shortcut: true},
-		[]*spath.HopField{
-			{ConsIngress: if_381, Xover: true},
-			{ConsIngress: if_311, Xover: true},
-			{ConsEgress: if_831, VerifyOnly: true},
-		})
-)
+// segment parses a string that defines a SCION path segment.
+// The info field should always be the first in the segment, then as many hop fields as needed.
+// The info fields syntax matches the following regex:
+//   ^\([C_][S_][P_]\) with C (ConsDir), S (Shortcut), P (Peer)
+// The hop fields syntax matches the following regex:
+//   \[([X_][V_]\.)?(0|[0-9]{3})\.(0|[0-9]{3})\] with X (Xover), V (VerifyOnly),
+// and the interfaces are either 0 or a 3 digit int.
+// Examples:
+//   (_S_)[211.0][X_.151.121][_V.511.0]
+//   (C__)[X_.0.141][411.0]
+func segment(input string, hashMac hash.Hash, hopIdxs ...int) *tpkt.Segment {
+	infoStr := regexp.MustCompile(`^\(...\)`).FindString(input)
+	if infoStr == "" {
+		panic(fmt.Sprintf("Bad segment syntax: %s", input))
+	}
+	infoF, err := decodeInfoF(infoStr)
+	if err != nil {
+		panic(fmt.Sprintf("%s\n%s", infoStr, err))
+	}
+	var hops []*spath.HopField
+	fields := regexp.MustCompile(`\[.*?\]`).FindAllString(input, -1)
+	for _, hf := range fields {
+		hop, err := decodeHopF(hf)
+		if err != nil {
+			panic(fmt.Sprintf("%s\n%s", input, err))
+		}
+		hops = append(hops, hop)
+	}
+	infoF.Hops = uint8(len(hops))
+	if len(hopIdxs) > 0 {
+		return tpkt.NewSegment(infoF, hops).Macs(hashMac, hopIdxs...)
+	}
+	return tpkt.NewSegment(infoF, hops)
+}
+
+func decodeInfoF(str string) (*spath.InfoField, error) {
+	// Validate InfoField flags syntax
+	match, _ := regexp.MatchString(`^\([C_][S_][P_]\)$`, str)
+	if !match {
+		return nil, fmt.Errorf("Bad Info Field flags syntax: %s", str)
+	}
+	// Decode and build Info Field
+	return &spath.InfoField{
+		ConsDir:  str[1] == 'C',
+		Shortcut: str[2] == 'S',
+		Peer:     str[3] == 'P',
+		TsInt:    tsNow32,
+		ISD:      1,
+	}, nil
+}
+
+func decodeHopF(str string) (*spath.HopField, error) {
+	// Validate InfoField flags syntax
+	match, _ := regexp.MatchString(`^\[([X_][V_]\.)?(0|[0-9]{3})\.(0|[0-9]{3})\]$`, str)
+	if !match {
+		return nil, fmt.Errorf("Bad Hop Field syntax: %s", str)
+	}
+	r, _ := regexp.Compile(`0|[1-9]{3,3}`)
+	ifids := r.FindAllString(str, 2)
+	ingress, err := strconv.ParseUint(ifids[0], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	egress, err := strconv.ParseUint(ifids[1], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	return &spath.HopField{
+		Xover:       str[1] == 'X',
+		VerifyOnly:  str[1] == 'V' || str[2] == 'V',
+		ConsIngress: common.IFIDType(ingress),
+		ConsEgress:  common.IFIDType(egress),
+	}, nil
+}

--- a/go/border/braccept/tpkt/extensions.go
+++ b/go/border/braccept/tpkt/extensions.go
@@ -80,6 +80,7 @@ func (l *baseExtension) LengthBytes() int {
 	return int(l.Length) * common.LineLen
 }
 
+var _ LayerBuilder = (*ScionSCMPExtn)(nil)
 var _ LayerMatcher = (*ScionSCMPExtn)(nil)
 
 var LayerTypeScionHBHSCMP = gopacket.RegisterLayerType(
@@ -94,6 +95,17 @@ type ScionSCMPExtn struct {
 	layers.BaseLayer
 	baseExtension
 	scmp.Extn
+}
+
+func NewSCMPExtn(nh common.L4ProtocolType, ext scmp.Extn) *ScionSCMPExtn {
+	return &ScionSCMPExtn{
+		baseExtension: baseExtension{NextHdr: nh, Length: 1, Type: common.ExtnSCMPType.Type},
+		Extn:          ext,
+	}
+}
+
+func (l *ScionSCMPExtn) Build() ([]gopacket.SerializableLayer, error) {
+	return []gopacket.SerializableLayer{l}, nil
 }
 
 func (l *ScionSCMPExtn) Match(pktLayers []gopacket.Layer,

--- a/go/border/braccept/tpkt/scnpath.go
+++ b/go/border/braccept/tpkt/scnpath.go
@@ -68,7 +68,7 @@ func (p *ScnPath) Parse(b []byte) error {
 	}
 	offset := 0
 	for offset < len(b) {
-		seg := &SegDef{}
+		seg := &Segment{}
 		l, err := seg.Parse(b[offset:])
 		if err != nil {
 			return err
@@ -107,7 +107,7 @@ func (p *ScnPath) Len() int {
 	return p.Segs.Len()
 }
 
-type Segments []*SegDef
+type Segments []*Segment
 
 func (segs Segments) Len() int {
 	l := 0
@@ -151,22 +151,22 @@ func PrintSegments(segs Segments, indent, sep string) string {
 
 var defaultMac = common.RawBytes{0xef, 0xef, 0xef}
 
-// SegDef defines a path segment
-type SegDef struct {
+// Segment defines a path segment
+type Segment struct {
 	Inf  *spath.InfoField
 	Hops []*spath.HopField
 	macs []hash.Hash
 }
 
-func NewSegment(infoF *spath.InfoField, hops []*spath.HopField) *SegDef {
-	return &SegDef{
+func NewSegment(infoF *spath.InfoField, hops []*spath.HopField) *Segment {
+	return &Segment{
 		Inf:  infoF,
 		Hops: hops,
 		macs: make([]hash.Hash, len(hops)),
 	}
 }
 
-func (s *SegDef) Macs(hashMac hash.Hash, hopIdxs ...int) *SegDef {
+func (s *Segment) Macs(hashMac hash.Hash, hopIdxs ...int) *Segment {
 	newSeg := s.Copy()
 	for _, i := range hopIdxs {
 		newSeg.macs[i] = hashMac
@@ -174,8 +174,8 @@ func (s *SegDef) Macs(hashMac hash.Hash, hopIdxs ...int) *SegDef {
 	return newSeg
 }
 
-func (s *SegDef) Copy() *SegDef {
-	newSeg := &SegDef{
+func (s *Segment) Copy() *Segment {
+	newSeg := &Segment{
 		Inf:  &spath.InfoField{},
 		Hops: make([]*spath.HopField, len(s.Hops)),
 		macs: make([]hash.Hash, len(s.Hops)),
@@ -189,7 +189,7 @@ func (s *SegDef) Copy() *SegDef {
 	return newSeg
 }
 
-func (s *SegDef) Parse(b []byte) (int, error) {
+func (s *Segment) Parse(b []byte) (int, error) {
 	inf, err := spath.InfoFFromRaw(b)
 	if err != nil {
 		return 0, err
@@ -209,7 +209,7 @@ func (s *SegDef) Parse(b []byte) (int, error) {
 	return segLen, nil
 }
 
-func (seg *SegDef) WriteTo(b []byte) (int, error) {
+func (seg *Segment) WriteTo(b []byte) (int, error) {
 	var err error
 	// Write Info Field
 	seg.Inf.Write(b)
@@ -255,7 +255,7 @@ func (seg *SegDef) WriteTo(b []byte) (int, error) {
 	return spath.InfoFieldLength + nHops*spath.HopFieldLength, nil
 }
 
-func (s *SegDef) String() string {
+func (s *Segment) String() string {
 	var str []string
 	var cons, short, peer string
 	if s.Inf.ConsDir {
@@ -281,11 +281,11 @@ func (s *SegDef) String() string {
 	return fmt.Sprintf("[%1s%1s%1s] %s", cons, short, peer, strings.Join(str, " <-> "))
 }
 
-func (s *SegDef) Len() int {
+func (s *Segment) Len() int {
 	return spath.InfoFieldLength + spath.HopFieldLength*len(s.Hops)
 }
 
-func (s *SegDef) Equal(o *SegDef) error {
+func (s *Segment) Equal(o *Segment) error {
 	if !s.Inf.Equal(o.Inf) {
 		return fmt.Errorf("Info Field mismatch\n  Expected: %s\n  Actual:   %s\n", s.Inf, o.Inf)
 	}


### PR DESCRIPTION
Add support and test for revocation. For such test, a Pre/Post step was
added to each test, providing the ability to send a packet before and
after (respectivily) the test itself. In the Pre step an IFStateInfo
deactiving an interface is sent to the BR, then a IFStateInfo activing
the same interface is sent in the Post, to restore the original BR
state.

Path segments are now defined as strings using an intuitive syntax,
maintaining all the previous flexibility to define path segments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2302)
<!-- Reviewable:end -->
