### PR TITLE
pathdb: Add GetAll method

### DIFF
--- a/go/lib/pathdb/metrics_test.go
+++ b/go/lib/pathdb/metrics_test.go
@@ -15,6 +15,7 @@
 package pathdb_test
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -25,14 +26,18 @@ import (
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
+type TestPathDB struct {
+	pathdb.PathDB
+}
+
+func (b *TestPathDB) Prepare(t *testing.T, _ context.Context) {
+	b.PathDB = setupDB(t)
+}
+
 func TestMetricWrapperFunctionality(t *testing.T) {
+	tdb := &TestPathDB{}
 	Convey("Test metrics wrapper functions normally", t, func() {
-		pathdbtest.TestPathDB(t,
-			func() pathdb.PathDB {
-				return setupDB(t)
-			},
-			func() {},
-		)
+		pathdbtest.TestPathDB(t, tdb)
 	})
 }
 

--- a/go/lib/pathdb/pathdb.go
+++ b/go/lib/pathdb/pathdb.go
@@ -39,7 +39,15 @@ type PathDB interface {
 	// Returns the number of deleted segments.
 	DeleteExpired(ctx context.Context, now time.Time) (int, error)
 	// Get returns all path segment(s) matching the parameters specified.
-	Get(context.Context, *query.Params) ([]*query.Result, error)
+	Get(context.Context, *query.Params) (query.Results, error)
+	// GetAll returns a channel that will provide all items in the path db. If the path db can't
+	// prepare the query a nil channel and the error are returned. If the querying succeeded the the
+	// channel will be filled with the segments in the database. If an error occurs during reading a
+	// segment the error is pushed in the channel and the operation is aborted, that means that the
+	// result might be incomplete. Note that implementations can spawn a goroutine to fill the
+	// channel, which means the channel must be fully drained to guarantee the destruction of the
+	// goroutine.
+	GetAll(context.Context) (<-chan query.ResultOrErr, error)
 	// InsertNextQuery inserts or updates the timestamp nextQuery for the given dst.
 	InsertNextQuery(ctx context.Context, dst addr.IA, nextQuery time.Time) (bool, error)
 	// GetNextQuery returns the nextQuery timestamp for the given dst,

--- a/go/lib/pathdb/query/query.go
+++ b/go/lib/pathdb/query/query.go
@@ -60,6 +60,12 @@ type Result struct {
 	HpCfgIDs   []*HPCfgID
 }
 
+// ResultOrErr is either a result or an error.
+type ResultOrErr struct {
+	Result *Result
+	Err    error
+}
+
 // Results is a type for convenience methods on a slice of Results.
 type Results []*Result
 

--- a/go/lib/pathdb/sqlite/BUILD.bazel
+++ b/go/lib/pathdb/sqlite/BUILD.bazel
@@ -26,7 +26,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/pathdb:go_default_library",
         "//go/lib/pathdb/pathdbtest:go_default_library",
         "//go/lib/pathdb/query:go_default_library",
         "//go/lib/xtest:go_default_library",


### PR DESCRIPTION
GetAll can be used to fetch all segments from the DB, via a channel.

Also:
-Return query.Results in Get method.
-Introduce a TestablePathDB interface for the test suite.
This makes the testing slightly simpler.

Fixes #2471

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2511)
<!-- Reviewable:end -->
