### PR TITLE
Save bazel and python caches out of home dir

### DIFF
--- a/.buildkite/scripts/build_scion_img
+++ b/.buildkite/scripts/build_scion_img
@@ -2,7 +2,7 @@
 
 set -e
 
-BASE_IMG=${BASE_IMG:-53f6706ca80058f26dcf78fc4eff95a1511f08ce3f21e6f8788a61c4ec4993b8}
+BASE_IMG=${BASE_IMG:-03073540ba587cbca43f7a9a72c108894fce3b6bfab14cc40bb9f02e7698ad14}
 
 docker pull scionproto/scion_base@sha256:$BASE_IMG
 docker tag scionproto/scion_base@sha256:$BASE_IMG scion_base:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,11 +21,11 @@ USER scion
 COPY --chown=scion:scion . $BASE/
 
 # Restore the python dependency cache from scion_base
-RUN tar xf ~/python_local.tar.gz -C ~
+RUN tar xf /scioncache/python_local.tar.gz -C ~
 
 # Restore the cache of Bazel dependencies
 # Bazel creates timestamps 10 years in the future, so let's not warn about that.
-RUN tar xf ~/bazel_cache.tar.gz -C ~ --warning=no-timestamp
+RUN tar xf /scioncache/bazel.tar.gz -C ~ --warning=no-timestamp
 
 # Make sure dependencies haven't been changed since scion_base was rebuilt
 RUN docker/deps_check

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -39,13 +39,16 @@ RUN sudo apt-get update && APTARGS=-y env/debian/deps && sudo apt-get clean
 COPY tools/install_bazel install_bazel
 RUN sudo ./install_bazel && rm install_bazel
 
+# Prepare a directory for caching
+RUN sudo mkdir -p /scioncache;
+
 # Pip packages
 COPY env/pip3 env/pip3
 COPY env/pip2 env/pip2
 RUN set -ex; \
     env/pip2/deps; \
     env/pip3/deps; \
-    tar czf ~/python_local.tar.gz --owner=scion -C ~ .local; \
+    sudo tar czf /scioncache/python_local.tar.gz --owner=scion -C ~ .local; \
     rm -r ~/.cache/pip ~/.local
 
 # Pip2 packages
@@ -63,7 +66,7 @@ RUN set -ex ; \
     tools/fetch.sh > BUILD.bazel ; \
     bazel fetch --noshow_progress //:fetch 2>&1 ; \
     rm -rf /home/scion/.cache/bazel/_bazel_scion/*/external/*/\.git ; \
-    tar czf ~/bazel_cache.tar.gz --owner=scion -C ~ .cache/bazel; \
+    sudo tar czf /scioncache/bazel.tar.gz --owner=scion -C ~ .cache/bazel; \
     sudo rm -r ~/.cache/bazel; \
     sudo rm -r ./*
 


### PR DESCRIPTION
This decreases the size of scion image by ~1/2 GB

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2497)
<!-- Reviewable:end -->
