### PR TITLE
Print SegReqFlags field names

### DIFF
--- a/go/lib/ctrl/path_mgmt/seg_req.go
+++ b/go/lib/ctrl/path_mgmt/seg_req.go
@@ -60,5 +60,5 @@ func (s *SegReq) Write(b common.RawBytes) (int, error) {
 }
 
 func (s *SegReq) String() string {
-	return fmt.Sprintf("%s -> %s, Flags: %v", s.SrcIA(), s.DstIA(), s.Flags)
+	return fmt.Sprintf("%s -> %s, Flags: %+v", s.SrcIA(), s.DstIA(), s.Flags)
 }


### PR DESCRIPTION
Before the output of `SegReq.String()` was:
`1-ff00:0:111 -> 1-ff00:0:110, Flags: {false false}`

Now the output is:
`1-ff00:0:111 -> 1-ff00:0:110, Flags: {Sibra:false CacheOnly:false}`

fixes #2210

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2594)
<!-- Reviewable:end -->
