### PR TITLE
itopo: Increase sleep in unit test

### DIFF
--- a/go/lib/infra/modules/itopo/itopo_test.go
+++ b/go/lib/infra/modules/itopo/itopo_test.go
@@ -328,7 +328,7 @@ type clbkCalled struct {
 
 func (c *clbkCalled) check(clean, drop, update bool) {
 	// Wait for callbacks to be executed
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 	SoMsg("clbk clean", c.clean, ShouldEqual, clean)
 	SoMsg("clbk drop", c.drop, ShouldEqual, drop)
 	SoMsg("clbk update", c.update, ShouldEqual, update)


### PR DESCRIPTION
Currently, the unit test fails occasionally on slow machines
due to the callback not being called in time. This change
increases the sleep period that waits for the callback being
called.

fixes #2455

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2456)
<!-- Reviewable:end -->
