### PR TITLE
Go dispatcher: Add SCMP ID tracking tables

### DIFF
--- a/go/godispatcher/internal/registration/iatable.go
+++ b/go/godispatcher/internal/registration/iatable.go
@@ -37,6 +37,12 @@ type UDPReference interface {
 	Reference
 	// UDPAddr returns the UDP address associated with this reference
 	UDPAddr() *net.UDPAddr
+	// RegisterID attaches an SCMP ID to this reference. The ID is released
+	// when the reference is freed. Registering another ID does not overwrite
+	// the previous; instead, multiple IDs get associated with the reference.
+	// SCMP messages targeted at the ID will get sent to the socket associated
+	// with the reference.
+	RegisterID(id uint64) error
 }
 
 // IATable manages the UDP/IP port registrations for a SCION Dispatcher.
@@ -61,7 +67,7 @@ type IATable interface {
 	//
 	// To unregister from the table, free the returned reference.
 	Register(ia addr.IA, public *net.UDPAddr, bind net.IP, svc addr.HostSVC,
-		value interface{}) (Reference, error)
+		value interface{}) (UDPReference, error)
 	// LookupPublic returns the value associated with the selected public
 	// address. Wildcard addresses are supported. If an entry is found, the
 	// returned boolean is set to true. Otherwise, it is set to false.
@@ -79,6 +85,11 @@ type IATable interface {
 	// If SVC is a multicast address, more than one entry can be returned. The
 	// bind address is ignored in this case.
 	LookupService(ia addr.IA, svc addr.HostSVC, bind net.IP) []interface{}
+	// LookupID returns the entry associated with the SCMP General class ID id.
+	// The ID is used for SCMP Echo, TraceRoute, and RecordPath functionality.
+	// If an entry is found, the returned boolean is set to true. Otherwise, it
+	// is set to false.
+	LookupID(id uint64) (interface{}, bool)
 }
 
 // NewIATable creates a new UDP/IP port registration table.
@@ -98,18 +109,29 @@ type iaTable struct {
 	ia      map[addr.IA]*Table
 	minPort int
 	maxPort int
+
+	scmpLock sync.RWMutex
+	// XXX(scrye): This is implemented here to achieve feature parity with the
+	// C-dispatcher, where SCMP General IDs are globally scoped (i.e., all IAs
+	// and all hosts share the same ID namespace, and thus can collide with
+	// each other). Because the IDs are random, it is very unlikely for a
+	// collision to occur (although faulty coding can increase the chance,
+	// e.g., if apps start with an ID of 1 and increment from there). We should
+	// revisit if SCMP General IDs should be scoped to IAs and/or IPs.
+	scmpTable *SCMPTable
 }
 
 func newIATable(minPort, maxPort int) *iaTable {
 	return &iaTable{
-		ia:      make(map[addr.IA]*Table),
-		minPort: minPort,
-		maxPort: maxPort,
+		ia:        make(map[addr.IA]*Table),
+		minPort:   minPort,
+		maxPort:   maxPort,
+		scmpTable: NewSCMPTable(),
 	}
 }
 
 func (t *iaTable) Register(ia addr.IA, public *net.UDPAddr, bind net.IP, svc addr.HostSVC,
-	value interface{}) (Reference, error) {
+	value interface{}) (UDPReference, error) {
 
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
@@ -132,6 +154,7 @@ func (t *iaTable) Register(ia addr.IA, public *net.UDPAddr, bind net.IP, svc add
 		table:    t,
 		ia:       ia,
 		entryRef: reference,
+		value:    value,
 	}, nil
 }
 
@@ -153,12 +176,33 @@ func (t *iaTable) LookupService(ia addr.IA, svc addr.HostSVC, bind net.IP) []int
 	return nil
 }
 
+func (t *iaTable) LookupID(id uint64) (interface{}, bool) {
+	t.scmpLock.RLock()
+	defer t.scmpLock.RUnlock()
+	return t.scmpTable.Lookup(id)
+}
+
+func (t *iaTable) registerID(id uint64, value interface{}) error {
+	t.scmpLock.Lock()
+	defer t.scmpLock.Unlock()
+	return t.scmpTable.Register(id, value)
+}
+
+func (t *iaTable) removeID(id uint64) error {
+	t.scmpLock.Lock()
+	defer t.scmpLock.Unlock()
+	return t.scmpTable.Remove(id)
+}
+
 var _ UDPReference = (*iaTableReference)(nil)
 
 type iaTableReference struct {
 	table    *iaTable
 	ia       addr.IA
-	entryRef Reference
+	entryRef *TableReference
+	// value is the main table information associated with this reference
+	value interface{}
+	ids   []uint64
 }
 
 func (r *iaTableReference) Free() {
@@ -168,8 +212,23 @@ func (r *iaTableReference) Free() {
 	if r.table.ia[r.ia].Size() == 0 {
 		delete(r.table.ia, r.ia)
 	}
+	for _, id := range r.ids {
+		if err := r.table.removeID(id); err != nil {
+			// This should never happen
+			panic(err)
+		}
+	}
 }
 
 func (r *iaTableReference) UDPAddr() *net.UDPAddr {
-	return r.entryRef.(UDPReference).UDPAddr()
+	return r.entryRef.UDPAddr()
+}
+
+func (r *iaTableReference) RegisterID(id uint64) error {
+	err := r.table.registerID(id, r.value)
+	if err != nil {
+		return err
+	}
+	r.ids = append(r.ids, id)
+	return nil
 }

--- a/go/godispatcher/internal/registration/iatable.go
+++ b/go/godispatcher/internal/registration/iatable.go
@@ -188,10 +188,10 @@ func (t *iaTable) registerID(id uint64, value interface{}) error {
 	return t.scmpTable.Register(id, value)
 }
 
-func (t *iaTable) removeID(id uint64) error {
+func (t *iaTable) removeID(id uint64) {
 	t.scmpLock.Lock()
 	defer t.scmpLock.Unlock()
-	return t.scmpTable.Remove(id)
+	t.scmpTable.Remove(id)
 }
 
 var _ UDPReference = (*iaTableReference)(nil)
@@ -213,10 +213,7 @@ func (r *iaTableReference) Free() {
 		delete(r.table.ia, r.ia)
 	}
 	for _, id := range r.ids {
-		if err := r.table.removeID(id); err != nil {
-			// This should never happen
-			panic(err)
-		}
+		r.table.removeID(id)
 	}
 }
 

--- a/go/godispatcher/internal/registration/iatable_test.go
+++ b/go/godispatcher/internal/registration/iatable_test.go
@@ -146,7 +146,7 @@ func TestIATableSCMPExistingRegistration(t *testing.T) {
 		xtest.FailOnErr(t, err)
 		err = ref.RegisterID(42)
 		xtest.FailOnErr(t, err)
-		Convey("Performing SCMP lookup now succeeds", func() {
+		Convey("Performing SCMP lookup succeeds", func() {
 			retValue, ok := table.LookupID(42)
 			SoMsg("ok", ok, ShouldBeTrue)
 			SoMsg("value", retValue, ShouldEqual, value)

--- a/go/godispatcher/internal/registration/iatable_test.go
+++ b/go/godispatcher/internal/registration/iatable_test.go
@@ -115,3 +115,57 @@ func TestIATableRegister(t *testing.T) {
 		})
 	})
 }
+
+func TestIATableSCMPRegistration(t *testing.T) {
+	Convey("Given a reference to an IATable registration", t, func() {
+		table := NewIATable(minPort, maxPort)
+		public := &net.UDPAddr{IP: net.IP{192, 0, 2, 1}, Port: 80}
+		value := "test value"
+		ia := xtest.MustParseIA("1-ff00:0:1")
+		ref, err := table.Register(ia, public, nil, addr.SvcNone, value)
+		xtest.FailOnErr(t, err)
+		Convey("Performing SCMP lookup fails", func() {
+			value, ok := table.LookupID(42)
+			SoMsg("ok", ok, ShouldBeFalse)
+			SoMsg("value", value, ShouldBeNil)
+		})
+		Convey("Registering an SCMP ID on the reference succeeds", func() {
+			err := ref.RegisterID(42)
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestIATableSCMPExistingRegistration(t *testing.T) {
+	Convey("Given an existing SCMP General ID registration", t, func() {
+		table := NewIATable(minPort, maxPort)
+		public := &net.UDPAddr{IP: net.IP{192, 0, 2, 1}, Port: 80}
+		value := "test value"
+		ia := xtest.MustParseIA("1-ff00:0:1")
+		ref, err := table.Register(ia, public, nil, addr.SvcNone, value)
+		xtest.FailOnErr(t, err)
+		err = ref.RegisterID(42)
+		xtest.FailOnErr(t, err)
+		Convey("Performing SCMP lookup now succeeds", func() {
+			retValue, ok := table.LookupID(42)
+			SoMsg("ok", ok, ShouldBeTrue)
+			SoMsg("value", retValue, ShouldEqual, value)
+		})
+		Convey("Freeing the reference makes lookup fail", func() {
+			ref.Free()
+			value, ok := table.LookupID(42)
+			SoMsg("ok", ok, ShouldBeFalse)
+			SoMsg("value", value, ShouldBeNil)
+		})
+		Convey("Registering a second SCMP ID on the same reference succeeds", func() {
+			err := ref.RegisterID(43)
+			So(err, ShouldBeNil)
+			Convey("Freeing the reference makes lookup on first registered id fail", func() {
+				ref.Free()
+				value, ok := table.LookupID(42)
+				SoMsg("ok", ok, ShouldBeFalse)
+				SoMsg("value", value, ShouldBeNil)
+			})
+		})
+	})
+}

--- a/go/godispatcher/internal/registration/scmp_table.go
+++ b/go/godispatcher/internal/registration/scmp_table.go
@@ -45,10 +45,6 @@ func (t *SCMPTable) Register(id uint64, value interface{}) error {
 	return nil
 }
 
-func (t *SCMPTable) Remove(id uint64) error {
-	if _, ok := t.m[id]; !ok {
-		return common.NewBasicError("element not found", nil, "id", id)
-	}
+func (t *SCMPTable) Remove(id uint64) {
 	delete(t.m, id)
-	return nil
 }

--- a/go/godispatcher/internal/registration/scmp_table.go
+++ b/go/godispatcher/internal/registration/scmp_table.go
@@ -1,0 +1,54 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registration
+
+import (
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+// SCMPTable tracks SCMP General class IDs.
+//
+// Attempting to register the same ID more than once will return an error.
+type SCMPTable struct {
+	m map[uint64]interface{}
+}
+
+func NewSCMPTable() *SCMPTable {
+	return &SCMPTable{m: make(map[uint64]interface{})}
+}
+
+func (t *SCMPTable) Lookup(id uint64) (interface{}, bool) {
+	value, ok := t.m[id]
+	return value, ok
+}
+
+func (t *SCMPTable) Register(id uint64, value interface{}) error {
+	if value == nil {
+		return common.NewBasicError("cannot register nil value", nil)
+	}
+	if _, ok := t.m[id]; ok {
+		return common.NewBasicError("id already registered", nil, "id", id)
+	}
+	t.m[id] = value
+	return nil
+}
+
+func (t *SCMPTable) Remove(id uint64) error {
+	if _, ok := t.m[id]; !ok {
+		return common.NewBasicError("element not found", nil, "id", id)
+	}
+	delete(t.m, id)
+	return nil
+}

--- a/go/godispatcher/internal/registration/scmp_table_test.go
+++ b/go/godispatcher/internal/registration/scmp_table_test.go
@@ -40,10 +40,6 @@ func TestSCMPEmptyTable(t *testing.T) {
 			err := table.Register(42, nil)
 			So(err, ShouldNotBeNil)
 		})
-		Convey("Removing an id fails", func() {
-			err := table.Remove(42)
-			So(err, ShouldNotBeNil)
-		})
 	})
 }
 
@@ -62,18 +58,11 @@ func TestSCMPTableWithOneItem(t *testing.T) {
 			err := table.Register(42, "some other value")
 			So(err, ShouldNotBeNil)
 		})
-		Convey("Removing the id succeeds", func() {
-			err := table.Remove(42)
-			So(err, ShouldBeNil)
-			Convey("Lookup now fails", func() {
-				value, ok := table.Lookup(42)
-				SoMsg("ok", ok, ShouldBeFalse)
-				SoMsg("value", value, ShouldBeNil)
-			})
-			Convey("Removing again fails", func() {
-				err := table.Remove(42)
-				So(err, ShouldNotBeNil)
-			})
+		Convey("After removing the ID, lookup fails", func() {
+			table.Remove(42)
+			value, ok := table.Lookup(42)
+			SoMsg("ok", ok, ShouldBeFalse)
+			SoMsg("value", value, ShouldBeNil)
 		})
 	})
 }

--- a/go/godispatcher/internal/registration/scmp_table_test.go
+++ b/go/godispatcher/internal/registration/scmp_table_test.go
@@ -1,0 +1,79 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registration
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/xtest"
+)
+
+func TestSCMPEmptyTable(t *testing.T) {
+	Convey("Given an empty table", t, func() {
+		table := NewSCMPTable()
+
+		Convey("Lookup for an id fails", func() {
+			value, ok := table.Lookup(42)
+			SoMsg("ok", ok, ShouldBeFalse)
+			SoMsg("value", value, ShouldBeNil)
+		})
+		Convey("Adding an item succeeds", func() {
+			value := "test value"
+			err := table.Register(42, value)
+			So(err, ShouldBeNil)
+		})
+		Convey("Adding an item with nil value fails", func() {
+			err := table.Register(42, nil)
+			So(err, ShouldNotBeNil)
+		})
+		Convey("Removing an id fails", func() {
+			err := table.Remove(42)
+			So(err, ShouldNotBeNil)
+		})
+	})
+}
+
+func TestSCMPTableWithOneItem(t *testing.T) {
+	Convey("Given a table with one element", t, func() {
+		table := NewSCMPTable()
+		value := "test value"
+		err := table.Register(42, value)
+		xtest.FailOnErr(t, err)
+		Convey("Lookup for the id succeeds", func() {
+			retValue, ok := table.Lookup(42)
+			SoMsg("ok", ok, ShouldBeTrue)
+			SoMsg("value", retValue, ShouldEqual, value)
+		})
+		Convey("Adding the same id fails", func() {
+			err := table.Register(42, "some other value")
+			So(err, ShouldNotBeNil)
+		})
+		Convey("Removing the id succeeds", func() {
+			err := table.Remove(42)
+			So(err, ShouldBeNil)
+			Convey("Lookup now fails", func() {
+				value, ok := table.Lookup(42)
+				SoMsg("ok", ok, ShouldBeFalse)
+				SoMsg("value", value, ShouldBeNil)
+			})
+			Convey("Removing again fails", func() {
+				err := table.Remove(42)
+				So(err, ShouldNotBeNil)
+			})
+		})
+	})
+}

--- a/go/godispatcher/internal/registration/table.go
+++ b/go/godispatcher/internal/registration/table.go
@@ -38,7 +38,7 @@ func NewTable(minPort, maxPort int) *Table {
 }
 
 func (t *Table) Register(public *net.UDPAddr, bind net.IP, svc addr.HostSVC,
-	value interface{}) (Reference, error) {
+	value interface{}) (*TableReference, error) {
 
 	if public == nil {
 		return nil, common.NewBasicError(ErrNoPublicAddress, nil)
@@ -59,7 +59,7 @@ func (t *Table) Register(public *net.UDPAddr, bind net.IP, svc addr.HostSVC,
 		return nil, err
 	}
 	t.size++
-	return &tableReference{table: t, address: address, svcRef: svcRef}, nil
+	return &TableReference{table: t, address: address, svcRef: svcRef}, nil
 }
 
 func (t *Table) insertSVCIfRequested(svc addr.HostSVC, bind net.IP, port int,
@@ -87,16 +87,14 @@ func (t *Table) Size() int {
 	return t.size
 }
 
-var _ UDPReference = (*tableReference)(nil)
-
-type tableReference struct {
+type TableReference struct {
 	table   *Table
 	freed   bool
 	address *net.UDPAddr
 	svcRef  Reference
 }
 
-func (r *tableReference) Free() {
+func (r *TableReference) Free() {
 	if r.freed {
 		panic("double free")
 	}
@@ -108,6 +106,6 @@ func (r *tableReference) Free() {
 	r.table.size--
 }
 
-func (r *tableReference) UDPAddr() *net.UDPAddr {
+func (r *TableReference) UDPAddr() *net.UDPAddr {
 	return r.address
 }


### PR DESCRIPTION
This is a stepping stone to implementing SCMP Echo, TraceRoute, and RecordPath support in the Go dispatcher.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2326)
<!-- Reviewable:end -->
