### PR TITLE
Socket plugin support for snet

### DIFF
--- a/go/lib/sciond/mock.go
+++ b/go/lib/sciond/mock.go
@@ -106,7 +106,7 @@ func (m *MockConn) Paths(ctx context.Context, dst, src addr.IA, max uint16,
 					ExpTime:    util.TimeToSecs(time.Now().Add(spath.MaxTTL * time.Second)),
 				},
 				HostInfo: hostinfo.HostInfo{
-				// TODO(scrye): leave nil for now since no tests use this
+					// TODO(scrye): leave nil for now since no tests use this
 				},
 			},
 		)

--- a/go/lib/sciond/mock.go
+++ b/go/lib/sciond/mock.go
@@ -106,7 +106,7 @@ func (m *MockConn) Paths(ctx context.Context, dst, src addr.IA, max uint16,
 					ExpTime:    util.TimeToSecs(time.Now().Add(spath.MaxTTL * time.Second)),
 				},
 				HostInfo: hostinfo.HostInfo{
-					// TODO(scrye): leave nil for now since no tests use this
+				// TODO(scrye): leave nil for now since no tests use this
 				},
 			},
 		)

--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -53,13 +53,13 @@ var _ net.PacketConn = (*SCIONConn)(nil)
 var _ Conn = (*SCIONConn)(nil)
 
 type SCIONConn struct {
-	conn *RawSCIONConn
+	conn PacketConn
 	scionConnBase
 	scionConnWriter
 	scionConnReader
 }
 
-func newSCIONConn(base *scionConnBase, pr pathmgr.Resolver, conn *RawSCIONConn) *SCIONConn {
+func newSCIONConn(base *scionConnBase, pr pathmgr.Resolver, conn PacketConn) *SCIONConn {
 	return &SCIONConn{
 		conn:            conn,
 		scionConnBase:   *base,

--- a/go/lib/snet/dispatcher.go
+++ b/go/lib/snet/dispatcher.go
@@ -1,0 +1,55 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snet
+
+import (
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/overlay"
+	"github.com/scionproto/scion/go/lib/sock/reliable"
+)
+
+// PacketDispatcherService constructs SCION sockets were applications have
+// fine-grained control over header fields.
+type PacketDispatcherService interface {
+	RegisterTimeout(ia addr.IA, public *addr.AppAddr, bind *overlay.OverlayAddr,
+		svc addr.HostSVC, timeout time.Duration) (PacketConn, uint16, error)
+}
+
+var _ PacketDispatcherService = (*DefaultPacketDispatcherService)(nil)
+
+type DefaultPacketDispatcherService struct {
+	dispatcherService reliable.DispatcherService
+}
+
+func NewDefaultPacketDispatcherService(
+	dispatcherService reliable.DispatcherService) *DefaultPacketDispatcherService {
+
+	return &DefaultPacketDispatcherService{
+		dispatcherService: dispatcherService,
+	}
+}
+
+func (s *DefaultPacketDispatcherService) RegisterTimeout(ia addr.IA, public *addr.AppAddr,
+	bind *overlay.OverlayAddr, svc addr.HostSVC,
+	timeout time.Duration) (PacketConn, uint16, error) {
+
+	rconn, port, err := s.dispatcherService.Register(ia, public, bind, svc)
+	if err != nil {
+		return nil, 0, err
+	}
+	return NewSCIONPacketConn(rconn), port, err
+}

--- a/go/lib/snet/dispatcher.go
+++ b/go/lib/snet/dispatcher.go
@@ -22,7 +22,7 @@ import (
 	"github.com/scionproto/scion/go/lib/sock/reliable"
 )
 
-// PacketDispatcherService constructs SCION sockets were applications have
+// PacketDispatcherService constructs SCION sockets where applications have
 // fine-grained control over header fields.
 type PacketDispatcherService interface {
 	RegisterTimeout(ia addr.IA, public *addr.AppAddr, bind *overlay.OverlayAddr,

--- a/go/lib/snet/packet_conn.go
+++ b/go/lib/snet/packet_conn.go
@@ -28,6 +28,17 @@ import (
 	"github.com/scionproto/scion/go/lib/spkt"
 )
 
+// PacketConn gives applications easy access to writing and reading custom
+// SCION packets.
+type PacketConn interface {
+	ReadFrom(pkt *SCIONPacket, ov *overlay.OverlayAddr) error
+	WriteTo(pkt *SCIONPacket, ov *overlay.OverlayAddr) error
+	SetReadDeadline(t time.Time) error
+	SetWriteDeadline(t time.Time) error
+	SetDeadline(t time.Time) error
+	Close() error
+}
+
 // Bytes contains the raw slices of data related to a packet. Most callers
 // can safely ignore it. For performance-critical applications, callers should
 // manually allocate/recycle the Bytes.
@@ -103,31 +114,28 @@ type SCIONAddress struct {
 	Host addr.HostAddr
 }
 
-// RawSCIONConn gives applications full control over the content of valid SCION
+// SCIONPacketConn gives applications full control over the content of valid SCION
 // packets.
-type RawSCIONConn struct {
+type SCIONPacketConn struct {
+	// conn is the connection to send/receive serialized packets on.
 	conn net.PacketConn
 }
 
-// NewRawSCIONConn implements reading and writing SCION packets on a
-// net.PacketConn. Usually, conn will be a SCION Dispatcher socket.
-//
-// SerializationOptions are not supported yet.
-func NewRawSCIONConn(conn net.PacketConn, _ SerializationOptions) *RawSCIONConn {
-	return &RawSCIONConn{
-		conn: conn,
-	}
+// NewSCIONPacketConn creates a new conn with packet serialization/decoding
+// support that transfers data over conn.
+func NewSCIONPacketConn(conn net.PacketConn) PacketConn {
+	return &SCIONPacketConn{conn: conn}
 }
 
-func (c *RawSCIONConn) SetDeadline(d time.Time) error {
+func (c *SCIONPacketConn) SetDeadline(d time.Time) error {
 	return c.conn.SetDeadline(d)
 }
 
-func (c *RawSCIONConn) Close() error {
+func (c *SCIONPacketConn) Close() error {
 	return c.conn.Close()
 }
 
-func (c *RawSCIONConn) WriteTo(pkt *SCIONPacket, ov *overlay.OverlayAddr) error {
+func (c *SCIONPacketConn) WriteTo(pkt *SCIONPacket, ov *overlay.OverlayAddr) error {
 	StableSortExtensions(pkt.Extensions)
 	hbh, e2e, err := hpkt.ValidateExtensions(pkt.Extensions)
 	if err != nil {
@@ -160,11 +168,11 @@ func (c *RawSCIONConn) WriteTo(pkt *SCIONPacket, ov *overlay.OverlayAddr) error 
 	return nil
 }
 
-func (c *RawSCIONConn) SetWriteDeadline(d time.Time) error {
+func (c *SCIONPacketConn) SetWriteDeadline(d time.Time) error {
 	return c.conn.SetWriteDeadline(d)
 }
 
-func (c *RawSCIONConn) ReadFrom(pkt *SCIONPacket, ov *overlay.OverlayAddr) error {
+func (c *SCIONPacketConn) ReadFrom(pkt *SCIONPacket, ov *overlay.OverlayAddr) error {
 	pkt.Prepare()
 	n, lastHopNetAddr, err := c.conn.ReadFrom(pkt.Bytes)
 	if err != nil {
@@ -202,7 +210,7 @@ func (c *RawSCIONConn) ReadFrom(pkt *SCIONPacket, ov *overlay.OverlayAddr) error
 	return nil
 }
 
-func (c *RawSCIONConn) SetReadDeadline(d time.Time) error {
+func (c *SCIONPacketConn) SetReadDeadline(d time.Time) error {
 	return c.conn.SetReadDeadline(d)
 }
 

--- a/go/lib/snet/packet_conn.go
+++ b/go/lib/snet/packet_conn.go
@@ -123,7 +123,7 @@ type SCIONPacketConn struct {
 
 // NewSCIONPacketConn creates a new conn with packet serialization/decoding
 // support that transfers data over conn.
-func NewSCIONPacketConn(conn net.PacketConn) PacketConn {
+func NewSCIONPacketConn(conn net.PacketConn) *SCIONPacketConn {
 	return &SCIONPacketConn{conn: conn}
 }
 

--- a/go/lib/snet/reader.go
+++ b/go/lib/snet/reader.go
@@ -30,13 +30,13 @@ import (
 
 type scionConnReader struct {
 	base *scionConnBase
-	conn *RawSCIONConn
+	conn PacketConn
 
 	mtx    sync.Mutex
 	buffer common.RawBytes
 }
 
-func newScionConnReader(base *scionConnBase, conn *RawSCIONConn) *scionConnReader {
+func newScionConnReader(base *scionConnBase, conn PacketConn) *scionConnReader {
 	return &scionConnReader{
 		base:   base,
 		conn:   conn,

--- a/go/lib/snet/writer.go
+++ b/go/lib/snet/writer.go
@@ -47,7 +47,7 @@ const (
 
 type scionConnWriter struct {
 	base     *scionConnBase
-	conn     *RawSCIONConn
+	conn     PacketConn
 	resolver *remoteAddressResolver
 
 	mtx    sync.Mutex
@@ -55,7 +55,7 @@ type scionConnWriter struct {
 }
 
 func newScionConnWriter(base *scionConnBase, pr pathmgr.Resolver,
-	conn *RawSCIONConn) *scionConnWriter {
+	conn PacketConn) *scionConnWriter {
 
 	return &scionConnWriter{
 		base: base,

--- a/go/lib/snet/writer_test.go
+++ b/go/lib/snet/writer_test.go
@@ -172,11 +172,11 @@ func TestSetDeadline(t *testing.T) {
 		).AnyTimes()
 		connMock := mock_net.NewMockPacketConn(ctrl)
 		connMock.EXPECT().SetWriteDeadline(gomock.Any()).AnyTimes().Return(nil)
-		rawConn := NewRawSCIONConn(connMock, SerializationOptions{})
+		packetConn := NewSCIONPacketConn(connMock)
 
 		conn := newScionConnWriter(&scionConnBase{
 			laddr: MustParseAddr("2-ff00:0:1,[127.0.0.1]:80"),
-		}, resolverMock, rawConn)
+		}, resolverMock, packetConn)
 		Convey("And writes to multiple destinations for which path resolution is slow", func() {
 			addresses := []*Addr{
 				MustParseAddr("1-ff00:0:1,[127.0.0.1]:80"),


### PR DESCRIPTION
Applications can now implement firewalls, shim layers, and specialized
SCMP handling on top of existing snet interfaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2462)
<!-- Reviewable:end -->
