### PR TITLE
CS: handle concurrent insertion of cust keys in startup

### DIFF
--- a/go/cert_srv/internal/csconfig/customers.go
+++ b/go/cert_srv/internal/csconfig/customers.go
@@ -63,6 +63,8 @@ func LoadCustomers(stateDir string, trustDB trustdb.TrustDB) error {
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
 	defer cancelF()
 	for ia, file := range activeKeys {
+		// If multiple servers start at the same time and try to insert at the same time
+		// we might have to retry in case of a CustKeyModifiedError.
 		for attempts := 0; attempts < 3; attempts++ {
 			key, err := keyconf.LoadKey(file, keyconf.RawKey)
 			if err != nil {

--- a/go/lib/infra/modules/trust/trustdb/errors.go
+++ b/go/lib/infra/modules/trust/trustdb/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Anapaya Systems
+// Copyright 2019 ETH Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go/lib/infra/modules/trust/trustdb/errors.go
+++ b/go/lib/infra/modules/trust/trustdb/errors.go
@@ -1,0 +1,34 @@
+// Copyright 2018 ETH Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustdb
+
+import (
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+const (
+	ErrCustKeyModified = "Cust key has been modified"
+)
+
+// IsCustKeyModifiedErr returns whether e is or contains ErrCustKeyModified.
+func IsCustKeyModifiedErr(e error) bool {
+	if common.GetErrorMsg(e) == ErrCustKeyModified {
+		return true
+	}
+	if n := common.GetNestedError(e); n != nil {
+		return IsCustKeyModifiedErr(n)
+	}
+	return false
+}

--- a/go/lib/infra/modules/trust/trustdb/trustdbsqlite/db.go
+++ b/go/lib/infra/modules/trust/trustdb/trustdbsqlite/db.go
@@ -533,7 +533,7 @@ func (db *executor) InsertCustKey(ctx context.Context, ia addr.IA,
 			return common.NewBasicError("Unable to determine affected rows", err)
 		}
 		if n == 0 {
-			return common.NewBasicError("Cust keys has been modified", nil, "ia", ia,
+			return common.NewBasicError(trustdb.ErrCustKeyModified, nil, "ia", ia,
 				"newVersion", version, "oldVersion", oldVersion)
 		}
 	}

--- a/go/lib/infra/modules/trust/trustdb/trustdbtest/trustdbtest.go
+++ b/go/lib/infra/modules/trust/trustdb/trustdbtest/trustdbtest.go
@@ -312,6 +312,16 @@ func testChain(t *testing.T, db rwTrustDB) {
 				SoMsg("chain", newChain, ShouldBeNil)
 			})
 		})
+		Convey("Given a DB with 2 chains, Getting a chain works fine", func() {
+			chain := insertChainFromFile(t, ctx, "testdata/ISD1-ASff00_0_311-V1.crt", db)
+			insertChainFromFile(t, ctx, "testdata/ISD2-ASff00_0_212-V1.crt", db)
+			newChain, err := db.GetChainMaxVersion(ctx, ia)
+			SoMsg("err", err, ShouldBeNil)
+			SoMsg("chain", newChain, ShouldResemble, chain)
+			newChain, err = db.GetChainVersion(ctx, ia, 1)
+			SoMsg("err", err, ShouldBeNil)
+			SoMsg("chain", newChain, ShouldResemble, chain)
+		})
 	})
 }
 
@@ -390,6 +400,8 @@ func testCustKey(t *testing.T, db rwTrustDB) {
 				SoMsg("No error expected", err, ShouldBeNil)
 				err = db.InsertCustKey(ctx, ia1_110, newVer, key_110_2, ver)
 				SoMsg("Error expected", err, ShouldNotBeNil)
+				SoMsg("IsCustKeyModifiedErr should return true",
+					trustdb.IsCustKeyModifiedErr(err), ShouldBeTrue)
 			})
 		})
 	})

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -169,8 +169,8 @@ class GoGenerator(object):
                 'Type': "CS"
             },
             'cs': {
-                'LeafReissueTime': "6h",
-                'IssuerReissueTime': "3d",
+                'LeafReissueLeadTime': "6h",
+                'IssuerReissueLeadTime': "3d",
                 'ReissueRate': "10s",
                 'ReissueTimeout': "5s",
             },


### PR DESCRIPTION
It could be that a cust key is inserted exactly at the time a server starts and therefore the insert of the cust key will fail. In this case we should just retry.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2304)
<!-- Reviewable:end -->
