### PR TITLE
revcache: Add GetAll, clean up API

### DIFF
--- a/go/lib/revcache/memrevcache/memrevcache_test.go
+++ b/go/lib/revcache/memrevcache/memrevcache_test.go
@@ -51,15 +51,13 @@ func (c *testRevCache) InsertExpired(t *testing.T, _ context.Context,
 	time.Sleep(20 * time.Millisecond)
 }
 
+func (c *testRevCache) Prepare(t *testing.T, _ context.Context) {
+	// For this backend the easiest is to create a new backend.
+	c.memRevCache = New()
+}
+
 func TestRevCacheSuite(t *testing.T) {
 	Convey("RevCache Suite", t, func() {
-		revcachetest.TestRevCache(t,
-			func() revcachetest.TestableRevCache {
-				return &testRevCache{
-					memRevCache: New(),
-				}
-			},
-			func() {},
-		)
+		revcachetest.TestRevCache(t, &testRevCache{memRevCache: New()})
 	})
 }

--- a/go/lib/revcache/revcache_test.go
+++ b/go/lib/revcache/revcache_test.go
@@ -1,0 +1,117 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package revcache_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/revcache"
+	"github.com/scionproto/scion/go/lib/revcache/mock_revcache"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/lib/xtest"
+	"github.com/scionproto/scion/go/proto"
+)
+
+var (
+	ia110  = xtest.MustParseIA("1-ff00:0:110")
+	ifid10 = common.IFIDType(10)
+	ifid11 = common.IFIDType(11)
+
+	now = time.Now()
+)
+
+func TestFilterNew(t *testing.T) {
+	sr10 := toSigned(t, defaultRevInfo(ia110, ifid10, now))
+	sr11 := toSigned(t, defaultRevInfo(ia110, ifid11, now))
+	sr11Old := toSigned(t, defaultRevInfo(ia110, ifid11, now.Add(-10*time.Second)))
+	Convey("TestFilterNew", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		revCache := mock_revcache.NewMockRevCache(ctrl)
+		Convey("Given an empty cache", func() {
+			revCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, nil)
+			rMap, err := revcache.RevocationToMap([]*path_mgmt.SignedRevInfo{sr10})
+			expectedMap := copy(rMap)
+			SoMsg("No error expected", err, ShouldBeNil)
+			err = rMap.FilterNew(context.Background(), revCache)
+			SoMsg("No error expected", err, ShouldBeNil)
+			SoMsg("All revocations should be considered new", rMap, ShouldResemble, expectedMap)
+		})
+		Convey("Given a cache with an old revocation", func() {
+			revCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(revcache.Revocations{
+				revcache.Key{IA: ia110, IfId: ifid11}: sr11Old,
+			}, nil)
+			rMap, err := revcache.RevocationToMap([]*path_mgmt.SignedRevInfo{sr10, sr11})
+			expectedMap := copy(rMap)
+			SoMsg("No error expected", err, ShouldBeNil)
+			err = rMap.FilterNew(context.Background(), revCache)
+			SoMsg("No error expected", err, ShouldBeNil)
+			SoMsg("All revocations should be considered new", rMap, ShouldResemble, expectedMap)
+		})
+		Convey("Given a cache with a newer revocation", func() {
+			revCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(revcache.Revocations{
+				revcache.Key{IA: ia110, IfId: ifid11}: sr11,
+			}, nil)
+			rMap, err := revcache.RevocationToMap([]*path_mgmt.SignedRevInfo{sr10, sr11Old})
+			expectedMap := copy(rMap)
+			delete(expectedMap, revcache.Key{IA: ia110, IfId: ifid11})
+			SoMsg("No error expected", err, ShouldBeNil)
+			err = rMap.FilterNew(context.Background(), revCache)
+			SoMsg("No error expected", err, ShouldBeNil)
+			SoMsg("Only new revocations should stay in map", rMap, ShouldResemble, expectedMap)
+		})
+		Convey("Given a cache with an error", func() {
+			expectedErr := common.NewBasicError("TESTERR", nil)
+			revCache.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, expectedErr)
+			rMap, err := revcache.RevocationToMap([]*path_mgmt.SignedRevInfo{})
+			SoMsg("No error expected", err, ShouldBeNil)
+			err = rMap.FilterNew(context.Background(), revCache)
+			SoMsg("Error from cache expected", err, ShouldResemble, expectedErr)
+		})
+	})
+
+}
+
+func copy(revs revcache.Revocations) revcache.Revocations {
+	res := make(revcache.Revocations, len(revs))
+	for k, v := range revs {
+		res[k] = v
+	}
+	return res
+}
+
+func toSigned(t *testing.T, r *path_mgmt.RevInfo) *path_mgmt.SignedRevInfo {
+	sr, err := path_mgmt.NewSignedRevInfo(r, nil)
+	xtest.FailOnErr(t, err)
+	return sr
+}
+
+func defaultRevInfo(ia addr.IA, ifId common.IFIDType, ts time.Time) *path_mgmt.RevInfo {
+	return &path_mgmt.RevInfo{
+		IfID:         ifId,
+		RawIsdas:     ia.IAInt(),
+		LinkType:     proto.LinkType_core,
+		RawTimestamp: util.TimeToSecs(ts),
+		RawTTL:       uint32((time.Duration(10) * time.Second).Seconds()),
+	}
+}

--- a/go/lib/revcache/revcachetest/revcachetest.go
+++ b/go/lib/revcache/revcachetest/revcachetest.go
@@ -47,26 +47,31 @@ type TestableRevCache interface {
 	// The testing parameter should be used to fail in case of an error.
 	// The method is used to test if expired revocations are not returned.
 	InsertExpired(t *testing.T, ctx context.Context, rev *path_mgmt.SignedRevInfo)
+	// Prepare should reset the internal state so that the cache is empty and is ready to be tested.
+	Prepare(t *testing.T, ctx context.Context)
 }
 
 // TestRevCache should be used to test any implementation of the RevCache interface.
 //
 // setup should return a RevCache in a clean state, i.e. no entries in the cache.
 // cleanup can be used to release any resources that have been allocated during setup.
-func TestRevCache(t *testing.T, setup func() TestableRevCache, cleanup func()) {
+func TestRevCache(t *testing.T, revCache TestableRevCache) {
 	testWrapper := func(test func(*testing.T, TestableRevCache)) func() {
 		return func() {
-			test(t, setup())
-			cleanup()
+			prepareCtx, cancelF := context.WithTimeout(context.Background(), TimeOut)
+			defer cancelF()
+			revCache.Prepare(t, prepareCtx)
+			test(t, revCache)
 		}
 	}
-
 	Convey("InsertGet", testWrapper(testInsertGet))
+	Convey("GetMultikey", testWrapper(testGetMultikey))
 	Convey("GetAll", testWrapper(testGetAll))
+	Convey("GetAllExpired", testWrapper(testGetAllExpired))
 	Convey("InsertExpired", testWrapper(testInsertExpired))
 	Convey("InsertNewer", testWrapper(testInsertNewer))
 	Convey("GetExpired", testWrapper(testGetExpired))
-	Convey("GetAllExpired", testWrapper(testGetAllExpired))
+	Convey("GetMultikeyExpired", testWrapper(testGetMuliKeysExpired))
 	Convey("DeleteExpired", testWrapper(testDeleteExpired))
 }
 
@@ -77,21 +82,21 @@ func testInsertGet(t *testing.T, revCache TestableRevCache) {
 	inserted, err := revCache.Insert(ctx, sr)
 	SoMsg("Insert should return true for a new entry", inserted, ShouldBeTrue)
 	SoMsg("Insert a new entry should not err", err, ShouldBeNil)
-	srCache, ok, err := revCache.Get(ctx, revcache.NewKey(ia110, ifId15))
-	MustParseRevInfo(t, srCache)
-	SoMsg("Get should return ok for existing entry", ok, ShouldBeTrue)
+	key1 := *revcache.NewKey(ia110, ifId15)
+	revs, err := revCache.Get(ctx, revcache.KeySet{key1: {}})
 	SoMsg("Get should not err for existing entry", err, ShouldBeNil)
-	SoMsg("Get should return previously inserted value", srCache, ShouldResemble, sr)
+	SoMsg("Get should return existing entry", revs, ShouldNotBeEmpty)
+	SoMsg("Get should return previously inserted value", revs[key1], ShouldResemble, sr)
+	MustParseRevInfo(t, revs[key1])
 	inserted, err = revCache.Insert(ctx, sr)
 	SoMsg("Insert should return false for already existing entry", inserted, ShouldBeFalse)
 	SoMsg("Insert should not err", err, ShouldBeNil)
-	srCache, ok, err = revCache.Get(ctx, revcache.NewKey(ia110, ifId19))
-	SoMsg("Get should return nil for not present value", srCache, ShouldBeNil)
-	SoMsg("Get should return false for not present value", ok, ShouldBeFalse)
+	revs, err = revCache.Get(ctx, revcache.SingleKey(ia110, ifId19))
 	SoMsg("Get should not err", err, ShouldBeNil)
+	SoMsg("Get should return empty result for not present value", revs, ShouldBeEmpty)
 }
 
-func testGetAll(t *testing.T, revCache TestableRevCache) {
+func testGetMultikey(t *testing.T, revCache TestableRevCache) {
 	sr1 := toSigned(t, defaultRevInfo(ia110, ifId15))
 	sr2 := toSigned(t, defaultRevInfo(ia110, ifId19))
 	sr3 := toSigned(t, defaultRevInfo(ia120, ifId15))
@@ -107,22 +112,62 @@ func testGetAll(t *testing.T, revCache TestableRevCache) {
 	_, err = revCache.Insert(ctx, sr4)
 	xtest.FailOnErr(t, err)
 
-	revs, err := revCache.GetAll(ctx, map[revcache.Key]struct{}{
-		*revcache.NewKey(ia110, ifId15): {},
-	})
-	SoMsg("GetAll should not err", err, ShouldBeNil)
+	key1 := *revcache.NewKey(ia110, ifId15)
+	revs, err := revCache.Get(ctx, revcache.KeySet{key1: {}})
+	SoMsg("Get should not err", err, ShouldBeNil)
 	SoMsg("Should contain one rev", 1, ShouldEqual, len(revs))
-	MustParseRevInfo(t, revs[0])
-	SoMsg("GetAll should return revs for the given keys", revs, ShouldResemble,
-		[]*path_mgmt.SignedRevInfo{sr1})
+	MustParseRevInfo(t, revs[key1])
+	SoMsg("Get should return revs for the given keys", revs, ShouldResemble,
+		revcache.Revocations{key1: sr1})
 
-	revs, err = revCache.GetAll(ctx, map[revcache.Key]struct{}{
-		*revcache.NewKey(ia110, ifId15): {},
-		*revcache.NewKey(ia110, ifId19): {},
-		*revcache.NewKey(ia120, ifId15): {},
-		*revcache.NewKey(ia120, ifId19): {},
-	})
-	SoMsg("GetAll should not err", err, ShouldBeNil)
+	key2 := *revcache.NewKey(ia110, ifId19)
+	key3 := *revcache.NewKey(ia120, ifId15)
+	key4 := *revcache.NewKey(ia120, ifId19) // not the key of sr4
+	searchKeys := revcache.KeySet{key1: {}, key2: {}, key3: {}, key4: {}}
+	revs, err = revCache.Get(ctx, searchKeys)
+	SoMsg("Get should not err", err, ShouldBeNil)
+	loadRevInfos(t, revs)
+	expectedResult := revcache.Revocations{
+		key1: sr1, key2: sr2, key3: sr3,
+	}
+	SoMsg("Get should return the requested revocations", revs, ShouldResemble,
+		expectedResult)
+}
+
+func testGetAll(t *testing.T, revCache TestableRevCache) {
+	ctx, cancelF := context.WithTimeout(context.Background(), TimeOut)
+	defer cancelF()
+	// Empty cache should return an empty chan
+	resChan, err := revCache.GetAll(ctx)
+	SoMsg("No error expected", err, ShouldBeNil)
+	res, more := <-resChan
+	SoMsg("No result expected", res, ShouldResemble, revcache.RevOrErr{})
+	SoMsg("No more entries expected", more, ShouldBeFalse)
+
+	// Insert some stuff and query again
+	sr1 := toSigned(t, defaultRevInfo(ia110, ifId15))
+	sr2 := toSigned(t, defaultRevInfo(ia110, ifId19))
+	sr3 := toSigned(t, defaultRevInfo(ia120, ifId15))
+	sr4 := toSigned(t, defaultRevInfo(ia120, common.IFIDType(20)))
+	_, err = revCache.Insert(ctx, sr1)
+	xtest.FailOnErr(t, err)
+	_, err = revCache.Insert(ctx, sr2)
+	xtest.FailOnErr(t, err)
+	_, err = revCache.Insert(ctx, sr3)
+	xtest.FailOnErr(t, err)
+	_, err = revCache.Insert(ctx, sr4)
+	xtest.FailOnErr(t, err)
+
+	expectedRevs := []*path_mgmt.SignedRevInfo{sr1, sr2, sr3, sr4}
+
+	resChan, err = revCache.GetAll(ctx)
+	SoMsg("No error expected", err, ShouldBeNil)
+	revs := make([]*path_mgmt.SignedRevInfo, 0, len(expectedRevs))
+	for res := range resChan {
+		SoMsg("No error expected", res.Err, ShouldBeNil)
+		SoMsg("Revocation expected", res.Rev, ShouldNotBeNil)
+		revs = append(revs, res.Rev)
+	}
 	// we don't care about the order, so sort here to make sure the comparison always works.
 	sort.Slice(revs, func(i, j int) bool {
 		iInfo, err := revs[i].RevInfo()
@@ -132,8 +177,27 @@ func testGetAll(t *testing.T, revCache TestableRevCache) {
 		return iInfo.IA().IAInt() < jInfo.IA().IAInt() ||
 			(iInfo.IA().IAInt() == jInfo.IA().IAInt() && iInfo.IfID < jInfo.IfID)
 	})
-	SoMsg("GetAll should return the requested revocations", revs, ShouldResemble,
-		[]*path_mgmt.SignedRevInfo{sr1, sr2, sr3})
+	SoMsg("All revocations should have been returned", revs, ShouldResemble, expectedRevs)
+}
+
+func testGetAllExpired(t *testing.T, revCache TestableRevCache) {
+	ctx, cancelF := context.WithTimeout(context.Background(), TimeOut)
+	defer cancelF()
+	// insert expired rev
+	srNew := toSigned(t, &path_mgmt.RevInfo{
+		IfID:         ifId15,
+		RawIsdas:     ia110.IAInt(),
+		LinkType:     proto.LinkType_core,
+		RawTimestamp: util.TimeToSecs(time.Now().Add(-2 * time.Second)),
+		RawTTL:       1,
+	})
+	revCache.InsertExpired(t, ctx, srNew)
+	// Now test that we don't get the expired rev
+	resChan, err := revCache.GetAll(ctx)
+	SoMsg("No error expected", err, ShouldBeNil)
+	res, more := <-resChan
+	SoMsg("No result expected", res, ShouldResemble, revcache.RevOrErr{})
+	SoMsg("No more entries expected", more, ShouldBeFalse)
 }
 
 func testInsertExpired(t *testing.T, revCache TestableRevCache) {
@@ -167,11 +231,13 @@ func testInsertNewer(t *testing.T, revCache TestableRevCache) {
 	inserted, err := revCache.Insert(ctx, srNew)
 	SoMsg("Insert should return true for a new entry", inserted, ShouldBeTrue)
 	SoMsg("Insert a new entry should not err", err, ShouldBeNil)
-	srCache, ok, err := revCache.Get(ctx, revcache.NewKey(ia110, ifId15))
-	MustParseRevInfo(t, srCache)
-	SoMsg("Get should return ok for existing entry", ok, ShouldBeTrue)
+	key1 := *revcache.NewKey(ia110, ifId15)
+	revs, err := revCache.Get(ctx, revcache.KeySet{key1: {}})
+	loadRevInfos(t, revs)
 	SoMsg("Get should not err for existing entry", err, ShouldBeNil)
-	SoMsg("Get should return previously inserted value", srCache, ShouldResemble, srNew)
+	SoMsg("Get should return non empty map for inserted value", revs, ShouldNotBeEmpty)
+	SoMsg("Get should return previously inserted value", revs[key1], ShouldResemble, srNew)
+	MustParseRevInfo(t, revs[key1])
 }
 
 func testGetExpired(t *testing.T, revCache TestableRevCache) {
@@ -185,13 +251,12 @@ func testGetExpired(t *testing.T, revCache TestableRevCache) {
 		RawTTL:       1,
 	})
 	revCache.InsertExpired(t, ctx, srNew)
-	srCache, ok, err := revCache.Get(ctx, revcache.NewKey(ia110, ifId15))
-	SoMsg("Expired entry should not be returned", ok, ShouldBeFalse)
+	revs, err := revCache.Get(ctx, revcache.SingleKey(ia110, ifId15))
+	SoMsg("Expired entry should not be returned", revs, ShouldBeEmpty)
 	SoMsg("Should not error for expired entry", err, ShouldBeNil)
-	SoMsg("Expired entry should not be returned", srCache, ShouldBeNil)
 }
 
-func testGetAllExpired(t *testing.T, revCache TestableRevCache) {
+func testGetMuliKeysExpired(t *testing.T, revCache TestableRevCache) {
 	ctx, cancelF := context.WithTimeout(context.Background(), TimeOut)
 	defer cancelF()
 	srNew := toSigned(t, &path_mgmt.RevInfo{
@@ -204,18 +269,15 @@ func testGetAllExpired(t *testing.T, revCache TestableRevCache) {
 	revCache.InsertExpired(t, ctx, srNew)
 	sr110_19 := toSigned(t, defaultRevInfo(ia110, ifId19))
 	revCache.Insert(ctx, sr110_19)
-	srCache, err := revCache.GetAll(ctx, map[revcache.Key]struct{}{
+	validKey := *revcache.NewKey(ia110, ifId19)
+	srCache, err := revCache.Get(ctx, revcache.KeySet{
 		*revcache.NewKey(ia110, ifId15): {},
-		*revcache.NewKey(ia110, ifId19): {},
+		validKey:                        {},
 	})
 	SoMsg("Should not error for expired entry", err, ShouldBeNil)
-	for i := range srCache {
-		// init revInfo so that comparison works.
-		_, err := srCache[i].RevInfo()
-		xtest.FailOnErr(t, err)
-	}
+	loadRevInfos(t, srCache)
 	SoMsg("Expired entry should not be returned", srCache, ShouldResemble,
-		[]*path_mgmt.SignedRevInfo{sr110_19})
+		revcache.Revocations{validKey: sr110_19})
 }
 
 func testDeleteExpired(t *testing.T, revCache TestableRevCache) {
@@ -264,4 +326,13 @@ func defaultRevInfo(ia addr.IA, ifId common.IFIDType) *path_mgmt.RevInfo {
 func MustParseRevInfo(t *testing.T, sr *path_mgmt.SignedRevInfo) {
 	_, err := sr.RevInfo()
 	xtest.FailOnErr(t, err)
+}
+
+func loadRevInfos(t *testing.T, revs revcache.Revocations) {
+	t.Helper()
+	for k := range revs {
+		// init revInfo so that comparison works.
+		_, err := revs[k].RevInfo()
+		xtest.FailOnErr(t, err)
+	}
 }

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -407,12 +407,12 @@ func (f *fetcherHandler) filterRevokedPaths(ctx context.Context,
 		for _, iface := range path.Interfaces {
 			// cache automatically expires outdated revocations every second,
 			// so a cache hit implies revocation is still active.
-			_, ok, err := f.revocationCache.Get(ctx, revcache.NewKey(iface.ISD_AS(), iface.IfID))
+			revs, err := f.revocationCache.Get(ctx, revcache.SingleKey(iface.ISD_AS(), iface.IfID))
 			if err != nil {
 				f.logger.Error("Failed to get revocation", "err", err)
 				// continue, the client might still get some usable paths like this.
 			}
-			revoked = revoked || ok
+			revoked = revoked || len(revs) > 0
 		}
 		if !revoked {
 			newPaths = append(newPaths, path)


### PR DESCRIPTION
The old Get and GetAll methods are merged into Get.
Get can now be queried with multiple keys.
The new GetAll returns all entries that are in the cache, provided by a channel.
The channel is used so that we don't have to have all entries in memory.

This also fixes FilterNew function that did a wrong comparison previously.

Fixes #2472

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2480)
<!-- Reviewable:end -->
