### PR TITLE
Add non-docker option for zookeeper back

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -77,7 +77,12 @@ load_cust_keys() {
 
 run_zk() {
     echo "Running zookeeper..."
-    ./tools/quiet ./tools/dc zk up -d
+    if is_docker_zk; then
+        host_zk_stop
+        ./tools/quiet ./tools/dc zk up -d
+    else
+        host_zk_start
+    fi
     if [ -n "$1" ]; then
         echo "Deleting all Zookeeper state"
         # Wait some time, such that zookeeper accepts connections again after startup
@@ -85,11 +90,19 @@ run_zk() {
         local addr="127.0.0.1:2181"
         if is_running_in_docker; then
             addr="${DOCKER0:-172.17.0.1}:2182"
-        elif is_docker_be; then
+        elif is_docker_zk; then
             addr="$(./tools/docker-ip):2181"
         fi
         tools/zkcleanslate --zk "$addr"
     fi
+}
+
+host_zk_start() {
+    systemctl is-active --quiet zookeeper || sudo -p "Starting local zk - [sudo] password for %p: " systemctl start zookeeper
+}
+
+host_zk_stop() {
+    systemctl is-active --quiet zookeeper && sudo -p "Stopping local zk - [sudo] password for %p: " systemctl stop zookeeper
 }
 
 cmd_mstart() {
@@ -209,6 +222,10 @@ glob_match() {
 
 is_docker_be() {
     [ -f gen/scion-dc.yml ]
+}
+
+is_docker_zk() {
+    is_docker_be || [ -f gen/zk-dc.yml ]
 }
 
 is_supervisor() {


### PR DESCRIPTION
For the scionlab installations, we prefer to run zookeeper directly on the host as opposed to running it in a container via docker-compose.
This PR adds back the old logic for running the zookeeper via systemd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2357)
<!-- Reviewable:end -->
