### PR TITLE
Discovery: Initial connection check

### DIFF
--- a/acceptance/common.sh
+++ b/acceptance/common.sh
@@ -87,3 +87,10 @@ fail() {
     echo "$(date -u +'%F %T.%6N%z') $@" >&2
     exit 1
 }
+
+#######################################
+# Returns whether is running in docker
+#######################################
+is_running_in_docker() {
+    cut -d: -f 3 /proc/1/cgroup | grep -q '^/docker/'
+}

--- a/acceptance/common.sh
+++ b/acceptance/common.sh
@@ -89,7 +89,7 @@ fail() {
 }
 
 #######################################
-# Returns whether is running in docker
+# Returns whether this script is running in docker
 #######################################
 is_running_in_docker() {
     cut -d: -f 3 /proc/1/cgroup | grep -q '^/docker/'

--- a/acceptance/discovery_br_fetches_dynamic_acceptance/test
+++ b/acceptance/discovery_br_fetches_dynamic_acceptance/test
@@ -44,6 +44,8 @@ test_run() {
     # Wait until dynamic topology expires.
     sleep 10
     check_connectivity "dynamic topology expired"
+
+    check_br_fail_action "dynamic"
 }
 
 check_connectivity() {

--- a/acceptance/discovery_br_fetches_static_acceptance/test
+++ b/acceptance/discovery_br_fetches_static_acceptance/test
@@ -56,6 +56,8 @@ test_run() {
     cp $TOPO $STATIC_FULL
     sleep 5
     check_connectivity "serve original static topology"
+
+    check_br_fail_action "static"
 }
 
 check_connectivity_broken() {

--- a/acceptance/discovery_infra_fetches_dynamic_acceptance/test
+++ b/acceptance/discovery_infra_fetches_dynamic_acceptance/test
@@ -32,6 +32,8 @@ test_run() {
     check_logs "ps$IA_FILE-1"
     check_logs "cs$IA_FILE-1"
     check_logs "sd$IA_FILE"
+
+    check_infra_fail_action "dynamic"
 }
 
 check_logs() {

--- a/acceptance/discovery_infra_fetches_static_acceptance/test
+++ b/acceptance/discovery_infra_fetches_static_acceptance/test
@@ -43,6 +43,8 @@ test_run() {
     check_diff "ps$IA_FILE-1"
     check_diff "cs$IA_FILE-1"
     check_diff "sd$IA_FILE"
+
+    check_infra_fail_action "static"
 }
 
 check_logs() {

--- a/acceptance/discovery_util/util.sh
+++ b/acceptance/discovery_util/util.sh
@@ -114,7 +114,7 @@ stop_mock_ds() {
 }
 
 check_running() {
-    ./tools/dc scion top "scion_$1" >/dev/null 2>/dev/null
+    ./tools/dc scion top "scion_$1" # >/dev/null 2>/dev/null
 }
 
 check_not_running() {

--- a/acceptance/discovery_util/util.sh
+++ b/acceptance/discovery_util/util.sh
@@ -114,7 +114,7 @@ stop_mock_ds() {
 }
 
 check_running() {
-    docker top "scion_$1" >/dev/null 2>/dev/null
+    ./tools/dc scion top "scion_$1" >/dev/null 2>/dev/null
 }
 
 check_not_running() {

--- a/acceptance/discovery_util/util.sh
+++ b/acceptance/discovery_util/util.sh
@@ -57,9 +57,65 @@ set_interval() {
     sed -i -e "/\[discovery.$2]/a Interval = \"1s\"" "$1"
 }
 
+set_connect() {
+    printf "\n[discovery.$2.Connect]\nInitialPeriod = \"$3\"" >> "$1"
+}
+
+set_fail_action() {
+    sed -i -e "/\[discovery.$2.Connect]/a FailAction = \"$3\"" "$1"
+}
+
 check_file() {
     curl -f -s -S "$( jq -r '.DiscoveryService[].Addrs[].Public | "\(.Addr):\(.L4Port)"' "$TOPO" )/discovery/v1/$1/full.json" > /dev/null
     curl -f -s -S "$( jq -r '.DiscoveryService[].Addrs[].Public | "\(.Addr):\(.L4Port)"' "$TOPO" )/discovery/v1/$1/default.json" > /dev/null
+}
+
+
+check_infra_fail_action() {
+    stop_mock_ds
+    # Check that services continue if fail action is not set.
+    for cfg in gen/ISD1/AS$AS_FILE/*/{{cs,ps}config,sciond}.toml; do
+        set_connect "$cfg" "$1" "5s"
+    done
+    ./tools/dc scion restart "scion_ps$IA_FILE-1" "scion_cs$IA_FILE-1" "scion_sd$IA_FILE"
+    sleep 10
+    local err="$( check_stopped_count "ps$IA_FILE-1" 1 )" || fail "Error: ps$IA_FILE-1 not running err=$err"
+    local err="$( check_stopped_count "cs$IA_FILE-1" 1 )" || fail "Error: cs$IA_FILE-1 not running err=$err"
+    local err="$( check_stopped_count "sd$IA_FILE" 1 )" || fail "Error: sd$IA_FILE not running err=$err"
+
+    # Check that services exit if fail action is fatal
+    for cfg in gen/ISD1/AS$AS_FILE/*/{{cs,ps}config,sciond}.toml; do
+        set_fail_action "$cfg" "$1" "Fatal"
+    done
+    ./tools/dc scion restart "scion_ps$IA_FILE-1" "scion_cs$IA_FILE-1" "scion_sd$IA_FILE"
+    sleep 10
+    local err="$( check_stopped_count "ps$IA_FILE-1" 3 )" || fail "Error: ps$IA_FILE-1 still running err=$err"
+    local err="$( check_stopped_count "cs$IA_FILE-1" 3 )" || fail "Error: cs$IA_FILE-1 still running err=$err"
+    local err="$( check_stopped_count "sd$IA_FILE" 3 )" || fail "Error: sd$IA_FILE still running err=$err"
+}
+
+check_br_fail_action() {
+    stop_mock_ds
+    # Check that services continue if fail action is not set.
+    set_connect "gen/ISD1/AS$AS_FILE/br$IA_FILE-1/brconfig.toml" "$1" "5s"
+    ./tools/dc scion restart "scion_br$IA_FILE-1"
+    sleep 10
+    local err="$( check_stopped_count "br$IA_FILE-1" 1 )" || fail "Error: br$IA_FILE-1 not running err=$err"
+
+    # Check that services exit if fail action is fatal
+    set_fail_action "gen/ISD1/AS$AS_FILE/br$IA_FILE-1/brconfig.toml" "$1" "Fatal"
+    ./tools/dc scion restart "scion_br$IA_FILE-1"
+    sleep 10
+    local err="$( check_stopped_count "br$IA_FILE-1" 3 )" || fail "Error: br$IA_FILE-1 still running err=$err"
+}
+
+stop_mock_ds() {
+    ./tools/dc scion stop 'mock_ds1-ff00_0_111-1'
+}
+
+check_stopped_count() {
+    local c="$( grep "\[INFO\] =====================> Service stopped" "logs/$1.log" | wc -l )"
+    [ "$c" == "$2" ] || echo "Invalid count expected=$2 actual=$c"
 }
 
 print_help() {

--- a/acceptance/discovery_util/util.sh
+++ b/acceptance/discovery_util/util.sh
@@ -114,7 +114,10 @@ stop_mock_ds() {
 }
 
 check_running() {
-    ./tools/dc scion top "scion_$1" # >/dev/null 2>/dev/null
+    if is_running_in_docker; then
+            local docker="docker_"
+    fi
+    docker top "scion_${docker}$1"
 }
 
 check_not_running() {

--- a/go/border/brconf/sample.go
+++ b/go/border/brconf/sample.go
@@ -78,6 +78,19 @@ const Sample = `[general]
     # empty string, the updated topologies are not written. (default "")
     Filename = ""
 
+    [discovery.static.connect]
+      # Maximum time spent attempting to fetch the topology from the
+      # discovery service on start. If no topology is successfully fetched
+      # in this period, the FailAction is executed. (default 20s)
+      InitialPeriod = "20s"
+
+      # The action to take if no topology is successfully fetched in
+      # the InitialPeriod.
+      # - Fatal: Exit process.
+      # - Continue: Log error and continue with execution.
+      # (Fatal | Continue) (default Continue)
+      FailAction = "Continue"
+
   [discovery.dynamic]
     # Enable periodic fetching of the dynamic topology. (default false)
     Enable = false
@@ -90,6 +103,18 @@ const Sample = `[general]
 
     # Require https connection. (default false)
     Https = false
+
+    [discovery.dynamic.connect]
+      # Maximum time spent attempting to fetch the topology from the
+      # discovery service on start. If no topology is successfully fetched
+      # in this period, the FailAction is executed. (default 20s)
+      InitialPeriod = "20s"
+
+      # The action to take if no topology is successfully fetched in InitialPeriod.
+      # - Fatal: Exit process.
+      # - Continue: Log error and continue with execution.
+      # (Fatal | Continue) (default Continue)
+      FailAction = "Continue"
 
 [br]
   # Enable cpu and memory profiling. (default false)

--- a/go/cert_srv/internal/config/config_test.go
+++ b/go/cert_srv/internal/config/config_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/BurntSushi/toml"
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
+	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery/idiscoverytest"
 )
 
 func TestSampleCorrect(t *testing.T) {
@@ -30,11 +30,7 @@ func TestSampleCorrect(t *testing.T) {
 		var cfg Config
 		// Make sure AutomaticRenewal is set during decoding.
 		cfg.CS.AutomaticRenewal = true
-		cfg.Discovery.Dynamic.Enable = true
-		cfg.Discovery.Dynamic.Https = true
-		cfg.Discovery.Static.Enable = true
-		cfg.Discovery.Static.Https = true
-		cfg.Discovery.Static.Filename = "topology.json"
+		idiscoverytest.InitTestConfig(t, &cfg.Discovery)
 		_, err := toml.Decode(Sample, &cfg)
 		SoMsg("err", err, ShouldBeNil)
 
@@ -48,19 +44,7 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection, ShouldEqual,
 			"/var/lib/scion/spki/cs-1.trust.db")
-		SoMsg("Discovery.Static.Enable correct", cfg.Discovery.Static.Enable, ShouldBeFalse)
-		SoMsg("Discovery.Static.Interval correct", cfg.Discovery.Static.Interval.Duration,
-			ShouldEqual, idiscovery.DefaultStaticFetchInterval)
-		SoMsg("Discovery.Static.Timeout correct", cfg.Discovery.Static.Timeout.Duration,
-			ShouldEqual, idiscovery.DefaultFetchTimeout)
-		SoMsg("Discovery.Static.Https correct", cfg.Discovery.Static.Https, ShouldBeFalse)
-		SoMsg("Discovery.Static.Filename correct", cfg.Discovery.Static.Filename, ShouldBeBlank)
-		SoMsg("Discovery.Dynamic.Enable correct", cfg.Discovery.Dynamic.Enable, ShouldBeFalse)
-		SoMsg("Discovery.Dynamic.Interval correct", cfg.Discovery.Dynamic.Interval.Duration,
-			ShouldEqual, idiscovery.DefaultDynamicFetchInterval)
-		SoMsg("Discovery.Dynamic.Timeout correct", cfg.Discovery.Dynamic.Timeout.Duration,
-			ShouldEqual, idiscovery.DefaultFetchTimeout)
-		SoMsg("Discovery.Dynamic.Https correct", cfg.Discovery.Dynamic.Https, ShouldBeFalse)
+		idiscoverytest.CheckTestConfig(t, cfg.Discovery)
 
 		// csconfig specific
 		SoMsg("LeafReissueLeadTime correct", cfg.CS.LeafReissueLeadTime.Duration,

--- a/go/cert_srv/internal/config/config_test.go
+++ b/go/cert_srv/internal/config/config_test.go
@@ -30,7 +30,7 @@ func TestSampleCorrect(t *testing.T) {
 		var cfg Config
 		// Make sure AutomaticRenewal is set during decoding.
 		cfg.CS.AutomaticRenewal = true
-		idiscoverytest.InitTestConfig(t, &cfg.Discovery)
+		idiscoverytest.InitTestConfig(&cfg.Discovery)
 		_, err := toml.Decode(Sample, &cfg)
 		SoMsg("err", err, ShouldBeNil)
 
@@ -44,7 +44,7 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection, ShouldEqual,
 			"/var/lib/scion/spki/cs-1.trust.db")
-		idiscoverytest.CheckTestConfig(t, cfg.Discovery)
+		idiscoverytest.CheckTestConfig(cfg.Discovery)
 
 		// csconfig specific
 		SoMsg("LeafReissueLeadTime correct", cfg.CS.LeafReissueLeadTime.Duration,

--- a/go/cert_srv/internal/config/sample.go
+++ b/go/cert_srv/internal/config/sample.go
@@ -90,6 +90,19 @@ const Sample = `[general]
     # empty string, the updated topologies are not written. (default "")
     Filename = ""
 
+    [discovery.static.connect]
+      # Maximum time spent attempting to fetch the topology from the
+      # discovery service on start. If no topology is successfully fetched
+      # in this period, the FailAction is executed. (default 20s)
+      InitialPeriod = "20s"
+
+      # The action to take if no topology is successfully fetched in
+      # the InitialPeriod.
+      # - Fatal: Exit process.
+      # - Continue: Log error and continue with execution.
+      # (Fatal | Continue) (default Continue)
+      FailAction = "Continue"
+
   [discovery.dynamic]
     # Enable periodic fetching of the dynamic topology. (default false)
     Enable = false
@@ -102,6 +115,18 @@ const Sample = `[general]
 
     # Require https connection. (default false)
     Https = false
+
+    [discovery.dynamic.connect]
+      # Maximum time spent attempting to fetch the topology from the
+      # discovery service on start. If no topology is successfully fetched
+      # in this period, the FailAction is executed. (default 20s)
+      InitialPeriod = "20s"
+
+      # The action to take if no topology is successfully fetched in InitialPeriod.
+      # - Fatal: Exit process.
+      # - Continue: Log error and continue with execution.
+      # (Fatal | Continue) (default Continue)
+      FailAction = "Continue"
 
 [cs]
   # Time between starting reissue requests and leaf cert expiration. If not

--- a/go/lib/infra/modules/idiscovery/config.go
+++ b/go/lib/infra/modules/idiscovery/config.go
@@ -56,6 +56,7 @@ type StaticConfig struct {
 }
 
 func (s *StaticConfig) InitDefaults() {
+	s.Connect.InitDefaults()
 	if s.Interval.Duration == 0 {
 		s.Interval.Duration = DefaultStaticFetchInterval
 	}

--- a/go/lib/infra/modules/idiscovery/config.go
+++ b/go/lib/infra/modules/idiscovery/config.go
@@ -71,13 +71,13 @@ type FetchConfig struct {
 	Enable bool
 	// Interval specifies the time between two queries.
 	Interval util.DurWrap
-	// Timeout specifies the timout for a single query.
+	// Timeout specifies the timeout for a single query.
 	Timeout util.DurWrap
 	// Https indicates whether https must be used to fetch the topology.
 	Https bool
 	// Connect contains the parameters for the initial connection
 	// check to the discovery service.
-	Connect Connect
+	Connect ConnectParams
 }
 
 func (f *FetchConfig) InitDefaults() {
@@ -90,7 +90,7 @@ func (f *FetchConfig) InitDefaults() {
 	}
 }
 
-type Connect struct {
+type ConnectParams struct {
 	// InitialPeriod indicates for how long the process tries to get a valid
 	// response from the discovery service until FailAction is executed.
 	InitialPeriod util.DurWrap
@@ -99,7 +99,7 @@ type Connect struct {
 	FailAction FailAction
 }
 
-func (c *Connect) InitDefaults() {
+func (c *ConnectParams) InitDefaults() {
 	if c.InitialPeriod.Duration == 0 {
 		c.InitialPeriod.Duration = DefaultInitialConnectPeriod
 	}

--- a/go/lib/infra/modules/idiscovery/config.go
+++ b/go/lib/infra/modules/idiscovery/config.go
@@ -15,8 +15,10 @@
 package idiscovery
 
 import (
+	"strings"
 	"time"
 
+	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/util"
 )
 
@@ -27,6 +29,9 @@ var (
 	DefaultStaticFetchInterval = 5 * time.Minute
 	// DefaultFetchTimeout is the default timeout for a query.
 	DefaultFetchTimeout = 1 * time.Second
+	// DefaultInitialConnectPeriod is the default total amount of time spent attempting
+	// to connect to the discovery service on start.
+	DefaultInitialConnectPeriod = 20 * time.Second
 )
 
 type Config struct {
@@ -69,13 +74,56 @@ type FetchConfig struct {
 	Timeout util.DurWrap
 	// Https indicates whether https must be used to fetch the topology.
 	Https bool
+	// Connect contains the parameters for the initial connection
+	// check to the discovery service.
+	Connect Connect
 }
 
 func (f *FetchConfig) InitDefaults() {
+	f.Connect.InitDefaults()
 	if f.Interval.Duration == 0 {
 		f.Interval.Duration = DefaultDynamicFetchInterval
 	}
 	if f.Timeout.Duration == 0 {
 		f.Timeout.Duration = DefaultFetchTimeout
 	}
+}
+
+type Connect struct {
+	// InitialPeriod indicates for how long the process tries to get a valid
+	// response from the discovery service until FailAction is executed.
+	InitialPeriod util.DurWrap
+	// FailAction indicates the action that should be taken if no topology can
+	// be fetched from the discovery service within the InitialPeriod.
+	FailAction FailAction
+}
+
+func (c *Connect) InitDefaults() {
+	if c.InitialPeriod.Duration == 0 {
+		c.InitialPeriod.Duration = DefaultInitialConnectPeriod
+	}
+	if c.FailAction != FailActionFatal {
+		c.FailAction = FailActionContinue
+	}
+}
+
+type FailAction string
+
+const (
+	// FailActionFatal indicates that the process exits on error.
+	FailActionFatal FailAction = "Fatal"
+	// FailActionContinue indicates that the process continues on error.
+	FailActionContinue FailAction = "Continue"
+)
+
+func (f *FailAction) UnmarshalText(text []byte) error {
+	switch strings.ToLower(string(text)) {
+	case strings.ToLower(string(FailActionFatal)):
+		*f = FailActionFatal
+	case strings.ToLower(string(FailActionContinue)):
+		*f = FailActionContinue
+	default:
+		return common.NewBasicError("Unknown FailAction", nil, "input", string(text))
+	}
+	return nil
 }

--- a/go/lib/infra/modules/idiscovery/idiscoverytest/config.go
+++ b/go/lib/infra/modules/idiscovery/idiscoverytest/config.go
@@ -19,10 +19,10 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	. "github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
+	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
 )
 
-func InitTestConfig(t *testing.T, cfg *Config) {
+func InitTestConfig(t *testing.T, cfg *idiscovery.Config) {
 	t.Helper()
 	cfg.Dynamic.Enable = true
 	cfg.Dynamic.Https = true
@@ -31,7 +31,7 @@ func InitTestConfig(t *testing.T, cfg *Config) {
 	cfg.Static.Filename = "topology.json"
 }
 
-func CheckTestConfig(t *testing.T, cfg Config) {
+func CheckTestConfig(t *testing.T, cfg idiscovery.Config) {
 	t.Helper()
 	Convey("The static part should be correct", func() {
 		checkCommon(t, cfg.Static.FetchConfig)
@@ -42,13 +42,14 @@ func CheckTestConfig(t *testing.T, cfg Config) {
 	})
 }
 
-func checkCommon(t *testing.T, cfg FetchConfig) {
+func checkCommon(t *testing.T, cfg idiscovery.FetchConfig) {
 	t.Helper()
 	SoMsg("Enable correct", cfg.Enable, ShouldBeFalse)
-	SoMsg("Timeout correct", cfg.Timeout.Duration, ShouldEqual, DefaultFetchTimeout)
+	SoMsg("Timeout correct", cfg.Timeout.Duration, ShouldEqual, idiscovery.DefaultFetchTimeout)
 	SoMsg("Https correct", cfg.Https, ShouldBeFalse)
 	SoMsg("Connect.InitialPeriod correct", cfg.Connect.InitialPeriod.Duration, ShouldEqual,
-		DefaultInitialConnectPeriod)
-	SoMsg("Connect.FailAction correct", cfg.Connect.FailAction, ShouldEqual, FailActionContinue)
+		idiscovery.DefaultInitialConnectPeriod)
+	SoMsg("Connect.FailAction correct", cfg.Connect.FailAction, ShouldEqual,
+		idiscovery.FailActionContinue)
 
 }

--- a/go/lib/infra/modules/idiscovery/idiscoverytest/config.go
+++ b/go/lib/infra/modules/idiscovery/idiscoverytest/config.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idiscoverytest
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	. "github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
+)
+
+func InitTestConfig(t *testing.T, cfg *Config) {
+	t.Helper()
+	cfg.Dynamic.Enable = true
+	cfg.Dynamic.Https = true
+	cfg.Static.Enable = true
+	cfg.Static.Https = true
+	cfg.Static.Filename = "topology.json"
+}
+
+func CheckTestConfig(t *testing.T, cfg Config) {
+	t.Helper()
+	Convey("The static part should be correct", func() {
+		checkCommon(t, cfg.Static.FetchConfig)
+		SoMsg("Discovery.Static.Filename correct", cfg.Static.Filename, ShouldBeBlank)
+	})
+	Convey("The dynamic part should be correct", func() {
+		checkCommon(t, cfg.Dynamic)
+	})
+}
+
+func checkCommon(t *testing.T, cfg FetchConfig) {
+	t.Helper()
+	SoMsg("Enable correct", cfg.Enable, ShouldBeFalse)
+	SoMsg("Timeout correct", cfg.Timeout.Duration, ShouldEqual, DefaultFetchTimeout)
+	SoMsg("Https correct", cfg.Https, ShouldBeFalse)
+	SoMsg("Connect.InitialPeriod correct", cfg.Connect.InitialPeriod.Duration, ShouldEqual,
+		DefaultInitialConnectPeriod)
+	SoMsg("Connect.FailAction correct", cfg.Connect.FailAction, ShouldEqual, FailActionContinue)
+
+}

--- a/go/lib/infra/modules/idiscovery/idiscoverytest/config.go
+++ b/go/lib/infra/modules/idiscovery/idiscoverytest/config.go
@@ -15,15 +15,12 @@
 package idiscoverytest
 
 import (
-	"testing"
-
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
 )
 
-func InitTestConfig(t *testing.T, cfg *idiscovery.Config) {
-	t.Helper()
+func InitTestConfig(cfg *idiscovery.Config) {
 	cfg.Dynamic.Enable = true
 	cfg.Dynamic.Https = true
 	cfg.Static.Enable = true
@@ -31,19 +28,17 @@ func InitTestConfig(t *testing.T, cfg *idiscovery.Config) {
 	cfg.Static.Filename = "topology.json"
 }
 
-func CheckTestConfig(t *testing.T, cfg idiscovery.Config) {
-	t.Helper()
+func CheckTestConfig(cfg idiscovery.Config) {
 	Convey("The static part should be correct", func() {
-		checkCommon(t, cfg.Static.FetchConfig)
+		checkCommon(cfg.Static.FetchConfig)
 		SoMsg("Discovery.Static.Filename correct", cfg.Static.Filename, ShouldBeBlank)
 	})
 	Convey("The dynamic part should be correct", func() {
-		checkCommon(t, cfg.Dynamic)
+		checkCommon(cfg.Dynamic)
 	})
 }
 
-func checkCommon(t *testing.T, cfg idiscovery.FetchConfig) {
-	t.Helper()
+func checkCommon(cfg idiscovery.FetchConfig) {
 	SoMsg("Enable correct", cfg.Enable, ShouldBeFalse)
 	SoMsg("Timeout correct", cfg.Timeout.Duration, ShouldEqual, idiscovery.DefaultFetchTimeout)
 	SoMsg("Https correct", cfg.Https, ShouldBeFalse)

--- a/go/lib/periodic/periodic.go
+++ b/go/lib/periodic/periodic.go
@@ -83,7 +83,7 @@ func StartPeriodicTask(task Task, ticker Ticker, timeout time.Duration) *Runner 
 	return runner
 }
 
-// Stop stops the peridioc execution of the Runner.
+// Stop stops the periodic execution of the Runner.
 // If the task is currently running this method will block until it is done.
 func (r *Runner) Stop() {
 	r.ticker.Stop()

--- a/go/path_srv/internal/config/sample.go
+++ b/go/path_srv/internal/config/sample.go
@@ -83,6 +83,19 @@ const Sample = `[general]
     # empty string, the updated topologies are not written. (default "")
     Filename = ""
 
+    [discovery.static.connect]
+      # Maximum time spent attempting to fetch the topology from the
+      # discovery service on start. If no topology is successfully fetched
+      # in this period, the FailAction is executed. (default 20s)
+      InitialPeriod = "20s"
+
+      # The action to take if no topology is successfully fetched in
+      # the InitialPeriod.
+      # - Fatal: Exit process.
+      # - Continue: Log error and continue with execution.
+      # (Fatal | Continue) (default Continue)
+      FailAction = "Continue"
+
   [discovery.dynamic]
     # Enable periodic fetching of the dynamic topology. (default false)
     Enable = false
@@ -95,6 +108,18 @@ const Sample = `[general]
 
     # Require https connection. (default false)
     Https = false
+
+    [discovery.dynamic.connect]
+      # Maximum time spent attempting to fetch the topology from the
+      # discovery service on start. If no topology is successfully fetched
+      # in this period, the FailAction is executed. (default 20s)
+      InitialPeriod = "20s"
+
+      # The action to take if no topology is successfully fetched in InitialPeriod.
+      # - Fatal: Exit process.
+      # - Continue: Log error and continue with execution.
+      # (Fatal | Continue) (default Continue)
+      FailAction = "Continue"
 
 [ps]
   # Enable the "old" replication of down segments between cores using SegSync

--- a/go/path_srv/internal/config/sample_test.go
+++ b/go/path_srv/internal/config/sample_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/BurntSushi/toml"
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
+	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery/idiscoverytest"
 )
 
 func TestSampleCorrect(t *testing.T) {
@@ -29,11 +29,7 @@ func TestSampleCorrect(t *testing.T) {
 		var cfg Config
 		// Make sure SegSync is set.
 		cfg.PS.SegSync = true
-		cfg.Discovery.Dynamic.Enable = true
-		cfg.Discovery.Dynamic.Https = true
-		cfg.Discovery.Static.Enable = true
-		cfg.Discovery.Static.Https = true
-		cfg.Discovery.Static.Filename = "topology.json"
+		idiscoverytest.InitTestConfig(t, &cfg.Discovery)
 		_, err := toml.Decode(Sample, &cfg)
 		SoMsg("err", err, ShouldBeNil)
 
@@ -47,19 +43,7 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection, ShouldEqual,
 			"/var/lib/scion/spki/ps-1.trust.db")
-		SoMsg("Discovery.Static.Enable correct", cfg.Discovery.Static.Enable, ShouldBeFalse)
-		SoMsg("Discovery.Static.Interval correct", cfg.Discovery.Static.Interval.Duration,
-			ShouldEqual, idiscovery.DefaultStaticFetchInterval)
-		SoMsg("Discovery.Static.Timeout correct", cfg.Discovery.Static.Timeout.Duration,
-			ShouldEqual, idiscovery.DefaultFetchTimeout)
-		SoMsg("Discovery.Static.Https correct", cfg.Discovery.Static.Https, ShouldBeFalse)
-		SoMsg("Discovery.Static.Filename correct", cfg.Discovery.Static.Filename, ShouldBeBlank)
-		SoMsg("Discovery.Dynamic.Enable correct", cfg.Discovery.Dynamic.Enable, ShouldBeFalse)
-		SoMsg("Discovery.Dynamic.Interval correct", cfg.Discovery.Dynamic.Interval.Duration,
-			ShouldEqual, idiscovery.DefaultDynamicFetchInterval)
-		SoMsg("Discovery.Dynamic.Timeout correct", cfg.Discovery.Dynamic.Timeout.Duration,
-			ShouldEqual, idiscovery.DefaultFetchTimeout)
-		SoMsg("Discovery.Dynamic.Https correct", cfg.Discovery.Dynamic.Https, ShouldBeFalse)
+		idiscoverytest.CheckTestConfig(t, cfg.Discovery)
 
 		// psconfig specific
 		SoMsg("PathDB.Backend correct", cfg.PS.PathDB.Backend, ShouldEqual, "sqlite")

--- a/go/path_srv/internal/config/sample_test.go
+++ b/go/path_srv/internal/config/sample_test.go
@@ -29,7 +29,7 @@ func TestSampleCorrect(t *testing.T) {
 		var cfg Config
 		// Make sure SegSync is set.
 		cfg.PS.SegSync = true
-		idiscoverytest.InitTestConfig(t, &cfg.Discovery)
+		idiscoverytest.InitTestConfig(&cfg.Discovery)
 		_, err := toml.Decode(Sample, &cfg)
 		SoMsg("err", err, ShouldBeNil)
 
@@ -43,7 +43,7 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection, ShouldEqual,
 			"/var/lib/scion/spki/ps-1.trust.db")
-		idiscoverytest.CheckTestConfig(t, cfg.Discovery)
+		idiscoverytest.CheckTestConfig(cfg.Discovery)
 
 		// psconfig specific
 		SoMsg("PathDB.Backend correct", cfg.PS.PathDB.Backend, ShouldEqual, "sqlite")

--- a/go/sciond/internal/config/sample.go
+++ b/go/sciond/internal/config/sample.go
@@ -82,6 +82,19 @@ const Sample = `[general]
     # empty string, the updated topologies are not written. (default "")
     Filename = ""
 
+    [discovery.static.connect]
+      # Maximum time spent attempting to fetch the topology from the
+      # discovery service on start. If no topology is successfully fetched
+      # in this period, the FailAction is executed. (default 20s)
+      InitialPeriod = "20s"
+
+      # The action to take if no topology is successfully fetched in
+      # the InitialPeriod.
+      # - Fatal: Exit process.
+      # - Continue: Log error and continue with execution.
+      # (Fatal | Continue) (default Continue)
+      FailAction = "Continue"
+
   [discovery.dynamic]
     # Enable periodic fetching of the dynamic topology. (default false)
     Enable = false
@@ -94,6 +107,18 @@ const Sample = `[general]
 
     # Require https connection. (default false)
     Https = false
+
+    [discovery.dynamic.connect]
+      # Maximum time spent attempting to fetch the topology from the
+      # discovery service on start. If no topology is successfully fetched
+      # in this period, the FailAction is executed. (default 20s)
+      InitialPeriod = "20s"
+
+      # The action to take if no topology is successfully fetched in InitialPeriod.
+      # - Fatal: Exit process.
+      # - Continue: Log error and continue with execution.
+      # (Fatal | Continue) (default Continue)
+      FailAction = "Continue"
 
 [sd]
   # Address to listen on via the reliable socket protocol. If empty,

--- a/go/sciond/internal/config/sample_test.go
+++ b/go/sciond/internal/config/sample_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/BurntSushi/toml"
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
+	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery/idiscoverytest"
 )
 
 func TestSampleCorrect(t *testing.T) {
@@ -29,10 +29,7 @@ func TestSampleCorrect(t *testing.T) {
 		var cfg Config
 		// Make sure DeleteSocket is set.
 		cfg.SD.DeleteSocket = true
-		cfg.Discovery.Dynamic.Enable = true
-		cfg.Discovery.Dynamic.Https = true
-		cfg.Discovery.Static.Enable = true
-		cfg.Discovery.Static.Https = true
+		idiscoverytest.InitTestConfig(t, &cfg.Discovery)
 		_, err := toml.Decode(Sample, &cfg)
 		SoMsg("err", err, ShouldBeNil)
 
@@ -46,19 +43,7 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection,
 			ShouldEqual, "/var/lib/scion/spki/sd.trust.db")
-		SoMsg("Discovery.Static.Enable correct", cfg.Discovery.Static.Enable, ShouldBeFalse)
-		SoMsg("Discovery.Static.Interval correct", cfg.Discovery.Static.Interval.Duration,
-			ShouldEqual, idiscovery.DefaultStaticFetchInterval)
-		SoMsg("Discovery.Static.Timeout correct", cfg.Discovery.Static.Timeout.Duration,
-			ShouldEqual, idiscovery.DefaultFetchTimeout)
-		SoMsg("Discovery.Static.Https correct", cfg.Discovery.Static.Https, ShouldBeFalse)
-		SoMsg("Discovery.Static.Filename correct", cfg.Discovery.Static.Filename, ShouldBeBlank)
-		SoMsg("Discovery.Dynamic.Enable correct", cfg.Discovery.Dynamic.Enable, ShouldBeFalse)
-		SoMsg("Discovery.Dynamic.Interval correct", cfg.Discovery.Dynamic.Interval.Duration,
-			ShouldEqual, idiscovery.DefaultDynamicFetchInterval)
-		SoMsg("Discovery.Dynamic.Timeout correct", cfg.Discovery.Dynamic.Timeout.Duration,
-			ShouldEqual, idiscovery.DefaultFetchTimeout)
-		SoMsg("Discovery.Dynamic.Https correct", cfg.Discovery.Dynamic.Https, ShouldBeFalse)
+		idiscoverytest.CheckTestConfig(t, cfg.Discovery)
 
 		// sdconfig specific
 		SoMsg("PathDB.Backend correct", cfg.SD.PathDB.Backend, ShouldEqual, "sqlite")

--- a/go/sciond/internal/config/sample_test.go
+++ b/go/sciond/internal/config/sample_test.go
@@ -29,7 +29,7 @@ func TestSampleCorrect(t *testing.T) {
 		var cfg Config
 		// Make sure DeleteSocket is set.
 		cfg.SD.DeleteSocket = true
-		idiscoverytest.InitTestConfig(t, &cfg.Discovery)
+		idiscoverytest.InitTestConfig(&cfg.Discovery)
 		_, err := toml.Decode(Sample, &cfg)
 		SoMsg("err", err, ShouldBeNil)
 
@@ -43,7 +43,7 @@ func TestSampleCorrect(t *testing.T) {
 		SoMsg("TrustDB.Backend correct", cfg.TrustDB.Backend, ShouldEqual, "sqlite")
 		SoMsg("TrustDB.Connection correct", cfg.TrustDB.Connection,
 			ShouldEqual, "/var/lib/scion/spki/sd.trust.db")
-		idiscoverytest.CheckTestConfig(t, cfg.Discovery)
+		idiscoverytest.CheckTestConfig(cfg.Discovery)
 
 		// sdconfig specific
 		SoMsg("PathDB.Backend correct", cfg.SD.PathDB.Backend, ShouldEqual, "sqlite")


### PR DESCRIPTION
Enables the `idiscovery` library to initially check that topologies can be successfully fetched from the discovery service.
On start up, the discovery service is queried every second until a valid response is received or the `InitialPeriod` has passed. If that period has passed, and no valid topology has been received,
the process will take the configured fail action:
* `Fatal`: Exit process with error
* `Ignore`: Ignore, and keep the periodic queries running

fixes #2431

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2459)
<!-- Reviewable:end -->
