### PR TITLE
log: always log to stderr

### DIFF
--- a/go/lib/log/log.go
+++ b/go/lib/log/log.go
@@ -34,6 +34,7 @@ import (
 
 func init() {
 	fmt15.TimeFmt = common.TimeFmt
+	SetupLogConsole(DefaultConsoleLevel)
 }
 
 var logBuf *syncBuf


### PR DESCRIPTION
The SCION log library logs to stdout *unless* an application calls `SetupLogConsole()` in which case it will log to stderr.  The problem is that `SetupLogConsole()` is not always called.  For instance, if an application calls `SetupFromFlags()`, `SetupLogConsole()` is only called when the `-log.console` flag is specified.  As a result, if the user does not specify the `-log.console` flag, the application will log to stdout.

I believe this is an oversight; you probably want to log to stderr always (and actually, I think that was the intention of #1698).  This can be achieved by calling `SetupLogConsole()` from `init()`.  Maybe there are better ways.

Example of the new behavior:

Before:
```
$ ./pingpong >/dev/null
$
```

After:
```
$ ./pingpong >/dev/null
2019-02-20 11:12:33.213727+0100 [CRIT] Missing remote address
$
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2465)
<!-- Reviewable:end -->
