### PR TITLE
Gazelle: Update to 0.17.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,8 +25,8 @@ go_register_toolchains(nogo = "@//:nogo")
 # Gazelle
 http_archive(
     name = "bazel_gazelle",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz"],
-    sha256 = "7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
+    sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")


### PR DESCRIPTION
We use gazelle diff mode to ensure consistency during lint.
Diff returns an non-zero exit code starting from commit
https://github.com/bazelbuild/bazel-gazelle/commit/386774d
Which is included starting from pre-release 0.17.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2603)
<!-- Reviewable:end -->
