### PR TITLE
discovery: Add default endpoint

### DIFF
--- a/go/examples/discovery_client/client.go
+++ b/go/examples/discovery_client/client.go
@@ -160,5 +160,5 @@ func file() discovery.File {
 	if *full {
 		return discovery.Full
 	}
-	return discovery.Reduced
+	return discovery.Endhost
 }

--- a/go/examples/discovery_client/server.sh
+++ b/go/examples/discovery_client/server.sh
@@ -4,7 +4,7 @@ BASE="discovery/v1"
 STATIC="static"
 DYNAMIC="dynamic"
 FULL="full.json"
-REDUCED="reduced.json"
+ENDHOST="endhost.json"
 
 ds_entry=$2
 if [ -z "$2" ]; then
@@ -16,7 +16,7 @@ temp_dir=$( mktemp -d )
 printf "Created temp dir: $temp_dir\n"
 mkdir -p "$temp_dir/$BASE/$STATIC"
 mkdir -p "$temp_dir/$BASE/$DYNAMIC"
-cat $1 | tee $temp_dir/$BASE/{$STATIC,$DYNAMIC}/{$FULL,$REDUCED} > /dev/null
+cat $1 | tee $temp_dir/$BASE/{$STATIC,$DYNAMIC}/{$FULL,$ENDHOST} > /dev/null
 
 count=$( jq -r '.DiscoveryService | length' $1 )
 printf "Using entry $ds_entry out of $count\n"

--- a/go/lib/discovery/discovery.go
+++ b/go/lib/discovery/discovery.go
@@ -33,11 +33,11 @@
 //
 // Files
 //
-// There are two privilege versions of the topology file. The reduced version
+// There are two privilege versions of the topology file. The endhost version
 // is intended for end hosts and non-privileged entities. The full version is
-// only intended for privileged entites that need all topology information.
+// only intended for privileged entities that need all topology information.
 //
-// Reduced: The reduced version of the topology file contains all the
+// Endhost: The endhost version of the topology file contains all the
 // information necessary for end hosts. Unnecessary information is stripped
 // from the file (e.g. border router interface addresses or beacon service
 // addresses).
@@ -46,13 +46,19 @@
 // This file is only accessible by privileged entities (e.g infrastructure
 // elements).
 //
+// Default: When the default version of the topology file is requested, the
+// discovery service decides which version to serve based on the privilege
+// of the requester.
+//
 // Paths
 //
 // The topology files are fetched with a simple http get request. The path
 // is dependent on the mode and file version:
-//  static  && reduced:  /discovery/v1/static/reduced.json
+//  static  && default:  /discovery/v1/static/default.json
+//  static  && endhost:  /discovery/v1/static/endhost.json
 //  static  && full:     /discovery/v1/static/full.json
-//  dynamic && reduced:  /discovery/v1/dynamic/reduced.json
+//  dynamic && default:  /discovery/v1/dynamic/default.json
+//  dynamic && endhost:  /discovery/v1/dynamic/endhost.json
 //  dynamic && full:     /discovery/v1/dynamic/full.json
 package discovery
 
@@ -74,7 +80,7 @@ import (
 type FetchParams struct {
 	// Mode indicates whether the static or the dynamic topology is requested.
 	Mode Mode
-	// File indicates whether the full or the reduced topology is requested.
+	// File indicates whether the full, endhost or default topology is requested.
 	File File
 	// Https indicates whether https should be used.
 	Https bool
@@ -94,8 +100,11 @@ type File string
 const (
 	// Full is the full topology file, including all service information.
 	Full File = "full.json"
-	// Reduced is a stripped down topology file for non-privileged entities.
-	Reduced File = "reduced.json"
+	// Endhost is a stripped down topology file for non-privileged entities.
+	Endhost File = "endhost.json"
+	// Default is a topology file whose content is based on the privilege of
+	// the requester.
+	Default File = "default.json"
 )
 
 const (

--- a/go/tools/topopruner/topopruner.go
+++ b/go/tools/topopruner/topopruner.go
@@ -29,8 +29,8 @@ import (
 var (
 	infn   = flag.String("in", "", "Input file name. Required.")
 	outfnf = flag.String("out", "", "Output file name for the full topology. Required.")
-	outfnr = flag.String("reduced", "",
-		"Output file name for the reduced topology. Defaults to not generating this output.")
+	outfnr = flag.String("endhost", "",
+		"Output file name for the endhost topology. Defaults to not generating this output.")
 	verbose = flag.Bool("verbose", false, "Be more verbose about what is going on")
 	version = flag.Bool("version", false, "Output version information and exit.")
 )
@@ -64,9 +64,9 @@ func main() {
 	}
 	if *outfnr != "" {
 		topology.StripServices(rt)
-		marshalAndWriteOrDie(rt, *outfnr, "reduced", finfo.Mode())
+		marshalAndWriteOrDie(rt, *outfnr, "endhost", finfo.Mode())
 		if *verbose {
-			fmt.Printf("Wrote pruned reduced topo to '%s'.\n", *outfnr)
+			fmt.Printf("Wrote pruned endhost topo to '%s'.\n", *outfnr)
 		}
 	}
 }


### PR DESCRIPTION
Add a third endpoint called `default`. The discovery service
serves either the full or endhost topology, based on the privilege
of the requesting entity.

This is used specifically in sciond to avoid explicit configuration
on infrastructure nodes.

Additionally, this rename the `reduced` topology to `endpoint` topology.

fixes #2441

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2450)
<!-- Reviewable:end -->
