### PR TITLE
Proto: Add beacon to union

### DIFF
--- a/go/lib/ctrl/BUILD.bazel
+++ b/go/lib/ctrl/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//go/lib/ctrl/ifid:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/ctrl/seg:go_default_library",
-        "//go/lib/log:go_default_library",
         "//go/proto:go_default_library",
         "//go/sig/mgmt:go_default_library",
     ],

--- a/go/lib/ctrl/BUILD.bazel
+++ b/go/lib/ctrl/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//go/lib/ctrl/ifid:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/ctrl/seg:go_default_library",
+        "//go/lib/log:go_default_library",
         "//go/proto:go_default_library",
         "//go/sig/mgmt:go_default_library",
     ],

--- a/go/lib/ctrl/ctrl.go
+++ b/go/lib/ctrl/ctrl.go
@@ -83,7 +83,7 @@ func (p *Pld) GetCertMgmt() (*cert_mgmt.Pld, *Data, error) {
 	return certP, p.Data, nil
 }
 
-// GetCertMgmt returns the PathMgmt payload and the CtrlPld's non-union Data.
+// GetPathMgmt returns the PathMgmt payload and the CtrlPld's non-union Data.
 // If the union type is not PathMgmt, an error is returned.
 func (p *Pld) GetPathMgmt() (*path_mgmt.Pld, *Data, error) {
 	u, err := p.Union()

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -45,6 +45,24 @@ type Verifier interface {
 	Verify(ctx context.Context, packedSegment common.RawBytes, sign *proto.SignS) error
 }
 
+var _ proto.Cerealizable = (*Beacon)(nil)
+
+// Beacon is kept for compatibility with python code.
+type Beacon struct {
+	Segment *PathSegment `capnp:"pathSeg"`
+}
+
+func (b *Beacon) ProtoId() proto.ProtoIdType {
+	return proto.PCB_TypeID
+}
+
+func (b *Beacon) String() string {
+	if b == nil {
+		return "<nil>"
+	}
+	return b.Segment.String()
+}
+
 var _ proto.Cerealizable = (*PathSegment)(nil)
 
 type PathSegment struct {

--- a/go/lib/ctrl/union.go
+++ b/go/lib/ctrl/union.go
@@ -29,23 +29,23 @@ import (
 
 // union represents the contents of the unnamed capnp union.
 type union struct {
-	Which       proto.CtrlPld_Which
-	PathSegment *seg.PathSegment `capnp:"pcb"`
-	IfID        *ifid.IFID       `capnp:"ifid"`
-	CertMgmt    *cert_mgmt.Pld
-	PathMgmt    *path_mgmt.Pld
-	Sibra       []byte `capnp:"-"` // Omit for now
-	DRKeyMgmt   []byte `capnp:"-"` // Omit for now
-	Sig         *sigmgmt.Pld
-	Extn        *extn.CtrlExtnDataList
-	Ack         *ack.Ack
+	Which     proto.CtrlPld_Which
+	Beacon    *seg.Beacon `capnp:"pcb"`
+	IfID      *ifid.IFID  `capnp:"ifid"`
+	CertMgmt  *cert_mgmt.Pld
+	PathMgmt  *path_mgmt.Pld
+	Sibra     []byte `capnp:"-"` // Omit for now
+	DRKeyMgmt []byte `capnp:"-"` // Omit for now
+	Sig       *sigmgmt.Pld
+	Extn      *extn.CtrlExtnDataList
+	Ack       *ack.Ack
 }
 
 func (u *union) set(c proto.Cerealizable) error {
 	switch p := c.(type) {
-	case *seg.PathSegment:
+	case *seg.Beacon:
 		u.Which = proto.CtrlPld_Which_pcb
-		u.PathSegment = p
+		u.Beacon = p
 	case *ifid.IFID:
 		u.Which = proto.CtrlPld_Which_ifid
 		u.IfID = p
@@ -74,7 +74,7 @@ func (u *union) set(c proto.Cerealizable) error {
 func (u *union) get() (proto.Cerealizable, error) {
 	switch u.Which {
 	case proto.CtrlPld_Which_pcb:
-		return u.PathSegment, nil
+		return u.Beacon, nil
 	case proto.CtrlPld_Which_ifid:
 		return u.IfID, nil
 	case proto.CtrlPld_Which_pathMgmt:

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -908,7 +908,7 @@ func validate(pld *ctrl.Pld) (infra.MessageType, proto.Cerealizable, error) {
 	// package are supported.
 	switch pld.Which {
 	case proto.CtrlPld_Which_pcb:
-		return infra.Seg, pld.PathSegment, nil
+		return infra.Seg, pld.Beacon.Segment, nil
 	case proto.CtrlPld_Which_ifid:
 		return infra.IfId, pld.IfID, nil
 	case proto.CtrlPld_Which_certMgmt:

--- a/go/lib/spath/BUILD.bazel
+++ b/go/lib/spath/BUILD.bazel
@@ -19,7 +19,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["path_test.go"],
+    srcs = [
+        "hop_test.go",
+        "path_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//go/lib/common:go_default_library",

--- a/go/lib/spath/hop.go
+++ b/go/lib/spath/hop.go
@@ -177,10 +177,10 @@ func (h *HopField) Equal(o *HopField) bool {
 
 type ExpTimeType uint8
 
-// ExpTimeFromDuration converts the relative expiration time from a
-// duration. The duration is rounded down to the next unit. If the duration
-// is smaller as the unit, the returned value is 0. If it is larger than
-// the 255 * unit, 255 is returned.
+// ExpTimeFromDuration converts a time duration to the relative expiration
+// time. The duration is rounded down to the next unit. If the duration is
+// smaller than the unit, the returned value is 0. If it is larger than the
+// maximum value, 255 is returned.
 func ExpTimeFromDuration(duration time.Duration) ExpTimeType {
 	unit := time.Duration(ExpTimeUnit) * time.Second
 	if duration < unit {

--- a/go/lib/spath/hop.go
+++ b/go/lib/spath/hop.go
@@ -183,17 +183,19 @@ type ExpTimeType uint8
 //
 // Round Up Mode:
 //
-// When rounding up is enabled, the duration is rounded up to the next unit
-// minus one, e.g. 1.3 is rounded to 1. In case the requested duration
-// exceeds the maximum value for the expiration time (256*Unit) in this
-// mode, an error is returned.
+// The round up mode guarantees that the resulting relative expiration time
+// is more than the provided duration. The duration is rounded up to the
+// next unit, and then 1 is subtracted from the result, e.g. 1.3 is rounded
+// to 1. In case the requested duration exceeds the maximum value for the
+// expiration time (256*Unit) in this mode, an error is returned.
 //
 // Round Down Mode:
 //
-// When rounding down is disabled, the duration is rounded down to the next
-// unit minus one, e.g. 1.3 is rounded to 0. In case the requested duration
-// is below the unit for the expiration time in this mode, an error is
-// returned.
+// The round down mode guarantees that the resulting relative expiration
+// time is less than the provided duration. The duration is rounded down to
+// the next unit, and then 1 is subtracted from the result, e.g. 1.3 is
+// rounded to 0. In case the requested duration is below the unit for the
+// expiration time in this mode, an error is returned.
 func ExpTimeFromDuration(duration time.Duration, roundUp bool) (ExpTimeType, error) {
 	unit := time.Duration(ExpTimeUnit) * time.Second
 	if duration > (time.Duration(MaxTTLField)+1)*unit {

--- a/go/lib/spath/hop_test.go
+++ b/go/lib/spath/hop_test.go
@@ -121,23 +121,27 @@ func TestExpTimeType(t *testing.T) {
 			Rounded: true,
 		},
 	}
-	Convey("Test conversion from duration", t, func() {
+	Convey("Conversion from duration to relative expiration time should be correct", t, func() {
 		for _, test := range tests {
 			Convey(test.Name, func() {
-				expTime, err := ExpTimeFromDuration(test.Duration, true)
-				xtest.SoMsgError("Round Up err", err, test.RoundUp.ExpErr)
-				if !test.RoundUp.ExpErr {
-					SoMsg("Round Up ExpTime", expTime, ShouldEqual, test.RoundUp.ExpTime)
-				}
-				expTime, err = ExpTimeFromDuration(test.Duration, false)
-				xtest.SoMsgError("Round Down err", err, test.RoundDown.ExpErr)
-				if !test.RoundDown.ExpErr {
-					SoMsg("Round Down ExpTime", expTime, ShouldEqual, test.RoundDown.ExpTime)
-				}
+				Convey("Rounding up", func() {
+					expTime, err := ExpTimeFromDuration(test.Duration, true)
+					xtest.SoMsgError("err", err, test.RoundUp.ExpErr)
+					if !test.RoundUp.ExpErr {
+						SoMsg("ExpTime", expTime, ShouldEqual, test.RoundUp.ExpTime)
+					}
+				})
+				Convey("Rounding down", func() {
+					expTime, err := ExpTimeFromDuration(test.Duration, false)
+					xtest.SoMsgError("err", err, test.RoundDown.ExpErr)
+					if !test.RoundDown.ExpErr {
+						SoMsg("ExpTime", expTime, ShouldEqual, test.RoundDown.ExpTime)
+					}
+				})
 			})
 		}
 	})
-	Convey("Test conversion to duration", t, func() {
+	Convey("Conversion from relative expiration time to duration should be correct", t, func() {
 		for _, test := range tests {
 			if !test.Rounded {
 				Convey(test.Name, func() {

--- a/go/lib/spath/hop_test.go
+++ b/go/lib/spath/hop_test.go
@@ -1,0 +1,77 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spath
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestExpTimeType(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Duration time.Duration
+		ExpTime  ExpTimeType
+		Rounded  bool
+	}{
+		{
+			Name:     "Smaller than unit",
+			Duration: 300 * time.Second,
+			ExpTime:  0,
+			Rounded:  true,
+		},
+		{
+			Name:     "Exactly the unit",
+			Duration: 337 * time.Second,
+			ExpTime:  0,
+		},
+		{
+			Name:     "Round down to unit",
+			Duration: 400 * time.Second,
+			ExpTime:  0,
+			Rounded:  true,
+		},
+		{
+			Name:     "Maximum expiration time",
+			Duration: 86272 * time.Second,
+			ExpTime:  255,
+		},
+		{
+			Name:     "Round down maximum expiration time",
+			Duration: 87000 * time.Second,
+			ExpTime:  255,
+			Rounded:  true,
+		},
+	}
+	Convey("Test conversion from duration", t, func() {
+		for _, test := range tests {
+			Convey(test.Name, func() {
+				expTime := ExpTimeFromDuration(test.Duration)
+				SoMsg("ExpTime", expTime, ShouldEqual, test.ExpTime)
+			})
+		}
+	})
+	Convey("Test conversion to duration", t, func() {
+		for _, test := range tests {
+			if !test.Rounded {
+				Convey(test.Name, func() {
+					SoMsg("ExpTime", test.ExpTime.ToDuration(), ShouldEqual, test.Duration)
+				})
+			}
+		}
+	})
+}


### PR DESCRIPTION
The pcb in the ctrl pld union should be `path_seg.PCB` instead of
`path_seg.PathSegment`.

This change is made to keep compatibility to python code.

Additionally, add `time.Duration` to `ExpTimeType` conversion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2583)
<!-- Reviewable:end -->
