### PR TITLE
braccept: more reliable ci tests

### DIFF
--- a/.buildkite/scripts/build_scion_img
+++ b/.buildkite/scripts/build_scion_img
@@ -2,7 +2,7 @@
 
 set -e
 
-BASE_IMG=${BASE_IMG:-a3bcdd559fd1148b4cdba736f6f93029f0930050ad432e2b08d45428abfb16e7}
+BASE_IMG=${BASE_IMG:-d0df659466340dfc30f277f383ade9f0e1069ae2d2ac621f1a04d3eed258f388}
 
 ./tools/ci/prepare_image "$BASE_IMG"
 ./docker.sh build

--- a/.buildkite/scripts/build_scion_img
+++ b/.buildkite/scripts/build_scion_img
@@ -2,7 +2,7 @@
 
 set -e
 
-BASE_IMG=${BASE_IMG:-4b82d061b2c2d504eb292c92e0e8c3edb9f6c1064dcae0b49b89c6de7cced043}
+BASE_IMG=${BASE_IMG:-a3bcdd559fd1148b4cdba736f6f93029f0930050ad432e2b08d45428abfb16e7}
 
 ./tools/ci/prepare_image "$BASE_IMG"
 ./docker.sh build

--- a/go/border/braccept/brD.go
+++ b/go/border/braccept/brD.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"hash"
+	"time"
 
 	"github.com/scionproto/scion/go/border/braccept/tpkt"
 	"github.com/scionproto/scion/go/lib/common"
@@ -235,7 +236,8 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 	}
 
 	revLocalFork := &BRTest{
-		Desc: "Multiple IFIDs - Revocation to local destination, fork to PS",
+		Desc:    "Multiple IFIDs - Revocation to local destination, fork to PS",
+		Timeout: 1 * time.Second, // Control packets need to go through the dispatcher
 		In: &tpkt.Pkt{
 			Dev: "ifid_151", Layers: []tpkt.LayerBuilder{
 				tpkt.GenOverlayIP4UDP("192.168.15.3", 40000, "192.168.15.2", 50000),
@@ -290,7 +292,8 @@ func genTestsBrD(hMac hash.Hash) []*BRTest {
 	}
 
 	revLocalFork = &BRTest{
-		Desc: "Multiple IFIDs - Revocation received on parent ifid, fork to PS",
+		Desc:    "Multiple IFIDs - Local ISD revocation on parent ifid, fork to PS and BS",
+		Timeout: 1 * time.Second, // Control packets need to go through the dispatcher
 		In: &tpkt.Pkt{
 			Dev: "ifid_171", Layers: []tpkt.LayerBuilder{
 				tpkt.GenOverlayIP4UDP("192.168.17.3", 40000, "192.168.17.2", 50000),

--- a/go/border/braccept/brtest.go
+++ b/go/border/braccept/brtest.go
@@ -27,10 +27,11 @@ import (
 
 // BRTest defines a single test
 type BRTest struct {
+	// Desc is a brief description of the test
 	Desc string
 	// Pre is the packet to be sent before the actual test packets.
 	// An example of this packet would be an IFState to deactivate the interface when testing
-	// for a revoked interface.
+	// for a revoked interface (OPTIONAL)
 	Pre *tpkt.Pkt
 	// In is the packet being sent to the border router
 	In *tpkt.Pkt
@@ -41,12 +42,12 @@ type BRTest struct {
 	// An example for this post packet would be an IFStateInfo to activate the interface and keep
 	// the border router in a known state.
 	Post *tpkt.Pkt
-	// Ignore is the list of packets that should be ignored.
+	// Ignore is the list of packets that should be ignored (OPTIONAL)
 	Ignore []*tpkt.ExpPkt
 	// Delay is the amount of time to wait after sending a packet. This is useful when sending
-	// control packets to the BR in the Pre stage to allow for its processing.
+	// control packets to the BR in the Pre stage to allow for its processing (OPTIONAL)
 	Delay time.Duration
-	// Timeout is the time to wait for packets from the BR.
+	// Timeout is the time to wait for packets from the BR (OPTIONAL)
 	Timeout time.Duration
 }
 

--- a/go/border/braccept/brtest.go
+++ b/go/border/braccept/brtest.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/kormat/fmt15"
 	"github.com/mattn/go-isatty"
@@ -42,6 +43,11 @@ type BRTest struct {
 	Post *tpkt.Pkt
 	// Ignore is the list of packets that should be ignored.
 	Ignore []*tpkt.ExpPkt
+	// Delay is the amount of time to wait after sending a packet. This is useful when sending
+	// control packets to the BR in the Pre stage to allow for its processing.
+	Delay time.Duration
+	// Timeout is the time to wait for packets from the BR.
+	Timeout time.Duration
 }
 
 func (t *BRTest) Summary(testPass bool) string {

--- a/go/border/braccept/main.go
+++ b/go/border/braccept/main.go
@@ -27,8 +27,8 @@ import (
 	"time"
 
 	"github.com/google/gopacket"
+	"github.com/google/gopacket/afpacket"
 	"github.com/google/gopacket/layers"
-	"github.com/google/gopacket/pcap"
 	"github.com/syndtr/gocapability/capability"
 	"golang.org/x/crypto/pbkdf2"
 
@@ -43,13 +43,14 @@ type ifInfo struct {
 	hostDev string
 	contDev string
 	mac     net.HardwareAddr
-	handle  *pcap.Handle
+	handle  *afpacket.TPacket
 }
 
 const (
-	snapshot_len int32         = 1024
-	promiscuous  bool          = true
-	timeout      time.Duration = 1 * time.Second
+	snapshot_len   int32         = 1024
+	promiscuous    bool          = true
+	defaultTimeout time.Duration = 250 * time.Millisecond
+	defaultDelay   time.Duration = 1 * time.Second
 )
 
 var (
@@ -102,12 +103,12 @@ func realMain() int {
 	cases := make([]reflect.SelectCase, timerIdx+1)
 	for i, ifi := range devList {
 		var err error
-		ifi.handle, err = pcap.OpenLive(ifi.hostDev, snapshot_len, promiscuous, pcap.BlockForever)
+		ifi.handle, err = afpacket.NewTPacket(afpacket.OptInterface(ifi.hostDev))
 		if err != nil {
 			log.Crit("", "err", err)
 			return 1
 		}
-		packetSource := gopacket.NewPacketSource(ifi.handle, ifi.handle.LinkType())
+		packetSource := gopacket.NewPacketSource(ifi.handle, layers.LinkTypeEthernet)
 		ch := packetSource.Packets()
 		cases[i] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ch)}
 		defer ifi.handle.Close()
@@ -232,16 +233,21 @@ func registerScionPorts() {
 func doTest(t *BRTest, cases []reflect.SelectCase) error {
 	var errStr []string
 	var err error
-	if err = sendPkt(t.Pre, true); err != nil {
+	noDelay := time.Duration(0)
+	delay := defaultDelay
+	if t.Delay != noDelay {
+		delay = t.Delay
+	}
+	if err = sendPkt(t.Pre, delay); err != nil {
 		errStr = append(errStr, err.Error())
 	}
-	if err = sendPkt(t.In, false); err == nil {
+	if err = sendPkt(t.In, noDelay); err == nil {
 		err = checkRecvPkts(t, cases)
 	}
 	if err != nil {
 		errStr = append(errStr, err.Error())
 	}
-	err = sendPkt(t.Post, true)
+	err = sendPkt(t.Post, delay)
 	if err != nil {
 		errStr = append(errStr, err.Error())
 	}
@@ -251,7 +257,7 @@ func doTest(t *BRTest, cases []reflect.SelectCase) error {
 	return nil
 }
 
-func sendPkt(pkt *tpkt.Pkt, to bool) error {
+func sendPkt(pkt *tpkt.Pkt, delay time.Duration) error {
 	if pkt == nil {
 		return nil
 	}
@@ -263,9 +269,8 @@ func sendPkt(pkt *tpkt.Pkt, to bool) error {
 	if err != nil {
 		return err
 	}
-	if to {
-		defer time.Sleep(timeout)
-	}
+	// A negative or zero duration causes Sleep to return immediately.
+	defer time.Sleep(delay)
 	return devInfo.handle.WritePacketData(raw)
 }
 
@@ -275,6 +280,10 @@ func sendPkt(pkt *tpkt.Pkt, to bool) error {
 // can check that only the expected packets were received.
 func checkRecvPkts(t *BRTest, cases []reflect.SelectCase) error {
 	timerIdx := len(devList)
+	timeout := defaultTimeout
+	if t.Timeout != time.Duration(0) {
+		timeout = t.Timeout
+	}
 	timerCh := time.After(timeout)
 	// Add timeout channel as the last select case.
 	cases[timerIdx] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(timerCh)}

--- a/go/border/braccept/main.go
+++ b/go/border/braccept/main.go
@@ -269,7 +269,6 @@ func sendPkt(pkt *tpkt.Pkt, delay time.Duration) error {
 	if err != nil {
 		return err
 	}
-	// A negative or zero duration causes Sleep to return immediately.
 	defer time.Sleep(delay)
 	return devInfo.handle.WritePacketData(raw)
 }

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -202,14 +202,14 @@
 			"revisionTime": "2018-10-23T10:10:25Z"
 		},
 		{
-			"checksumSHA1": "um5piGuv1mDW1MSN2W2MOk9I+lc=",
-			"path": "github.com/google/gopacket/layers",
-			"revision": "a35e09f9f224786863ce609de910bc82fc4d4faf",
-			"revisionTime": "2018-10-23T10:10:25Z"
+			"checksumSHA1": "PS5Gm5bHjKEAgonKZ6eAF5lpEE8=",
+			"path": "github.com/google/gopacket/afpacket",
+			"revision": "102d5ca2098cc070c7fdc9d7dbd504658bc92363",
+			"revisionTime": "2019-01-23T01:18:26Z"
 		},
 		{
-			"checksumSHA1": "K/ZCqnn9Y7FMc4c7aijBWt1bQoY=",
-			"path": "github.com/google/gopacket/pcap",
+			"checksumSHA1": "um5piGuv1mDW1MSN2W2MOk9I+lc=",
+			"path": "github.com/google/gopacket/layers",
 			"revision": "a35e09f9f224786863ce609de910bc82fc4d4faf",
 			"revisionTime": "2018-10-23T10:10:25Z"
 		},

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -196,10 +196,10 @@
 			"revisionTime": "2018-11-15T01:20:43Z"
 		},
 		{
-			"checksumSHA1": "bBQats+Oofu1ynsNBZcZEfldr8U=",
+			"checksumSHA1": "ya0ZqXQqWm8vlRXF7Yg34RyfDto=",
 			"path": "github.com/google/gopacket",
-			"revision": "a35e09f9f224786863ce609de910bc82fc4d4faf",
-			"revisionTime": "2018-10-23T10:10:25Z"
+			"revision": "102d5ca2098cc070c7fdc9d7dbd504658bc92363",
+			"revisionTime": "2019-01-23T01:18:26Z"
 		},
 		{
 			"checksumSHA1": "PS5Gm5bHjKEAgonKZ6eAF5lpEE8=",
@@ -208,10 +208,10 @@
 			"revisionTime": "2019-01-23T01:18:26Z"
 		},
 		{
-			"checksumSHA1": "um5piGuv1mDW1MSN2W2MOk9I+lc=",
+			"checksumSHA1": "zr24UchDVS+JpKoJRutLq5ioJ6A=",
 			"path": "github.com/google/gopacket/layers",
-			"revision": "a35e09f9f224786863ce609de910bc82fc4d4faf",
-			"revisionTime": "2018-10-23T10:10:25Z"
+			"revision": "102d5ca2098cc070c7fdc9d7dbd504658bc92363",
+			"revisionTime": "2019-01-23T01:18:26Z"
 		},
 		{
 			"checksumSHA1": "P3zGmsNjW8m15a+nks4FdVpFKwE=",


### PR DESCRIPTION
This changes are intended to solve some reliability issues encountered
when running the br acceptance tests in CI.

It adds per test timeout and delay paramenters and replaces libpcap with
AF_PACKET which seems to solve most of the timeout issues seen so far.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2398)
<!-- Reviewable:end -->
