### PR TITLE
Fix docker.sh base

### DIFF
--- a/.buildkite/scripts/build_scion_img
+++ b/.buildkite/scripts/build_scion_img
@@ -2,7 +2,7 @@
 
 set -e
 
-BASE_IMG=${BASE_IMG:-bece380d3c2534200a80ea08b11298754dccff65823a484c9d7788aefe4d9cc0}
+BASE_IMG=${BASE_IMG:-6325cf459d2a5ba2b68d89aa1ea38123674f8bbeb9d6a56e9ba846dc6b4a9286}
 
 docker pull scionproto/scion_base@sha256:$BASE_IMG
 docker tag scionproto/scion_base@sha256:$BASE_IMG scion_base:latest

--- a/tools/fetch.sh
+++ b/tools/fetch.sh
@@ -12,6 +12,12 @@ ROOTDIR=$(dirname "$0")/..
 # Add any bazel packages to prefetch to the beginning of the following block.
 cat <<EOF
 load("@com_github_jmhodges_bazel_gomock//:gomock.bzl", "gomock")
+load("@io_bazel_rules_go//go:def.bzl", "nogo")
+
+nogo(
+    name = "nogo",
+    visibility = ["//visibility:public"],
+)
 
 genrule(
     name = "fetch",


### PR DESCRIPTION
The generated BUILD file which is used for fetching dependencies haven't
contained nogo target that is referenced by WORKSPACE file. This
patch adds a fake no-op target to fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2528)
<!-- Reviewable:end -->
