### PR TITLE
BR: Add dynamic topology fetching acceptance test

### DIFF
--- a/acceptance/discovery_br_fetches_dynamic_acceptance/test
+++ b/acceptance/discovery_br_fetches_dynamic_acceptance/test
@@ -2,6 +2,13 @@
 
 # This test checks that the border router fetches the dynamic topology
 # from the discovery service, and that an expired dynamic topology is dropped.
+#
+# The test is structured as follows:
+# 1. Check connectivity
+# 2. Serve dynamic topology with invalid BS address -> link goes down
+# 3. Check connectivity is broken
+# 4. Let dynamic topology expire -> link goes up
+# 5. Check connectivity is up again
 
 PROGRAM=`basename "$0"`
 COMMAND="$1"

--- a/acceptance/discovery_br_fetches_dynamic_acceptance/test
+++ b/acceptance/discovery_br_fetches_dynamic_acceptance/test
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# This test checks that the border router fetches the dynamic topology
+# from the discovery service, and that an expired dynamic topology is dropped.
+
+PROGRAM=`basename "$0"`
+COMMAND="$1"
+TEST_NAME="discovery_br_fetches_dynamic"
+
+DST_IA=${DST_IA:-1-ff00:0:112}
+
+. acceptance/common.sh
+. acceptance/discovery_util/util.sh
+
+test_setup() {
+    set -e
+    base_setup
+
+    local cfg="gen/ISD1/AS$AS_FILE/br$IA_FILE-1/brconfig.toml"
+    echo $cfg
+    set_log_lvl "$cfg"
+    set_interval "$cfg" "dynamic"
+
+    ./scion.sh run nobuild
+}
+
+test_run() {
+    set -e
+    sleep 10
+    check_connectivity "initial check"
+
+    # Start serving dynamic topology with invalid beacon service.
+    jq ".BeaconService[].Addrs.IPv4.Public.Addr = \"127.42.42.42\" | .Timestamp = $( date +%s) | .TTL = 15" $TOPO | sponge $DYNAMIC_FULL
+    sleep 5
+    check_connectivity_broken "invalid beacon service address"
+
+    # Wait until dynamic topology expires.
+    sleep 10
+    check_connectivity "dynamic topology expired"
+}
+
+check_connectivity() {
+    bin/end2end_integration -src $IA -dst $DST_IA -attempts 5 -d || { echo "FAIL: Traffic does not pass. step=( $1 )" ; return 1; }
+}
+
+check_connectivity_broken() {
+    bin/end2end_integration -src $IA -dst $DST_IA -attempts 1 -d -log.console=crit || local failed=$?
+    if [ -z ${failed+x} ]; then
+        echo "FAIL: Traffic still passes. step=( $1 )"
+        return 1
+    fi
+}
+
+shift
+do_command $PROGRAM $COMMAND $TEST_NAME "$@"


### PR DESCRIPTION
This acceptance test checks that the border router fetches the
dynamic topology from the discovery service.

The test is structured as follows:
1. Check connectivity
2. Serve dynamic topology with invalid BS address -> link goes down
3. Check connectivity is broken
4. Let dynamic topology expire -> link goes up
5. Check connectivity is up again

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2426)
<!-- Reviewable:end -->
