### PR TITLE
Remove ctx from deduper.Request method

### DIFF
--- a/go/lib/infra/dedupe/dedupe.go
+++ b/go/lib/infra/dedupe/dedupe.go
@@ -94,7 +94,10 @@ type Deduper interface {
 	// Objects written to the channel might share the same address space, so
 	// callers should copy the value drained from the channel if they want to have
 	// exclusive ownership.
-	Request(ctx context.Context, req Request) (<-chan Response, CancelFunc)
+	//
+	// Note this method explicitly takes no context, when waiting on the response
+	// you should always also read from the ctx.Done() channel.
+	Request(req Request) (<-chan Response, CancelFunc)
 }
 
 type deduper struct {
@@ -134,7 +137,7 @@ func New(f RequestFunc, dedupeLifetime, responseValidity time.Duration) Deduper 
 	}
 }
 
-func (dd *deduper) Request(ctx context.Context, req Request) (<-chan Response, CancelFunc) {
+func (dd *deduper) Request(req Request) (<-chan Response, CancelFunc) {
 	ch := make(chan Response, 1)
 	if ctx := dd.notifications.Add(req, ch, dd.dedupeLifetime); ctx != nil {
 		go func() {

--- a/go/lib/infra/dedupe/dedupe_test.go
+++ b/go/lib/infra/dedupe/dedupe_test.go
@@ -221,7 +221,7 @@ func TestDeduper(t *testing.T) {
 				chs := make(map[int]<-chan Response)
 				for i := range tc.requests {
 					<-time.After(time.Duration(tc.requests[i].Delay) * time.Millisecond)
-					ch, cancelF := deduper.Request(context.TODO(), &tc.requests[i])
+					ch, cancelF := deduper.Request(&tc.requests[i])
 					chs[i] = ch
 					defer cancelF()
 				}

--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -239,7 +239,7 @@ func (store *Store) getTRC(ctx context.Context, isd addr.ISD, version uint64,
 }
 
 func (store *Store) getTRCFromNetwork(ctx context.Context, req *trcRequest) (*trc.TRC, error) {
-	responseC, cancelF := store.trcDeduper.Request(ctx, req)
+	responseC, cancelF := store.trcDeduper.Request(req)
 	defer cancelF()
 	select {
 	case response := <-responseC:
@@ -451,7 +451,7 @@ func verifyChain(validator *trc.TRC, chain *cert.Chain) error {
 func (store *Store) getChainFromNetwork(ctx context.Context,
 	req *chainRequest) (*cert.Chain, error) {
 
-	responseC, cancelF := store.chainDeduper.Request(ctx, req)
+	responseC, cancelF := store.chainDeduper.Request(req)
 	defer cancelF()
 	select {
 	case response := <-responseC:

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -150,7 +150,7 @@ func (h *segReqHandler) fetchAndSaveSegs(ctx context.Context, src, dst addr.IA,
 func (h *segReqHandler) getSegsFromNetwork(ctx context.Context,
 	req *path_mgmt.SegReq, server net.Addr, id uint64) (*path_mgmt.SegReply, error) {
 
-	responseC, cancelF := h.segsDeduper.Request(ctx, &segReq{
+	responseC, cancelF := h.segsDeduper.Request(&segReq{
 		segReq: req,
 		server: server,
 		id:     id,


### PR DESCRIPTION
The context was shadowed in the current implementation anyway.
Furthermore it could lead to weird interactions:
If the first caller of a deduped request has a long timeout and the second one a short one
Only the timeout of the first requestor would be respected.
That is why callers of Request anyway also select on the ctx.Done() channel,
thus we don't have to pass it to the Request method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2553)
<!-- Reviewable:end -->
