### PR TITLE
BK: Specify Acceptance tests

### DIFF
--- a/.buildkite/steps/acceptance
+++ b/.buildkite/steps/acceptance
@@ -4,7 +4,7 @@ host_acceptance="brA brB brC brD core_brA core_brB core_brC"
 
 for test in ./acceptance/*_acceptance; do
     name="$(basename ${test%_acceptance})"
-    if [[ ! "$name" =~ $ACCEPTANCE_TEST ]]; then
+    if [[ ! "$name" =~ "$ACCEPTANCE_TEST" ]]; then
         continue
     fi
     RUN_HOST=n

--- a/.buildkite/steps/acceptance
+++ b/.buildkite/steps/acceptance
@@ -4,6 +4,9 @@ host_acceptance="brA brB brC brD core_brA core_brB core_brC"
 
 for test in ./acceptance/*_acceptance; do
     name="$(basename ${test%_acceptance})"
+    if [[ ! "$name" =~ $ACCEPTANCE_TEST ]]; then
+        continue
+    fi
     RUN_HOST=n
     for host in $host_acceptance; do
         if [ "$host" = "$name" ]; then

--- a/.buildkite/steps/docker-integration.yml
+++ b/.buildkite/steps/docker-integration.yml
@@ -1,4 +1,4 @@
-- label: Docker Integration Tests
+- label: Integration - docker
   command:
   - $BASE/scripts/all_images pull
   - $BASE/run_step integration -d -a


### PR DESCRIPTION
Now one can pass ACCEPTANCE_TEST="regex" to the CI and only matching acceptance tests will be executed. The options are:
- `export ACCEPTANCE_TEST="regex"` in pipeline.sh
- ACCEPTANCE_TEST="regex" as env var on the BK UI

Fixes #2438 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2501)
<!-- Reviewable:end -->
