### PR TITLE
Infra: Fetch static topology from the discovery service

### DIFF
--- a/acceptance/discovery_br_fetches_dynamic_acceptance/test
+++ b/acceptance/discovery_br_fetches_dynamic_acceptance/test
@@ -28,7 +28,7 @@ test_setup() {
     set_log_lvl "$cfg"
     set_interval "$cfg" "dynamic"
 
-    ./scion.sh run nobuild
+    base_start_scion
 }
 
 test_run() {

--- a/acceptance/discovery_infra_fetches_dynamic_acceptance/test
+++ b/acceptance/discovery_infra_fetches_dynamic_acceptance/test
@@ -19,7 +19,7 @@ test_setup() {
         set_interval "$cfg" "dynamic"
     done
 
-    ./scion.sh run nobuild
+    base_start_scion
 }
 
 test_run() {

--- a/acceptance/discovery_infra_fetches_static_acceptance/test
+++ b/acceptance/discovery_infra_fetches_static_acceptance/test
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This test checks that the infra services fetch the static topology
+# from the discovery service.
+
+PROGRAM=`basename "$0"`
+COMMAND="$1"
+TEST_NAME="discovery_infra_fetches_static"
+
+. acceptance/common.sh
+. acceptance/discovery_util/util.sh
+
+test_setup() {
+    set -e
+    base_setup
+
+    for cfg in gen/ISD1/AS$AS_FILE/*/{cs,ps}config.toml; do
+        set_log_lvl "$cfg"
+        set_interval "$cfg" "static"
+    done
+
+    ./scion.sh run nobuild
+}
+
+test_run() {
+    set -e
+    # Start serving static topology.
+    jq ".BorderRouters[].InternalAddrs.IPv4.PublicOverlay = {Addr: \"127.42.42.42\", OverlayPort: 39999} | .Timestamp = $( date +%s) | .TTL = 3" $TOPO | sponge $STATIC_FULL
+    sleep 6
+    check_file "static"
+    check_logs "ps$IA_FILE-1"
+    check_logs "cs$IA_FILE-1"
+}
+
+check_logs() {
+    grep -q "\[discovery\] Set topology .* Mode=static" "logs/$1.log" || \
+        { echo "Setting static topology not found in logs. id=$1"; return 1; }
+}
+
+shift
+do_command $PROGRAM $COMMAND $TEST_NAME "$@"

--- a/acceptance/discovery_infra_fetches_static_acceptance/test
+++ b/acceptance/discovery_infra_fetches_static_acceptance/test
@@ -19,7 +19,7 @@ test_setup() {
         set_interval "$cfg" "static"
     done
 
-    ./scion.sh run nobuild
+    base_start_scion
 }
 
 test_run() {

--- a/acceptance/discovery_util/dc.tmpl
+++ b/acceptance/discovery_util/dc.tmpl
@@ -1,4 +1,4 @@
-  scion_ds1-ff00_0_111-1:
+  mock_ds1-ff00_0_111-1:
     image: scion_discovery_test
     volumes:
     - ${DISC_DIR}:/var/www/localhost/htdocs:ro

--- a/acceptance/discovery_util/util.sh
+++ b/acceptance/discovery_util/util.sh
@@ -11,7 +11,7 @@ UTIL_PATH="acceptance/discovery_util"
 TEST_TOPOLOGY="topology/Tiny.topo"
 
 HTTP_DIR="gen/discovery_acceptance"
-STATIC_DIR="$HTTP_DIR/discovery/v1/dynamic"
+STATIC_DIR="$HTTP_DIR/discovery/v1/static"
 STATIC_FULL="$STATIC_DIR/full.json"
 DYNAMIC_DIR="$HTTP_DIR/discovery/v1/dynamic"
 DYNAMIC_FULL="$DYNAMIC_DIR/full.json"

--- a/acceptance/discovery_util/util.sh
+++ b/acceptance/discovery_util/util.sh
@@ -42,6 +42,11 @@ base_setup() {
     sed -e "s/REPLACE_NETWORK/$network/" "$UTIL_PATH/dc.tmpl" | sed -i -e "/services:/r /dev/stdin" "gen/scion-dc.yml"
 }
 
+base_start_scion() {
+    ./scion.sh run nobuild
+    ./tools/dc scion up -d 'mock_ds1-ff00_0_111-1'
+}
+
 set_log_lvl() {
     sed -i -e 's/Level = .*$/Level = "trace"/g' -e '/\[logging\.file\]/a FlushInterval = 1' "$1"
 }

--- a/go/cert_srv/internal/config/config_test.go
+++ b/go/cert_srv/internal/config/config_test.go
@@ -31,6 +31,9 @@ func TestSampleCorrect(t *testing.T) {
 		// Make sure AutomaticRenweal is set during decoding.
 		cfg.CS.AutomaticRenewal = true
 		cfg.Discovery.Dynamic.Enable = true
+		cfg.Discovery.Dynamic.Https = true
+		cfg.Discovery.Static.Enable = true
+		cfg.Discovery.Static.Https = true
 		_, err := toml.Decode(Sample, &cfg)
 		SoMsg("err", err, ShouldBeNil)
 
@@ -44,11 +47,18 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection, ShouldEqual,
 			"/var/lib/scion/spki/cs-1.trust.db")
+		SoMsg("Discovery.Static.Enable correct", cfg.Discovery.Static.Enable, ShouldBeFalse)
+		SoMsg("Discovery.Static.Interval correct", cfg.Discovery.Static.Interval.Duration,
+			ShouldEqual, idiscovery.DefaultStaticFetchInterval)
+		SoMsg("Discovery.Static.Timeout correct", cfg.Discovery.Static.Timeout.Duration,
+			ShouldEqual, idiscovery.DefaultFetchTimeout)
+		SoMsg("Discovery.Static.Https correct", cfg.Discovery.Static.Https, ShouldBeFalse)
 		SoMsg("Discovery.Dynamic.Enable correct", cfg.Discovery.Dynamic.Enable, ShouldBeFalse)
 		SoMsg("Discovery.Dynamic.Interval correct", cfg.Discovery.Dynamic.Interval.Duration,
-			ShouldEqual, idiscovery.DefaultFetchInterval)
+			ShouldEqual, idiscovery.DefaultDynamicFetchInterval)
 		SoMsg("Discovery.Dynamic.Timeout correct", cfg.Discovery.Dynamic.Timeout.Duration,
 			ShouldEqual, idiscovery.DefaultFetchTimeout)
+		SoMsg("Discovery.Dynamic.Https correct", cfg.Discovery.Dynamic.Https, ShouldBeFalse)
 
 		// csconfig specific
 		SoMsg("LeafReissueLeadTime correct", cfg.CS.LeafReissueLeadTime.Duration,

--- a/go/cert_srv/internal/config/config_test.go
+++ b/go/cert_srv/internal/config/config_test.go
@@ -28,7 +28,7 @@ import (
 func TestSampleCorrect(t *testing.T) {
 	Convey("Load", t, func() {
 		var cfg Config
-		// Make sure AutomaticRenweal is set during decoding.
+		// Make sure AutomaticRenewal is set during decoding.
 		cfg.CS.AutomaticRenewal = true
 		cfg.Discovery.Dynamic.Enable = true
 		cfg.Discovery.Dynamic.Https = true

--- a/go/cert_srv/internal/config/sample.go
+++ b/go/cert_srv/internal/config/sample.go
@@ -73,6 +73,19 @@ const Sample = `[general]
   Connection = "/var/lib/scion/spki/cs-1.trust.db"
 
 [discovery]
+  [discovery.static]
+    # Enable periodic fetching of the static topology. (default false)
+    Enable = false
+
+    # Time between two consecutive static topology query. (default 5m)
+    Interval = "5m"
+
+    # Timeout for querying the static topology.  (default 1s)
+    Timeout = "1s"
+
+    # Require https connection. (default false)
+    Https = false
+
   [discovery.dynamic]
     # Enable periodic fetching of the dynamic topology. (default false)
     Enable = false

--- a/go/cert_srv/internal/config/sample.go
+++ b/go/cert_srv/internal/config/sample.go
@@ -77,7 +77,7 @@ const Sample = `[general]
     # Enable periodic fetching of the static topology. (default false)
     Enable = false
 
-    # Time between two consecutive static topology query. (default 5m)
+    # Time between two consecutive static topology queries. (default 5m)
     Interval = "5m"
 
     # Timeout for querying the static topology.  (default 1s)
@@ -90,7 +90,7 @@ const Sample = `[general]
     # Enable periodic fetching of the dynamic topology. (default false)
     Enable = false
 
-    # Time between two consecutive dynamic topology query. (default 5s)
+    # Time between two consecutive dynamic topology queries. (default 5s)
     Interval = "5s"
 
     # Timeout for querying the dynamic topology.  (default 1s)

--- a/go/lib/infra/modules/idiscovery/config.go
+++ b/go/lib/infra/modules/idiscovery/config.go
@@ -21,20 +21,39 @@ import (
 )
 
 var (
-	// DefaultFetchInterval is the default time between two queries.
-	DefaultFetchInterval = 5 * time.Second
+	// DefaultDynamicFetchInterval is the default time between two dynamic topology queries.
+	DefaultDynamicFetchInterval = 5 * time.Second
+	// DefaultStaticFetchInterval is the default time between two static topology queries.
+	DefaultStaticFetchInterval = 5 * time.Minute
 	// DefaultFetchTimeout is the default timeout for a query.
 	DefaultFetchTimeout = 1 * time.Second
 )
 
 type Config struct {
+	// Static contains the parameters for fetching the static
+	// topology from the discovery service.
+	Static StaticConfig
 	// Dynamic contains the parameters for fetching the dynamic
 	// topology from the discovery service.
 	Dynamic FetchConfig
 }
 
 func (c *Config) InitDefaults() {
+	c.Static.InitDefaults()
 	c.Dynamic.InitDefaults()
+}
+
+type StaticConfig struct {
+	FetchConfig
+}
+
+func (s *StaticConfig) InitDefaults() {
+	if s.Interval.Duration == 0 {
+		s.Interval.Duration = DefaultStaticFetchInterval
+	}
+	if s.Timeout.Duration == 0 {
+		s.Timeout.Duration = DefaultFetchTimeout
+	}
 }
 
 type FetchConfig struct {
@@ -51,7 +70,7 @@ type FetchConfig struct {
 
 func (f *FetchConfig) InitDefaults() {
 	if f.Interval.Duration == 0 {
-		f.Interval.Duration = DefaultFetchInterval
+		f.Interval.Duration = DefaultDynamicFetchInterval
 	}
 	if f.Timeout.Duration == 0 {
 		f.Timeout.Duration = DefaultFetchTimeout

--- a/go/path_srv/internal/config/sample.go
+++ b/go/path_srv/internal/config/sample.go
@@ -66,6 +66,19 @@ const Sample = `[general]
   Connection = "/var/lib/scion/spki/ps-1.trust.db"
 
 [discovery]
+  [discovery.static]
+    # Enable periodic fetching of the static topology. (default false)
+    Enable = false
+
+    # Time between two consecutive static topology query. (default 5m)
+    Interval = "5m"
+
+    # Timeout for querying the static topology.  (default 1s)
+    Timeout = "1s"
+
+    # Require https connection. (default false)
+    Https = false
+
   [discovery.dynamic]
     # Enable periodic fetching of the dynamic topology. (default false)
     Enable = false

--- a/go/path_srv/internal/config/sample.go
+++ b/go/path_srv/internal/config/sample.go
@@ -70,7 +70,7 @@ const Sample = `[general]
     # Enable periodic fetching of the static topology. (default false)
     Enable = false
 
-    # Time between two consecutive static topology query. (default 5m)
+    # Time between two consecutive static topology queries. (default 5m)
     Interval = "5m"
 
     # Timeout for querying the static topology.  (default 1s)
@@ -83,7 +83,7 @@ const Sample = `[general]
     # Enable periodic fetching of the dynamic topology. (default false)
     Enable = false
 
-    # Time between two consecutive dynamic topology query. (default 5s)
+    # Time between two consecutive dynamic topology queries. (default 5s)
     Interval = "5s"
 
     # Timeout for querying the dynamic topology.  (default 1s)

--- a/go/path_srv/internal/config/sample_test.go
+++ b/go/path_srv/internal/config/sample_test.go
@@ -30,6 +30,9 @@ func TestSampleCorrect(t *testing.T) {
 		// Make sure SegSync is set.
 		cfg.PS.SegSync = true
 		cfg.Discovery.Dynamic.Enable = true
+		cfg.Discovery.Dynamic.Https = true
+		cfg.Discovery.Static.Enable = true
+		cfg.Discovery.Static.Https = true
 		_, err := toml.Decode(Sample, &cfg)
 		SoMsg("err", err, ShouldBeNil)
 
@@ -43,11 +46,18 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection, ShouldEqual,
 			"/var/lib/scion/spki/ps-1.trust.db")
+		SoMsg("Discovery.Static.Enable correct", cfg.Discovery.Static.Enable, ShouldBeFalse)
+		SoMsg("Discovery.Static.Interval correct", cfg.Discovery.Static.Interval.Duration,
+			ShouldEqual, idiscovery.DefaultStaticFetchInterval)
+		SoMsg("Discovery.Static.Timeout correct", cfg.Discovery.Static.Timeout.Duration,
+			ShouldEqual, idiscovery.DefaultFetchTimeout)
+		SoMsg("Discovery.Static.Https correct", cfg.Discovery.Static.Https, ShouldBeFalse)
 		SoMsg("Discovery.Dynamic.Enable correct", cfg.Discovery.Dynamic.Enable, ShouldBeFalse)
 		SoMsg("Discovery.Dynamic.Interval correct", cfg.Discovery.Dynamic.Interval.Duration,
-			ShouldEqual, idiscovery.DefaultFetchInterval)
+			ShouldEqual, idiscovery.DefaultDynamicFetchInterval)
 		SoMsg("Discovery.Dynamic.Timeout correct", cfg.Discovery.Dynamic.Timeout.Duration,
 			ShouldEqual, idiscovery.DefaultFetchTimeout)
+		SoMsg("Discovery.Dynamic.Https correct", cfg.Discovery.Dynamic.Https, ShouldBeFalse)
 
 		// psconfig specific
 		SoMsg("PathDB.Backend correct", cfg.PS.PathDB.Backend, ShouldEqual, "sqlite")

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -222,8 +222,11 @@ class GoGenerator(object):
 
     def _discovery_entry(self):
         entry = {
-            "dynamic": {
-                "Enable": self.args.discovery,
+            'static': {
+                'Enable': self.args.discovery,
+            },
+            'dynamic': {
+                'Enable': self.args.discovery,
             }
         }
         return entry


### PR DESCRIPTION
This PR adds parameters for static topology fetching from the DS to the config of infra services and modifies `idiscovery` to periodically fetch the static topology if enabled.

Also, an acceptance test is added to check that the static topology is actually fetched by the infra services.
The test gets its own directory because it will become more extensive in the future.
We plan to enable `idiscovery` to write the static topology to disc (when enabled) which will differentiate the test from the `dynamic` counter part.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2429)
<!-- Reviewable:end -->
