### PR TITLE
BK: Add retry for jobs when an agent failed

### DIFF
--- a/.buildkite/steps/build.yml
+++ b/.buildkite/steps/build.yml
@@ -2,6 +2,9 @@
   command: SCION_IMG="$SCION_BUILD_IMG" $BASE/run_step lint
   artifact_paths:
     - "artifacts.out/**/*"
+  retry:
+    automatic:
+      exit_status: -1
 - label: Build code and push "$SCION_IMG"
   command:
   - $BASE/scripts/registry_login
@@ -14,4 +17,7 @@
   - docker push $SCION_IMG
   artifact_paths:
     - "artifacts.out/**/*"
+  retry:
+    automatic:
+      exit_status: -1
 - wait

--- a/.buildkite/steps/build_all.yml
+++ b/.buildkite/steps/build_all.yml
@@ -7,4 +7,7 @@
   - make -C docker/perapp apps
   - ./docker.sh tester
   - $BASE/scripts/all_images push
+  retry:
+    automatic:
+      exit_status: -1
 - wait

--- a/.buildkite/steps/setup.yml
+++ b/.buildkite/steps/setup.yml
@@ -4,4 +4,7 @@
       - docker tag scion $SCION_BUILD_IMG
       - $BASE/scripts/registry_login
       - docker push $SCION_BUILD_IMG
+  retry:
+    automatic:
+      exit_status: -1
 - wait

--- a/.buildkite/steps/test.yml
+++ b/.buildkite/steps/test.yml
@@ -2,3 +2,6 @@
   command: $BASE/run_step test
   artifact_paths:
       - "artifacts.out/**/*"
+  retry:
+    automatic:
+      exit_status: -1


### PR DESCRIPTION
Buildkite: A job will show an exit status of -1 if the connection to the agent is lost. 
When agents haven't been used for some time there can be a race condition between AWS stopping machines and a new build acquiring an agent. Then the agent may be stopped while already running a job again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2350)
<!-- Reviewable:end -->
