### PR TITLE
Docker base image: Use chown only when needed

### DIFF
--- a/.buildkite/scripts/build_scion_img
+++ b/.buildkite/scripts/build_scion_img
@@ -2,7 +2,7 @@
 
 set -e
 
-BASE_IMG=${BASE_IMG:-d0df659466340dfc30f277f383ade9f0e1069ae2d2ac621f1a04d3eed258f388}
+BASE_IMG=${BASE_IMG:-c8338797bd7d23aed113fae069545c79a6024ddda67ec61524c356766e9122e4}
 
 docker pull scionproto/scion_base@sha256:$BASE_IMG
 docker tag scionproto/scion_base@sha256:$BASE_IMG scion_base:latest

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -91,8 +91,9 @@ COPY docker/profile $HOME/.profile
 # Install basic screen config
 COPY docker/screenrc $HOME/.screenrc
 
-# Fix ownership one last time:
-RUN sudo chown -R scion: $HOME
+# Fix ownership one last time. Chown is an expensive operation in terms of docker
+# image size so chown only the files that belong to different users.
+RUN sudo find $HOME -not -user scion -execdir chown scion {} \+
 
 COPY docker/docker-entrypoint.sh /
 

--- a/env/debian/pkgs.txt
+++ b/env/debian/pkgs.txt
@@ -17,7 +17,6 @@ libffi-dev
 libjs-jquery-hotkeys
 libjs-jquery-isonscreen
 libjs-jquery-tablesorter
-libpcap-dev
 libssl-dev
 make
 moreutils
@@ -47,5 +46,6 @@ python3-yaml
 screen
 sqlite3
 sudo
+tzdata
 uthash-dev
 vim-common


### PR DESCRIPTION
Using chown when building a docker image is expensive. It in fact copies
each file that's touched growing the size of the layer a lot.

This particular step resulted in a 84MB layer. After the change it's 422
bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2457)
<!-- Reviewable:end -->
