### PR TITLE
BR acceptance tests: Increase timeout

### DIFF
--- a/go/border/braccept/main.go
+++ b/go/border/braccept/main.go
@@ -49,7 +49,7 @@ type ifInfo struct {
 const (
 	snapshot_len int32         = 1024
 	promiscuous  bool          = true
-	timeout      time.Duration = 500 * time.Millisecond
+	timeout      time.Duration = 1 * time.Second
 )
 
 var (


### PR DESCRIPTION
Increase timeout for BR acceptance tests s.t. the probability for a timeout decreases, especially on the CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2354)
<!-- Reviewable:end -->
