### PR TITLE
Go dispatcher: make Python integration pass

### DIFF
--- a/go/godispatcher/network/app_socket.go
+++ b/go/godispatcher/network/app_socket.go
@@ -181,7 +181,7 @@ func (h *AppConnHandler) RunAppToNetDataplane(ref registration.UDPReference) {
 		// let the GC take care of this situation as they should be fairly
 		// rare.
 
-		if err := pkt.DecodeFromConn(h.Conn); err != nil {
+		if err := pkt.DecodeFromReliableConn(h.Conn); err != nil {
 			if err == io.EOF {
 				h.Logger.Info("[app->network] EOF received from client")
 			} else {

--- a/go/lib/spkt/extn_generic.go
+++ b/go/lib/spkt/extn_generic.go
@@ -27,7 +27,9 @@ type UnknownExtension struct {
 }
 
 func (o UnknownExtension) Write(b common.RawBytes) error {
-	copy(b, make(common.RawBytes, o.Length))
+	for i := 0; i < o.Length; i++ {
+		b[i] = 0
+	}
 	return nil
 }
 
@@ -53,14 +55,13 @@ func (o UnknownExtension) Len() int {
 }
 
 func (o UnknownExtension) Class() common.L4ProtocolType {
-	// FIXME(scrye): unknown class, use None
-	return 0
+	return common.L4None
 }
 
 func (o UnknownExtension) Type() common.ExtnType {
 	return common.ExtnType{Type: o.TypeField}
 }
 
-func (o *UnknownExtension) String() string {
+func (o UnknownExtension) String() string {
 	return "Unknown"
 }

--- a/go/lib/spkt/extn_generic.go
+++ b/go/lib/spkt/extn_generic.go
@@ -1,0 +1,66 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spkt
+
+import (
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+var _ common.Extension = (*UnknownExtension)(nil)
+
+type UnknownExtension struct {
+	// Length, in bytes, including 3-byte extension header
+	Length    int
+	TypeField uint8
+}
+
+func (o UnknownExtension) Write(b common.RawBytes) error {
+	copy(b, make(common.RawBytes, o.Length))
+	return nil
+}
+
+func (o UnknownExtension) Pack() (common.RawBytes, error) {
+	b := make(common.RawBytes, o.Len())
+	if err := o.Write(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (o UnknownExtension) Copy() common.Extension {
+	return &UnknownExtension{Length: o.Length}
+}
+
+func (o UnknownExtension) Reverse() (bool, error) {
+	// Reversing removes the extension.
+	return false, nil
+}
+
+func (o UnknownExtension) Len() int {
+	return o.Length
+}
+
+func (o UnknownExtension) Class() common.L4ProtocolType {
+	// FIXME(scrye): unknown class, use None
+	return 0
+}
+
+func (o UnknownExtension) Type() common.ExtnType {
+	return common.ExtnType{Type: o.TypeField}
+}
+
+func (o *UnknownExtension) String() string {
+	return "Unknown"
+}

--- a/go/lib/spkt/extn_onehoppath.go
+++ b/go/lib/spkt/extn_onehoppath.go
@@ -25,7 +25,9 @@ type OneHopPath struct{}
 const OneHopPathLen = common.ExtnFirstLineLen
 
 func (o OneHopPath) Write(b common.RawBytes) error {
-	copy(b, make(common.RawBytes, OneHopPathLen))
+	for i := 0; i < OneHopPathLen; i++ {
+		b[i] = 0
+	}
 	return nil
 }
 
@@ -58,6 +60,6 @@ func (o OneHopPath) Type() common.ExtnType {
 	return common.ExtnOneHopPathType
 }
 
-func (o *OneHopPath) String() string {
+func (o OneHopPath) String() string {
 	return "OneHopPath"
 }


### PR DESCRIPTION
Specifically:
- make Go SCION parser skip E2E extensions;
- disable validation checks on egress packets in the dispatcher (thus allowing tests to trigger SCMP error conditions by sending malformed packets on the network)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2361)
<!-- Reviewable:end -->
