### PR TITLE
CS: Push local chain to all core CSes in ISD

### DIFF
--- a/go/cert_srv/internal/reiss/corepush.go
+++ b/go/cert_srv/internal/reiss/corepush.go
@@ -1,0 +1,139 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reiss
+
+import (
+	"context"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/periodic"
+	"github.com/scionproto/scion/go/lib/scrypto/cert"
+	"github.com/scionproto/scion/go/lib/scrypto/trc"
+	"github.com/scionproto/scion/go/lib/snet"
+)
+
+var (
+	RetrySleep = time.Second
+)
+
+var _ periodic.Task = (*CorePusher)(nil)
+
+// CorePusher is a periodic.Task that pushes the local chain to all core CSes in the ISD.
+// The interval this task is run in is expected to be rather large (e.g. 1h).
+type CorePusher struct {
+	LocalIA addr.IA
+	TrustDB trustdb.TrustDB
+	Msger   infra.Messenger
+}
+
+// Run makes sure all core CS have the chain of the local AS.
+// Run implements periodic.Task.Run.
+func (p *CorePusher) Run(ctx context.Context) {
+	chain, err := p.TrustDB.GetChainMaxVersion(ctx, p.LocalIA)
+	if err != nil {
+		log.Error("[corePusher] Failed to get local chain from DB", "err", err)
+		return
+	}
+	coreMap, err := p.coreASes(ctx)
+	if err != nil {
+		log.Error("[corePusher] Failed to determine core ASes", "err", err)
+		return
+	}
+	cores := coreMap.ASList()
+	for syncTries := 0; syncTries < 3 && ctx.Err() == nil; syncTries++ {
+		time.Sleep(time.Duration(syncTries) * RetrySleep)
+		cores, err = p.syncCores(ctx, chain, cores)
+		if err == nil {
+			log.Info("[corePusher] Successfully pushed chain to cores", "cores", len(coreMap))
+			return
+		}
+		if err != nil {
+			log.Error("[corePusher] Failed to sync cores", "err", err, "remaining", cores)
+		}
+	}
+}
+
+// syncCores tries to sync to the given cores and returns the cores for which the syncing failed.
+func (p *CorePusher) syncCores(ctx context.Context, chain *cert.Chain,
+	cores []addr.IA) ([]addr.IA, error) {
+
+	checkErrors := 0
+	sendErrors := 0
+	var remainingCores []addr.IA
+	for _, coreIA := range cores {
+		hasChain, err := p.hasChain(ctx, coreIA, chain)
+		if err != nil {
+			checkErrors++
+			// fall-through explicitly, we just assume the core doesn't have it and send it.
+		}
+		if err != nil || !hasChain {
+			if err = p.sendChain(ctx, coreIA, chain); err != nil {
+				remainingCores = append(remainingCores, coreIA)
+				sendErrors++
+			}
+		}
+	}
+	if checkErrors > 0 || sendErrors > 0 {
+		return remainingCores, common.NewBasicError("Sync error", nil,
+			"checkErrors", checkErrors, "sendErrors", sendErrors)
+	}
+	return nil, nil
+}
+
+func (p *CorePusher) coreASes(ctx context.Context) (trc.CoreASMap, error) {
+	trc, err := p.TrustDB.GetTRCMaxVersion(ctx, p.LocalIA.I)
+	if err != nil {
+		return nil, common.NewBasicError("Failed to get TRC for localIA", err)
+	}
+	return trc.CoreASes, err
+}
+
+func (p *CorePusher) hasChain(ctx context.Context, coreAS addr.IA,
+	expectedChain *cert.Chain) (bool, error) {
+
+	chainIA, ver := expectedChain.IAVer()
+	req := &cert_mgmt.ChainReq{
+		RawIA:     chainIA.IAInt(),
+		Version:   ver,
+		CacheOnly: true,
+	}
+	coreAddr := &snet.Addr{IA: coreAS, Host: addr.NewSVCUDPAppAddr(addr.SvcCS)}
+	reply, err := p.Msger.GetCertChain(ctx, req, coreAddr, messenger.NextId())
+	if err != nil {
+		return false, common.NewBasicError("Error during fetch", err)
+	}
+	chain, err := reply.Chain()
+	return chain != nil, err
+}
+
+func (p *CorePusher) sendChain(ctx context.Context, coreAS addr.IA, chain *cert.Chain) error {
+	rawChain, err := chain.Compress()
+	if err != nil {
+		return common.NewBasicError("Failed to compress chain", err)
+	}
+	msg := &cert_mgmt.Chain{
+		RawChain: rawChain,
+	}
+	coreAddr := &snet.Addr{IA: coreAS, Host: addr.NewSVCUDPAppAddr(addr.SvcCS)}
+	// TODO(lukedirtwalker): Expect Acks.
+	return p.Msger.SendCertChain(ctx, msg, coreAddr, messenger.NextId())
+}

--- a/go/cert_srv/internal/reiss/corepush.go
+++ b/go/cert_srv/internal/reiss/corepush.go
@@ -100,7 +100,17 @@ func (p *CorePusher) coreASes(ctx context.Context) ([]addr.IA, error) {
 	if err != nil {
 		return nil, common.NewBasicError("Unable to get TRC for local ISD", err)
 	}
-	return trc.CoreASes.ASList(), err
+	return p.filterLocalIA(trc.CoreASes.ASList()), nil
+}
+
+func (p *CorePusher) filterLocalIA(allCores []addr.IA) []addr.IA {
+	cores := make([]addr.IA, 0, len(allCores))
+	for _, coreIA := range allCores {
+		if !p.LocalIA.Equal(coreIA) {
+			cores = append(cores, coreIA)
+		}
+	}
+	return cores
 }
 
 func (p *CorePusher) hasChain(ctx context.Context, coreAS addr.IA,

--- a/go/cert_srv/internal/reiss/corepush_test.go
+++ b/go/cert_srv/internal/reiss/corepush_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/scionproto/scion/go/lib/scrypto/cert"
 	"github.com/scionproto/scion/go/lib/scrypto/trc"
 	"github.com/scionproto/scion/go/lib/xtest"
+	"github.com/scionproto/scion/go/lib/xtest/matchers"
 )
 
 func init() {
@@ -97,23 +98,23 @@ func TestNonExistingChainsArePushed(t *testing.T) {
 	defer ctrl.Finish()
 
 	msger.EXPECT().GetCertChain(
-		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_110), gomock.Any()).Return(
+		gomock.Any(), gomock.Any(), matchers.IsSnetAddrWithIA(core1_110), gomock.Any()).Return(
 		emptyChainMsg, nil,
 	)
 	msger.EXPECT().GetCertChain(
-		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_120), gomock.Any()).Return(
+		gomock.Any(), gomock.Any(), matchers.IsSnetAddrWithIA(core1_120), gomock.Any()).Return(
 		emptyChainMsg, nil,
 	)
 	msger.EXPECT().GetCertChain(
-		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_130), gomock.Any()).Return(
+		gomock.Any(), gomock.Any(), matchers.IsSnetAddrWithIA(core1_130), gomock.Any()).Return(
 		emptyChainMsg, nil,
 	)
 	msger.EXPECT().SendCertChain(
-		gomock.Any(), matchesChain(rawChain1), xtest.IsSnetAddrWithIA(core1_110), gomock.Any())
+		gomock.Any(), matchesChain(rawChain1), matchers.IsSnetAddrWithIA(core1_110), gomock.Any())
 	msger.EXPECT().SendCertChain(
-		gomock.Any(), matchesChain(rawChain1), xtest.IsSnetAddrWithIA(core1_120), gomock.Any())
+		gomock.Any(), matchesChain(rawChain1), matchers.IsSnetAddrWithIA(core1_120), gomock.Any())
 	msger.EXPECT().SendCertChain(
-		gomock.Any(), matchesChain(rawChain1), xtest.IsSnetAddrWithIA(core1_130), gomock.Any())
+		gomock.Any(), matchesChain(rawChain1), matchers.IsSnetAddrWithIA(core1_130), gomock.Any())
 	pusher.Run(ctx)
 }
 
@@ -124,19 +125,19 @@ func TestExistingChainsAreNotRequested(t *testing.T) {
 	defer ctrl.Finish()
 
 	msger.EXPECT().GetCertChain(
-		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_110), gomock.Any()).Return(
+		gomock.Any(), gomock.Any(), matchers.IsSnetAddrWithIA(core1_110), gomock.Any()).Return(
 		chain1Msg, nil,
 	)
 	msger.EXPECT().GetCertChain(
-		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_120), gomock.Any()).Return(
+		gomock.Any(), gomock.Any(), matchers.IsSnetAddrWithIA(core1_120), gomock.Any()).Return(
 		chain1Msg, nil,
 	)
 	msger.EXPECT().GetCertChain(
-		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_130), gomock.Any()).Return(
+		gomock.Any(), gomock.Any(), matchers.IsSnetAddrWithIA(core1_130), gomock.Any()).Return(
 		emptyChainMsg, nil,
 	)
 	msger.EXPECT().SendCertChain(
-		gomock.Any(), matchesChain(rawChain1), xtest.IsSnetAddrWithIA(core1_130), gomock.Any())
+		gomock.Any(), matchesChain(rawChain1), matchers.IsSnetAddrWithIA(core1_130), gomock.Any())
 	pusher.Run(ctx)
 }
 
@@ -147,27 +148,27 @@ func TestErrDuringSendIsRetried(t *testing.T) {
 	defer ctrl.Finish()
 
 	msger.EXPECT().GetCertChain(
-		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_110), gomock.Any()).Return(
+		gomock.Any(), gomock.Any(), matchers.IsSnetAddrWithIA(core1_110), gomock.Any()).Return(
 		chain1Msg, nil,
 	)
 	msger.EXPECT().GetCertChain(
-		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_120), gomock.Any()).Return(
+		gomock.Any(), gomock.Any(), matchers.IsSnetAddrWithIA(core1_120), gomock.Any()).Return(
 		chain1Msg, nil,
 	)
 	msger.EXPECT().GetCertChain(
-		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_130), gomock.Any()).Return(
+		gomock.Any(), gomock.Any(), matchers.IsSnetAddrWithIA(core1_130), gomock.Any()).Return(
 		emptyChainMsg, nil,
 	)
 	gomock.InOrder(
 		msger.EXPECT().SendCertChain(
-			gomock.Any(), matchesChain(rawChain1), xtest.IsSnetAddrWithIA(core1_130),
+			gomock.Any(), matchesChain(rawChain1), matchers.IsSnetAddrWithIA(core1_130),
 			gomock.Any()).Return(common.NewBasicError("test error", nil)),
 		msger.EXPECT().GetCertChain(
-			gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_130), gomock.Any()).Return(
+			gomock.Any(), gomock.Any(), matchers.IsSnetAddrWithIA(core1_130), gomock.Any()).Return(
 			emptyChainMsg, nil,
 		),
 		msger.EXPECT().SendCertChain(
-			gomock.Any(), matchesChain(rawChain1), xtest.IsSnetAddrWithIA(core1_130), gomock.Any()),
+			gomock.Any(), matchesChain(rawChain1), matchers.IsSnetAddrWithIA(core1_130), gomock.Any()),
 	)
 	pusher.Run(ctx)
 }

--- a/go/cert_srv/internal/reiss/corepush_test.go
+++ b/go/cert_srv/internal/reiss/corepush_test.go
@@ -1,0 +1,197 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reiss
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/lib/infra/mock_infra"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb/mock_trustdb"
+	"github.com/scionproto/scion/go/lib/periodic"
+	"github.com/scionproto/scion/go/lib/scrypto/cert"
+	"github.com/scionproto/scion/go/lib/scrypto/trc"
+	"github.com/scionproto/scion/go/lib/xtest"
+)
+
+func init() {
+	var err error
+	chain1, err = cert.ChainFromFile("testdata/ISD1-ASff00_0_311-V1.crt", false)
+	if err != nil {
+		panic(err)
+	}
+	rawChain1, err = chain1.Compress()
+	if err != nil {
+		panic(err)
+	}
+	chain1Msg = &cert_mgmt.Chain{RawChain: rawChain1}
+
+	RetrySleep = 0
+}
+
+var (
+	localIA  = xtest.MustParseIA("1-ff00:0:311")
+	localISD = localIA.I
+
+	core1_110 = xtest.MustParseIA("1-ff00:0:110")
+	core1_130 = xtest.MustParseIA("1-ff00:0:130")
+	core1_120 = xtest.MustParseIA("1-ff00:0:120")
+
+	trc1 = &trc.TRC{
+		CoreASes: trc.CoreASMap{
+			core1_110: nil,
+			core1_120: nil,
+			core1_130: nil,
+		},
+	}
+
+	chain1 = &cert.Chain{
+		Leaf: &cert.Certificate{
+			Subject: localIA,
+			Version: uint64(1),
+		},
+	}
+	rawChain1 common.RawBytes
+	chain1Msg *cert_mgmt.Chain
+
+	emptyChainMsg = &cert_mgmt.Chain{RawChain: nil}
+)
+
+func setup(t *testing.T) (*gomock.Controller, *mock_infra.MockMessenger, periodic.Task) {
+	ctrl := gomock.NewController(t)
+	trustDB := mock_trustdb.NewMockTrustDB(ctrl)
+	msger := mock_infra.NewMockMessenger(ctrl)
+	pusher := &CorePusher{
+		LocalIA: localIA,
+		TrustDB: trustDB,
+		Msger:   msger,
+	}
+	trustDB.EXPECT().GetTRCMaxVersion(gomock.Any(), gomock.Eq(localISD)).Return(trc1, nil)
+	trustDB.EXPECT().GetChainMaxVersion(gomock.Any(), gomock.Eq(localIA)).Return(chain1, nil)
+	return ctrl, msger, pusher
+}
+
+func TestNonExistingChainsArePushed(t *testing.T) {
+	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
+	defer cancelF()
+	ctrl, msger, pusher := setup(t)
+	defer ctrl.Finish()
+
+	msger.EXPECT().GetCertChain(
+		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_110), gomock.Any()).Return(
+		emptyChainMsg, nil,
+	)
+	msger.EXPECT().GetCertChain(
+		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_120), gomock.Any()).Return(
+		emptyChainMsg, nil,
+	)
+	msger.EXPECT().GetCertChain(
+		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_130), gomock.Any()).Return(
+		emptyChainMsg, nil,
+	)
+	msger.EXPECT().SendCertChain(
+		gomock.Any(), matchesChain(rawChain1), xtest.IsSnetAddrWithIA(core1_110), gomock.Any())
+	msger.EXPECT().SendCertChain(
+		gomock.Any(), matchesChain(rawChain1), xtest.IsSnetAddrWithIA(core1_120), gomock.Any())
+	msger.EXPECT().SendCertChain(
+		gomock.Any(), matchesChain(rawChain1), xtest.IsSnetAddrWithIA(core1_130), gomock.Any())
+	pusher.Run(ctx)
+}
+
+func TestExistingChainsAreNotRequested(t *testing.T) {
+	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
+	defer cancelF()
+	ctrl, msger, pusher := setup(t)
+	defer ctrl.Finish()
+
+	msger.EXPECT().GetCertChain(
+		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_110), gomock.Any()).Return(
+		chain1Msg, nil,
+	)
+	msger.EXPECT().GetCertChain(
+		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_120), gomock.Any()).Return(
+		chain1Msg, nil,
+	)
+	msger.EXPECT().GetCertChain(
+		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_130), gomock.Any()).Return(
+		emptyChainMsg, nil,
+	)
+	msger.EXPECT().SendCertChain(
+		gomock.Any(), matchesChain(rawChain1), xtest.IsSnetAddrWithIA(core1_130), gomock.Any())
+	pusher.Run(ctx)
+}
+
+func TestErrDuringSendIsRetried(t *testing.T) {
+	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
+	defer cancelF()
+	ctrl, msger, pusher := setup(t)
+	defer ctrl.Finish()
+
+	msger.EXPECT().GetCertChain(
+		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_110), gomock.Any()).Return(
+		chain1Msg, nil,
+	)
+	msger.EXPECT().GetCertChain(
+		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_120), gomock.Any()).Return(
+		chain1Msg, nil,
+	)
+	msger.EXPECT().GetCertChain(
+		gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_130), gomock.Any()).Return(
+		emptyChainMsg, nil,
+	)
+	gomock.InOrder(
+		msger.EXPECT().SendCertChain(
+			gomock.Any(), matchesChain(rawChain1), xtest.IsSnetAddrWithIA(core1_130),
+			gomock.Any()).Return(common.NewBasicError("test error", nil)),
+		msger.EXPECT().GetCertChain(
+			gomock.Any(), gomock.Any(), xtest.IsSnetAddrWithIA(core1_130), gomock.Any()).Return(
+			emptyChainMsg, nil,
+		),
+		msger.EXPECT().SendCertChain(
+			gomock.Any(), matchesChain(rawChain1), xtest.IsSnetAddrWithIA(core1_130), gomock.Any()),
+	)
+	pusher.Run(ctx)
+}
+
+var _ gomock.Matcher = (*chainMsgMatcher)(nil)
+
+type chainMsgMatcher struct {
+	rawChain common.RawBytes
+}
+
+func matchesChain(rawChain common.RawBytes) *chainMsgMatcher {
+	return &chainMsgMatcher{
+		rawChain: rawChain,
+	}
+}
+
+func (m *chainMsgMatcher) Matches(x interface{}) bool {
+	msg, ok := x.(*cert_mgmt.Chain)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(m.rawChain, msg.RawChain)
+}
+
+func (m *chainMsgMatcher) String() string {
+	return fmt.Sprintf("Chain msg with raw: %s", m.rawChain)
+}

--- a/go/cert_srv/internal/reiss/requester.go
+++ b/go/cert_srv/internal/reiss/requester.go
@@ -41,10 +41,11 @@ var _ periodic.Task = (*Requester)(nil)
 // Requester requests reissued certificate chains before
 // expiration of the currently active certificate chain.
 type Requester struct {
-	Msgr     infra.Messenger
-	State    *config.State
-	IA       addr.IA
-	LeafTime time.Duration
+	Msgr       infra.Messenger
+	State      *config.State
+	IA         addr.IA
+	LeafTime   time.Duration
+	CorePusher *periodic.Runner
 }
 
 // Run requests reissued certificate chains from the issuer AS.
@@ -122,6 +123,7 @@ func (r *Requester) handleRep(ctx context.Context, rep *cert_mgmt.ChainIssRep) (
 	r.State.SetSigner(signer)
 	r.Msgr.UpdateSigner(signer, []infra.MessageType{infra.ChainIssueRequest})
 	log.Info("[reiss.Requester] Updated certificate chain", "chain", chain)
+	r.CorePusher.TriggerRun()
 	return false, nil
 }
 

--- a/go/cert_srv/internal/reiss/self.go
+++ b/go/cert_srv/internal/reiss/self.go
@@ -37,11 +37,12 @@ var _ periodic.Task = (*Self)(nil)
 // on an issuer AS before the old one expires.
 type Self struct {
 	// Msgr is used to propagate key updates to the messenger, and not for network traffic
-	Msgr     infra.Messenger
-	State    *config.State
-	IA       addr.IA
-	IssTime  time.Duration
-	LeafTime time.Duration
+	Msgr       infra.Messenger
+	State      *config.State
+	IA         addr.IA
+	IssTime    time.Duration
+	LeafTime   time.Duration
+	CorePusher *periodic.Runner
 }
 
 // Run issues certificate chains for the local AS.
@@ -77,6 +78,7 @@ func (s *Self) run(ctx context.Context) error {
 			return common.NewBasicError("Unable to issue certificate chain", err)
 		}
 	}
+	s.CorePusher.TriggerRun()
 	return nil
 }
 

--- a/go/cert_srv/internal/reiss/testdata/ISD1-ASff00_0_311-V1.crt
+++ b/go/cert_srv/internal/reiss/testdata/ISD1-ASff00_0_311-V1.crt
@@ -1,0 +1,32 @@
+{
+    "0": {
+    "SignAlgorithm": "ed25519",
+    "SubjectSignKey": "5YYo/Djor8KoUPbcG89m0sOXbhaxU/wserVf7X4w0W4=",
+    "Version": 1,
+    "EncAlgorithm": "curve25519xsalsa20poly1305",
+    "SubjectEncKey": "nP1HkZwkW8ujqeEO82Rb9cN6AVqFPO1UIiypdZU+dHI=",
+    "TRCVersion": 2,
+    "ExpirationTime": 1539868933,
+    "Signature": "36dhobVsPBt6UlMCZtmYHoKJbuS3MbZNvu24nA+kt780bf4ZenIreuvnxphIxuI327cBoeDsB+Tg1EvSPnwEBg==",
+    "Issuer": "1-ff00:0:110",
+    "CanIssue": false,
+    "Subject": "1-ff00:0:311",
+    "IssuingTime": 1508332933,
+    "Comment": "AS Certificate\u2602\u2602\u2602\u2602"
+    },
+    "1": {
+    "SignAlgorithm": "ed25519",
+    "SubjectSignKey": "kqh9WJfVH10/apH278var5ec3AYIU5LjdS1n7SP5+p8=",
+    "Version": 1,
+    "EncAlgorithm": "curve25519xsalsa20poly1305",
+    "SubjectEncKey": "MxxFIP+KlhIyqxsv6B0Um72D+NPoLKGuBPNt8b14/RI=",
+    "TRCVersion": 2,
+    "ExpirationTime": 1539868933,
+    "Signature": "CbjEsqIe4LW7kjMsyMBim4RdRn0YwM4kCjED+1Lbja4o3lwQVHqxVzQ8Rx0CsmHdsm4mwPoNg++KKUlUxrRmCg==",
+    "Issuer": "1-ff00:0:110",
+    "CanIssue": true,
+    "Subject": "1-ff00:0:110",
+    "IssuingTime": 1508332933,
+    "Comment": "Core AS Certificate"
+    }
+}

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -129,7 +129,7 @@ func startReissRunner() {
 				Msger:   msgr,
 			},
 			periodic.NewTicker(time.Hour),
-			59*time.Minute,
+			time.Minute,
 		)
 		corePusher.TriggerRun()
 	}

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	_ "net/http/pprof"
 	"os"
+	"time"
 
 	"github.com/BurntSushi/toml"
 
@@ -41,6 +42,7 @@ var (
 	environment *env.Env
 	reissRunner *periodic.Runner
 	msgr        infra.Messenger
+	corePusher  *periodic.Runner
 )
 
 func init() {
@@ -119,6 +121,18 @@ func reload() error {
 // startReissRunner starts a periodic reissuance task. Core starts self-issuer.
 // Non-core starts a requester.
 func startReissRunner() {
+	if !cfg.General.Topology.Core {
+		corePusher = periodic.StartPeriodicTask(
+			&reiss.CorePusher{
+				LocalIA: cfg.General.Topology.ISD_AS,
+				TrustDB: state.TrustDB,
+				Msger:   msgr,
+			},
+			periodic.NewTicker(time.Hour),
+			59*time.Minute,
+		)
+		corePusher.TriggerRun()
+	}
 	if !cfg.CS.AutomaticRenewal {
 		log.Info("Reissue disabled, not starting reiss task.")
 		return
@@ -141,10 +155,11 @@ func startReissRunner() {
 	log.Info("Starting periodic reiss.Requester task")
 	reissRunner = periodic.StartPeriodicTask(
 		&reiss.Requester{
-			Msgr:     msgr,
-			State:    state,
-			IA:       cfg.General.Topology.ISD_AS,
-			LeafTime: cfg.CS.LeafReissueLeadTime.Duration,
+			Msgr:       msgr,
+			State:      state,
+			IA:         cfg.General.Topology.ISD_AS,
+			LeafTime:   cfg.CS.LeafReissueLeadTime.Duration,
+			CorePusher: corePusher,
 		},
 		periodic.NewTicker(cfg.CS.ReissueRate.Duration),
 		cfg.CS.ReissueTimeout.Duration,
@@ -152,6 +167,9 @@ func startReissRunner() {
 }
 
 func stopReissRunner() {
+	if corePusher != nil {
+		corePusher.Stop()
+	}
 	if reissRunner != nil {
 		reissRunner.Stop()
 	}

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -121,18 +121,16 @@ func reload() error {
 // startReissRunner starts a periodic reissuance task. Core starts self-issuer.
 // Non-core starts a requester.
 func startReissRunner() {
-	if !cfg.General.Topology.Core {
-		corePusher = periodic.StartPeriodicTask(
-			&reiss.CorePusher{
-				LocalIA: cfg.General.Topology.ISD_AS,
-				TrustDB: state.TrustDB,
-				Msger:   msgr,
-			},
-			periodic.NewTicker(time.Hour),
-			time.Minute,
-		)
-		corePusher.TriggerRun()
-	}
+	corePusher = periodic.StartPeriodicTask(
+		&reiss.CorePusher{
+			LocalIA: cfg.General.Topology.ISD_AS,
+			TrustDB: state.TrustDB,
+			Msger:   msgr,
+		},
+		periodic.NewTicker(time.Hour),
+		time.Minute,
+	)
+	corePusher.TriggerRun()
 	if !cfg.CS.AutomaticRenewal {
 		log.Info("Reissue disabled, not starting reiss task.")
 		return
@@ -141,11 +139,12 @@ func startReissRunner() {
 		log.Info("Starting periodic reiss.Self task")
 		reissRunner = periodic.StartPeriodicTask(
 			&reiss.Self{
-				Msgr:     msgr,
-				State:    state,
-				IA:       cfg.General.Topology.ISD_AS,
-				IssTime:  cfg.CS.IssuerReissueLeadTime.Duration,
-				LeafTime: cfg.CS.LeafReissueLeadTime.Duration,
+				Msgr:       msgr,
+				State:      state,
+				IA:         cfg.General.Topology.ISD_AS,
+				IssTime:    cfg.CS.IssuerReissueLeadTime.Duration,
+				LeafTime:   cfg.CS.LeafReissueLeadTime.Duration,
+				CorePusher: corePusher,
 			},
 			periodic.NewTicker(cfg.CS.ReissueRate.Duration),
 			cfg.CS.ReissueTimeout.Duration,

--- a/go/lib/xtest/matchers.go
+++ b/go/lib/xtest/matchers.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// File matchers contains matchers for gomock.
+
+package xtest
+
+import (
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/snet"
+)
+
+var _ gomock.Matcher = (*addrIAMatcher)(nil)
+
+type addrIAMatcher struct {
+	ia addr.IA
+}
+
+// IsSnetAddrWithIA returns a matcher for a snet.Addr with the given IA.
+func IsSnetAddrWithIA(ia addr.IA) gomock.Matcher {
+	return &addrIAMatcher{ia: ia}
+}
+
+func (m *addrIAMatcher) Matches(x interface{}) bool {
+	sAddr, ok := x.(*snet.Addr)
+	if !ok {
+		return false
+	}
+	return sAddr.IA.Equal(m.ia)
+}
+
+func (m *addrIAMatcher) String() string {
+	return fmt.Sprintf("Matching addr with IA %v", m.ia)
+}

--- a/go/lib/xtest/matchers/matchers.go
+++ b/go/lib/xtest/matchers/matchers.go
@@ -14,7 +14,7 @@
 
 // File matchers contains matchers for gomock.
 
-package xtest
+package matchers
 
 import (
 	"fmt"


### PR DESCRIPTION
Each CS periodically pushes the local chain to all core CSes.
This is required to change the lookup logic of CSes (to only look up at cores).
Additionally this will help in the future to list all ASes in an ISD at a core CS.

Fixes #2308

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2399)
<!-- Reviewable:end -->
