### PR TITLE
BS: Add Filtering

### DIFF
--- a/go/beacon_srv/internal/beacon/BUILD.bazel
+++ b/go/beacon_srv/internal/beacon/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -12,5 +12,19 @@ go_library(
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/ctrl/seg:go_default_library",
+        "@in_gopkg_yaml_v2//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["policy_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/ctrl/seg:go_default_library",
+        "//go/lib/xtest:go_default_library",
+        "@com_github_smartystreets_goconvey//convey:go_default_library",
     ],
 )

--- a/go/beacon_srv/internal/beacon/policy.go
+++ b/go/beacon_srv/internal/beacon/policy.go
@@ -14,7 +14,14 @@
 
 package beacon
 
-import "github.com/scionproto/scion/go/lib/addr"
+import (
+	"io/ioutil"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+)
 
 // PolicyType is the policy type.
 type PolicyType string
@@ -63,6 +70,32 @@ func (p *Policy) InitDefaults() {
 	p.Filter.InitDefaults()
 }
 
+// Load loads the policy.
+func Load(b common.RawBytes, t PolicyType) (*Policy, error) {
+	p := &Policy{}
+	if err := yaml.Unmarshal(b, p); err != nil {
+		return nil, common.NewBasicError("Unable to parse policy", err)
+	}
+	p.InitDefaults()
+	if p.Type == "" {
+		p.Type = t
+	}
+	if p.Type != t {
+		return nil, common.NewBasicError("Specified policy type does not match", nil,
+			"expected", t, "actual", p.Type)
+	}
+	return p, nil
+}
+
+// LoadFromFile loads the policy from the file.
+func LoadFromFile(path string, t PolicyType) (*Policy, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, common.NewBasicError("Unable to read policy file", err, "path", path)
+	}
+	return Load(b, t)
+}
+
 // Filter filters beacons.
 type Filter struct {
 	// MaxHopsLength is the maximum number of hops a segment can have.
@@ -78,4 +111,26 @@ func (f *Filter) InitDefaults() {
 	if f.MaxHopsLength == 0 {
 		f.MaxHopsLength = DefaultMaxHopsLength
 	}
+}
+
+// Apply returns an error if the beacon is filtered.
+func (f Filter) Apply(beacon Beacon) error {
+	if len(beacon.Segment.ASEntries) > f.MaxHopsLength {
+		return common.NewBasicError("MaxHopsLength exceeded", nil, "max", f.MaxHopsLength,
+			"actual", len(beacon.Segment.ASEntries))
+	}
+	for _, entry := range beacon.Segment.ASEntries {
+		ia := entry.IA()
+		for _, as := range f.AsBlackList {
+			if ia.A == as {
+				return common.NewBasicError("Contains blacklisted AS", nil, "ia", ia)
+			}
+		}
+		for _, isd := range f.IsdBlackList {
+			if ia.I == isd {
+				return common.NewBasicError("Contains blacklisted ISD", nil, "isd", ia)
+			}
+		}
+	}
+	return nil
 }

--- a/go/beacon_srv/internal/beacon/policy.go
+++ b/go/beacon_srv/internal/beacon/policy.go
@@ -70,8 +70,8 @@ func (p *Policy) InitDefaults() {
 	p.Filter.InitDefaults()
 }
 
-// Load loads the policy.
-func Load(b common.RawBytes, t PolicyType) (*Policy, error) {
+// ParseYaml parses the policy in yaml format and initializes the default values.
+func ParseYaml(b common.RawBytes, t PolicyType) (*Policy, error) {
 	p := &Policy{}
 	if err := yaml.Unmarshal(b, p); err != nil {
 		return nil, common.NewBasicError("Unable to parse policy", err)
@@ -87,13 +87,14 @@ func Load(b common.RawBytes, t PolicyType) (*Policy, error) {
 	return p, nil
 }
 
-// LoadFromFile loads the policy from the file.
-func LoadFromFile(path string, t PolicyType) (*Policy, error) {
+// LoadFromYaml loads the policy from a yaml file and initializes the
+// default values.
+func LoadFromYaml(path string, t PolicyType) (*Policy, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to read policy file", err, "path", path)
 	}
-	return Load(b, t)
+	return ParseYaml(b, t)
 }
 
 // Filter filters beacons.

--- a/go/beacon_srv/internal/beacon/policy_test.go
+++ b/go/beacon_srv/internal/beacon/policy_test.go
@@ -1,0 +1,127 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beacon
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/ctrl/seg"
+	"github.com/scionproto/scion/go/lib/xtest"
+)
+
+func TestLoadFromFile(t *testing.T) {
+	checkPolicy := func(p *Policy, t PolicyType) {
+		SoMsg("BestSetSize", p.BestSetSize, ShouldEqual, 6)
+		SoMsg("CandidateSetSize", p.CandidateSetSize, ShouldEqual, 20)
+		SoMsg("Type", p.Type, ShouldEqual, t)
+		SoMsg("MaxHopsLength", p.Filter.MaxHopsLength, ShouldEqual, 8)
+		SoMsg("AsBlackList", p.Filter.AsBlackList, ShouldResemble,
+			[]addr.AS{xtest.MustParseAS("ff00:0:110"), xtest.MustParseAS("ff00:0:111")})
+		SoMsg("IsdBlackList", p.Filter.IsdBlackList, ShouldResemble, []addr.ISD{1, 2, 3})
+
+	}
+	Convey("Given a policy file with policy type set", t, func() {
+		fn := "testdata/typedPolicy.yml"
+		Convey("The policy is parsed correctly if the type matches", func() {
+			p, err := LoadFromFile(fn, PropPolicy)
+			SoMsg("err", err, ShouldBeNil)
+			checkPolicy(p, PropPolicy)
+		})
+		Convey("An error is returned if the type does not match", func() {
+			_, err := LoadFromFile(fn, UpRegPolicy)
+			SoMsg("err", err, ShouldNotBeNil)
+		})
+
+	})
+	Convey("Given a policy file with policy type unset", t, func() {
+		loadWithType := func(polType PolicyType) {
+			Convey(string("Load with type "+polType+" should succeed"), func() {
+				p, err := LoadFromFile("testdata/policy.yml", polType)
+				SoMsg("err", err, ShouldBeNil)
+				checkPolicy(p, polType)
+			})
+		}
+		for _, t := range []PolicyType{PropPolicy, UpRegPolicy, DownRegPolicy, CoreRegPolicy} {
+			loadWithType(t)
+		}
+	})
+}
+
+func TestFilterApply(t *testing.T) {
+	ia := func(raw string) addr.IA {
+		return xtest.MustParseIA(raw)
+	}
+	Convey("Given a filter", t, func() {
+		f := Filter{
+			MaxHopsLength: 2,
+			AsBlackList:   []addr.AS{xtest.MustParseAS("ff00:0:112")},
+			IsdBlackList:  []addr.ISD{2},
+		}
+		table := []struct {
+			Beacon       Beacon
+			ShouldFilter bool
+			Name         string
+		}{
+			{
+				Beacon:       newTestBeacon(ia("1-ff00:0:110"), ia("1-ff00:0:111")),
+				ShouldFilter: false,
+				Name:         "Accepted: [1-ff00:0:110, 1-ff00:0:111]",
+			},
+			{
+				Beacon: newTestBeacon(ia("1-ff00:0:110"), ia("1-ff00:0:111"),
+					ia("1-ff00:0:113")),
+				ShouldFilter: true,
+				Name:         "Too Long: [1-ff00:0:110, 1-ff00:0:111, 1-ff00:0:113]",
+			},
+			{
+				Beacon:       newTestBeacon(ia("1-ff00:0:112")),
+				ShouldFilter: true,
+				Name:         "Blacklisted AS: [1-ff00:0:112]",
+			},
+			{
+				Beacon:       newTestBeacon(ia("2-ff00:0:110")),
+				ShouldFilter: true,
+				Name:         "Blacklisted ISD[2-ff00:0:110]",
+			},
+		}
+
+		for _, entry := range table {
+			Convey(entry.Name, func() {
+				expected := ShouldBeNil
+				if entry.ShouldFilter {
+					expected = ShouldNotBeNil
+				}
+				SoMsg("filter", f.Apply(entry.Beacon), expected)
+			})
+		}
+	})
+
+}
+
+func newTestBeacon(hops ...addr.IA) Beacon {
+	var entries []*seg.ASEntry
+	for _, hop := range hops {
+		entries = append(entries, &seg.ASEntry{RawIA: hop.IAInt()})
+	}
+	b := Beacon{
+		Segment: &seg.PathSegment{
+			ASEntries: entries,
+		},
+	}
+	return b
+}

--- a/go/beacon_srv/internal/beacon/testdata/policy.yml
+++ b/go/beacon_srv/internal/beacon/testdata/policy.yml
@@ -1,0 +1,8 @@
+---
+BestSetSize: 6
+CandidateSetSize: 20
+Filter:
+  MaxHopsLength: 8
+  AsBlackList: ["ff00:0:110", "ff00:0:111"]
+  IsdBlackList: [1, 2, 3]
+

--- a/go/beacon_srv/internal/beacon/testdata/typedPolicy.yml
+++ b/go/beacon_srv/internal/beacon/testdata/typedPolicy.yml
@@ -1,0 +1,8 @@
+---
+BestSetSize: 6
+CandidateSetSize: 20
+Filter:
+  MaxHopsLength: 8
+  AsBlackList: ["ff00:0:110", "ff00:0:111"]
+  IsdBlackList: [1, 2, 3]
+Type: Propagation


### PR DESCRIPTION
Add the `Apply` method to the policy filter. This allows
filtering beacons according to a policy.

Additionally, add the possibility to load the policy from a yaml file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2545)
<!-- Reviewable:end -->
