### PR TITLE
pingpong: check for missing remote port when validating flags

### DIFF
--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -94,12 +94,6 @@ func main() {
 	initNetwork()
 	switch *mode {
 	case ModeClient:
-		if remote.Host == nil {
-			LogFatal("Missing remote address")
-		}
-		if remote.Host.L4.Port() == 0 {
-			LogFatal("Invalid remote port", "remote port", remote.Host.L4.Port())
-		}
 		c := newClient()
 		setSignalHandler(c)
 		c.run()
@@ -113,8 +107,16 @@ func validateFlags() {
 	if *mode != ModeClient && *mode != ModeServer {
 		LogFatal("Unknown mode, must be either '" + ModeClient + "' or '" + ModeServer + "'")
 	}
-	if *mode == ModeClient && remote.Host == nil {
-		LogFatal("Missing remote address")
+	if *mode == ModeClient {
+		if remote.Host == nil {
+			LogFatal("Missing remote address")
+		}
+		if remote.Host.L4 == nil {
+			LogFatal("Missing remote port")
+		}
+		if remote.Host.L4.Port() == 0 {
+			LogFatal("Invalid remote port", "remote port", remote.Host.L4.Port())
+		}
 	}
 	if local.Host == nil {
 		LogFatal("Missing local address")


### PR DESCRIPTION
While there, consolidate the validation of flags.

Without this change, `./bin/pingpong` crashes if I fail to specify the remote port:

```
$ ./bin/pingpong -local 17-ffaa:1:bb9,[127.0.0.1] -remote 19-ffaa:0:1303,[141.44.25.144]
2019-01-28 11:56:39.559543+0100 [CRIT] Panic msg="runtime error: invalid memory address or nil pointer dereference" stack=
>  goroutine 1 [running]:
>  runtime/debug.Stack(0xc4201fbd98, 0xab2780, 0x10be990)
>       /usr/local/go/src/runtime/debug/stack.go:24 +0xa7
>  github.com/scionproto/scion/go/lib/log.LogPanicAndExit()
>       /home/scion/go/src/github.com/scionproto/scion/go/lib/log/log.go:142 +0x6e
>  panic(0xab2780, 0x10be990)
>       /usr/local/go/src/runtime/panic.go:491 +0x283
>  main.main()
>       /home/scion/go/src/github.com/scionproto/scion/go/examples/pingpong/pingpong.go:99 +0x163
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2401)
<!-- Reviewable:end -->
