### PR TITLE
sciond: Fix request logging

### DIFF
--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -101,7 +101,7 @@ func (h *ASInfoRequestHandler) Handle(ctx context.Context, transport infra.Trans
 	pld *sciond.Pld) {
 
 	logger := log.FromCtx(ctx)
-	logger.Debug("[ASInfoRequestHandler] Received request", "request", &pld.AsInfoReq)
+	logger.Debug("[ASInfoRequestHandler] Received request", "req", pld.AsInfoReq)
 	workCtx, workCancelF := context.WithTimeout(ctx, DefaultWorkTimeout)
 	defer workCancelF()
 	// NOTE(scrye): Only support single-homed SCIONDs for now (returned slice
@@ -165,7 +165,7 @@ func (h *IFInfoRequestHandler) Handle(ctx context.Context, transport infra.Trans
 	pld *sciond.Pld) {
 
 	logger := log.FromCtx(ctx)
-	logger.Debug("[IFInfoRequestHandler] Received request", "request", &pld.IfInfoRequest)
+	logger.Debug("[IFInfoRequestHandler] Received request", "req", pld.IfInfoRequest)
 	ifInfoRequest := pld.IfInfoRequest
 	ifInfoReply := &sciond.IFInfoReply{}
 	topo := itopo.Get()
@@ -218,8 +218,7 @@ func (h *SVCInfoRequestHandler) Handle(ctx context.Context, transport infra.Tran
 	src net.Addr, pld *sciond.Pld) {
 
 	logger := log.FromCtx(ctx)
-	logger.Debug("[SVCInfoRequestHandler] Received request",
-		"request", &pld.ServiceInfoRequest)
+	logger.Debug("[SVCInfoRequestHandler] Received request", "req", pld.ServiceInfoRequest)
 	svcInfoRequest := pld.ServiceInfoRequest
 	svcInfoReply := &sciond.ServiceInfoReply{}
 	topo := itopo.Get()


### PR DESCRIPTION
Instead of logging the address of the pointer to the struct, log the struct.
Also unify the log context name to "req".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2500)
<!-- Reviewable:end -->
