### PR TITLE
Go dispatcher: Clean socket on shutdown

### DIFF
--- a/go/godispatcher/internal/config/config.go
+++ b/go/godispatcher/internal/config/config.go
@@ -33,6 +33,9 @@ type Config struct {
 		// PerfData starts the pprof HTTP server on the specified address. If not set,
 		// the server is not started.
 		PerfData string
+		// DeleteSocket specifies whether the dispatcher should delete the
+		// socket file prior to attempting to create a new one.
+		DeleteSocket bool
 	}
 	Logging env.Logging
 	Metrics env.Metrics

--- a/go/godispatcher/internal/config/config_test.go
+++ b/go/godispatcher/internal/config/config_test.go
@@ -40,5 +40,6 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("ApplicationSocket", cfg.Dispatcher.ApplicationSocket, ShouldEqual,
 			reliable.DefaultDispPath)
 		SoMsg("OverlayPort", cfg.Dispatcher.OverlayPort, ShouldEqual, overlay.EndhostPort)
+		SoMsg("DeleteSocket", cfg.Dispatcher.DeleteSocket, ShouldBeFalse)
 	})
 }

--- a/go/godispatcher/internal/config/sample.go
+++ b/go/godispatcher/internal/config/sample.go
@@ -29,6 +29,10 @@ const Sample = `
   # the server is not started.
   # PerfData = "127.0.0.1:6060"
 
+  # Set DeleteSock to true to have the Dispatcher remove the socket file (if it
+  # exists) on start (default false)
+  DeleteSocket = false
+
 [logging]
   [logging.file]
     # Location of the logging file.

--- a/go/lib/env/env.go
+++ b/go/lib/env/env.go
@@ -133,6 +133,8 @@ type Env struct {
 	AppShutdownSignal chan struct{}
 }
 
+// SetupEnv initializes a basic environment for applications. If reloadF is not
+// nil, the application will call reloadF whenever it receives a SIGHUP signal.
 func SetupEnv(reloadF func()) *Env {
 	e := &Env{}
 	e.setupSignals(reloadF)
@@ -140,7 +142,8 @@ func SetupEnv(reloadF func()) *Env {
 }
 
 // setupSignals sets up a goroutine that closes AppShutdownSignal on received
-// SIGTERM/SIGINT signals, and calls reloadF on SIGHUP.
+// SIGTERM/SIGINT signals. If reloadF is not nil, setupSignals also calls
+// reloadF on SIGHUP.
 func (e *Env) setupSignals(reloadF func()) {
 	e.AppShutdownSignal = make(chan struct{})
 	sig := make(chan os.Signal, 2)
@@ -152,15 +155,17 @@ func (e *Env) setupSignals(reloadF func()) {
 		log.Info("Received signal, exiting...", "signal", s)
 		close(e.AppShutdownSignal)
 	}()
-	go func() {
-		defer log.LogPanicAndExit()
-		for range sighupC {
-			log.Info("Received config reload signal")
-			if reloadF != nil {
-				reloadF()
+	if reloadF != nil {
+		go func() {
+			defer log.LogPanicAndExit()
+			for range sighupC {
+				log.Info("Received config reload signal")
+				if reloadF != nil {
+					reloadF()
+				}
 			}
-		}
-	}()
+		}()
+	}
 }
 
 func ReloadTopology(topologyPath string) {


### PR DESCRIPTION
Also, the Dispatcher config file can now specify whether the Dispatcher
should remove the old socket file on application start.