### PR TITLE
Infra: Add dynamic topology fetching

### DIFF
--- a/go/cert_srv/internal/config/config.go
+++ b/go/cert_srv/internal/config/config.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/as_conf"
 	"github.com/scionproto/scion/go/lib/env"
+	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
 	"github.com/scionproto/scion/go/lib/scrypto/cert"
 	"github.com/scionproto/scion/go/lib/truststorage"
 	"github.com/scionproto/scion/go/lib/util"
@@ -39,16 +40,18 @@ const (
 )
 
 type Config struct {
-	General env.General
-	Sciond  env.SciondClient `toml:"sd_client"`
-	Logging env.Logging
-	Metrics env.Metrics
-	TrustDB truststorage.TrustDBConf
-	Infra   env.Infra
-	CS      CSConfig
+	General   env.General
+	Sciond    env.SciondClient `toml:"sd_client"`
+	Logging   env.Logging
+	Metrics   env.Metrics
+	TrustDB   truststorage.TrustDBConf
+	Infra     env.Infra
+	Discovery idiscovery.Config
+	CS        CSConfig
 }
 
 func (c *Config) Init(confDir string) error {
+	c.Discovery.InitDefaults()
 	return c.CS.Init(confDir)
 }
 

--- a/go/cert_srv/internal/config/config_test.go
+++ b/go/cert_srv/internal/config/config_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/BurntSushi/toml"
 	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
 )
 
 func TestSampleCorrect(t *testing.T) {
@@ -28,6 +30,7 @@ func TestSampleCorrect(t *testing.T) {
 		var cfg Config
 		// Make sure AutomaticRenweal is set during decoding.
 		cfg.CS.AutomaticRenewal = true
+		cfg.Discovery.Dynamic.Enable = true
 		_, err := toml.Decode(Sample, &cfg)
 		SoMsg("err", err, ShouldBeNil)
 
@@ -41,6 +44,11 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection, ShouldEqual,
 			"/var/lib/scion/spki/cs-1.trust.db")
+		SoMsg("Discovery.Dynamic.Enable correct", cfg.Discovery.Dynamic.Enable, ShouldBeFalse)
+		SoMsg("Discovery.Dynamic.Interval correct", cfg.Discovery.Dynamic.Interval.Duration,
+			ShouldEqual, idiscovery.DefaultFetchInterval)
+		SoMsg("Discovery.Dynamic.Timeout correct", cfg.Discovery.Dynamic.Timeout.Duration,
+			ShouldEqual, idiscovery.DefaultFetchTimeout)
 
 		// csconfig specific
 		SoMsg("LeafReissueLeadTime correct", cfg.CS.LeafReissueLeadTime.Duration,

--- a/go/cert_srv/internal/config/sample.go
+++ b/go/cert_srv/internal/config/sample.go
@@ -72,6 +72,17 @@ const Sample = `[general]
   # Connection for the trust database
   Connection = "/var/lib/scion/spki/cs-1.trust.db"
 
+[discovery]
+  [discovery.dynamic]
+    # Enable periodic fetching of the dynamic topology. (default false)
+    Enable = false
+
+    # Time between two consecutive dynamic topology query. (default 5s)
+    Interval = "5s"
+
+    # Timeout for querying the dynamic topology.  (default 1s)
+    Timeout = "1s"
+
 [cs]
   # Time between starting reissue requests and leaf cert expiration. If not
   # specified, this is set to PathSegmentTTL.

--- a/go/lib/infra/modules/idiscovery/config.go
+++ b/go/lib/infra/modules/idiscovery/config.go
@@ -34,9 +34,7 @@ type Config struct {
 }
 
 func (c *Config) InitDefaults() {
-	if c.Dynamic.Enable {
-		c.Dynamic.InitDefaults()
-	}
+	c.Dynamic.InitDefaults()
 }
 
 type FetchConfig struct {

--- a/go/lib/infra/modules/idiscovery/config.go
+++ b/go/lib/infra/modules/idiscovery/config.go
@@ -1,0 +1,61 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idiscovery
+
+import (
+	"time"
+
+	"github.com/scionproto/scion/go/lib/util"
+)
+
+var (
+	// DefaultFetchInterval is the default time between two queries.
+	DefaultFetchInterval = 5 * time.Second
+	// DefaultFetchTimeout is the default timeout for a query.
+	DefaultFetchTimeout = 1 * time.Second
+)
+
+type Config struct {
+	// Dynamic contains the parameters for fetching the dynamic
+	// topology from the discovery service.
+	Dynamic FetchConfig
+}
+
+func (c *Config) InitDefaults() {
+	if c.Dynamic.Enable {
+		c.Dynamic.InitDefaults()
+	}
+}
+
+type FetchConfig struct {
+	// Enable indicates whether the discovery service is queried
+	// for updated topologies.
+	Enable bool
+	// Interval specifies the time between two queries.
+	Interval util.DurWrap
+	// Timeout specifies the timout for a single query.
+	Timeout util.DurWrap
+	// Https indicates whether https must be used to fetch the topology.
+	Https bool
+}
+
+func (f *FetchConfig) InitDefaults() {
+	if f.Interval.Duration == 0 {
+		f.Interval.Duration = DefaultFetchInterval
+	}
+	if f.Timeout.Duration == 0 {
+		f.Timeout.Duration = DefaultFetchTimeout
+	}
+}

--- a/go/lib/infra/modules/idiscovery/idiscovery.go
+++ b/go/lib/infra/modules/idiscovery/idiscovery.go
@@ -60,6 +60,7 @@ func StartRunners(cfg Config, file discovery.File, client *http.Client) (Runners
 		if err := startDynamic(&r, cfg.Dynamic, file, client); err != nil {
 			return Runners{}, err
 		}
+		r.Cleaner = itopo.StartCleaner(1*time.Second, 1*time.Second)
 		log.Info("[idiscovery] Started dynamic topology fetcher")
 	}
 	return r, nil
@@ -103,7 +104,6 @@ func startDynamic(r *Runners, cfg FetchConfig, file discovery.File, client *http
 	}
 	r.Dynamic = periodic.StartPeriodicTask(fetcher, periodic.NewTicker(cfg.Interval.Duration),
 		cfg.Timeout.Duration)
-	r.Cleaner = itopo.StartCleaner(1*time.Second, 1*time.Second)
 	return nil
 }
 

--- a/go/lib/infra/modules/idiscovery/idiscovery.go
+++ b/go/lib/infra/modules/idiscovery/idiscovery.go
@@ -1,0 +1,131 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package idiscovery fetches the topology from the discovery service.
+//
+// Client packages can start a periodic.Runner with StartDynamic that
+// periodically fetches a dynamic topology from the discovery service.
+// The received topology is set in itopo.
+//
+// A periodic.Taks with a customized TopoHandler can be created with
+// NewFetcher, if the client package requires more control.
+package idiscovery
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/discovery"
+	"github.com/scionproto/scion/go/lib/discovery/topofetcher"
+	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/periodic"
+	"github.com/scionproto/scion/go/lib/topology"
+)
+
+// TopoHandler handles a topology fetched from the discovery service, and
+// returns whether the provided topology is an update.
+type TopoHandler func(topo *topology.Topo) (bool, error)
+
+// dynamicSetter sets the dynamic topology in itopo with the provided topology.
+func dynamicSetter(topo *topology.Topo) (bool, error) {
+	_, updated, err := itopo.SetDynamic(topo)
+	return updated, err
+}
+
+// StartDynamic starts two periodic runners. The first runner periodically fetches
+// the dynamic topology and sets it in itopo. The second runner periodically cleans
+// the expired dynamic topologies from itopo.
+func StartDynamic(cfg FetchConfig, file discovery.File,
+	client *http.Client) (*periodic.Runner, *periodic.Runner, error) {
+
+	if !cfg.Enable {
+		return nil, nil, common.NewBasicError("Fetching not enabled", nil)
+	}
+	fetcher, err := NewFetcher(
+		dynamicSetter,
+		discovery.FetchParams{
+			Mode:  discovery.Dynamic,
+			File:  file,
+			Https: cfg.Https,
+		},
+		client,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	fetcherRunner := periodic.StartPeriodicTask(fetcher,
+		periodic.NewTicker(cfg.Interval.Duration), cfg.Timeout.Duration,
+	)
+	itopoCleaner := itopo.StartCleaner(1*time.Second, 1*time.Second)
+	return fetcherRunner, itopoCleaner, nil
+}
+
+// task is a periodic.Task that fetches the topology from the discovery service.
+type task struct {
+	log.Logger
+	handler TopoHandler
+	fetcher *topofetcher.Fetcher
+}
+
+// NewFetcher creates a periodic.Task that fetches the topology from the discovery
+// service and calls the provided handler on the received topology.
+func NewFetcher(handler TopoHandler, params discovery.FetchParams,
+	client *http.Client) (*task, error) {
+
+	if handler == nil {
+		return nil, common.NewBasicError("handler must not be nil", nil)
+	}
+	t := &task{
+		Logger:  log.New("Part", "Discovery", "Mode", params.Mode),
+		handler: handler,
+	}
+	var err error
+	t.fetcher, err = topofetcher.New(
+		itopo.Get().DS,
+		params,
+		topofetcher.Callbacks{
+			Error:  t.handleErr,
+			Update: t.handleTopo,
+		},
+		client,
+	)
+	if err != nil {
+		return nil, common.NewBasicError("Unable to initialize fetcher", err)
+	}
+	return t, nil
+}
+
+func (t *task) Run(ctx context.Context) {
+	if err := t.fetcher.UpdateInstances(itopo.Get().DS); err != nil {
+		log.Error("[discovery] Unable to update instances", "err", err)
+		return
+	}
+	t.fetcher.Run(ctx)
+}
+
+func (t *task) handleErr(err error) {
+	t.Error("[discovery] Unable to fetch topology", "err", err)
+}
+
+func (t *task) handleTopo(topo *topology.Topo) {
+	updated, err := t.handler(topo)
+	if err != nil {
+		t.Error("[discovery] Unable to handle topology", "err", err)
+	} else if updated {
+		t.Trace("[discovery] Set topology", "params", t.fetcher.Params)
+	}
+}

--- a/go/lib/infra/modules/idiscovery/idiscovery.go
+++ b/go/lib/infra/modules/idiscovery/idiscovery.go
@@ -123,7 +123,7 @@ func NewFetcher(handler TopoHandler, params discovery.FetchParams,
 		return nil, common.NewBasicError("handler must not be nil", nil)
 	}
 	t := &task{
-		Logger:  log.New("Part", "Discovery", "Mode", params.Mode),
+		Logger:  log.New("Module", "Discovery", "Mode", params.Mode),
 		handler: handler,
 	}
 	var err error

--- a/go/lib/infra/modules/itopo/cleaner.go
+++ b/go/lib/infra/modules/itopo/cleaner.go
@@ -39,6 +39,7 @@ func (c cleaner) Run(ctx context.Context) {
 		log.Info("[itopo.Cleaner] Dropping expired dynamic topology",
 			"ts", st.topo.dynamic.Timestamp, "ttl", st.topo.dynamic.TTL,
 			"expired", st.topo.dynamic.Expiry())
+		st.topo.dynamic = nil
 		call(st.clbks.DropDynamic)
 	}
 }

--- a/go/lib/infra/modules/itopo/itopo.go
+++ b/go/lib/infra/modules/itopo/itopo.go
@@ -56,6 +56,14 @@ func Get() *topology.Topo {
 	return st.topo.Get()
 }
 
+// SetDynamic atomically sets the dynamic topology. The returned topology is a pointer
+// to the currently active topology at the end of the function call. It might differ from
+// the input topology. The second return value indicates whether the in-memory
+// copy of the dynamic topology has been updated.
+func SetDynamic(static *topology.Topo) (*topology.Topo, bool, error) {
+	return st.setDynamic(static)
+}
+
 // SetStatic atomically sets the static topology. Whether semi-mutable fields are
 // allowed to change can be specified using semiMutAllowed. The returned
 // topology is a pointer to the currently active topology at the end of the function call.
@@ -128,6 +136,20 @@ func newState(id string, svc proto.ServiceType, clbks Callbacks) *state {
 		clbks:     clbks,
 	}
 	return s
+}
+
+// setDynamic atomically sets the dynamic topology.
+func (s *state) setDynamic(dynamic *topology.Topo) (*topology.Topo, bool, error) {
+	s.Lock()
+	defer s.Unlock()
+	if err := s.validator.Validate(dynamic, s.topo.static, false); err != nil {
+		return nil, false, err
+	}
+	if keepOld(dynamic, s.topo.dynamic) {
+		return s.topo.Get(), true, nil
+	}
+	s.topo.dynamic = dynamic
+	return s.topo.Get(), true, nil
 }
 
 // setStatic atomically sets the static topology.

--- a/go/lib/infra/modules/itopo/itopo.go
+++ b/go/lib/infra/modules/itopo/itopo.go
@@ -142,6 +142,9 @@ func newState(id string, svc proto.ServiceType, clbks Callbacks) *state {
 func (s *state) setDynamic(dynamic *topology.Topo) (*topology.Topo, bool, error) {
 	s.Lock()
 	defer s.Unlock()
+	if s.topo.static == nil {
+		return nil, false, common.NewBasicError("Static topology must be set", nil)
+	}
 	if err := s.validator.Validate(dynamic, s.topo.static, false); err != nil {
 		return nil, false, err
 	}

--- a/go/path_srv/internal/config/config.go
+++ b/go/path_srv/internal/config/config.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/env"
+	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
 	"github.com/scionproto/scion/go/lib/pathstorage"
 	"github.com/scionproto/scion/go/lib/truststorage"
 	"github.com/scionproto/scion/go/lib/util"
@@ -29,16 +30,18 @@ var (
 )
 
 type Config struct {
-	General env.General
-	Logging env.Logging
-	Metrics env.Metrics
-	TrustDB truststorage.TrustDBConf
-	Infra   env.Infra
-	PS      PSConfig
+	General   env.General
+	Logging   env.Logging
+	Metrics   env.Metrics
+	TrustDB   truststorage.TrustDBConf
+	Infra     env.Infra
+	Discovery idiscovery.Config
+	PS        PSConfig
 }
 
 func (c *Config) InitDefaults() {
 	c.PS.initDefaults()
+	c.Discovery.InitDefaults()
 }
 
 type PSConfig struct {

--- a/go/path_srv/internal/config/sample.go
+++ b/go/path_srv/internal/config/sample.go
@@ -65,6 +65,17 @@ const Sample = `[general]
   # Connection for the trust database
   Connection = "/var/lib/scion/spki/ps-1.trust.db"
 
+[discovery]
+  [discovery.dynamic]
+    # Enable periodic fetching of the dynamic topology. (default false)
+    Enable = false
+
+    # Time between two consecutive dynamic topology query. (default 5s)
+    Interval = "5s"
+
+    # Timeout for querying the dynamic topology.  (default 1s)
+    Timeout = "1s"
+
 [ps]
   # Enable the "old" replication of down segments between cores using SegSync
   # messages (default false)

--- a/go/path_srv/internal/config/sample_test.go
+++ b/go/path_srv/internal/config/sample_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/BurntSushi/toml"
 	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
 )
 
 func TestSampleCorrect(t *testing.T) {
@@ -27,6 +29,7 @@ func TestSampleCorrect(t *testing.T) {
 		var cfg Config
 		// Make sure SegSync is set.
 		cfg.PS.SegSync = true
+		cfg.Discovery.Dynamic.Enable = true
 		_, err := toml.Decode(Sample, &cfg)
 		SoMsg("err", err, ShouldBeNil)
 
@@ -40,6 +43,11 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection, ShouldEqual,
 			"/var/lib/scion/spki/ps-1.trust.db")
+		SoMsg("Discovery.Dynamic.Enable correct", cfg.Discovery.Dynamic.Enable, ShouldBeFalse)
+		SoMsg("Discovery.Dynamic.Interval correct", cfg.Discovery.Dynamic.Interval.Duration,
+			ShouldEqual, idiscovery.DefaultFetchInterval)
+		SoMsg("Discovery.Dynamic.Timeout correct", cfg.Discovery.Dynamic.Timeout.Duration,
+			ShouldEqual, idiscovery.DefaultFetchTimeout)
 
 		// psconfig specific
 		SoMsg("PathDB.Backend correct", cfg.PS.PathDB.Backend, ShouldEqual, "sqlite")

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -110,7 +110,7 @@ class GoGenerator(object):
             'infra': {
                 'Type': "PS"
             },
-            'Discovery': self._discovery_entry(),
+            'discovery': self._discovery_entry(),
             'ps': {
                 'PathDB': {
                     'Backend': 'sqlite',

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -110,6 +110,7 @@ class GoGenerator(object):
             'infra': {
                 'Type': "PS"
             },
+            'Discovery': self._discovery_entry(),
             'ps': {
                 'PathDB': {
                     'Backend': 'sqlite',
@@ -177,6 +178,7 @@ class GoGenerator(object):
             'infra': {
                 'Type': "CS"
             },
+            'discovery': self._discovery_entry(),
             'cs': {
                 'LeafReissueLeadTime': "6h",
                 'IssuerReissueLeadTime': "3d",
@@ -216,6 +218,14 @@ class GoGenerator(object):
                 'Prometheus': prometheus_addr,
             },
         }
+
+    def _discovery_entry(self):
+        entry = {
+            "dynamic": {
+                "Enable": self.args.discovery,
+            }
+        }
+        return entry
 
     def _log_entry(self, name):
         entry = {


### PR DESCRIPTION
This PR adds dynamic topology fetching from the discovery service
to the certificate and path server.

Fetching can be enabled through the config file.

To mock the discovery service, a simple http server can be started (`go/examples/server.sh`)
```
./scion.sh topology -ds
./go/examples/server.sh gen/ISD1/ASff00_0_111/endhost/topology.json
# BLAH is the dir created by server.sh
vim /tmp/tmp.BLAH/discovery/v1/dynamic/full.json 
```

Acceptance tests will be added in a follow-up PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2409)
<!-- Reviewable:end -->
