### PR TITLE
Allow empty chain&trc replies for cache-only reqs

### DIFF
--- a/go/integration/cert_req/main.go
+++ b/go/integration/cert_req/main.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -115,6 +116,9 @@ func (c client) requestCert() (*cert.Chain, error) {
 	if err != nil {
 		return nil, common.NewBasicError("Unable to parse chain", err)
 	}
+	if chain == nil {
+		return nil, common.NewBasicError("Empty reply", nil)
+	}
 	if !chain.Leaf.Subject.Equal(remoteIA) {
 		return nil, common.NewBasicError("Invalid subject", nil,
 			"expected", remoteIA, "actual", chain.Leaf.Subject)
@@ -139,6 +143,9 @@ func (c client) requestTRC(chain *cert.Chain) error {
 	trc, err := rawTrc.TRC()
 	if err != nil {
 		return common.NewBasicError("Unable to parse trc", err)
+	}
+	if trc == nil {
+		return common.NewBasicError("Empty reply", nil)
 	}
 	if trc.ISD != remoteIA.I {
 		return common.NewBasicError("Invalid ISD", nil,

--- a/go/lib/ctrl/cert_mgmt/chain.go
+++ b/go/lib/ctrl/cert_mgmt/chain.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +30,9 @@ type Chain struct {
 }
 
 func (c *Chain) Chain() (*cert.Chain, error) {
+	if c.RawChain == nil {
+		return nil, nil
+	}
 	return cert.ChainFromRaw(c.RawChain, true)
 }
 
@@ -40,6 +44,9 @@ func (c *Chain) String() string {
 	chain, err := c.Chain()
 	if err != nil {
 		return fmt.Sprintf("Invalid CertificateChain: %v", err)
+	}
+	if chain == nil {
+		return "Chain{nil}"
 	}
 	return chain.String()
 }

--- a/go/lib/ctrl/cert_mgmt/chain.go
+++ b/go/lib/ctrl/cert_mgmt/chain.go
@@ -45,8 +45,5 @@ func (c *Chain) String() string {
 	if err != nil {
 		return fmt.Sprintf("Invalid CertificateChain: %v", err)
 	}
-	if chain == nil {
-		return "Chain{nil}"
-	}
 	return chain.String()
 }

--- a/go/lib/ctrl/cert_mgmt/trc.go
+++ b/go/lib/ctrl/cert_mgmt/trc.go
@@ -45,8 +45,5 @@ func (t *TRC) String() string {
 	if err != nil {
 		return fmt.Sprintf("Invalid TRC: %v", err)
 	}
-	if u == nil {
-		return "TRC{nil}"
-	}
 	return u.String()
 }

--- a/go/lib/ctrl/cert_mgmt/trc.go
+++ b/go/lib/ctrl/cert_mgmt/trc.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +30,9 @@ type TRC struct {
 }
 
 func (t *TRC) TRC() (*trc.TRC, error) {
+	if t.RawTRC == nil {
+		return nil, nil
+	}
 	return trc.TRCFromRaw(t.RawTRC, true)
 }
 
@@ -40,6 +44,9 @@ func (t *TRC) String() string {
 	u, err := t.TRC()
 	if err != nil {
 		return fmt.Sprintf("Invalid TRC: %v", err)
+	}
+	if u == nil {
+		return "TRC{nil}"
 	}
 	return u.String()
 }

--- a/go/lib/infra/modules/trust/handlers.go
+++ b/go/lib/infra/modules/trust/handlers.go
@@ -17,13 +17,12 @@ package trust
 import (
 	"context"
 
-	"github.com/scionproto/scion/go/lib/scrypto/cert"
-
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/messenger"
 	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/scrypto/cert"
 	"github.com/scionproto/scion/go/lib/scrypto/trc"
 	"github.com/scionproto/scion/go/proto"
 )

--- a/go/lib/infra/modules/trust/trust_test.go
+++ b/go/lib/infra/modules/trust/trust_test.go
@@ -506,13 +506,13 @@ func TestTRCReqHandler(t *testing.T) {
 		{
 			Name: "ask for unknown isd=2, version=max, cache-only, recursive",
 			ISD:  2, Version: scrypto.LatestVer,
-			ExpData: nil, ExpError: true,
+			ExpData: nil, ExpError: false,
 			RecursionEnabled: true, CacheOnly: true,
 		},
 		{
 			Name: "ask for unknown isd=2, version=max, cache-only, non-recursive",
 			ISD:  2, Version: scrypto.LatestVer,
-			ExpData: nil, ExpError: true,
+			ExpData: nil, ExpError: false,
 			RecursionEnabled: false, CacheOnly: true,
 		},
 		{
@@ -536,7 +536,7 @@ func TestTRCReqHandler(t *testing.T) {
 		{
 			Name: "ask for bogus isd=42, version=max, cache-only=true, non-recursive",
 			ISD:  42, Version: scrypto.LatestVer,
-			ExpData: nil, ExpError: true,
+			ExpData: nil, ExpError: false,
 			RecursionEnabled: false, CacheOnly: true,
 		},
 	}
@@ -648,13 +648,13 @@ func TestChainReqHandler(t *testing.T) {
 		{
 			Name: "ask for unknown chain=1-2, version=max, cache-only, recursive",
 			IA:   xtest.MustParseIA("1-ff00:0:2"), Version: scrypto.LatestVer,
-			ExpData: nil, ExpError: true,
+			ExpData: nil, ExpError: false,
 			RecursionEnabled: true, CacheOnly: true,
 		},
 		{
 			Name: "ask for unknown chain=1-2, version=max, cache-only, non-recursive",
 			IA:   xtest.MustParseIA("1-ff00:0:2"), Version: scrypto.LatestVer,
-			ExpData: nil, ExpError: true,
+			ExpData: nil, ExpError: false,
 			RecursionEnabled: false, CacheOnly: true,
 		},
 		{

--- a/go/lib/scrypto/cert/chain.go
+++ b/go/lib/scrypto/cert/chain.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -209,6 +210,9 @@ func (c *Chain) Copy() *Chain {
 }
 
 func (c *Chain) String() string {
+	if c == nil {
+		return "CertificateChain <nil>"
+	}
 	return fmt.Sprintf("CertificateChain %sv%d", c.Leaf.Subject, c.Leaf.Version)
 }
 

--- a/go/lib/scrypto/trc/trc.go
+++ b/go/lib/scrypto/trc/trc.go
@@ -413,6 +413,9 @@ func (t *TRC) UnmarshalJSON(b []byte) error {
 }
 
 func (t *TRC) String() string {
+	if t == nil {
+		return "TRC <nil>"
+	}
 	return fmt.Sprintf("TRC %dv%d", t.ISD, t.Version)
 }
 

--- a/python/scion_elem/scion_elem.py
+++ b/python/scion_elem/scion_elem.py
@@ -565,6 +565,9 @@ class SCIONElement(object):
         cmgt = cpld.union
         rep = cmgt.union
         assert isinstance(rep, TRCReply), type(rep)
+        if not rep.trc:
+            logging.debug("Empty TRC reply received.")
+            return
         isd, ver = rep.trc.get_isd_ver()
         logging.info("TRC reply received for %sv%s from %s [id: %s]",
                      isd, ver, meta, cpld.req_id_str())
@@ -623,6 +626,9 @@ class SCIONElement(object):
         rep = cmgt.union
         assert isinstance(rep, CertChainReply), type(rep)
         meta.close()
+        if not rep.chain:
+            logging.debug("Empty cert chain reply received")
+            return
         isd_as, ver = rep.chain.get_leaf_isd_as_ver()
         logging.info("Cert chain reply received for %sv%s from %s [id: %s]",
                      isd_as, ver, meta, cpld.req_id_str())


### PR DESCRIPTION
In case of a cache only request the serving side should have the possibility to reply with an empty message.
This is helpful for querying whether a certain CS has a chain (used for pushing of chains see #2308)

Fixes #2392

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2396)
<!-- Reviewable:end -->
