### PR TITLE
BS: Add Keepalive sender

### DIFF
--- a/go/beacon_srv/internal/keepalive/BUILD.bazel
+++ b/go/beacon_srv/internal/keepalive/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["sender.go"],
+    importpath = "github.com/scionproto/scion/go/beacon_srv/internal/keepalive",
+    visibility = ["//go/beacon_srv:__subpackages__"],
+    deps = [
+        "//go/beacon_srv/internal/onehop:go_default_library",
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/ctrl:go_default_library",
+        "//go/lib/ctrl/ifid:go_default_library",
+        "//go/lib/infra/modules/itopo:go_default_library",
+        "//go/lib/log:go_default_library",
+        "//go/lib/periodic:go_default_library",
+        "//go/lib/snet:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["sender_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
+    deps = [
+        "//go/beacon_srv/internal/onehop:go_default_library",
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/ctrl:go_default_library",
+        "//go/lib/infra/modules/itopo:go_default_library",
+        "//go/lib/overlay:go_default_library",
+        "//go/lib/scrypto:go_default_library",
+        "//go/lib/snet:go_default_library",
+        "//go/lib/topology:go_default_library",
+        "//go/lib/xtest:go_default_library",
+        "//go/lib/xtest/p2p:go_default_library",
+        "//go/proto:go_default_library",
+        "@com_github_smartystreets_goconvey//convey:go_default_library",
+    ],
+)

--- a/go/beacon_srv/internal/keepalive/sender.go
+++ b/go/beacon_srv/internal/keepalive/sender.go
@@ -50,12 +50,17 @@ func (s *Sender) Run(_ context.Context) {
 			log.Error("[KeepaliveSender] Unable to create payload", "err", err)
 			continue
 		}
-		dst := snet.SCIONAddress{
-			IA:   intf.ISD_AS,
-			Host: addr.SvcBS | addr.SVCMcast,
+		msg := &onehop.Msg{
+			Dst: snet.SCIONAddress{
+				IA:   intf.ISD_AS,
+				Host: addr.SvcBS | addr.SVCMcast,
+			},
+			Ifid:     ifid,
+			Pld:      pld,
+			InfoTime: time.Now(),
 		}
 		ov := intf.InternalAddrs.PublicOverlay(intf.InternalAddrs.Overlay)
-		if err := s.Send(dst, ifid, ov, pld, time.Now()); err != nil {
+		if err := s.Send(msg, ov); err != nil {
 			log.Error("[KeepaliveSender] Unable to send packet", "err", err)
 		}
 	}

--- a/go/beacon_srv/internal/keepalive/sender.go
+++ b/go/beacon_srv/internal/keepalive/sender.go
@@ -1,0 +1,124 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keepalive
+
+import (
+	"context"
+	"hash"
+	"sync"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/ctrl/ifid"
+	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
+	"github.com/scionproto/scion/go/lib/l4"
+	"github.com/scionproto/scion/go/lib/layers"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/periodic"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/spath"
+	"github.com/scionproto/scion/go/lib/topology"
+)
+
+var _ periodic.Task = (*Sender)(nil)
+
+// Sender sends ifid keepalive messages on all border routers.
+type Sender struct {
+	Conn      *snet.SCIONPacketConn
+	Addr      *addr.AppAddr
+	HFMacPool *sync.Pool
+	Signer    ctrl.Signer
+}
+
+// Run sends ifid keepalive messages on all border routers.
+func (s *Sender) Run(_ context.Context) {
+	topo := itopo.Get()
+	if topo == nil {
+		log.Error("[KeepaliveSender] Unable to send keepalive, no topology set")
+		return
+	}
+	for ifid, intf := range topo.IFInfoMap {
+		pkt, err := s.createPkt(topo, ifid, intf, time.Now())
+		if err != nil {
+			log.Error("[KeepaliveSender] Unable to create packet", "err", err)
+			continue
+		}
+		brAddr := intf.InternalAddrs
+		if err := s.Conn.WriteTo(pkt, brAddr.PublicOverlay(brAddr.Overlay)); err != nil {
+			log.Error("[KeepaliveSender] Unable to send packet", "err", err)
+		}
+	}
+}
+
+// createPkt creates a scion packet with a one-hop path and the ifid keepalive payload.
+func (s *Sender) createPkt(topo *topology.Topo, origIfid common.IFIDType, intf topology.IFInfo,
+	now time.Time) (*snet.SCIONPacket, error) {
+
+	path, err := s.createPath(topo.ISD_AS.I, origIfid, now)
+	if err != nil {
+		return nil, err
+	}
+	pld, err := s.createPld(origIfid)
+	if err != nil {
+		return nil, err
+	}
+	pkt := &snet.SCIONPacket{
+		SCIONPacketInfo: snet.SCIONPacketInfo{
+			Destination: snet.SCIONAddress{
+				IA:   intf.ISD_AS,
+				Host: addr.SvcBS | addr.SVCMcast,
+			},
+			Source: snet.SCIONAddress{
+				IA:   topo.ISD_AS,
+				Host: s.Addr.L3,
+			},
+			Path:       path,
+			Extensions: []common.Extension{layers.ExtnOHP{}},
+			L4Header: &l4.UDP{
+				SrcPort: s.Addr.L4.Port(),
+			},
+			Payload: pld,
+		},
+	}
+	return pkt, nil
+}
+
+// createPath creates the one-hop path and initializes it.
+func (s *Sender) createPath(isd addr.ISD, origIfid common.IFIDType,
+	now time.Time) (*spath.Path, error) {
+
+	mac := s.HFMacPool.Get().(hash.Hash)
+	defer s.HFMacPool.Put(mac)
+	path, err := spath.NewOneHop(isd, origIfid, time.Now(), spath.DefaultHopFExpiry, mac)
+	if err != nil {
+		return nil, err
+	}
+	return path, path.InitOffsets()
+}
+
+// createPld creates a ifid keepalive payload that is signed and packed.
+func (s *Sender) createPld(origIfid common.IFIDType) (common.Payload, error) {
+	pld, err := ctrl.NewPld(&ifid.IFID{OrigIfID: origIfid}, nil)
+	if err != nil {
+		return nil, err
+	}
+	spld, err := s.Signer.Sign(pld)
+	if err != nil {
+		return nil, err
+	}
+	return spld.PackPld()
+}

--- a/go/beacon_srv/internal/keepalive/sender.go
+++ b/go/beacon_srv/internal/keepalive/sender.go
@@ -56,8 +56,8 @@ func (s *Sender) Run(_ context.Context) {
 				Host: addr.SvcBS | addr.SVCMcast,
 			},
 			Ifid:     ifid,
-			Pld:      pld,
 			InfoTime: time.Now(),
+			Pld:      pld,
 		}
 		ov := intf.InternalAddrs.PublicOverlay(intf.InternalAddrs.Overlay)
 		if err := s.Send(msg, ov); err != nil {

--- a/go/beacon_srv/internal/keepalive/sender_test.go
+++ b/go/beacon_srv/internal/keepalive/sender_test.go
@@ -16,7 +16,6 @@ package keepalive
 
 import (
 	"net"
-	"sync"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -38,22 +37,18 @@ import (
 func TestSenderRun(t *testing.T) {
 	setupItopo(t)
 	Convey("Run sends ifid packets on all interfaces", t, func() {
+		mac, err := scrypto.InitMac(make(common.RawBytes, 16))
+		xtest.FailOnErr(t, err)
 		wconn, rconn := p2p.NewPacketConns()
-		// Create sender.
 		s := Sender{
 			Sender: &onehop.Sender{
-				SrcIA: xtest.MustParseIA("1-ff00:0:111"),
-				Conn:  snet.NewSCIONPacketConn(wconn),
+				IA:   xtest.MustParseIA("1-ff00:0:111"),
+				Conn: snet.NewSCIONPacketConn(wconn),
 				Addr: &addr.AppAddr{
 					L3: addr.HostFromIPStr("127.0.0.1"),
 					L4: addr.NewL4UDPInfo(4242),
 				},
-				HFMacPool: &sync.Pool{
-					New: func() interface{} {
-						mac, _ := scrypto.InitMac(make(common.RawBytes, 16))
-						return mac
-					},
-				},
+				MAC: mac,
 			},
 			Signer: testSigner{},
 		}

--- a/go/beacon_srv/internal/keepalive/sender_test.go
+++ b/go/beacon_srv/internal/keepalive/sender_test.go
@@ -1,0 +1,144 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keepalive
+
+import (
+	"hash"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
+	"github.com/scionproto/scion/go/lib/overlay"
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/topology"
+	"github.com/scionproto/scion/go/lib/xtest"
+	"github.com/scionproto/scion/go/lib/xtest/p2p"
+	"github.com/scionproto/scion/go/proto"
+)
+
+func TestSenderRun(t *testing.T) {
+	setupItopo(t)
+	Convey("Run sends ifid packets on all interfaces", t, func() {
+		wconn, rconn := p2p.NewPacketConns()
+		// Create sender.
+		s := Sender{
+			Conn: snet.NewSCIONPacketConn(wconn),
+			Addr: &addr.AppAddr{
+				L3: addr.HostFromIPStr("127.0.0.1"),
+				L4: addr.NewL4UDPInfo(4242),
+			},
+			HFMacPool: &sync.Pool{
+				New: func() interface{} {
+					mac, _ := scrypto.InitMac(make(common.RawBytes, 16))
+					return mac
+				},
+			},
+			Signer: testSigner{},
+		}
+		var pkts []*snet.SCIONPacket
+		done := make(chan struct{})
+		// Read packets from the connection to unblock.
+		go func() {
+			conn := snet.NewSCIONPacketConn(&testConn{rconn})
+			for range itopo.Get().IFInfoMap {
+				pkt := &snet.SCIONPacket{}
+				conn.ReadFrom(pkt, &overlay.OverlayAddr{})
+				pkts = append(pkts, pkt)
+			}
+			close(done)
+		}()
+		// Start keepalive messages.
+		s.Run(nil)
+		<-done
+		SoMsg("Pkts", len(pkts), ShouldEqual, len(itopo.Get().IFInfoMap))
+
+		// Check packets are correct.
+		for _, pkt := range pkts {
+			// Source
+			SoMsg("SrcIA", pkt.Source.IA, ShouldResemble, xtest.MustParseIA("1-ff00:0:111"))
+			SoMsg("SrcHost", pkt.Source.Host, ShouldResemble, addr.HostFromIPStr("127.0.0.1"))
+
+			// Payload
+			spld, err := ctrl.NewSignedPldFromRaw(pkt.Payload.(common.RawBytes))
+			SoMsg("SPldErr", err, ShouldBeNil)
+			pld, err := spld.Pld()
+			SoMsg("PldErr", err, ShouldBeNil)
+			_, ok := itopo.Get().IFInfoMap[pld.IfID.OrigIfID]
+			SoMsg("Intf", ok, ShouldBeTrue)
+			src, err := ctrl.NewSignSrcDefFromRaw(spld.Sign.Src)
+			SoMsg("Src err", err, ShouldBeNil)
+			SoMsg("Src.IA", src.IA, ShouldResemble, xtest.MustParseIA("1-ff00:0:84"))
+			SoMsg("Src.ChainVer", src.ChainVer, ShouldEqual, 42)
+			SoMsg("Src.TrcVer", src.TRCVer, ShouldEqual, 21)
+
+			// Path
+			err = pkt.Path.InitOffsets()
+			SoMsg("InitOffsets", err, ShouldBeNil)
+			info, err := pkt.Path.GetInfoField(pkt.Path.InfOff)
+			SoMsg("InfoErr", err, ShouldBeNil)
+			SoMsg("Info.ISD", info.ISD, ShouldEqual, itopo.Get().ISD_AS.I)
+			SoMsg("Info.Timestamp", time.Now().Sub(info.Timestamp()), ShouldBeLessThan, time.Second)
+			hop, err := pkt.Path.GetHopField(pkt.Path.HopOff)
+			SoMsg("HopErr", err, ShouldBeNil)
+			SoMsg("Hop.Ifid", hop.ConsEgress, ShouldEqual, pld.IfID.OrigIfID)
+			SoMsg("Hop.Verify", hop.Verify(s.HFMacPool.Get().(hash.Hash), info.TsInt, nil),
+				ShouldBeNil)
+			err = pkt.Path.IncOffsets()
+			SoMsg("Path has second hop", err, ShouldBeNil)
+			err = pkt.Path.IncOffsets()
+			SoMsg("Path of length 2", err, ShouldNotBeNil)
+		}
+
+	})
+
+}
+
+func setupItopo(t *testing.T) {
+	itopo.Init("", proto.ServiceType_unset, itopo.Callbacks{})
+	topo, err := topology.LoadFromFile("testdata/topology.json")
+	xtest.FailOnErr(t, err)
+	_, _, err = itopo.SetStatic(topo, true)
+	xtest.FailOnErr(t, err)
+}
+
+// testConn is a packet conn that returns an empty overlay address.
+type testConn struct {
+	net.PacketConn
+}
+
+func (conn *testConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	n, _, err := conn.PacketConn.ReadFrom(b)
+	return n, &overlay.OverlayAddr{}, err
+}
+
+// testSigner is a signer that sets the source.
+type testSigner struct{}
+
+func (testSigner) Sign(pld *ctrl.Pld) (*ctrl.SignedPld, error) {
+	src := &ctrl.SignSrcDef{
+		IA:       xtest.MustParseIA("1-ff00:0:84"),
+		ChainVer: 42,
+		TRCVer:   21,
+	}
+	return ctrl.NewSignedPld(pld, proto.NewSignS(proto.SignType_none, src.Pack()), nil)
+}

--- a/go/beacon_srv/internal/keepalive/testdata/topology.json
+++ b/go/beacon_srv/internal/keepalive/testdata/topology.json
@@ -1,0 +1,52 @@
+{
+  "Overlay": "UDP/IPv4",
+  "MTU": 1472,
+  "ISD_AS": "1-ff00:0:111",
+  "Core": false,
+  "BorderRouters": {
+    "br1-ff00_0_111-1": {
+      "InternalAddrs": {
+        "IPv4": {
+          "PublicOverlay": {
+            "Addr": "127.0.0.17"
+          }
+        }
+      },
+      "CtrlAddr": {
+        "IPv4": {
+          "Public": {
+            "Addr": "127.0.0.17"
+          }
+        }
+      },
+      "Interfaces": {
+        "41": {
+          "RemoteOverlay": {
+            "Addr": "127.0.0.4"
+          },
+          "MTU": 1280,
+          "PublicOverlay": {
+            "Addr": "127.0.0.5"
+          },
+          "Overlay": "UDP/IPv4",
+          "Bandwidth": 1000,
+          "ISD_AS": "1-ff00:0:110",
+          "LinkTo": "PARENT"
+        },
+        "42": {
+            "RemoteOverlay": {
+              "Addr": "127.0.0.4"
+            },
+            "MTU": 1280,
+            "PublicOverlay": {
+              "Addr": "127.0.0.5"
+            },
+            "Overlay": "UDP/IPv4",
+            "Bandwidth": 1000,
+            "ISD_AS": "1-ff00:0:110",
+            "LinkTo": "PARENT"
+          }
+      }
+    }
+  }
+}

--- a/go/beacon_srv/internal/onehop/BUILD.bazel
+++ b/go/beacon_srv/internal/onehop/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["sender.go"],
+    importpath = "github.com/scionproto/scion/go/beacon_srv/internal/onehop",
+    visibility = ["//go/beacon_srv:__subpackages__"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/l4:go_default_library",
+        "//go/lib/layers:go_default_library",
+        "//go/lib/overlay:go_default_library",
+        "//go/lib/snet:go_default_library",
+        "//go/lib/spath:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["sender_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/l4:go_default_library",
+        "//go/lib/layers:go_default_library",
+        "//go/lib/overlay:go_default_library",
+        "//go/lib/scrypto:go_default_library",
+        "//go/lib/snet:go_default_library",
+        "//go/lib/spath:go_default_library",
+        "//go/lib/util:go_default_library",
+        "//go/lib/xtest:go_default_library",
+        "//go/lib/xtest/p2p:go_default_library",
+        "@com_github_smartystreets_goconvey//convey:go_default_library",
+    ],
+)

--- a/go/beacon_srv/internal/onehop/sender.go
+++ b/go/beacon_srv/internal/onehop/sender.go
@@ -1,0 +1,101 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package onehop
+
+import (
+	"hash"
+	"sync"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/l4"
+	"github.com/scionproto/scion/go/lib/layers"
+	"github.com/scionproto/scion/go/lib/overlay"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/spath"
+)
+
+// Path is a one-hop path.
+type Path spath.Path
+
+// Sender is used to send payloads on a one-hop path.
+type Sender struct {
+	// SrcIA is the ISD-AS of the local AS.
+	SrcIA addr.IA
+	// Addr is the address that is set as the source.
+	Addr *addr.AppAddr
+	// Conn is the connection to sent the packets.
+	Conn *snet.SCIONPacketConn
+	// HFMacPool is the mac pool to issue hop fields.
+	HFMacPool *sync.Pool
+}
+
+// Send sends the payload on a one-hop path.
+func (s *Sender) Send(dst snet.SCIONAddress, ifid common.IFIDType, nextHop *overlay.OverlayAddr,
+	pld common.Payload, infoTime time.Time) error {
+
+	pkt, err := s.Pkt(dst, ifid, pld, infoTime)
+	if err != nil {
+		return common.NewBasicError("Unable to create packet", err)
+	}
+	return s.Conn.WriteTo(pkt, nextHop)
+}
+
+// Pkt creates a scion packet with a one-hop path and the payload.
+func (s *Sender) Pkt(dst snet.SCIONAddress, ifid common.IFIDType, pld common.Payload,
+	now time.Time) (*snet.SCIONPacket, error) {
+
+	path, err := s.CreatePath(ifid, now)
+	if err != nil {
+		return nil, err
+	}
+	return s.CreatePkt(dst, path, pld), nil
+}
+
+// CreatePath creates the one-hop path and initializes it.
+func (s *Sender) CreatePath(ifid common.IFIDType, now time.Time) (*Path, error) {
+
+	mac := s.HFMacPool.Get().(hash.Hash)
+	defer s.HFMacPool.Put(mac)
+	path, err := spath.NewOneHop(s.SrcIA.I, ifid, time.Now(), spath.DefaultHopFExpiry, mac)
+	if err != nil {
+		return nil, err
+	}
+	return (*Path)(path), path.InitOffsets()
+}
+
+// CreatePkt creates a scion packet with a one-hop extension, and the
+// provided path and payload.
+func (s *Sender) CreatePkt(dst snet.SCIONAddress, path *Path,
+	pld common.Payload) *snet.SCIONPacket {
+
+	pkt := &snet.SCIONPacket{
+		SCIONPacketInfo: snet.SCIONPacketInfo{
+			Destination: dst,
+			Source: snet.SCIONAddress{
+				IA:   s.SrcIA,
+				Host: s.Addr.L3,
+			},
+			Path:       (*spath.Path)(path),
+			Extensions: []common.Extension{&layers.ExtnOHP{}},
+			L4Header: &l4.UDP{
+				SrcPort: s.Addr.L4.Port(),
+			},
+			Payload: pld,
+		},
+	}
+	return pkt
+}

--- a/go/beacon_srv/internal/onehop/sender_test.go
+++ b/go/beacon_srv/internal/onehop/sender_test.go
@@ -1,0 +1,173 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package onehop
+
+import (
+	"hash"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/l4"
+	"github.com/scionproto/scion/go/lib/layers"
+	"github.com/scionproto/scion/go/lib/overlay"
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/spath"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/lib/xtest"
+	"github.com/scionproto/scion/go/lib/xtest/p2p"
+)
+
+func TestSenderCreatePath(t *testing.T) {
+	Convey("Create Path creates a correct path", t, func() {
+		s := &Sender{
+			SrcIA: xtest.MustParseIA("1-ff00:0:110"),
+			HFMacPool: &sync.Pool{
+				New: func() interface{} {
+					mac, _ := scrypto.InitMac(make(common.RawBytes, 16))
+					return mac
+				},
+			},
+		}
+		now := time.Now()
+		oneHopPath, err := s.CreatePath(12, now)
+		SoMsg("err", err, ShouldBeNil)
+		path := (*spath.Path)(oneHopPath)
+
+		// Info check
+		info, err := path.GetInfoField(path.InfOff)
+		SoMsg("InfoErr", err, ShouldBeNil)
+		SoMsg("Info.ISD", info.ISD, ShouldEqual, s.SrcIA.I)
+		SoMsg("Info.ConsDir", info.ConsDir, ShouldBeTrue)
+		SoMsg("Info.Shortcut", info.Shortcut, ShouldBeFalse)
+		SoMsg("Info.Peer", info.Peer, ShouldBeFalse)
+		SoMsg("Info.TsInt", info.TsInt, ShouldEqual, util.TimeToSecs(now))
+		SoMsg("Info.ISD", info.ISD, ShouldEqual, 1)
+		SoMsg("Info.Hops", info.Hops, ShouldEqual, 2)
+
+		// Hop check
+		hop, err := path.GetHopField(path.HopOff)
+		SoMsg("HopErr", err, ShouldBeNil)
+		SoMsg("Hop.Xover", hop.Xover, ShouldBeFalse)
+		SoMsg("Hop.VerifyOnly", hop.VerifyOnly, ShouldBeFalse)
+		SoMsg("Hop.ExpTime", hop.ExpTime, ShouldEqual, spath.DefaultHopFExpiry)
+		SoMsg("Hop.ConsIngress", hop.ConsIngress, ShouldEqual, 0)
+		SoMsg("Hop.ConsEgress", hop.ConsEgress, ShouldEqual, 12)
+		SoMsg("Hop.Verify", hop.Verify(s.HFMacPool.Get().(hash.Hash), info.TsInt, nil), ShouldBeNil)
+
+		// Second hop field set.
+		err = path.IncOffsets()
+		SoMsg("Path has second hop", err, ShouldBeNil)
+
+		// Path of length 2.
+		err = path.IncOffsets()
+		SoMsg("Path of length 2", err, ShouldNotBeNil)
+	})
+}
+
+func TestSenderPkt(t *testing.T) {
+	Convey("Pkt creates a correct packet", t, func() {
+		s := &Sender{
+			SrcIA: xtest.MustParseIA("1-ff00:0:110"),
+			Addr: &addr.AppAddr{
+				L3: addr.HostFromIPStr("127.0.0.1"),
+				L4: addr.NewL4UDPInfo(4242),
+			},
+			HFMacPool: &sync.Pool{
+				New: func() interface{} {
+					mac, _ := scrypto.InitMac(make(common.RawBytes, 16))
+					return mac
+				},
+			},
+		}
+		dst := snet.SCIONAddress{
+			IA:   xtest.MustParseIA("1-ff00:0:111"),
+			Host: addr.SvcBS,
+		}
+		now := time.Now()
+		pkt, err := s.Pkt(dst, 12, common.RawBytes{1, 2, 3, 4}, now)
+		SoMsg("err", err, ShouldBeNil)
+		checkTestPkt(t, s, 12, dst, now, common.RawBytes{1, 2, 3, 4}, pkt)
+	})
+}
+
+func TestSenderSend(t *testing.T) {
+	Convey("Send sends packet", t, func() {
+		wconn, rconn := p2p.NewPacketConns()
+		s := &Sender{
+			SrcIA: xtest.MustParseIA("1-ff00:0:110"),
+			Conn:  snet.NewSCIONPacketConn(wconn),
+			Addr: &addr.AppAddr{
+				L3: addr.HostFromIPStr("127.0.0.1"),
+				L4: addr.NewL4UDPInfo(4242),
+			},
+			HFMacPool: &sync.Pool{
+				New: func() interface{} {
+					mac, _ := scrypto.InitMac(make(common.RawBytes, 16))
+					return mac
+				},
+			},
+		}
+		// Read from connection to unblock sender.
+		pkt := &snet.SCIONPacket{}
+		done := make(chan struct{})
+		go func() {
+			snet.NewSCIONPacketConn(&testConn{rconn}).ReadFrom(pkt, &overlay.OverlayAddr{})
+			close(done)
+		}()
+		// Create and send packet.
+		dst := snet.SCIONAddress{
+			IA:   xtest.MustParseIA("1-ff00:0:111"),
+			Host: addr.SvcBS,
+		}
+		now := time.Now()
+		err := s.Send(dst, 12, &overlay.OverlayAddr{}, common.RawBytes{1, 2, 3, 4}, now)
+		SoMsg("err", err, ShouldBeNil)
+		<-done
+		checkTestPkt(t, s, 12, dst, now, common.RawBytes{1, 2, 3, 4}, pkt)
+	})
+}
+
+func checkTestPkt(t *testing.T, s *Sender, ifid common.IFIDType, dst snet.SCIONAddress,
+	now time.Time, pld common.Payload, pkt *snet.SCIONPacket) {
+
+	SoMsg("dst", pkt.Destination, ShouldResemble, dst)
+	SoMsg("src", pkt.Source, ShouldResemble, snet.SCIONAddress{
+		IA:   s.SrcIA,
+		Host: addr.HostFromIPStr("127.0.0.1"),
+	})
+	SoMsg("exts", pkt.Extensions, ShouldContain, &layers.ExtnOHP{})
+	SoMsg("l4", pkt.L4Header.(*l4.UDP).SrcPort, ShouldEqual, 4242)
+	SoMsg("pld", pkt.Payload, ShouldResemble, pld)
+	path, err := s.CreatePath(ifid, now)
+	xtest.FailOnErr(t, err)
+	SoMsg("path", pkt.Path, ShouldResemble, (*spath.Path)(path))
+}
+
+// testConn is a packet conn that returns an empty overlay address.
+type testConn struct {
+	net.PacketConn
+}
+
+func (conn *testConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	n, _, err := conn.PacketConn.ReadFrom(b)
+	return n, &overlay.OverlayAddr{}, err
+}

--- a/go/beacon_srv/internal/onehop/sender_test.go
+++ b/go/beacon_srv/internal/onehop/sender_test.go
@@ -93,8 +93,8 @@ func TestSenderCreatePkt(t *testing.T) {
 				Host: addr.SvcBS,
 			},
 			Ifid:     12,
-			Pld:      common.RawBytes{1, 2, 3, 4},
 			InfoTime: time.Now(),
+			Pld:      common.RawBytes{1, 2, 3, 4},
 		}
 		pkt, err := s.CreatePkt(msg)
 		SoMsg("err", err, ShouldBeNil)
@@ -127,8 +127,8 @@ func TestSenderSend(t *testing.T) {
 				Host: addr.SvcBS,
 			},
 			Ifid:     12,
-			Pld:      common.RawBytes{1, 2, 3, 4},
 			InfoTime: time.Now(),
+			Pld:      common.RawBytes{1, 2, 3, 4},
 		}
 		err := s.Send(msg, &overlay.OverlayAddr{})
 		SoMsg("err", err, ShouldBeNil)

--- a/go/lib/spath/BUILD.bazel
+++ b/go/lib/spath/BUILD.bazel
@@ -10,8 +10,10 @@ go_library(
     importpath = "github.com/scionproto/scion/go/lib/spath",
     visibility = ["//visibility:public"],
     deps = [
+        "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/scrypto:go_default_library",
+        "//go/lib/util:go_default_library",
     ],
 )
 
@@ -21,6 +23,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/common:go_default_library",
+        "//go/lib/scrypto:go_default_library",
+        "//go/lib/util:go_default_library",
+        "//go/lib/xtest:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
     ],
 )

--- a/go/lib/spath/path_test.go
+++ b/go/lib/spath/path_test.go
@@ -15,12 +15,16 @@
 package spath
 
 import (
+	"encoding/hex"
 	"fmt"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 type pathCase struct {
@@ -132,4 +136,56 @@ func makeSeg(b common.RawBytes, consDir bool, isd uint16, hops []uint8) {
 			b[InfoFieldLength+i*HopFieldLength+j] = hop
 		}
 	}
+}
+
+func TestNewOneHop(t *testing.T) {
+	// Compute the correct tag.
+	mac, err := scrypto.InitMac(make(common.RawBytes, 16))
+	xtest.FailOnErr(t, err)
+	rawHop, err := hex.DecodeString("00000003000400000b00000000000000")
+	xtest.FailOnErr(t, err)
+	tag, err := scrypto.Mac(mac, rawHop)
+	xtest.FailOnErr(t, err)
+	mac.Reset()
+
+	Convey("The one hop path should be created correctly", t, func() {
+		p, err := NewOneHop(1, 11, util.SecsToTime(3), 4, mac)
+		SoMsg("err", err, ShouldBeNil)
+		err = p.InitOffsets()
+		SoMsg("InitOffsets", err, ShouldBeNil)
+		// Check the info field is set correctly.
+		info, err := p.GetInfoField(p.InfOff)
+		SoMsg("GetInfoField", err, ShouldBeNil)
+		Convey("The info field is correct", func() {
+			SoMsg("ConsDir", info.ConsDir, ShouldBeTrue)
+			SoMsg("Shortcut", info.Shortcut, ShouldBeFalse)
+			SoMsg("Peer", info.Peer, ShouldBeFalse)
+			SoMsg("TsInt", info.TsInt, ShouldEqual, 3)
+			SoMsg("ISD", info.ISD, ShouldEqual, 1)
+			SoMsg("Hops", info.Hops, ShouldEqual, 2)
+		})
+		// Check the first hop field is set correctly.
+		hop, err := p.GetHopField(p.HopOff)
+		SoMsg("GetHopField", err, ShouldBeNil)
+		Convey("The first hop field is correct", func() {
+			SoMsg("Xover", hop.Xover, ShouldBeFalse)
+			SoMsg("VerifyOnly", hop.VerifyOnly, ShouldBeFalse)
+			SoMsg("ExpTime", hop.ExpTime, ShouldEqual, 4)
+			SoMsg("ConsIngress", hop.ConsIngress, ShouldEqual, 0)
+			SoMsg("ConsEgress", hop.ConsEgress, ShouldEqual, 11)
+			SoMsg("Mac", hop.Mac, ShouldResemble, tag[:MacLen])
+		})
+		// Check the path has two hop fields.
+		oldInfoOff := p.InfOff
+		err = p.IncOffsets()
+		SoMsg("IncOffsets", err, ShouldBeNil)
+		SoMsg("Same info field", p.InfOff, ShouldEqual, oldInfoOff)
+		// Check the second hop field is empty.
+		hop, err = p.GetHopField(p.HopOff)
+		SoMsg("GetHopField", err, ShouldBeNil)
+		Convey("The second hop field is empty", func() {
+			SoMsg("hop", hop, ShouldResemble, &HopField{Mac: common.RawBytes{0, 0, 0}})
+		})
+
+	})
 }

--- a/go/lib/spath/path_test.go
+++ b/go/lib/spath/path_test.go
@@ -15,7 +15,6 @@
 package spath
 
 import (
-	"encoding/hex"
 	"fmt"
 	"testing"
 
@@ -139,12 +138,10 @@ func makeSeg(b common.RawBytes, consDir bool, isd uint16, hops []uint8) {
 }
 
 func TestNewOneHop(t *testing.T) {
-	// Compute the correct tag.
 	mac, err := scrypto.InitMac(make(common.RawBytes, 16))
 	xtest.FailOnErr(t, err)
-	rawHop, err := hex.DecodeString("00000003000400000b00000000000000")
-	xtest.FailOnErr(t, err)
-	tag, err := scrypto.Mac(mac, rawHop)
+	// Compute the correct tag for the first hop field.
+	tag, err := (&HopField{ConsEgress: 11, ExpTime: 4}).CalcMac(mac, 3, nil)
 	xtest.FailOnErr(t, err)
 	mac.Reset()
 
@@ -186,6 +183,5 @@ func TestNewOneHop(t *testing.T) {
 		Convey("The second hop field is empty", func() {
 			SoMsg("hop", hop, ShouldResemble, &HopField{Mac: common.RawBytes{0, 0, 0}})
 		})
-
 	})
 }


### PR DESCRIPTION
The keepalive sender periodically sends keepalive messages
on all interfaces.

Additionally, add one-hop creation function to `spath`.

fixes #2567

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2573)
<!-- Reviewable:end -->
