### PR TITLE
itopo: Split topo in static and dynamic

### DIFF
--- a/.buildkite/scripts/build_scion_img
+++ b/.buildkite/scripts/build_scion_img
@@ -2,7 +2,7 @@
 
 set -e
 
-BASE_IMG=${BASE_IMG:-aa88b1da1b510af630544ff6a8ff4c09111c595764efb025e3565b95759f043b}
+BASE_IMG=${BASE_IMG:-4b82d061b2c2d504eb292c92e0e8c3edb9f6c1064dcae0b49b89c6de7cced043}
 
 ./tools/ci/prepare_image "$BASE_IMG"
 ./docker.sh build

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -100,7 +100,7 @@ func realMain() int {
 func reload() error {
 	// FIXME(roosd): KeyConf reloading is not yet supported.
 	// https://github.com/scionproto/scion/issues/2077
-	cfg.General.Topology = itopo.GetCurrentTopology()
+	cfg.General.Topology = itopo.Get()
 	var newConf config.Config
 	// Load new config to get the CS parameters.
 	if _, err := toml.DecodeFile(env.ConfigFile(), &newConf); err != nil {

--- a/go/cert_srv/setup.go
+++ b/go/cert_srv/setup.go
@@ -61,7 +61,7 @@ func setup() error {
 	if err := env.InitGeneral(&cfg.General); err != nil {
 		return common.NewBasicError("Unable to initialize General config", err)
 	}
-	itopo.Init(proto.ServiceType_cs, itopo.Clbks{})
+	itopo.Init(proto.ServiceType_cs, itopo.Callbacks{})
 	if _, _, err := itopo.SetStatic(cfg.General.Topology, false); err != nil {
 		return common.NewBasicError("Unable to set initial static topology", err)
 	}

--- a/go/cert_srv/setup.go
+++ b/go/cert_srv/setup.go
@@ -61,7 +61,7 @@ func setup() error {
 	if err := env.InitGeneral(&cfg.General); err != nil {
 		return common.NewBasicError("Unable to initialize General config", err)
 	}
-	itopo.SetCurrentTopology(cfg.General.Topology)
+	itopo.InitSvc(cfg.General.ID, proto.ServiceType_cs, cfg.General.Topology, nil)
 	env.InitSciondClient(&cfg.Sciond)
 	if err := cfg.Init(cfg.General.ConfigDir); err != nil {
 		return common.NewBasicError("Unable to initialize CS config", err)

--- a/go/cert_srv/setup.go
+++ b/go/cert_srv/setup.go
@@ -61,7 +61,10 @@ func setup() error {
 	if err := env.InitGeneral(&cfg.General); err != nil {
 		return common.NewBasicError("Unable to initialize General config", err)
 	}
-	itopo.InitSvc(cfg.General.ID, proto.ServiceType_cs, cfg.General.Topology, nil)
+	itopo.Init(proto.ServiceType_cs, itopo.Clbks{})
+	if _, _, err := itopo.SetStatic(cfg.General.Topology, false); err != nil {
+		return common.NewBasicError("Unable to set initial static topology", err)
+	}
 	env.InitSciondClient(&cfg.Sciond)
 	if err := cfg.Init(cfg.General.ConfigDir); err != nil {
 		return common.NewBasicError("Unable to initialize CS config", err)

--- a/go/lib/env/env.go
+++ b/go/lib/env/env.go
@@ -172,7 +172,7 @@ func ReloadTopology(topologyPath string) {
 		log.Error("Unable to reload topology", "err", err)
 		return
 	}
-	itopo.SetCurrentTopology(topo)
+	itopo.SetStatic(topo, true)
 	log.Info("Reloaded topology")
 }
 

--- a/go/lib/infra/modules/itopo/cleaner.go
+++ b/go/lib/infra/modules/itopo/cleaner.go
@@ -33,11 +33,12 @@ type cleaner struct{}
 
 // Run deletes expired dynamic topologies and calls the dropFunc passed to Init.
 func (c cleaner) Run(ctx context.Context) {
-	topologyMtx.Lock()
-	defer topologyMtx.Unlock()
-	if dynamicTopo != nil && !dynamicTopo.Active(time.Now()) {
-		log.Info("[itopo.Cleaner] Dropping expired dynamic topology", "ts", dynamicTopo.Timestamp,
-			"ttl", dynamicTopo.TTL, "expired", dynamicTopo.Timestamp.Add(dynamicTopo.TTL))
-		call(clbks.DropDynamic)
+	s.state.Lock()
+	defer s.state.Unlock()
+	if s.state.topo.dynamic != nil && !s.state.topo.dynamic.Active(time.Now()) {
+		log.Info("[itopo.Cleaner] Dropping expired dynamic topology",
+			"ts", s.state.topo.dynamic.Timestamp, "ttl", s.state.topo.dynamic.TTL,
+			"expired", s.state.topo.dynamic.Expiry())
+		call(s.state.clbks.DropDynamic)
 	}
 }

--- a/go/lib/infra/modules/itopo/cleaner.go
+++ b/go/lib/infra/modules/itopo/cleaner.go
@@ -1,0 +1,43 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package itopo
+
+import (
+	"context"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/periodic"
+)
+
+var _ periodic.Task = cleaner{}
+
+// StartCleaner starts a periodic task that removes expired dynamic topologies.
+func StartCleaner(tick, timeout time.Duration) *periodic.Runner {
+	return periodic.StartPeriodicTask(cleaner{}, periodic.NewTicker(tick), timeout)
+}
+
+type cleaner struct{}
+
+// Run deletes expired dynamic topologies and calls the dropFunc passed to Init.
+func (c cleaner) Run(ctx context.Context) {
+	topologyMtx.Lock()
+	defer topologyMtx.Unlock()
+	if dynamicTopo != nil && !dynamicTopo.Active(time.Now()) {
+		log.Info("[itopo.Cleaner] Dropping expired dynamic topology", "ts", dynamicTopo.Timestamp,
+			"ttl", dynamicTopo.TTL, "expired", dynamicTopo.Timestamp.Add(dynamicTopo.TTL))
+		call(clbks.DropDynamic)
+	}
+}

--- a/go/lib/infra/modules/itopo/cleaner.go
+++ b/go/lib/infra/modules/itopo/cleaner.go
@@ -33,12 +33,12 @@ type cleaner struct{}
 
 // Run deletes expired dynamic topologies and calls the dropFunc passed to Init.
 func (c cleaner) Run(ctx context.Context) {
-	s.state.Lock()
-	defer s.state.Unlock()
-	if s.state.topo.dynamic != nil && !s.state.topo.dynamic.Active(time.Now()) {
+	st.Lock()
+	defer st.Unlock()
+	if st.topo.dynamic != nil && !st.topo.dynamic.Active(time.Now()) {
 		log.Info("[itopo.Cleaner] Dropping expired dynamic topology",
-			"ts", s.state.topo.dynamic.Timestamp, "ttl", s.state.topo.dynamic.TTL,
-			"expired", s.state.topo.dynamic.Expiry())
-		call(s.state.clbks.DropDynamic)
+			"ts", st.topo.dynamic.Timestamp, "ttl", st.topo.dynamic.TTL,
+			"expired", st.topo.dynamic.Expiry())
+		call(st.clbks.DropDynamic)
 	}
 }

--- a/go/lib/infra/modules/itopo/doc.go
+++ b/go/lib/infra/modules/itopo/doc.go
@@ -1,0 +1,134 @@
+// Copyright 2018 ETH Zurich
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package itopo stores the static and dynamic topology. Client packages
+that grab a reference with Get are guaranteed to receive a stable
+snapshot of the topology. The returned value is the topology that is
+currently active.
+
+There are two types of topologies, the static and the dynamic topology.
+For more information see lib/discovery.
+
+Initialization
+
+The package must be initialized with Init or InitSvc. In subsequent
+updates through SetStatic or SetDynamic, the new topology is checked
+whether it is compatible with the previous version. The rules differ
+between services.
+
+If the dynamic topology is set, the initializing client should start
+the periodic cleaner to evict expired dynamic topologies.
+
+Updates
+
+The update of the topology is only valid if a set of constraints is
+met. The constraints differ between dynamic and static topology, and
+also between the initialized service type.
+
+In a static topology update, when the diff is empty, the static
+topology is only updated if it expires later than the current static.
+Otherwise, SetStatic succeeds and indicates that the in-memory copy
+has not been updated.
+
+A static topology update can force the dynamic topology to be dropped,
+if it does no longer meet the constraints.
+
+Constraints
+
+The topology is split into four parts. An update is valid under the
+constraints, if the constraints for each part are met.
+
+Immutable:
+This part may not differ from the initial static topology.
+
+Mutable:
+This part may differ from the initial static topology. It may also
+differ between the currently active static and dynamic topology.
+
+Semi-Mutable:
+This part may differ between static topology versions. However, it
+may not differ between the current dynamic and static topology.
+If an update to the static topology modifies this part, the dynamic
+topology is dropped.
+
+Time:
+This part is ignored when validating the constraints. It is used
+to determine if a topology shall be updated if there are no
+differences in the other parts.
+
+Default Topology Split
+
+The topology file for default initialization (calling Init) is split
+into immutable, mutable and time.
+
+ ISD_AS                Immutable
+ Core                  Immutable
+ Overlay               Immutable
+ MTU                   Immutable
+
+ Service Entries       Mutable
+ BorderRouter Entries  Mutable
+
+ Timestamp             Time
+ TimestampHuman        Time
+ TTL                   Time
+
+Service Topology Split
+
+The topology file for services is split into immutable, mutable
+and time.
+
+ ISD_AS                Immutable
+ Core                  Immutable
+ Overlay               Immutable
+ MTU                   Immutable
+ OwnSvcType[OwnID]     Immutable // The service entry for the initialized element.
+
+ Service Entries       Mutable   // Except OwnSvcType[OwnID].
+ BorderRouter Entries  Mutable
+
+ Timestamp             Time
+ TimestampHuman        Time
+ TTL                   Time
+
+Border Router Topology Split
+
+The topology file for border routers is split into immutable,
+semi-mutable, mutable and time.
+
+ ISD_AS                              Immutable
+ Core                                Immutable
+ Overlay                             Immutable
+ MTU                                 Immutable
+ OwnSvcType[OwnID]                   Immutable
+ BorderRouters[OwnId][InternalAddrs] Immutable    // Internal address of initialized router.
+ BorderRouters[OwnId][CtrlAddr]      Immutable    // Control address of initialized router.
+
+ BorderRouters[OwnId][Interfaces]    Semi-Mutable // Interfaces of initialized router.
+
+ Service Entries       Mutable                    // Except BorderRouters[OwnId].
+ BorderRouter Entries  Mutable
+
+ Timestamp             Time
+ TimestampHuman        Time
+ TTL                   Time
+
+Callbacks
+
+The client package can register callbacks to be notified about
+certain events.
+*/
+package itopo

--- a/go/lib/infra/modules/itopo/doc.go
+++ b/go/lib/infra/modules/itopo/doc.go
@@ -23,10 +23,9 @@ For more information see lib/discovery.
 
 Initialization
 
-The package must be initialized with Init or InitSvc. In subsequent
-updates through SetStatic or SetDynamic, the new topology is checked
-whether it is compatible with the previous version. The rules differ
-between services.
+The package must be initialized with Init. In subsequent updates through
+SetStatic or SetDynamic, the new topology is checked whether it is
+compatible with the previous version. The rules differ between services.
 
 If the dynamic topology is set, the initializing client should start
 the periodic cleaner to evict expired dynamic topologies.

--- a/go/lib/infra/modules/itopo/doc.go
+++ b/go/lib/infra/modules/itopo/doc.go
@@ -1,4 +1,3 @@
-// Copyright 2018 ETH Zurich
 // Copyright 2019 Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/go/lib/infra/modules/itopo/doc.go
+++ b/go/lib/infra/modules/itopo/doc.go
@@ -47,7 +47,7 @@ if it does no longer meet the constraints.
 
 Constraints
 
-The topology is split into four parts. An update is valid under the
+The topology is split into five parts. An update is valid under the
 constraints, if the constraints for each part are met.
 
 Immutable:
@@ -68,10 +68,13 @@ This part is ignored when validating the constraints. It is used
 to determine if a topology shall be updated if there are no
 differences in the other parts.
 
+Ignored:
+This part is always ignored.
+
 Default Topology Split
 
 The topology file for default initialization (calling Init) is split
-into immutable, mutable and time.
+into immutable, mutable, time and ignored.
 
  ISD_AS                Immutable
  Core                  Immutable
@@ -82,13 +85,14 @@ into immutable, mutable and time.
  BorderRouter Entries  Mutable
 
  Timestamp             Time
- TimestampHuman        Time
  TTL                   Time
+
+ TimestampHuman        Ignored
 
 Service Topology Split
 
-The topology file for services is split into immutable, mutable
-and time.
+The topology file for services is split into immutable, mutable,
+time and ignored.
 
  ISD_AS                Immutable
  Core                  Immutable
@@ -100,30 +104,31 @@ and time.
  BorderRouter Entries  Mutable
 
  Timestamp             Time
- TimestampHuman        Time
  TTL                   Time
+
+ TimestampHuman        Ignored
 
 Border Router Topology Split
 
 The topology file for border routers is split into immutable,
-semi-mutable, mutable and time.
+semi-mutable, mutable, time and ignored.
 
  ISD_AS                              Immutable
  Core                                Immutable
  Overlay                             Immutable
  MTU                                 Immutable
- OwnSvcType[OwnID]                   Immutable
  BorderRouters[OwnId][InternalAddrs] Immutable    // Internal address of initialized router.
  BorderRouters[OwnId][CtrlAddr]      Immutable    // Control address of initialized router.
 
  BorderRouters[OwnId][Interfaces]    Semi-Mutable // Interfaces of initialized router.
 
- Service Entries       Mutable                    // Except BorderRouters[OwnId].
- BorderRouter Entries  Mutable
+ Service Entries       Mutable
+ BorderRouter Entries  Mutable                    // Except BorderRouters[OwnId].
 
  Timestamp             Time
- TimestampHuman        Time
  TTL                   Time
+
+ TimestampHuman        Ignored
 
 Callbacks
 

--- a/go/lib/infra/modules/itopo/itopo.go
+++ b/go/lib/infra/modules/itopo/itopo.go
@@ -27,10 +27,7 @@ import (
 	"github.com/scionproto/scion/go/proto"
 )
 
-var s struct {
-	sync.Mutex
-	state *state
-}
+var st *state
 
 // Callbacks are callbacks to respond to specific topology update events.
 type Callbacks struct {
@@ -45,19 +42,17 @@ type Callbacks struct {
 // Init initializes itopo with the particular validator. A topology must be
 // initialized by calling SetStatic.
 func Init(svc proto.ServiceType, clbks Callbacks) {
-	s.Lock()
-	defer s.Unlock()
-	if s.state != nil {
+	if st != nil {
 		panic("Must not re-initialize itopo")
 	}
-	s.state = newState(svc, clbks)
+	st = newState(svc, clbks)
 }
 
 // Get atomically gets the pointer to the current topology.
 func Get() *topology.Topo {
-	s.state.RLock()
-	defer s.state.RUnlock()
-	return s.state.topo.curr()
+	st.RLock()
+	defer st.RUnlock()
+	return st.topo.curr()
 }
 
 // SetStatic atomically sets the static topology. Whether semi-mutable fields are
@@ -67,7 +62,7 @@ func Get() *topology.Topo {
 // or dynamic set and still valid). The second return value indicates whether the in-memory
 // copy of the static topology has been updated.
 func SetStatic(static *topology.Topo, semiMutAllowed bool) (*topology.Topo, bool, error) {
-	return s.state.setStatic(static, semiMutAllowed)
+	return st.setStatic(static, semiMutAllowed)
 }
 
 // topo stores the currently active static and dynamic topologies.

--- a/go/lib/infra/modules/itopo/itopo.go
+++ b/go/lib/infra/modules/itopo/itopo.go
@@ -13,122 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package itopo stores the static and dynamic topology. Client packages
-// that grab a reference with Get are guaranteed to receive a stable
-// snapshot of the topology. The returned value is the topology that is
-// currently active.
-//
-// There are two types of topologies, the static and the dynamic topology.
-// For more information see lib/discovery.
-//
-// Initialization
-//
-// The package must be initialized with Init or InitSvc. In subsequent
-// updates through SetStatic or SetDynamic, the new topology is checked
-// whether it is compatible with the previous version. The rules differ
-// between services.
-//
-// If the dynamic topology is set, the initializing client should start
-// the periodic cleaner to evict expired dynamic topologies.
-//
-// Updates
-//
-// The update of the topology is only valid if a set of constraints is
-// met. The constraints differ between dynamic and static topology, and
-// also between the initialized service type.
-//
-// In a static topology update, when the diff is empty, the static
-// topology is only updated if it expires later than the current static.
-// Otherwise, SetStatic succeeds and indicates that the in-memory copy
-// has not been updated.
-//
-// A static topology update can force the dynamic topology to be dropped,
-// if it does no longer meet the constraints.
-//
-// Constraints
-//
-// The topology is split into four parts. An update is valid under the
-// constraints, if the constraints for each part are met.
-//
-// Immutable:
-// This part may not differ from the initial static topology.
-//
-// Mutable:
-// This part may differ from the initial static topology. It may also
-// differ between the currently active static and dynamic topology.
-//
-// Semi-Mutable:
-// This part may differ between static topology versions. However, it
-// may not differ between the current dynamic and static topology.
-// If an update to the static topology modifies this part, the dynamic
-// topology is dropped.
-//
-// Time:
-// This part is ignored when validating the constraints. It is used
-// to determine if a topology shall be updated if there are no
-// differences in the other parts.
-//
-// Default Topology Split
-//
-// The topology file for default initialization (calling Init) is split
-// into immutable, mutable and time.
-//
-//  ISD_AS                Immutable
-//  Core                  Immutable
-//  Overlay               Immutable
-//  MTU                   Immutable
-//
-//  Service Entries       Mutable
-//  BorderRouter Entries  Mutable
-//
-//  Timestamp             Time
-//  TimestampHuman        Time
-//  TTL                   Time
-//
-// Service Topology Split
-//
-// The topology file for services is split into immutable, mutable
-// and time.
-//
-//  ISD_AS                Immutable
-//  Core                  Immutable
-//  Overlay               Immutable
-//  MTU                   Immutable
-//  OwnSvcType[OwnID]     Immutable // The service entry for the initialized element.
-//
-//  Service Entries       Mutable   // Except OwnSvcType[OwnID].
-//  BorderRouter Entries  Mutable
-//
-//  Timestamp             Time
-//  TimestampHuman        Time
-//  TTL                   Time
-//
-// Border Router Topology Split
-//
-// The topology file for border routers is split into immutable,
-// semi-mutable, mutable and time.
-//
-//  ISD_AS                              Immutable
-//  Core                                Immutable
-//  Overlay                             Immutable
-//  MTU                                 Immutable
-//  OwnSvcType[OwnID]                   Immutable
-//  BorderRouters[OwnId][InternalAddrs] Immutable    // Internal address of initialized router.
-//  BorderRouters[OwnId][CtrlAddr]      Immutable    // Control address of initialized router.
-//
-//  BorderRouters[OwnId][Interfaces]    Semi-Mutable // Interfaces of initialized router.
-//
-//  Service Entries       Mutable                    // Except BorderRouters[OwnId].
-//  BorderRouter Entries  Mutable
-//
-//  Timestamp             Time
-//  TimestampHuman        Time
-//  TTL                   Time
-//
-// Callbacks
-//
-// The client package can register callbacks to be notified about
-// certain events.
 package itopo
 
 import (
@@ -138,19 +22,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/proto"
 )
 
-var (
-	validate    validator
-	clbks       Clbks
-	topologyMtx sync.RWMutex
-	staticTopo  *topology.Topo = nil
-	dynamicTopo *topology.Topo = nil
-)
+var s struct {
+	sync.Mutex
+	state *state
+}
 
 // Clbks are callbacks to respond to specific topology update events.
 type Clbks struct {
@@ -162,50 +42,22 @@ type Clbks struct {
 	UpdateStatic func()
 }
 
-// Init initializes itopo without a particular element set. When setting the topology,
-// only the immutable fields are checked.
-func Init(static *topology.Topo, callbacks *Clbks) error {
-	return InitSvc("", proto.ServiceType_unset, static, callbacks)
-}
-
-// InitSvc initializes itopo with a particular element set. When setting the topology,
-// the immutable and semi-mutable fields are checked.
-func InitSvc(id string, svc proto.ServiceType, static *topology.Topo, callbacks *Clbks) error {
-	if staticTopo != nil {
-		return common.NewBasicError("Must not re-initialize itopo", nil)
+// Init initializes itopo with the particular validator. A topology must be
+// initialized by calling SetStatic.
+func Init(svc proto.ServiceType, clbks Clbks) {
+	s.Lock()
+	defer s.Unlock()
+	if s.state != nil {
+		panic("Must not re-initialize itopo")
 	}
-	switch svc {
-	case proto.ServiceType_unset:
-		validate = &generalValidator{}
-	case proto.ServiceType_br:
-		// FIXME(roosd): add validator for border router.
-		validate = &generalValidator{}
-	default:
-		// FIMXE(roosd): add validator for service.
-		validate = &generalValidator{}
-	}
-	if err := validate.General(static); err != nil {
-		return common.NewBasicError("Unable to validate initial static topo", err)
-	}
-	if callbacks != nil {
-		clbks = *callbacks
-	}
-	staticTopo = static
-	return nil
+	s.state = newState(svc, clbks)
 }
 
 // Get atomically gets the pointer to the current topology.
 func Get() *topology.Topo {
-	topologyMtx.Lock()
-	defer topologyMtx.Unlock()
-	return currTopo()
-}
-
-func currTopo() *topology.Topo {
-	if dynamicTopo != nil && dynamicTopo.Active(time.Now()) {
-		return dynamicTopo
-	}
-	return staticTopo
+	s.state.RLock()
+	defer s.state.RUnlock()
+	return s.state.topo.curr()
 }
 
 // SetStatic atomically sets the static topology. Whether semi-mutable fields are
@@ -213,39 +65,89 @@ func currTopo() *topology.Topo {
 // topology is a pointer to the currently active topology. It might differ from
 // the input topology. The second return value indicates whether the in-memory
 // copy of the static topology has been updated.
-func SetStatic(topo *topology.Topo, semiMutAllowed bool) (*topology.Topo, bool, error) {
-	topologyMtx.Lock()
-	defer topologyMtx.Unlock()
-	if err := validate.General(topo); err != nil {
-		return nil, false, err
-	}
-	if err := validate.Immutable(topo, staticTopo); err != nil {
-		return nil, false, err
-	}
-	if err := validate.SemiMutable(topo, staticTopo, semiMutAllowed); err != nil {
-		return nil, false, err
-	}
-	updated := setStatic(topo, validate.DropDynamic(topo, staticTopo))
-	return currTopo(), updated, nil
+func SetStatic(static *topology.Topo, semiMutAllowed bool) (*topology.Topo, bool, error) {
+	return s.state.setStatic(static, semiMutAllowed)
 }
 
-// setStatic sets the static topology and calls the necessary callbacks.
-func setStatic(topo *topology.Topo, dropDynamic bool) bool {
-	expiresLater := staticTopo.TTL != 0 && (topo.TTL == 0 ||
-		topo.Timestamp.Add(topo.TTL).After(staticTopo.Timestamp.Add(staticTopo.TTL)))
+// topo stores the currently active static and dynamic topologies.
+type topo struct {
+	static  *topology.Topo
+	dynamic *topology.Topo
+}
+
+// curr returns the currently active topology.
+func (t *topo) curr() *topology.Topo {
+	if t.dynamic != nil && t.dynamic.Active(time.Now()) {
+		return t.dynamic
+	}
+	return t.static
+}
+
+// state keeps track of the active topologies and enforces update rules.
+type state struct {
+	sync.RWMutex
+	topo      topo
+	validator validator
+	clbks     Clbks
+}
+
+func newState(svc proto.ServiceType, clbks Clbks) *state {
+	s := &state{
+		validator: validatorFactory(svc),
+		clbks:     clbks,
+	}
+	return s
+}
+
+// setStatic atomically sets the static topology.
+func (s *state) setStatic(static *topology.Topo, allowed bool) (*topology.Topo, bool, error) {
+	s.Lock()
+	defer s.Unlock()
+	if err := s.validate(static, allowed); err != nil {
+		return nil, false, err
+	}
+	updated := s.updateStatic(static)
+	return s.topo.curr(), updated, nil
+}
+
+// validate validates that the new topology is valid given the currently active topology.
+func (s *state) validate(static *topology.Topo, allowed bool) error {
+	if err := s.validator.General(static); err != nil {
+		return err
+	}
+	if err := s.validator.Immutable(static, s.topo.static); err != nil {
+		return err
+	}
+	if err := s.validator.SemiMutable(static, s.topo.static, allowed); err != nil {
+		return err
+	}
+	return nil
+}
+
+// updateStatic updates the static topology, if necessary, and calls the corresponding callbacks.
+func (s *state) updateStatic(static *topology.Topo) bool {
 	// Only update static topology if the new one is different or longer valid for.
-	if cmp.Equal(topo, staticTopo, cmpopts.IgnoreFields(topology.Topo{},
-		"Timestamp", "TimestampHuman", "TTL")) && !expiresLater {
+	if cmp.Equal(static, s.topo.static, cmpopts.IgnoreFields(topology.Topo{},
+		"Timestamp", "TimestampHuman", "TTL")) && !expiresLater(static, s.topo.static) {
 		return false
 	}
-	staticTopo = topo
 	// Drop dynamic topology if necessary.
-	if dropDynamic && dynamicTopo != nil {
-		dynamicTopo = nil
-		call(clbks.DropDynamic)
+	if s.validator.MustDropDynamic(static, s.topo.static) && s.topo.dynamic != nil {
+		s.topo.dynamic = nil
+		call(s.clbks.DropDynamic)
 	}
-	call(clbks.UpdateStatic)
+	s.topo.static = static
+	call(s.clbks.UpdateStatic)
 	return true
+}
+
+func expiresLater(newTopo, oldTopo *topology.Topo) bool {
+	if oldTopo == nil {
+		return true
+	}
+	newExpiry := newTopo.Expiry()
+	oldExpiry := oldTopo.Expiry()
+	return !oldExpiry.IsZero() && (newExpiry.IsZero() || newExpiry.After(oldExpiry))
 }
 
 func call(clbk func()) {

--- a/go/lib/infra/modules/itopo/itopo.go
+++ b/go/lib/infra/modules/itopo/itopo.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,38 +13,246 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package itopo stores a singleton topology for reloading. Client packages
-// that grab a reference with GetCurrentTopology are guaranteed to receive a
-// stable snapshot of the topology.
+// Package itopo stores the static and dynamic topology. Client packages
+// that grab a reference with Get are guaranteed to receive a stable
+// snapshot of the topology. The returned value is the topology that is
+// currently active.
 //
-// To change the pointer for future GetCurrentTopology calls, use
-// SetCurrentTopology whenever topology information changes.
+// There are two types of topologies, the static and the dynamic topology.
+// For more information see lib/discovery.
+//
+// Initialization
+//
+// The package must be initialized with Init or InitSvc. In subsequent
+// updates through SetStatic or SetDynamic, the new topology is checked
+// whether it is compatible with the previous version. The rules differ
+// between services.
+//
+// If the dynamic topology is set, the initializing client should start
+// the periodic cleaner to evict expired dynamic topologies.
+//
+// Updates
+//
+// The update of the topology is only valid if a set of constraints is
+// met. The constraints differ between dynamic and static topology, and
+// also between the initialized service type.
+//
+// In a static topology update, when the diff is empty, the static
+// topology is only updated if it expires later than the current static.
+// Otherwise, SetStatic succeeds and indicates that the in-memory copy
+// has not been updated.
+//
+// A static topology update can force the dynamic topology to be dropped,
+// if it does no longer meet the constraints.
+//
+// Constraints
+//
+// The topology is split into four parts. An update is valid under the
+// constraints, if the constraints for each part are met.
+//
+// Immutable:
+// This part may not differ from the initial static topology.
+//
+// Mutable:
+// This part may differ from the initial static topology. It may also
+// differ between the currently active static and dynamic topology.
+//
+// Semi-Mutable:
+// This part may differ between static topology versions. However, it
+// may not differ between the current dynamic and static topology.
+// If an update to the static topology modifies this part, the dynamic
+// topology is dropped.
+//
+// Time:
+// This part is ignored when validating the constraints. It is used
+// to determine if a topology shall be updated if there are no
+// differences in the other parts.
+//
+// Default Topology Split
+//
+// The topology file for default initialization (calling Init) is split
+// into immutable, mutable and time.
+//
+//  ISD_AS                Immutable
+//  Core                  Immutable
+//  Overlay               Immutable
+//  MTU                   Immutable
+//
+//  Service Entries       Mutable
+//  BorderRouter Entries  Mutable
+//
+//  Timestamp             Time
+//  TimestampHuman        Time
+//  TTL                   Time
+//
+// Service Topology Split
+//
+// The topology file for services is split into immutable, mutable
+// and time.
+//
+//  ISD_AS                Immutable
+//  Core                  Immutable
+//  Overlay               Immutable
+//  MTU                   Immutable
+//  OwnSvcType[OwnID]     Immutable // The service entry for the initialized element.
+//
+//  Service Entries       Mutable   // Except OwnSvcType[OwnID].
+//  BorderRouter Entries  Mutable
+//
+//  Timestamp             Time
+//  TimestampHuman        Time
+//  TTL                   Time
+//
+// Border Router Topology Split
+//
+// The topology file for border routers is split into immutable,
+// semi-mutable, mutable and time.
+//
+//  ISD_AS                              Immutable
+//  Core                                Immutable
+//  Overlay                             Immutable
+//  MTU                                 Immutable
+//  OwnSvcType[OwnID]                   Immutable
+//  BorderRouters[OwnId][InternalAddrs] Immutable    // Internal address of initialized router.
+//  BorderRouters[OwnId][CtrlAddr]      Immutable    // Control address of initialized router.
+//
+//  BorderRouters[OwnId][Interfaces]    Semi-Mutable // Interfaces of initialized router.
+//
+//  Service Entries       Mutable                    // Except BorderRouters[OwnId].
+//  BorderRouter Entries  Mutable
+//
+//  Timestamp             Time
+//  TimestampHuman        Time
+//  TTL                   Time
+//
+// Callbacks
+//
+// The client package can register callbacks to be notified about
+// certain events.
 package itopo
 
 import (
 	"sync"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/topology"
+	"github.com/scionproto/scion/go/proto"
 )
 
 var (
-	topologyMtx     sync.RWMutex
-	currentTopology *topology.Topo = nil
+	validate    validator
+	clbks       Clbks
+	topologyMtx sync.RWMutex
+	staticTopo  *topology.Topo = nil
+	dynamicTopo *topology.Topo = nil
 )
 
-// SetCurrentTopology atomically sets the package-wide default topology to
-// topo.
-func SetCurrentTopology(topo *topology.Topo) {
-	topologyMtx.Lock()
-	currentTopology = topo
-	topologyMtx.Unlock()
+// Clbks are callbacks to respond to specific topology update events.
+type Clbks struct {
+	// CleanDynamic is called whenever dynamic topology is dropped due to expiration.
+	CleanDynamic func()
+	// DropDynamic is called whenever dynamic topology is dropped due to static update.
+	DropDynamic func()
+	// UpdateStatic is called whenever the pointer to static topology is updated.
+	UpdateStatic func()
 }
 
-// GetCurrentTopology atomically returns a pointer to the package-wide
-// default topology.
-func GetCurrentTopology() *topology.Topo {
-	topologyMtx.RLock()
-	t := currentTopology
-	topologyMtx.RUnlock()
-	return t
+// Init initializes itopo without a particular element set. When setting the topology,
+// only the immutable fields are checked.
+func Init(static *topology.Topo, callbacks *Clbks) error {
+	return InitSvc("", proto.ServiceType_unset, static, callbacks)
+}
+
+// InitSvc initializes itopo with a particular element set. When setting the topology,
+// the immutable and semi-mutable fields are checked.
+func InitSvc(id string, svc proto.ServiceType, static *topology.Topo, callbacks *Clbks) error {
+	if staticTopo != nil {
+		return common.NewBasicError("Must not re-initialize itopo", nil)
+	}
+	switch svc {
+	case proto.ServiceType_unset:
+		validate = &generalValidator{}
+	case proto.ServiceType_br:
+		// FIXME(roosd): add validator for border router.
+		validate = &generalValidator{}
+	default:
+		// FIMXE(roosd): add validator for service.
+		validate = &generalValidator{}
+	}
+	if err := validate.General(static); err != nil {
+		return common.NewBasicError("Unable to validate initial static topo", err)
+	}
+	if callbacks != nil {
+		clbks = *callbacks
+	}
+	staticTopo = static
+	return nil
+}
+
+// Get atomically gets the pointer to the current topology.
+func Get() *topology.Topo {
+	topologyMtx.Lock()
+	defer topologyMtx.Unlock()
+	return currTopo()
+}
+
+func currTopo() *topology.Topo {
+	if dynamicTopo != nil && dynamicTopo.Active(time.Now()) {
+		return dynamicTopo
+	}
+	return staticTopo
+}
+
+// SetStatic atomically sets the static topology. Whether semi-mutable fields are
+// allowed to change can be specified using semiMutAllowed. The returned
+// topology is a pointer to the currently active topology. It might differ from
+// the input topology. The second return value indicates whether the in-memory
+// copy of the static topology has been updated.
+func SetStatic(topo *topology.Topo, semiMutAllowed bool) (*topology.Topo, bool, error) {
+	topologyMtx.Lock()
+	defer topologyMtx.Unlock()
+	if err := validate.General(topo); err != nil {
+		return nil, false, err
+	}
+	if err := validate.Immutable(topo, staticTopo); err != nil {
+		return nil, false, err
+	}
+	if err := validate.SemiMutable(topo, staticTopo, semiMutAllowed); err != nil {
+		return nil, false, err
+	}
+	updated := setStatic(topo, validate.DropDynamic(topo, staticTopo))
+	return currTopo(), updated, nil
+}
+
+// setStatic sets the static topology and calls the necessary callbacks.
+func setStatic(topo *topology.Topo, dropDynamic bool) bool {
+	expiresLater := staticTopo.TTL != 0 && (topo.TTL == 0 ||
+		topo.Timestamp.Add(topo.TTL).After(staticTopo.Timestamp.Add(staticTopo.TTL)))
+	// Only update static topology if the new one is different or longer valid for.
+	if cmp.Equal(topo, staticTopo, cmpopts.IgnoreFields(topology.Topo{},
+		"Timestamp", "TimestampHuman", "TTL")) && !expiresLater {
+		return false
+	}
+	staticTopo = topo
+	// Drop dynamic topology if necessary.
+	if dropDynamic && dynamicTopo != nil {
+		dynamicTopo = nil
+		call(clbks.DropDynamic)
+	}
+	call(clbks.UpdateStatic)
+	return true
+}
+
+func call(clbk func()) {
+	if clbk != nil {
+		go func() {
+			defer log.LogPanicAndExit()
+			clbk()
+		}()
+	}
 }

--- a/go/lib/infra/modules/itopo/itopo.go
+++ b/go/lib/infra/modules/itopo/itopo.go
@@ -103,25 +103,11 @@ func newState(svc proto.ServiceType, clbks Clbks) *state {
 func (s *state) setStatic(static *topology.Topo, allowed bool) (*topology.Topo, bool, error) {
 	s.Lock()
 	defer s.Unlock()
-	if err := s.validate(static, allowed); err != nil {
+	if err := s.validator.Validate(static, s.topo.static, allowed); err != nil {
 		return nil, false, err
 	}
 	updated := s.updateStatic(static)
 	return s.topo.curr(), updated, nil
-}
-
-// validate validates that the new topology is valid given the currently active topology.
-func (s *state) validate(static *topology.Topo, allowed bool) error {
-	if err := s.validator.General(static); err != nil {
-		return err
-	}
-	if err := s.validator.Immutable(static, s.topo.static); err != nil {
-		return err
-	}
-	if err := s.validator.SemiMutable(static, s.topo.static, allowed); err != nil {
-		return err
-	}
-	return nil
 }
 
 // updateStatic updates the static topology, if necessary, and calls the corresponding callbacks.

--- a/go/lib/infra/modules/itopo/itopo_test.go
+++ b/go/lib/infra/modules/itopo/itopo_test.go
@@ -1,0 +1,109 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package itopo
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSetStatic(t *testing.T) {
+	Convey("When itopo is initialized with no specific element", t, func() {
+		staticTopo = nil
+		called := clbkCalled{}
+		err := Init(loadTopo(fn, t), called.clbks())
+		SoMsg("err", err, ShouldBeNil)
+		dynamicTopo = staticTopo
+		topo := loadTopo(fn, t)
+		Convey("Calling with modified topo should succeed", func() {
+			ifinfo := topo.IFInfoMap[1]
+			ifinfo.MTU = 42
+			topo.IFInfoMap[1] = ifinfo
+			newTopo, updated, err := SetStatic(topo, true)
+			SoMsg("err", err, ShouldBeNil)
+			SoMsg("updated", updated, ShouldBeTrue)
+			SoMsg("topo", newTopo, ShouldEqual, topo)
+			called.check(false, false, true)
+		})
+		testNilTopo(&called, t)
+		testNoModified(&called, t)
+	})
+}
+
+func testNilTopo(called *clbkCalled, t *testing.T) {
+	Convey("Calling with nil topo should fail", func() {
+		_, updated, err := SetStatic(nil, true)
+		SoMsg("err", err, ShouldNotBeNil)
+		SoMsg("updated", updated, ShouldBeFalse)
+		called.check(false, false, false)
+	})
+}
+
+func testNoModified(called *clbkCalled, t *testing.T) {
+	t.Helper()
+	Convey("Calling with non-modified topo should succeed", func() {
+		topo := loadTopo(fn, t)
+		Convey("No update without time changes", func() {
+			prevTopo := staticTopo
+			newTopo, updated, err := SetStatic(topo, true)
+			SoMsg("err", err, ShouldBeNil)
+			SoMsg("updated", updated, ShouldBeFalse)
+			SoMsg("topo", newTopo, ShouldEqual, prevTopo)
+			called.check(false, false, false)
+		})
+		Convey("No update if expires earlier", func() {
+			topo.Timestamp = topo.Timestamp.Add(time.Second)
+			topo.TTL -= 2 * time.Second
+			prevTopo := staticTopo
+			newTopo, updated, err := SetStatic(topo, true)
+			SoMsg("err", err, ShouldBeNil)
+			SoMsg("updated", updated, ShouldBeFalse)
+			SoMsg("topo", newTopo, ShouldEqual, prevTopo)
+			called.check(false, false, false)
+		})
+		Convey("Update if expires later", func() {
+			topo.Timestamp = topo.Timestamp.Add(time.Second)
+			newTopo, updated, err := SetStatic(topo, true)
+			SoMsg("err", err, ShouldBeNil)
+			SoMsg("updated", updated, ShouldBeTrue)
+			SoMsg("topo", newTopo, ShouldEqual, topo)
+			called.check(false, false, true)
+		})
+	})
+}
+
+type clbkCalled struct {
+	clean  bool
+	drop   bool
+	update bool
+}
+
+func (c *clbkCalled) check(clean, drop, update bool) {
+	// Wait for callbacks to be executed
+	time.Sleep(10 * time.Millisecond)
+	SoMsg("clbk clean", c.clean, ShouldEqual, clean)
+	SoMsg("clbk drop", c.drop, ShouldEqual, drop)
+	SoMsg("clbk update", c.update, ShouldEqual, update)
+}
+
+func (c *clbkCalled) clbks() *Clbks {
+	return &Clbks{
+		CleanDynamic: func() { c.clean = true },
+		DropDynamic:  func() { c.drop = true },
+		UpdateStatic: func() { c.update = true },
+	}
+}

--- a/go/lib/infra/modules/itopo/itopo_test.go
+++ b/go/lib/infra/modules/itopo/itopo_test.go
@@ -25,8 +25,8 @@ import (
 
 func TestInit(t *testing.T) {
 	Convey("Initializing itopo twice should panic", t, func() {
-		SoMsg("first", func() { Init(0, Clbks{}) }, ShouldNotPanic)
-		SoMsg("second", func() { Init(0, Clbks{}) }, ShouldPanic)
+		SoMsg("first", func() { Init(0, Callbacks{}) }, ShouldNotPanic)
+		SoMsg("second", func() { Init(0, Callbacks{}) }, ShouldPanic)
 	})
 }
 
@@ -109,8 +109,8 @@ func (c *clbkCalled) check(clean, drop, update bool) {
 	SoMsg("clbk update", c.update, ShouldEqual, update)
 }
 
-func (c *clbkCalled) clbks() Clbks {
-	return Clbks{
+func (c *clbkCalled) clbks() Callbacks {
+	return Callbacks{
 		CleanDynamic: func() { c.clean = true },
 		DropDynamic:  func() { c.drop = true },
 		UpdateStatic: func() { c.update = true },

--- a/go/lib/infra/modules/itopo/testdata/topo.json
+++ b/go/lib/infra/modules/itopo/testdata/topo.json
@@ -1,0 +1,41 @@
+{
+    "Timestamp": 168570123,
+    "TimestampHuman": "1975-05-06 01:02:03.000000+0000",
+    "TTL": 3600,
+    "ISD_AS": "1-ff00:0:311",
+    "MTU": 1472,
+    "Overlay": "IPv4+6",
+    "Core": false,
+    "BorderRouters": {
+        "br1-ff00:0:311-1": {
+            "InternalAddrs": {
+                "IPv4": {"PublicOverlay": {"Addr": "10.1.0.1"}},
+                "IPv6": {"PublicOverlay": {"Addr": "2001:db8:a0b:12f0::1"}}
+            },
+            "CtrlAddr": {
+                "IPv4": {"Public": {"Addr": "10.1.0.1", "L4Port": 30098}},
+                "IPv6": {"Public": {"Addr": "2001:db8:a0b:12f0::1", "L4Port": 30098}}
+            },
+            "Interfaces": {
+                "1": {
+                    "Overlay": "UDP/IPv4",
+                    "BindOverlay": {"Addr": "10.0.0.1"},
+                    "PublicOverlay": {"Addr": "192.0.2.1", "OverlayPort": 44997},
+                    "RemoteOverlay": {"Addr": "192.0.2.2", "OverlayPort": 44998},
+                    "Bandwidth": 1000,
+                    "ISD_AS": "1-ff00:0:312",
+                    "LinkTo": "PARENT",
+                    "MTU": 1472
+                }
+            }
+        }
+    },
+    "CertificateService": {
+        "cs1-ff00:0:311-1": {"Addrs": {
+            "IPv4": {"Public": {"Addr": "127.0.0.66", "L4Port": 30081},
+                     "Bind": {"Addr": "127.0.0.67", "L4Port": 30081}}}
+        },
+        "cs1-ff00:0:311-2": {"Addrs": {
+            "IPv4": {"Public": {"Addr": "127.0.0.67", "L4Port": 30073}}}}
+    }
+}

--- a/go/lib/infra/modules/itopo/validate.go
+++ b/go/lib/infra/modules/itopo/validate.go
@@ -1,0 +1,69 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package itopo
+
+import (
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/topology"
+)
+
+// validator is used to validate that the topology update is permissible.
+type validator interface {
+	General(topo *topology.Topo) error
+	Immutable(topo, oldTopo *topology.Topo) error
+	SemiMutable(topo, oldTopo *topology.Topo, allowed bool) error
+	DropDynamic(topo, oldTopo *topology.Topo) bool
+}
+
+var _ validator = (*generalValidator)(nil)
+
+// generalValidator is used to validate updates if no specific element information
+// is set. It only checks that the topology is non-nil and the immutable fields are
+// not modified.
+type generalValidator struct{}
+
+func (v *generalValidator) General(topo *topology.Topo) error {
+	if topo == nil {
+		return common.NewBasicError("Topo must not be nil", nil)
+	}
+	return nil
+}
+
+func (v *generalValidator) Immutable(topo, oldTopo *topology.Topo) error {
+	if !topo.ISD_AS.Equal(oldTopo.ISD_AS) {
+		return common.NewBasicError("IA is immutable", nil,
+			"expected", oldTopo.ISD_AS, "actual", topo.ISD_AS)
+	}
+	if topo.Core != oldTopo.Core {
+		return common.NewBasicError("Core is immutable", nil,
+			"expected", oldTopo.Core, "actual", topo.Core)
+	}
+	if topo.Overlay != oldTopo.Overlay {
+		return common.NewBasicError("Overlay is immutable", nil,
+			"expected", oldTopo.Overlay, "actual", topo.Overlay)
+	}
+	if topo.MTU != oldTopo.MTU {
+		return common.NewBasicError("MTU is immutable", nil,
+			"expected", oldTopo.MTU, "actual", topo.MTU)
+	}
+	return nil
+}
+func (*generalValidator) SemiMutable(_, _ *topology.Topo, _ bool) error {
+	return nil
+}
+
+func (*generalValidator) DropDynamic(_, _ *topology.Topo) bool {
+	return false
+}

--- a/go/lib/infra/modules/itopo/validate.go
+++ b/go/lib/infra/modules/itopo/validate.go
@@ -47,7 +47,7 @@ func validatorFactory(svc proto.ServiceType) validator {
 	}
 }
 
-// validatorWrap wraps the internalValidator and only exposes Validate and MustDropDynamic.
+// validatorWrap wraps the internalValidator and implements validator.
 type validatorWrap struct {
 	internalValidator
 }
@@ -72,7 +72,7 @@ type internalValidator interface {
 	// specific to the validator. However, at the very least, this check ensures that the
 	// provided topology is non-nil.
 	General(topo *topology.Topo) error
-	// Immutable checks that the immutable parts of the topology update are valid.
+	// Immutable checks that the immutable parts of the topology do not change.
 	Immutable(topo, oldTopo *topology.Topo) error
 	// SemiMutable checks that the semi-mutable parts of the topology update are valid.
 	SemiMutable(topo, oldTopo *topology.Topo, allowed bool) error

--- a/go/lib/infra/modules/itopo/validate_test.go
+++ b/go/lib/infra/modules/itopo/validate_test.go
@@ -46,7 +46,7 @@ func TestGeneralValidatorImmutable(t *testing.T) {
 	})
 }
 
-func testGenImmutable(v validator, topo, oldTopo *topology.Topo, t *testing.T) {
+func testGenImmutable(v internalValidator, topo, oldTopo *topology.Topo, t *testing.T) {
 	t.Helper()
 	Convey("Updating the IA is not allowed", func() {
 		topo.ISD_AS.I = 0

--- a/go/lib/infra/modules/itopo/validate_test.go
+++ b/go/lib/infra/modules/itopo/validate_test.go
@@ -1,0 +1,79 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package itopo
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/overlay"
+	"github.com/scionproto/scion/go/lib/topology"
+)
+
+var fn = "testdata/topo.json"
+
+func TestGeneralValidatorGeneral(t *testing.T) {
+	Convey("Given a general validator", t, func() {
+		v := generalValidator{}
+		Convey("A nil topology is not valid", func() {
+			SoMsg("err", v.General(nil), ShouldNotBeNil)
+		})
+		Convey("A topology should be valid", func() {
+			SoMsg("err", v.General(loadTopo(fn, t)), ShouldBeNil)
+		})
+	})
+}
+
+func TestGeneralValidatorImmutable(t *testing.T) {
+	Convey("Given a general validator", t, func() {
+		oldTopo := loadTopo(fn, t)
+		topo := loadTopo(fn, t)
+		testGenImmutable(&generalValidator{}, topo, oldTopo, t)
+	})
+}
+
+func testGenImmutable(v validator, topo, oldTopo *topology.Topo, t *testing.T) {
+	t.Helper()
+	Convey("Updating the IA is not allowed", func() {
+		topo.ISD_AS.I = 0
+		SoMsg("err", v.Immutable(topo, oldTopo), ShouldNotBeNil)
+	})
+	Convey("Updating the core flag is not allowed", func() {
+		topo.Core = true
+		SoMsg("err", v.Immutable(topo, oldTopo), ShouldNotBeNil)
+	})
+	Convey("Updating the overlay is not allowed", func() {
+		topo.Overlay = overlay.IPv6
+		SoMsg("err", v.Immutable(topo, oldTopo), ShouldNotBeNil)
+	})
+	Convey("Updating the mtu is not allowed", func() {
+		topo.MTU = 42
+		SoMsg("err", v.Immutable(topo, oldTopo), ShouldNotBeNil)
+	})
+	Convey("Changing a mutable field is allowed", func() {
+		topo.TTL = time.Second
+	})
+}
+
+func loadTopo(filename string, t *testing.T) *topology.Topo {
+	t.Helper()
+	topo, err := topology.LoadFromFile(filename)
+	if err != nil {
+		t.Fatalf("Error loading config from '%s': %v", filename, err)
+	}
+	return topo
+}

--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -639,7 +639,7 @@ func (store *Store) isLocal(address net.Addr) error {
 // ChooseServer builds a CS address for crypto material regarding the
 // destination AS.
 func (store *Store) ChooseServer(ctx context.Context, destination addr.IA) (net.Addr, error) {
-	topo := itopo.GetCurrentTopology()
+	topo := itopo.Get()
 	if store.config.ServiceType != proto.ServiceType_cs {
 		svcInfo, err := topo.GetSvcInfo(proto.ServiceType_cs)
 		if err != nil {

--- a/go/lib/infra/modules/trust/trust_test.go
+++ b/go/lib/infra/modules/trust/trust_test.go
@@ -759,7 +759,7 @@ func initStore(t *testing.T, ctrl *gomock.Controller,
 	topo := topology.NewTopo()
 	topotestutil.AddServer(topo, proto.ServiceType_cs, "foo",
 		topology.TestTopoAddr(nil, nil, nil, nil))
-	itopo.SetCurrentTopology(topo)
+	itopo.Init(topo, nil)
 	store, err := NewStore(db, ia, &Config{}, log.Root())
 	xtest.FailOnErr(t, err)
 	// Enable fake network access for trust database

--- a/go/lib/infra/modules/trust/trust_test.go
+++ b/go/lib/infra/modules/trust/trust_test.go
@@ -764,7 +764,7 @@ func initStore(t *testing.T, ctrl *gomock.Controller,
 	topotestutil.AddServer(topo, proto.ServiceType_cs, "foo",
 		topology.TestTopoAddr(nil, nil, nil, nil))
 	itopoOnce.Do(func() {
-		itopo.Init(proto.ServiceType_unset, itopo.Clbks{})
+		itopo.Init(proto.ServiceType_unset, itopo.Callbacks{})
 	})
 	_, _, err = itopo.SetStatic(topo, false)
 	xtest.FailOnErr(t, err)

--- a/go/lib/infra/modules/trust/trust_test.go
+++ b/go/lib/infra/modules/trust/trust_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -66,6 +67,9 @@ var (
 	}
 	tmpDir string
 )
+
+// itopoOnce makes sure that itopo is only initialized once.
+var itopoOnce sync.Once
 
 func TestMain(m *testing.M) {
 	var cleanF func()
@@ -759,7 +763,11 @@ func initStore(t *testing.T, ctrl *gomock.Controller,
 	topo := topology.NewTopo()
 	topotestutil.AddServer(topo, proto.ServiceType_cs, "foo",
 		topology.TestTopoAddr(nil, nil, nil, nil))
-	itopo.Init(topo, nil)
+	itopoOnce.Do(func() {
+		itopo.Init(proto.ServiceType_unset, itopo.Clbks{})
+	})
+	_, _, err = itopo.SetStatic(topo, false)
+	xtest.FailOnErr(t, err)
 	store, err := NewStore(db, ia, &Config{}, log.Root())
 	xtest.FailOnErr(t, err)
 	// Enable fake network access for trust database

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -276,6 +276,14 @@ func (t *Topo) Active(now time.Time) bool {
 		now.Before(t.Timestamp.Add(t.TTL)))
 }
 
+// Expiry returns the expiration time of the topology. If TTL is zero, the zero value is returned.
+func (t *Topo) Expiry() time.Time {
+	if t.TTL == 0 {
+		return time.Time{}
+	}
+	return t.Timestamp.Add(t.TTL)
+}
+
 func (t *Topo) GetTopoAddrs(id string, svc proto.ServiceType) (*TopoAddr, error) {
 	svcInfo, err := t.GetSvcInfo(svc)
 	if err != nil {

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -227,6 +227,9 @@ func (t *Topo) populateBR(raw *RawTopo) error {
 			}
 			t.IFInfoMap[ifid] = ifinfo
 		}
+		sort.Slice(brInfo.IFIDs, func(i, j int) bool {
+			return brInfo.IFIDs[i] < brInfo.IFIDs[j]
+		})
 		t.BR[name] = brInfo
 		t.BRNames = append(t.BRNames, name)
 	}
@@ -271,6 +274,18 @@ func (t *Topo) populateServices(raw *RawTopo) error {
 func (t *Topo) Active(now time.Time) bool {
 	return !now.Before(t.Timestamp) && (t.TTL == 0 ||
 		now.Before(t.Timestamp.Add(t.TTL)))
+}
+
+func (t *Topo) GetTopoAddrs(id string, svc proto.ServiceType) (*TopoAddr, error) {
+	svcInfo, err := t.GetSvcInfo(svc)
+	if err != nil {
+		return nil, err
+	}
+	topoAddr := svcInfo.idTopoAddrMap.GetById(id)
+	if topoAddr == nil {
+		return nil, common.NewBasicError("Element not found", nil, "id", id)
+	}
+	return topoAddr, nil
 }
 
 func (t *Topo) GetAllTopoAddrs(svc proto.ServiceType) ([]TopoAddr, error) {

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -284,18 +284,6 @@ func (t *Topo) Expiry() time.Time {
 	return t.Timestamp.Add(t.TTL)
 }
 
-func (t *Topo) GetTopoAddrs(id string, svc proto.ServiceType) (*TopoAddr, error) {
-	svcInfo, err := t.GetSvcInfo(svc)
-	if err != nil {
-		return nil, err
-	}
-	topoAddr := svcInfo.idTopoAddrMap.GetById(id)
-	if topoAddr == nil {
-		return nil, common.NewBasicError("Element not found", nil, "id", id)
-	}
-	return topoAddr, nil
-}
-
 func (t *Topo) GetAllTopoAddrs(svc proto.ServiceType) ([]TopoAddr, error) {
 	svcInfo, err := t.GetSvcInfo(svc)
 	if err != nil {

--- a/go/path_srv/internal/cryptosyncer/cryptosyncer.go
+++ b/go/path_srv/internal/cryptosyncer/cryptosyncer.go
@@ -66,7 +66,7 @@ func (c *Syncer) Run(ctx context.Context) {
 }
 
 func (c *Syncer) chooseServer() (net.Addr, error) {
-	topo := itopo.GetCurrentTopology()
+	topo := itopo.Get()
 	svcInfo, err := topo.GetSvcInfo(proto.ServiceType_cs)
 	if err != nil {
 		return nil, err

--- a/go/path_srv/internal/handlers/common.go
+++ b/go/path_srv/internal/handlers/common.go
@@ -67,7 +67,7 @@ func newBaseHandler(request *infra.Request, args HandlerArgs) *baseHandler {
 		trustStore: args.TrustStore,
 		retryInt:   time.Second,
 		config:     args.Config,
-		topology:   itopo.GetCurrentTopology(),
+		topology:   itopo.Get(),
 	}
 }
 

--- a/go/path_srv/internal/segsyncer/segsyncer.go
+++ b/go/path_srv/internal/segsyncer/segsyncer.go
@@ -109,7 +109,7 @@ func (s *SegSyncer) getDstAddr(ctx context.Context) (net.Addr, error) {
 	var cPs net.Addr
 	// select a seg to reach the dst
 	for _, ps := range coreSegs {
-		cPs, err = addrutil.GetPath(addr.SvcPS, ps, ps.FirstIA(), itopo.GetCurrentTopology())
+		cPs, err = addrutil.GetPath(addr.SvcPS, ps, ps.FirstIA(), itopo.Get())
 		if err == nil {
 			return cPs, nil
 		}

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -92,7 +92,7 @@ func realMain() int {
 		log.Crit("Unable to initialize trustDB", "err", err)
 		return 1
 	}
-	topo := itopo.GetCurrentTopology()
+	topo := itopo.Get()
 	trustConf := &trust.Config{
 		ServiceType: proto.ServiceType_ps,
 	}
@@ -243,7 +243,7 @@ func setup() error {
 	if err := env.InitGeneral(&cfg.General); err != nil {
 		return err
 	}
-	itopo.SetCurrentTopology(cfg.General.Topology)
+	itopo.InitSvc(cfg.General.ID, proto.ServiceType_ps, cfg.General.Topology, nil)
 	environment = infraenv.InitInfraEnvironment(cfg.General.TopologyPath)
 	cfg.InitDefaults()
 	return nil

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -243,7 +243,7 @@ func setup() error {
 	if err := env.InitGeneral(&cfg.General); err != nil {
 		return err
 	}
-	itopo.Init(proto.ServiceType_ps, itopo.Clbks{})
+	itopo.Init(proto.ServiceType_ps, itopo.Callbacks{})
 	if _, _, err := itopo.SetStatic(cfg.General.Topology, false); err != nil {
 		return common.NewBasicError("Unable to set initial static topology", err)
 	}

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -243,7 +243,10 @@ func setup() error {
 	if err := env.InitGeneral(&cfg.General); err != nil {
 		return err
 	}
-	itopo.InitSvc(cfg.General.ID, proto.ServiceType_ps, cfg.General.Topology, nil)
+	itopo.Init(proto.ServiceType_ps, itopo.Clbks{})
+	if _, _, err := itopo.SetStatic(cfg.General.Topology, false); err != nil {
+		return common.NewBasicError("Unable to set initial static topology", err)
+	}
 	environment = infraenv.InitInfraEnvironment(cfg.General.TopologyPath)
 	cfg.InitDefaults()
 	return nil

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -75,7 +75,7 @@ func (f *Fetcher) GetPaths(ctx context.Context, req *sciond.PathReq,
 
 	handler := &fetcherHandler{
 		Fetcher:  f,
-		topology: itopo.GetCurrentTopology(),
+		topology: itopo.Get(),
 		logger:   logger,
 	}
 	return handler.GetPaths(ctx, req, earlyReplyInterval)

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -107,7 +107,7 @@ func (h *ASInfoRequestHandler) Handle(ctx context.Context, transport infra.Trans
 	// NOTE(scrye): Only support single-homed SCIONDs for now (returned slice
 	// will at most contain one element).
 	reqIA := pld.AsInfoReq.Isdas.IA()
-	topo := itopo.GetCurrentTopology()
+	topo := itopo.Get()
 	if reqIA.IsZero() {
 		reqIA = topo.ISD_AS
 	}
@@ -168,7 +168,7 @@ func (h *IFInfoRequestHandler) Handle(ctx context.Context, transport infra.Trans
 	logger.Debug("[IFInfoRequestHandler] Received request", "request", &pld.IfInfoRequest)
 	ifInfoRequest := pld.IfInfoRequest
 	ifInfoReply := &sciond.IFInfoReply{}
-	topo := itopo.GetCurrentTopology()
+	topo := itopo.Get()
 	if len(ifInfoRequest.IfIDs) == 0 {
 		// Reply with all the IFIDs we know
 		for ifid, ifInfo := range topo.IFInfoMap {
@@ -222,7 +222,7 @@ func (h *SVCInfoRequestHandler) Handle(ctx context.Context, transport infra.Tran
 		"request", &pld.ServiceInfoRequest)
 	svcInfoRequest := pld.ServiceInfoRequest
 	svcInfoReply := &sciond.ServiceInfoReply{}
-	topo := itopo.GetCurrentTopology()
+	topo := itopo.Get()
 	for _, t := range svcInfoRequest.ServiceTypes {
 		var hostInfos []hostinfo.HostInfo
 		hostInfos = makeHostInfos(topo, t)

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -172,7 +172,7 @@ func setup() error {
 	if err := env.InitGeneral(&cfg.General); err != nil {
 		return err
 	}
-	itopo.SetCurrentTopology(cfg.General.Topology)
+	itopo.Init(cfg.General.Topology, nil)
 	environment = infraenv.InitInfraEnvironment(cfg.General.TopologyPath)
 	cfg.InitDefaults()
 	return cfg.SD.CreateSocketDirs()

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -172,7 +172,7 @@ func setup() error {
 	if err := env.InitGeneral(&cfg.General); err != nil {
 		return err
 	}
-	itopo.Init(proto.ServiceType_unset, itopo.Clbks{})
+	itopo.Init(proto.ServiceType_unset, itopo.Callbacks{})
 	if _, _, err := itopo.SetStatic(cfg.General.Topology, false); err != nil {
 		return common.NewBasicError("Unable to set initial static topology", err)
 	}

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -172,7 +172,10 @@ func setup() error {
 	if err := env.InitGeneral(&cfg.General); err != nil {
 		return err
 	}
-	itopo.Init(cfg.General.Topology, nil)
+	itopo.Init(proto.ServiceType_unset, itopo.Clbks{})
+	if _, _, err := itopo.SetStatic(cfg.General.Topology, false); err != nil {
+		return common.NewBasicError("Unable to set initial static topology", err)
+	}
 	environment = infraenv.InitInfraEnvironment(cfg.General.TopologyPath)
 	cfg.InitDefaults()
 	return cfg.SD.CreateSocketDirs()

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -166,6 +166,36 @@
 			"revisionTime": "2016-10-12T20:53:35Z"
 		},
 		{
+			"checksumSHA1": "/H0fnTKou1lxzJOKMc/DvkG7osg=",
+			"path": "github.com/google/go-cmp/cmp",
+			"revision": "2248b49eaa8e1c8c0963ee77b40841adbc19d4ca",
+			"revisionTime": "2018-11-15T01:20:43Z"
+		},
+		{
+			"checksumSHA1": "bYLOpB2x8d265x+J5a6Yk6LTh7Q=",
+			"path": "github.com/google/go-cmp/cmp/cmpopts",
+			"revision": "2248b49eaa8e1c8c0963ee77b40841adbc19d4ca",
+			"revisionTime": "2018-11-15T01:20:43Z"
+		},
+		{
+			"checksumSHA1": "oLBV7th4sxzxzmf1b91NVVbdOfI=",
+			"path": "github.com/google/go-cmp/cmp/internal/diff",
+			"revision": "2248b49eaa8e1c8c0963ee77b40841adbc19d4ca",
+			"revisionTime": "2018-11-15T01:20:43Z"
+		},
+		{
+			"checksumSHA1": "kYtvRhMjM0X4bvEjR3pqEHLw1qo=",
+			"path": "github.com/google/go-cmp/cmp/internal/function",
+			"revision": "2248b49eaa8e1c8c0963ee77b40841adbc19d4ca",
+			"revisionTime": "2018-11-15T01:20:43Z"
+		},
+		{
+			"checksumSHA1": "FLgIRNmxNGpYuHemKzoSzaPrqiQ=",
+			"path": "github.com/google/go-cmp/cmp/internal/value",
+			"revision": "2248b49eaa8e1c8c0963ee77b40841adbc19d4ca",
+			"revisionTime": "2018-11-15T01:20:43Z"
+		},
+		{
 			"checksumSHA1": "bBQats+Oofu1ynsNBZcZEfldr8U=",
 			"path": "github.com/google/gopacket",
 			"revision": "a35e09f9f224786863ce609de910bc82fc4d4faf",


### PR DESCRIPTION
Split itopo topology into a static and dynamic version.

Currently, only the static topology can be set and fetched.
The code also contains an outline how the dynamic topology
will be used in a future PR.

The services currently only support setting the static
topology through a sighup reload. Querying the discovery
service will be added in a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2375)
<!-- Reviewable:end -->
