### PR TITLE
Sciond: Enable idiscovery

### DIFF
--- a/acceptance/discovery_infra_fetches_dynamic_acceptance/test
+++ b/acceptance/discovery_infra_fetches_dynamic_acceptance/test
@@ -14,7 +14,7 @@ test_setup() {
     set -e
     base_setup
 
-    for cfg in gen/ISD1/AS$AS_FILE/*/{cs,ps}config.toml; do
+    for cfg in gen/ISD1/AS$AS_FILE/*/{{cs,ps}config,sciond}.toml; do
         set_log_lvl "$cfg"
         set_interval "$cfg" "dynamic"
     done
@@ -24,12 +24,14 @@ test_setup() {
 
 test_run() {
     set -e
-    # Start serving dynamic topology.
+    # Start serving dynamic topology. Full for infra services, default for sciond.
     jq ".BorderRouters[].InternalAddrs.IPv4.PublicOverlay = {Addr: \"127.42.42.42\", OverlayPort: 39999} | .Timestamp = $( date +%s) | .TTL = 3" $TOPO | sponge $DYNAMIC_FULL
+    cp $DYNAMIC_FULL $DYNAMIC_DEFAULT
     sleep 6
     check_file "dynamic"
     check_logs "ps$IA_FILE-1"
     check_logs "cs$IA_FILE-1"
+    check_logs "sd$IA_FILE"
 }
 
 check_logs() {

--- a/acceptance/discovery_infra_fetches_static_acceptance/test
+++ b/acceptance/discovery_infra_fetches_static_acceptance/test
@@ -14,11 +14,13 @@ test_setup() {
     set -e
     base_setup
 
-    for elem in gen/ISD1/AS$AS_FILE/{cs,ps}*; do
+    for elem in gen/ISD1/AS$AS_FILE/{cs,ps,endhost}*; do
         for cfg in $elem/*.toml; do
             set_log_lvl "$cfg"
             set_interval "$cfg" "static"
-            sed -i -e "/\[discovery.static]/a Filename = \"/share/cache/${elem##*/}-topo.json\"" $cfg
+            elem=${elem##*/}
+            [ "$elem" != "endhost" ] || elem="sd$IA_FILE"
+            sed -i -e "/\[discovery.static]/a Filename = \"/share/cache/$elem-topo.json\"" $cfg
         done
     done
 
@@ -27,17 +29,20 @@ test_setup() {
 
 test_run() {
     set -e
-    # Start serving static topology.
+    # Start serving static topology. Full for infra services, default for sciond.
     jq ".BorderRouters[].InternalAddrs.IPv4.PublicOverlay = {Addr: \"127.42.42.42\", OverlayPort: 39999} | .Timestamp = $( date +%s) | .TTL = 3" $TOPO | sponge $STATIC_FULL
+    cp $STATIC_FULL $STATIC_DEFAULT
     sleep 6
     # Check that the mock ds serves the file
     check_file "static"
     # Check that the logs contain setting and writing the topo.
     check_logs "ps$IA_FILE-1"
     check_logs "cs$IA_FILE-1"
+    check_logs "sd$IA_FILE"
     # Check that the written file does not differ from the served file.
     check_diff "ps$IA_FILE-1"
     check_diff "cs$IA_FILE-1"
+    check_diff "sd$IA_FILE"
 }
 
 check_logs() {

--- a/acceptance/discovery_util/util.sh
+++ b/acceptance/discovery_util/util.sh
@@ -13,8 +13,10 @@ TEST_TOPOLOGY="topology/Tiny.topo"
 HTTP_DIR="gen/discovery_acceptance"
 STATIC_DIR="$HTTP_DIR/discovery/v1/static"
 STATIC_FULL="$STATIC_DIR/full.json"
+STATIC_DEFAULT="$STATIC_DIR/default.json"
 DYNAMIC_DIR="$HTTP_DIR/discovery/v1/dynamic"
 DYNAMIC_FULL="$DYNAMIC_DIR/full.json"
+DYNAMIC_DEFAULT="$DYNAMIC_DIR/default.json"
 
 
 base_setup() {
@@ -57,6 +59,7 @@ set_interval() {
 
 check_file() {
     curl -f -s -S "$( jq -r '.DiscoveryService[].Addrs[].Public | "\(.Addr):\(.L4Port)"' "$TOPO" )/discovery/v1/$1/full.json" > /dev/null
+    curl -f -s -S "$( jq -r '.DiscoveryService[].Addrs[].Public | "\(.Addr):\(.L4Port)"' "$TOPO" )/discovery/v1/$1/default.json" > /dev/null
 }
 
 print_help() {

--- a/go/sciond/internal/config/config.go
+++ b/go/sciond/internal/config/config.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/env"
+	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
 	"github.com/scionproto/scion/go/lib/pathstorage"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
@@ -34,14 +35,16 @@ var (
 )
 
 type Config struct {
-	General env.General
-	Logging env.Logging
-	Metrics env.Metrics
-	TrustDB truststorage.TrustDBConf
-	SD      SDConfig
+	General   env.General
+	Logging   env.Logging
+	Metrics   env.Metrics
+	TrustDB   truststorage.TrustDBConf
+	Discovery idiscovery.Config
+	SD        SDConfig
 }
 
 func (c *Config) InitDefaults() {
+	c.Discovery.InitDefaults()
 	c.SD.initDefaults()
 }
 

--- a/go/sciond/internal/config/sample.go
+++ b/go/sciond/internal/config/sample.go
@@ -64,6 +64,37 @@ const Sample = `[general]
   # Connection for the trust database
   Connection = "/var/lib/scion/spki/sd.trust.db"
 
+[discovery]
+  [discovery.static]
+    # Enable periodic fetching of the static topology. (default false)
+    Enable = false
+
+    # Time between two consecutive static topology queries. (default 5m)
+    Interval = "5m"
+
+    # Timeout for querying the static topology. (default 1s)
+    Timeout = "1s"
+
+    # Require https connection. (default false)
+    Https = false
+
+    # Filename where the updated static topologies are written. In case of the
+    # empty string, the updated topologies are not written. (default "")
+    Filename = ""
+
+  [discovery.dynamic]
+    # Enable periodic fetching of the dynamic topology. (default false)
+    Enable = false
+
+    # Time between two consecutive dynamic topology queries. (default 5s)
+    Interval = "5s"
+
+    # Timeout for querying the dynamic topology. (default 1s)
+    Timeout = "1s"
+
+    # Require https connection. (default false)
+    Https = false
+
 [sd]
   # Address to listen on via the reliable socket protocol. If empty,
   # a reliable socket server on the default socket is started.

--- a/go/sciond/internal/config/sample_test.go
+++ b/go/sciond/internal/config/sample_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/BurntSushi/toml"
 	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
 )
 
 func TestSampleCorrect(t *testing.T) {
@@ -27,6 +29,10 @@ func TestSampleCorrect(t *testing.T) {
 		var cfg Config
 		// Make sure DeleteSocket is set.
 		cfg.SD.DeleteSocket = true
+		cfg.Discovery.Dynamic.Enable = true
+		cfg.Discovery.Dynamic.Https = true
+		cfg.Discovery.Static.Enable = true
+		cfg.Discovery.Static.Https = true
 		_, err := toml.Decode(Sample, &cfg)
 		SoMsg("err", err, ShouldBeNil)
 
@@ -40,6 +46,19 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection,
 			ShouldEqual, "/var/lib/scion/spki/sd.trust.db")
+		SoMsg("Discovery.Static.Enable correct", cfg.Discovery.Static.Enable, ShouldBeFalse)
+		SoMsg("Discovery.Static.Interval correct", cfg.Discovery.Static.Interval.Duration,
+			ShouldEqual, idiscovery.DefaultStaticFetchInterval)
+		SoMsg("Discovery.Static.Timeout correct", cfg.Discovery.Static.Timeout.Duration,
+			ShouldEqual, idiscovery.DefaultFetchTimeout)
+		SoMsg("Discovery.Static.Https correct", cfg.Discovery.Static.Https, ShouldBeFalse)
+		SoMsg("Discovery.Static.Filename correct", cfg.Discovery.Static.Filename, ShouldBeBlank)
+		SoMsg("Discovery.Dynamic.Enable correct", cfg.Discovery.Dynamic.Enable, ShouldBeFalse)
+		SoMsg("Discovery.Dynamic.Interval correct", cfg.Discovery.Dynamic.Interval.Duration,
+			ShouldEqual, idiscovery.DefaultDynamicFetchInterval)
+		SoMsg("Discovery.Dynamic.Timeout correct", cfg.Discovery.Dynamic.Timeout.Duration,
+			ShouldEqual, idiscovery.DefaultFetchTimeout)
+		SoMsg("Discovery.Dynamic.Https correct", cfg.Discovery.Dynamic.Https, ShouldBeFalse)
 
 		// sdconfig specific
 		SoMsg("PathDB.Backend correct", cfg.SD.PathDB.Backend, ShouldEqual, "sqlite")

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -140,6 +140,7 @@ class GoGenerator(object):
             },
             'logging': self._log_entry(name),
             'TrustDB': trust_db_conf_entry(self.args, name),
+            'discovery': self._discovery_entry(),
             'sd': {
                 'Reliable': os.path.join(SCIOND_API_SOCKDIR, "%s.sock" % name),
                 'Unix': os.path.join(SCIOND_API_SOCKDIR, "%s.unix" % name),


### PR DESCRIPTION
This change enables the use of `idiscovery` in sciond.
The requests are sent to the `default` endpoint of the DS.

fixes #2432 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2453)
<!-- Reviewable:end -->
