### PR TITLE
BR: Fetch static topology 

### DIFF
--- a/acceptance/discovery_br_fetches_static_acceptance/test
+++ b/acceptance/discovery_br_fetches_static_acceptance/test
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# This test checks that the border router fetches the static topology
+# from the discovery service, and that it writes the update to disk.
+#
+# The test is structured as follows:
+# 1. Check connectivity
+# 2. Serve static topology with invalid BS address -> link goes down
+# 3. Check connectivity is broken
+# 4. Check logs, and file diff
+# 4. Serve original static topology -> link goes up
+# 6. Check connectivity is up again
+
+
+PROGRAM=`basename "$0"`
+COMMAND="$1"
+TEST_NAME="discovery_br_fetches_static"
+
+DST_IA=${DST_IA:-1-ff00:0:112}
+
+. acceptance/common.sh
+. acceptance/discovery_util/util.sh
+
+
+test_setup() {
+    set -e
+    base_setup
+
+    for elem in gen/ISD1/AS$AS_FILE/br*; do
+        for cfg in $elem/*.toml; do
+            set_log_lvl "$cfg"
+            set_interval "$cfg" "static"
+            sed -i -e "/\[discovery.static]/a Filename = \"/share/logs/${elem##*/}-topo.json\"" $cfg
+        done
+    done
+
+    ./scion.sh run nobuild
+}
+
+test_run() {
+    set -e
+    sleep 10
+    check_connectivity "initial check"
+
+    # Start serving dynamic topology with invalid beacon service.
+    jq ".BeaconService[].Addrs.IPv4.Public.Addr = \"127.42.42.42\" | .Timestamp = $( date +%s) | .TTL = 15" $TOPO | sponge $STATIC_FULL
+    sleep 5
+    check_connectivity_broken "invalid beacon service address"
+
+    # Check that the logs contain setting and writing the topo.
+    check_logs "br$IA_FILE-1"
+    # Check that the written file does not differ from the served file.
+    diff -q $STATIC_FULL logs/br$IA_FILE-1-topo.json
+
+    # Wait until dynamic topology expires.
+    cp $TOPO $STATIC_FULL
+    sleep 5
+    check_connectivity "serve original static topology"
+}
+
+check_connectivity_broken() {
+    bin/end2end_integration -src $IA -dst $DST_IA -attempts 1 -d -log.console=crit || local failed=$?
+    if [ -z ${failed+x} ]; then
+        echo "FAIL: Traffic still passes. step=( $1 )"
+        return 1
+    fi
+}
+
+check_connectivity() {
+    bin/end2end_integration -src $IA -dst $DST_IA -attempts 5 -d || { echo "FAIL: Traffic does not pass. step=( $1 )" ; return 1; }
+}
+
+check_logs() {
+    grep -q "\[discovery\] Set topology .* Mode=static" "logs/$1.log" || \
+        { echo "Setting static topology not found in logs. id=$1"; return 1; }
+    grep -q "\[discovery\] Topology written to filesystem .* Mode=static" "logs/$1.log" || \
+        { echo "Writing static topology not found in logs. id=$1"; return 1; }
+}
+
+shift
+do_command $PROGRAM $COMMAND $TEST_NAME "$@"

--- a/acceptance/discovery_br_fetches_static_acceptance/test
+++ b/acceptance/discovery_br_fetches_static_acceptance/test
@@ -34,7 +34,7 @@ test_setup() {
         done
     done
 
-    ./scion.sh run nobuild
+    base_start_scion
 }
 
 test_run() {

--- a/go/border/brconf/params.go
+++ b/go/border/brconf/params.go
@@ -14,7 +14,10 @@
 
 package brconf
 
-import "github.com/scionproto/scion/go/lib/common"
+import (
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
+)
 
 type BR struct {
 	// Profile enables cpu and memory profiling.
@@ -28,6 +31,13 @@ func (b *BR) InitDefaults() {
 	if b.RollbackFailAction != FailActionContinue {
 		b.RollbackFailAction = FailActionFatal
 	}
+}
+
+type Discovery struct {
+	idiscovery.Config
+	// AllowSemiMutable indicates whether changes to the semi-mutable
+	// section in the static topology are allowed.
+	AllowSemiMutable bool
 }
 
 type FailAction string

--- a/go/border/brconf/sample.go
+++ b/go/border/brconf/sample.go
@@ -57,6 +57,27 @@ const Sample = `[general]
   # Prometheus = "127.0.0.1:8000"
 
 [discovery]
+  # Allow changes to the semi-mutable section during updates to the static
+  # topology fetched from the discovery service. (default false)
+  AllowSemiMutable = false
+
+  [discovery.static]
+    # Enable periodic fetching of the static topology. (default false)
+    Enable = false
+
+    # Time between two consecutive static topology query. (default 5m)
+    Interval = "5m"
+
+    # Timeout for querying the static topology.  (default 1s)
+    Timeout = "1s"
+
+    # Require https connection. (default false)
+    Https = false
+
+    # Filename where the updated static topologies are written. In case of the
+    # empty string, the updated topologies are not written. (default "")
+    Filename = ""
+
   [discovery.dynamic]
     # Enable periodic fetching of the dynamic topology. (default false)
     Enable = false

--- a/go/border/brconf/sample.go
+++ b/go/border/brconf/sample.go
@@ -65,10 +65,10 @@ const Sample = `[general]
     # Enable periodic fetching of the static topology. (default false)
     Enable = false
 
-    # Time between two consecutive static topology query. (default 5m)
+    # Time between two consecutive static topology queries. (default 5m)
     Interval = "5m"
 
-    # Timeout for querying the static topology.  (default 1s)
+    # Timeout for querying the static topology. (default 1s)
     Timeout = "1s"
 
     # Require https connection. (default false)
@@ -82,10 +82,10 @@ const Sample = `[general]
     # Enable periodic fetching of the dynamic topology. (default false)
     Enable = false
 
-    # Time between two consecutive dynamic topology query. (default 5s)
+    # Time between two consecutive dynamic topology queries. (default 5s)
     Interval = "5s"
 
-    # Timeout for querying the dynamic topology.  (default 1s)
+    # Timeout for querying the dynamic topology. (default 1s)
     Timeout = "1s"
 
     # Require https connection. (default false)

--- a/go/border/main.go
+++ b/go/border/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/env"
 	"github.com/scionproto/scion/go/lib/fatal"
-	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/profile"
 )
@@ -42,7 +41,7 @@ type Config struct {
 	General   env.General
 	Logging   env.Logging
 	Metrics   env.Metrics
-	Discovery idiscovery.Config
+	Discovery brconf.Discovery
 	BR        brconf.BR
 }
 

--- a/go/cert_srv/internal/config/sample.go
+++ b/go/cert_srv/internal/config/sample.go
@@ -86,7 +86,7 @@ const Sample = `[general]
     # Require https connection. (default false)
     Https = false
 
-    # Filename where the updated static topologies are written. In case of the 
+    # Filename where the updated static topologies are written. In case of the
     # empty string, the updated topologies are not written. (default "")
     Filename = ""
 

--- a/go/cert_srv/internal/config/sample.go
+++ b/go/cert_srv/internal/config/sample.go
@@ -80,7 +80,7 @@ const Sample = `[general]
     # Time between two consecutive static topology queries. (default 5m)
     Interval = "5m"
 
-    # Timeout for querying the static topology.  (default 1s)
+    # Timeout for querying the static topology. (default 1s)
     Timeout = "1s"
 
     # Require https connection. (default false)
@@ -97,7 +97,7 @@ const Sample = `[general]
     # Time between two consecutive dynamic topology queries. (default 5s)
     Interval = "5s"
 
-    # Timeout for querying the dynamic topology.  (default 1s)
+    # Timeout for querying the dynamic topology. (default 1s)
     Timeout = "1s"
 
     # Require https connection. (default false)

--- a/go/path_srv/internal/config/sample.go
+++ b/go/path_srv/internal/config/sample.go
@@ -73,7 +73,7 @@ const Sample = `[general]
     # Time between two consecutive static topology queries. (default 5m)
     Interval = "5m"
 
-    # Timeout for querying the static topology.  (default 1s)
+    # Timeout for querying the static topology. (default 1s)
     Timeout = "1s"
 
     # Require https connection. (default false)
@@ -90,7 +90,7 @@ const Sample = `[general]
     # Time between two consecutive dynamic topology queries. (default 5s)
     Interval = "5s"
 
-    # Timeout for querying the dynamic topology.  (default 1s)
+    # Timeout for querying the dynamic topology. (default 1s)
     Timeout = "1s"
 
     # Require https connection. (default false)

--- a/go/path_srv/internal/config/sample.go
+++ b/go/path_srv/internal/config/sample.go
@@ -79,7 +79,7 @@ const Sample = `[general]
     # Require https connection. (default false)
     Https = false
 
-    # Filename where the updated static topologies are written. In case of the 
+    # Filename where the updated static topologies are written. In case of the
     # empty string, the updated topologies are not written. (default "")
     Filename = ""
 


### PR DESCRIPTION
This PR enables static topology fetching from the discovery service.

The BR can be configured to periodically fetch the static topology from the discovery service and, if desired, write the updated version to disk.
Whether modifications to the semi-mutable part (i.e. the interfaces) of the topology are possible, can be enabled and disabled.

Additionally, acceptance tests are added to check that the BR fetches steady topologies as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2435)
<!-- Reviewable:end -->
