### PR TITLE
BR: Split topology in static and dynamic

### DIFF
--- a/go/border/router.go
+++ b/go/border/router.go
@@ -77,7 +77,7 @@ func (r *Router) ReloadConfig() error {
 	if config, err = r.loadNewConfig(); err != nil {
 		return common.NewBasicError("Unable to load config", err)
 	}
-	if err := r.setupNewContext(config); err != nil {
+	if err := r.setupCtxFromConfig(config); err != nil {
 		return common.NewBasicError("Unable to set up new context", err)
 	}
 	return nil

--- a/go/border/setup.go
+++ b/go/border/setup.go
@@ -205,7 +205,7 @@ func (r *Router) rollbackNet(ctx, oldCtx *rctx.Ctx,
 		handleErr(common.NewBasicError("Unable to rollback local interface", err))
 	}
 	if oldCtx != nil {
-		// Start sockets that are possibly created in rollback.
+		// Start sockets that are possibly created by rollback.
 		startSocks(oldCtx)
 	}
 }

--- a/go/border/setup.go
+++ b/go/border/setup.go
@@ -122,7 +122,7 @@ func (r *Router) setupCtxFromConfig(config *brconf.Conf) error {
 	log.Debug("====> Setting up new context from config")
 	// We want to keep itopo and the context that is set in sync.
 	// We attempt to set the context with the topology that will be current
-	// after setting itopo. If setting itopo fails in the end, we can rollback the context.
+	// after setting itopo. If setting itopo fails in the end, we rollback the context.
 	info, err := itopo.CheckStatic(config.Topo, true)
 	if err != nil {
 		return err

--- a/go/border/setup.go
+++ b/go/border/setup.go
@@ -134,10 +134,7 @@ func (r *Router) setupCtxFromConfig(config *brconf.Conf) error {
 	if err != nil {
 		return err
 	}
-	if err := r.setupNewContext(rctx.New(newConf), tx); err != nil {
-		return err
-	}
-	return nil
+	return r.setupNewContext(rctx.New(newConf), tx)
 }
 
 // setupNewContext sets up a new router context.
@@ -163,10 +160,7 @@ func (r *Router) setupNetAndTopo(ctx *rctx.Ctx, oldCtx *rctx.Ctx,
 	if err := r.setupNet(ctx, oldCtx, sockConf); err != nil {
 		return err
 	}
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	return nil
+	return tx.Commit()
 }
 
 // setupNet configures networking for the router, using any setup hooks that

--- a/go/border/setup.go
+++ b/go/border/setup.go
@@ -204,8 +204,10 @@ func (r *Router) rollbackNet(ctx, oldCtx *rctx.Ctx,
 	if err != nil {
 		handleErr(common.NewBasicError("Unable to rollback local interface", err))
 	}
-	// Start sockets that are possible created in rollback.
-	startSocks(oldCtx)
+	if oldCtx != nil {
+		// Start sockets that are possible created in rollback.
+		startSocks(oldCtx)
+	}
 }
 
 // teardownOldNet tears down the sockets of removed external interfaces.

--- a/go/border/setup.go
+++ b/go/border/setup.go
@@ -120,32 +120,32 @@ func (r *Router) loadNewConfig() (*brconf.Conf, error) {
 // This method is called on initial start and when a sighup is received.
 func (r *Router) setupCtxFromConfig(config *brconf.Conf) error {
 	log.Debug("====> Setting up new context from config")
-	// We want to keep itopo and the context that is set in sync.
+	// We want to keep in sync itopo and the context that is set.
 	// We attempt to set the context with the topology that will be current
 	// after setting itopo. If setting itopo fails in the end, we rollback the context.
-	info, err := itopo.CheckStatic(config.Topo, true)
+	tx, err := itopo.BeginSetStatic(config.Topo, true)
 	if err != nil {
 		return err
 	}
-	// Set config to used the appropriate topology. The returned topology is
+	// Set config to use the appropriate topology. The returned topology is
 	// not necessarily the same as config.Topo. It can be an other static
 	// or dynamic topology.
-	newConf, err := brconf.WithNewTopo(r.Id, info.Current(), config)
+	newConf, err := brconf.WithNewTopo(r.Id, tx.Get(), config)
 	if err != nil {
 		return err
 	}
-	if err := r.setupNewContext(rctx.New(newConf), info); err != nil {
+	if err := r.setupNewContext(rctx.New(newConf), tx); err != nil {
 		return err
 	}
 	return nil
 }
 
 // setupNewContext sets up a new router context.
-func (r *Router) setupNewContext(ctx *rctx.Ctx, info itopo.CheckInfo) error {
+func (r *Router) setupNewContext(ctx *rctx.Ctx, tx itopo.Transaction) error {
 	oldCtx := rctx.Get()
 	// TODO(roosd): Eventually, this will be configurable through brconfig.toml.
 	sockConf := brconf.SockConf{Default: PosixSock}
-	if err := r.setupNetAndTopo(ctx, oldCtx, info, sockConf); err != nil {
+	if err := r.setupNetAndTopo(ctx, oldCtx, tx, sockConf); err != nil {
 		r.rollbackNet(ctx, oldCtx, sockConf, handleRollbackErr)
 		return err
 	}
@@ -157,13 +157,13 @@ func (r *Router) setupNewContext(ctx *rctx.Ctx, info itopo.CheckInfo) error {
 }
 
 // setupNetAndTopo sets up the net context and set the topology in itopo.
-func (r *Router) setupNetAndTopo(ctx *rctx.Ctx, oldCtx *rctx.Ctx, info itopo.CheckInfo,
-	sockConf brconf.SockConf) error {
+func (r *Router) setupNetAndTopo(ctx *rctx.Ctx, oldCtx *rctx.Ctx,
+	tx itopo.Transaction, sockConf brconf.SockConf) error {
 
 	if err := r.setupNet(ctx, oldCtx, sockConf); err != nil {
 		return err
 	}
-	if err := itopo.SetStaticFromCheck(info); err != nil {
+	if err := tx.Commit(); err != nil {
 		return err
 	}
 	return nil

--- a/go/border/setup.go
+++ b/go/border/setup.go
@@ -128,7 +128,7 @@ func (r *Router) setupCtxFromConfig(config *brconf.Conf) error {
 		return err
 	}
 	// Set config to use the appropriate topology. The returned topology is
-	// not necessarily the same as config.Topo. It can be an other static
+	// not necessarily the same as config.Topo. It can be another static
 	// or dynamic topology.
 	newConf, err := brconf.WithNewTopo(r.Id, tx.Get(), config)
 	if err != nil {
@@ -142,7 +142,7 @@ func (r *Router) setupNewContext(ctx *rctx.Ctx, tx itopo.Transaction) error {
 	oldCtx := rctx.Get()
 	// TODO(roosd): Eventually, this will be configurable through brconfig.toml.
 	sockConf := brconf.SockConf{Default: PosixSock}
-	if err := r.setupNetAndTopo(ctx, oldCtx, tx, sockConf); err != nil {
+	if err := r.setupNetAndTopo(ctx, oldCtx, sockConf, tx); err != nil {
 		r.rollbackNet(ctx, oldCtx, sockConf, handleRollbackErr)
 		return err
 	}
@@ -155,7 +155,7 @@ func (r *Router) setupNewContext(ctx *rctx.Ctx, tx itopo.Transaction) error {
 
 // setupNetAndTopo sets up the net context and set the topology in itopo.
 func (r *Router) setupNetAndTopo(ctx *rctx.Ctx, oldCtx *rctx.Ctx,
-	tx itopo.Transaction, sockConf brconf.SockConf) error {
+	sockConf brconf.SockConf, tx itopo.Transaction) error {
 
 	if err := r.setupNet(ctx, oldCtx, sockConf); err != nil {
 		return err
@@ -205,7 +205,7 @@ func (r *Router) rollbackNet(ctx, oldCtx *rctx.Ctx,
 		handleErr(common.NewBasicError("Unable to rollback local interface", err))
 	}
 	if oldCtx != nil {
-		// Start sockets that are possible created in rollback.
+		// Start sockets that are possibly created in rollback.
 		startSocks(oldCtx)
 	}
 }

--- a/go/lib/infra/modules/itopo/itopo.go
+++ b/go/lib/infra/modules/itopo/itopo.go
@@ -34,9 +34,12 @@ var st *state
 // a view which topology will be valid if it commits to setting the topology
 // provided during the check.
 type CheckInfo struct {
+	// topo contains the view of the static and dynamic topologies.
 	topo
+	// prevStatic stores the currently active topology during the check.
 	prevStatic *topology.Topo
-	newStatic  *topology.Topo
+	// newStatic stores the provided static topology during the check.
+	newStatic *topology.Topo
 }
 
 // Callbacks are callbacks to respond to specific topology update events.
@@ -83,6 +86,8 @@ func CheckStatic(static *topology.Topo, semiMutAllowed bool) (CheckInfo, error) 
 
 // SetStaticFromCheck sets the topology based on the info from a previous check.
 // An error is returned, if the current static topology changed in the meantime.
+// The dynamic topology is allowed to change in the meantime, but will be dropped
+// when necessary.
 func SetStaticFromCheck(info CheckInfo) error {
 	return st.setStaticFromCheck(info)
 }

--- a/go/lib/infra/modules/itopo/testdata/topo.json
+++ b/go/lib/infra/modules/itopo/testdata/topo.json
@@ -28,6 +28,26 @@
                     "MTU": 1472
                 }
             }
+        },
+        "br1-ff00:0:311-2": {
+            "InternalAddrs": {
+                "IPv4": {"PublicOverlay": {"Addr": "10.1.0.2"}}
+            },
+            "CtrlAddr": {
+                "IPv4": {"Public": {"Addr": "10.1.0.2", "L4Port": 30098}}
+            },
+            "Interfaces": {
+                "2": {
+                    "Overlay": "UDP/IPv4",
+                    "BindOverlay": {"Addr": "10.0.0.2"},
+                    "PublicOverlay": {"Addr": "192.0.2.11", "OverlayPort": 44997},
+                    "RemoteOverlay": {"Addr": "192.0.2.12", "OverlayPort": 44998},
+                    "Bandwidth": 1000,
+                    "ISD_AS": "1-ff00:0:312",
+                    "LinkTo": "PARENT",
+                    "MTU": 1472
+                }
+            }
         }
     },
     "CertificateService": {


### PR DESCRIPTION
The split is achieved by using the itopo package.

This change adds a border router specific validator to itopo
which enforces the mutability rules according to `itopo/doc.go`.

On sighup, the border router sets the new static topology of itopo.
The following mechanisms that interact with itopo are implemented later:
- fetching static topology from discovery service
- fetching dynamic topology from discovery service
- dropping expired dynamic topology

`itopo` acts as a mediator between these 4 ways of changing the topology
and shall contain the `truth`.

Since the border router uses `rctx` to atomically get the context for a packet,
this means that the topology in `rctx` and `itopo` need to be kept in sync.
To achieve this, the context setup is done as follows:
1. Get view what the state will be like if itopo is set with the new topology.
2. Set `rctx` with this view.
3. Set `itopo` with the previously acquired view.
4. Rollback if failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2390)
<!-- Reviewable:end -->
