### PR TITLE
BS: Implement data structure for interface state

### DIFF
--- a/go/beacon_srv/internal/ifstate/ifstate.go
+++ b/go/beacon_srv/internal/ifstate/ifstate.go
@@ -1,0 +1,195 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ifstate
+
+import (
+	"sync"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/topology"
+)
+
+const (
+	// KeepaliveInterval is the time between sending IFID keepalive packets
+	// to the neighbor.
+	KeepaliveInterval = time.Second
+	// KeepaliveTimeout specifies for how long an interface can receive no
+	// IFID keepalive packets until it is considered expired.
+	KeepaliveTimeout = 3 * KeepaliveInterval
+)
+
+// State is the state of an interface.
+type State string
+
+const (
+	// Inactive indicates that the interface has not been activated or
+	// expired yet.
+	Inactive State = "Inactive"
+	// Active indicates that the interface is active.
+	Active State = "Active"
+	// Expired indicates that the interface is expired.
+	Expired State = "Expired"
+	// Revoked indicates that the interface is revoked.
+	Revoked State = "Revoked"
+)
+
+// Infos keeps track of all interfaces infos of the AS.
+type Infos struct {
+	mu    sync.RWMutex
+	intfs map[common.IFIDType]*Info
+}
+
+// Update updates the interface mapping. Interfaces no longer present in
+// the topology are removed. The state of existing interfaces is preserved.
+// New interfaces are added as inactive.
+func (infos *Infos) Update(ifInfomap topology.IfInfoMap) {
+	infos.mu.Lock()
+	defer infos.mu.Unlock()
+	m := make(map[common.IFIDType]*Info, len(infos.intfs))
+	for ifid, info := range ifInfomap {
+		if intf, ok := infos.intfs[ifid]; ok {
+			intf.updateTopoInfo(info)
+			m[ifid] = intf
+		} else {
+			m[ifid] = &Info{
+				topoInfo:     info,
+				state:        Inactive,
+				lastActivate: time.Now(),
+			}
+		}
+	}
+	infos.intfs = m
+}
+
+// Reset resets all interface states to inactive. This should be called
+// by the beacon server if it is elected leader.
+func (infos *Infos) Reset() {
+	infos.mu.RLock()
+	defer infos.mu.RUnlock()
+	for _, intf := range infos.intfs {
+		intf.reset()
+	}
+}
+
+// All returns a copy of the map from interface id to info.
+func (infos *Infos) All() map[common.IFIDType]*Info {
+	infos.mu.RLock()
+	defer infos.mu.RUnlock()
+	res := make(map[common.IFIDType]*Info, len(infos.intfs))
+	for ifid, intf := range infos.intfs {
+		res[ifid] = intf
+	}
+	return res
+}
+
+// Get returns the info for the specified interface id, or nil if not present.
+func (infos *Infos) Get(ifid common.IFIDType) *Info {
+	infos.mu.RLock()
+	defer infos.mu.RUnlock()
+	return infos.intfs[ifid]
+}
+
+type Info struct {
+	mu           sync.RWMutex
+	topoInfo     topology.IFInfo
+	state        State
+	revocation   *path_mgmt.SignedRevInfo
+	lastActivate time.Time
+}
+
+// Activate activates the interfaces the keep alive is received from when
+// necessary, and sets the remote interface id. The return value indicates
+// the previous state of the interface.
+func (inf *Info) Activate(remote common.IFIDType) State {
+	inf.mu.Lock()
+	defer inf.mu.Unlock()
+	prev := inf.state
+	inf.state = Active
+	inf.lastActivate = time.Now()
+	inf.topoInfo.RemoteIFID = remote
+	inf.revocation = nil
+	return prev
+}
+
+// Expire checks whether the interface has not been activated for a certain
+// amount of time. If that is the case and the current state is inactive or
+// active, the state changes to Expired. The return value indicates,
+// whether the state is expired or revoked when the call returns.
+func (inf *Info) Expire() bool {
+	inf.mu.Lock()
+	defer inf.mu.Unlock()
+	if inf.state == Expired || inf.state == Revoked {
+		return true
+	}
+	if time.Now().Sub(inf.lastActivate) > KeepaliveTimeout {
+		inf.state = Expired
+		return true
+	}
+	return false
+}
+
+// Revoke changes the state of the interface to revoked and updates the
+// revocation, unless the current state is active. In that case, the
+// interface has been activated in the meantime. This is indicated through
+// an error.
+func (inf *Info) Revoke(rev *path_mgmt.SignedRevInfo) error {
+	inf.mu.Lock()
+	defer inf.mu.Unlock()
+	if inf.state == Active {
+		return common.NewBasicError("Interface activated in the meantime", nil)
+	}
+	inf.state = Revoked
+	inf.revocation = rev
+	return nil
+}
+
+// Revocation returns the revocation.
+func (inf *Info) Revocation() *path_mgmt.SignedRevInfo {
+	inf.mu.RLock()
+	defer inf.mu.RUnlock()
+	return inf.revocation
+}
+
+// TopoInfo returns the topology information.
+func (inf *Info) TopoInfo() topology.IFInfo {
+	inf.mu.RLock()
+	defer inf.mu.RUnlock()
+	return inf.topoInfo
+}
+
+// State returns the current state of the interface.
+func (inf *Info) State() State {
+	inf.mu.RLock()
+	defer inf.mu.RUnlock()
+	return inf.state
+}
+
+func (inf *Info) reset() {
+	inf.mu.Lock()
+	defer inf.mu.Unlock()
+	inf.state = Inactive
+	inf.revocation = nil
+	inf.lastActivate = time.Now()
+}
+
+func (inf *Info) updateTopoInfo(topoInfo topology.IFInfo) {
+	inf.mu.Lock()
+	defer inf.mu.Unlock()
+	// Keep remote topo info.
+	topoInfo.RemoteIFID = inf.topoInfo.RemoteIFID
+	inf.topoInfo = topoInfo
+}

--- a/go/beacon_srv/internal/ifstate/ifstate_test.go
+++ b/go/beacon_srv/internal/ifstate/ifstate_test.go
@@ -1,0 +1,201 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ifstate
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/topology"
+)
+
+func TestInfosUpdate(t *testing.T) {
+	Convey("Given an interface infos map with existing entries", t, func() {
+		infos := initInfos()
+		Convey("The update retains the state of the interface", func() {
+			topoMap := topology.IfInfoMap{
+				1: {BRName: "BR-1-new"},
+				2: {BRName: "BR-2-new"},
+			}
+			infos.Update(topoMap)
+			// The topo info should come from the updated map.
+			SoMsg("Name 1", infos.Get(1).TopoInfo().BRName, ShouldEqual, "BR-1-new")
+			SoMsg("Name 2", infos.Get(2).TopoInfo().BRName, ShouldEqual, "BR-2-new")
+			// The remote ifid should be kept
+			SoMsg("Ifid 1", infos.Get(1).TopoInfo().RemoteIFID, ShouldEqual, 11)
+			SoMsg("Ifid 2", infos.Get(2).TopoInfo().RemoteIFID, ShouldEqual, 22)
+			// The state should be kept
+			SoMsg("State 1", infos.Get(1).State(), ShouldEqual, Active)
+			SoMsg("State 2", infos.Get(2).State(), ShouldEqual, Revoked)
+		})
+		Convey("The update adds new interfaces and removes missing", func() {
+			topoMap := topology.IfInfoMap{
+				3: {BRName: "BR-3-new"},
+			}
+			infos.Update(topoMap)
+			SoMsg("Gone 1", infos.Get(1), ShouldBeNil)
+			SoMsg("Gone 2", infos.Get(2), ShouldBeNil)
+			SoMsg("Name 3", infos.Get(3).TopoInfo().BRName, ShouldEqual, "BR-3-new")
+		})
+	})
+}
+
+func TestInfosReset(t *testing.T) {
+	Convey("Given an interface infos map with existing entries", t, func() {
+		infos := initInfos()
+		Convey("Reset resets the info state", func() {
+			infos.Reset()
+			// The topo info should remain.
+			SoMsg("Name 1", infos.Get(1).TopoInfo().BRName, ShouldEqual, "BR-1")
+			SoMsg("Name 2", infos.Get(2).TopoInfo().BRName, ShouldEqual, "BR-2")
+			SoMsg("Ifid 1", infos.Get(1).TopoInfo().RemoteIFID, ShouldEqual, 11)
+			SoMsg("Ifid 2", infos.Get(2).TopoInfo().RemoteIFID, ShouldEqual, 22)
+			// The state and revocations should be reset.
+			SoMsg("State 1", infos.Get(1).State(), ShouldEqual, Inactive)
+			SoMsg("State 2", infos.Get(2).State(), ShouldEqual, Inactive)
+			SoMsg("Revocation 1", infos.Get(1).Revocation(), ShouldBeNil)
+			SoMsg("Revocation 2", infos.Get(2).Revocation(), ShouldBeNil)
+		})
+	})
+}
+
+func TestInfosAll(t *testing.T) {
+	Convey("Given an interface infos map with existing entries", t, func() {
+		infos := initInfos()
+		Convey("All should return all infos", func() {
+			all := infos.All()
+			// The topo info should remain.
+			SoMsg("Name 1", all[1].TopoInfo().BRName, ShouldEqual, "BR-1")
+			SoMsg("Name 2", all[2].TopoInfo().BRName, ShouldEqual, "BR-2")
+			SoMsg("Ifid 1", all[1].TopoInfo().RemoteIFID, ShouldEqual, 11)
+			SoMsg("Ifid 2", all[2].TopoInfo().RemoteIFID, ShouldEqual, 22)
+			SoMsg("State 1", all[1].State(), ShouldEqual, Active)
+			SoMsg("State 2", all[2].State(), ShouldEqual, Revoked)
+			SoMsg("Revocation 1", all[1].Revocation(), ShouldBeNil)
+			SoMsg("Revocation 2", all[2].Revocation(), ShouldNotBeNil)
+		})
+	})
+}
+
+func TestInfoActivate(t *testing.T) {
+	for _, state := range []State{Inactive, Active, Expired, Revoked} {
+		Convey("Activate switches correctly from "+string(state), t, func() {
+			info := &Info{state: state, revocation: &path_mgmt.SignedRevInfo{}}
+			prev := info.Activate(11)
+			SoMsg("State", prev, ShouldEqual, state)
+			SoMsg("Active", info.state, ShouldEqual, Active)
+			SoMsg("Revocation", info.revocation, ShouldBeNil)
+			SoMsg("LastActivate", time.Now().Sub(info.lastActivate), ShouldBeLessThanOrEqualTo,
+				100*time.Millisecond)
+		})
+	}
+}
+
+func TestInfoExpire(t *testing.T) {
+	Convey("Given an interface that has not received a keepalive", t, func() {
+		testCases := []struct {
+			PrevState State
+			NextState State
+		}{
+			{PrevState: Inactive, NextState: Expired},
+			{PrevState: Active, NextState: Expired},
+			{PrevState: Expired, NextState: Expired},
+			{PrevState: Revoked, NextState: Revoked},
+		}
+		for _, test := range testCases {
+			Convey("Test "+string(test.PrevState), func() {
+				info := &Info{
+					state:        test.PrevState,
+					lastActivate: time.Now().Add(-KeepaliveTimeout),
+				}
+				expired := info.Expire()
+				SoMsg("Expired", expired, ShouldBeTrue)
+				SoMsg("State", info.State(), ShouldEqual, test.NextState)
+				SoMsg("LastActivate", time.Now().Sub(info.lastActivate),
+					ShouldBeGreaterThanOrEqualTo, KeepaliveTimeout)
+			})
+		}
+	})
+	Convey("Given the keepalive has been received in the last keepalive timeout", t, func() {
+		testCases := []struct {
+			PrevState State
+			NextState State
+			Expired   bool
+		}{
+			{PrevState: Inactive, NextState: Inactive, Expired: false},
+			{PrevState: Active, NextState: Active, Expired: false},
+			{PrevState: Expired, NextState: Expired, Expired: true},
+			{PrevState: Revoked, NextState: Revoked, Expired: true},
+		}
+		for _, test := range testCases {
+			Convey("Test "+string(test.PrevState), func() {
+				info := &Info{
+					state:        test.PrevState,
+					lastActivate: time.Now().Add(-KeepaliveInterval),
+				}
+				expired := info.Expire()
+				SoMsg("Expired", expired, ShouldEqual, test.Expired)
+				SoMsg("State", info.State(), ShouldEqual, test.NextState)
+			})
+		}
+	})
+}
+
+func TestInfoRevoke(t *testing.T) {
+	Convey("Given an interface in a certain state", t, func() {
+		testCases := []struct {
+			PrevState State
+			NextState State
+			Error     bool
+		}{
+			{PrevState: Inactive, NextState: Revoked, Error: false},
+			{PrevState: Active, NextState: Active, Error: true},
+			{PrevState: Expired, NextState: Revoked, Error: false},
+			{PrevState: Revoked, NextState: Revoked, Error: false},
+		}
+		for _, test := range testCases {
+			Convey("Test "+string(test.PrevState), func() {
+				info := &Info{
+					state: test.PrevState,
+				}
+				err := info.Revoke(&path_mgmt.SignedRevInfo{})
+				SoMsg("State", info.State(), ShouldEqual, test.NextState)
+				if test.Error {
+					SoMsg("err", err, ShouldNotBeNil)
+					SoMsg("Revocation", info.Revocation(), ShouldBeNil)
+				} else {
+					SoMsg("err", err, ShouldBeNil)
+					SoMsg("Revocation", info.Revocation(), ShouldNotBeNil)
+				}
+			})
+		}
+	})
+}
+
+func initInfos() *Infos {
+	topoMap := topology.IfInfoMap{
+		1: {BRName: "BR-1"},
+		2: {BRName: "BR-2"},
+	}
+	infos := &Infos{}
+	infos.Update(topoMap)
+	infos.Get(1).Activate(11)
+	infos.Get(2).topoInfo.RemoteIFID = 22
+	infos.Get(2).Revoke(&path_mgmt.SignedRevInfo{})
+	return infos
+}


### PR DESCRIPTION
This PR adds an in-memory data structure to keep track
of the interface state of a given AS.

fixes #2485

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2552)
<!-- Reviewable:end -->
