### PR TITLE
Fix BK retry status and docker-integration

### DIFF
--- a/.buildkite/steps/build.yml
+++ b/.buildkite/steps/build.yml
@@ -4,7 +4,7 @@
     - "artifacts.out/**/*"
   retry:
     automatic:
-      exit_status: -1
+      exit_status: 255
 - label: Build code and push "$SCION_IMG"
   command:
   - $BASE/scripts/registry_login
@@ -19,5 +19,5 @@
     - "artifacts.out/**/*"
   retry:
     automatic:
-      exit_status: -1
+      exit_status: 255
 - wait

--- a/.buildkite/steps/build_all.yml
+++ b/.buildkite/steps/build_all.yml
@@ -9,5 +9,5 @@
   - $BASE/scripts/all_images push
   retry:
     automatic:
-      exit_status: -1
+      exit_status: 255
 - wait

--- a/.buildkite/steps/setup.yml
+++ b/.buildkite/steps/setup.yml
@@ -6,5 +6,5 @@
       - docker push $SCION_BUILD_IMG
   retry:
     automatic:
-      exit_status: -1
+      exit_status: 255
 - wait

--- a/.buildkite/steps/test.yml
+++ b/.buildkite/steps/test.yml
@@ -4,4 +4,4 @@
       - "artifacts.out/**/*"
   retry:
     automatic:
-      exit_status: -1
+      exit_status: 255

--- a/tools/ci/integration
+++ b/tools/ci/integration
@@ -29,8 +29,7 @@ revocation() {
 
 run_tests() {
     result=0
-    go_infra
-    result=$((result+$?))
+    [ -z "$DOCKER_BE" ] && { go_infra; result=$((result+$?)); }
     go_integration
     result=$((result+$?))
     if [ -n "$ALL" ]; then


### PR DESCRIPTION
The buildkite docs are somewhat missleading or the UI is inconsistent with the exit code when agent disconnected, see buildkite/docs#306.
Also docker-integration should not run go_infra.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2366)
<!-- Reviewable:end -->
