### PR TITLE
Implement dispatcher service interface

### DIFF
--- a/go/border/rctrl/ctrl.go
+++ b/go/border/rctrl/ctrl.go
@@ -34,7 +34,6 @@ const (
 )
 
 var (
-	dispPath string = reliable.DefaultDispPath
 	snetConn snet.Conn
 	ia       addr.IA
 	logger   log.Logger
@@ -45,7 +44,7 @@ func Control(sRevInfoQ chan rpkt.RawSRevCallbackArgs) {
 	logger = log.New("Part", "Control")
 	ctx := rctx.Get()
 	ia = ctx.Conf.IA
-	if err = snet.Init(ia, "", dispPath); err != nil {
+	if err = snet.Init(ia, "", reliable.NewDispatcherService("")); err != nil {
 		logger.Error("Initializing SNET", "err", err)
 		return
 	}

--- a/go/cert_srv/setup.go
+++ b/go/cert_srv/setup.go
@@ -34,6 +34,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/sock/reliable"
 	"github.com/scionproto/scion/go/proto"
 )
 
@@ -153,7 +154,8 @@ func setMessenger(cfg *config.Config) error {
 	}
 	// FIXME(roosd): Hack to make Store.ChooseServer not panic.
 	// Remove when https://github.com/scionproto/scion/issues/2029 is resolved.
-	if err := snet.Init(cfg.General.Topology.ISD_AS, cfg.Sciond.Path, ""); err != nil {
+	err = snet.Init(cfg.General.Topology.ISD_AS, cfg.Sciond.Path, reliable.NewDispatcherService(""))
+	if err != nil {
 		return common.NewBasicError("Unable to initialize snet", err)
 	}
 	msgr.AddHandler(infra.ChainRequest, state.Store.NewChainReqHandler(true))

--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -41,6 +41,7 @@ import (
 	sd "github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/snet/squic"
+	"github.com/scionproto/scion/go/lib/sock/reliable"
 	"github.com/scionproto/scion/go/lib/spath"
 )
 
@@ -152,7 +153,7 @@ func LogFatal(msg string, a ...interface{}) {
 
 func initNetwork() {
 	// Initialize default SCION networking context
-	if err := snet.Init(local.IA, *sciond, *dispatcher); err != nil {
+	if err := snet.Init(local.IA, *sciond, reliable.NewDispatcherService(*dispatcher)); err != nil {
 		LogFatal("Unable to initialize SCION network", "err", err)
 	}
 	log.Debug("SCION network successfully initialized")

--- a/go/integration/common.go
+++ b/go/integration/common.go
@@ -24,6 +24,7 @@ import (
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/sock/reliable"
 )
 
 const (
@@ -78,7 +79,7 @@ func validateFlags() {
 
 func initNetwork() {
 	// Initialize default SCION networking context
-	if err := snet.Init(Local.IA, Sciond, ""); err != nil {
+	if err := snet.Init(Local.IA, Sciond, reliable.NewDispatcherService("")); err != nil {
 		LogFatal("Unable to initialize SCION network", "err", err)
 	}
 	log.Debug("SCION network successfully initialized")

--- a/go/lib/infra/infraenv/infraenv.go
+++ b/go/lib/infra/infraenv/infraenv.go
@@ -29,6 +29,7 @@ import (
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/snet/snetproxy"
+	"github.com/scionproto/scion/go/lib/sock/reliable"
 )
 
 const (
@@ -95,7 +96,8 @@ func initNetwork(ia addr.IA, sciond env.SciondClient) (snet.Network, error) {
 	// done transparently and pushed to snet.NewNetwork.
 Top:
 	for {
-		if network, err = snet.NewNetwork(ia, sciond.Path, ""); err == nil || sciond.Path == "" {
+		network, err = snet.NewNetwork(ia, sciond.Path, reliable.NewDispatcherService(""))
+		if err == nil || sciond.Path == "" {
 			break
 		}
 		select {

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -82,6 +82,40 @@ const (
 	defBufSize      = 1 << 18
 )
 
+// DispatcherService controls how SCION applications open sockets in the SCION world.
+type DispatcherService interface {
+	Register(ia addr.IA, public *addr.AppAddr, bind *overlay.OverlayAddr,
+		svc addr.HostSVC) (*Conn, uint16, error)
+	RegisterTimeout(ia addr.IA, public *addr.AppAddr, bind *overlay.OverlayAddr,
+		svc addr.HostSVC, timeout time.Duration) (*Conn, uint16, error)
+}
+
+// NewDispatcherService creates a new dispatcher API endpoint on top of a UNIX
+// STREAM reliable socket. If name is empty, the default dispatcher path is
+// chosen.
+func NewDispatcherService(name string) DispatcherService {
+	if name == "" {
+		name = DefaultDispPath
+	}
+	return &dispatcherService{Address: name}
+}
+
+type dispatcherService struct {
+	Address string
+}
+
+func (d *dispatcherService) Register(ia addr.IA, public *addr.AppAddr, bind *overlay.OverlayAddr,
+	svc addr.HostSVC) (*Conn, uint16, error) {
+
+	return Register(d.Address, ia, public, bind, svc)
+}
+
+func (d *dispatcherService) RegisterTimeout(ia addr.IA, public *addr.AppAddr,
+	bind *overlay.OverlayAddr, svc addr.HostSVC, timeout time.Duration) (*Conn, uint16, error) {
+
+	return RegisterTimeout(d.Address, ia, public, bind, svc, timeout)
+}
+
 var _ net.Conn = (*Conn)(nil)
 var _ net.PacketConn = (*Conn)(nil)
 

--- a/go/sig/sigcmn/common.go
+++ b/go/sig/sigcmn/common.go
@@ -25,6 +25,7 @@ import (
 	"github.com/scionproto/scion/go/lib/env"
 	"github.com/scionproto/scion/go/lib/pathmgr"
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/sock/reliable"
 	"github.com/scionproto/scion/go/sig/internal/sigconfig"
 	"github.com/scionproto/scion/go/sig/mgmt"
 )
@@ -94,7 +95,8 @@ func initSNET(cfg sigconfig.Conf, sdCfg env.SciondClient) error {
 	defer timer.Stop()
 Top:
 	for {
-		if err = snet.Init(cfg.IA, sdCfg.Path, cfg.Dispatcher); err == nil {
+		err = snet.Init(cfg.IA, sdCfg.Path, reliable.NewDispatcherService(cfg.Dispatcher))
+		if err == nil {
 			break
 		}
 		select {

--- a/go/tools/showpaths/paths.go
+++ b/go/tools/showpaths/paths.go
@@ -163,7 +163,7 @@ func getStatuses(paths []sciond.PathReplyEntry) map[string]string {
 	// with invalid address via the path. The border router at the destination
 	// is going to reply with SCMP error. Receiving the error means that
 	// the path is alive.
-	if err := snet.Init(srcIA, "", reliable.DefaultDispPath); err != nil {
+	if err := snet.Init(srcIA, "", reliable.NewDispatcherService("")); err != nil {
 		LogFatal("Initializing SNET", "err", err)
 	}
 	snetConn, err := snet.ListenSCION("udp4", &local)


### PR DESCRIPTION
This allows applications to inject custom dispatcher backends (e.g., for
bypass, non-SOCKSTREAM implementations, testing, etc.).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2460)
<!-- Reviewable:end -->
