### PR TITLE
Limit number of segments returned in path request

### DIFF
--- a/go/lib/infra/modules/combinator/graph.go
+++ b/go/lib/infra/modules/combinator/graph.go
@@ -354,7 +354,7 @@ func (solution *PathSolution) GetFwdPathMetadata() *Path {
 	return path
 }
 
-// Get the segments constituting this path
+// Segments returns the segments in this path
 func (solution *PathSolution) Segments() []*InputSegment {
 	segs := make([]*InputSegment, 0, len(solution.edges))
 	for _, e := range solution.edges {

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -332,7 +332,7 @@ func selectConnectedSegs(maxNumSegments int, upSegs, coreSegs, downSegs *seg.Seg
 }
 
 func matchReqIA(addr, req addr.IA) bool {
-	return addr.Eq(req) || (addr.I == req.I && req.A == 0)
+	return addr.Equal(req) || (addr.I == req.I && req.A == 0)
 }
 
 // Helper for selectConnectedSegs.
@@ -361,7 +361,7 @@ func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
 		// Up-Down direct
 		for _, upSeg := range *upSegs {
 			for _, downSeg := range *downSegs {
-				if upSeg.FirstIA().Eq(downSeg.FirstIA()) {
+				if upSeg.FirstIA().Equal(downSeg.FirstIA()) {
 					paths = append(paths, connectedSegs{
 						Up:   upSeg,
 						Core: nil,
@@ -373,11 +373,11 @@ func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
 		// Up-Core-Down
 		for _, upSeg := range *upSegs {
 			for _, coreSeg := range *coreSegs {
-				if !upSeg.FirstIA().Eq(coreSeg.LastIA()) {
+				if !upSeg.FirstIA().Equal(coreSeg.LastIA()) {
 					continue
 				}
 				for _, downSeg := range *downSegs {
-					if !coreSeg.FirstIA().Eq(downSeg.FirstIA()) {
+					if !coreSeg.FirstIA().Equal(downSeg.FirstIA()) {
 						continue
 					}
 					paths = append(paths, connectedSegs{
@@ -402,7 +402,7 @@ func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
 		// Core-Down
 		for _, coreSeg := range *coreSegs {
 			for _, downSeg := range *downSegs {
-				if !coreSeg.LastIA().Eq(downSeg.FirstIA()) {
+				if !coreSeg.LastIA().Equal(downSeg.FirstIA()) {
 					continue
 				}
 				paths = append(paths, connectedSegs{
@@ -426,7 +426,7 @@ func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
 		// Up-Core
 		for _, upSeg := range *upSegs {
 			for _, coreSeg := range *coreSegs {
-				if !upSeg.FirstIA().Eq(coreSeg.LastIA()) {
+				if !upSeg.FirstIA().Equal(coreSeg.LastIA()) {
 					continue
 				}
 				paths = append(paths, connectedSegs{

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -277,8 +277,10 @@ func (p *connectedSegs) numHops() int {
 	return n
 }
 
-// Filter upSegs, coreSegs and downSegs to include at most maxNumSegments segments. Ensures that the remaining segments can be connected to allow forming paths between srcIA and dstIA.
-func selectConnectedSegs(maxNumSegments int, upSegs, coreSegs, downSegs *seg.Segments, srcIA, dstIA addr.IA) {
+// Filter upSegs, coreSegs and downSegs to include at most maxNumSegments segments. Ensures that the
+// remaining segments can be connected to allow forming paths between srcIA and dstIA.
+func selectConnectedSegs(maxNumSegments int, upSegs, coreSegs, downSegs *seg.Segments,
+	srcIA, dstIA addr.IA) {
 
 	plen := func(s *seg.Segments) int {
 		if s != nil {
@@ -340,9 +342,9 @@ func matchReqIA(addr, req addr.IA) bool {
 // - if downSegs is present, downSegs end (==LastIA()) in dstIA
 // - if upSegs are present, srcIA is not core
 // - if downSegs are present, dstIA is not core
-func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments, srcIA, dstIA addr.IA) []connectedSegs {
+func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
+	srcIA, dstIA addr.IA) []connectedSegs {
 
-	log.Trace("allConnectedSegs:")
 	paths := make([]connectedSegs, 0)
 
 	// Core direct
@@ -389,7 +391,6 @@ func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments, srcIA, dstIA add
 	} else if upSegs == nil {
 		// Down from src
 		for _, downSeg := range *downSegs {
-			log.Trace("down from src", "downFirst", downSeg.FirstIA(), "downLast", downSeg.LastIA(), "src", srcIA, "dst", dstIA)
 			if matchReqIA(downSeg.FirstIA(), srcIA) {
 				paths = append(paths, connectedSegs{
 					Up:   nil,
@@ -401,7 +402,6 @@ func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments, srcIA, dstIA add
 		// Core-Down
 		for _, coreSeg := range *coreSegs {
 			for _, downSeg := range *downSegs {
-				log.Trace("core-down", "coreFirst", coreSeg.FirstIA(), "coreLast", coreSeg.LastIA(), "downFirst", downSeg.FirstIA(), "downLast", downSeg.LastIA(), "src", srcIA, "dst", dstIA)
 				if !coreSeg.LastIA().Eq(downSeg.FirstIA()) {
 					continue
 				}
@@ -415,7 +415,6 @@ func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments, srcIA, dstIA add
 	} else if downSegs == nil {
 		// Up to dst
 		for _, upSeg := range *upSegs {
-			log.Trace("up to dst", "upFirst", upSeg.FirstIA(), "upLast", upSeg.LastIA(), "src", srcIA, "dst", dstIA)
 			if matchReqIA(upSeg.FirstIA(), dstIA) {
 				paths = append(paths, connectedSegs{
 					Up:   upSeg,
@@ -427,7 +426,6 @@ func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments, srcIA, dstIA add
 		// Up-Core
 		for _, upSeg := range *upSegs {
 			for _, coreSeg := range *coreSegs {
-				log.Trace("up-core:", "upFirst", upSeg.FirstIA(), "upLast", upSeg.LastIA(), "coreFirst", coreSeg.FirstIA(), "coreLast", coreSeg.LastIA(), "src", srcIA, "dst", dstIA)
 				if !upSeg.FirstIA().Eq(coreSeg.LastIA()) {
 					continue
 				}

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -256,40 +256,13 @@ func (h *segReqHandler) shouldRefetchSegsForDst(ctx context.Context, dst addr.IA
 func selectConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
 	src, dst addr.IA) {
 
-	var tmpUp, tmpCore, tmpDown seg.Segments
-	if upSegs != nil {
-		tmpUp = *upSegs
-	}
-	if coreSegs != nil {
-		tmpCore = *coreSegs
-	}
-	if downSegs != nil {
-		tmpDown = *downSegs
-	}
-
-	tmpUp, tmpCore, tmpDown = selectConnectedSegsImpl(tmpUp, tmpCore, tmpDown, src, dst)
-
-	if upSegs != nil {
-		*upSegs = tmpUp
-	}
-	if coreSegs != nil {
-		*coreSegs = tmpCore
-	}
-	if downSegs != nil {
-		*downSegs = tmpDown
-	}
-}
-
-func selectConnectedSegsImpl(upSegs, coreSegs, downSegs seg.Segments,
-	src, dst addr.IA) (seg.Segments, seg.Segments, seg.Segments) {
-
 	if assert.On {
 		assert.Must(!src.IsWildcard(), "Wildcard not expected for src-IA")
 		assert.Must(dst.I != 0, "Wildcard not expected for dst-ISD")
 	}
 
-	dsts := expandWildcard(upSegs, coreSegs, downSegs, dst)
-	graph := combinator.NewDMG(upSegs, coreSegs, downSegs)
+	dsts := expandWildcard(*upSegs, *coreSegs, *downSegs, dst)
+	graph := combinator.NewDMG(*upSegs, *coreSegs, *downSegs)
 	var paths combinator.PathSolutionList
 	for _, d := range dsts {
 		sdpaths := graph.GetPaths(combinator.VertexFromIA(src), combinator.VertexFromIA(d))
@@ -327,7 +300,6 @@ func selectConnectedSegsImpl(upSegs, coreSegs, downSegs seg.Segments,
 	upSegs.FilterSegs(selSegFunc)
 	coreSegs.FilterSegs(selSegFunc)
 	downSegs.FilterSegs(selSegFunc)
-	return upSegs, coreSegs, downSegs
 }
 
 // expandWildcard returns all core AS matching wildcard ia.

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -282,17 +282,6 @@ func (p *connectedSegs) numHops() int {
 func selectConnectedSegs(maxNumSegments int, upSegs, coreSegs, downSegs *seg.Segments,
 	srcIA, dstIA addr.IA) {
 
-	plen := func(s *seg.Segments) int {
-		if s != nil {
-			return len(*s)
-		}
-		return 0
-	}
-
-	if plen(upSegs)+plen(coreSegs)+plen(downSegs) < maxNumSegments {
-		return
-	}
-
 	paths := allConnectedSegs(upSegs, coreSegs, downSegs, srcIA, dstIA)
 	// Sort by least number of hops for path
 	sort.Slice(paths, func(i, j int) bool {
@@ -388,7 +377,7 @@ func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
 				}
 			}
 		}
-	} else if upSegs == nil {
+	} else if downSegs != nil {
 		// Down from src
 		for _, downSeg := range *downSegs {
 			if matchReqIA(downSeg.FirstIA(), srcIA) {
@@ -412,7 +401,7 @@ func allConnectedSegs(upSegs, coreSegs, downSegs *seg.Segments,
 				})
 			}
 		}
-	} else if downSegs == nil {
+	} else if upSegs != nil {
 		// Up to dst
 		for _, upSeg := range *upSegs {
 			if matchReqIA(upSeg.FirstIA(), dstIA) {

--- a/go/path_srv/internal/handlers/segreqcore.go
+++ b/go/path_srv/internal/handlers/segreqcore.go
@@ -130,7 +130,7 @@ func (h *segReqCoreHandler) handleReq(ctx context.Context,
 		}
 	}
 	logger.Debug("[segReqCoreHandler] found segs", "core", len(coreSegs), "down", len(downSegs))
-	selectConnectedSegs(maxResSegs, nil, &coreSegs, &downSegs, segReq.SrcIA(), segReq.DstIA())
+	selectConnectedSegs(nil, &coreSegs, &downSegs, segReq.SrcIA(), segReq.DstIA())
 	logger.Debug("[segReqCoreHandler] returning segs", "core", len(coreSegs), "down", len(downSegs))
 	h.sendReply(ctx, msger, nil, coreSegs, downSegs, segReq)
 }
@@ -146,7 +146,7 @@ func (h *segReqCoreHandler) handleCoreDst(ctx context.Context,
 		return
 	}
 	logger.Debug("[segReqHandler:handleCoreDst] found segs", "core", len(coreSegs))
-	selectConnectedSegs(maxResSegs, nil, &coreSegs, nil, segReq.SrcIA(), segReq.DstIA())
+	selectConnectedSegs(nil, &coreSegs, nil, segReq.SrcIA(), segReq.DstIA())
 	logger.Debug("[segReqHandler:handleCoreDst] returning segs", "core", len(coreSegs))
 	h.sendReply(ctx, msger, nil, coreSegs, nil, segReq)
 }

--- a/go/path_srv/internal/handlers/segreqcore.go
+++ b/go/path_srv/internal/handlers/segreqcore.go
@@ -139,14 +139,13 @@ func (h *segReqCoreHandler) handleCoreDst(ctx context.Context,
 	msger infra.Messenger, segReq *path_mgmt.SegReq) {
 
 	logger := log.FromCtx(ctx)
-	var coreSegs seg.Segments
 	coreSegs, err := h.fetchCoreSegsFromDB(ctx, []addr.IA{segReq.DstIA()}, !segReq.Flags.CacheOnly)
 	if err != nil {
 		logger.Error("Failed to find core segs", "err", err)
 		return
 	}
 	logger.Debug("[segReqHandler:handleCoreDst] found segs", "core", len(coreSegs))
-	selectConnectedSegs(nil, &coreSegs, nil, segReq.SrcIA(), segReq.DstIA())
+	selectConnectedSegs(nil, (*seg.Segments)(&coreSegs), nil, segReq.SrcIA(), segReq.DstIA())
 	logger.Debug("[segReqHandler:handleCoreDst] returning segs", "core", len(coreSegs))
 	h.sendReply(ctx, msger, nil, coreSegs, nil, segReq)
 }

--- a/go/path_srv/internal/handlers/segreqcore.go
+++ b/go/path_srv/internal/handlers/segreqcore.go
@@ -130,7 +130,8 @@ func (h *segReqCoreHandler) handleReq(ctx context.Context,
 		}
 	}
 	logger.Debug("[segReqCoreHandler] found segs", "core", len(coreSegs), "down", len(downSegs))
-	selectConnectedSegs(nil, &coreSegs, &downSegs, segReq.SrcIA(), segReq.DstIA())
+	selectConnectedSegs(&seg.Segments{}, &coreSegs, &downSegs,
+		segReq.SrcIA(), segReq.DstIA())
 	logger.Debug("[segReqCoreHandler] returning segs", "core", len(coreSegs), "down", len(downSegs))
 	h.sendReply(ctx, msger, nil, coreSegs, downSegs, segReq)
 }
@@ -145,7 +146,8 @@ func (h *segReqCoreHandler) handleCoreDst(ctx context.Context,
 		return
 	}
 	logger.Debug("[segReqHandler:handleCoreDst] found segs", "core", len(coreSegs))
-	selectConnectedSegs(nil, (*seg.Segments)(&coreSegs), nil, segReq.SrcIA(), segReq.DstIA())
+	selectConnectedSegs(&seg.Segments{}, (*seg.Segments)(&coreSegs), &seg.Segments{},
+		segReq.SrcIA(), segReq.DstIA())
 	logger.Debug("[segReqHandler:handleCoreDst] returning segs", "core", len(coreSegs))
 	h.sendReply(ctx, msger, nil, coreSegs, nil, segReq)
 }

--- a/go/path_srv/internal/handlers/segreqnoncore.go
+++ b/go/path_srv/internal/handlers/segreqnoncore.go
@@ -133,7 +133,7 @@ func (h *segReqNonCoreHandler) handleCoreDst(ctx context.Context, segReq *path_m
 	}
 
 	logger.Debug("[segReqHandler] found segs", "up", len(upSegs), "core", len(coreSegs))
-	selectConnectedSegs(&upSegs, &coreSegs, nil, h.localIA, dst)
+	selectConnectedSegs(&upSegs, &coreSegs, &seg.Segments{}, h.localIA, dst)
 	logger.Debug("[segReqHandler] returning segs", "up", len(upSegs), "core", len(coreSegs))
 	h.sendReply(ctx, msger, upSegs, coreSegs, nil, segReq)
 }

--- a/go/path_srv/internal/handlers/segreqnoncore.go
+++ b/go/path_srv/internal/handlers/segreqnoncore.go
@@ -116,15 +116,7 @@ func (h *segReqNonCoreHandler) handleCoreDst(ctx context.Context, segReq *path_m
 	}
 	// TODO(lukedirtwalker): in case of CacheOnly we can use a single query,
 	// else we should start go routines for the core segs here.
-	var coreSegs []*seg.PathSegment
-	// All firstIAs of upSegs that are connected, used for filtering later.
-	connFirstIAs := make(map[addr.IA]struct{})
-	// For a local wildcard we return all the upSegs.
-	if segReq.DstIA().A == 0 && segReq.DstIA().I == h.localIA.I {
-		for _, ia := range coreASes {
-			connFirstIAs[ia] = struct{}{}
-		}
-	}
+	var coreSegs seg.Segments
 	// TODO(lukedirtwalker): we shouldn't just query all cores, this could be a lot of overhead.
 	// Add a limit of cores we query.
 	for _, src := range upSegs.FirstIAs() {
@@ -136,18 +128,14 @@ func (h *segReqNonCoreHandler) handleCoreDst(ctx context.Context, segReq *path_m
 			}
 			if len(res) > 0 {
 				coreSegs = append(coreSegs, res...)
-				connFirstIAs[src] = struct{}{}
 			}
-		} else {
-			connFirstIAs[src] = struct{}{}
 		}
 	}
-	// Make sure we only return connected segments.
-	upSegs.FilterSegs(func(s *seg.PathSegment) bool {
-		_, connected := connFirstIAs[s.FirstIA()]
-		return connected
-	})
-	logger.Debug("[segReqHandler] found", "up", len(upSegs), "core", len(coreSegs))
+
+	logger.Debug("[segReqHandler] found segs", "up", len(upSegs), "core", len(coreSegs))
+	selectConnectedSegs(maxResSegs, &upSegs, &coreSegs, nil, h.localIA, dst)
+
+	logger.Debug("[segReqHandler] returning segs", "up", len(upSegs), "core", len(coreSegs))
 	h.sendReply(ctx, msger, upSegs, coreSegs, nil, segReq)
 }
 
@@ -175,10 +163,8 @@ func (h *segReqNonCoreHandler) handleNonCoreDst(ctx context.Context, segReq *pat
 		h.sendEmptySegReply(ctx, segReq, msger)
 		return
 	}
-	var coreSegs []*seg.PathSegment
-	// All firstIAs of up-/down-Segs that are connected, used for filtering later.
-	connUpFirstIAs := make(map[addr.IA]struct{})
-	connDownFirstIAs := make(map[addr.IA]struct{})
+
+	var coreSegs seg.Segments
 	// TODO(lukedirtwalker): in case of CacheOnly we can use a single query,
 	// else we should start go routines for the core segs here.
 	for _, dst := range downSegs.FirstIAs() {
@@ -186,8 +172,6 @@ func (h *segReqNonCoreHandler) handleNonCoreDst(ctx context.Context, segReq *pat
 		// Add a limit of cores we query.
 		for _, src := range upSegs.FirstIAs() {
 			if src.Equal(dst) {
-				connUpFirstIAs[src] = struct{}{}
-				connDownFirstIAs[dst] = struct{}{}
 				continue
 			}
 			cs, err := h.fetchCoreSegs(ctx, msger, src, dst, segReq.Flags.CacheOnly)
@@ -195,24 +179,13 @@ func (h *segReqNonCoreHandler) handleNonCoreDst(ctx context.Context, segReq *pat
 				logger.Error("Failed to find core segs", "src", src, "dst", dst, "err", err)
 				continue
 			}
-			if len(cs) > 0 {
-				coreSegs = append(coreSegs, cs...)
-				connUpFirstIAs[src] = struct{}{}
-				connDownFirstIAs[dst] = struct{}{}
-			}
+			coreSegs = append(coreSegs, cs...)
 		}
 	}
-	// Make sure we only return connected segments.
-	// No need to filter cores, since we only query for connected ones.
-	upSegs.FilterSegs(func(s *seg.PathSegment) bool {
-		_, connected := connUpFirstIAs[s.FirstIA()]
-		return connected
-	})
-	downSegs.FilterSegs(func(s *seg.PathSegment) bool {
-		_, connected := connDownFirstIAs[s.FirstIA()]
-		return connected
-	})
 	logger.Debug("[segReqHandler:handleNonCoreDst] found segs",
+		"up", len(upSegs), "core", len(coreSegs), "down", len(downSegs))
+	selectConnectedSegs(maxResSegs, &upSegs, &coreSegs, &downSegs, h.localIA, dstIA)
+	logger.Debug("[segReqHandler:handleNonCoreDst] returning segs",
 		"up", len(upSegs), "core", len(coreSegs), "down", len(downSegs))
 	h.sendReply(ctx, msger, upSegs, coreSegs, downSegs, segReq)
 }

--- a/go/path_srv/internal/handlers/segreqnoncore.go
+++ b/go/path_srv/internal/handlers/segreqnoncore.go
@@ -133,7 +133,7 @@ func (h *segReqNonCoreHandler) handleCoreDst(ctx context.Context, segReq *path_m
 	}
 
 	logger.Debug("[segReqHandler] found segs", "up", len(upSegs), "core", len(coreSegs))
-	selectConnectedSegs(maxResSegs, &upSegs, &coreSegs, nil, h.localIA, dst)
+	selectConnectedSegs(&upSegs, &coreSegs, nil, h.localIA, dst)
 	logger.Debug("[segReqHandler] returning segs", "up", len(upSegs), "core", len(coreSegs))
 	h.sendReply(ctx, msger, upSegs, coreSegs, nil, segReq)
 }
@@ -183,7 +183,7 @@ func (h *segReqNonCoreHandler) handleNonCoreDst(ctx context.Context, segReq *pat
 	}
 	logger.Debug("[segReqHandler:handleNonCoreDst] found segs",
 		"up", len(upSegs), "core", len(coreSegs), "down", len(downSegs))
-	selectConnectedSegs(maxResSegs, &upSegs, &coreSegs, &downSegs, h.localIA, dstIA)
+	selectConnectedSegs(&upSegs, &coreSegs, &downSegs, h.localIA, dstIA)
 	logger.Debug("[segReqHandler:handleNonCoreDst] returning segs",
 		"up", len(upSegs), "core", len(coreSegs), "down", len(downSegs))
 	h.sendReply(ctx, msger, upSegs, coreSegs, downSegs, segReq)

--- a/go/path_srv/internal/handlers/segreqnoncore.go
+++ b/go/path_srv/internal/handlers/segreqnoncore.go
@@ -134,7 +134,6 @@ func (h *segReqNonCoreHandler) handleCoreDst(ctx context.Context, segReq *path_m
 
 	logger.Debug("[segReqHandler] found segs", "up", len(upSegs), "core", len(coreSegs))
 	selectConnectedSegs(maxResSegs, &upSegs, &coreSegs, nil, h.localIA, dst)
-
 	logger.Debug("[segReqHandler] returning segs", "up", len(upSegs), "core", len(coreSegs))
 	h.sendReply(ctx, msger, upSegs, coreSegs, nil, segReq)
 }

--- a/go/path_srv/internal/handlers/segreqnoncore_test.go
+++ b/go/path_srv/internal/handlers/segreqnoncore_test.go
@@ -51,6 +51,8 @@ var (
 	core1_110 = xtest.MustParseIA("1-ff00:0:110")
 	core1_130 = xtest.MustParseIA("1-ff00:0:130")
 	core1_120 = xtest.MustParseIA("1-ff00:0:120")
+	core1_any = xtest.MustParseIA("1-0")
+	as1_112   = xtest.MustParseIA("1-ff00:0:112")
 	as1_132   = xtest.MustParseIA("1-ff00:0:132")
 
 	core2_210 = xtest.MustParseIA("2-ff00:0:210")
@@ -59,10 +61,12 @@ var (
 	as2_221   = xtest.MustParseIA("2-ff00:0:221")
 	as2_222   = xtest.MustParseIA("2-ff00:0:222")
 
-	seg130_132 = g.Beacon([]common.IFIDType{graph.If_130_A_131_X, graph.If_131_X_132_X})
 	seg110_130 = g.Beacon([]common.IFIDType{graph.If_110_X_130_A})
+	seg120_112 = g.Beacon([]common.IFIDType{graph.If_120_X_111_B, graph.If_111_A_112_X})
+	seg120_130 = g.Beacon([]common.IFIDType{graph.If_120_A_130_B})
 	seg120_210 = g.Beacon([]common.IFIDType{graph.If_120_B_220_X, graph.If_220_X_210_X})
 	seg120_220 = g.Beacon([]common.IFIDType{graph.If_120_B_220_X})
+	seg130_132 = g.Beacon([]common.IFIDType{graph.If_130_A_131_X, graph.If_131_X_132_X})
 
 	seg210_211 = g.Beacon([]common.IFIDType{graph.If_210_X_211_A})
 	seg210_220 = g.Beacon([]common.IFIDType{graph.If_210_X_220_X})
@@ -202,6 +206,17 @@ func TestSegReqLocal(t *testing.T) {
 			Expected: expectedSegs([]*seg.PathSegment{seg130_132},
 				[]*seg.PathSegment{seg110_130}, nil),
 		},
+		/*
+			{
+				Name:  "CoreDST: Single up, dst: core local wildcard",
+				SrcIA: as1_132,
+				DstIA: core1_any,
+				Ups:   []*seg.PathSegment{seg130_132},
+				Cores: []*seg.PathSegment{seg110_130, seg120_130},
+				Expected: expectedSegs([]*seg.PathSegment{seg130_132},
+					[]*seg.PathSegment{seg110_130, seg120_130}, nil),
+			},
+		*/
 		{
 			Name:  "CoreDST: Single up, dst: core remote",
 			SrcIA: as1_132,
@@ -238,10 +253,10 @@ func TestSegReqLocal(t *testing.T) {
 		},
 		{
 			Name:     "NonCoreDST: Single up, no core, single down",
-			SrcIA:    as2_222,
-			DstIA:    as2_211,
-			Ups:      []*seg.PathSegment{seg220_222},
-			Downs:    []*seg.PathSegment{seg210_211},
+			SrcIA:    as1_132,
+			DstIA:    as1_112,
+			Ups:      []*seg.PathSegment{seg130_132},
+			Downs:    []*seg.PathSegment{seg120_112},
 			Expected: expectedSegs(nil, nil, nil),
 		},
 		{
@@ -253,6 +268,15 @@ func TestSegReqLocal(t *testing.T) {
 			Downs: []*seg.PathSegment{seg210_211},
 			Expected: expectedSegs([]*seg.PathSegment{seg220_222},
 				[]*seg.PathSegment{seg210_220}, []*seg.PathSegment{seg210_211}),
+		},
+		{
+			Name:  "NonCoreDST: Single up, no core, single down with peering",
+			SrcIA: as2_222,
+			DstIA: as2_211,
+			Ups:   []*seg.PathSegment{seg220_222},
+			Downs: []*seg.PathSegment{seg210_211},
+			Expected: expectedSegs([]*seg.PathSegment{seg220_222}, nil,
+				[]*seg.PathSegment{seg210_211}),
 		},
 		{
 			Name:  "NonCoreDst: On up path dst",

--- a/go/path_srv/internal/handlers/segreqnoncore_test.go
+++ b/go/path_srv/internal/handlers/segreqnoncore_test.go
@@ -206,17 +206,15 @@ func TestSegReqLocal(t *testing.T) {
 			Expected: expectedSegs([]*seg.PathSegment{seg130_132},
 				[]*seg.PathSegment{seg110_130}, nil),
 		},
-		/*
-			{
-				Name:  "CoreDST: Single up, dst: core local wildcard",
-				SrcIA: as1_132,
-				DstIA: core1_any,
-				Ups:   []*seg.PathSegment{seg130_132},
-				Cores: []*seg.PathSegment{seg110_130, seg120_130},
-				Expected: expectedSegs([]*seg.PathSegment{seg130_132},
-					[]*seg.PathSegment{seg110_130, seg120_130}, nil),
-			},
-		*/
+		{
+			Name:  "CoreDST: Single up, dst: core local wildcard",
+			SrcIA: as1_132,
+			DstIA: core1_any,
+			Ups:   []*seg.PathSegment{seg130_132},
+			Cores: []*seg.PathSegment{seg110_130, seg120_130},
+			Expected: expectedSegs([]*seg.PathSegment{seg130_132},
+				[]*seg.PathSegment{seg110_130, seg120_130}, nil),
+		},
 		{
 			Name:  "CoreDST: Single up, dst: core remote",
 			SrcIA: as1_132,


### PR DESCRIPTION
Fix for #2413

Note on implementation: a first attempt was to filter the lists of up, down and core segments individually -- as far as I understand this is analogous to how this happens in the python PS.
However, the filtering to only return segments that can be connected to paths became rather unwieldy. Also, when selecting the segments, only the number of hops in an individual segment could be considered. The current implementation considers the number of hops in a _path_ (consisting of a combination of up/core/down segments) which seems to make more sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2452)
<!-- Reviewable:end -->
