### PR TITLE
Handle empty TRC&Chain messages in python

### DIFF
--- a/python/lib/packet/cert_mgmt.py
+++ b/python/lib/packet/cert_mgmt.py
@@ -1,4 +1,5 @@
 # Copyright 2015 ETH Zurich
+# Copyright 2019 ETH Zurich, Anapaya Systems
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -70,7 +71,9 @@ class CertChainReply(Cerealizable):  # pragma: no cover
 
     def __init__(self, p):
         super().__init__(p)
-        self.chain = CertificateChain.from_raw(p.chain, lz4_=True)
+        self.chain = None
+        if p.chain:
+            self.chain = CertificateChain.from_raw(p.chain, lz4_=True)
 
     @classmethod
     def from_values(cls, chain):
@@ -108,7 +111,9 @@ class TRCReply(Cerealizable):  # pragma: no cover
 
     def __init__(self, p):
         super().__init__(p)
-        self.trc = TRC.from_raw(p.trc, lz4_=True)
+        self.trc = None
+        if p.trc:
+            self.trc = TRC.from_raw(p.trc, lz4_=True)
 
     @classmethod
     def from_values(cls, trc):


### PR DESCRIPTION
In #2396 we started to allow empty replies for cache only TRC&Chain requests,
we need to handle this properly in python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2403)
<!-- Reviewable:end -->
