### PR TITLE
BR: Transactional context setup

### DIFF
--- a/acceptance/topo_br_reload_if_ip_acceptance/test
+++ b/acceptance/topo_br_reload_if_ip_acceptance/test
@@ -89,7 +89,6 @@ check_change_remote_ip() {
 
 change_remote_ip() {
     # Connectivity is broken at this point
-    unblock_socket $1 $2
     jq ".BorderRouters[].Interfaces[].RemoteOverlay.Addr = $3" $1 | sponge $1
     ./tools/dc dc kill -s HUP scion_br"$2"-1
     sleep 2
@@ -98,22 +97,11 @@ change_remote_ip() {
 
 check_change_initial_ip() {
     check_connectivity "Start check_change_initial_ip"
-    unblock_socket $SRC_TOPO $SRC_IA_FILE
-    unblock_socket $DST_TOPO $DST_IA_FILE
     local pre=".BorderRouters[].Interfaces[]"
     jq "$pre.PublicOverlay = $orig_src | $pre.RemoteOverlay = $orig_dst" $SRC_TOPO | sponge $SRC_TOPO
     jq "$pre.PublicOverlay = $orig_dst | $pre.RemoteOverlay = $orig_src" $DST_TOPO | sponge $DST_TOPO
     ./tools/dc dc kill -s HUP scion_br"$SRC_IA_FILE"-1 scion_br"$DST_IA_FILE"-1
     check_connectivity "End check_change_initial_ip"
-}
-
-unblock_socket() {
-    # FIXME(roosd): This is a work around to get the BR to reload the config.
-    # When https://github.com/scionproto/scion/issues/2254 is fixed, this part shall be removed.
-    local port=$(jq '.BorderRouters[].Interfaces[].PublicOverlay.OverlayPort' $1)
-    jq '.BorderRouters[].Interfaces[].PublicOverlay.OverlayPort = 42425' $1 | sponge $1
-    ./tools/dc dc kill -s HUP scion_br"$2"-1
-    jq ".BorderRouters[].Interfaces[].PublicOverlay.OverlayPort = $port" $1 | sponge $1
 }
 
 test_teardown() {

--- a/acceptance/topo_br_reload_if_port_acceptance/test
+++ b/acceptance/topo_br_reload_if_port_acceptance/test
@@ -48,7 +48,6 @@ check_change_local_port() {
 
 check_change_remote_port() {
     # Connectivity is broken at this point
-    unblock_socket
     jq '.BorderRouters[].Interfaces[].RemoteOverlay.OverlayPort = 42424' $DST_TOPO | sponge $DST_TOPO
     ./tools/dc dc kill -s HUP scion_br"$DST_IA_FILE"-1
     sleep 2
@@ -58,20 +57,11 @@ check_change_remote_port() {
 
 check_change_initial_port() {
     check_connectivity "Start check_change_initial_port"
-    unblock_socket
     jq ".BorderRouters[].Interfaces[].PublicOverlay = $orig_src" $SRC_TOPO | sponge $SRC_TOPO
     jq ".BorderRouters[].Interfaces[].RemoteOverlay = $orig_src" $DST_TOPO | sponge $DST_TOPO
     ./tools/dc dc kill -s HUP scion_br"$SRC_IA_FILE"-1
     ./tools/dc dc kill -s HUP scion_br"$DST_IA_FILE"-1
     check_connectivity "End check_change_initial_port"
-}
-
-unblock_socket() {
-    # FIXME(roosd): This is a work around to get the BR to reload the config.
-    # When https://github.com/scionproto/scion/issues/2254 is fixed, this part shall be removed.
-    jq '.BorderRouters[].Interfaces[].PublicOverlay.OverlayPort = 42425' $DST_TOPO | sponge $DST_TOPO
-    ./tools/dc dc kill -s HUP scion_br"$DST_IA_FILE"-1
-    jq ".BorderRouters[].Interfaces[].PublicOverlay = $orig_dst" $DST_TOPO | sponge $DST_TOPO
 }
 
 test_teardown() {

--- a/go/border/brconf/params.go
+++ b/go/border/brconf/params.go
@@ -14,7 +14,39 @@
 
 package brconf
 
+import "github.com/scionproto/scion/go/lib/common"
+
 type BR struct {
 	// Profile enables cpu and memory profiling.
 	Profile bool
+	// RollbackFailAction indicates the action that should be taken
+	// if the rollback fails.
+	RollbackFailAction FailAction
+}
+
+func (b *BR) InitDefaults() {
+	if b.RollbackFailAction != FailActionContinue {
+		b.RollbackFailAction = FailActionFatal
+	}
+}
+
+type FailAction string
+
+const (
+	// FailActionFatal indicates that the process exits on error.
+	FailActionFatal FailAction = "Fatal"
+	// FailActionContinue indicates that the process continues on error.
+	FailActionContinue FailAction = "Continue"
+)
+
+func (f *FailAction) UnmarshalText(text []byte) error {
+	switch FailAction(text) {
+	case FailActionFatal:
+		*f = FailActionFatal
+	case FailActionContinue:
+		*f = FailActionContinue
+	default:
+		return common.NewBasicError("Unknown FailAction", nil, "input", string(text))
+	}
+	return nil
 }

--- a/go/border/brconf/sample.go
+++ b/go/border/brconf/sample.go
@@ -59,4 +59,8 @@ const Sample = `[general]
 [br]
   # Enable cpu and memory profiling. (default false)
   Profile = false
+
+  # Action that should be taken when an error occurres during a context rollback.
+  # (Fatal | Continue) (default Fatal) 
+  RollbackFailAction = "Fatal"
 `

--- a/go/border/main.go
+++ b/go/border/main.go
@@ -118,6 +118,7 @@ func setup() error {
 	if err := env.InitGeneral(&config.General); err != nil {
 		return err
 	}
+	config.BR.InitDefaults()
 	environment = env.SetupEnv(func() {
 		if r == nil {
 			log.Error("Unable to reload config", "err", "router not set")

--- a/go/border/setup-posix.go
+++ b/go/border/setup-posix.go
@@ -22,10 +22,8 @@ import (
 	"github.com/scionproto/scion/go/border/netconf"
 	"github.com/scionproto/scion/go/border/rcmn"
 	"github.com/scionproto/scion/go/border/rctx"
-	"github.com/scionproto/scion/go/lib/assert"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/log"
-	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/overlay/conn"
 	"github.com/scionproto/scion/go/lib/prom"
 	"github.com/scionproto/scion/go/lib/ringbuf"
@@ -38,8 +36,6 @@ func init() {
 	registeredExtSockOps[PosixSock] = posixExt{}
 }
 
-var _ locSockOps = posixLoc{}
-
 type posixLoc struct{}
 
 // Setup configures a local POSIX(/BSD) socket.
@@ -47,25 +43,47 @@ func (p posixLoc) Setup(r *Router, ctx *rctx.Ctx, labels prometheus.Labels,
 	oldCtx *rctx.Ctx) error {
 
 	// Check if the existing socket can be reused. On startup, oldCtx is nil.
-	if oldCtx != nil && ctx.Conf.Net.LocAddr.Equal(oldCtx.Conf.Net.LocAddr) {
-		log.Debug("No change detected for local socket.")
-		// Nothing changed. Copy I/O functions from old context.
-		ctx.LocSockIn = oldCtx.LocSockIn
-		ctx.LocSockOut = oldCtx.LocSockOut
-		return nil
+	if oldCtx != nil {
+		// The socket can be reused if the local address does not change.
+		if ctx.Conf.Net.LocAddr.Equal(oldCtx.Conf.Net.LocAddr) {
+			log.Trace("No change detected for local socket.")
+			// Nothing changed. Copy I/O functions from old context.
+			ctx.LocSockIn = oldCtx.LocSockIn
+			ctx.LocSockOut = oldCtx.LocSockOut
+			return nil
+		}
+		log.Debug("Closing existing local socket", "conn", oldCtx.LocSockIn.Conn.LocalAddr())
+		oldCtx.LocSockIn.Stop()
+		oldCtx.LocSockOut.Stop()
 	}
 	// New bind address. Configure Posix I/O.
-	// Get Bind address if set, Public otherwise
-	bind := ctx.Conf.Net.LocAddr.BindOrPublicOverlay(ctx.Conf.Topo.Overlay)
-	if err := p.addSock(r, ctx, bind, labels); err != nil {
-		return err
-	}
-	return nil
+	return p.addSock(r, ctx, labels)
 }
 
-func (p posixLoc) addSock(r *Router, ctx *rctx.Ctx, bind *overlay.OverlayAddr,
-	labels prometheus.Labels) error {
+func (p posixLoc) Rollback(r *Router, ctx *rctx.Ctx, labels prometheus.Labels,
+	oldCtx *rctx.Ctx) error {
 
+	// Do nothing if socket is reused.
+	if oldCtx != nil && ctx.Conf.Net.LocAddr.Equal(oldCtx.Conf.Net.LocAddr) {
+		return nil
+	}
+	// Remove new socket if it exists. It might not be set if the setup failed.
+	if ctx.LocSockIn != nil {
+		log.Debug("Rolling back local socket", "conn", ctx.LocSockIn.Conn.LocalAddr)
+		ctx.LocSockIn.Stop()
+		ctx.LocSockOut.Stop()
+	}
+	// No need to start socket if the old context unset or the socket is still running.
+	if oldCtx == nil || oldCtx.LocSockIn.Running() {
+		return nil
+	}
+	// Replace previously closed socket.
+	return p.addSock(r, oldCtx, labels)
+}
+
+func (p posixLoc) addSock(r *Router, ctx *rctx.Ctx, labels prometheus.Labels) error {
+	// Get Bind address if set, Public otherwise
+	bind := ctx.Conf.Net.LocAddr.BindOrPublicOverlay(ctx.Conf.Topo.Overlay)
 	log.Debug("Setting up new local socket.", "bind", bind)
 	// Listen on the socket.
 	over, err := conn.New(bind, nil, labels)
@@ -81,28 +99,6 @@ func (p posixLoc) addSock(r *Router, ctx *rctx.Ctx, bind *overlay.OverlayAddr,
 	return nil
 }
 
-func (p posixLoc) Rollback(r *Router, ctx *rctx.Ctx, oldCtx *rctx.Ctx) {
-	if oldCtx != nil && ctx.Conf.Net.LocAddr.Equal(oldCtx.Conf.Net.LocAddr) {
-		return
-	}
-	if ctx.LocSockIn != nil {
-		log.Debug("Rolling back local socket", "conn", ctx.LocSockIn.Conn.LocalAddr)
-		ctx.LocSockIn.Stop()
-		ctx.LocSockOut.Stop()
-	}
-}
-
-func (p posixLoc) Teardown(r *Router, ctx *rctx.Ctx, oldCtx *rctx.Ctx) {
-	if oldCtx == nil || ctx.LocSockIn == oldCtx.LocSockIn {
-		return
-	}
-	log.Debug("Tearing down unused local socket", "conn", ctx.LocSockIn.Conn.LocalAddr())
-	oldCtx.LocSockIn.Stop()
-	oldCtx.LocSockOut.Stop()
-}
-
-var _ extSockOps = posixExt{}
-
 type posixExt posixLoc
 
 // Setup configures a POSIX(/BSD) interface socket.
@@ -111,34 +107,46 @@ func (p posixExt) Setup(r *Router, ctx *rctx.Ctx, intf *netconf.Interface,
 
 	// No old context. This happens during startup of the router.
 	if oldCtx == nil {
-		if err := p.addIntf(r, ctx, intf, labels); err != nil {
-			return err
-		}
-		return nil
+		return p.addIntf(r, ctx, intf, labels)
 	}
 	if oldIntf, ok := oldCtx.Conf.Net.IFs[intf.Id]; ok {
 		// Reuse socket if the interface has not changed.
 		if !interfaceChanged(intf, oldIntf) {
-			log.Debug("No change detected for external socket.", "conn",
+			log.Trace("No change detected for external socket.", "conn",
 				intf.IFAddr.BindOrPublicOverlay(ctx.Conf.Topo.Overlay))
 			ctx.ExtSockIn[intf.Id] = oldCtx.ExtSockIn[intf.Id]
 			ctx.ExtSockOut[intf.Id] = oldCtx.ExtSockOut[intf.Id]
 			return nil
 		}
-		// FIXME(roosd): If the local address is the same, we need to release
-		// the socket in order to successfully bind afterwards.
-		// After switching to go 1.11+, this can be avoided by using SO_REUSEPORT.
-		if intf.IFAddr.Equal(oldIntf.IFAddr) {
-			log.Debug("Closing existing external socket to free addr", "old", oldIntf, "new", intf)
-			oldCtx.ExtSockIn[intf.Id].Stop()
-			oldCtx.ExtSockOut[intf.Id].Stop()
-		}
-		log.Debug("Existing interface changed", "old", oldIntf, "new", intf)
+		log.Debug("Closing existing external socket", "old", oldIntf, "new", intf)
+		oldCtx.ExtSockIn[intf.Id].Stop()
+		oldCtx.ExtSockOut[intf.Id].Stop()
 	}
-	if err := p.addIntf(r, ctx, intf, labels); err != nil {
-		return err
+	return p.addIntf(r, ctx, intf, labels)
+}
+
+func (p posixExt) Rollback(r *Router, ctx *rctx.Ctx, intf *netconf.Interface,
+	labels prometheus.Labels, oldCtx *rctx.Ctx) error {
+
+	var oldIntf *netconf.Interface
+	if oldCtx != nil {
+		oldIntf = oldCtx.Conf.Net.IFs[intf.Id]
 	}
-	return nil
+	// Do not rollback socket if it is reused by new context.
+	if oldIntf != nil && !interfaceChanged(intf, oldIntf) {
+		return nil
+	}
+	// Stop new socket if it exists. It might not exist if the Setup failed.
+	if _, ok := ctx.ExtSockIn[intf.Id]; ok {
+		log.Debug("Rolling back external socket", "intf", intf)
+		ctx.ExtSockIn[intf.Id].Stop()
+		ctx.ExtSockOut[intf.Id].Stop()
+	}
+	// No need to start socket if it is not present in old context or still running.
+	if oldIntf == nil || oldCtx.ExtSockIn[oldIntf.Id].Running() {
+		return nil
+	}
+	return p.addIntf(r, oldCtx, oldIntf, labels)
 }
 
 func (p posixExt) addIntf(r *Router, ctx *rctx.Ctx, intf *netconf.Interface,
@@ -160,42 +168,12 @@ func (p posixExt) addIntf(r *Router, ctx *rctx.Ctx, intf *netconf.Interface,
 	return nil
 }
 
-func (p posixExt) Rollback(r *Router, ctx *rctx.Ctx, intf *netconf.Interface, oldCtx *rctx.Ctx) {
-	var oldIntf *netconf.Interface
-	if oldCtx != nil {
-		var ok bool
-		// Do not rollback socket if it is reused by new context.
-		if oldIntf, ok = oldCtx.Conf.Net.IFs[intf.Id]; ok && !interfaceChanged(intf, oldIntf) {
-			return
-		}
-	}
-	log.Debug("Rolling back external socket", "intf", intf)
-	if _, ok := ctx.ExtSockIn[intf.Id]; ok {
-		ctx.ExtSockIn[intf.Id].Stop()
-		ctx.ExtSockOut[intf.Id].Stop()
-	}
-	// In case the old socket was closed in order to allow bind of new socket, restore it.
-	if oldIntf != nil && intf.IFAddr.Equal(oldIntf.IFAddr) {
-		labels := mkSockFromRingLabels(oldCtx.ExtSockIn[oldIntf.Id].Labels)
-		if err := p.addIntf(r, oldCtx, oldIntf, labels); err != nil {
-			log.Crit("Unable to rollback closed socket", err, "intf", oldIntf)
-			if assert.On {
-				assert.Must(false, "Must not fail to open socket in rollback")
-			}
-		} else {
-			log.Debug("Rolling back closed external sockets", "old", oldIntf, "new", intf)
-			oldCtx.ExtSockIn[intf.Id].Start()
-			oldCtx.ExtSockOut[intf.Id].Start()
-		}
-	}
-}
-
 func (p posixExt) Teardown(r *Router, ctx *rctx.Ctx, intf *netconf.Interface, oldCtx *rctx.Ctx) {
 	if oldCtx == nil || oldCtx.ExtSockIn[intf.Id] == nil {
 		return
 	}
-	if newSock, ok := ctx.ExtSockIn[intf.Id]; !ok || newSock != oldCtx.ExtSockIn[intf.Id] {
-		log.Debug("Tearing down unused external socket", "intf", intf)
+	if _, ok := ctx.ExtSockIn[intf.Id]; !ok {
+		log.Debug("Tearing down socket from removed external interface", "intf", intf)
 		oldCtx.ExtSockIn[intf.Id].Stop()
 		oldCtx.ExtSockOut[intf.Id].Stop()
 	}
@@ -215,12 +193,4 @@ func mkRingLabels(labels prometheus.Labels) prometheus.Labels {
 	ringLabels["ringId"] = labels["sock"]
 	delete(ringLabels, "sock")
 	return ringLabels
-}
-
-// Create a set of labels from ringbuf labels with `ringId` renamed to `sock`.
-func mkSockFromRingLabels(labels prometheus.Labels) prometheus.Labels {
-	sockLabel := prom.CopyLabels(labels)
-	sockLabel["sock"] = labels["ringId"]
-	delete(sockLabel, "ringId")
-	return sockLabel
 }

--- a/go/border/setup-posix.go
+++ b/go/border/setup-posix.go
@@ -36,6 +36,8 @@ func init() {
 	registeredExtSockOps[PosixSock] = posixExt{}
 }
 
+var _ locSockOps = posixLoc{}
+
 type posixLoc struct{}
 
 // Setup configures a local POSIX(/BSD) socket.
@@ -98,6 +100,8 @@ func (p posixLoc) addSock(r *Router, ctx *rctx.Ctx, labels prometheus.Labels) er
 	log.Debug("Done setting up new local socket.", "conn", over.LocalAddr())
 	return nil
 }
+
+var _ extSockOps = posixExt{}
 
 type posixExt posixLoc
 

--- a/go/border/setup-posix.go
+++ b/go/border/setup-posix.go
@@ -46,15 +46,13 @@ type posixLoc struct{}
 func (p posixLoc) Setup(r *Router, ctx *rctx.Ctx, labels prometheus.Labels,
 	oldCtx *rctx.Ctx) error {
 
-	// No old context. This happens during startup of the router.
-	if oldCtx != nil {
-		if ctx.Conf.Net.LocAddr.Equal(oldCtx.Conf.Net.LocAddr) {
-			log.Debug("No change detected for local socket.")
-			// Nothing changed. Copy I/O functions from old context.
-			ctx.LocSockIn = oldCtx.LocSockIn
-			ctx.LocSockOut = oldCtx.LocSockOut
-			return nil
-		}
+	// Check if the existing socket can be reused. On startup, oldCtx is nil.
+	if oldCtx != nil && ctx.Conf.Net.LocAddr.Equal(oldCtx.Conf.Net.LocAddr) {
+		log.Debug("No change detected for local socket.")
+		// Nothing changed. Copy I/O functions from old context.
+		ctx.LocSockIn = oldCtx.LocSockIn
+		ctx.LocSockOut = oldCtx.LocSockOut
+		return nil
 	}
 	// New bind address. Configure Posix I/O.
 	// Get Bind address if set, Public otherwise

--- a/go/border/setup-posix.go
+++ b/go/border/setup-posix.go
@@ -143,6 +143,7 @@ func (p posixExt) Rollback(r *Router, ctx *rctx.Ctx, intf *netconf.Interface,
 		ctx.ExtSockOut[intf.Id].Stop()
 	}
 	// No need to start socket if it is not present in old context or still running.
+	// The socket is still running if setupNet failed before iterating over this socket.
 	if oldIntf == nil || oldCtx.ExtSockIn[oldIntf.Id].Running() {
 		return nil
 	}

--- a/go/border/setup.go
+++ b/go/border/setup.go
@@ -198,6 +198,9 @@ func (r *Router) rollbackNet(ctx, oldCtx *rctx.Ctx,
 
 // teardownOldNet tears down the sockets of removed external interfaces.
 func (r *Router) teardownNet(ctx, oldCtx *rctx.Ctx, sockConf brconf.SockConf) {
+	if oldCtx == nil {
+		return
+	}
 	// Iterate on oldCtx to catch removed interfaces.
 	for _, intf := range oldCtx.Conf.Net.IFs {
 		registeredExtSockOps[sockConf.Ext(intf.Id)].Teardown(r, ctx, intf, oldCtx)

--- a/go/border/setup_test.go
+++ b/go/border/setup_test.go
@@ -56,6 +56,7 @@ func TestSetupNet(t *testing.T) {
 		// Modify local socket address. A new socket should be opened when
 		// setting up the context.
 		ctx.Conf.Net.LocAddr.PublicOverlay(ctx.Conf.Net.LocAddr.Overlay).L3().IP()[3] = 255
+		SoMsg("In", oldCtx.LocSockIn, ShouldNotBeNil)
 		clean := updateTestRouter(r, ctx, oldCtx)
 		defer clean()
 		// Check that the local socket changed
@@ -65,9 +66,8 @@ func TestSetupNet(t *testing.T) {
 		checkExtSocksUnchanged("New vs Old", ctx, oldCtx)
 		// Check that external sockets are still running.
 		checkExtSocksRunning("ctx", ctx, true)
-		// FIXME(roosd): Check state of the local socket when reload logic is improved.
 	})
-	Convey("Changing interface local address does not affect old socket", t, func() {
+	Convey("Changing interface local address closes old socket", t, func() {
 		r, oldCtx := setupTestRouter(t)
 		copyCtx := copyContext(oldCtx)
 		ctx := rctx.New(loadConfig(t))
@@ -84,8 +84,9 @@ func TestSetupNet(t *testing.T) {
 		// Change socket for modified interface.
 		SoMsg("IFID 12", ctx.ExtSockIn[12], ShouldNotEqual, oldCtx.ExtSockIn[12])
 		SoMsg("IFID 12", ctx.ExtSockOut[12], ShouldNotEqual, oldCtx.ExtSockOut[12])
-		// Old socket should still be running.
-		checkExtSocksRunning("Old", oldCtx, true)
+		// Old socket must be closed.
+		SoMsg("Old 12 In running", oldCtx.ExtSockIn[12].Running(), ShouldBeFalse)
+		SoMsg("Old 12 Out running", oldCtx.ExtSockOut[12].Running(), ShouldBeFalse)
 	})
 	Convey("Changing interface remote address closes old socket", t, func() {
 		r, oldCtx := setupTestRouter(t)
@@ -118,7 +119,9 @@ func TestRollbackNet(t *testing.T) {
 		clean := updateTestRouter(r, ctx, oldCtx)
 		defer clean()
 		// Rollback the changes.
-		r.rollbackNet(ctx, copyCtx, brconf.SockConf{Default: PosixSock})
+		r.rollbackNet(ctx, oldCtx, brconf.SockConf{Default: PosixSock}, func(err error) {
+			SoMsg("Rollback err", err, ShouldBeNil)
+		})
 		// Check that the original context has not been modified.
 		checkLocSocksUnchanged("Old vs copy", oldCtx, copyCtx)
 		checkExtSocksUnchanged("Old vs copy", oldCtx, copyCtx)
@@ -126,7 +129,8 @@ func TestRollbackNet(t *testing.T) {
 		checkLocSocksRunning("Old", oldCtx, true)
 		checkExtSocksRunning("Old", oldCtx, true)
 	})
-	Convey("Rolling back config with changed local address does not affect old sockets", t, func() {
+	Convey("Rolling back config with changed local address does "+
+		"not affect external sockets", t, func() {
 		r, oldCtx := setupTestRouter(t)
 		copyCtx := copyContext(oldCtx)
 		ctx := rctx.New(loadConfig(t))
@@ -134,16 +138,17 @@ func TestRollbackNet(t *testing.T) {
 		clean := updateTestRouter(r, ctx, oldCtx)
 		defer clean()
 		// Rollback the changes.
-		r.rollbackNet(ctx, copyCtx, brconf.SockConf{Default: PosixSock})
-		// Check that the original context has not been modified.
-		checkLocSocksUnchanged("Old vs copy", oldCtx, copyCtx)
+		r.rollbackNet(ctx, oldCtx, brconf.SockConf{Default: PosixSock}, func(err error) {
+			SoMsg("Rollback err", err, ShouldBeNil)
+		})
+		// Check that the external interfaces of original context has not been modified.
 		checkExtSocksUnchanged("Old vs copy", oldCtx, copyCtx)
 		// Check that all sockets are still running
 		checkLocSocksRunning("Old", oldCtx, true)
 		checkExtSocksRunning("Old", oldCtx, true)
 	})
-	Convey("Rolling back config with changed public address on "+
-		"interface does not affect old socket", t, func() {
+	Convey("Rolling back config with changed external interface "+
+		"does not affect local socket", t, func() {
 		r, oldCtx := setupTestRouter(t)
 		copyCtx := copyContext(oldCtx)
 		ctx := rctx.New(loadConfig(t))
@@ -151,10 +156,11 @@ func TestRollbackNet(t *testing.T) {
 		clean := updateTestRouter(r, ctx, oldCtx)
 		defer clean()
 		// Rollback the changes.
-		r.rollbackNet(ctx, oldCtx, brconf.SockConf{Default: PosixSock})
-		// Check that the original context has not been modified.
+		r.rollbackNet(ctx, oldCtx, brconf.SockConf{Default: PosixSock}, func(err error) {
+			SoMsg("Rollback err", err, ShouldBeNil)
+		})
+		// Check that the local socket of the original context has not been modified.
 		checkLocSocksUnchanged("Old vs copy", oldCtx, copyCtx)
-		checkExtSocksUnchanged("Old vs copy", oldCtx, copyCtx)
 		// Check that all sockets are still running
 		checkLocSocksRunning("Old", oldCtx, true)
 		checkExtSocksRunning("Old", oldCtx, true)
@@ -162,36 +168,6 @@ func TestRollbackNet(t *testing.T) {
 		SoMsg("New Ifid 12 In running", ctx.ExtSockIn[12].Running(), ShouldBeFalse)
 		SoMsg("New ifid 12 Out running", ctx.ExtSockOut[12].Running(), ShouldBeFalse)
 	})
-	Convey("Rolling back config with changed remote address on "+
-		"interface does not affect old socket", t, func() {
-		r, oldCtx := setupTestRouter(t)
-		copyCtx := copyContext(oldCtx)
-		ctx := rctx.New(loadConfig(t))
-		ctx.Conf.Net.IFs[12].RemoteAddr.L3().IP()[3] = 255
-		clean := updateTestRouter(r, ctx, oldCtx)
-		defer clean()
-		// Rollback the changes.
-		r.rollbackNet(ctx, oldCtx, brconf.SockConf{Default: PosixSock})
-		// Check that the local socket of the  original context has not been modified.
-		checkLocSocksUnchanged("Old vs copy", oldCtx, copyCtx)
-		// Check that all sockets are still running. The closed socket is reopened in
-		// the rollback.
-		checkLocSocksRunning("Old", oldCtx, true)
-		checkExtSocksRunning("Old", oldCtx, true)
-		// Unaffected socket still running.
-		SoMsg("IFID 11 In running", oldCtx.ExtSockIn[11].Running(), ShouldBeTrue)
-		SoMsg("IFID 11 Out running", oldCtx.ExtSockOut[11].Running(), ShouldBeTrue)
-		// Check created sockets are stopped.
-		SoMsg("New IFID 12 In running", ctx.ExtSockIn[12].Running(), ShouldBeFalse)
-		SoMsg("New IFID 12 Out running", ctx.ExtSockOut[12].Running(), ShouldBeFalse)
-		// Check original sockets are stopped (to free address).
-		SoMsg("Orig IFID 12 In running", oldCtx.ExtSockIn[12].Running(), ShouldBeTrue)
-		SoMsg("Orig IFID 12 Out running", oldCtx.ExtSockOut[12].Running(), ShouldBeTrue)
-		// Check sockets were reopened for old context.
-		SoMsg("Old IFID 12 In running", copyCtx.ExtSockIn[12].Running(), ShouldBeFalse)
-		SoMsg("Old IFID 12 Out running", copyCtx.ExtSockOut[12].Running(), ShouldBeFalse)
-	})
-
 }
 
 func TestTeardownNet(t *testing.T) {
@@ -212,7 +188,7 @@ func TestTeardownNet(t *testing.T) {
 		checkExtSocksRunning("New", ctx, true)
 		checkLocSocksRunning("New", ctx, true)
 	})
-	Convey("Tearing down config with changed local address should close unused socks", t, func() {
+	Convey("Tearing down config with changed local address  should be a noop", t, func() {
 		r, oldCtx := setupTestRouter(t)
 		ctx := rctx.New(loadConfig(t))
 		ctx.Conf.Net.LocAddr.PublicOverlay(ctx.Conf.Net.LocAddr.Overlay).L3().IP()[3] = 255
@@ -229,10 +205,8 @@ func TestTeardownNet(t *testing.T) {
 		// Check that teardown does not close the needed sockets.
 		checkExtSocksRunning("New", ctx, true)
 		checkLocSocksRunning("New", ctx, true)
-		// Check that the teardown closes the no longer needed socket.
-		checkLocSocksRunning("Old", oldCtx, false)
 	})
-	Convey("Tearing down config with changed interface should close unused socks", t, func() {
+	Convey("Tearing down config with changed interface should be a noop", t, func() {
 		r, oldCtx := setupTestRouter(t)
 		ctx := rctx.New(loadConfig(t))
 		ctx.Conf.Net.IFs[12].IFAddr.PublicOverlay(overlay.IPv4).L3().IP()[3] = 255
@@ -240,6 +214,7 @@ func TestTeardownNet(t *testing.T) {
 		defer clean()
 		// Start sockets on the new context.
 		startSocks(ctx)
+		// Create copy of the new context to catch changes.
 		// Create copy of the new context to catch changes.
 		copyCtx := copyContext(ctx)
 		r.teardownNet(ctx, oldCtx, brconf.SockConf{Default: PosixSock})
@@ -249,11 +224,29 @@ func TestTeardownNet(t *testing.T) {
 		// Check that teardown does not close the needed sockets.
 		checkExtSocksRunning("New", ctx, true)
 		checkLocSocksRunning("New", ctx, true)
-		// The old socket for interface should be closed.
-		SoMsg("Old Ifid 12 In running", oldCtx.ExtSockIn[12].Running(), ShouldBeFalse)
-		SoMsg("Old ifid 12 Out running", oldCtx.ExtSockOut[12].Running(), ShouldBeFalse)
 	})
-
+	Convey("Tearing down config with removed interface should close socket", t, func() {
+		r, oldCtx := setupTestRouter(t)
+		ctx := rctx.New(loadConfig(t))
+		delete(ctx.Conf.Net.IFs, 12)
+		clean := updateTestRouter(r, ctx, oldCtx)
+		defer clean()
+		// Start sockets on the new context.
+		startSocks(ctx)
+		// Create copy of the new context to catch changes.
+		// Create copy of the new context to catch changes.
+		copyCtx := copyContext(ctx)
+		r.teardownNet(ctx, oldCtx, brconf.SockConf{Default: PosixSock})
+		// Check that teardown does not modify the context
+		checkLocSocksUnchanged("New vs copy", ctx, copyCtx)
+		checkExtSocksUnchanged("New vs copy", ctx, copyCtx)
+		// Check that teardown does not close the needed sockets.
+		checkExtSocksRunning("New", ctx, true)
+		checkLocSocksRunning("New", ctx, true)
+		// Check removed interface is no longer running
+		SoMsg("New Ifid 12 In running", oldCtx.ExtSockIn[12].Running(), ShouldBeFalse)
+		SoMsg("New ifid 12 Out running", oldCtx.ExtSockOut[12].Running(), ShouldBeFalse)
+	})
 }
 
 // checkLocSocksUnchanged compares that both contexts point to the same local socket.


### PR DESCRIPTION
Make context setup during a topology reload transactional.
Either the complete setup completes, or all changes are rolled back to the previous stage.

The context setup is executed in the following phases:
1. setupNet
   - reuse unchanged sockets from old context
   - setup socket for new changed interfaces
   - (if local addr clashes) close socket to allow new socket to bind
2. rollbackNet (if error in setupNet)
   - close freshly setup sockets
   - restart previously closed sockets
3. teardownNet (if no error in setupNet)
   - close no longer used  sockets of old context.

To simplify the handling, the following restrictions are introduced:
1. No address must be reassigned to a different interface.
2. No address must be reassigned from internal to interface,
   and vice versa.

Doing these changes requires a two-step reload by the operator.

Remove socket unblocking from the `topo_br_*` acceptance
test to test proper handling in the br code.

fixes #2254 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2316)
<!-- Reviewable:end -->
