### PR TITLE
PathDB: Add a metrics wrapper

### DIFF
--- a/go/lib/pathdb/metrics.go
+++ b/go/lib/pathdb/metrics.go
@@ -54,9 +54,8 @@ type dbCounters struct {
 }
 
 // WithMetrics wraps the given PathDB into one that also exports metrics.
-// InitMetrics must have been called previously, otherwise this method panics.
+// dbName will be added as a label to all metrics, so that multiple path DBs can be differentiatetd.
 func WithMetrics(dbName string, pathDB PathDB) PathDB {
-
 	return &metricsPathDB{
 		pathDB: pathDB,
 		metrics: &dbCounters{
@@ -70,7 +69,7 @@ func WithMetrics(dbName string, pathDB PathDB) PathDB {
 			}),
 			errAnyTotal: errorsTotal.With(prometheus.Labels{
 				promDBName:    dbName,
-				prom.LabelErr: prom.ErrAny,
+				prom.LabelErr: prom.ErrNotClassified,
 			}),
 			errTimeoutTotal: errorsTotal.With(prometheus.Labels{
 				promDBName:    dbName,
@@ -79,6 +78,8 @@ func WithMetrics(dbName string, pathDB PathDB) PathDB {
 		},
 	}
 }
+
+var _ (PathDB) = (*metricsPathDB)(nil)
 
 // metricsPathDB is a PathDB wrapper that exports the counts of operations as prometheus metrics.
 type metricsPathDB struct {

--- a/go/lib/pathdb/metrics.go
+++ b/go/lib/pathdb/metrics.go
@@ -1,0 +1,154 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pathdb
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/ctrl/seg"
+	"github.com/scionproto/scion/go/lib/pathdb/query"
+	"github.com/scionproto/scion/go/lib/prom"
+)
+
+const (
+	promSubsyst = "pathdb"
+
+	promQuery  = "query"
+	promDBName = "db"
+	promError  = "err"
+)
+
+var (
+	queriesTotal *prometheus.CounterVec
+	errorsTotal  *prometheus.CounterVec
+)
+
+type dbCounters struct {
+	readQueriesTotal  prometheus.Counter
+	writeQueriesTotal prometheus.Counter
+	errorsTotal       *prometheus.CounterVec
+}
+
+// InitMetrics prepares the usage of metrics in the pathdb module.
+func InitMetrics(namespace string) {
+	queriesTotal = prom.NewCounterVec(namespace, promSubsyst, "queries_total",
+		"Total queries to the database.", []string{promDBName, promQuery})
+	errorsTotal = prom.NewCounterVec(namespace, promSubsyst, "errors_total",
+		"Amount of pathdb errors.", []string{promDBName, promError})
+}
+
+// WithMetrics wraps the given PathDB into one that also exports metrics.
+// InitMetrics must have been called previously, otherwise this method panics.
+func WithMetrics(dbName string, pathDB PathDB) PathDB {
+	if queriesTotal == nil || errorsTotal == nil {
+		panic("Must call InitMetrics first!")
+	}
+	return &metricsPathDB{
+		pathDB: pathDB,
+		metrics: &dbCounters{
+			readQueriesTotal: queriesTotal.With(prometheus.Labels{
+				promDBName: dbName,
+				promQuery:  "read",
+			}),
+			writeQueriesTotal: queriesTotal.With(prometheus.Labels{
+				promDBName: dbName,
+				promQuery:  "write",
+			}),
+			errorsTotal: errorsTotal.MustCurryWith(prometheus.Labels{
+				promDBName: dbName,
+			}),
+		},
+	}
+}
+
+type metricsPathDB struct {
+	pathDB  PathDB
+	metrics *dbCounters
+}
+
+func (db *metricsPathDB) Insert(ctx context.Context, meta *seg.Meta) (int, error) {
+	db.incWrite()
+	cnt, err := db.pathDB.Insert(ctx, meta)
+	db.incErr(err)
+	return cnt, err
+}
+
+func (db *metricsPathDB) InsertWithHPCfgIDs(ctx context.Context,
+	meta *seg.Meta, hpCfgIds []*query.HPCfgID) (int, error) {
+
+	db.incWrite()
+	cnt, err := db.pathDB.InsertWithHPCfgIDs(ctx, meta, hpCfgIds)
+	db.incErr(err)
+	return cnt, err
+}
+
+func (db *metricsPathDB) Delete(ctx context.Context, params *query.Params) (int, error) {
+	db.incWrite()
+	cnt, err := db.pathDB.Delete(ctx, params)
+	db.incErr(err)
+	return cnt, err
+}
+func (db *metricsPathDB) DeleteExpired(ctx context.Context, now time.Time) (int, error) {
+
+	db.incWrite()
+	cnt, err := db.pathDB.DeleteExpired(ctx, now)
+	db.incErr(err)
+	return cnt, err
+}
+func (db *metricsPathDB) Get(ctx context.Context,
+	params *query.Params) ([]*query.Result, error) {
+
+	db.incRead()
+	res, err := db.pathDB.Get(ctx, params)
+	db.incErr(err)
+	return res, err
+}
+func (db *metricsPathDB) InsertNextQuery(ctx context.Context,
+	dst addr.IA, nextQuery time.Time) (bool, error) {
+
+	db.incWrite()
+	ok, err := db.pathDB.InsertNextQuery(ctx, dst, nextQuery)
+	db.incErr(err)
+	return ok, err
+}
+func (db *metricsPathDB) GetNextQuery(ctx context.Context, dst addr.IA) (*time.Time, error) {
+	db.incRead()
+	t, err := db.pathDB.GetNextQuery(ctx, dst)
+	db.incErr(err)
+	return t, err
+}
+
+func (db *metricsPathDB) incRead() {
+	db.metrics.readQueriesTotal.Inc()
+}
+
+func (db *metricsPathDB) incWrite() {
+	db.metrics.writeQueriesTotal.Inc()
+}
+
+func (db *metricsPathDB) incErr(err error) {
+	if err == nil {
+		return
+	}
+	db.metrics.errorsTotal.With(prometheus.Labels{promError: errDesc(err)}).Inc()
+}
+
+func errDesc(err error) string {
+	return "err_any"
+}

--- a/go/lib/pathdb/metrics.go
+++ b/go/lib/pathdb/metrics.go
@@ -48,27 +48,9 @@ const (
 
 var (
 	queriesTotal *prometheus.CounterVec
-	errorsTotal  *prometheus.CounterVec
-)
+	resultsTotal *prometheus.CounterVec
 
-func init() {
-	queriesTotal = prom.NewCounterVec(promNamespace, "", "queries_total",
-		"Total queries to the database.", []string{promDBName, promOpLabel})
-	errorsTotal = prom.NewCounterVec(promNamespace, "", "errors_total",
-		"Amount of pathdb errors.", []string{promDBName, prom.LabelErr})
-}
-
-type dbCounters struct {
-	opCounters      map[promOp]prometheus.Counter
-	errAnyTotal     prometheus.Counter
-	errTimeoutTotal prometheus.Counter
-}
-
-// WithMetrics wraps the given PathDB into one that also exports metrics.
-// dbName will be added as a label to all metrics, so that multiple path DBs can be differentiated.
-func WithMetrics(dbName string, pathDB PathDB) PathDB {
-	opCounters := make(map[promOp]prometheus.Counter)
-	allOps := []promOp{
+	allOps = []promOp{
 		promOpInsert,
 		promOpInsertHpCfg,
 		promOpDelete,
@@ -77,26 +59,64 @@ func WithMetrics(dbName string, pathDB PathDB) PathDB {
 		promOpInsertNextQuery,
 		promOpGetNextQuery,
 	}
+
+	allResults = []string{
+		prom.ResultOk,
+		prom.ErrNotClassified,
+		prom.ErrTimeout,
+	}
+)
+
+func init() {
+	// Cardinality: X (dbName) * 7 (len(allOps))
+	queriesTotal = prom.NewCounterVec(promNamespace, "", "queries_total",
+		"Total queries to the database.", []string{promDBName, promOpLabel})
+	// Cardinality: X (dbNmae) * 7 (len(allOps)) * 3 (len(allResults))
+	resultsTotal = prom.NewCounterVec(promNamespace, "", "results_total",
+		"The results of the pathdb ops.", []string{promDBName, prom.LabelResult, promOpLabel})
+}
+
+type dbCounters struct {
+	opCounters     map[promOp]prometheus.Counter
+	resultCounters map[promOp]map[string]prometheus.Counter
+}
+
+// WithMetrics wraps the given PathDB into one that also exports metrics.
+// dbName will be added as a label to all metrics, so that multiple path DBs can be differentiated.
+func WithMetrics(dbName string, pathDB PathDB) PathDB {
+	return &metricsPathDB{
+		pathDB: pathDB,
+		metrics: &dbCounters{
+			opCounters:     opCounters(dbName),
+			resultCounters: resultCounters(dbName),
+		},
+	}
+}
+
+func opCounters(dbName string) map[promOp]prometheus.Counter {
+	opCounters := make(map[promOp]prometheus.Counter)
 	for _, op := range allOps {
 		opCounters[op] = queriesTotal.With(prometheus.Labels{
 			promDBName:  dbName,
 			promOpLabel: string(op),
 		})
 	}
-	return &metricsPathDB{
-		pathDB: pathDB,
-		metrics: &dbCounters{
-			opCounters: opCounters,
-			errAnyTotal: errorsTotal.With(prometheus.Labels{
-				promDBName:    dbName,
-				prom.LabelErr: prom.ErrNotClassified,
-			}),
-			errTimeoutTotal: errorsTotal.With(prometheus.Labels{
-				promDBName:    dbName,
-				prom.LabelErr: prom.ErrTimeout,
-			}),
-		},
+	return opCounters
+}
+
+func resultCounters(dbName string) map[promOp]map[string]prometheus.Counter {
+	resultCounters := make(map[promOp]map[string]prometheus.Counter)
+	for _, op := range allOps {
+		resultCounters[op] = make(map[string]prometheus.Counter)
+		for _, res := range allResults {
+			resultCounters[op][res] = resultsTotal.With(prometheus.Labels{
+				promDBName:       dbName,
+				promOpLabel:      string(op),
+				prom.LabelResult: res,
+			})
+		}
 	}
+	return resultCounters
 }
 
 var _ (PathDB) = (*metricsPathDB)(nil)
@@ -110,7 +130,7 @@ type metricsPathDB struct {
 func (db *metricsPathDB) Insert(ctx context.Context, meta *seg.Meta) (int, error) {
 	db.incOp(promOpInsert)
 	cnt, err := db.pathDB.Insert(ctx, meta)
-	db.incErr(err)
+	db.incErr(promOpInsert, err)
 	return cnt, err
 }
 
@@ -119,21 +139,21 @@ func (db *metricsPathDB) InsertWithHPCfgIDs(ctx context.Context,
 
 	db.incOp(promOpInsertHpCfg)
 	cnt, err := db.pathDB.InsertWithHPCfgIDs(ctx, meta, hpCfgIds)
-	db.incErr(err)
+	db.incErr(promOpInsertHpCfg, err)
 	return cnt, err
 }
 
 func (db *metricsPathDB) Delete(ctx context.Context, params *query.Params) (int, error) {
 	db.incOp(promOpDelete)
 	cnt, err := db.pathDB.Delete(ctx, params)
-	db.incErr(err)
+	db.incErr(promOpDelete, err)
 	return cnt, err
 }
 
 func (db *metricsPathDB) DeleteExpired(ctx context.Context, now time.Time) (int, error) {
 	db.incOp(promOpDeleteExpired)
 	cnt, err := db.pathDB.DeleteExpired(ctx, now)
-	db.incErr(err)
+	db.incErr(promOpDeleteExpired, err)
 	return cnt, err
 }
 
@@ -142,7 +162,7 @@ func (db *metricsPathDB) Get(ctx context.Context,
 
 	db.incOp(promOpGet)
 	res, err := db.pathDB.Get(ctx, params)
-	db.incErr(err)
+	db.incErr(promOpGet, err)
 	return res, err
 }
 
@@ -151,14 +171,14 @@ func (db *metricsPathDB) InsertNextQuery(ctx context.Context,
 
 	db.incOp(promOpInsertNextQuery)
 	ok, err := db.pathDB.InsertNextQuery(ctx, dst, nextQuery)
-	db.incErr(err)
+	db.incErr(promOpInsertNextQuery, err)
 	return ok, err
 }
 
 func (db *metricsPathDB) GetNextQuery(ctx context.Context, dst addr.IA) (*time.Time, error) {
 	db.incOp(promOpGetNextQuery)
 	t, err := db.pathDB.GetNextQuery(ctx, dst)
-	db.incErr(err)
+	db.incErr(promOpGetNextQuery, err)
 	return t, err
 }
 
@@ -166,15 +186,14 @@ func (db *metricsPathDB) incOp(op promOp) {
 	db.metrics.opCounters[op].Inc()
 }
 
-func (db *metricsPathDB) incErr(err error) {
-	if err == nil {
-		return
-	}
+func (db *metricsPathDB) incErr(op promOp, err error) {
 	// TODO(lukedirtwalker): categorize error better.
 	switch {
+	case err == nil:
+		db.metrics.resultCounters[op][prom.ResultOk].Inc()
 	case common.IsTimeoutErr(err):
-		db.metrics.errTimeoutTotal.Inc()
+		db.metrics.resultCounters[op][prom.ErrTimeout].Inc()
 	default:
-		db.metrics.errAnyTotal.Inc()
+		db.metrics.resultCounters[op][prom.ErrNotClassified].Inc()
 	}
 }

--- a/go/lib/pathdb/metrics.go
+++ b/go/lib/pathdb/metrics.go
@@ -30,8 +30,20 @@ import (
 const (
 	promNamespace = "pathdb"
 
-	promOp     = "op"
-	promDBName = "db"
+	promOpLabel = "op"
+	promDBName  = "db"
+)
+
+type promOp string
+
+const (
+	promOpInsert          promOp = "insert"
+	promOpInsertHpCfg     promOp = "insert_with_hpcfg"
+	promOpDelete          promOp = "delete"
+	promOpDeleteExpired   promOp = "delete_expired"
+	promOpGet             promOp = "get"
+	promOpInsertNextQuery promOp = "insert_next_query"
+	promOpGetNextQuery    promOp = "get_next_query"
 )
 
 var (
@@ -41,7 +53,7 @@ var (
 
 func init() {
 	queriesTotal = prom.NewCounterVec(promNamespace, "", "queries_total",
-		"Total queries to the database.", []string{promDBName, promOp})
+		"Total queries to the database.", []string{promDBName, promOpLabel})
 	errorsTotal = prom.NewCounterVec(promNamespace, "", "errors_total",
 		"Amount of pathdb errors.", []string{promDBName, prom.LabelErr})
 }
@@ -60,12 +72,12 @@ func WithMetrics(dbName string, pathDB PathDB) PathDB {
 		pathDB: pathDB,
 		metrics: &dbCounters{
 			readQueriesTotal: queriesTotal.With(prometheus.Labels{
-				promDBName: dbName,
-				promOp:     "read",
+				promDBName:  dbName,
+				promOpLabel: "read",
 			}),
 			writeQueriesTotal: queriesTotal.With(prometheus.Labels{
-				promDBName: dbName,
-				promOp:     "write",
+				promDBName:  dbName,
+				promOpLabel: "write",
 			}),
 			errAnyTotal: errorsTotal.With(prometheus.Labels{
 				promDBName:    dbName,

--- a/go/lib/pathdb/metrics_test.go
+++ b/go/lib/pathdb/metrics_test.go
@@ -1,0 +1,47 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pathdb_test
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/pathdb"
+	"github.com/scionproto/scion/go/lib/pathdb/pathdbtest"
+	"github.com/scionproto/scion/go/lib/pathdb/sqlite"
+	"github.com/scionproto/scion/go/lib/xtest"
+)
+
+func init() {
+	pathdb.InitMetrics("test")
+}
+
+func TestMetricWrapperFunctionality(t *testing.T) {
+	Convey("Test metrics wrapper functions normally", t, func() {
+		pathdbtest.TestPathDB(t,
+			func() pathdb.PathDB {
+				return setupDB(t)
+			},
+			func() {},
+		)
+	})
+}
+
+func setupDB(t *testing.T) pathdb.PathDB {
+	db, err := sqlite.New(":memory:")
+	xtest.FailOnErr(t, err)
+	return pathdb.WithMetrics("testdb", db)
+}

--- a/go/lib/pathdb/metrics_test.go
+++ b/go/lib/pathdb/metrics_test.go
@@ -25,10 +25,6 @@ import (
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
-func init() {
-	pathdb.InitMetrics("test")
-}
-
 func TestMetricWrapperFunctionality(t *testing.T) {
 	Convey("Test metrics wrapper functions normally", t, func() {
 		pathdbtest.TestPathDB(t,

--- a/go/lib/prom/prom.go
+++ b/go/lib/prom/prom.go
@@ -22,6 +22,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+const (
+	// LabelErr is the label for error classifications.
+	LabelErr = "err"
+	// LabelElem is the label for the element id that is added to all metrics.
+	LabelElem = "elem"
+
+	// ErrAny is any error not further classified.
+	ErrAny = "err_any"
+	// ErrTimeout is a timeout error.
+	ErrTimeout = "err_timeout"
+)
+
 func CopyLabels(labels prometheus.Labels) prometheus.Labels {
 	l := make(prometheus.Labels)
 	for k, v := range labels {
@@ -35,7 +47,7 @@ func CopyLabels(labels prometheus.Labels) prometheus.Labels {
 // Note this should be called before any other interaction with prometheus.
 // See also: https://github.com/prometheus/client_golang/issues/515
 func UseDefaultRegWithElem(elemId string) {
-	labels := prometheus.Labels{"elem": elemId}
+	labels := prometheus.Labels{LabelElem: elemId}
 	reg := prometheus.NewRegistry()
 	prometheus.DefaultRegisterer = prometheus.WrapRegistererWith(labels, reg)
 	prometheus.DefaultGatherer = reg

--- a/go/lib/prom/prom.go
+++ b/go/lib/prom/prom.go
@@ -28,8 +28,8 @@ const (
 	// LabelElem is the label for the element id that is added to all metrics.
 	LabelElem = "elem"
 
-	// ErrAny is any error not further classified.
-	ErrAny = "err_any"
+	// ErrNotClassified is an error that is not further classified.
+	ErrNotClassified = "err_not_classified"
 	// ErrTimeout is a timeout error.
 	ErrTimeout = "err_timeout"
 )

--- a/go/lib/prom/prom.go
+++ b/go/lib/prom/prom.go
@@ -23,11 +23,13 @@ import (
 )
 
 const (
-	// LabelErr is the label for error classifications.
-	LabelErr = "err"
+	// LabelResult is the label for result classifications.
+	LabelResult = "result"
 	// LabelElem is the label for the element id that is added to all metrics.
 	LabelElem = "elem"
 
+	// ResultOk is no error.
+	ResultOk = "ok"
 	// ErrNotClassified is an error that is not further classified.
 	ErrNotClassified = "err_not_classified"
 	// ErrTimeout is a timeout error.

--- a/go/path_srv/internal/metrics/metrics.go
+++ b/go/path_srv/internal/metrics/metrics.go
@@ -15,7 +15,6 @@
 package metrics
 
 import (
-	"github.com/scionproto/scion/go/lib/pathdb"
 	"github.com/scionproto/scion/go/lib/prom"
 )
 
@@ -26,5 +25,4 @@ const (
 // Init initializes the metrics for the PS.
 func Init(elem string) {
 	prom.UseDefaultRegWithElem(elem)
-	pathdb.InitMetrics(namespace)
 }

--- a/go/path_srv/internal/metrics/metrics.go
+++ b/go/path_srv/internal/metrics/metrics.go
@@ -15,6 +15,7 @@
 package metrics
 
 import (
+	"github.com/scionproto/scion/go/lib/pathdb"
 	"github.com/scionproto/scion/go/lib/prom"
 )
 
@@ -25,4 +26,5 @@ const (
 // Init initializes the metrics for the PS.
 func Init(elem string) {
 	prom.UseDefaultRegWithElem(elem)
+	pathdb.InitMetrics(namespace)
 }

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -86,6 +86,7 @@ func realMain() int {
 		log.Crit("Unable to initialize path storage", "err", err)
 		return 1
 	}
+	pathDB = pathdb.WithMetrics("std", pathDB)
 	trustDB, err := cfg.TrustDB.New()
 	if err != nil {
 		log.Crit("Unable to initialize trustDB", "err", err)


### PR DESCRIPTION
The wrapper can be used to export metrics about any implementation of pathDB.

Rationale: 
The error counters help to detect where an issue of a service might be (i.e. in this case the DB).
The total counters give an idea on the pressure on the DB.

Contributes #2329

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2358)
<!-- Reviewable:end -->
