### PR TITLE
Rename Eq to Equal

### DIFF
--- a/go/border/braccept/tpkt/addrhdr.go
+++ b/go/border/braccept/tpkt/addrhdr.go
@@ -109,9 +109,12 @@ func (a *AddrHdr) Write(b common.RawBytes) int {
 	return offset + addrPad
 }
 
-func (a *AddrHdr) Eq(o *AddrHdr) bool {
-	return a.DstIA.Eq(o.DstIA) && a.SrcIA.Eq(o.SrcIA) &&
-		a.DstHost.Eq(o.DstHost) && a.SrcHost.Eq(o.SrcHost)
+func (a *AddrHdr) Equal(o *AddrHdr) bool {
+	if a == nil || o == nil {
+		return a == o
+	}
+	return a.DstIA.Equal(o.DstIA) && a.SrcIA.Equal(o.SrcIA) &&
+		a.DstHost.Equal(o.DstHost) && a.SrcHost.Equal(o.SrcHost)
 }
 
 func (a *AddrHdr) String() string {

--- a/go/border/braccept/tpkt/addrhdr.go
+++ b/go/border/braccept/tpkt/addrhdr.go
@@ -113,8 +113,10 @@ func (a *AddrHdr) Equal(o *AddrHdr) bool {
 	if a == nil || o == nil {
 		return a == o
 	}
-	return a.DstIA.Equal(o.DstIA) && a.SrcIA.Equal(o.SrcIA) &&
-		a.DstHost.Equal(o.DstHost) && a.SrcHost.Equal(o.SrcHost)
+	return a.DstIA.Equal(o.DstIA) &&
+		a.SrcIA.Equal(o.SrcIA) &&
+		a.DstHost.Equal(o.DstHost) &&
+		a.SrcHost.Equal(o.SrcHost)
 }
 
 func (a *AddrHdr) String() string {

--- a/go/border/braccept/tpkt/scionlayer.go
+++ b/go/border/braccept/tpkt/scionlayer.go
@@ -109,7 +109,7 @@ func (l *ScionLayer) Match(pktLayers []gopacket.Layer, lc *LayerCache) ([]gopack
 		return nil, fmt.Errorf("Common header mismatch\nExpected %v\nActual   %v",
 			&l.CmnHdr, &scn.CmnHdr)
 	}
-	if !l.AddrHdr.Eq(&scn.AddrHdr) {
+	if !l.AddrHdr.Equal(&scn.AddrHdr) {
 		return nil, fmt.Errorf("Address header mismatch\nExpected %v\nActual   %v",
 			&l.AddrHdr, &scn.AddrHdr)
 	}

--- a/go/border/braccept/tpkt/scnpath.go
+++ b/go/border/braccept/tpkt/scnpath.go
@@ -286,14 +286,14 @@ func (s *SegDef) Len() int {
 }
 
 func (s *SegDef) Equal(o *SegDef) error {
-	if !s.Inf.Eq(o.Inf) {
+	if !s.Inf.Equal(o.Inf) {
 		return fmt.Errorf("Info Field mismatch\n  Expected: %s\n  Actual:   %s\n", s.Inf, o.Inf)
 	}
 	if len(s.Hops) != len(o.Hops) {
 		return fmt.Errorf("Different number of Hop Fields\n  Expected: %s\n  Actual:   %s\n", s, o)
 	}
 	for i := range s.Hops {
-		if !s.Hops[i].Eq(o.Hops[i]) {
+		if !s.Hops[i].Equal(o.Hops[i]) {
 			return fmt.Errorf("Hop Field mismatch\n  Expected: %s\n  Actual:   %s\n",
 				s.Hops[i], o.Hops[i])
 		}

--- a/go/border/error.go
+++ b/go/border/error.go
@@ -80,7 +80,7 @@ func (r *Router) doPktError(rp *rpkt.RtrPkt, perr error) {
 		return
 	}
 	// Certain errors are not respondable to if the source lies in a remote AS.
-	if !srcIA.Eq(rp.Ctx.Conf.IA) {
+	if !srcIA.Equal(rp.Ctx.Conf.IA) {
 		switch serr.CT.Class {
 		case scmp.C_CmnHdr:
 			switch serr.CT.Type {

--- a/go/border/rpkt/create.go
+++ b/go/border/rpkt/create.go
@@ -195,7 +195,7 @@ func (rp *RtrPkt) CreateReply(sp *spkt.ScnPkt) (*RtrPkt, error) {
 		return nil, err
 	}
 	// Only (potentially) call IncPath if the dest is not in the local AS.
-	if !dstIA.Eq(rp.Ctx.Conf.IA) {
+	if !dstIA.Equal(rp.Ctx.Conf.IA) {
 		hopF, err := reply.HopF()
 		if err != nil {
 			return nil, err
@@ -232,7 +232,7 @@ func (rp *RtrPkt) CreateReply(sp *spkt.ScnPkt) (*RtrPkt, error) {
 // address to use when replying to a packet.
 func (rp *RtrPkt) replyEgress(dir rcmn.Dir, dst *overlay.OverlayAddr, ifid common.IFIDType) error {
 	// Destination is the local AS
-	if rp.dstIA.Eq(rp.Ctx.Conf.IA) {
+	if rp.dstIA.Equal(rp.Ctx.Conf.IA) {
 		// Write to local socket
 		rp.Egress = append(rp.Egress, EgressPair{S: rp.Ctx.LocSockOut, Dst: dst})
 		return nil

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -37,7 +37,7 @@ func (rp *RtrPkt) Parse() error {
 	if _, err := rp.DstIA(); err != nil {
 		return err
 	}
-	if rp.dstIA.Eq(rp.Ctx.Conf.IA) {
+	if rp.dstIA.Equal(rp.Ctx.Conf.IA) {
 		// If the destination is local, parse the destination host as well.
 		if _, err := rp.DstHost(); err != nil {
 			return err

--- a/go/border/rpkt/process.go
+++ b/go/border/rpkt/process.go
@@ -31,7 +31,7 @@ import (
 // forward a packet (e.g. resolve an SVC destination address).
 func (rp *RtrPkt) NeedsLocalProcessing() error {
 	// Check if SVC packet to local AS
-	if rp.dstIA.Eq(rp.Ctx.Conf.IA) && rp.CmnHdr.DstType == addr.HostTypeSVC {
+	if rp.dstIA.Equal(rp.Ctx.Conf.IA) && rp.CmnHdr.DstType == addr.HostTypeSVC {
 		// SVC address needs to be resolved for delivery.
 		rp.hooks.Route = append(rp.hooks.Route, rp.RouteResolveSVC)
 	} else {
@@ -196,7 +196,7 @@ func (rp *RtrPkt) processSCMPRevocation() error {
 		if len(rp.Ctx.Conf.Topo.PS) > 0 {
 			args.Addrs = append(args.Addrs, addr.SvcPS)
 		}
-	} else if rp.dstIA.Eq(rp.Ctx.Conf.IA) && len(rp.Ctx.Conf.Topo.PS) > 0 {
+	} else if rp.dstIA.Equal(rp.Ctx.Conf.IA) && len(rp.Ctx.Conf.Topo.PS) > 0 {
 		// Case 3
 		args.Addrs = append(args.Addrs, addr.SvcPS)
 	}

--- a/go/border/rpkt/route.go
+++ b/go/border/rpkt/route.go
@@ -114,7 +114,7 @@ func (rp *RtrPkt) forwardFromExternal() (HookResult, error) {
 	// extensions that replace the path header.
 	var onLastSeg = rp.CmnHdr.InfoFOffBytes()+int(rp.infoF.Hops+1)*common.LineLen ==
 		rp.CmnHdr.HdrLenBytes()
-	if onLastSeg && rp.dstIA.Eq(rp.Ctx.Conf.IA) {
+	if onLastSeg && rp.dstIA.Equal(rp.Ctx.Conf.IA) {
 		// Destination is a host in the local ISD-AS.
 		l4 := addr.NewL4UDPInfo(overlay.EndhostPort)
 		dst, err := overlay.NewOverlayAddr(rp.dstHost, l4)

--- a/go/border/rpkt/rpkt_hook_test.go
+++ b/go/border/rpkt/rpkt_hook_test.go
@@ -101,22 +101,22 @@ func TestHooksSrcDstHost(t *testing.T) {
 		var host addr.HostAddr
 
 		host, err = rpkt.DstHost()
-		SoMsg("Destination host wrong", host.Eq(dstHost), ShouldBeTrue)
+		SoMsg("Destination host wrong", host.Equal(dstHost), ShouldBeTrue)
 		SoMsg("Should be no error when calling destination host getter", err, ShouldBeNil)
 
 		host, err = rpkt.DstHost()
-		SoMsg("Destination host wrong on second getter call", host.Eq(dstHost), ShouldBeTrue)
+		SoMsg("Destination host wrong on second getter call", host.Equal(dstHost), ShouldBeTrue)
 		SoMsg("Should be no error when calling destination host getter for cached value", err,
 			ShouldBeNil)
 		SoMsg("Destination host must only be fetched once, cached value must be reused on the "+
 			"second call", fetched, ShouldEqual, 1)
 
 		host, err = rpkt.SrcHost()
-		SoMsg("Source host wrong", host.Eq(srcHost), ShouldBeTrue)
+		SoMsg("Source host wrong", host.Equal(srcHost), ShouldBeTrue)
 		SoMsg("Should be no error when calling source host getter", err, ShouldBeNil)
 
 		host, err = rpkt.SrcHost()
-		SoMsg("Source host wrong on cached getter call", host.Eq(srcHost), ShouldBeTrue)
+		SoMsg("Source host wrong on cached getter call", host.Equal(srcHost), ShouldBeTrue)
 		SoMsg("Should be no error when calling destination host getter for cached value", err,
 			ShouldBeNil)
 		SoMsg("Two fetches are expected (both source and destination host, each exactly once)",

--- a/go/border/setup-posix.go
+++ b/go/border/setup-posix.go
@@ -189,7 +189,7 @@ func (p posixExt) Teardown(r *Router, ctx *rctx.Ctx, intf *netconf.Interface, ol
 func interfaceChanged(newIntf *netconf.Interface, oldIntf *netconf.Interface) bool {
 	return (newIntf.Id != oldIntf.Id ||
 		!newIntf.IFAddr.Equal(oldIntf.IFAddr) ||
-		!newIntf.RemoteAddr.Eq(oldIntf.RemoteAddr))
+		!newIntf.RemoteAddr.Equal(oldIntf.RemoteAddr))
 }
 
 // Create a set of labels for ringbuf with `sock` renamed to `ringId`.

--- a/go/cert_srv/internal/reiss/handler.go
+++ b/go/cert_srv/internal/reiss/handler.go
@@ -129,7 +129,7 @@ func (h *Handler) validateSign(ctx context.Context, addr *snet.Addr,
 			"expected", verChain.Leaf.SignAlgorithm, "actual", signed.Sign.Type)
 	}
 	// Verify that the requester matches the signer
-	if !verChain.Leaf.Subject.Eq(addr.IA) {
+	if !verChain.Leaf.Subject.Equal(addr.IA) {
 		return nil, common.NewBasicError("Origin AS does not match signer", nil,
 			"signer", verChain.Leaf.Subject, "origin", addr.IA)
 	}
@@ -141,7 +141,7 @@ func (h *Handler) validateSign(ctx context.Context, addr *snet.Addr,
 func (h *Handler) validateReq(c *cert.Certificate, vKey common.RawBytes,
 	vChain, maxChain *cert.Chain) error {
 
-	if !c.Subject.Eq(vChain.Leaf.Subject) {
+	if !c.Subject.Equal(vChain.Leaf.Subject) {
 		return common.NewBasicError("Requester does not match subject", nil, "ia",
 			vChain.Leaf.Subject, "sub", c.Subject)
 	}
@@ -149,7 +149,7 @@ func (h *Handler) validateReq(c *cert.Certificate, vKey common.RawBytes,
 		return common.NewBasicError("Invalid version", nil, "expected", maxChain.Leaf.Version+1,
 			"actual", c.Version)
 	}
-	if !c.Issuer.Eq(h.IA) {
+	if !c.Issuer.Equal(h.IA) {
 		return common.NewBasicError("Requested Issuer is not this AS", nil, "iss",
 			c.Issuer, "expected", h.IA)
 	}

--- a/go/cert_srv/internal/reiss/requester.go
+++ b/go/cert_srv/internal/reiss/requester.go
@@ -140,7 +140,7 @@ func (r *Requester) validateRep(ctx context.Context, chain *cert.Chain) error {
 		return err
 	}
 	issuer := chain.Leaf.Issuer
-	if !chain.Leaf.Issuer.Eq(issuer) {
+	if !chain.Leaf.Issuer.Equal(issuer) {
 		return common.NewBasicError("Invalid Issuer", nil, "expected",
 			issuer, "actual", chain.Leaf.Issuer)
 	}

--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -272,7 +272,7 @@ func (c *client) Close() error {
 }
 
 func (c client) setupPath() {
-	if !remote.IA.Eq(local.IA) {
+	if !remote.IA.Equal(local.IA) {
 		pathEntry := choosePath(*interactive)
 		if pathEntry == nil {
 			LogFatal("No paths available to remote destination")

--- a/go/integration/cert_req/main.go
+++ b/go/integration/cert_req/main.go
@@ -114,7 +114,7 @@ func (c client) requestCert() (*cert.Chain, error) {
 	if err != nil {
 		return nil, common.NewBasicError("Unable to parse chain", err)
 	}
-	if !chain.Leaf.Subject.Eq(remoteIA) {
+	if !chain.Leaf.Subject.Equal(remoteIA) {
 		return nil, common.NewBasicError("Invalid subject", nil,
 			"expected", remoteIA, "actual", chain.Leaf.Subject)
 	}

--- a/go/integration/end2end/main.go
+++ b/go/integration/end2end/main.go
@@ -154,7 +154,7 @@ func (c client) ping(n int) error {
 }
 
 func (c client) getRemote(n int) error {
-	if remote.IA.Eq(integration.Local.IA) {
+	if remote.IA.Equal(integration.Local.IA) {
 		return nil
 	}
 	// Get paths from sciond

--- a/go/lib/addr/appaddr.go
+++ b/go/lib/addr/appaddr.go
@@ -27,11 +27,11 @@ func (a *AppAddr) Copy() *AppAddr {
 	return &AppAddr{L3: a.L3.Copy(), L4: a.L4.Copy()}
 }
 
-func (a *AppAddr) Eq(o *AppAddr) bool {
+func (a *AppAddr) Equal(o *AppAddr) bool {
 	if (a == nil) || (o == nil) {
 		return a == o
 	}
-	return a.L3.Eq(o.L3) && a.L4.Eq(o.L4)
+	return a.L3.Equal(o.L3) && a.L4.Equal(o.L4)
 }
 
 func (a *AppAddr) EqType(o *AppAddr) bool {

--- a/go/lib/addr/host.go
+++ b/go/lib/addr/host.go
@@ -75,7 +75,7 @@ type HostAddr interface {
 	Pack() common.RawBytes
 	IP() net.IP
 	Copy() HostAddr
-	Eq(HostAddr) bool
+	Equal(HostAddr) bool
 	fmt.Stringer
 }
 
@@ -103,7 +103,7 @@ func (h HostNone) Copy() HostAddr {
 	return HostNone{}
 }
 
-func (h HostNone) Eq(o HostAddr) bool {
+func (h HostNone) Equal(o HostAddr) bool {
 	_, ok := o.(HostNone)
 	return ok
 }
@@ -137,7 +137,7 @@ func (h HostIPv4) Copy() HostAddr {
 	return HostIPv4(append(net.IP(nil), h...))
 }
 
-func (h HostIPv4) Eq(o HostAddr) bool {
+func (h HostIPv4) Equal(o HostAddr) bool {
 	ha, ok := o.(HostIPv4)
 	return ok && net.IP(h).Equal(net.IP(ha))
 }
@@ -170,7 +170,7 @@ func (h HostIPv6) Copy() HostAddr {
 	return HostIPv6(append(net.IP(nil), h...))
 }
 
-func (h HostIPv6) Eq(o HostAddr) bool {
+func (h HostIPv6) Equal(o HostAddr) bool {
 	ha, ok := o.(HostIPv6)
 	return ok && net.IP(h).Equal(net.IP(ha))
 }
@@ -246,7 +246,7 @@ func (h HostSVC) Copy() HostAddr {
 	return h
 }
 
-func (h HostSVC) Eq(o HostAddr) bool {
+func (h HostSVC) Equal(o HostAddr) bool {
 	ha, ok := o.(HostSVC)
 	return ok && h == ha
 }

--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -239,7 +239,7 @@ func (ia IA) IsZero() bool {
 	return ia.I == 0 && ia.A == 0
 }
 
-func (ia IA) Eq(other IA) bool {
+func (ia IA) Equal(other IA) bool {
 	return ia.I == other.I && ia.A == other.A
 }
 

--- a/go/lib/addr/l4info.go
+++ b/go/lib/addr/l4info.go
@@ -25,7 +25,7 @@ type L4Info interface {
 	Type() common.L4ProtocolType
 	Port() uint16
 	Copy() L4Info
-	Eq(L4Info) bool
+	Equal(L4Info) bool
 	String() string
 }
 
@@ -62,7 +62,7 @@ func (l *l4AddrInfo) Copy() L4Info {
 	return &l4AddrInfo{pType: l.pType, port: l.port}
 }
 
-func (a *l4AddrInfo) Eq(other L4Info) bool {
+func (a *l4AddrInfo) Equal(other L4Info) bool {
 	o, ok := other.(*l4AddrInfo)
 	return ok && a.pType == o.pType && a.port == o.port
 }

--- a/go/lib/ctrl/path_mgmt/rev_info.go
+++ b/go/lib/ctrl/path_mgmt/rev_info.go
@@ -122,7 +122,10 @@ func (r *RevInfo) RelativeTTL(reference time.Time) time.Duration {
 	return expiration.Sub(reference)
 }
 
-func (r *RevInfo) Eq(other *RevInfo) bool {
+func (r *RevInfo) Equal(other *RevInfo) bool {
+	if r == nil || other == nil {
+		return r == other
+	}
 	return r.SameIntf(other) &&
 		r.RawTimestamp == other.RawTimestamp &&
 		r.RawTTL == other.RawTTL

--- a/go/lib/ctrl/seg/as.go
+++ b/go/lib/ctrl/seg/as.go
@@ -54,13 +54,13 @@ func (ase *ASEntry) Validate(prevIA addr.IA, nextIA addr.IA) error {
 	}
 	for i := range ase.HopEntries {
 		h := ase.HopEntries[i]
-		if i == 0 && !prevIA.Eq(h.InIA()) {
+		if i == 0 && !prevIA.Equal(h.InIA()) {
 			// Only perform this checks for the first HopEntry, as we can't validate
 			// peering HopEntries from the available information.
 			return common.NewBasicError("HopEntry InIA mismatch", nil,
 				"hopIdx", i, "expected", h.InIA(), "actual", prevIA)
 		}
-		if !nextIA.Eq(h.OutIA()) {
+		if !nextIA.Equal(h.OutIA()) {
 			return common.NewBasicError("HopEntry OutIA mismatch", nil,
 				"hopIdx", i, "expected", h.OutIA(), "actual", prevIA)
 		}

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -169,7 +169,7 @@ func (ps *PathSegment) ContainsInterface(ia addr.IA, ifid common.IFIDType) bool 
 				// is possible to extract the hop field.
 				panic(err)
 			}
-			if asEntry.IA().Eq(ia) && (hf.ConsEgress == ifid || hf.ConsIngress == ifid) {
+			if asEntry.IA().Equal(ia) && (hf.ConsEgress == ifid || hf.ConsIngress == ifid) {
 				return true
 			}
 		}

--- a/go/lib/ctrl/seg/segs_test.go
+++ b/go/lib/ctrl/seg/segs_test.go
@@ -107,7 +107,7 @@ func Test_FilterSegments(t *testing.T) {
 			Name:     "First IA core 1_110",
 			Segs:     []*PathSegment{seg110_120, seg120_110},
 			Filtered: []*PathSegment{seg120_110},
-			KeepF:    func(s *PathSegment) bool { return core1_120.Eq(s.FirstIA()) },
+			KeepF:    func(s *PathSegment) bool { return core1_120.Equal(s.FirstIA()) },
 		},
 	}
 	Convey("Test filtering segments", t, func() {

--- a/go/lib/discovery/discoveryinfo/info.go
+++ b/go/lib/discovery/discoveryinfo/info.go
@@ -57,7 +57,7 @@ func New(key string, addr *addr.AppAddr) *Info {
 func (h *Info) Update(a *addr.AppAddr) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if !a.Eq(h.addr) {
+	if !a.Equal(h.addr) {
 		h.addr = a.Copy()
 		h.failCount = 0
 		h.lastFail = time.Now()

--- a/go/lib/hpkt/hpkt_test.go
+++ b/go/lib/hpkt/hpkt_test.go
@@ -138,8 +138,8 @@ func Test_ScnPkt_Write(t *testing.T) {
 		c := &spkt.ScnPkt{}
 		err = ParseScnPkt(c, b[:n])
 		SoMsg("Read error", err, ShouldBeNil)
-		SoMsg("Dst IAs must match", s.DstIA.Eq(c.DstIA), ShouldBeTrue)
-		SoMsg("Src IAs must match", s.SrcIA.Eq(c.SrcIA), ShouldBeTrue)
+		SoMsg("Dst IAs must match", s.DstIA.Equal(c.DstIA), ShouldBeTrue)
+		SoMsg("Src IAs must match", s.SrcIA.Equal(c.SrcIA), ShouldBeTrue)
 		SoMsg("Dst host types must match", s.DstHost.Type(), ShouldEqual, c.DstHost.Type())
 		SoMsg("Dst host IPs must match", s.DstHost.IP().Equal(c.DstHost.IP()), ShouldBeTrue)
 		SoMsg("Raw paths must match", s.Path.Raw, ShouldResemble, c.Path.Raw)

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -556,7 +556,7 @@ func (m *Messenger) verifySignedPld(ctx context.Context, signedPld *ctrl.SignedP
 	if err := ctrl.VerifySig(ctx, signedPld, verifier); err != nil {
 		return common.NewBasicError("Unable to verify signature", err)
 	}
-	if !addr.IA.Eq(src.IA) {
+	if !addr.IA.Equal(src.IA) {
 		return common.NewBasicError("Sender IA does not match signed src IA", nil,
 			"expected", src.IA, "actual", addr.IA)
 	}

--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -303,7 +303,7 @@ func (store *Store) getValidChain(ctx context.Context, ia addr.IA, recurse bool,
 	if err != nil || chain != nil {
 		return chain, err
 	}
-	if store.config.MustHaveLocalChain && store.ia.Eq(ia) {
+	if store.config.MustHaveLocalChain && store.ia.Equal(ia) {
 		return nil, common.NewBasicError(ErrMissingAuthoritative, nil,
 			"requested_ia", ia)
 	}
@@ -349,7 +349,7 @@ func (store *Store) getChain(ctx context.Context, ia addr.IA, version uint64,
 		return chain, err
 	}
 	// If we're authoritative for the requested IA, error out now.
-	if store.config.MustHaveLocalChain && store.ia.Eq(ia) {
+	if store.config.MustHaveLocalChain && store.ia.Equal(ia) {
 		return nil, common.NewBasicError(ErrMissingAuthoritative, nil,
 			"requested ia", ia)
 	}
@@ -543,7 +543,7 @@ func (store *Store) LoadAuthoritativeChain(dir string) error {
 			return err
 		case fileChain.Leaf.Version == dbChain.Leaf.Version:
 			// Because it is the same version, check if the chains match
-			if !fileChain.Eq(dbChain) {
+			if !fileChain.Equal(dbChain) {
 				return common.NewBasicError("Conflicting chains found for same version", nil,
 					"db", dbChain, "file", fileChain)
 			}
@@ -627,7 +627,7 @@ func (store *Store) isLocal(address net.Addr) error {
 		case !ok:
 			return common.NewBasicError("Unable to determine AS of address",
 				nil, "addr", address)
-		case !store.ia.Eq(saddr.IA):
+		case !store.ia.Equal(saddr.IA):
 			return common.NewBasicError("Object not found in DB, and recursion not "+
 				"allowed for clients outside AS", nil, "addr", address)
 		}

--- a/go/lib/integration/integration.go
+++ b/go/lib/integration/integration.go
@@ -171,7 +171,7 @@ func generateAllSrcDst(hostAddr HostAddr, unique bool) []IAPair {
 	pairs := make([]IAPair, 0, len(srcASes)*len(dstASes))
 	for _, src := range srcASes {
 		for _, dst := range dstASes {
-			if !unique || !src.IA.Eq(dst.IA) {
+			if !unique || !src.IA.Equal(dst.IA) {
 				pairs = append(pairs, IAPair{src, dst})
 			}
 		}

--- a/go/lib/overlay/addr.go
+++ b/go/lib/overlay/addr.go
@@ -75,25 +75,25 @@ func (a *OverlayAddr) Copy() *OverlayAddr {
 	return &OverlayAddr{l3: a.l3.Copy(), l4: a.l4.Copy()}
 }
 
-func (a *OverlayAddr) Eq(o *OverlayAddr) bool {
+func (a *OverlayAddr) Equal(o *OverlayAddr) bool {
 	if (a == nil) || (o == nil) {
 		return a == o
 	}
 	if a.l3 != nil {
-		if !a.l3.Eq(o.l3) {
+		if !a.l3.Equal(o.l3) {
 			return false
 		}
 	} else if o.l3 != nil {
-		if !o.l3.Eq(a.l3) {
+		if !o.l3.Equal(a.l3) {
 			return false
 		}
 	}
 	if a.l4 != nil {
-		if !a.l4.Eq(o.l4) {
+		if !a.l4.Equal(o.l4) {
 			return false
 		}
 	} else if o.l4 != nil {
-		if !o.l4.Eq(a.l4) {
+		if !o.l4.Equal(a.l4) {
 			return false
 		}
 	}

--- a/go/lib/pathdb/pathdbtest/pathdbtest.go
+++ b/go/lib/pathdb/pathdbtest/pathdbtest.go
@@ -531,7 +531,7 @@ func checkSameHpCfgs(msg string, actual, expected []*query.HPCfgID) {
 	sort.Slice(actual, func(i, j int) bool {
 		return actual[i].IA.I < actual[j].IA.I ||
 			actual[i].IA.I == actual[j].IA.I && actual[i].IA.A < actual[j].IA.A ||
-			actual[i].IA.Eq(actual[j].IA) && actual[i].ID < actual[j].ID
+			actual[i].IA.Equal(actual[j].IA) && actual[i].ID < actual[j].ID
 	})
 	SoMsg(msg, actual, ShouldResemble, expected)
 }

--- a/go/lib/pathdb/query/query.go
+++ b/go/lib/pathdb/query/query.go
@@ -30,8 +30,11 @@ type HPCfgID struct {
 	ID uint64
 }
 
-func (h *HPCfgID) Eq(other *HPCfgID) bool {
-	return h.IA.Eq(other.IA) && h.ID == other.ID
+func (h *HPCfgID) Equal(other *HPCfgID) bool {
+	if h == nil || other == nil {
+		return h == other
+	}
+	return h.IA.Equal(other.IA) && h.ID == other.ID
 }
 
 var NullHpCfgID = HPCfgID{IA: addr.IAInt(0).IA(), ID: 0}

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -278,7 +278,7 @@ func dropRevoked(aps spathmeta.AppPathSet, pi sciond.PathInterface) spathmeta.Ap
 
 func matches(path *spathmeta.AppPath, predicatePI sciond.PathInterface) bool {
 	for _, pi := range path.Entry.Path.Interfaces {
-		if pi.Eq(&predicatePI) {
+		if pi.Equal(&predicatePI) {
 			return true
 		}
 	}

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -360,7 +360,7 @@ func (iface *PathInterface) ISD_AS() addr.IA {
 	return iface.RawIsdas.IA()
 }
 
-func (iface *PathInterface) Eq(other *PathInterface) bool {
+func (iface *PathInterface) Equal(other *PathInterface) bool {
 	if iface == nil || other == nil {
 		return iface == other
 	}

--- a/go/lib/scrypto/cert/cert.go
+++ b/go/lib/scrypto/cert/cert.go
@@ -99,7 +99,7 @@ func CertificateFromRaw(raw common.RawBytes) (*Certificate, error) {
 // associated signature algorithm. Further, it verifies that the certificate belongs to the given
 // subject, and that it is valid at the current time.
 func (c *Certificate) Verify(subject addr.IA, verifyKey common.RawBytes, signAlgo string) error {
-	if !subject.Eq(c.Subject) {
+	if !subject.Equal(c.Subject) {
 		return common.NewBasicError(InvalidSubject, nil,
 			"expected", c.Subject, "actual", subject)
 	}
@@ -223,15 +223,18 @@ func (c *Certificate) UnmarshalJSON(b []byte) error {
 	return json.Unmarshal(b, (*Alias)(c))
 }
 
-func (c *Certificate) Eq(o *Certificate) bool {
+func (c *Certificate) Equal(o *Certificate) bool {
+	if c == nil || o == nil {
+		return c == o
+	}
 	return c.CanIssue == o.CanIssue &&
 		c.Comment == o.Comment &&
 		c.ExpirationTime == o.ExpirationTime &&
 		c.IssuingTime == o.IssuingTime &&
 		c.TRCVersion == o.TRCVersion &&
 		c.Version == o.Version &&
-		c.Issuer.Eq(o.Issuer) &&
-		c.Subject.Eq(o.Subject) &&
+		c.Issuer.Equal(o.Issuer) &&
+		c.Subject.Equal(o.Subject) &&
 		c.SignAlgorithm == o.SignAlgorithm &&
 		c.EncAlgorithm == o.EncAlgorithm &&
 		bytes.Equal(c.SubjectEncKey, o.SubjectEncKey) &&

--- a/go/lib/scrypto/cert/cert_test.go
+++ b/go/lib/scrypto/cert/cert_test.go
@@ -191,7 +191,7 @@ func Test_Certificate_JSON(t *testing.T) {
 	})
 }
 
-func Test_Certificate_Eq(t *testing.T) {
+func Test_Certificate_Equal(t *testing.T) {
 	Convey("Load Certificate from Raw", t, func() {
 		c1 := loadCert(fnLeaf, t)
 		c2 := loadCert(fnLeaf, t)

--- a/go/lib/scrypto/cert/cert_test.go
+++ b/go/lib/scrypto/cert/cert_test.go
@@ -197,59 +197,59 @@ func Test_Certificate_Eq(t *testing.T) {
 		c2 := loadCert(fnLeaf, t)
 
 		Convey("Certificates are equal", func() {
-			SoMsg("Eq", c1.Eq(c2), ShouldBeTrue)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeTrue)
 		})
 		Convey("Certificates are unequal (CanIssue)", func() {
 			c1.CanIssue = true
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (Comment)", func() {
 			c1.Comment = "Nope"
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (EncAlgorithm)", func() {
 			c1.EncAlgorithm = "Caesar Cipher"
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (ExpirationTime)", func() {
 			c1.ExpirationTime = 0
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (Issuer)", func() {
 			c1.Issuer = addr.IA{I: 13, A: 37}
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (IssuingTime)", func() {
 			c1.IssuingTime = 0
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (SignAlgorithm)", func() {
 			c1.SignAlgorithm = "ByHand"
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (Signature)", func() {
 			c1.Signature[0] ^= 0xFF
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (Subject)", func() {
 			c1.Subject = addr.IA{I: 13, A: 37}
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (SubjectEncKey)", func() {
 			c1.SubjectEncKey[0] ^= 0xFF
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (SubjectSigKey)", func() {
 			c1.SubjectSignKey[0] ^= 0xFF
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (TRCVersion)", func() {
 			c1.TRCVersion = 10
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Certificates are unequal (Version)", func() {
 			c1.Version = 10
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 	})
 }

--- a/go/lib/scrypto/cert/chain.go
+++ b/go/lib/scrypto/cert/chain.go
@@ -124,7 +124,7 @@ func ChainFromDir(dir string, ia addr.IA, f func(err error)) (*Chain, error) {
 			f(common.NewBasicError("Unable to read Chain file", err))
 			continue
 		}
-		if !chain.Leaf.Subject.Eq(ia) {
+		if !chain.Leaf.Subject.Equal(ia) {
 			return nil, common.NewBasicError("IA mismatch", nil, "expected", ia,
 				"found", chain.Leaf.Subject)
 		}
@@ -147,7 +147,7 @@ func ChainFromSlice(certs []*Certificate) (*Chain, error) {
 		return nil, common.NewBasicError("Certificates must not be nil", nil, "leaf", certs[0],
 			"iss", certs[1])
 	}
-	if !certs[0].Issuer.Eq(certs[1].Subject) {
+	if !certs[0].Issuer.Equal(certs[1].Subject) {
 		return nil, common.NewBasicError("Leaf not signed by issuer", nil, "expected",
 			certs[0].Issuer, "actual", certs[1].Subject)
 	}
@@ -235,8 +235,11 @@ func (c *Chain) UnmarshalJSON(b []byte) error {
 	return json.Unmarshal(b, (*Alias)(c))
 }
 
-func (c *Chain) Eq(o *Chain) bool {
-	return c.Leaf.Eq(o.Leaf) && c.Issuer.Eq(o.Issuer)
+func (c *Chain) Equal(o *Chain) bool {
+	if c == nil || o == nil {
+		return c == o
+	}
+	return c.Leaf.Equal(o.Leaf) && c.Issuer.Equal(o.Issuer)
 }
 
 func (c *Chain) IAVer() (addr.IA, uint64) {

--- a/go/lib/scrypto/cert/chain_test.go
+++ b/go/lib/scrypto/cert/chain_test.go
@@ -46,12 +46,12 @@ func Test_ChainFromRaw(t *testing.T) {
 		SoMsg("err", err, ShouldBeNil)
 		Convey("Leaf Certificate is parsed correctly", func() {
 			cert := loadCert(fnLeaf, t)
-			SoMsg("Leaf", chain.Leaf.Eq(cert), ShouldBeTrue)
+			SoMsg("Leaf", chain.Leaf.Equal(cert), ShouldBeTrue)
 		})
 
 		Convey("Issuer Certificate is parsed correctly", func() {
 			cert := loadCert(fnCore, t)
-			SoMsg("Issuer", chain.Issuer.Eq(cert), ShouldBeTrue)
+			SoMsg("Issuer", chain.Issuer.Equal(cert), ShouldBeTrue)
 		})
 	})
 
@@ -130,7 +130,7 @@ func Test_Chain_Compress(t *testing.T) {
 		comp, err := chain.Compress()
 		SoMsg("err", err, ShouldBeNil)
 		pChain, _ := ChainFromRaw(comp, true)
-		SoMsg("Compare", pChain.Eq(chain), ShouldBeTrue)
+		SoMsg("Compare", pChain.Equal(chain), ShouldBeTrue)
 	})
 }
 
@@ -155,7 +155,7 @@ func Test_Chain_IAVer(t *testing.T) {
 	Convey("IA version tuple is returned correctly", t, func() {
 		chain := loadChain(fnChain, t)
 		ia, ver := chain.IAVer()
-		SoMsg("IA", ia.Eq(addr.IA{I: 1, A: 0xff0000000311}), ShouldBeTrue)
+		SoMsg("IA", ia.Equal(addr.IA{I: 1, A: 0xff0000000311}), ShouldBeTrue)
 		SoMsg("Ver", ver, ShouldEqual, 1)
 	})
 }
@@ -166,15 +166,15 @@ func Test_Chain_Eq(t *testing.T) {
 		c2 := loadChain(fnChain, t)
 
 		Convey("Chains are equal", func() {
-			SoMsg("Eq", c1.Eq(c2), ShouldBeTrue)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeTrue)
 		})
 		Convey("Chains are unequal (Leaf)", func() {
 			c1.Leaf.CanIssue = true
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 		Convey("Chains are unequal (Issuer)", func() {
 			c1.Issuer.CanIssue = false
-			SoMsg("Eq", c1.Eq(c2), ShouldBeFalse)
+			SoMsg("Eq", c1.Equal(c2), ShouldBeFalse)
 		})
 	})
 }

--- a/go/lib/scrypto/cert/chain_test.go
+++ b/go/lib/scrypto/cert/chain_test.go
@@ -62,12 +62,12 @@ func Test_ChainFromRaw(t *testing.T) {
 
 	//	Convey("Leaf Certificate is parsed correctly", func() {
 	//		cert := loadCert(fnLeaf, t)
-	//		SoMsg("Leaf", chain.Leaf.Eq(cert), ShouldBeTrue)
+	//		SoMsg("Leaf", chain.Leaf.Equal(cert), ShouldBeTrue)
 	//	})
 
 	//	Convey("Issuer Certificate is parsed correctly", func() {
 	//		cert := loadCert(fnCore, t)
-	//		SoMsg("Issuer", chain.Issuer.Eq(cert), ShouldBeTrue)
+	//		SoMsg("Issuer", chain.Issuer.Equal(cert), ShouldBeTrue)
 	//	})
 	//})
 
@@ -160,7 +160,7 @@ func Test_Chain_IAVer(t *testing.T) {
 	})
 }
 
-func Test_Chain_Eq(t *testing.T) {
+func Test_Chain_Equal(t *testing.T) {
 	Convey("Load Certificate from Raw", t, func() {
 		c1 := loadChain(fnChain, t)
 		c2 := loadChain(fnChain, t)

--- a/go/lib/snet/addr.go
+++ b/go/lib/snet/addr.go
@@ -61,8 +61,8 @@ func (a *Addr) Desc() string {
 	return fmt.Sprintf("%s Path: %t NextHop: %v", a, a.Path != nil, a.NextHop)
 }
 
-// EqAddr compares the IA/Host/L4port values with the supplied Addr
-func (a *Addr) EqAddr(o *Addr) bool {
+// EqualAddr compares the IA/Host/L4port values with the supplied Addr
+func (a *Addr) EqualAddr(o *Addr) bool {
 	if a == nil || o == nil {
 		return a == o
 	}

--- a/go/lib/snet/addr.go
+++ b/go/lib/snet/addr.go
@@ -66,10 +66,10 @@ func (a *Addr) EqAddr(o *Addr) bool {
 	if a == nil || o == nil {
 		return a == o
 	}
-	if !a.IA.Eq(o.IA) {
+	if !a.IA.Equal(o.IA) {
 		return false
 	}
-	return a.Host.Eq(o.Host)
+	return a.Host.Equal(o.Host)
 }
 
 func (a *Addr) Copy() *Addr {

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -252,7 +252,7 @@ func (n *SCIONNetwork) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr
 	if conn.laddr.IA.IsZero() {
 		conn.laddr.IA = n.IA()
 	}
-	if !conn.laddr.IA.Eq(conn.scionNet.localIA) {
+	if !conn.laddr.IA.Equal(conn.scionNet.localIA) {
 		return nil, common.NewBasicError("Unable to listen on non-local IA", nil,
 			"expected", conn.scionNet.localIA, "actual", conn.laddr.IA, "type", "public")
 	}
@@ -264,7 +264,7 @@ func (n *SCIONNetwork) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr
 		if err != nil {
 			return nil, common.NewBasicError("Unable to construct overlay bind address", err)
 		}
-		if !conn.baddr.IA.Eq(conn.scionNet.localIA) {
+		if !conn.baddr.IA.Equal(conn.scionNet.localIA) {
 			return nil, common.NewBasicError("Unable to listen on non-local IA", nil,
 				"expected", conn.scionNet.localIA, "actual", conn.baddr.IA, "type", "bind")
 		}

--- a/go/lib/snet/snetproxy/conn.go
+++ b/go/lib/snet/snetproxy/conn.go
@@ -318,7 +318,7 @@ func addressesEq(x, y net.Addr) bool {
 	}
 	xSnet := x.(*snet.Addr)
 	ySnet := y.(*snet.Addr)
-	return xSnet.EqAddr(ySnet)
+	return xSnet.EqualAddr(ySnet)
 }
 
 func returnOnDeadline(deadline time.Time) <-chan time.Time {

--- a/go/lib/snet/writer.go
+++ b/go/lib/snet/writer.go
@@ -171,7 +171,7 @@ func (r *remoteAddressResolver) resolveAddr(address *Addr) (*Addr, error) {
 	if address.Host == nil {
 		return nil, common.NewBasicError(ErrNoApplicationAddress, nil)
 	}
-	if r.localIA.Eq(address.IA) {
+	if r.localIA.Equal(address.IA) {
 		return r.resolveLocalDestination(address)
 	}
 	return r.resolveRemoteDestination(address)

--- a/go/lib/spath/hop.go
+++ b/go/lib/spath/hop.go
@@ -162,7 +162,10 @@ func (h *HopField) expTimeIfIdsPack() uint32 {
 	return uint32(h.ExpTime)<<24 | uint32(h.ConsIngress&0xFFF)<<12 | uint32(h.ConsEgress&0xFFF)
 }
 
-func (h *HopField) Eq(o *HopField) bool {
+func (h *HopField) Equal(o *HopField) bool {
+	if h == nil || o == nil {
+		return h == o
+	}
 	return h.Xover == o.Xover && h.VerifyOnly == o.VerifyOnly && h.ExpTime == o.ExpTime &&
 		h.ConsIngress == o.ConsIngress && h.ConsEgress == o.ConsEgress && bytes.Equal(h.Mac, o.Mac)
 }

--- a/go/lib/spath/info.go
+++ b/go/lib/spath/info.go
@@ -107,6 +107,9 @@ func (inf *InfoField) WriteTo(w io.Writer) (int64, error) {
 	return int64(n), err
 }
 
-func (h *InfoField) Eq(o *InfoField) bool {
+func (h *InfoField) Equal(o *InfoField) bool {
+	if h == nil || o == nil {
+		return h == o
+	}
 	return *h == *o
 }

--- a/go/lib/topology/addr.go
+++ b/go/lib/topology/addr.go
@@ -108,7 +108,7 @@ func (t *TopoAddr) fromRaw(s RawAddrMap) error {
 					"AddrType", hostType, "Addr", pbo.bind)
 			}
 			// Check pub and bind are not the same address
-			if pbo.pub.Eq(pbo.bind) {
+			if pbo.pub.Equal(pbo.bind) {
 				return common.NewBasicError(ErrBindAddrEqPubAddr, nil,
 					"bindAddr", pbo.bind, "pubAddr", pbo.pub)
 			}
@@ -148,13 +148,16 @@ func (t *TopoAddr) getAddr(ot overlay.Type) *pubBindAddr {
 }
 
 func (t *TopoAddr) Equal(o *TopoAddr) bool {
+	if t == nil || o == nil {
+		return t == o
+	}
 	if t.Overlay != o.Overlay {
 		return false
 	}
-	if !t.IPv4.equal(o.IPv4) {
+	if !t.IPv4.Equal(o.IPv4) {
 		return false
 	}
-	if !t.IPv6.equal(o.IPv6) {
+	if !t.IPv6.Equal(o.IPv6) {
 		return false
 	}
 	return true
@@ -234,20 +237,20 @@ func (t *pubBindAddr) BindOrPublic() *addr.AppAddr {
 	return t.bind
 }
 
-func (t1 *pubBindAddr) equal(t2 *pubBindAddr) bool {
+func (t1 *pubBindAddr) Equal(t2 *pubBindAddr) bool {
 	if (t1 == nil) && (t2 == nil) {
 		return true
 	}
 	if (t1 == nil) != (t2 == nil) {
 		return false
 	}
-	if !t1.pub.Eq(t2.pub) {
+	if !t1.pub.Equal(t2.pub) {
 		return false
 	}
-	if !t1.bind.Eq(t2.bind) {
+	if !t1.bind.Equal(t2.bind) {
 		return false
 	}
-	if !t1.overlay.Eq(t2.overlay) {
+	if !t1.overlay.Equal(t2.overlay) {
 		return false
 	}
 	return true

--- a/go/lib/topology/addr_test.go
+++ b/go/lib/topology/addr_test.go
@@ -221,7 +221,7 @@ func newOverlay(rapo *RawAddrPortOverlay) *overlay.OverlayAddr {
 }
 
 func shouldEqPubBindAddr(actual interface{}, expected ...interface{}) string {
-	if actual.(*pubBindAddr).equal(expected[0].(*pubBindAddr)) {
+	if actual.(*pubBindAddr).Equal(expected[0].(*pubBindAddr)) {
 		return ""
 	}
 	return fmt.Sprintf("Expected:\n\t%+v\nActual:\n\t%+v", expected[0], actual)

--- a/go/lib/topology/braddr.go
+++ b/go/lib/topology/braddr.go
@@ -75,7 +75,7 @@ func (t *TopoBRAddr) fromRaw(s RawBRAddrMap) error {
 					"AddrType", hostType, "Addr", ob.BindOverlay)
 			}
 			// Check PublicOverlay and BindOverlay are not the same address
-			if ob.PublicOverlay.Eq(ob.BindOverlay) {
+			if ob.PublicOverlay.Equal(ob.BindOverlay) {
 				return common.NewBasicError(ErrBindAddrEqPubAddr, nil,
 					"BindOverlayAddr", ob.BindOverlay, "PublicOverlayAddr", ob.PublicOverlay)
 			}
@@ -111,13 +111,16 @@ func (t *TopoBRAddr) getAddr(ot overlay.Type) *overBindAddr {
 }
 
 func (t *TopoBRAddr) Equal(o *TopoBRAddr) bool {
+	if t == nil || o == nil {
+		return t == o
+	}
 	if t.Overlay != o.Overlay {
 		return false
 	}
-	if !t.IPv4.equal(o.IPv4) {
+	if !t.IPv4.Equal(o.IPv4) {
 		return false
 	}
-	if !t.IPv6.equal(o.IPv6) {
+	if !t.IPv6.Equal(o.IPv6) {
 		return false
 	}
 	return true
@@ -171,17 +174,17 @@ func (t *overBindAddr) BindOrPublicOverlay() *overlay.OverlayAddr {
 	return t.PublicOverlay
 }
 
-func (t1 *overBindAddr) equal(t2 *overBindAddr) bool {
+func (t1 *overBindAddr) Equal(t2 *overBindAddr) bool {
 	if (t1 == nil) && (t2 == nil) {
 		return true
 	}
 	if (t1 == nil) != (t2 == nil) {
 		return false
 	}
-	if !t1.PublicOverlay.Eq(t2.PublicOverlay) {
+	if !t1.PublicOverlay.Equal(t2.PublicOverlay) {
 		return false
 	}
-	if !t1.BindOverlay.Eq(t2.BindOverlay) {
+	if !t1.BindOverlay.Equal(t2.BindOverlay) {
 		return false
 	}
 	return true

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -54,7 +54,7 @@ func (h *segReqHandler) sendEmptySegReply(ctx context.Context,
 // false otherwise.
 func (h *segReqHandler) isValidDst(segReq *path_mgmt.SegReq) bool {
 	// No validation on source here!
-	if segReq.DstIA().IsZero() || segReq.DstIA().I == 0 || segReq.DstIA().Eq(h.localIA) {
+	if segReq.DstIA().IsZero() || segReq.DstIA().I == 0 || segReq.DstIA().Equal(h.localIA) {
 		logger := log.FromCtx(h.request.Context())
 		logger.Warn("[segReqHandler] Drop, invalid dstIA", "dstIA", segReq.DstIA())
 		return false

--- a/go/path_srv/internal/handlers/segreqcore.go
+++ b/go/path_srv/internal/handlers/segreqcore.go
@@ -109,11 +109,11 @@ func (h *segReqCoreHandler) handleReq(ctx context.Context,
 	}
 	var coreSegs []*seg.PathSegment
 	// if request came from same AS also return core segs, to start of down segs.
-	if segReq.SrcIA().Eq(h.localIA) {
+	if segReq.SrcIA().Equal(h.localIA) {
 		ias := downSegs.FirstIAs()
 		downIAs := ias[:0]
 		for _, ia := range ias {
-			if !ia.Eq(h.localIA) {
+			if !ia.Equal(h.localIA) {
 				downIAs = append(downIAs, ia)
 			}
 		}

--- a/go/path_srv/internal/handlers/segreqnoncore.go
+++ b/go/path_srv/internal/handlers/segreqnoncore.go
@@ -91,7 +91,7 @@ func (h *segReqNonCoreHandler) Handle() {
 
 func (h *segReqNonCoreHandler) validSrcDst(segReq *path_mgmt.SegReq) bool {
 	logger := log.FromCtx(h.request.Context())
-	if !segReq.SrcIA().IsZero() && !segReq.SrcIA().Eq(h.localIA) {
+	if !segReq.SrcIA().IsZero() && !segReq.SrcIA().Equal(h.localIA) {
 		logger.Warn("[segReqHandler] Drop, invalid srcIA",
 			"srcIA", segReq.SrcIA())
 		return false
@@ -128,7 +128,7 @@ func (h *segReqNonCoreHandler) handleCoreDst(ctx context.Context, segReq *path_m
 	// TODO(lukedirtwalker): we shouldn't just query all cores, this could be a lot of overhead.
 	// Add a limit of cores we query.
 	for _, src := range upSegs.FirstIAs() {
-		if !src.Eq(dst) {
+		if !src.Equal(dst) {
 			res, err := h.fetchCoreSegs(ctx, msger, src, dst, segReq.Flags.CacheOnly)
 			if err != nil {
 				logger.Error("[segReqHandler] Failed to find core segs", "err", err)
@@ -185,7 +185,7 @@ func (h *segReqNonCoreHandler) handleNonCoreDst(ctx context.Context, segReq *pat
 		// TODO(lukedirtwalker): we shouldn't just query all cores, this could be a lot of overhead.
 		// Add a limit of cores we query.
 		for _, src := range upSegs.FirstIAs() {
-			if src.Eq(dst) {
+			if src.Equal(dst) {
 				connUpFirstIAs[src] = struct{}{}
 				connDownFirstIAs[dst] = struct{}{}
 				continue

--- a/go/path_srv/internal/segsyncer/segsyncer.go
+++ b/go/path_srv/internal/segsyncer/segsyncer.go
@@ -60,7 +60,7 @@ func StartAll(args handlers.HandlerArgs, msger infra.Messenger) ([]*periodic.Run
 	}
 	segSyncers := make([]*periodic.Runner, 0, len(trc.CoreASes)-1)
 	for coreAS := range trc.CoreASes {
-		if coreAS.Eq(args.IA) {
+		if coreAS.Equal(args.IA) {
 			continue
 		}
 		syncer := &SegSyncer{

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -104,7 +104,7 @@ func (f *fetcherHandler) GetPaths(ctx context.Context, req *sciond.PathReq,
 	if req.Src.IA().IsZero() {
 		req.Src = f.topology.ISD_AS.IAInt()
 	}
-	if !req.Src.IA().Eq(f.topology.ISD_AS) {
+	if !req.Src.IA().Equal(f.topology.ISD_AS) {
 		return f.buildSCIONDReply(nil, 0, sciond.ErrorBadSrcIA),
 			common.NewBasicError("Bad source AS", nil, "ia", req.Src.IA())
 	}
@@ -125,7 +125,7 @@ func (f *fetcherHandler) GetPaths(ctx context.Context, req *sciond.PathReq,
 		return f.buildSCIONDReply(nil, 0, sciond.ErrorBadDstIA),
 			common.NewBasicError("Bad destination AS", nil, "ia", req.Dst.IA())
 	}
-	if req.Dst.IA().Eq(f.topology.ISD_AS) {
+	if req.Dst.IA().Equal(f.topology.ISD_AS) {
 		return f.buildSCIONDReply(nil, 0, sciond.ErrorOk), nil
 	}
 	// A ISD-0 destination should not require a TRC lookup in sciond, it could lead to a

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -118,7 +118,7 @@ func (h *ASInfoRequestHandler) Handle(ctx context.Context, transport infra.Trans
 		// the future.
 		asInfoReply.Entries = []sciond.ASInfoReplyEntry{}
 	}
-	if reqIA.IsZero() || reqIA.Eq(topo.ISD_AS) {
+	if reqIA.IsZero() || reqIA.Equal(topo.ISD_AS) {
 		// Requested AS is us
 		asInfoReply.Entries = []sciond.ASInfoReplyEntry{
 			{

--- a/go/sig/egress/router/router.go
+++ b/go/sig/egress/router/router.go
@@ -120,5 +120,8 @@ func newCanonNet(ipnet *net.IPNet) *canonNet {
 }
 
 func (cn *canonNet) Equal(other *canonNet) bool {
+	if cn == nil || other == nil {
+		return cn == other
+	}
 	return cn.Mask.String() == other.Mask.String() && cn.IP.Equal(other.IP)
 }

--- a/go/sig/egress/session/sessmon.go
+++ b/go/sig/egress/session/sessmon.go
@@ -230,7 +230,7 @@ func (sm *sessMonitor) handleRep(rpld *disp.RegPld) {
 			"src", rpld.Addr, "type", common.TypeOf(rpld.P), "pld", rpld.P)
 		return
 	}
-	if !sm.sess.IA().Eq(rpld.Addr.IA) {
+	if !sm.sess.IA().Equal(rpld.Addr.IA) {
 		sm.Error("sessMonitor: SIGPollRep from wrong IA",
 			"expected", sm.sess.IA(), "actual", rpld.Addr.IA)
 		return
@@ -248,7 +248,7 @@ func (sm *sessMonitor) handleRep(rpld *disp.RegPld) {
 		}
 		// Update session's remote, if needed.
 		sessRemote := sm.sess.Remote()
-		if sessRemote == nil || !sm.smRemote.Sig.Eq(sessRemote.Sig) {
+		if sessRemote == nil || !sm.smRemote.Sig.Equal(sessRemote.Sig) {
 			sm.Info("sessMonitor: updating remote Info", "msgId", rpld.Id, "remote", sm.smRemote)
 			sm.sess.currRemote.Store(sm.smRemote)
 		}

--- a/go/sig/siginfo/sig.go
+++ b/go/sig/siginfo/sig.go
@@ -38,12 +38,12 @@ func (s *Sig) EncapSnetAddr() *snet.Addr {
 	return &snet.Addr{IA: s.IA, Host: &addr.AppAddr{L3: s.Host, L4: l4}}
 }
 
-func (s *Sig) Eq(x *Sig) bool {
+func (s *Sig) Equal(x *Sig) bool {
 	if s == nil || x == nil {
 		return s == x
 	}
 	return s.IA == x.IA &&
-		s.Host.Eq(x.Host) &&
+		s.Host.Equal(x.Host) &&
 		s.CtrlL4Port == x.CtrlL4Port &&
 		s.EncapL4Port == x.EncapL4Port
 }

--- a/go/tools/scion-pki/internal/pkicmn/pkicmn.go
+++ b/go/tools/scion-pki/internal/pkicmn/pkicmn.go
@@ -125,7 +125,7 @@ func asFromDir(dir string) (addr.AS, error) {
 
 func Contains(ases []addr.IA, as addr.IA) bool {
 	for _, ia := range ases {
-		if ia.Eq(as) {
+		if ia.Equal(as) {
 			return true
 		}
 	}

--- a/go/tools/scmp/main.go
+++ b/go/tools/scmp/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	// If remote is not in local AS, we need a path!
 	var pathStr string
-	if !cmn.Remote.IA.Eq(cmn.Local.IA) {
+	if !cmn.Remote.IA.Equal(cmn.Local.IA) {
 		cmn.Mtu = setPathAndMtu()
 		pathStr = cmn.PathEntry.Path.String()
 	} else {


### PR DESCRIPTION
The codebase inconsistently names equality checks `Eq` and `Equal`.
This PR renames all `Eq` to `Equal`.

Additionally, make all `Equal` methods handle nil gracefully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2371)
<!-- Reviewable:end -->
