### PR TITLE
Ringbuf: Avoid getting stuck writing/reading 0 entries

### DIFF
--- a/go/lib/ringbuf/ringbuf.go
+++ b/go/lib/ringbuf/ringbuf.go
@@ -76,7 +76,7 @@ func (r *Ring) Write(entries EntryList, block bool) (int, bool) {
 	defer r.mutex.Unlock()
 	var blocked bool
 	r.metrics.writeCalls.Inc()
-	if r.writable == 0 && !r.closed {
+	if len(entries) > 0 && r.writable == 0 && !r.closed {
 		if !block {
 			return 0, blocked
 		}
@@ -110,7 +110,7 @@ func (r *Ring) Read(entries EntryList, block bool) (int, bool) {
 	defer r.mutex.Unlock()
 	var blocked bool
 	r.metrics.readCalls.Inc()
-	if r.readable == 0 && !r.closed {
+	if len(entries) > 0 && r.readable == 0 && !r.closed {
 		if !block {
 			return 0, blocked
 		}


### PR DESCRIPTION
Previously, when returning a slice of length zero to the
ringbuffer using `Write` and the number of writable packets
is zero, the call is blocked until the next read happens.

Previously, when reading a slice of length zero from the
ringbuffer using `Read` and the number of readable packets
is zero, the call is blocked until the next write happens.

Now the calls follow the expected behaviour and are no
longer blocked under these conditions,.