### PR TITLE
Add error messages to infra RPC

### DIFF
--- a/go/lib/infra/common.go
+++ b/go/lib/infra/common.go
@@ -285,6 +285,16 @@ func MessengerFromContext(ctx context.Context) (Messenger, bool) {
 	return msger, ok
 }
 
+var _ error = (*Error)(nil)
+
+type Error struct {
+	Message *ack.Ack
+}
+
+func (e *Error) Error() string {
+	return e.Message.ErrDesc
+}
+
 type TrustStore interface {
 	GetValidChain(ctx context.Context, ia addr.IA, source net.Addr) (*cert.Chain, error)
 	GetValidTRC(ctx context.Context, isd addr.ISD, source net.Addr) (*trc.TRC, error)


### PR DESCRIPTION
Waiting for Acks/Errors can be enabled via a new flag in the Messenger config.

Only two RPC calls are implemented right now, as a proof of concept. The complete PR will implement error support for all calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2481)
<!-- Reviewable:end -->
