### PR TITLE
DB: Make Max{Open,Idle}Conns configurable

### DIFF
--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra/infraenv"
 	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
 	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/periodic"
 )
@@ -46,6 +47,7 @@ var (
 	discRunners idiscovery.Runners
 	corePusher  *periodic.Runner
 	msgr        infra.Messenger
+	trustDB     trustdb.TrustDB
 )
 
 func init() {
@@ -192,4 +194,5 @@ func stop() {
 	stopReissRunner()
 	discRunners.Stop()
 	msgr.CloseServer()
+	trustDB.Close()
 }

--- a/go/cert_srv/setup.go
+++ b/go/cert_srv/setup.go
@@ -88,8 +88,7 @@ func setup() error {
 func initState(cfg *config.Config) error {
 	topo := itopo.Get()
 	var err error
-	trustDB, err = cfg.TrustDB.New()
-	if err != nil {
+	if trustDB, err = cfg.TrustDB.New(); err != nil {
 		return common.NewBasicError("Unable to initialize trustDB", err)
 	}
 	trustDB = trustdb.WithMetrics("std", trustDB)

--- a/go/cert_srv/setup.go
+++ b/go/cert_srv/setup.go
@@ -87,7 +87,8 @@ func setup() error {
 // initState sets the state.
 func initState(cfg *config.Config) error {
 	topo := itopo.Get()
-	trustDB, err := cfg.TrustDB.New()
+	var err error
+	trustDB, err = cfg.TrustDB.New()
 	if err != nil {
 		return common.NewBasicError("Unable to initialize trustDB", err)
 	}

--- a/go/lib/infra/modules/db/BUILD.bazel
+++ b/go/lib/infra/modules/db/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
+        "limits.go",
         "sqler.go",
         "sqlite.go",
     ],

--- a/go/lib/infra/modules/db/limits.go
+++ b/go/lib/infra/modules/db/limits.go
@@ -12,20 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package truststorage
+package db
 
-const trustDbSample = `
-# The type of trustdb backend. (default sqlite)
-Backend = "sqlite"
-
-# Connection for the trust database.
-Connection = "/var/lib/scion/spki/%s.trust.db"
-
-# The maximum number of open connections to the database. In case of the
-# empty string, the limit is not set and uses the go default. (default "")
-MaxOpenConns = ""
-
-# The maximum number of idle connections to the database. In case of the
-# empty string, the limit is not set and uses the go default. (default "")
-MaxIdleConns = ""
-`
+// LimitSetter allows setting the database connection limits.
+type LimitSetter interface {
+	SetMaxOpenConns(maxOpenConns int)
+	SetMaxIdleConns(maxIdleConns int)
+}

--- a/go/lib/infra/modules/db/limits.go
+++ b/go/lib/infra/modules/db/limits.go
@@ -14,6 +14,10 @@
 
 package db
 
+import "database/sql"
+
+var _ LimitSetter = (*sql.DB)(nil)
+
 // LimitSetter allows setting the database connection limits.
 type LimitSetter interface {
 	SetMaxOpenConns(maxOpenConns int)

--- a/go/lib/infra/modules/trust/trustdb/BUILD.bazel
+++ b/go/lib/infra/modules/trust/trustdb/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
+        "//go/lib/infra/modules/db:go_default_library",
         "//go/lib/prom:go_default_library",
         "//go/lib/scrypto/cert:go_default_library",
         "//go/lib/scrypto/trc:go_default_library",

--- a/go/lib/infra/modules/trust/trustdb/metrics.go
+++ b/go/lib/infra/modules/trust/trustdb/metrics.go
@@ -203,6 +203,14 @@ func (db *metricsTrustDB) BeginTransaction(ctx context.Context,
 	}, err
 }
 
+func (db *metricsTrustDB) SetMaxOpenConns(maxOpenConns int) {
+	db.db.SetMaxOpenConns(maxOpenConns)
+}
+
+func (db *metricsTrustDB) SetMaxIdleConns(maxIdleConns int) {
+	db.db.SetMaxIdleConns(maxIdleConns)
+}
+
 func (db *metricsTrustDB) Close() error {
 	return db.db.Close()
 }

--- a/go/lib/infra/modules/trust/trustdb/trustdb.go
+++ b/go/lib/infra/modules/trust/trustdb/trustdb.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/infra/modules/db"
 	"github.com/scionproto/scion/go/lib/scrypto/cert"
 	"github.com/scionproto/scion/go/lib/scrypto/trc"
 )
@@ -34,6 +35,7 @@ import (
 type TrustDB interface {
 	ReadWrite
 	BeginTransaction(ctx context.Context, opts *sql.TxOptions) (Transaction, error)
+	db.LimitSetter
 	io.Closer
 }
 

--- a/go/lib/infra/modules/trust/trustdb/trustdbsqlite/db.go
+++ b/go/lib/infra/modules/trust/trustdb/trustdbsqlite/db.go
@@ -199,6 +199,14 @@ func New(path string) (trustdb.TrustDB, error) {
 	return tdb, nil
 }
 
+func (db *tdb) SetMaxOpenConns(maxOpenConns int) {
+	db.db.SetMaxOpenConns(maxOpenConns)
+}
+
+func (db *tdb) SetMaxIdleConns(maxIdleConns int) {
+	db.db.SetMaxIdleConns(maxIdleConns)
+}
+
 // Close closes the database connection.
 func (db *tdb) Close() error {
 	return db.db.Close()

--- a/go/lib/pathdb/BUILD.bazel
+++ b/go/lib/pathdb/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/ctrl/seg:go_default_library",
+        "//go/lib/infra/modules/db:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/pathdb/query:go_default_library",
         "//go/lib/periodic:go_default_library",

--- a/go/lib/pathdb/metrics.go
+++ b/go/lib/pathdb/metrics.go
@@ -164,6 +164,17 @@ type metricsPathDB struct {
 	db PathDB
 }
 
+func (db *metricsPathDB) Close() error {
+	return db.db.Close()
+}
+
+func (db *metricsPathDB) SetMaxOpenConns(maxOpenConns int) {
+	db.db.SetMaxOpenConns(maxOpenConns)
+}
+func (db *metricsPathDB) SetMaxIdleConns(maxIdleConns int) {
+	db.db.SetMaxIdleConns(maxIdleConns)
+}
+
 func (db *metricsPathDB) BeginTransaction(ctx context.Context,
 	opts *sql.TxOptions) (Transaction, error) {
 

--- a/go/lib/pathdb/pathdb.go
+++ b/go/lib/pathdb/pathdb.go
@@ -18,10 +18,12 @@ package pathdb
 import (
 	"context"
 	"database/sql"
+	"io"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
+	"github.com/scionproto/scion/go/lib/infra/modules/db"
 	"github.com/scionproto/scion/go/lib/pathdb/query"
 )
 
@@ -77,4 +79,6 @@ type Transaction interface {
 type PathDB interface {
 	ReadWrite
 	BeginTransaction(ctx context.Context, opts *sql.TxOptions) (Transaction, error)
+	db.LimitSetter
+	io.Closer
 }

--- a/go/lib/pathdb/sqlite/sqlite.go
+++ b/go/lib/pathdb/sqlite/sqlite.go
@@ -68,6 +68,17 @@ func New(path string) (*Backend, error) {
 	}, nil
 }
 
+func (b *Backend) Close() error {
+	return b.db.Close()
+}
+
+func (b *Backend) SetMaxOpenConns(maxOpenConns int) {
+	b.db.SetMaxOpenConns(maxOpenConns)
+}
+func (b *Backend) SetMaxIdleConns(maxIdleConns int) {
+	b.db.SetMaxIdleConns(maxIdleConns)
+}
+
 func (b *Backend) BeginTransaction(ctx context.Context,
 	opts *sql.TxOptions) (pathdb.Transaction, error) {
 

--- a/go/lib/pathstorage/BUILD.bazel
+++ b/go/lib/pathstorage/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//go/lib/common:go_default_library",
         "//go/lib/config:go_default_library",
+        "//go/lib/infra/modules/db:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/pathdb:go_default_library",
         "//go/lib/pathdb/sqlite:go_default_library",

--- a/go/lib/pathstorage/pathstorage.go
+++ b/go/lib/pathstorage/pathstorage.go
@@ -17,9 +17,11 @@ package pathstorage
 import (
 	"fmt"
 	"io"
+	"strconv"
 
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/config"
+	"github.com/scionproto/scion/go/lib/infra/modules/db"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/pathdb"
 	sqlitepathdb "github.com/scionproto/scion/go/lib/pathdb/sqlite"
@@ -37,8 +39,10 @@ const (
 )
 
 const (
-	BackendKey    = "backend"
-	ConnectionKey = "connection"
+	BackendKey      = "backend"
+	ConnectionKey   = "connection"
+	MaxOpenConnsKey = "maxopenconns"
+	MaxIdleConnsKey = "maxidleconns"
 )
 
 var _ config.Config = (*PathDBConf)(nil)
@@ -66,8 +70,21 @@ func (cfg *PathDBConf) Connection() string {
 	return (*cfg)[ConnectionKey]
 }
 
+func (cfg *PathDBConf) MaxOpenConns() (int, bool) {
+	val, ok, _ := parsedInt(*cfg, MaxOpenConnsKey)
+	return val, ok
+}
+
+func (cfg *PathDBConf) MaxIdleConns() (int, bool) {
+	val, ok, _ := parsedInt(*cfg, MaxIdleConnsKey)
+	return val, ok
+}
+
 // Validate validates the configuration, should be called after InitDefaults.
 func (cfg *PathDBConf) Validate() error {
+	if err := validateLimits(*cfg); err != nil {
+		return err
+	}
 	switch cfg.Backend() {
 	case BackendSqlite:
 		return nil
@@ -120,8 +137,21 @@ func (cfg *RevCacheConf) Connection() string {
 	return (*cfg)[ConnectionKey]
 }
 
+func (cfg *RevCacheConf) MaxOpenConns() (int, bool) {
+	val, ok, _ := parsedInt(*cfg, MaxOpenConnsKey)
+	return val, ok
+}
+
+func (cfg *RevCacheConf) MaxIdleConns() (int, bool) {
+	val, ok, _ := parsedInt(*cfg, MaxIdleConnsKey)
+	return val, ok
+}
+
 // Validate validates the configuration, should be called after InitDefaults.
 func (cfg *RevCacheConf) Validate() error {
+	if err := validateLimits(*cfg); err != nil {
+		return err
+	}
 	switch cfg.Backend() {
 	case BackendSqlite, BackendMem:
 		return nil
@@ -147,6 +177,25 @@ func (cfg *RevCacheConf) Sample(dst io.Writer, _ config.Path, _ config.CtxMap) {
 
 func (cfg *RevCacheConf) ConfigName() string {
 	return "revCache"
+}
+
+func validateLimits(cfg map[string]string) error {
+	if _, _, err := parsedInt(cfg, MaxOpenConnsKey); err != nil {
+		return common.NewBasicError("Invalid MaxOpenConns", nil, "value", cfg[MaxOpenConnsKey])
+	}
+	if _, _, err := parsedInt(cfg, MaxIdleConnsKey); err != nil {
+		return common.NewBasicError("Invalid MaxIdleConns", nil, "value", cfg[MaxIdleConnsKey])
+	}
+	return nil
+}
+
+func parsedInt(cfg map[string]string, key string) (int, bool, error) {
+	val, ok := cfg[key]
+	if !ok || val == "" {
+		return 0, false, nil
+	}
+	i, err := strconv.Atoi(val)
+	return i, true, err
 }
 
 // NewPathStorage creates a PathStorage from the given configs.
@@ -188,14 +237,19 @@ func newCombinedBackend(pdbConf PathDBConf,
 
 func newPathDB(conf PathDBConf) (pathdb.PathDB, error) {
 	log.Info("Connecting PathDB", "backend", conf.Backend(), "connection", conf.Connection())
+
+	var err error
+	var pdb pathdb.PathDB
 	switch conf.Backend() {
 	case BackendSqlite:
-		return sqlitepathdb.New(conf.Connection())
+		pdb, err = sqlitepathdb.New(conf.Connection())
 	case BackendNone:
 		return nil, nil
 	default:
 		return nil, common.NewBasicError("Unsupported backend", nil, "backend", conf.Backend())
 	}
+	return pdb, setConnLimitsOrErr(&conf, pdb, err)
+
 }
 
 func newRevCache(conf RevCacheConf) (revcache.RevCache, error) {
@@ -208,4 +262,23 @@ func newRevCache(conf RevCacheConf) (revcache.RevCache, error) {
 	default:
 		return nil, common.NewBasicError("Unsupported backend", nil, "backend", conf.Backend())
 	}
+}
+
+type limitConfig interface {
+	MaxOpenConns() (int, bool)
+	MaxIdleConns() (int, bool)
+}
+
+// setConnLimitsOrErr sets the connection limits or returns the error if non-nil
+func setConnLimitsOrErr(cfg limitConfig, db db.LimitSetter, err error) error {
+	if err != nil {
+		return err
+	}
+	if m, ok := cfg.MaxOpenConns(); ok {
+		db.SetMaxOpenConns(m)
+	}
+	if m, ok := cfg.MaxIdleConns(); ok {
+		db.SetMaxIdleConns(m)
+	}
+	return nil
 }

--- a/go/lib/pathstorage/pathstoragetest/config.go
+++ b/go/lib/pathstorage/pathstoragetest/config.go
@@ -23,12 +23,22 @@ import (
 	"github.com/scionproto/scion/go/lib/util"
 )
 
-func InitTestPathDBConf(cfg *pathstorage.PathDBConf) {}
+func InitTestPathDBConf(cfg *pathstorage.PathDBConf) {
+	*cfg = make(pathstorage.PathDBConf)
+	(*cfg)[pathstorage.MaxOpenConnsKey] = "maxOpenConns"
+	(*cfg)[pathstorage.MaxIdleConnsKey] = "maxIdleConns"
+}
 
-func InitTestRevCacheConf(cfg *pathstorage.RevCacheConf) {}
+func InitTestRevCacheConf(cfg *pathstorage.RevCacheConf) {
+	*cfg = make(pathstorage.RevCacheConf)
+	(*cfg)[pathstorage.MaxOpenConnsKey] = "maxOpenConns"
+	(*cfg)[pathstorage.MaxIdleConnsKey] = "maxIdleConns"
+}
 
 func CheckTestPathDBConf(cfg *pathstorage.PathDBConf, id string) {
 	util.LowerKeys(*cfg)
+	SoMsg("MaxOpenConns", isSet(cfg.MaxOpenConns()), ShouldBeFalse)
+	SoMsg("MaxIdleConns", isSet(cfg.MaxIdleConns()), ShouldBeFalse)
 	SoMsg("Backend correct", cfg.Backend(), ShouldEqual, pathstorage.BackendSqlite)
 	SoMsg("Connection correct", cfg.Connection(), ShouldEqual,
 		fmt.Sprintf("/var/lib/scion/pathdb/%s.path.db", id))
@@ -36,5 +46,11 @@ func CheckTestPathDBConf(cfg *pathstorage.PathDBConf, id string) {
 
 func CheckTestRevCacheConf(cfg *pathstorage.RevCacheConf) {
 	util.LowerKeys(*cfg)
+	SoMsg("MaxOpenConns", isSet(cfg.MaxOpenConns()), ShouldBeFalse)
+	SoMsg("MaxIdleConns", isSet(cfg.MaxIdleConns()), ShouldBeFalse)
 	SoMsg("Backend correct", cfg.Backend(), ShouldEqual, pathstorage.BackendMem)
+}
+
+func isSet(_ int, set bool) bool {
+	return set
 }

--- a/go/lib/pathstorage/pathstoragetest/config.go
+++ b/go/lib/pathstorage/pathstoragetest/config.go
@@ -24,13 +24,17 @@ import (
 )
 
 func InitTestPathDBConf(cfg *pathstorage.PathDBConf) {
-	*cfg = make(pathstorage.PathDBConf)
+	if *cfg == nil {
+		*cfg = make(pathstorage.PathDBConf)
+	}
 	(*cfg)[pathstorage.MaxOpenConnsKey] = "maxOpenConns"
 	(*cfg)[pathstorage.MaxIdleConnsKey] = "maxIdleConns"
 }
 
 func InitTestRevCacheConf(cfg *pathstorage.RevCacheConf) {
-	*cfg = make(pathstorage.RevCacheConf)
+	if *cfg == nil {
+		*cfg = make(pathstorage.RevCacheConf)
+	}
 	(*cfg)[pathstorage.MaxOpenConnsKey] = "maxOpenConns"
 	(*cfg)[pathstorage.MaxIdleConnsKey] = "maxIdleConns"
 }

--- a/go/lib/pathstorage/sample.go
+++ b/go/lib/pathstorage/sample.go
@@ -20,9 +20,25 @@ Backend = "sqlite"
 
 # Path to the path database.
 Connection = "/var/lib/scion/pathdb/%s.path.db"
+
+# The maximum number of open connections to the database. In case of the
+# empty string, the limit is not set and uses the go default. (default "")
+MaxOpenConns = ""
+
+# The maximum number of idle connections to the database. In case of the
+# empty string, the limit is not set and uses the go default. (default "")
+MaxIdleConns = ""
 `
 
 const revSample = `
 # The type of RevCache backend.
 Backend = "mem"
+
+# The maximum number of open connections to the database. In case of the
+# empty string, the limit is not set and uses the go default. (default "")
+MaxOpenConns = ""
+
+# The maximum number of idle connections to the database. In case of the
+# empty string, the limit is not set and uses the go default. (default "")
+MaxIdleConns = ""
 `

--- a/go/lib/revcache/BUILD.bazel
+++ b/go/lib/revcache/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
+        "//go/lib/infra/modules/db:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/periodic:go_default_library",
     ],

--- a/go/lib/revcache/memrevcache/memrevcache.go
+++ b/go/lib/revcache/memrevcache/memrevcache.go
@@ -116,3 +116,9 @@ func (c *memRevCache) DeleteExpired(_ context.Context) (int64, error) {
 	c.c.DeleteExpired()
 	return cnt, nil
 }
+
+func (c *memRevCache) Close() error { return nil }
+
+func (c *memRevCache) SetMaxOpenConns(_ int) {}
+
+func (c *memRevCache) SetMaxIdleConns(_ int) {}

--- a/go/lib/revcache/revcache.go
+++ b/go/lib/revcache/revcache.go
@@ -17,10 +17,12 @@ package revcache
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/infra/modules/db"
 )
 
 // Key denotes the key for the revocation cache.
@@ -78,6 +80,8 @@ type RevCache interface {
 	// ever growing cache.
 	// Returns the amount of deleted entries.
 	DeleteExpired(ctx context.Context) (int64, error)
+	db.LimitSetter
+	io.Closer
 }
 
 // Revocations is the map of revocations.

--- a/go/lib/truststorage/truststorage.go
+++ b/go/lib/truststorage/truststorage.go
@@ -20,6 +20,7 @@ package truststorage
 import (
 	"fmt"
 	"io"
+	"strconv"
 
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/config"
@@ -37,8 +38,10 @@ const (
 )
 
 const (
-	BackendKey    = "backend"
-	ConnectionKey = "connection"
+	BackendKey      = "backend"
+	ConnectionKey   = "connection"
+	MaxOpenConnsKey = "maxopenconns"
+	MaxIdleConnsKey = "maxidleconns"
 )
 
 var _ (config.Config) = (*TrustDBConf)(nil)
@@ -66,7 +69,29 @@ func (cfg *TrustDBConf) Connection() string {
 	return (*cfg)[ConnectionKey]
 }
 
+func (cfg *TrustDBConf) MaxOpenConns() (int, bool) {
+	val, ok, _ := cfg.parsedInt(MaxOpenConnsKey)
+	return val, ok
+}
+
+func (cfg *TrustDBConf) MaxIdleConns() (int, bool) {
+	val, ok, _ := cfg.parsedInt(MaxIdleConnsKey)
+	return val, ok
+}
+
+func (cfg *TrustDBConf) parsedInt(key string) (int, bool, error) {
+	val, ok := (*cfg)[key]
+	if !ok || val == "" {
+		return 0, false, nil
+	}
+	i, err := strconv.Atoi(val)
+	return i, true, err
+}
+
 func (cfg *TrustDBConf) Validate() error {
+	if err := cfg.validateLimits(); err != nil {
+		return err
+	}
 	switch cfg.Backend() {
 	case BackendSqlite:
 		return nil
@@ -74,6 +99,16 @@ func (cfg *TrustDBConf) Validate() error {
 		return common.NewBasicError("No backend set", nil)
 	}
 	return common.NewBasicError("Unsupported backend", nil, "backend", cfg.Backend())
+}
+
+func (cfg *TrustDBConf) validateLimits() error {
+	if _, _, err := cfg.parsedInt(MaxOpenConnsKey); err != nil {
+		return common.NewBasicError("Invalid MaxOpenConns", nil, "value", (*cfg)[MaxOpenConnsKey])
+	}
+	if _, _, err := cfg.parsedInt(MaxIdleConnsKey); err != nil {
+		return common.NewBasicError("Invalid MaxIdleConns", nil, "value", (*cfg)[MaxIdleConnsKey])
+	}
+	return nil
 }
 
 func (cfg *TrustDBConf) Sample(dst io.Writer, path config.Path, ctx config.CtxMap) {
@@ -89,8 +124,21 @@ func (cfg *TrustDBConf) New() (trustdb.TrustDB, error) {
 	log.Info("Connecting TrustDB", "backend", cfg.Backend(), "connection", cfg.Connection())
 	switch cfg.Backend() {
 	case BackendSqlite:
-		return trustdbsqlite.New(cfg.Connection())
+		return cfg.withConnLimits(trustdbsqlite.New(cfg.Connection()))
 	default:
 		return nil, common.NewBasicError("Unsupported backend", nil, "backend", cfg.Backend())
 	}
+}
+
+func (cfg *TrustDBConf) withConnLimits(db trustdb.TrustDB, err error) (trustdb.TrustDB, error) {
+	if err != nil {
+		return db, err
+	}
+	if m, ok := cfg.MaxOpenConns(); ok {
+		db.SetMaxOpenConns(m)
+	}
+	if m, ok := cfg.MaxIdleConns(); ok {
+		db.SetMaxIdleConns(m)
+	}
+	return db, err
 }

--- a/go/lib/truststorage/truststoragetest/config.go
+++ b/go/lib/truststorage/truststoragetest/config.go
@@ -23,11 +23,21 @@ import (
 	"github.com/scionproto/scion/go/lib/util"
 )
 
-func InitTestConfig(cfg *truststorage.TrustDBConf) {}
+func InitTestConfig(cfg *truststorage.TrustDBConf) {
+	(*cfg)[truststorage.MaxOpenConnsKey] = "maxOpenConns"
+	(*cfg)[truststorage.MaxIdleConnsKey] = "maxIdleConns"
+}
 
 func CheckTestConfig(cfg *truststorage.TrustDBConf, id string) {
 	util.LowerKeys(*cfg)
+	SoMsg("MaxOpenConns", stripInt(cfg.MaxOpenConns()), ShouldBeFalse)
+	SoMsg("MaxIdleConns", stripInt(cfg.MaxIdleConns()), ShouldBeFalse)
 	SoMsg("Backend correct", cfg.Backend(), ShouldEqual, truststorage.BackendSqlite)
 	SoMsg("Connection correct", cfg.Connection(), ShouldEqual,
 		fmt.Sprintf("/var/lib/scion/spki/%s.trust.db", id))
+
+}
+
+func stripInt(_ int, set bool) bool {
+	return set
 }

--- a/go/lib/truststorage/truststoragetest/config.go
+++ b/go/lib/truststorage/truststoragetest/config.go
@@ -24,20 +24,21 @@ import (
 )
 
 func InitTestConfig(cfg *truststorage.TrustDBConf) {
+	*cfg = make(truststorage.TrustDBConf)
 	(*cfg)[truststorage.MaxOpenConnsKey] = "maxOpenConns"
 	(*cfg)[truststorage.MaxIdleConnsKey] = "maxIdleConns"
 }
 
 func CheckTestConfig(cfg *truststorage.TrustDBConf, id string) {
 	util.LowerKeys(*cfg)
-	SoMsg("MaxOpenConns", stripInt(cfg.MaxOpenConns()), ShouldBeFalse)
-	SoMsg("MaxIdleConns", stripInt(cfg.MaxIdleConns()), ShouldBeFalse)
+	SoMsg("MaxOpenConns", isSet(cfg.MaxOpenConns()), ShouldBeFalse)
+	SoMsg("MaxIdleConns", isSet(cfg.MaxIdleConns()), ShouldBeFalse)
 	SoMsg("Backend correct", cfg.Backend(), ShouldEqual, truststorage.BackendSqlite)
 	SoMsg("Connection correct", cfg.Connection(), ShouldEqual,
 		fmt.Sprintf("/var/lib/scion/spki/%s.trust.db", id))
 
 }
 
-func stripInt(_ int, set bool) bool {
+func isSet(_ int, set bool) bool {
 	return set
 }

--- a/go/lib/truststorage/truststoragetest/config.go
+++ b/go/lib/truststorage/truststoragetest/config.go
@@ -24,7 +24,9 @@ import (
 )
 
 func InitTestConfig(cfg *truststorage.TrustDBConf) {
-	*cfg = make(truststorage.TrustDBConf)
+	if *cfg == nil {
+		*cfg = make(truststorage.TrustDBConf)
+	}
 	(*cfg)[truststorage.MaxOpenConnsKey] = "maxOpenConns"
 	(*cfg)[truststorage.MaxIdleConnsKey] = "maxIdleConns"
 }
@@ -36,7 +38,6 @@ func CheckTestConfig(cfg *truststorage.TrustDBConf, id string) {
 	SoMsg("Backend correct", cfg.Backend(), ShouldEqual, truststorage.BackendSqlite)
 	SoMsg("Connection correct", cfg.Connection(), ShouldEqual,
 		fmt.Sprintf("/var/lib/scion/spki/%s.trust.db", id))
-
 }
 
 func isSet(_ int, set bool) bool {

--- a/go/lib/truststorage/truststoragetest/config_test.go
+++ b/go/lib/truststorage/truststoragetest/config_test.go
@@ -28,9 +28,8 @@ import (
 func TestConfigSample(t *testing.T) {
 	Convey("Sample correct", t, func() {
 		var sample bytes.Buffer
-		cfg := make(truststorage.TrustDBConf, 1)
+		var cfg truststorage.TrustDBConf
 		cfg.Sample(&sample, nil, map[string]string{config.ID: "test"})
-		SoMsg("n", cfg, ShouldNotBeNil)
 		InitTestConfig(&cfg)
 		meta, err := toml.Decode(sample.String(), &cfg)
 		SoMsg("err", err, ShouldBeNil)

--- a/go/lib/truststorage/truststoragetest/config_test.go
+++ b/go/lib/truststorage/truststoragetest/config_test.go
@@ -28,8 +28,9 @@ import (
 func TestConfigSample(t *testing.T) {
 	Convey("Sample correct", t, func() {
 		var sample bytes.Buffer
-		cfg := make(truststorage.TrustDBConf)
+		cfg := make(truststorage.TrustDBConf, 1)
 		cfg.Sample(&sample, nil, map[string]string{config.ID: "test"})
+		SoMsg("n", cfg, ShouldNotBeNil)
 		InitTestConfig(&cfg)
 		meta, err := toml.Decode(sample.String(), &cfg)
 		SoMsg("err", err, ShouldBeNil)

--- a/go/lib/truststorage/truststoragetest/config_test.go
+++ b/go/lib/truststorage/truststoragetest/config_test.go
@@ -28,7 +28,7 @@ import (
 func TestConfigSample(t *testing.T) {
 	Convey("Sample correct", t, func() {
 		var sample bytes.Buffer
-		var cfg truststorage.TrustDBConf
+		cfg := make(truststorage.TrustDBConf)
 		cfg.Sample(&sample, nil, map[string]string{config.ID: "test"})
 		InitTestConfig(&cfg)
 		meta, err := toml.Decode(sample.String(), &cfg)

--- a/go/path_srv/internal/handlers/common.go
+++ b/go/path_srv/internal/handlers/common.go
@@ -162,6 +162,9 @@ func (h *baseHandler) verifyAndStore(ctx context.Context, src net.Addr,
 	for _, s := range verifiedSegs {
 		n, err := tx.Insert(ctx, s)
 		if err != nil {
+			if errRollback := tx.Rollback(); errRollback != nil {
+				err = common.NewBasicError("Unable to rollback", err, "rollbackErr", errRollback)
+			}
 			logger.Error("Unable to insert segment into path database",
 				"seg", s.Segment, "err", err)
 			return

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -89,12 +89,15 @@ func realMain() int {
 		log.Crit("Unable to initialize path storage", "err", err)
 		return 1
 	}
+	defer pathDB.Close()
+	defer revCache.Close()
 	pathDB = pathdb.WithMetrics("std", pathDB)
 	trustDB, err := cfg.TrustDB.New()
 	if err != nil {
 		log.Crit("Unable to initialize trustDB", "err", err)
 		return 1
 	}
+	defer trustDB.Close()
 	topo := itopo.Get()
 	trustConf := &trust.Config{
 		ServiceType: proto.ServiceType_ps,

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -89,9 +89,9 @@ func realMain() int {
 		log.Crit("Unable to initialize path storage", "err", err)
 		return 1
 	}
-	defer pathDB.Close()
 	defer revCache.Close()
 	pathDB = pathdb.WithMetrics("std", pathDB)
+	defer pathDB.Close()
 	trustDB, err := cfg.TrustDB.New()
 	if err != nil {
 		log.Crit("Unable to initialize trustDB", "err", err)

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -92,11 +92,14 @@ func realMain() int {
 		log.Crit("Unable to initialize path storage", "err", err)
 		return 1
 	}
+	defer pathDB.Close()
+	defer revCache.Close()
 	trustDB, err := cfg.TrustDB.New()
 	if err != nil {
 		log.Crit("Unable to initialize trustDB", "err", err)
 		return 1
 	}
+	defer trustDB.Close()
 	trustStore, err := trust.NewStore(trustDB, itopo.Get().ISD_AS, nil, log.Root())
 	if err != nil {
 		log.Crit("Unable to initialize trust store", "err", err)


### PR DESCRIPTION
This PR makes the MaxOpenConns and MaxIdleConns of the trust database,
path database and revocation cache configurable.

Additionally, fixes #2536 and #2537

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2540)
<!-- Reviewable:end -->
