### PR TITLE
infra.Messenger: expose UpdateSigner/UpdateVerifier

### DIFF
--- a/go/border/braccept/brA.go
+++ b/go/border/braccept/brA.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/scionproto/scion/go/border/braccept/tpkt"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/l4"
 	"github.com/scionproto/scion/go/lib/scmp"
 )
@@ -161,15 +161,15 @@ func genTestsBrA(hMac hash.Hash) []*BRTest {
 	signedRevInfo := tpkt.MustSRevInfo(121, "1-ff00:0:1", "peer", tsNow32, 60)
 
 	ifStateInfoDown := &tpkt.PathMgmtPld{
-		Signer:      ctrl.NullSigner,
-		SigVerifier: ctrl.NullSigVerifier,
+		Signer:      infra.NullSigner,
+		SigVerifier: infra.NullSigVerifier,
 		Instance: &path_mgmt.IFStateInfos{Infos: []*path_mgmt.IFStateInfo{
 			{IfID: 121, Active: false, SRevInfo: signedRevInfo},
 		}},
 	}
 	ifStateInfoUp := &tpkt.PathMgmtPld{
-		Signer:      ctrl.NullSigner,
-		SigVerifier: ctrl.NullSigVerifier,
+		Signer:      infra.NullSigner,
+		SigVerifier: infra.NullSigVerifier,
 		Instance: &path_mgmt.IFStateInfos{Infos: []*path_mgmt.IFStateInfo{
 			{IfID: 121, Active: true, SRevInfo: nil},
 		}},

--- a/go/border/braccept/brD.go
+++ b/go/border/braccept/brD.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/scionproto/scion/go/border/braccept/tpkt"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/l4"
 	"github.com/scionproto/scion/go/lib/scmp"
 )
@@ -229,8 +229,8 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 	revPsScionHdr := tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.104", "1-ff00:0:1", "PS",
 		nil, common.L4UDP)
 	revPsPld := &tpkt.PathMgmtPld{
-		Signer:      ctrl.NullSigner,
-		SigVerifier: ctrl.NullSigVerifier,
+		Signer:      infra.NullSigner,
+		SigVerifier: infra.NullSigVerifier,
 		Instance:    sRevInfo,
 	}
 
@@ -284,8 +284,8 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 	revBsScionHdr := tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.104", "1-ff00:0:1", "BS",
 		nil, common.L4UDP)
 	revPsPld = &tpkt.PathMgmtPld{
-		Signer:      ctrl.NullSigner,
-		SigVerifier: ctrl.NullSigVerifier,
+		Signer:      infra.NullSigner,
+		SigVerifier: infra.NullSigVerifier,
 		Instance:    sRevInfo,
 	}
 
@@ -383,15 +383,15 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 	signedRevInfo := tpkt.MustSRevInfo(161, "1-ff00:0:1", "parent", tsNow32, 60)
 
 	ifStateInfoDown := &tpkt.PathMgmtPld{
-		Signer:      ctrl.NullSigner,
-		SigVerifier: ctrl.NullSigVerifier,
+		Signer:      infra.NullSigner,
+		SigVerifier: infra.NullSigVerifier,
 		Instance: &path_mgmt.IFStateInfos{Infos: []*path_mgmt.IFStateInfo{
 			{IfID: 161, Active: false, SRevInfo: signedRevInfo},
 		}},
 	}
 	ifStateInfoUp := &tpkt.PathMgmtPld{
-		Signer:      ctrl.NullSigner,
-		SigVerifier: ctrl.NullSigVerifier,
+		Signer:      infra.NullSigner,
+		SigVerifier: infra.NullSigVerifier,
 		Instance: &path_mgmt.IFStateInfos{Infos: []*path_mgmt.IFStateInfo{
 			{IfID: 161, Active: true, SRevInfo: nil},
 		}},

--- a/go/border/braccept/common_tests.go
+++ b/go/border/braccept/common_tests.go
@@ -20,7 +20,7 @@ import (
 	"github.com/scionproto/scion/go/border/braccept/tpkt"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
-	"github.com/scionproto/scion/go/lib/infra/modules/trust"
+	"github.com/scionproto/scion/go/lib/infra"
 )
 
 var (
@@ -61,7 +61,7 @@ var (
 )
 
 var ifStateReq = &tpkt.PathMgmtPld{
-	Signer:      trust.NullSigner,
-	SigVerifier: trust.NullSigVerifier,
+	Signer:      infra.NullSigner,
+	SigVerifier: infra.NullSigVerifier,
 	Instance:    &path_mgmt.IFStateReq{},
 }

--- a/go/border/braccept/common_tests.go
+++ b/go/border/braccept/common_tests.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/scionproto/scion/go/border/braccept/tpkt"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 )
 
 var (
@@ -61,7 +61,7 @@ var (
 )
 
 var ifStateReq = &tpkt.PathMgmtPld{
-	Signer:      ctrl.NullSigner,
-	SigVerifier: ctrl.NullSigVerifier,
+	Signer:      trust.NullSigner,
+	SigVerifier: trust.NullSigVerifier,
 	Instance:    &path_mgmt.IFStateReq{},
 }

--- a/go/border/braccept/core_brA.go
+++ b/go/border/braccept/core_brA.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/scionproto/scion/go/border/braccept/tpkt"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/l4"
 	"github.com/scionproto/scion/go/lib/scmp"
 )
@@ -263,8 +263,8 @@ func genTestsCoreBrA(hMac hash.Hash) []*BRTest {
 	revBsScionHdr := tpkt.NewGenCmnHdr("1-ff00:0:1", "192.168.0.101", "1-ff00:0:1", "BS",
 		nil, common.L4UDP)
 	revPld := &tpkt.PathMgmtPld{
-		Signer:      ctrl.NullSigner,
-		SigVerifier: ctrl.NullSigVerifier,
+		Signer:      infra.NullSigner,
+		SigVerifier: infra.NullSigVerifier,
 		Instance:    sRevInfo,
 	}
 

--- a/go/border/rctrl/ifstate.go
+++ b/go/border/rctrl/ifstate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/snet"
 )
 
@@ -51,7 +52,7 @@ func genIFStateReq() {
 		logger.Error("Generating IFStateReq Ctrl payload", "err", err)
 		return
 	}
-	scpld, err := cpld.SignedPld(ctrl.NullSigner)
+	scpld, err := cpld.SignedPld(trust.NullSigner)
 	if err != nil {
 		logger.Error("Generating IFStateReq signed Ctrl payload", "err", err)
 		return

--- a/go/border/rctrl/ifstate.go
+++ b/go/border/rctrl/ifstate.go
@@ -21,7 +21,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
-	"github.com/scionproto/scion/go/lib/infra/modules/trust"
+	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/snet"
 )
 
@@ -52,7 +52,7 @@ func genIFStateReq() {
 		logger.Error("Generating IFStateReq Ctrl payload", "err", err)
 		return
 	}
-	scpld, err := cpld.SignedPld(trust.NullSigner)
+	scpld, err := cpld.SignedPld(infra.NullSigner)
 	if err != nil {
 		logger.Error("Generating IFStateReq signed Ctrl payload", "err", err)
 		return

--- a/go/border/rctrl/revinfo.go
+++ b/go/border/rctrl/revinfo.go
@@ -20,7 +20,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
-	"github.com/scionproto/scion/go/lib/infra/modules/trust"
+	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
 )
@@ -49,7 +49,7 @@ func fwdRevInfo(sRevInfo *path_mgmt.SignedRevInfo, dstHost addr.HostSVC) {
 		log.Error("Error generating RevInfo Ctrl payload", "err", err)
 		return
 	}
-	scpld, err := cpld.SignedPld(trust.NullSigner)
+	scpld, err := cpld.SignedPld(infra.NullSigner)
 	if err != nil {
 		log.Error("Error generating RevInfo signed Ctrl payload", "err", err)
 		return

--- a/go/border/rctrl/revinfo.go
+++ b/go/border/rctrl/revinfo.go
@@ -20,6 +20,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
 )
@@ -48,7 +49,7 @@ func fwdRevInfo(sRevInfo *path_mgmt.SignedRevInfo, dstHost addr.HostSVC) {
 		log.Error("Error generating RevInfo Ctrl payload", "err", err)
 		return
 	}
-	scpld, err := cpld.SignedPld(ctrl.NullSigner)
+	scpld, err := cpld.SignedPld(trust.NullSigner)
 	if err != nil {
 		log.Error("Error generating RevInfo signed Ctrl payload", "err", err)
 		return

--- a/go/cert_srv/internal/reiss/handler.go
+++ b/go/cert_srv/internal/reiss/handler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/scrypto/cert"
@@ -120,7 +121,7 @@ func (h *Handler) validateSign(ctx context.Context, addr *snet.Addr,
 	if err != nil {
 		return nil, err
 	}
-	verChain, err := ctrl.GetChainForSign(ctx, src, h.State.Store)
+	verChain, err := trust.GetChainForSign(ctx, src, h.State.Store)
 	if err != nil {
 		return nil, err
 	}

--- a/go/cert_srv/internal/reiss/requester.go
+++ b/go/cert_srv/internal/reiss/requester.go
@@ -24,7 +24,6 @@ import (
 	"github.com/scionproto/scion/go/cert_srv/internal/config"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/messenger"
@@ -42,7 +41,7 @@ var _ periodic.Task = (*Requester)(nil)
 // Requester requests reissued certificate chains before
 // expiration of the currently active certificate chain.
 type Requester struct {
-	Msgr     *messenger.Messenger
+	Msgr     infra.Messenger
 	State    *config.State
 	IA       addr.IA
 	LeafTime time.Duration
@@ -119,7 +118,7 @@ func (r *Requester) handleRep(ctx context.Context, rep *cert_mgmt.ChainIssRep) (
 	if err != nil {
 		return true, common.NewBasicError("Unable to set new signer", err)
 	}
-	signer := ctrl.NewBasicSigner(sign, r.State.GetSigningKey())
+	signer := trust.NewBasicSigner(sign, r.State.GetSigningKey())
 	r.State.SetSigner(signer)
 	r.Msgr.UpdateSigner(signer, []infra.MessageType{infra.ChainIssueRequest})
 	log.Info("[reiss.Requester] Updated certificate chain", "chain", chain)

--- a/go/cert_srv/internal/reiss/self.go
+++ b/go/cert_srv/internal/reiss/self.go
@@ -21,9 +21,7 @@ import (
 	"github.com/scionproto/scion/go/cert_srv/internal/config"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/infra"
-	"github.com/scionproto/scion/go/lib/infra/messenger"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/periodic"
@@ -39,7 +37,7 @@ var _ periodic.Task = (*Self)(nil)
 // on an issuer AS before the old one expires.
 type Self struct {
 	// Msgr is used to propagate key updates to the messenger, and not for network traffic
-	Msgr     *messenger.Messenger
+	Msgr     infra.Messenger
 	State    *config.State
 	IA       addr.IA
 	IssTime  time.Duration
@@ -110,7 +108,7 @@ func (s *Self) createLeafCert(ctx context.Context, leaf *cert.Certificate) error
 	if err != nil {
 		log.Error("[reiss.Self] Unable to set create new sign", "err", err)
 	}
-	signer := ctrl.NewBasicSigner(sign, s.State.GetSigningKey())
+	signer := trust.NewBasicSigner(sign, s.State.GetSigningKey())
 	s.State.SetSigner(signer)
 	s.Msgr.UpdateSigner(signer, []infra.MessageType{infra.ChainIssueReply})
 	return nil

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -28,8 +28,8 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/env"
 	"github.com/scionproto/scion/go/lib/fatal"
+	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/infraenv"
-	"github.com/scionproto/scion/go/lib/infra/messenger"
 	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/periodic"
@@ -40,7 +40,7 @@ var (
 	state       *config.State
 	environment *env.Env
 	reissRunner *periodic.Runner
-	msgr        *messenger.Messenger
+	msgr        infra.Messenger
 )
 
 func init() {

--- a/go/integration/cert_req/main.go
+++ b/go/integration/cert_req/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/scionproto/scion/go/lib/hostinfo"
 	"github.com/scionproto/scion/go/lib/infra/disp"
 	"github.com/scionproto/scion/go/lib/infra/messenger"
-	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/infra/transport"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/scrypto"
@@ -68,14 +67,13 @@ func (c client) run() int {
 		integration.LogFatal("Unable to listen", "err", err)
 	}
 	log.Debug("Send on", "local", c.conn.LocalAddr())
-	ts, _ := trust.NewStore(nil, addr.IA{}, nil, log.Root())
 	c.msgr = messenger.New(
 		integration.Local.IA,
 		disp.New(
 			transport.NewPacketTransport(c.conn),
 			messenger.DefaultAdapter,
 			log.Root(),
-		), ts, log.Root(), nil,
+		), nil, log.Root(), nil,
 	)
 	if err = getRemote(); err != nil {
 		integration.LogFatal("Error finding remote address", err)

--- a/go/integration/cert_req/main.go
+++ b/go/integration/cert_req/main.go
@@ -19,6 +19,8 @@ import (
 	"flag"
 	"os"
 
+	"github.com/scionproto/scion/go/lib/infra/modules/trust"
+
 	"github.com/scionproto/scion/go/integration"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
@@ -67,13 +69,14 @@ func (c client) run() int {
 		integration.LogFatal("Unable to listen", "err", err)
 	}
 	log.Debug("Send on", "local", c.conn.LocalAddr())
+	ts, _ := trust.NewStore(nil, addr.IA{}, nil, log.Root())
 	c.msgr = messenger.New(
 		integration.Local.IA,
 		disp.New(
 			transport.NewPacketTransport(c.conn),
 			messenger.DefaultAdapter,
 			log.Root(),
-		), nil, log.Root(), nil,
+		), ts, log.Root(), nil,
 	)
 	if err = getRemote(); err != nil {
 		integration.LogFatal("Error finding remote address", err)

--- a/go/integration/cert_req/main.go
+++ b/go/integration/cert_req/main.go
@@ -19,8 +19,6 @@ import (
 	"flag"
 	"os"
 
-	"github.com/scionproto/scion/go/lib/infra/modules/trust"
-
 	"github.com/scionproto/scion/go/integration"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
@@ -28,6 +26,7 @@ import (
 	"github.com/scionproto/scion/go/lib/hostinfo"
 	"github.com/scionproto/scion/go/lib/infra/disp"
 	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/infra/transport"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/scrypto"

--- a/go/lib/ctrl/ctrl.go
+++ b/go/lib/ctrl/ctrl.go
@@ -119,7 +119,7 @@ func (p *Pld) SignedPld(signer Signer) (*SignedPld, error) {
 }
 
 func (p *Pld) WritePld(b common.RawBytes) (int, error) {
-	sp, err := newSignedPld(p, nil, nil)
+	sp, err := NewSignedPld(p, nil, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -127,7 +127,7 @@ func (p *Pld) WritePld(b common.RawBytes) (int, error) {
 }
 
 func (p *Pld) PackPld() (common.RawBytes, error) {
-	sp, err := newSignedPld(p, nil, nil)
+	sp, err := NewSignedPld(p, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/lib/ctrl/signed.go
+++ b/go/lib/ctrl/signed.go
@@ -33,7 +33,7 @@ type SignedPld struct {
 	pld  *Pld
 }
 
-func newSignedPld(cpld *Pld, sign *proto.SignS, key common.RawBytes) (*SignedPld, error) {
+func NewSignedPld(cpld *Pld, sign *proto.SignS, key common.RawBytes) (*SignedPld, error) {
 	// Make a copy of signer, so the caller can re-use it.
 	spld := &SignedPld{Sign: sign.Copy()}
 	if spld.Sign == nil && assert.On {

--- a/go/lib/ctrl/signed_util.go
+++ b/go/lib/ctrl/signed_util.go
@@ -19,43 +19,21 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
-	"github.com/scionproto/scion/go/lib/infra"
-	"github.com/scionproto/scion/go/lib/scrypto/cert"
-	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/proto"
 )
-
-const SignatureValidity = 2 * time.Second
 
 // Signer takes a Pld and signs it, producing a SignedPld.
 type Signer interface {
 	Sign(*Pld) (*SignedPld, error)
 }
 
-var _ Signer = (*BasicSigner)(nil)
-
-// BasicSigner is a simple implementation of Signer.
-type BasicSigner struct {
-	s   *proto.SignS
-	key common.RawBytes
+// SigVerifier verifies the signature of a SignedPld.
+type SigVerifier interface { // interfaces -> infra
+	Verify(context.Context, *SignedPld) error
 }
-
-// NewBasicSigner creates a Signer that uses the supplied s and key to sign Pld's.
-func NewBasicSigner(s *proto.SignS, key common.RawBytes) *BasicSigner {
-	return &BasicSigner{s: s, key: key}
-}
-
-func (b *BasicSigner) Sign(pld *Pld) (*SignedPld, error) {
-	return newSignedPld(pld, b.s, b.key)
-}
-
-// NullSigner is a Signer that creates SignedPld's with no signature.
-var NullSigner Signer = NewBasicSigner(nil, nil)
 
 // VerifySig does some sanity checks on p, and then verifies the signature using sigV.
 func VerifySig(ctx context.Context, p *SignedPld, sigV SigVerifier) error {
@@ -71,109 +49,6 @@ func VerifySig(ctx context.Context, p *SignedPld, sigV SigVerifier) error {
 		return common.NewBasicError("SignedPld is missing signature", nil, "type", p.Sign.Type)
 	}
 	return sigV.Verify(ctx, p)
-}
-
-// SigVerifier verifies the signature of a SignedPld.
-type SigVerifier interface {
-	Verify(context.Context, *SignedPld) error
-}
-
-var _ SigVerifier = (*BasicSigVerifier)(nil)
-
-// BasicSigVerifier is a SigVerifier that ignores signatures on cert_mgmt.TRC
-// and cert_mgmt.Chain messages, to avoid dependency cycles.
-type BasicSigVerifier struct {
-	tStore infra.TrustStore
-}
-
-func NewBasicSigVerifier(tStore infra.TrustStore) *BasicSigVerifier {
-	return &BasicSigVerifier{
-		tStore: tStore,
-	}
-}
-
-func (v *BasicSigVerifier) Verify(ctx context.Context, p *SignedPld) error {
-	cpld, err := p.Pld()
-	if err != nil {
-		return err
-	}
-	if v.ignoreSign(cpld) {
-		return nil
-	}
-	now := time.Now()
-	ts := p.Sign.Time()
-	diff := now.Sub(ts)
-	if diff < 0 {
-		return common.NewBasicError("Invalid timestamp. Signature from future", nil,
-			"ts", util.TimeToString(ts), "now", util.TimeToString(now))
-	}
-	if diff > SignatureValidity {
-		return common.NewBasicError("Invalid timestamp. Signature expired", nil,
-			"ts", util.TimeToString(ts), "now", util.TimeToString(now),
-			"validity", SignatureValidity)
-	}
-	vKey, err := v.getVerifyKeyForSign(ctx, p.Sign)
-	if err != nil {
-		return err
-	}
-	return p.Sign.Verify(vKey, p.Blob)
-}
-
-func (v *BasicSigVerifier) ignoreSign(p *Pld) bool {
-	u0, _ := p.Union()
-	outer, ok := u0.(*cert_mgmt.Pld)
-	if !ok {
-		return false
-	}
-	u1, _ := outer.Union()
-	switch u1.(type) {
-	case *cert_mgmt.Chain, *cert_mgmt.TRC:
-		return true
-	default:
-		return false
-	}
-}
-
-func (v *BasicSigVerifier) getVerifyKeyForSign(ctx context.Context,
-	s *proto.SignS) (common.RawBytes, error) {
-
-	if s.Type == proto.SignType_none {
-		return nil, nil
-	}
-	sigSrc, err := NewSignSrcDefFromRaw(s.Src)
-	if err != nil {
-		return nil, err
-	}
-	chain, err := GetChainForSign(ctx, sigSrc, v.tStore)
-	if err != nil {
-		return nil, err
-	}
-	return chain.Leaf.SubjectSignKey, nil
-}
-
-func GetChainForSign(ctx context.Context, s *SignSrcDef,
-	tStore infra.TrustStore) (*cert.Chain, error) {
-
-	t, err := tStore.GetTRC(ctx, s.IA.I, s.TRCVer)
-	if err != nil {
-		return nil, common.NewBasicError("Unable to get TRC", err)
-	}
-	c, err := tStore.GetChain(ctx, s.IA, s.ChainVer)
-	if err != nil {
-		return nil, common.NewBasicError("Unable to get certificate chain", err)
-	}
-	maxTRC, err := tStore.GetValidTRC(ctx, t.ISD, nil)
-	if err != nil {
-		return nil, common.NewBasicError("Unable to get maxTRC", err)
-	}
-	if err := t.IsActive(maxTRC); err != nil {
-		// The certificate chain might still be verifiable with the max TRC
-		t = maxTRC
-	}
-	if err := c.Verify(c.Leaf.Subject, t); err != nil {
-		return nil, common.NewBasicError("Unable to verify certificate chain", err)
-	}
-	return c, nil
 }
 
 const (
@@ -217,15 +92,4 @@ func (s *SignSrcDef) Pack() common.RawBytes {
 
 func (s *SignSrcDef) String() string {
 	return fmt.Sprintf("IA: %s ChainVer: %d TRCVer: %d", s.IA, s.ChainVer, s.TRCVer)
-}
-
-var _ SigVerifier = (*nullSigVerifier)(nil)
-
-// NullSigVerifier ignores signatures on all messages.
-var NullSigVerifier SigVerifier = &nullSigVerifier{}
-
-type nullSigVerifier struct{}
-
-func (_ *nullSigVerifier) Verify(_ context.Context, p *SignedPld) error {
-	return nil
 }

--- a/go/lib/infra/common.go
+++ b/go/lib/infra/common.go
@@ -248,7 +248,28 @@ type TrustStore interface {
 
 type MsgVerificationFactory interface {
 	NewSigner(s *proto.SignS, key common.RawBytes) ctrl.Signer
-	NullSigner() ctrl.Signer
 	NewSigVerifier() ctrl.SigVerifier
-	NullSigVerifier() ctrl.SigVerifier
+}
+
+var (
+	// NullSigner is a Signer that creates SignedPld's with no signature.
+	NullSigner ctrl.Signer = &nullSigner{}
+	// NullSigVerifier ignores signatures on all messages.
+	NullSigVerifier ctrl.SigVerifier = &nullSigVerifier{}
+)
+
+var _ ctrl.Signer = (*nullSigner)(nil)
+
+type nullSigner struct{}
+
+func (*nullSigner) Sign(pld *ctrl.Pld) (*ctrl.SignedPld, error) {
+	return ctrl.NewSignedPld(pld, nil, nil)
+}
+
+var _ ctrl.SigVerifier = (*nullSigVerifier)(nil)
+
+type nullSigVerifier struct{}
+
+func (*nullSigVerifier) Verify(context.Context, *ctrl.SignedPld) error {
+	return nil
 }

--- a/go/lib/infra/common.go
+++ b/go/lib/infra/common.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/ack"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/ifid"
@@ -221,6 +222,8 @@ type Messenger interface {
 		id uint64) (*cert_mgmt.ChainIssRep, error)
 	SendChainIssueReply(ctx context.Context, msg *cert_mgmt.ChainIssRep, a net.Addr,
 		id uint64) error
+	UpdateSigner(signer ctrl.Signer, types []MessageType)
+	UpdateVerifier(verifier ctrl.SigVerifier)
 	AddHandler(msgType MessageType, h Handler)
 	ListenAndServe()
 	CloseServer() error
@@ -240,4 +243,12 @@ type TrustStore interface {
 	NewTRCReqHandler(recurseAllowed bool) Handler
 	NewChainReqHandler(recurseAllowed bool) Handler
 	SetMessenger(msger Messenger)
+	MsgVerificationFactory
+}
+
+type MsgVerificationFactory interface {
+	NewSigner(s *proto.SignS, key common.RawBytes) ctrl.Signer
+	NullSigner() ctrl.Signer
+	NewSigVerifier() ctrl.SigVerifier
+	NullSigVerifier() ctrl.SigVerifier
 }

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -169,8 +169,8 @@ func New(ia addr.IA, dispatcher *disp.Dispatcher, store infra.TrustStore, logger
 		ia:         ia,
 		config:     config,
 		dispatcher: dispatcher,
-		signer:     ctrl.NullSigner,
-		verifier:   ctrl.NullSigVerifier,
+		signer:     store.NullSigner(),
+		verifier:   store.NullSigVerifier(),
 		trustStore: store,
 		handlers:   make(map[infra.MessageType]infra.Handler),
 		closeChan:  make(chan struct{}),
@@ -731,7 +731,7 @@ func (m *Messenger) UpdateVerifier(verifier ctrl.SigVerifier) {
 func (m *Messenger) getRequester(reqT, respT infra.MessageType) *pathingRequester {
 	m.cryptoLock.RLock()
 	defer m.cryptoLock.RUnlock()
-	signer := ctrl.NullSigner
+	signer := m.trustStore.NullSigner()
 	if _, ok := m.signMask[reqT]; ok {
 		signer = m.signer
 	}

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -169,8 +169,8 @@ func New(ia addr.IA, dispatcher *disp.Dispatcher, store infra.TrustStore, logger
 		ia:         ia,
 		config:     config,
 		dispatcher: dispatcher,
-		signer:     store.NullSigner(),
-		verifier:   store.NullSigVerifier(),
+		signer:     infra.NullSigner,
+		verifier:   infra.NullSigVerifier,
 		trustStore: store,
 		handlers:   make(map[infra.MessageType]infra.Handler),
 		closeChan:  make(chan struct{}),
@@ -731,7 +731,7 @@ func (m *Messenger) UpdateVerifier(verifier ctrl.SigVerifier) {
 func (m *Messenger) getRequester(reqT, respT infra.MessageType) *pathingRequester {
 	m.cryptoLock.RLock()
 	defer m.cryptoLock.RUnlock()
-	signer := m.trustStore.NullSigner()
+	signer := infra.NullSigner
 	if _, ok := m.signMask[reqT]; ok {
 		signer = m.signer
 	}

--- a/go/lib/infra/messenger/messenger_test.go
+++ b/go/lib/infra/messenger/messenger_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package messenger
+package messenger_test
 
 import (
 	"context"
@@ -28,6 +28,8 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/disp"
+	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet/rpt"
 	"github.com/scionproto/scion/go/lib/xtest"
@@ -45,7 +47,7 @@ func MockTRCHandler(request *infra.Request) {
 		log.Warn("Unable to service request, no Messenger interface found")
 		return
 	}
-	messenger, ok := messengerI.(*Messenger)
+	messenger, ok := messengerI.(*messenger.Messenger)
 	if !ok {
 		log.Warn("Unable to service request, bad Messenger value found")
 		return
@@ -85,11 +87,12 @@ func TestTRCExchange(t *testing.T) {
 	})
 }
 
-func setupMessenger(ia addr.IA, conn net.PacketConn, name string) *Messenger {
+func setupMessenger(ia addr.IA, conn net.PacketConn, name string) *messenger.Messenger {
 	transport := rpt.New(conn, log.New("name", name))
-	dispatcher := disp.New(transport, DefaultAdapter, log.New("name", name))
-	config := &Config{DisableSignatureVerification: true}
-	return New(ia, dispatcher, nil, log.Root().New("name", name), config)
+	dispatcher := disp.New(transport, messenger.DefaultAdapter, log.New("name", name))
+	config := &messenger.Config{DisableSignatureVerification: true}
+	ts, _ := trust.NewStore(nil, addr.IA{}, nil, nil)
+	return messenger.New(ia, dispatcher, ts, log.Root().New("name", name), config)
 }
 
 func TestMain(m *testing.M) {

--- a/go/lib/infra/messenger/messenger_test.go
+++ b/go/lib/infra/messenger/messenger_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/disp"
 	"github.com/scionproto/scion/go/lib/infra/messenger"
-	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet/rpt"
 	"github.com/scionproto/scion/go/lib/xtest"
@@ -91,8 +90,7 @@ func setupMessenger(ia addr.IA, conn net.PacketConn, name string) *messenger.Mes
 	transport := rpt.New(conn, log.New("name", name))
 	dispatcher := disp.New(transport, messenger.DefaultAdapter, log.New("name", name))
 	config := &messenger.Config{DisableSignatureVerification: true}
-	ts, _ := trust.NewStore(nil, addr.IA{}, nil, nil)
-	return messenger.New(ia, dispatcher, ts, log.Root().New("name", name), config)
+	return messenger.New(ia, dispatcher, nil, log.Root().New("name", name), config)
 }
 
 func TestMain(m *testing.M) {

--- a/go/lib/infra/modules/trust/helpers.go
+++ b/go/lib/infra/modules/trust/helpers.go
@@ -93,24 +93,10 @@ func VerifyChain(subject addr.IA, chain *cert.Chain, store infra.TrustStore) err
 func GetChainForSign(ctx context.Context, s *ctrl.SignSrcDef,
 	tStore infra.TrustStore) (*cert.Chain, error) {
 
-	t, err := tStore.GetTRC(ctx, s.IA.I, s.TRCVer)
-	if err != nil {
-		return nil, common.NewBasicError("Unable to get TRC", err)
-	}
 	c, err := tStore.GetChain(ctx, s.IA, s.ChainVer)
 	if err != nil {
-		return nil, common.NewBasicError("Unable to get certificate chain", err)
+		return nil, err
 	}
-	maxTRC, err := tStore.GetValidTRC(ctx, t.ISD, nil)
-	if err != nil {
-		return nil, common.NewBasicError("Unable to get maxTRC", err)
-	}
-	if err := t.IsActive(maxTRC); err != nil {
-		// The certificate chain might still be verifiable with the max TRC
-		t = maxTRC
-	}
-	if err := c.Verify(c.Leaf.Subject, t); err != nil {
-		return nil, common.NewBasicError("Unable to verify certificate chain", err)
-	}
-	return c, nil
+	err = VerifyChain(s.IA, c, tStore)
+	return c, err
 }

--- a/go/lib/infra/modules/trust/helpers.go
+++ b/go/lib/infra/modules/trust/helpers.go
@@ -89,3 +89,28 @@ func VerifyChain(subject addr.IA, chain *cert.Chain, store infra.TrustStore) err
 	}
 	return nil
 }
+
+func GetChainForSign(ctx context.Context, s *ctrl.SignSrcDef,
+	tStore infra.TrustStore) (*cert.Chain, error) {
+
+	t, err := tStore.GetTRC(ctx, s.IA.I, s.TRCVer)
+	if err != nil {
+		return nil, common.NewBasicError("Unable to get TRC", err)
+	}
+	c, err := tStore.GetChain(ctx, s.IA, s.ChainVer)
+	if err != nil {
+		return nil, common.NewBasicError("Unable to get certificate chain", err)
+	}
+	maxTRC, err := tStore.GetValidTRC(ctx, t.ISD, nil)
+	if err != nil {
+		return nil, common.NewBasicError("Unable to get maxTRC", err)
+	}
+	if err := t.IsActive(maxTRC); err != nil {
+		// The certificate chain might still be verifiable with the max TRC
+		t = maxTRC
+	}
+	if err := c.Verify(c.Leaf.Subject, t); err != nil {
+		return nil, common.NewBasicError("Unable to verify certificate chain", err)
+	}
+	return c, nil
+}

--- a/go/lib/infra/modules/trust/helpers.go
+++ b/go/lib/infra/modules/trust/helpers.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,6 +98,5 @@ func GetChainForSign(ctx context.Context, s *ctrl.SignSrcDef,
 	if err != nil {
 		return nil, err
 	}
-	err = VerifyChain(s.IA, c, tStore)
-	return c, err
+	return c, VerifyChain(s.IA, c, tStore)
 }

--- a/go/lib/infra/modules/trust/signhelper.go
+++ b/go/lib/infra/modules/trust/signhelper.go
@@ -1,0 +1,137 @@
+// Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package trust
+
+package trust
+
+import (
+	"context"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/proto"
+)
+
+const (
+	SignatureValidity = 2 * time.Second
+)
+
+var (
+	// NullSigner is a Signer that creates SignedPld's with no signature.
+	NullSigner ctrl.Signer = NewBasicSigner(nil, nil)
+	// NullSigVerifier ignores signatures on all messages.
+	NullSigVerifier ctrl.SigVerifier = &nullSigVerifier{}
+)
+
+var _ ctrl.Signer = (*BasicSigner)(nil)
+
+// BasicSigner is a simple implementation of Signer.
+type BasicSigner struct {
+	s   *proto.SignS
+	key common.RawBytes
+}
+
+// NewBasicSigner creates a Signer that uses the supplied s and key to sign Pld's.
+func NewBasicSigner(s *proto.SignS, key common.RawBytes) *BasicSigner {
+	return &BasicSigner{s: s, key: key}
+}
+
+func (b *BasicSigner) Sign(pld *ctrl.Pld) (*ctrl.SignedPld, error) {
+	return ctrl.NewSignedPld(pld, b.s, b.key)
+}
+
+var _ ctrl.SigVerifier = (*BasicSigVerifier)(nil)
+
+// BasicSigVerifier is a SigVerifier that ignores signatures on cert_mgmt.TRC
+// and cert_mgmt.Chain messages, to avoid dependency cycles.
+type BasicSigVerifier struct {
+	tStore infra.TrustStore
+}
+
+func NewBasicSigVerifier(tStore infra.TrustStore) *BasicSigVerifier {
+	return &BasicSigVerifier{
+		tStore: tStore,
+	}
+}
+
+func (v *BasicSigVerifier) Verify(ctx context.Context, p *ctrl.SignedPld) error {
+	cpld, err := p.Pld()
+	if err != nil {
+		return err
+	}
+	if v.ignoreSign(cpld) {
+		return nil
+	}
+	now := time.Now()
+	ts := p.Sign.Time()
+	diff := now.Sub(ts)
+	if diff < 0 {
+		return common.NewBasicError("Invalid timestamp. Signature from future", nil,
+			"ts", util.TimeToString(ts), "now", util.TimeToString(now))
+	}
+	if diff > SignatureValidity {
+		return common.NewBasicError("Invalid timestamp. Signature expired", nil,
+			"ts", util.TimeToString(ts), "now", util.TimeToString(now),
+			"validity", SignatureValidity)
+	}
+	vKey, err := v.getVerifyKeyForSign(ctx, p.Sign)
+	if err != nil {
+		return err
+	}
+	return p.Sign.Verify(vKey, p.Blob)
+}
+
+func (v *BasicSigVerifier) ignoreSign(p *ctrl.Pld) bool {
+	u0, _ := p.Union()
+	outer, ok := u0.(*cert_mgmt.Pld)
+	if !ok {
+		return false
+	}
+	u1, _ := outer.Union()
+	switch u1.(type) {
+	case *cert_mgmt.Chain, *cert_mgmt.TRC:
+		return true
+	default:
+		return false
+	}
+}
+
+func (v *BasicSigVerifier) getVerifyKeyForSign(ctx context.Context,
+	s *proto.SignS) (common.RawBytes, error) {
+
+	if s.Type == proto.SignType_none {
+		return nil, nil
+	}
+	sigSrc, err := ctrl.NewSignSrcDefFromRaw(s.Src)
+	if err != nil {
+		return nil, err
+	}
+	chain, err := GetChainForSign(ctx, sigSrc, v.tStore)
+	if err != nil {
+		return nil, err
+	}
+	return chain.Leaf.SubjectSignKey, nil
+}
+
+var _ ctrl.SigVerifier = (*nullSigVerifier)(nil)
+
+type nullSigVerifier struct{}
+
+func (_ *nullSigVerifier) Verify(_ context.Context, p *ctrl.SignedPld) error {
+	return nil
+}

--- a/go/lib/infra/modules/trust/signhelper.go
+++ b/go/lib/infra/modules/trust/signhelper.go
@@ -31,13 +31,6 @@ const (
 	SignatureValidity = 2 * time.Second
 )
 
-var (
-	// NullSigner is a Signer that creates SignedPld's with no signature.
-	NullSigner ctrl.Signer = NewBasicSigner(nil, nil)
-	// NullSigVerifier ignores signatures on all messages.
-	NullSigVerifier ctrl.SigVerifier = &nullSigVerifier{}
-)
-
 var _ ctrl.Signer = (*BasicSigner)(nil)
 
 // BasicSigner is a simple implementation of Signer.
@@ -126,12 +119,4 @@ func (v *BasicSigVerifier) getVerifyKeyForSign(ctx context.Context,
 		return nil, err
 	}
 	return chain.Leaf.SubjectSignKey, nil
-}
-
-var _ ctrl.SigVerifier = (*nullSigVerifier)(nil)
-
-type nullSigVerifier struct{}
-
-func (_ *nullSigVerifier) Verify(_ context.Context, p *ctrl.SignedPld) error {
-	return nil
 }

--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/dedupe"
@@ -665,6 +666,22 @@ func (store *Store) ChooseServer(ctx context.Context, destination addr.IA) (net.
 	}
 	a := &snet.Addr{IA: destination, Host: addr.NewSVCUDPAppAddr(addr.SvcCS)}
 	return a, nil
+}
+
+func (store *Store) NewSigner(s *proto.SignS, key common.RawBytes) ctrl.Signer {
+	return NewBasicSigner(s, key)
+}
+
+func (store *Store) NullSigner() ctrl.Signer {
+	return NullSigner
+}
+
+func (store *Store) NewSigVerifier() ctrl.SigVerifier {
+	return NewBasicSigVerifier(store)
+}
+
+func (store *Store) NullSigVerifier() ctrl.SigVerifier {
+	return NullSigVerifier
 }
 
 // wrapErr build a dedupe.Response object containing nil data and error err.

--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -672,16 +672,8 @@ func (store *Store) NewSigner(s *proto.SignS, key common.RawBytes) ctrl.Signer {
 	return NewBasicSigner(s, key)
 }
 
-func (store *Store) NullSigner() ctrl.Signer {
-	return NullSigner
-}
-
 func (store *Store) NewSigVerifier() ctrl.SigVerifier {
 	return NewBasicSigVerifier(store)
-}
-
-func (store *Store) NullSigVerifier() ctrl.SigVerifier {
-	return NullSigVerifier
 }
 
 // wrapErr build a dedupe.Response object containing nil data and error err.

--- a/go/sig/base/pollhdlr.go
+++ b/go/sig/base/pollhdlr.go
@@ -19,7 +19,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl"
-	"github.com/scionproto/scion/go/lib/infra/modules/trust"
+	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/sig/disp"
@@ -48,7 +48,7 @@ func PollReqHdlr() {
 			log.Error("PollReqHdlr: Error creating Ctrl payload", "err", err)
 			break
 		}
-		scpld, err := cpld.SignedPld(trust.NullSigner)
+		scpld, err := cpld.SignedPld(infra.NullSigner)
 		if err != nil {
 			log.Error("PollReqHdlr: Error creating signed Ctrl payload", "err", err)
 			break

--- a/go/sig/base/pollhdlr.go
+++ b/go/sig/base/pollhdlr.go
@@ -19,6 +19,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/sig/disp"
@@ -47,7 +48,7 @@ func PollReqHdlr() {
 			log.Error("PollReqHdlr: Error creating Ctrl payload", "err", err)
 			break
 		}
-		scpld, err := cpld.SignedPld(ctrl.NullSigner)
+		scpld, err := cpld.SignedPld(trust.NullSigner)
 		if err != nil {
 			log.Error("PollReqHdlr: Error creating signed Ctrl payload", "err", err)
 			break

--- a/go/sig/egress/session/sessmon.go
+++ b/go/sig/egress/session/sessmon.go
@@ -21,6 +21,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/sig/disp"
@@ -194,7 +195,7 @@ func (sm *sessMonitor) sendReq() {
 		sm.Error("sessMonitor: Error creating Ctrl payload", "err", err)
 		return
 	}
-	scpld, err := cpld.SignedPld(ctrl.NullSigner)
+	scpld, err := cpld.SignedPld(trust.NullSigner)
 	if err != nil {
 		sm.Error("sessMonitor: Error creating signed Ctrl payload", "err", err)
 		return

--- a/go/sig/egress/session/sessmon.go
+++ b/go/sig/egress/session/sessmon.go
@@ -21,7 +21,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl"
-	"github.com/scionproto/scion/go/lib/infra/modules/trust"
+	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/sig/disp"
@@ -195,7 +195,7 @@ func (sm *sessMonitor) sendReq() {
 		sm.Error("sessMonitor: Error creating Ctrl payload", "err", err)
 		return
 	}
-	scpld, err := cpld.SignedPld(trust.NullSigner)
+	scpld, err := cpld.SignedPld(infra.NullSigner)
 	if err != nil {
 		sm.Error("sessMonitor: Error creating signed Ctrl payload", "err", err)
 		return


### PR DESCRIPTION
Moves signer and verifier implementation from ctrl to the trust package.
Use infra.Messenger in CS instead of *messenger.Messenger.

Fixes #2030

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2379)
<!-- Reviewable:end -->
