### PR TITLE
snet: Expose packet fields to SCION apps

### DIFF
--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -53,18 +53,18 @@ var _ net.PacketConn = (*SCIONConn)(nil)
 var _ Conn = (*SCIONConn)(nil)
 
 type SCIONConn struct {
-	conn net.PacketConn
-	*scionConnBase
-	*scionConnWriter
-	*scionConnReader
+	conn *RawSCIONConn
+	scionConnBase
+	scionConnWriter
+	scionConnReader
 }
 
-func newSCIONConn(base *scionConnBase, pr pathmgr.Resolver, conn net.PacketConn) *SCIONConn {
+func newSCIONConn(base *scionConnBase, pr pathmgr.Resolver, conn *RawSCIONConn) *SCIONConn {
 	return &SCIONConn{
 		conn:            conn,
-		scionConnBase:   base,
-		scionConnWriter: newScionConnWriter(base, pr, conn),
-		scionConnReader: newScionConnReader(base, conn),
+		scionConnBase:   *base,
+		scionConnWriter: *newScionConnWriter(base, pr, conn),
+		scionConnReader: *newScionConnReader(base, conn),
 	}
 }
 

--- a/go/lib/snet/raw.go
+++ b/go/lib/snet/raw.go
@@ -1,0 +1,229 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snet
+
+import (
+	"net"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/hpkt"
+	"github.com/scionproto/scion/go/lib/l4"
+	"github.com/scionproto/scion/go/lib/overlay"
+	"github.com/scionproto/scion/go/lib/spath"
+	"github.com/scionproto/scion/go/lib/spkt"
+)
+
+// BaseLayer contains the raw slices of data related to a packet. Most callers
+// can safely ignore it. For performance-critical applications, callers should
+// manually allocate/recycle the BaseLayer.
+//
+// Prior to serialization/decoding, the internal slice is reset to its full
+// capacity, so be careful about passing in slices that have runoff data after
+// their length.
+//
+// After a packet has been serialized/decoded, the length of Contents will be
+// equal to the size of the entire packet data. The capacity remains unchanged.
+//
+// If the BaseLayer is unitialized, space will be allocated during
+// serialization/decoding.
+type BaseLayer struct {
+	Contents common.RawBytes
+}
+
+// Prepare readies a layer for use.
+//
+// If the layer is not allocated, a backing buffer of maximum packet size is
+// allocated.
+//
+// If the layer is already allocated, its length is reset to its capacity.
+func (layer *BaseLayer) Prepare() {
+	if layer.Contents == nil {
+		layer.Contents = make(common.RawBytes, common.MaxMTU)
+	}
+	layer.Contents = layer.Contents[:cap(layer.Contents)]
+}
+
+type SCIONPacket struct {
+	BaseLayer
+	SCIONPacketInfo
+}
+
+// SCIONPacketInfo contains the data needed to construct a SCION packet.
+//
+// This is a high-level structure, and can only be used to create valid
+// packets. The documentation for each field specifies cases where
+// serialization might fail due to some violation of SCION protocol rules.
+type SCIONPacketInfo struct {
+	// Destination contains the destination address.
+	Destination NodeAddress
+	// Source contains the source address. If it is an SVC address, packet
+	// serialization will return an error.
+	Source NodeAddress
+	// Path contains a SCION forwarding path. The field must be nil or an empty
+	// path if the source and destination are inside the same AS.
+	//
+	// If the source and destination are in different ASes but the path is
+	// nil or empty, an error is returned during serialization.
+	Path *spath.Path
+	// Extensions contains SCION HBH and E2E extensions. When received from a
+	// RawSCIONConn, extensions are present in the order they were found in the packet.
+	//
+	// When writing to a RawSCIONConn, the serializer will attempt
+	// to reorder the extensions, depending on their type, in the correct
+	// order. If the number of extensions is over the limit allowed by SCION,
+	// serialization will fail. Whenever multiple orders are valid, the stable
+	// sorting is preferred.
+	//
+	// The SCMP HBH extension needs to be manually included by calling code,
+	// even when the L4Header and Payload demand one (as is the case, for
+	// example, for a SCMP::General::RecordPathRequest packet).
+	Extensions []common.Extension
+	// L4Header contains L4 header information.
+	L4Header l4.L4Header
+	Payload  common.Payload
+}
+
+// NodeAddress is the fully-specified SCION address of a host.
+type NodeAddress struct {
+	IA   addr.IA
+	Host addr.HostAddr
+}
+
+// RawSCIONConn gives applications full control over the content of valid SCION
+// packets.
+type RawSCIONConn struct {
+	conn net.PacketConn
+	rawSCIONConnWriter
+	rawSCIONConnReader
+}
+
+// NewRawSCIONConn implements reading and writing SCION packets on a
+// net.PacketConn. Usually, conn will be a SCION Dispatcher socket.
+//
+// SerializationOptions are not supported yet.
+func NewRawSCIONConn(conn net.PacketConn, _ SerializationOptions) *RawSCIONConn {
+	return &RawSCIONConn{
+		conn: conn,
+		rawSCIONConnWriter: rawSCIONConnWriter{
+			conn: conn,
+		},
+		rawSCIONConnReader: rawSCIONConnReader{
+			conn: conn,
+		},
+	}
+}
+
+func (c *RawSCIONConn) SetDeadline(d time.Time) error {
+	return c.conn.SetDeadline(d)
+}
+
+func (c *RawSCIONConn) Close() error {
+	return c.conn.Close()
+}
+
+type rawSCIONConnWriter struct {
+	conn net.PacketConn
+}
+
+func (c *rawSCIONConnWriter) WriteTo(pkt *SCIONPacket, ov *overlay.OverlayAddr) error {
+	// TODO(scrye): scnPkt is a temporary solution. Its functionality will be
+	// absorbed by the easier to use SCIONPacket structure in this package.
+	scnPkt := &spkt.ScnPkt{
+		DstIA:   pkt.Destination.IA,
+		SrcIA:   pkt.Source.IA,
+		DstHost: pkt.Destination.Host,
+		SrcHost: pkt.Source.Host,
+		Path:    pkt.Path,
+		L4:      pkt.L4Header,
+		Pld:     pkt.Payload,
+	}
+	pkt.BaseLayer.Prepare()
+	n, err := hpkt.WriteScnPkt(scnPkt, pkt.Contents)
+	if err != nil {
+		return common.NewBasicError("Unable to serialize SCION packet", err)
+	}
+	pkt.Contents = pkt.Contents[:n]
+	// Send message
+	_, err = c.conn.WriteTo(pkt.Contents, ov)
+	if err != nil {
+		return common.NewBasicError("Reliable socket write error", err)
+	}
+	return nil
+}
+
+func (c *rawSCIONConnWriter) SetWriteDeadline(d time.Time) error {
+	return c.conn.SetWriteDeadline(d)
+}
+
+type rawSCIONConnReader struct {
+	conn net.PacketConn
+}
+
+func (c *rawSCIONConnReader) ReadFrom(pkt *SCIONPacket, ov *overlay.OverlayAddr) error {
+	pkt.BaseLayer.Prepare()
+	n, lastHopNetAddr, err := c.conn.ReadFrom(pkt.Contents)
+	if err != nil {
+		return common.NewBasicError("Reliable socket read error", err)
+	}
+	pkt.Contents = pkt.Contents[:n]
+	var lastHop *overlay.OverlayAddr
+
+	var ok bool
+	lastHop, ok = lastHopNetAddr.(*overlay.OverlayAddr)
+	if !ok {
+		return common.NewBasicError("Invalid lastHop address Type", nil,
+			"Actual", lastHopNetAddr)
+	}
+
+	// TODO(scrye): scnPkt is a temporary solution. Its functionality will be
+	// absorbed by the easier to use SCIONPacket structure in this package.
+	scnPkt := &spkt.ScnPkt{
+		DstIA: addr.IA{},
+		SrcIA: addr.IA{},
+	}
+	err = hpkt.ParseScnPkt(scnPkt, pkt.Contents)
+	if err != nil {
+		return common.NewBasicError("SCION packet parse error", err)
+	}
+
+	pkt.Destination = NodeAddress{IA: scnPkt.DstIA, Host: scnPkt.DstHost}
+	pkt.Source = NodeAddress{IA: scnPkt.SrcIA, Host: scnPkt.SrcHost}
+	pkt.Path = scnPkt.Path
+	pkt.L4Header = scnPkt.L4
+	pkt.Payload = scnPkt.Pld
+	*ov = *lastHop
+	return nil
+}
+
+func (c *rawSCIONConnReader) SetReadDeadline(d time.Time) error {
+	return c.conn.SetReadDeadline(d)
+}
+
+type SerializationOptions struct {
+	// If ComputeChecksums is true, the checksums in sent SCIONPackets are
+	// recomputed. Otherwise, the checksum value is left intact.
+	ComputeChecksums bool
+	// If FixLengths is true, any lengths in sent SCIONPackets are recomputed
+	// to match the data contained in payloads/inner layers. This currently
+	// concerns extension headers and the L4 header.
+	FixLengths bool
+	// If InitializePaths is set to true, then forwarding paths are reset to
+	// their starting InfoField/HopField during serialization, irrespective of
+	// previous offsets. If it is set to false, then the fields are left
+	// unchanged.
+	InitializePaths bool
+}

--- a/go/lib/snet/reader.go
+++ b/go/lib/snet/reader.go
@@ -17,32 +17,25 @@ package snet
 import (
 	"context"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/hpkt"
 	"github.com/scionproto/scion/go/lib/l4"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/scmp"
-	"github.com/scionproto/scion/go/lib/spkt"
 )
 
 type scionConnReader struct {
 	base *scionConnBase
-
-	conn       net.PacketConn
-	readMutex  sync.Mutex
-	recvBuffer common.RawBytes
+	conn *RawSCIONConn
 }
 
-func newScionConnReader(base *scionConnBase, conn net.PacketConn) *scionConnReader {
+func newScionConnReader(base *scionConnBase, conn *RawSCIONConn) *scionConnReader {
 	return &scionConnReader{
-		base:       base,
-		recvBuffer: make(common.RawBytes, BufSize),
-		conn:       conn,
+		base: base,
+		conn: conn,
 	}
 }
 
@@ -67,44 +60,29 @@ func (c *scionConnReader) Read(b []byte) (int, error) {
 // read returns the number of bytes read, the address that sent the bytes and
 // an error (if one occurred).
 func (c *scionConnReader) read(b []byte, from bool) (int, *Addr, error) {
-	c.readMutex.Lock()
-	defer c.readMutex.Unlock()
-	var err error
-	var remote *Addr
 	if c.base.scionNet == nil {
 		return 0, nil, common.NewBasicError("SCION network not initialized", nil)
 	}
-	n, lastHopNetAddr, err := c.conn.ReadFrom(c.recvBuffer)
+
+	var pkt SCIONPacket
+	var lastHop overlay.OverlayAddr
+	err := c.conn.ReadFrom(&pkt, &lastHop)
 	if err != nil {
-		return 0, nil, common.NewBasicError("Dispatcher read error", err)
+		return 0, nil, err
 	}
-	var lastHop *overlay.OverlayAddr
-	if from {
-		var ok bool
-		lastHop, ok = lastHopNetAddr.(*overlay.OverlayAddr)
-		if !ok {
-			return 0, nil, common.NewBasicError("Invalid lastHop address Type", nil,
-				"Actual", lastHopNetAddr)
-		}
-	}
-	pkt := &spkt.ScnPkt{
-		DstIA: addr.IA{},
-		SrcIA: addr.IA{},
-	}
-	err = hpkt.ParseScnPkt(pkt, c.recvBuffer[:n])
-	if err != nil {
-		return 0, nil, common.NewBasicError("SCION packet parse error", err)
-	}
+
 	// Copy data, extract address
-	n, err = pkt.Pld.WritePld(b)
+	n, err := pkt.Payload.WritePld(b)
 	if err != nil {
 		return 0, nil, common.NewBasicError("Unable to copy payload", err)
 	}
+
+	var remote *Addr
 	// On UDP4 network we can get either UDP traffic or SCMP messages
 	if c.base.net == "udp4" {
 		// Extract remote address
 		remote = &Addr{
-			IA:   pkt.SrcIA,
+			IA:   pkt.Source.IA,
 			Path: pkt.Path,
 		}
 		// Extract path
@@ -114,45 +92,44 @@ func (c *scionConnReader) read(b []byte, from bool) (int, *Addr, error) {
 					common.NewBasicError("Unable to reverse path on received packet", err)
 			}
 		}
-		// Extract last hop
-		if lastHop != nil {
-			// XXX When do we not get a lastHop?
-			// Copy the address to prevent races. See
-			// https://github.com/scionproto/scion/issues/1659.
-			remote.NextHop = lastHop.Copy()
-		}
+
+		// Copy the address to prevent races. See
+		// https://github.com/scionproto/scion/issues/1659.
+		remote.NextHop = lastHop.Copy()
+
 		var err error
 		var l4i addr.L4Info
-		switch hdr := pkt.L4.(type) {
+		switch hdr := pkt.L4Header.(type) {
 		case *l4.UDP:
 			l4i = addr.NewL4UDPInfo(hdr.SrcPort)
 		case *scmp.Hdr:
 			l4i = addr.NewL4SCMPInfo()
-			c.handleSCMP(hdr, pkt)
+			c.handleSCMP(hdr, &pkt)
 			err = &OpError{scmp: hdr}
 		default:
 			err = common.NewBasicError("Unexpected SCION L4 protocol", nil,
-				"expected", "UDP or SCMP", "actual", pkt.L4.L4Type())
+				"expected", "UDP or SCMP", "actual", pkt.L4Header.L4Type())
 		}
 		// Copy the address to prevent races. See
 		// https://github.com/scionproto/scion/issues/1659.
-		remote.Host = &addr.AppAddr{L3: pkt.SrcHost.Copy(), L4: l4i}
+		remote.Host = &addr.AppAddr{L3: pkt.Source.Host.Copy(), L4: l4i}
 		return n, remote, err
 	}
 	return 0, nil, common.NewBasicError("Unknown network", nil, "net", c.base.net)
 }
 
-func (c *scionConnReader) handleSCMP(hdr *scmp.Hdr, pkt *spkt.ScnPkt) {
+func (c *scionConnReader) handleSCMP(hdr *scmp.Hdr, pkt *SCIONPacket) {
 	// Only handle revocations for now
 	if hdr.Class == scmp.C_Path && hdr.Type == scmp.T_P_RevokedIF {
 		c.handleSCMPRev(hdr, pkt)
 	}
 }
 
-func (c *scionConnReader) handleSCMPRev(hdr *scmp.Hdr, pkt *spkt.ScnPkt) {
-	scmpPayload, ok := pkt.Pld.(*scmp.Payload)
+func (c *scionConnReader) handleSCMPRev(hdr *scmp.Hdr, pkt *SCIONPacket) {
+	scmpPayload, ok := pkt.Payload.(*scmp.Payload)
 	if !ok {
-		log.Error("Unable to type assert payload to SCMP payload", "type", common.TypeOf(pkt.Pld))
+		log.Error("Unable to type assert payload to SCMP payload",
+			"type", common.TypeOf(pkt.Payload))
 	}
 	info, ok := scmpPayload.Info.(*scmp.InfoRevocation)
 	if !ok {

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -278,8 +278,9 @@ func (n *SCIONNetwork) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr
 		// Update port
 		conn.laddr.Host.L4 = addr.NewL4UDPInfo(port)
 	}
+	rawConn := NewRawSCIONConn(rconn, SerializationOptions{})
 	log.Debug("Registered with dispatcher", "addr", conn.laddr)
-	return newSCIONConn(conn, n.pathResolver, rconn), nil
+	return newSCIONConn(conn, n.pathResolver, rawConn), nil
 }
 
 // PathResolver returns the pathmgr.PR that the network is using.

--- a/go/lib/snet/writer.go
+++ b/go/lib/snet/writer.go
@@ -17,18 +17,15 @@ package snet
 import (
 	"context"
 	"net"
-	"sync"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/hpkt"
 	"github.com/scionproto/scion/go/lib/l4"
 	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/pathmgr"
 	"github.com/scionproto/scion/go/lib/snet/internal/ctxmonitor"
 	"github.com/scionproto/scion/go/lib/snet/internal/pathsource"
-	"github.com/scionproto/scion/go/lib/spkt"
 )
 
 // Possible write errors
@@ -48,21 +45,17 @@ const (
 )
 
 type scionConnWriter struct {
-	base *scionConnBase
-	conn net.PacketConn
-
-	mtx      sync.Mutex
-	buffer   common.RawBytes
+	base     *scionConnBase
+	conn     *RawSCIONConn
 	resolver *remoteAddressResolver
 }
 
 func newScionConnWriter(base *scionConnBase, pr pathmgr.Resolver,
-	conn net.PacketConn) *scionConnWriter {
+	conn *RawSCIONConn) *scionConnWriter {
 
 	return &scionConnWriter{
-		base:   base,
-		buffer: make(common.RawBytes, BufSize),
-		conn:   conn,
+		base: base,
+		conn: conn,
 		resolver: &remoteAddressResolver{
 			localIA:      base.laddr.IA,
 			pathResolver: pathsource.NewPathSource(pr),
@@ -99,32 +92,23 @@ func (c *scionConnWriter) write(b []byte, raddr *Addr) (int, error) {
 }
 
 func (c *scionConnWriter) writeWithLock(b []byte, raddr *Addr) (int, error) {
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-	pkt := &spkt.ScnPkt{
-		DstIA:   raddr.IA,
-		SrcIA:   c.base.laddr.IA,
-		DstHost: raddr.Host.L3,
-		SrcHost: c.base.laddr.Host.L3,
-		Path:    raddr.Path,
-		L4: &l4.UDP{
-			SrcPort:  c.base.laddr.Host.L4.Port(),
-			DstPort:  raddr.Host.L4.Port(),
-			TotalLen: uint16(l4.UDPLen + len(b)),
+	pkt := &SCIONPacket{
+		SCIONPacketInfo: SCIONPacketInfo{
+			Destination: NodeAddress{IA: raddr.IA, Host: raddr.Host.L3},
+			Source:      NodeAddress{IA: c.base.laddr.IA, Host: c.base.laddr.Host.L3},
+			Path:        raddr.Path,
+			L4Header: &l4.UDP{
+				SrcPort:  c.base.laddr.Host.L4.Port(),
+				DstPort:  raddr.Host.L4.Port(),
+				TotalLen: uint16(l4.UDPLen + len(b)),
+			},
+			Payload: common.RawBytes(b),
 		},
-		Pld: common.RawBytes(b),
 	}
-	// Serialize packet to internal buffer
-	n, err := hpkt.WriteScnPkt(pkt, c.buffer)
-	if err != nil {
-		return 0, common.NewBasicError("Unable to serialize SCION packet", err)
+	if err := c.conn.WriteTo(pkt, raddr.NextHop); err != nil {
+		return 0, err
 	}
-	// Send message
-	n, err = c.conn.WriteTo(c.buffer[:n], raddr.NextHop)
-	if err != nil {
-		return 0, common.NewBasicError("Dispatcher write error", err)
-	}
-	return pkt.Pld.Len(), nil
+	return len(b), nil
 }
 
 func (c *scionConnWriter) SetWriteDeadline(t time.Time) error {

--- a/go/lib/snet/writer_test.go
+++ b/go/lib/snet/writer_test.go
@@ -172,10 +172,11 @@ func TestSetDeadline(t *testing.T) {
 		).AnyTimes()
 		connMock := mock_net.NewMockPacketConn(ctrl)
 		connMock.EXPECT().SetWriteDeadline(gomock.Any()).AnyTimes().Return(nil)
+		rawConn := NewRawSCIONConn(connMock, SerializationOptions{})
 
 		conn := newScionConnWriter(&scionConnBase{
 			laddr: MustParseAddr("2-ff00:0:1,[127.0.0.1]:80"),
-		}, resolverMock, connMock)
+		}, resolverMock, rawConn)
 		Convey("And writes to multiple destinations for which path resolution is slow", func() {
 			addresses := []*Addr{
 				MustParseAddr("1-ff00:0:1,[127.0.0.1]:80"),


### PR DESCRIPTION
This adds a new connection type to snet that can be used by SCION
applications that want explicit control over extensions, or that want to
craft SCMP packets.