### PR TITLE
TrustDB: Add metrics wrapper

### DIFF
--- a/go/cert_srv/internal/metrics/metrics.go
+++ b/go/cert_srv/internal/metrics/metrics.go
@@ -15,7 +15,6 @@
 package metrics
 
 import (
-	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
 	"github.com/scionproto/scion/go/lib/prom"
 )
 
@@ -26,5 +25,4 @@ const (
 // Init initializes the metrics for the CS.
 func Init(elem string) {
 	prom.UseDefaultRegWithElem(elem)
-	trustdb.InitMetrics(namespace)
 }

--- a/go/cert_srv/internal/metrics/metrics.go
+++ b/go/cert_srv/internal/metrics/metrics.go
@@ -15,6 +15,7 @@
 package metrics
 
 import (
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
 	"github.com/scionproto/scion/go/lib/prom"
 )
 
@@ -25,4 +26,5 @@ const (
 // Init initializes the metrics for the CS.
 func Init(elem string) {
 	prom.UseDefaultRegWithElem(elem)
+	trustdb.InitMetrics(namespace)
 }

--- a/go/cert_srv/setup.go
+++ b/go/cert_srv/setup.go
@@ -17,6 +17,8 @@ package main
 import (
 	"path/filepath"
 
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
+
 	"github.com/BurntSushi/toml"
 
 	"github.com/scionproto/scion/go/cert_srv/internal/config"
@@ -83,6 +85,7 @@ func initState(cfg *config.Config) error {
 	if err != nil {
 		return common.NewBasicError("Unable to initialize trustDB", err)
 	}
+	trustDB = trustdb.WithMetrics("std", trustDB)
 	trustConf := &trust.Config{
 		MustHaveLocalChain: true,
 		ServiceType:        proto.ServiceType_cs,

--- a/go/cert_srv/setup.go
+++ b/go/cert_srv/setup.go
@@ -17,8 +17,6 @@ package main
 import (
 	"path/filepath"
 
-	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
-
 	"github.com/BurntSushi/toml"
 
 	"github.com/scionproto/scion/go/cert_srv/internal/config"
@@ -33,6 +31,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra/messenger"
 	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/proto"

--- a/go/lib/infra/modules/trust/trustdb/metrics.go
+++ b/go/lib/infra/modules/trust/trustdb/metrics.go
@@ -1,0 +1,326 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustdb
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/prom"
+	"github.com/scionproto/scion/go/lib/scrypto/cert"
+	"github.com/scionproto/scion/go/lib/scrypto/trc"
+)
+
+const (
+	promSubsyst = "trustdb"
+
+	promOp     = "op"
+	promDBName = "db"
+	promError  = "err"
+
+	promOpRead       = "read"
+	promOpWrite      = "write"
+	promOpBeginTx    = "tx_begin"
+	promOpCommitTx   = "tx_commit"
+	promOpRollbackTx = "tx_rollback"
+
+	promErrAny     = "err_any"
+	promErrTimeout = "err_timeout"
+)
+
+var (
+	queriesTotal *prometheus.CounterVec
+	errorsTotal  *prometheus.CounterVec
+)
+
+// InitMetrics prepares the usage of metrics in the trustdb module.
+func InitMetrics(namespace string) {
+	queriesTotal = prom.NewCounterVec(namespace, promSubsyst, "queries_total",
+		"Total queries to the database.", []string{promDBName, promOp})
+	errorsTotal = prom.NewCounterVec(namespace, promSubsyst, "errors_total",
+		"Amount of trustdb errors.", []string{promDBName, promError})
+}
+
+// WithMetrics wraps the given TrustDB into one that also exports metrics.
+// InitMetrics must have been called previously, otherwise this method panics.
+func WithMetrics(dbName string, trustDB TrustDB) TrustDB {
+	return &metricsTrustDB{
+		db: trustDB,
+		metricsExecutor: &metricsExecutor{
+			trustDB: trustDB,
+			metrics: newCounters(dbName),
+		},
+	}
+}
+
+type counters struct {
+	errAnyTotal       prometheus.Counter
+	errTimeoutTotal   prometheus.Counter
+	readQueriesTotal  prometheus.Counter
+	writeQueriesTotal prometheus.Counter
+	beginTxTotal      prometheus.Counter
+	commitTxTotal     prometheus.Counter
+	rollbackTxTotal   prometheus.Counter
+}
+
+func newCounters(dbName string) *counters {
+	return &counters{
+		errAnyTotal: errorsTotal.With(prometheus.Labels{
+			promDBName: dbName,
+			promError:  promErrAny,
+		}),
+		errTimeoutTotal: errorsTotal.With(prometheus.Labels{
+			promDBName: dbName,
+			promError:  promErrTimeout,
+		}),
+		readQueriesTotal: queriesTotal.With(prometheus.Labels{
+			promDBName: dbName,
+			promOp:     promOpRead,
+		}),
+		writeQueriesTotal: queriesTotal.With(prometheus.Labels{
+			promDBName: dbName,
+			promOp:     promOpWrite,
+		}),
+		beginTxTotal: queriesTotal.With(prometheus.Labels{
+			promDBName: dbName,
+			promOp:     promOpBeginTx,
+		}),
+		commitTxTotal: queriesTotal.With(prometheus.Labels{
+			promDBName: dbName,
+			promOp:     promOpCommitTx,
+		}),
+		rollbackTxTotal: queriesTotal.With(prometheus.Labels{
+			promDBName: dbName,
+			promOp:     promOpRollbackTx,
+		}),
+	}
+}
+
+type metricsTrustDB struct {
+	db TrustDB
+	*metricsExecutor
+}
+
+func (db *metricsTrustDB) BeginTransaction(ctx context.Context,
+	opts *sql.TxOptions) (Transaction, error) {
+
+	db.metrics.beginTxTotal.Inc()
+	tx, err := db.db.BeginTransaction(ctx, opts)
+	db.incErr(err)
+	if err != nil {
+		return nil, err
+	}
+	return &metricsTransaction{
+		tx: tx,
+		metricsExecutor: &metricsExecutor{
+			trustDB: tx,
+			metrics: db.metricsExecutor.metrics,
+		},
+	}, err
+}
+
+func (db *metricsTrustDB) Close() error {
+	return db.db.Close()
+}
+
+type metricsTransaction struct {
+	tx Transaction
+	*metricsExecutor
+}
+
+func (tx *metricsTransaction) Commit() error {
+	tx.metrics.commitTxTotal.Inc()
+	err := tx.tx.Commit()
+	tx.incErr(err)
+	return err
+}
+
+func (tx *metricsTransaction) Rollback() error {
+	tx.metrics.rollbackTxTotal.Inc()
+	err := tx.tx.Rollback()
+	tx.incErr(err)
+	return err
+}
+
+type rwDB interface {
+	Read
+	Write
+}
+
+type metricsExecutor struct {
+	trustDB rwDB
+	metrics *counters
+}
+
+func (db *metricsExecutor) incRead() {
+	db.metrics.readQueriesTotal.Inc()
+}
+
+func (db *metricsExecutor) incWrite() {
+	db.metrics.writeQueriesTotal.Inc()
+}
+
+func (db *metricsExecutor) incErr(err error) {
+	if err == nil {
+		return
+	}
+	// TODO(lukedirtwalker): categorize error better.
+	switch {
+	case common.IsTimeoutErr(err):
+		db.metrics.errTimeoutTotal.Inc()
+	default:
+		db.metrics.errAnyTotal.Inc()
+	}
+}
+
+// below here is very boilerplaty code that implements all DB ops and calls the inc functions.
+
+func (db *metricsExecutor) InsertIssCert(ctx context.Context,
+	crt *cert.Certificate) (int64, error) {
+
+	db.incWrite()
+	cnt, err := db.trustDB.InsertIssCert(ctx, crt)
+	db.incErr(err)
+	return cnt, err
+}
+
+func (db *metricsExecutor) InsertLeafCert(ctx context.Context,
+	crt *cert.Certificate) (int64, error) {
+
+	db.incWrite()
+	cnt, err := db.trustDB.InsertLeafCert(ctx, crt)
+	db.incErr(err)
+	return cnt, err
+}
+
+func (db *metricsExecutor) InsertChain(ctx context.Context, chain *cert.Chain) (int64, error) {
+	db.incWrite()
+	cnt, err := db.trustDB.InsertChain(ctx, chain)
+	db.incErr(err)
+	return cnt, err
+}
+
+func (db *metricsExecutor) InsertTRC(ctx context.Context, trcobj *trc.TRC) (int64, error) {
+	db.incWrite()
+	cnt, err := db.trustDB.InsertTRC(ctx, trcobj)
+	db.incErr(err)
+	return cnt, err
+}
+
+func (db *metricsExecutor) InsertCustKey(ctx context.Context, ia addr.IA, version uint64,
+	key common.RawBytes, oldVersion uint64) error {
+
+	db.incWrite()
+	err := db.trustDB.InsertCustKey(ctx, ia, version, key, oldVersion)
+	db.incErr(err)
+	return err
+}
+
+func (db *metricsExecutor) GetIssCertVersion(ctx context.Context, ia addr.IA,
+	version uint64) (*cert.Certificate, error) {
+
+	db.incRead()
+	res, err := db.trustDB.GetIssCertVersion(ctx, ia, version)
+	db.incErr(err)
+	return res, err
+}
+
+func (db *metricsExecutor) GetIssCertMaxVersion(ctx context.Context,
+	ia addr.IA) (*cert.Certificate, error) {
+
+	db.incRead()
+	res, err := db.trustDB.GetIssCertMaxVersion(ctx, ia)
+	db.incErr(err)
+	return res, err
+}
+
+func (db *metricsExecutor) GetLeafCertVersion(ctx context.Context, ia addr.IA,
+	version uint64) (*cert.Certificate, error) {
+
+	db.incRead()
+	res, err := db.trustDB.GetLeafCertVersion(ctx, ia, version)
+	db.incErr(err)
+	return res, err
+}
+
+func (db *metricsExecutor) GetLeafCertMaxVersion(ctx context.Context,
+	ia addr.IA) (*cert.Certificate, error) {
+
+	db.incRead()
+	res, err := db.trustDB.GetLeafCertMaxVersion(ctx, ia)
+	db.incErr(err)
+	return res, err
+}
+
+func (db *metricsExecutor) GetChainVersion(ctx context.Context, ia addr.IA,
+	version uint64) (*cert.Chain, error) {
+
+	db.incRead()
+	res, err := db.trustDB.GetChainVersion(ctx, ia, version)
+	db.incErr(err)
+	return res, err
+}
+
+func (db *metricsExecutor) GetChainMaxVersion(ctx context.Context,
+	ia addr.IA) (*cert.Chain, error) {
+
+	db.incRead()
+	res, err := db.trustDB.GetChainMaxVersion(ctx, ia)
+	db.incErr(err)
+	return res, err
+}
+
+func (db *metricsExecutor) GetAllChains(ctx context.Context) ([]*cert.Chain, error) {
+	db.incRead()
+	res, err := db.trustDB.GetAllChains(ctx)
+	db.incErr(err)
+	return res, err
+}
+
+func (db *metricsExecutor) GetTRCVersion(ctx context.Context, isd addr.ISD,
+	version uint64) (*trc.TRC, error) {
+
+	db.incRead()
+	res, err := db.trustDB.GetTRCVersion(ctx, isd, version)
+	db.incErr(err)
+	return res, err
+}
+
+func (db *metricsExecutor) GetTRCMaxVersion(ctx context.Context, isd addr.ISD) (*trc.TRC, error) {
+	db.incRead()
+	res, err := db.trustDB.GetTRCMaxVersion(ctx, isd)
+	db.incErr(err)
+	return res, err
+}
+
+func (db *metricsExecutor) GetAllTRCs(ctx context.Context) ([]*trc.TRC, error) {
+	db.incRead()
+	res, err := db.trustDB.GetAllTRCs(ctx)
+	db.incErr(err)
+	return res, err
+}
+
+func (db *metricsExecutor) GetCustKey(ctx context.Context,
+	ia addr.IA) (common.RawBytes, uint64, error) {
+
+	db.incRead()
+	res, ver, err := db.trustDB.GetCustKey(ctx, ia)
+	db.incErr(err)
+	return res, ver, err
+}

--- a/go/lib/infra/modules/trust/trustdb/metrics.go
+++ b/go/lib/infra/modules/trust/trustdb/metrics.go
@@ -17,6 +17,7 @@ package trustdb
 import (
 	"context"
 	"database/sql"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -28,108 +29,175 @@ import (
 )
 
 const (
-	promSubsyst = "trustdb"
+	promNamespace = "trustdb"
 
-	promOp     = "op"
-	promDBName = "db"
-	promError  = "err"
+	promOpLabel = "op"
+	promDBName  = "db"
+)
 
-	promOpRead       = "read"
-	promOpWrite      = "write"
-	promOpBeginTx    = "tx_begin"
-	promOpCommitTx   = "tx_commit"
-	promOpRollbackTx = "tx_rollback"
+type promOp string
 
-	promErrAny     = "err_any"
-	promErrTimeout = "err_timeout"
+const (
+	promOpGetIssCert    promOp = "get_iss_cert"
+	promOpGetIssCertMV  promOp = "get_iss_cert_mv"
+	promOpGetLeafCert   promOp = "get_leaf_cert"
+	promOpGetLeafCertMV promOp = "get_leaf_cert_mv"
+	promOpGetChain      promOp = "get_chain"
+	promOpGetChainMV    promOp = "get_chain_mv"
+	promOpGetAllChains  promOp = "get_all_chains"
+	promOpGetTRC        promOp = "get_trc"
+	promOpGetTRCMV      promOp = "get_trc_mv"
+	promOpGetAllTRCs    promOp = "get_all_trcs"
+	promOpGetCustKey    promOp = "get_cust_key"
+
+	promOpInsertIssCert  promOp = "insert_iss_cert"
+	promOpInsertLeafCert promOp = "insert_leaf_cert"
+	promOpInsertChain    promOp = "insert_chain"
+	promOpInsertTRC      promOp = "insert_trc"
+	promOpInsertCustKey  promOp = "insert_cust_key"
+
+	promOpBeginTx    promOp = "tx_begin"
+	promOpCommitTx   promOp = "tx_commit"
+	promOpRollbackTx promOp = "tx_rollback"
 )
 
 var (
 	queriesTotal *prometheus.CounterVec
-	errorsTotal  *prometheus.CounterVec
+	resultsTotal *prometheus.CounterVec
+
+	allOps = []promOp{
+		promOpGetIssCert,
+		promOpGetIssCertMV,
+		promOpGetLeafCert,
+		promOpGetLeafCertMV,
+		promOpGetChain,
+		promOpGetChainMV,
+		promOpGetAllChains,
+		promOpGetTRC,
+		promOpGetTRCMV,
+		promOpGetAllTRCs,
+		promOpGetCustKey,
+
+		promOpInsertIssCert,
+		promOpInsertLeafCert,
+		promOpInsertChain,
+		promOpInsertTRC,
+		promOpInsertCustKey,
+
+		promOpBeginTx,
+		promOpCommitTx,
+		promOpRollbackTx,
+	}
+
+	allResults = []string{
+		prom.ResultOk,
+		prom.ErrNotClassified,
+		prom.ErrTimeout,
+	}
+
+	initMetricsOnce sync.Once
 )
 
-// InitMetrics prepares the usage of metrics in the trustdb module.
-func InitMetrics(namespace string) {
-	queriesTotal = prom.NewCounterVec(namespace, promSubsyst, "queries_total",
-		"Total queries to the database.", []string{promDBName, promOp})
-	errorsTotal = prom.NewCounterVec(namespace, promSubsyst, "errors_total",
-		"Amount of trustdb errors.", []string{promDBName, promError})
+func initMetrics() {
+	initMetricsOnce.Do(func() {
+		// Cardinality: X (dbName) * 19 (len(allOps))
+		queriesTotal = prom.NewCounterVec(promNamespace, "", "queries_total",
+			"Total queries to the database.", []string{promDBName, promOpLabel})
+		// Cardinality: X (dbName) * 19 (len(allOps)) * 3 (len(allResults))
+		resultsTotal = prom.NewCounterVec(promNamespace, "", "results_total",
+			"Results of trustdb operations.", []string{promDBName, promOpLabel, prom.LabelResult})
+	})
 }
 
 // WithMetrics wraps the given TrustDB into one that also exports metrics.
-// InitMetrics must have been called previously, otherwise this method panics.
 func WithMetrics(dbName string, trustDB TrustDB) TrustDB {
+	initMetrics()
+	metricsCounters := newCounters(dbName)
+	rwDBWrapper := &metricsExecutor{
+		rwDB:    trustDB,
+		metrics: metricsCounters,
+	}
 	return &metricsTrustDB{
-		db: trustDB,
-		metricsExecutor: &metricsExecutor{
-			trustDB: trustDB,
-			metrics: newCounters(dbName),
-		},
+		metricsExecutor: rwDBWrapper,
+		db:              trustDB,
 	}
 }
 
 type counters struct {
-	errAnyTotal       prometheus.Counter
-	errTimeoutTotal   prometheus.Counter
-	readQueriesTotal  prometheus.Counter
-	writeQueriesTotal prometheus.Counter
-	beginTxTotal      prometheus.Counter
-	commitTxTotal     prometheus.Counter
-	rollbackTxTotal   prometheus.Counter
+	opCounters     map[promOp]prometheus.Counter
+	resultCounters map[promOp]map[string]prometheus.Counter
 }
 
 func newCounters(dbName string) *counters {
 	return &counters{
-		errAnyTotal: errorsTotal.With(prometheus.Labels{
-			promDBName: dbName,
-			promError:  promErrAny,
-		}),
-		errTimeoutTotal: errorsTotal.With(prometheus.Labels{
-			promDBName: dbName,
-			promError:  promErrTimeout,
-		}),
-		readQueriesTotal: queriesTotal.With(prometheus.Labels{
-			promDBName: dbName,
-			promOp:     promOpRead,
-		}),
-		writeQueriesTotal: queriesTotal.With(prometheus.Labels{
-			promDBName: dbName,
-			promOp:     promOpWrite,
-		}),
-		beginTxTotal: queriesTotal.With(prometheus.Labels{
-			promDBName: dbName,
-			promOp:     promOpBeginTx,
-		}),
-		commitTxTotal: queriesTotal.With(prometheus.Labels{
-			promDBName: dbName,
-			promOp:     promOpCommitTx,
-		}),
-		rollbackTxTotal: queriesTotal.With(prometheus.Labels{
-			promDBName: dbName,
-			promOp:     promOpRollbackTx,
-		}),
+		opCounters:     opCounters(dbName),
+		resultCounters: resultCounters(dbName),
 	}
 }
 
+func opCounters(dbName string) map[promOp]prometheus.Counter {
+	opCounters := make(map[promOp]prometheus.Counter)
+	for _, op := range allOps {
+		opCounters[op] = queriesTotal.With(prometheus.Labels{
+			promDBName:  dbName,
+			promOpLabel: string(op),
+		})
+	}
+	return opCounters
+}
+
+func resultCounters(dbName string) map[promOp]map[string]prometheus.Counter {
+	resultCounters := make(map[promOp]map[string]prometheus.Counter)
+	for _, op := range allOps {
+		resultCounters[op] = make(map[string]prometheus.Counter)
+		for _, res := range allResults {
+			resultCounters[op][res] = resultsTotal.With(prometheus.Labels{
+				promDBName:       dbName,
+				promOpLabel:      string(op),
+				prom.LabelResult: res,
+			})
+		}
+	}
+	return resultCounters
+}
+
+func (c *counters) incOp(op promOp) {
+	c.opCounters[op].Inc()
+}
+
+func (c *counters) incResult(op promOp, err error) {
+	// TODO(lukedirtwalker): categorize error better.
+	switch {
+	case err == nil:
+		c.resultCounters[op][prom.ResultOk].Inc()
+	case common.IsTimeoutErr(err):
+		c.resultCounters[op][prom.ErrTimeout].Inc()
+	default:
+		c.resultCounters[op][prom.ErrNotClassified].Inc()
+	}
+}
+
+var _ (TrustDB) = (*metricsTrustDB)(nil)
+
 type metricsTrustDB struct {
-	db TrustDB
 	*metricsExecutor
+	// db is only needed to have Close and BeginTransaction methods.
+	db TrustDB
 }
 
 func (db *metricsTrustDB) BeginTransaction(ctx context.Context,
 	opts *sql.TxOptions) (Transaction, error) {
 
-	db.metrics.beginTxTotal.Inc()
+	db.metricsExecutor.metrics.incOp(promOpBeginTx)
 	tx, err := db.db.BeginTransaction(ctx, opts)
-	db.incErr(err)
+	db.metricsExecutor.metrics.incResult(promOpBeginTx, err)
 	if err != nil {
 		return nil, err
 	}
 	return &metricsTransaction{
 		tx: tx,
 		metricsExecutor: &metricsExecutor{
-			trustDB: tx,
+			rwDB:    tx,
 			metrics: db.metricsExecutor.metrics,
 		},
 	}, err
@@ -139,54 +207,31 @@ func (db *metricsTrustDB) Close() error {
 	return db.db.Close()
 }
 
+var _ (Transaction) = (*metricsTransaction)(nil)
+
 type metricsTransaction struct {
-	tx Transaction
 	*metricsExecutor
+	// tx is only used for Commit and Rollback.
+	tx Transaction
 }
 
 func (tx *metricsTransaction) Commit() error {
-	tx.metrics.commitTxTotal.Inc()
+	tx.metrics.incOp(promOpCommitTx)
 	err := tx.tx.Commit()
-	tx.incErr(err)
+	tx.metrics.incResult(promOpCommitTx, err)
 	return err
 }
 
 func (tx *metricsTransaction) Rollback() error {
-	tx.metrics.rollbackTxTotal.Inc()
+	tx.metrics.incOp(promOpRollbackTx)
 	err := tx.tx.Rollback()
-	tx.incErr(err)
+	tx.metrics.incResult(promOpRollbackTx, err)
 	return err
 }
 
-type rwDB interface {
-	Read
-	Write
-}
-
 type metricsExecutor struct {
-	trustDB rwDB
+	rwDB    ReadWrite
 	metrics *counters
-}
-
-func (db *metricsExecutor) incRead() {
-	db.metrics.readQueriesTotal.Inc()
-}
-
-func (db *metricsExecutor) incWrite() {
-	db.metrics.writeQueriesTotal.Inc()
-}
-
-func (db *metricsExecutor) incErr(err error) {
-	if err == nil {
-		return
-	}
-	// TODO(lukedirtwalker): categorize error better.
-	switch {
-	case common.IsTimeoutErr(err):
-		db.metrics.errTimeoutTotal.Inc()
-	default:
-		db.metrics.errAnyTotal.Inc()
-	}
 }
 
 // below here is very boilerplaty code that implements all DB ops and calls the inc functions.
@@ -194,133 +239,133 @@ func (db *metricsExecutor) incErr(err error) {
 func (db *metricsExecutor) InsertIssCert(ctx context.Context,
 	crt *cert.Certificate) (int64, error) {
 
-	db.incWrite()
-	cnt, err := db.trustDB.InsertIssCert(ctx, crt)
-	db.incErr(err)
+	db.metrics.incOp(promOpInsertIssCert)
+	cnt, err := db.rwDB.InsertIssCert(ctx, crt)
+	db.metrics.incResult(promOpInsertIssCert, err)
 	return cnt, err
 }
 
 func (db *metricsExecutor) InsertLeafCert(ctx context.Context,
 	crt *cert.Certificate) (int64, error) {
 
-	db.incWrite()
-	cnt, err := db.trustDB.InsertLeafCert(ctx, crt)
-	db.incErr(err)
+	db.metrics.incOp(promOpInsertLeafCert)
+	cnt, err := db.rwDB.InsertLeafCert(ctx, crt)
+	db.metrics.incResult(promOpInsertLeafCert, err)
 	return cnt, err
 }
 
 func (db *metricsExecutor) InsertChain(ctx context.Context, chain *cert.Chain) (int64, error) {
-	db.incWrite()
-	cnt, err := db.trustDB.InsertChain(ctx, chain)
-	db.incErr(err)
+	db.metrics.incOp(promOpInsertChain)
+	cnt, err := db.rwDB.InsertChain(ctx, chain)
+	db.metrics.incResult(promOpInsertChain, err)
 	return cnt, err
 }
 
 func (db *metricsExecutor) InsertTRC(ctx context.Context, trcobj *trc.TRC) (int64, error) {
-	db.incWrite()
-	cnt, err := db.trustDB.InsertTRC(ctx, trcobj)
-	db.incErr(err)
+	db.metrics.incOp(promOpInsertTRC)
+	cnt, err := db.rwDB.InsertTRC(ctx, trcobj)
+	db.metrics.incResult(promOpInsertTRC, err)
 	return cnt, err
 }
 
 func (db *metricsExecutor) InsertCustKey(ctx context.Context, ia addr.IA, version uint64,
 	key common.RawBytes, oldVersion uint64) error {
 
-	db.incWrite()
-	err := db.trustDB.InsertCustKey(ctx, ia, version, key, oldVersion)
-	db.incErr(err)
+	db.metrics.incOp(promOpInsertCustKey)
+	err := db.rwDB.InsertCustKey(ctx, ia, version, key, oldVersion)
+	db.metrics.incResult(promOpInsertCustKey, err)
 	return err
 }
 
 func (db *metricsExecutor) GetIssCertVersion(ctx context.Context, ia addr.IA,
 	version uint64) (*cert.Certificate, error) {
 
-	db.incRead()
-	res, err := db.trustDB.GetIssCertVersion(ctx, ia, version)
-	db.incErr(err)
+	db.metrics.incOp(promOpGetIssCert)
+	res, err := db.rwDB.GetIssCertVersion(ctx, ia, version)
+	db.metrics.incResult(promOpGetIssCert, err)
 	return res, err
 }
 
 func (db *metricsExecutor) GetIssCertMaxVersion(ctx context.Context,
 	ia addr.IA) (*cert.Certificate, error) {
 
-	db.incRead()
-	res, err := db.trustDB.GetIssCertMaxVersion(ctx, ia)
-	db.incErr(err)
+	db.metrics.incOp(promOpGetIssCertMV)
+	res, err := db.rwDB.GetIssCertMaxVersion(ctx, ia)
+	db.metrics.incResult(promOpGetIssCertMV, err)
 	return res, err
 }
 
 func (db *metricsExecutor) GetLeafCertVersion(ctx context.Context, ia addr.IA,
 	version uint64) (*cert.Certificate, error) {
 
-	db.incRead()
-	res, err := db.trustDB.GetLeafCertVersion(ctx, ia, version)
-	db.incErr(err)
+	db.metrics.incOp(promOpGetLeafCert)
+	res, err := db.rwDB.GetLeafCertVersion(ctx, ia, version)
+	db.metrics.incResult(promOpGetLeafCert, err)
 	return res, err
 }
 
 func (db *metricsExecutor) GetLeafCertMaxVersion(ctx context.Context,
 	ia addr.IA) (*cert.Certificate, error) {
 
-	db.incRead()
-	res, err := db.trustDB.GetLeafCertMaxVersion(ctx, ia)
-	db.incErr(err)
+	db.metrics.incOp(promOpGetLeafCertMV)
+	res, err := db.rwDB.GetLeafCertMaxVersion(ctx, ia)
+	db.metrics.incResult(promOpGetLeafCertMV, err)
 	return res, err
 }
 
 func (db *metricsExecutor) GetChainVersion(ctx context.Context, ia addr.IA,
 	version uint64) (*cert.Chain, error) {
 
-	db.incRead()
-	res, err := db.trustDB.GetChainVersion(ctx, ia, version)
-	db.incErr(err)
+	db.metrics.incOp(promOpGetChain)
+	res, err := db.rwDB.GetChainVersion(ctx, ia, version)
+	db.metrics.incResult(promOpGetChain, err)
 	return res, err
 }
 
 func (db *metricsExecutor) GetChainMaxVersion(ctx context.Context,
 	ia addr.IA) (*cert.Chain, error) {
 
-	db.incRead()
-	res, err := db.trustDB.GetChainMaxVersion(ctx, ia)
-	db.incErr(err)
+	db.metrics.incOp(promOpGetChainMV)
+	res, err := db.rwDB.GetChainMaxVersion(ctx, ia)
+	db.metrics.incResult(promOpGetChainMV, err)
 	return res, err
 }
 
 func (db *metricsExecutor) GetAllChains(ctx context.Context) ([]*cert.Chain, error) {
-	db.incRead()
-	res, err := db.trustDB.GetAllChains(ctx)
-	db.incErr(err)
+	db.metrics.incOp(promOpGetAllChains)
+	res, err := db.rwDB.GetAllChains(ctx)
+	db.metrics.incResult(promOpGetAllChains, err)
 	return res, err
 }
 
 func (db *metricsExecutor) GetTRCVersion(ctx context.Context, isd addr.ISD,
 	version uint64) (*trc.TRC, error) {
 
-	db.incRead()
-	res, err := db.trustDB.GetTRCVersion(ctx, isd, version)
-	db.incErr(err)
+	db.metrics.incOp(promOpGetTRC)
+	res, err := db.rwDB.GetTRCVersion(ctx, isd, version)
+	db.metrics.incResult(promOpGetTRC, err)
 	return res, err
 }
 
 func (db *metricsExecutor) GetTRCMaxVersion(ctx context.Context, isd addr.ISD) (*trc.TRC, error) {
-	db.incRead()
-	res, err := db.trustDB.GetTRCMaxVersion(ctx, isd)
-	db.incErr(err)
+	db.metrics.incOp(promOpGetTRCMV)
+	res, err := db.rwDB.GetTRCMaxVersion(ctx, isd)
+	db.metrics.incResult(promOpGetTRCMV, err)
 	return res, err
 }
 
 func (db *metricsExecutor) GetAllTRCs(ctx context.Context) ([]*trc.TRC, error) {
-	db.incRead()
-	res, err := db.trustDB.GetAllTRCs(ctx)
-	db.incErr(err)
+	db.metrics.incOp(promOpGetAllTRCs)
+	res, err := db.rwDB.GetAllTRCs(ctx)
+	db.metrics.incResult(promOpGetAllTRCs, err)
 	return res, err
 }
 
 func (db *metricsExecutor) GetCustKey(ctx context.Context,
 	ia addr.IA) (common.RawBytes, uint64, error) {
 
-	db.incRead()
-	res, ver, err := db.trustDB.GetCustKey(ctx, ia)
-	db.incErr(err)
+	db.metrics.incOp(promOpGetCustKey)
+	res, ver, err := db.rwDB.GetCustKey(ctx, ia)
+	db.metrics.incResult(promOpGetCustKey, err)
 	return res, ver, err
 }

--- a/go/lib/infra/modules/trust/trustdb/metrics_test.go
+++ b/go/lib/infra/modules/trust/trustdb/metrics_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func init() {
-	trustdb.InitMetrics("test")
 	trustdbtest.TestDataRelPath = "trustdbtest/testdata"
 }
 

--- a/go/lib/infra/modules/trust/trustdb/metrics_test.go
+++ b/go/lib/infra/modules/trust/trustdb/metrics_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustdb_test
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb/trustdbsqlite"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb/trustdbtest"
+	"github.com/scionproto/scion/go/lib/xtest"
+)
+
+func init() {
+	trustdb.InitMetrics("test")
+	trustdbtest.TestDataRelPath = "trustdbtest/testdata"
+}
+
+func TestFunctionalityWorks(t *testing.T) {
+	setup := func() trustdb.TrustDB {
+		return newDatabase(t)
+	}
+	cleanup := func(db trustdb.TrustDB) {
+		db.Close()
+	}
+	Convey("TestMetricsWrapper functions normally", t, func() {
+		trustdbtest.TestTrustDB(t, setup, cleanup)
+	})
+}
+
+func newDatabase(t *testing.T) trustdb.TrustDB {
+	db, err := trustdbsqlite.New(":memory:")
+	xtest.FailOnErr(t, err)
+	return trustdb.WithMetrics("testdb", db)
+}

--- a/go/lib/infra/modules/trust/trustdb/trustdb.go
+++ b/go/lib/infra/modules/trust/trustdb/trustdb.go
@@ -98,9 +98,7 @@ type Transaction interface {
 	Read
 	Write
 	// Commit commits the transaction.
-	// Returns the underlying TrustDB connection.
 	Commit() error
 	// Rollback rollbacks the transaction.
-	// Returns the underlying TrustDB connection.
 	Rollback() error
 }

--- a/go/lib/infra/modules/trust/trustdb/trustdb.go
+++ b/go/lib/infra/modules/trust/trustdb/trustdb.go
@@ -32,8 +32,7 @@ import (
 // Read and Write interactions with this interface have to happen in individual transactions
 // (either explicit or implicit).
 type TrustDB interface {
-	Read
-	Write
+	ReadWrite
 	BeginTransaction(ctx context.Context, opts *sql.TxOptions) (Transaction, error)
 	io.Closer
 }
@@ -91,12 +90,17 @@ type Write interface {
 		key common.RawBytes, oldVersion uint64) error
 }
 
+// ReadWrite contains all read and write operations of the trust DB.
+type ReadWrite interface {
+	Read
+	Write
+}
+
 // Transaction represents a trust DB transaction with an ongoing transaction.
 // To end the transaction either Rollback or Commit should be called. Calling Commit or Rollback
 // multiple times will result in an error.
 type Transaction interface {
-	Read
-	Write
+	ReadWrite
 	// Commit commits the transaction.
 	Commit() error
 	// Rollback rollbacks the transaction.


### PR DESCRIPTION
Rationale:
The error counters help to detect where an issue of a service might be (i.e. in this case the DB).
The total counters give an idea on the pressure on the DB.

Contributes #2329

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2362)
<!-- Reviewable:end -->
