### PR TITLE
Lint: Ensure bazel files are consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ bazel: vendor
 	sudo setcap cap_net_admin,cap_net_raw+ep bin/braccept
 
 gazelle:
-	gazelle update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor ./go
+	bazel run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build ./go
 
 # Order is important
 clibs: libscion libfilter

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: all clean clibs libscion libfilter dispatcher uninstall tags vendor
 
+GAZELLE_MODE?=fix
+
 SRC_DIRS = c/lib/scion c/lib/filter c/dispatcher
 
 all: tags clibs dispatcher bazel
@@ -19,7 +21,7 @@ bazel: vendor
 	sudo setcap cap_net_admin,cap_net_raw+ep bin/braccept
 
 gazelle:
-	gazelle update -index=false -external=external -exclude go/vendor ./go
+	gazelle update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor ./go
 
 # Order is important
 clibs: libscion libfilter

--- a/go/lib/infra/modules/trust/trustdb/mock_trustdb/BUILD.bazel
+++ b/go/lib/infra/modules/trust/trustdb/mock_trustdb/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/infra/modules/trust/trustdb:go_default_library",
         "//go/lib/scrypto/cert:go_default_library",
         "//go/lib/scrypto/trc:go_default_library",

--- a/go/lib/infra/modules/trust/trustdb/trustdbsqlite/BUILD.bazel
+++ b/go/lib/infra/modules/trust/trustdb/trustdbsqlite/BUILD.bazel
@@ -22,7 +22,6 @@ go_test(
     srcs = ["db_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//go/lib/infra/modules/trust/trustdb:go_default_library",
         "//go/lib/infra/modules/trust/trustdb/trustdbtest:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",

--- a/go/tools/scion-custpk-load/BUILD.bazel
+++ b/go/tools/scion-custpk-load/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/common:go_default_library",
+        "//go/lib/infra/modules/trust/trustdb:go_default_library",
         "//go/lib/infra/modules/trust/trustdb/mock_trustdb:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",

--- a/nogo.json
+++ b/nogo.json
@@ -1,4 +1,14 @@
 {
+  "assign": {
+    "exclude_files": {
+      "gazelle/walk/walk.go": ""
+    }
+  },
+  "composites": {
+    "exclude_files": {
+      "gazelle/language/go/resolve.go": ""
+    }
+  },
   "printf": {
     "exclude_files": {
       "/com_github_antlr_antlr4/runtime/Go/antlr/": "",

--- a/scion.sh
+++ b/scion.sh
@@ -308,6 +308,8 @@ go_lint() {
     if [ -n "$out" ]; then echo "$out"; ret=1; fi
     echo "======> misspell"
     $TMPDIR/misspell -error $LOCAL_DIRS || ret=1
+    echo "======> bazel"
+    make gazelle GAZELLE_MODE=diff || ret=1
     # Clean up the binaries
     rm -rf $TMPDIR
     return $ret


### PR DESCRIPTION
This PR changes the linter to ensure that the bazel files
do not differ from the auto generated files.

fixes #2582

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2590)
<!-- Reviewable:end -->
