### PR TITLE
Accept: Add fail function

### DIFF
--- a/acceptance/cert_renewal_acceptance/test
+++ b/acceptance/cert_renewal_acceptance/test
@@ -39,16 +39,16 @@ test_setup() {
 test_run() {
     set -e
     sleep 10
-    bin/end2end_integration -src $IA -dst $CORE_IA -attempts 5 -d || { echo "FAIL: Traffic does not pass." ; return 1; }
+    bin/end2end_integration -src $IA -dst $CORE_IA -attempts 5 -d || fail "FAIL: Traffic does not pass."
     # Make sure a reissue cycle has passed.
     sleep 10
     # Check that reissued certificates appear in the logs.
     grep -q '\[reiss.Self\] Created issuer certificate cert="Certificate' "logs/cs$CORE_IA_FILE-1.log" || \
-        { echo "Issuer certificate updated for $CORE_IA not found in logs"; return 1; }
+        fail "Issuer certificate updated for $CORE_IA not found in logs"
     grep -q "\[reiss.Self\] Created certificate chain chain=\"CertificateChain $CORE_IA" "logs/cs$CORE_IA_FILE-1.log" || \
-        { echo "Certificate chain updated for $CORE_IA not found in logs"; return 1; }
+        fail "Certificate chain updated for $CORE_IA not found in logs"
     grep -q "\[reiss.Requester\] Updated certificate chain chain=\"CertificateChain $IA" "logs/cs$IA_FILE-1.log" || \
-        { echo "Certificate chain updated for $IA not found in logs"; return 1; }
+        fail "Certificate chain updated for $IA not found in logs"
 }
 
 test_teardown() {

--- a/acceptance/common.sh
+++ b/acceptance/common.sh
@@ -79,3 +79,11 @@ test_teardown() {
 log() {
     echo "$(date -u +"%F %T.%6N%z") $@"
 }
+
+#######################################
+# Fail: Echo with a timestamp to stderr and exit with 1
+#######################################
+fail() {
+    echo "$(date -u +'%F %T.%6N%z') $@" >&2
+    exit 1
+}

--- a/acceptance/discovery_br_fetches_dynamic_acceptance/test
+++ b/acceptance/discovery_br_fetches_dynamic_acceptance/test
@@ -47,7 +47,7 @@ test_run() {
 }
 
 check_connectivity() {
-    bin/end2end_integration -src $IA -dst $DST_IA -attempts 5 -d || { echo "FAIL: Traffic does not pass. step=( $1 )" ; return 1; }
+    bin/end2end_integration -src $IA -dst $DST_IA -attempts 5 -d || fail "FAIL: Traffic does not pass. step=( $1 )"
 }
 
 check_connectivity_broken() {

--- a/acceptance/discovery_br_fetches_static_acceptance/test
+++ b/acceptance/discovery_br_fetches_static_acceptance/test
@@ -67,14 +67,14 @@ check_connectivity_broken() {
 }
 
 check_connectivity() {
-    bin/end2end_integration -src $IA -dst $DST_IA -attempts 5 -d || { echo "FAIL: Traffic does not pass. step=( $1 )" ; return 1; }
+    bin/end2end_integration -src $IA -dst $DST_IA -attempts 5 -d || fail "FAIL: Traffic does not pass. step=( $1 )"
 }
 
 check_logs() {
     grep -q "\[discovery\] Set topology .* Mode=static" "logs/$1.log" || \
-        { echo "Setting static topology not found in logs. id=$1"; return 1; }
+        fail "Setting static topology not found in logs. id=$1"
     grep -q "\[discovery\] Topology written to filesystem .* Mode=static" "logs/$1.log" || \
-        { echo "Writing static topology not found in logs. id=$1"; return 1; }
+        fail "Writing static topology not found in logs. id=$1"
 }
 
 shift

--- a/acceptance/discovery_infra_fetches_dynamic_acceptance/test
+++ b/acceptance/discovery_infra_fetches_dynamic_acceptance/test
@@ -34,9 +34,9 @@ test_run() {
 
 check_logs() {
     grep -q "\[discovery\] Set topology .* Mode=dynamic" "logs/$1.log" || \
-        { echo "Setting dynamic topology not found in logs. id=$1"; return 1; }
+        fail "Setting dynamic topology not found in logs. id=$1"
     grep -q "\[itopo.Cleaner\] Dropping expired dynamic topology" "logs/$1.log" || \
-        { echo "Setting dynamic topology not found in logs. id=$1"; return 1; }
+        fail "Setting dynamic topology not found in logs. id=$1"
 }
 
 shift

--- a/acceptance/discovery_infra_fetches_static_acceptance/test
+++ b/acceptance/discovery_infra_fetches_static_acceptance/test
@@ -42,9 +42,9 @@ test_run() {
 
 check_logs() {
     grep -q "\[discovery\] Set topology .* Mode=static" "logs/$1.log" || \
-        { echo "Setting static topology not found in logs. id=$1"; return 1; }
+        fail "Setting static topology not found in logs. id=$1"
     grep -q "\[discovery\] Topology written to filesystem .* Mode=static" "logs/$1.log" || \
-        { echo "Writing static topology not found in logs. id=$1"; return 1; }
+        fail "Writing static topology not found in logs. id=$1"
 }
 
 check_diff () {

--- a/acceptance/topo_br_reload_util/util.sh
+++ b/acceptance/topo_br_reload_util/util.sh
@@ -13,11 +13,11 @@ DST_TOPO="gen/ISD1/AS$DST_AS_FILE/br$DST_IA_FILE-1/topology.json"
 . acceptance/common.sh
 
 check_logs() {
-    fgrep -q "$1" "logs/br$2-1.log" || { echo "Not found: $1"; return 1; }
+    fgrep -q "$1" "logs/br$2-1.log" || fail "Not found: $1"
 }
 
 check_connectivity() {
-    bin/end2end_integration -src $SRC_IA -dst $DST_IA -attempts 5 -d || { echo "FAIL: Traffic does not pass. step=( $1 )" ; return 1; }
+    bin/end2end_integration -src $SRC_IA -dst $DST_IA -attempts 5 -d || fail "FAIL: Traffic does not pass. step=( $1 )"
 }
 
 unqoute() {

--- a/acceptance/topo_ps_reloads_br_acceptance/test
+++ b/acceptance/topo_ps_reloads_br_acceptance/test
@@ -36,7 +36,7 @@ test_run() {
     ./tools/dc exec_tester $SRC_IA_FILE bin/showpaths -srcIA $SRC_IA -dstIA $DST_IA -sciondFromIA || true
     sleep 2
     grep -q "NextHop=\[127\.42\.42\.42\]:39999" "logs/ps$SRC_IA_FILE-1.log" || \
-        { echo "PS path request with next-hop 127.42.42.42:39999 not found in logs"; return 1; }
+        fail "PS path request with next-hop 127.42.42.42:39999 not found in logs"
 }
 
 print_help() {

--- a/acceptance/topo_ps_reloads_cs_acceptance/test
+++ b/acceptance/topo_ps_reloads_cs_acceptance/test
@@ -33,7 +33,7 @@ test_run() {
     # Wait for 30 (PS crypto push interval) + 1 (logging flush interval) seconds to guarantee a push is seen
     sleep 31
     grep -q "\[INFO\].*Sent crypto to CS.*$IA,\[127\.42\.42\.42\]:39999" "logs/ps$IA_FILE-1.log" || \
-        { echo "Crypto material push to 127.42.42.42:39999 not found in logs"; return 1; }
+        fail "Crypto material push to 127.42.42.42:39999 not found in logs"
 }
 
 print_help() {

--- a/acceptance/topo_sd_reloads_br_acceptance/test
+++ b/acceptance/topo_sd_reloads_br_acceptance/test
@@ -36,7 +36,7 @@ test_run() {
     ./tools/dc exec_tester $SRC_IA_FILE bin/showpaths -srcIA $SRC_IA -dstIA $DST_IA -sciondFromIA || true
     sleep 2
     grep -q "NextHop=\[127\.42\.42\.42\]:39999" "logs/sd$SRC_IA_FILE.log" || \
-        { echo "SD Path reply with next-hop 127.42.42.42:39999 not found in logs"; return 1; }
+        fail "SD Path reply with next-hop 127.42.42.42:39999 not found in logs"
 }
 
 print_help() {

--- a/acceptance/topo_sd_reloads_cs_acceptance/test
+++ b/acceptance/topo_sd_reloads_cs_acceptance/test
@@ -37,7 +37,7 @@ test_run() {
     ./tools/dc exec_tester $SRC_IA_FILE bin/showpaths -srcIA $SRC_IA -dstIA $DST_IA -sciondFromIA -refresh || true
     sleep 2
     grep -q "\[TRACE\] \[Messenger\] Sending request .*req_type=ChainRequest .*$SRC_IA,\[127\.42\.42\.42\]:39999" "logs/sd$SRC_IA_FILE.log" || \
-        { echo "Certificate chain request to 127.42.42.42:39999 not found in logs"; return 1; }
+        fail "Certificate chain request to 127.42.42.42:39999 not found in logs"
 }
 
 print_help() {

--- a/acceptance/topo_sd_reloads_ps_acceptance/test
+++ b/acceptance/topo_sd_reloads_ps_acceptance/test
@@ -36,7 +36,7 @@ test_run() {
     ./tools/dc exec_tester $SRC_IA_FILE bin/showpaths -srcIA $SRC_IA -dstIA $DST_IA -sciondFromIA -refresh || true
     sleep 2
     grep -q "\[TRACE\] \[Messenger\] Sending request.*req_type=SegRequest.*$SRC_IA,\[127\.42\.42\.42\]:39999" "logs/sd$SRC_IA_FILE.log" || \
-        { echo "Path segment request to 127.42.42.42:39999 not found in logs"; return 1; }
+        fail "Path segment request to 127.42.42.42:39999 not found in logs"
 }
 
 print_help() {


### PR DESCRIPTION
Add fail function to `acceptance/common.sh` that writes the timestamped message to stderr and exits with code 1.

Refactor all acceptance tests from the `|| { echo blah; exit 1 }` to `|| fail blah` pattern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2442)
<!-- Reviewable:end -->
