### PR TITLE
BS: Implement beacon originator

### DIFF
--- a/go/beacon_srv/internal/propagation/BUILD.bazel
+++ b/go/beacon_srv/internal/propagation/BUILD.bazel
@@ -1,0 +1,53 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "config.go",
+        "originator.go",
+    ],
+    importpath = "github.com/scionproto/scion/go/beacon_srv/internal/propagation",
+    visibility = ["//go/beacon_srv:__subpackages__"],
+    deps = [
+        "//go/beacon_srv/internal/ifstate:go_default_library",
+        "//go/beacon_srv/internal/onehop:go_default_library",
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/ctrl:go_default_library",
+        "//go/lib/ctrl/seg:go_default_library",
+        "//go/lib/infra:go_default_library",
+        "//go/lib/log:go_default_library",
+        "//go/lib/periodic:go_default_library",
+        "//go/lib/snet:go_default_library",
+        "//go/lib/spath:go_default_library",
+        "//go/lib/topology:go_default_library",
+        "//go/lib/util:go_default_library",
+        "//go/proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["originator_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
+    deps = [
+        "//go/beacon_srv/internal/ifstate:go_default_library",
+        "//go/beacon_srv/internal/onehop:go_default_library",
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/ctrl:go_default_library",
+        "//go/lib/infra:go_default_library",
+        "//go/lib/infra/modules/itopo:go_default_library",
+        "//go/lib/infra/modules/trust:go_default_library",
+        "//go/lib/overlay:go_default_library",
+        "//go/lib/scrypto:go_default_library",
+        "//go/lib/snet:go_default_library",
+        "//go/lib/spath:go_default_library",
+        "//go/lib/topology:go_default_library",
+        "//go/lib/xtest:go_default_library",
+        "//go/lib/xtest/p2p:go_default_library",
+        "//go/proto:go_default_library",
+        "@com_github_smartystreets_goconvey//convey:go_default_library",
+    ],
+)

--- a/go/beacon_srv/internal/propagation/config.go
+++ b/go/beacon_srv/internal/propagation/config.go
@@ -1,0 +1,55 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propagation
+
+import (
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/infra"
+)
+
+const (
+	// DefaultIfidSize is the default bit-size for ifids in the hop-fields.
+	DefaultIfidSize = 12
+)
+
+type Config struct {
+	// Signer is used to sign path segments.
+	Signer infra.Signer
+	// IfidSize is the bit-size of the ifid in the hop-fields.
+	IfidSize uint8
+	// MTU is the MTU value set in the AS entries.
+	MTU uint16
+}
+
+// InitDefaults initializes the default values, if not set.
+func (cfg *Config) InitDefaults() {
+	if cfg.IfidSize == 0 {
+		cfg.IfidSize = DefaultIfidSize
+	}
+}
+
+// Validate checks that the config contains a signer.
+func (cfg *Config) Validate() error {
+	if cfg.Signer == nil {
+		return common.NewBasicError("Signer must be set", nil)
+	}
+	if cfg.IfidSize == 0 {
+		return common.NewBasicError("IfidSize must be set", nil)
+	}
+	if cfg.MTU == 0 {
+		return common.NewBasicError("MTU must be set", nil)
+	}
+	return nil
+}

--- a/go/beacon_srv/internal/propagation/config.go
+++ b/go/beacon_srv/internal/propagation/config.go
@@ -17,6 +17,7 @@ package propagation
 import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/spath"
 )
 
 const (
@@ -27,16 +28,25 @@ const (
 type Config struct {
 	// Signer is used to sign path segments.
 	Signer infra.Signer
-	// IfidSize is the bit-size of the ifid in the hop-fields.
-	IfidSize uint8
 	// MTU is the MTU value set in the AS entries.
 	MTU uint16
+	// IfidSize is the bit-size of the ifid in the hop-fields.
+	IfidSize uint8
+	// MaxExpTime is the maximum relative expiration time.
+	MaxExpTime *spath.ExpTimeType
+	// maxExpTime is a copy of MaxExpTime to avoid using the captured
+	// reference from the calling code.
+	maxExpTime spath.ExpTimeType
 }
 
 // InitDefaults initializes the default values, if not set.
 func (cfg *Config) InitDefaults() {
 	if cfg.IfidSize == 0 {
 		cfg.IfidSize = DefaultIfidSize
+	}
+	if cfg.MaxExpTime == nil {
+		expiry := spath.DefaultHopFExpiry
+		cfg.MaxExpTime = &expiry
 	}
 }
 
@@ -51,5 +61,9 @@ func (cfg *Config) Validate() error {
 	if cfg.MTU == 0 {
 		return common.NewBasicError("MTU must be set", nil)
 	}
+	if cfg.MaxExpTime == nil {
+		return common.NewBasicError("MaxExpTime must be set", nil)
+	}
+	cfg.maxExpTime = *cfg.MaxExpTime
 	return nil
 }

--- a/go/beacon_srv/internal/propagation/originator.go
+++ b/go/beacon_srv/internal/propagation/originator.go
@@ -1,0 +1,207 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propagation
+
+import (
+	"context"
+	"time"
+
+	"github.com/scionproto/scion/go/beacon_srv/internal/ifstate"
+	"github.com/scionproto/scion/go/beacon_srv/internal/onehop"
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/ctrl/seg"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/periodic"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/spath"
+	"github.com/scionproto/scion/go/lib/topology"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/proto"
+)
+
+var _ periodic.Task = (*Originator)(nil)
+
+// Originator originates beacons. It should only be used by core ASes.
+type Originator struct {
+	sender  *onehop.Sender
+	cfg     Config
+	ifState *ifstate.Infos
+}
+
+// NewOriginator creates a new originator. It takes ownership of the
+// one-hop sender.
+func NewOriginator(infos *ifstate.Infos, cfg Config, sender *onehop.Sender) (*Originator, error) {
+	cfg.InitDefaults()
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	o := &Originator{
+		sender:  sender,
+		cfg:     cfg,
+		ifState: infos,
+	}
+	return o, nil
+}
+
+// Run originates core and downstream beacons.
+func (o *Originator) Run(_ context.Context) {
+	infos := o.ifState.All()
+	o.originateBeacons(infos, proto.LinkType_core)
+	o.originateBeacons(infos, proto.LinkType_child)
+}
+
+// originateBeacons creates and sends a beacon for each active interface of
+// the specified link type.
+func (o *Originator) originateBeacons(infos map[common.IFIDType]*ifstate.Info, lt proto.LinkType) {
+	infoF := o.createInfoF(time.Now())
+	for ifid, info := range infos {
+		intf := info.TopoInfo()
+		if intf.LinkType != lt {
+			continue
+		}
+		state := info.State()
+		if state != ifstate.Active {
+			log.Debug("[Originator] Skipping non-active interface", "ifid", ifid, "state", state)
+			continue
+		}
+		msg, err := o.createBeaconMsg(ifid, intf, infoF)
+		if err != nil {
+			log.Error("[Originator] Skipping interface on error", "ifid", ifid, "err", err)
+			continue
+		}
+		ov := intf.InternalAddrs.PublicOverlay(intf.InternalAddrs.Overlay)
+		if err := o.sender.Send(msg, ov); err != nil {
+			log.Error("[Originator] Unable to send packet", "ifid", "err", err)
+		}
+	}
+}
+
+// crateInfoF creates the info field.
+func (o *Originator) createInfoF(now time.Time) spath.InfoField {
+	infoF := spath.InfoField{
+		ConsDir: true,
+		ISD:     uint16(o.sender.IA.I),
+		TsInt:   util.TimeToSecs(now),
+	}
+	return infoF
+}
+
+// createBeaconMsg creates a beacon for the given interface, signs it and
+// wraps it in a one-hop message.
+func (o *Originator) createBeaconMsg(ifid common.IFIDType, intf topology.IFInfo,
+	infoF spath.InfoField) (*onehop.Msg, error) {
+
+	bseg, err := o.createBeacon(ifid, intf, infoF)
+	if err != nil {
+		return nil, common.NewBasicError("Unable to create beacon", err, "ifid", ifid)
+	}
+	pld, err := ctrl.NewPld(bseg, nil)
+	if err != nil {
+		return nil, common.NewBasicError("Unable to create payload", err)
+	}
+	spld, err := pld.SignedPld(o.cfg.Signer)
+	if err != nil {
+		return nil, common.NewBasicError("Unable to sign payload", err)
+	}
+	packed, err := spld.PackPld()
+	if err != nil {
+		return nil, common.NewBasicError("Unable to pack payload", err)
+	}
+	msg := &onehop.Msg{
+		Dst: snet.SCIONAddress{
+			IA:   intf.ISD_AS,
+			Host: addr.SvcBS,
+		},
+		Ifid:     ifid,
+		InfoTime: time.Now(),
+		Pld:      packed,
+	}
+	return msg, nil
+}
+
+func (o *Originator) createBeacon(ifid common.IFIDType, intf topology.IFInfo,
+	infoF spath.InfoField) (*seg.Beacon, error) {
+
+	bseg, err := seg.NewSeg(&infoF)
+	if err != nil {
+		return nil, err
+	}
+	hopEntries, err := o.createHopEntry(ifid, intf, infoF.Timestamp())
+	if err != nil {
+		return nil, err
+	}
+	meta := o.cfg.Signer.Meta()
+	asEntry := &seg.ASEntry{
+		RawIA:      meta.Src.IA.IAInt(),
+		CertVer:    meta.Src.ChainVer,
+		TrcVer:     meta.Src.TRCVer,
+		IfIDSize:   o.cfg.IfidSize,
+		MTU:        o.cfg.MTU,
+		HopEntries: hopEntries,
+	}
+	if err := bseg.AddASEntry(asEntry, o.cfg.Signer); err != nil {
+		return nil, err
+	}
+	return &seg.Beacon{Segment: bseg}, nil
+}
+
+func (o *Originator) createHopEntry(ifid common.IFIDType, intf topology.IFInfo,
+	ts time.Time) ([]*seg.HopEntry, error) {
+
+	if intf.RemoteIFID == 0 {
+		return nil, common.NewBasicError("Remote ifid is not set", nil)
+	}
+	if intf.ISD_AS.IsWildcard() {
+		return nil, common.NewBasicError("Remote IA is wildcard", nil, "ia", intf.ISD_AS)
+	}
+	rawHopF, err := o.createRawHop(ifid, ts)
+	if err != nil {
+		return nil, err
+	}
+	hop := &seg.HopEntry{
+		RawHopField: rawHopF,
+		RawOutIA:    intf.ISD_AS.IAInt(),
+		RemoteOutIF: intf.RemoteIFID,
+	}
+	return []*seg.HopEntry{hop}, nil
+}
+
+func (o *Originator) createRawHop(ifid common.IFIDType, ts time.Time) (common.RawBytes, error) {
+	meta := o.cfg.Signer.Meta()
+	diff := meta.ExpTime.Sub(ts)
+	if diff < 30*time.Minute {
+		log.Warn("[Originator] Signer expiration time is near",
+			"chainExpiration", meta.ExpTime, "src", meta.Src)
+	}
+	expiry, err := spath.ExpTimeFromDuration(diff, false)
+	if err != nil {
+		min := ts.Add(spath.ExpTimeType(0).ToDuration())
+		return nil, common.NewBasicError("Chain does not cover minimum hop expiration time", nil,
+			"minimumExpiration", min, "chainExpiration", meta.ExpTime, "src", meta.Src)
+	}
+	if expiry > spath.DefaultHopFExpiry {
+		expiry = spath.DefaultHopFExpiry
+	}
+	hop := &spath.HopField{
+		ConsEgress: ifid,
+		ExpTime:    expiry,
+	}
+	if hop.Mac, err = hop.CalcMac(o.sender.MAC, util.TimeToSecs(ts), nil); err != nil {
+		return nil, common.NewBasicError("Unable to create MAC", err)
+	}
+	return hop.Pack(), nil
+}

--- a/go/beacon_srv/internal/propagation/originator_test.go
+++ b/go/beacon_srv/internal/propagation/originator_test.go
@@ -101,13 +101,11 @@ func TestOriginatorRun(t *testing.T) {
 			SoMsg("SPldErr", err, ShouldBeNil)
 			pld, err := spld.UnsafePld()
 			SoMsg("PldErr", err, ShouldBeNil)
-			pseg := pld.Beacon.Segment
-			SoMsg("pseg", pseg, ShouldNotBeNil)
-			err = pseg.ParseRaw(true)
+			err = pld.Beacon.Parse()
 			SoMsg("ParseErr", err, ShouldBeNil)
 
 			// Check the as entry is verifiable and the source is set correctly.
-			err = pseg.VerifyASEntry(context.Background(), segVerifier(pub), 0)
+			err = pld.Beacon.Segment.VerifyASEntry(context.Background(), segVerifier(pub), 0)
 			SoMsg("VerifyErr", err, ShouldBeNil)
 			src, err := ctrl.NewSignSrcDefFromRaw(spld.Sign.Src)
 			SoMsg("Src err", err, ShouldBeNil)
@@ -116,7 +114,7 @@ func TestOriginatorRun(t *testing.T) {
 			SoMsg("Src.TrcVer", src.TRCVer, ShouldEqual, 84)
 
 			// Check the AS entry is set correctly.
-			entry := pseg.ASEntries[0]
+			entry := pld.Beacon.Segment.ASEntries[0]
 			SoMsg("ChainVer", entry.CertVer, ShouldEqual, 42)
 			SoMsg("TRCVer", entry.TrcVer, ShouldEqual, 84)
 			SoMsg("IfIDSize", entry.IfIDSize, ShouldEqual, DefaultIfidSize)
@@ -128,7 +126,7 @@ func TestOriginatorRun(t *testing.T) {
 			// Check the hop field is set correctly.
 			hopF, err := spath.HopFFromRaw(hop.RawHopField)
 			SoMsg("Parse hop field", err, ShouldBeNil)
-			infoF, err := pseg.InfoF()
+			infoF, err := pld.Beacon.Segment.InfoF()
 			SoMsg("Parse info field", err, ShouldBeNil)
 			SoMsg("hopF.ConsIngress", hopF.ConsIngress, ShouldBeZeroValue)
 			SoMsg("hopF.Mac", hopF.Verify(o.sender.MAC, infoF.TsInt, nil), ShouldBeNil)

--- a/go/beacon_srv/internal/propagation/originator_test.go
+++ b/go/beacon_srv/internal/propagation/originator_test.go
@@ -1,0 +1,182 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package propagation
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/beacon_srv/internal/ifstate"
+	"github.com/scionproto/scion/go/beacon_srv/internal/onehop"
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust"
+	"github.com/scionproto/scion/go/lib/overlay"
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/spath"
+	"github.com/scionproto/scion/go/lib/topology"
+	"github.com/scionproto/scion/go/lib/xtest"
+	"github.com/scionproto/scion/go/lib/xtest/p2p"
+	"github.com/scionproto/scion/go/proto"
+)
+
+func TestOriginatorRun(t *testing.T) {
+	setupItopo(t)
+	Convey("Run originates ifid packets on all core and child interfaces", t, func() {
+		mac, err := scrypto.InitMac(make(common.RawBytes, 16))
+		xtest.FailOnErr(t, err)
+		infos := ifstate.NewInfos(itopo.Get().IFInfoMap, ifstate.Config{})
+		pub, priv, err := scrypto.GenKeyPair(scrypto.Ed25519)
+		xtest.FailOnErr(t, err)
+		wconn, rconn := p2p.NewPacketConns()
+
+		signer, err := trust.NewBasicSigner(priv, infra.SignerMeta{
+			Src: ctrl.SignSrcDef{
+				ChainVer: 42,
+				TRCVer:   84,
+				IA:       xtest.MustParseIA("1-ff00:0:110"),
+			},
+			Algo:    scrypto.Ed25519,
+			ExpTime: time.Now().Add(time.Hour),
+		})
+		xtest.FailOnErr(t, err)
+
+		msg := common.RawBytes{1, 2, 3, 4, 5}
+		sign, err := signer.Sign(msg)
+		signn, err := scrypto.Sign(msg, priv, scrypto.Ed25519)
+		xtest.FailOnErr(t, err)
+		err = segVerifier(pub).Verify(context.Background(), msg, sign)
+		xtest.FailOnErr(t, err)
+		err = scrypto.Verify(msg, signn, pub, scrypto.Ed25519)
+
+		o, err := NewOriginator(infos,
+			Config{
+				MTU:    uint16(itopo.Get().MTU),
+				Signer: signer,
+			},
+			&onehop.Sender{
+				IA:   xtest.MustParseIA("1-ff00:0:110"),
+				Conn: snet.NewSCIONPacketConn(wconn),
+				Addr: &addr.AppAddr{
+					L3: addr.HostFromIPStr("127.0.0.1"),
+					L4: addr.NewL4UDPInfo(4242),
+				},
+				MAC: mac,
+			},
+		)
+		var pkts []*snet.SCIONPacket
+		done := make(chan struct{})
+		// Read packets from the connection to unblock sender.
+		go func() {
+			conn := snet.NewSCIONPacketConn(&testConn{rconn})
+			for range itopo.Get().IFInfoMap {
+				pkt := &snet.SCIONPacket{}
+				conn.ReadFrom(pkt, &overlay.OverlayAddr{})
+				pkts = append(pkts, pkt)
+			}
+			close(done)
+		}()
+		infos.Get(41).Activate(82)
+		infos.Get(42).Activate(84)
+		// Start beacon messages.
+		o.Run(nil)
+		<-done
+		SoMsg("Pkts", len(pkts), ShouldEqual, len(itopo.Get().IFInfoMap))
+		for _, pkt := range pkts {
+			// Extract segment from the payload
+			spld, err := ctrl.NewSignedPldFromRaw(pkt.Payload.(common.RawBytes))
+			SoMsg("SPldErr", err, ShouldBeNil)
+			pld, err := spld.UnsafePld()
+			SoMsg("PldErr", err, ShouldBeNil)
+			pseg := pld.Beacon.Segment
+			SoMsg("pseg", pseg, ShouldNotBeNil)
+			err = pseg.ParseRaw(true)
+			SoMsg("ParseErr", err, ShouldBeNil)
+			// Check the as entry is verifiable and the source is set correctly.
+			err = pseg.VerifyASEntry(context.Background(), segVerifier(pub), 0)
+			SoMsg("VerifyErr", err, ShouldBeNil)
+			src, err := ctrl.NewSignSrcDefFromRaw(spld.Sign.Src)
+			SoMsg("Src err", err, ShouldBeNil)
+			SoMsg("Src.IA", src.IA, ShouldResemble, xtest.MustParseIA("1-ff00:0:110"))
+			SoMsg("Src.ChainVer", src.ChainVer, ShouldEqual, 42)
+			SoMsg("Src.TrcVer", src.TRCVer, ShouldEqual, 84)
+
+			// Check the AS entry is set correctly.
+			entry := pseg.ASEntries[0]
+			SoMsg("ChainVer", entry.CertVer, ShouldEqual, 42)
+			SoMsg("TRCVer", entry.TrcVer, ShouldEqual, 84)
+			SoMsg("IfIDSize", entry.IfIDSize, ShouldEqual, DefaultIfidSize)
+			SoMsg("MTU", entry.MTU, ShouldEqual, itopo.Get().MTU)
+			SoMsg("IA", entry.IA(), ShouldResemble, o.sender.IA)
+			SoMsg("HopEntries length", len(entry.HopEntries), ShouldEqual, 1)
+			hop := entry.HopEntries[0]
+
+			// Check the hop field is set correctly.
+			hopF, err := spath.HopFFromRaw(hop.RawHopField)
+			SoMsg("Parse hop field", err, ShouldBeNil)
+			infoF, err := pseg.InfoF()
+			SoMsg("Parse info field", err, ShouldBeNil)
+			SoMsg("hopF.ConsIngress", hopF.ConsIngress, ShouldBeZeroValue)
+			SoMsg("hopF.Mac", hopF.Verify(o.sender.MAC, infoF.TsInt, nil), ShouldBeNil)
+			expiry, err := spath.ExpTimeFromDuration(
+				signer.Meta().ExpTime.Sub(infoF.Timestamp()), false)
+			xtest.FailOnErr(t, err)
+			SoMsg("hopF.ExpTime", hopF.ExpTime, ShouldEqual, expiry)
+
+			// Check the hop entry is set correctly.
+			intf := infos.Get(hopF.ConsEgress)
+			SoMsg("Intf exists", intf, ShouldNotBeNil)
+			SoMsg("Hop.InIA", hop.InIA(), ShouldResemble, addr.IA{})
+			SoMsg("Hop.InIf", hop.RemoteInIF, ShouldBeZeroValue)
+			SoMsg("hop.InMTU", hop.InMTU, ShouldBeZeroValue)
+			SoMsg("Hop.OutIA", hop.OutIA(), ShouldResemble, intf.TopoInfo().ISD_AS)
+			SoMsg("Hop.OutIf", hop.RemoteOutIF, ShouldResemble, intf.TopoInfo().RemoteIFID)
+
+		}
+	})
+}
+
+func setupItopo(t *testing.T) {
+	itopo.Init("", proto.ServiceType_unset, itopo.Callbacks{})
+	topo, err := topology.LoadFromFile("testdata/topology.json")
+	xtest.FailOnErr(t, err)
+	_, _, err = itopo.SetStatic(topo, true)
+	xtest.FailOnErr(t, err)
+}
+
+type segVerifier common.RawBytes
+
+func (v segVerifier) Verify(_ context.Context, msg common.RawBytes, sign *proto.SignS) error {
+	return scrypto.Verify(sign.SigInput(msg, false), sign.Signature,
+		common.RawBytes(v), scrypto.Ed25519)
+}
+
+// testConn is a packet conn that returns an empty overlay address.
+type testConn struct {
+	net.PacketConn
+}
+
+func (conn *testConn) ReadFrom(b []byte) (int, net.Addr, error) {
+	n, _, err := conn.PacketConn.ReadFrom(b)
+	return n, &overlay.OverlayAddr{}, err
+}

--- a/go/beacon_srv/internal/propagation/originator_test.go
+++ b/go/beacon_srv/internal/propagation/originator_test.go
@@ -112,6 +112,7 @@ func TestOriginatorRun(t *testing.T) {
 			SoMsg("pseg", pseg, ShouldNotBeNil)
 			err = pseg.ParseRaw(true)
 			SoMsg("ParseErr", err, ShouldBeNil)
+
 			// Check the as entry is verifiable and the source is set correctly.
 			err = pseg.VerifyASEntry(context.Background(), segVerifier(pub), 0)
 			SoMsg("VerifyErr", err, ShouldBeNil)

--- a/go/beacon_srv/internal/propagation/testdata/topology.json
+++ b/go/beacon_srv/internal/propagation/testdata/topology.json
@@ -1,0 +1,52 @@
+{
+  "Overlay": "UDP/IPv4",
+  "MTU": 1472,
+  "ISD_AS": "1-ff00:0:110",
+  "Core": true,
+  "BorderRouters": {
+    "br1-ff00_0_111-1": {
+      "InternalAddrs": {
+        "IPv4": {
+          "PublicOverlay": {
+            "Addr": "127.0.0.17"
+          }
+        }
+      },
+      "CtrlAddr": {
+        "IPv4": {
+          "Public": {
+            "Addr": "127.0.0.17"
+          }
+        }
+      },
+      "Interfaces": {
+        "41": {
+          "RemoteOverlay": {
+            "Addr": "127.0.0.4"
+          },
+          "MTU": 1280,
+          "PublicOverlay": {
+            "Addr": "127.0.0.5"
+          },
+          "Overlay": "UDP/IPv4",
+          "Bandwidth": 1000,
+          "ISD_AS": "1-ff00:0:120",
+          "LinkTo": "CORE"
+        },
+        "42": {
+            "RemoteOverlay": {
+              "Addr": "127.0.0.4"
+            },
+            "MTU": 1280,
+            "PublicOverlay": {
+              "Addr": "127.0.0.5"
+            },
+            "Overlay": "UDP/IPv4",
+            "Bandwidth": 1000,
+            "ISD_AS": "1-ff00:0:111",
+            "LinkTo": "CHILD"
+          }
+      }
+    }
+  }
+}

--- a/go/lib/ctrl/path_mgmt/seg_recs.go
+++ b/go/lib/ctrl/path_mgmt/seg_recs.go
@@ -54,7 +54,7 @@ func (s *SegRecs) String() string {
 // capnp fields.
 func (s *SegRecs) ParseRaw() error {
 	for i, segMeta := range s.Recs {
-		if err := segMeta.Segment.ParseRaw(); err != nil {
+		if err := segMeta.Segment.ParseRaw(false); err != nil {
 			return common.NewBasicError("Unable to parse segment", err, "seg_index", i,
 				"segment", segMeta.Segment)
 		}

--- a/go/lib/ctrl/seg/as.go
+++ b/go/lib/ctrl/seg/as.go
@@ -48,7 +48,7 @@ func (ase *ASEntry) IA() addr.IA {
 	return ase.RawIA.IA()
 }
 
-func (ase *ASEntry) Validate(prevIA addr.IA, nextIA addr.IA) error {
+func (ase *ASEntry) Validate(prevIA addr.IA, nextIA addr.IA, ignoreNext bool) error {
 	if ase.IA().IsWildcard() {
 		return common.NewBasicError("ASEntry has wildcard IA", nil, "ia", ase.IA())
 	}
@@ -63,7 +63,7 @@ func (ase *ASEntry) Validate(prevIA addr.IA, nextIA addr.IA) error {
 			return common.NewBasicError("HopEntry InIA mismatch", nil,
 				"hopIdx", i, "expected", h.InIA(), "actual", prevIA)
 		}
-		if !nextIA.Equal(h.OutIA()) {
+		if !ignoreNext && !nextIA.Equal(h.OutIA()) {
 			return common.NewBasicError("HopEntry OutIA mismatch", nil,
 				"hopIdx", i, "expected", h.OutIA(), "actual", prevIA)
 		}

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -48,8 +48,17 @@ type Verifier interface {
 var _ proto.Cerealizable = (*Beacon)(nil)
 
 // Beacon is kept for compatibility with python code.
+// Before using the enclosed segment, the beacon should be parsed.
 type Beacon struct {
 	Segment *PathSegment `capnp:"pathSeg"`
+}
+
+// Parse parses and validates the enclosed path segment.
+func (b *Beacon) Parse() error {
+	if b.Segment == nil {
+		return common.NewBasicError("Beacon does not contain a segment", nil)
+	}
+	return b.Segment.ParseRaw(ValidateBeacon)
 }
 
 func (b *Beacon) ProtoId() proto.ProtoIdType {
@@ -62,6 +71,23 @@ func (b *Beacon) String() string {
 	}
 	return b.Segment.String()
 }
+
+// ValidationMethod is the method that is used during validation.
+type ValidationMethod bool
+
+const (
+	// ValidateSegment validates that remote ingress and egress ISD-AS for
+	// each AS entry are consistent with the segment. The ingress ISD-AS of
+	// the first entry, and the egress ISD-AS of the last entry must be the
+	// zero value. Additionally, it is validated that each hop field is
+	// parsable.
+	ValidateSegment ValidationMethod = false
+	// ValidateBeacon validates the segment in the same manner as
+	// ValidateSegment, except for the last AS entry. The egress values for
+	// the last AS entry are ignored, since they are under construction in
+	// a beacon.
+	ValidateBeacon ValidationMethod = true
+)
 
 var _ proto.Cerealizable = (*PathSegment)(nil)
 
@@ -76,6 +102,8 @@ type PathSegment struct {
 	fullId    common.RawBytes
 }
 
+// NewSeg creates a new path segment with the specified info field. The AS
+// entries are empty and should be added using AddASEntry.
 func NewSeg(infoF *spath.InfoField) (*PathSegment, error) {
 	pss := newPathSegmentSignedData(infoF)
 	rawPss, err := proto.PackRoot(pss)
@@ -88,25 +116,25 @@ func NewSeg(infoF *spath.InfoField) (*PathSegment, error) {
 
 // NewSegFromRaw creates a segment from raw data.
 func NewSegFromRaw(b common.RawBytes) (*PathSegment, error) {
-	return newSegFromRaw(b, false)
+	return newSegFromRaw(b, ValidateSegment)
 }
 
 // NewBeaconFromRaw creates a segment from raw data. The last AS entry is
 // not assumed to terminate the path segment.
 func NewBeaconFromRaw(b common.RawBytes) (*PathSegment, error) {
-	return newSegFromRaw(b, true)
+	return newSegFromRaw(b, ValidateBeacon)
 }
 
-func newSegFromRaw(b common.RawBytes, isBeacon bool) (*PathSegment, error) {
+func newSegFromRaw(b common.RawBytes, validationMethod ValidationMethod) (*PathSegment, error) {
 	ps := &PathSegment{}
 	err := proto.ParseFromRaw(ps, ps.ProtoId(), b)
 	if err != nil {
 		return nil, err
 	}
-	return ps, ps.ParseRaw(isBeacon)
+	return ps, ps.ParseRaw(validationMethod)
 }
 
-func (ps *PathSegment) ParseRaw(isBeacon bool) error {
+func (ps *PathSegment) ParseRaw(validationMethod ValidationMethod) error {
 	var err error
 	ps.SData, err = NewPathSegmentSignedDataFromRaw(ps.RawSData)
 	if err != nil {
@@ -119,7 +147,7 @@ func (ps *PathSegment) ParseRaw(isBeacon bool) error {
 			return err
 		}
 	}
-	return ps.Validate(isBeacon)
+	return ps.Validate(validationMethod)
 }
 
 // ID returns a hash of the segment covering all hops, except for peerings.
@@ -169,7 +197,10 @@ func (ps *PathSegment) InfoF() (*spath.InfoField, error) {
 	return ps.SData.InfoF()
 }
 
-func (ps *PathSegment) Validate(isBeacon bool) error {
+// Validate validates that remote ingress and egress ISD-AS for each AS
+// entry are consistent with the segment. In case a beacon is validated,
+// the egress ISD-AS of the last AS entry is ignored.
+func (ps *PathSegment) Validate(validationMethod ValidationMethod) error {
 	if err := ps.SData.Validate(); err != nil {
 		return err
 	}
@@ -193,7 +224,7 @@ func (ps *PathSegment) Validate(isBeacon bool) error {
 		}
 		// The last AS entry in a beacon should ignore whether the next IA
 		// matches, since it is not set yet.
-		ignoreNext := i == len(ps.ASEntries)-1 && isBeacon
+		ignoreNext := i == len(ps.ASEntries)-1 && (ValidateBeacon == ValidateBeacon)
 		if err := ps.ASEntries[i].Validate(prevIA, nextIA, ignoreNext); err != nil {
 			return err
 		}

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -224,7 +224,7 @@ func (ps *PathSegment) Validate(validationMethod ValidationMethod) error {
 		}
 		// The last AS entry in a beacon should ignore whether the next IA
 		// matches, since it is not set yet.
-		ignoreNext := i == len(ps.ASEntries)-1 && (ValidateBeacon == ValidateBeacon)
+		ignoreNext := i == len(ps.ASEntries)-1 && (validationMethod == ValidateBeacon)
 		if err := ps.ASEntries[i].Validate(prevIA, nextIA, ignoreNext); err != nil {
 			return err
 		}

--- a/go/lib/infra/modules/trust/helpers.go
+++ b/go/lib/infra/modules/trust/helpers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
 	"github.com/scionproto/scion/go/lib/scrypto/cert"
 	"github.com/scionproto/scion/go/lib/scrypto/trc"
+	"github.com/scionproto/scion/go/lib/util"
 )
 
 // FIXME(scrye): Reconsider whether these functions should access the trust
@@ -51,6 +52,7 @@ func CreateSignMeta(ctx context.Context, ia addr.IA,
 			ChainVer: c.Leaf.Version,
 			TRCVer:   t.Version,
 		},
+		ExpTime: util.SecsToTime(c.Leaf.ExpirationTime),
 	}
 	return meta, nil
 }

--- a/go/path_srv/internal/handlers/segreqnoncore_test.go
+++ b/go/path_srv/internal/handlers/segreqnoncore_test.go
@@ -142,7 +142,7 @@ func insertSegs(t *testing.T, pathDB pathdb.PathDB, segs []*seg.PathSegment, st 
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
 	defer cancelF()
 	for _, s := range segs {
-		err := s.Validate()
+		err := s.Validate(false)
 		xtest.FailOnErr(t, err)
 		_, err = pathDB.Insert(ctx, seg.NewMeta(s, st))
 		xtest.FailOnErr(t, err)

--- a/go/path_srv/internal/handlers/segreqnoncore_test.go
+++ b/go/path_srv/internal/handlers/segreqnoncore_test.go
@@ -142,7 +142,7 @@ func insertSegs(t *testing.T, pathDB pathdb.PathDB, segs []*seg.PathSegment, st 
 	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
 	defer cancelF()
 	for _, s := range segs {
-		err := s.Validate(false)
+		err := s.Validate(seg.ValidateSegment)
 		xtest.FailOnErr(t, err)
 		_, err = pathDB.Insert(ctx, seg.NewMeta(s, st))
 		xtest.FailOnErr(t, err)

--- a/tools/gomocks
+++ b/tools/gomocks
@@ -39,11 +39,11 @@ MOCK_TARGETS = [
         (SCION_PACKAGE_PREFIX + "/go/lib/pathdb", "PathDB,Transaction,ReadWrite"),
         (SCION_PACKAGE_PREFIX + "/go/lib/pathmgr", "Querier,Resolver"),
         (SCION_PACKAGE_PREFIX + "/go/lib/revcache", "RevCache"),
+        (SCION_PACKAGE_PREFIX + "/go/lib/sciond", "Service,Connector"),
         (SCION_PACKAGE_PREFIX + "/go/lib/snet", "Conn,Network"),
         (SCION_PACKAGE_PREFIX + "/go/lib/snet/snetproxy", "IOOperation,Reconnecter"),
         (SCION_PACKAGE_PREFIX + "/go/lib/snet/internal/ctxmonitor", "Monitor"),
         (SCION_PACKAGE_PREFIX + "/go/lib/snet/internal/pathsource", "PathSource"),
-        (SCION_PACKAGE_PREFIX + "/go/lib/sciond", "Service,Connector"),
 ]
 
 


### PR DESCRIPTION
This change adds the beacon originator task.
The originator uses a one-hop sender to send the beacons on all active interfaces of the LinkTo Core/Child type.

The task should only be run by core ASes.

fixes #2564

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2592)
<!-- Reviewable:end -->
