### PR TITLE
Proto: Catch pogs panic

### DIFF
--- a/go/proto/cereal.go
+++ b/go/proto/cereal.go
@@ -134,7 +134,13 @@ func readRootFromReader(r io.Reader) (_ capnp.Struct, err error) {
 }
 
 // parseStruct parses a capnp struct into a Cerealizable instance.
-func parseStruct(c Cerealizable, s capnp.Struct) error {
+func parseStruct(c Cerealizable, s capnp.Struct) (err error) {
+	// Convert pogs panics to errors
+	defer func() {
+		if rec := recover(); rec != nil {
+			err = common.NewBasicError("pogs panic", nil, "panic", rec)
+		}
+	}()
 	if err := pogs.Extract(c, uint64(c.ProtoId()), s); err != nil {
 		return common.NewBasicError("Failed to extract struct from capnp message", err)
 	}


### PR DESCRIPTION
Catch panics when deserializing capnp messages using pogs.
This could happen on malformed input, see capnproto/go-capnproto2#137

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2605)
<!-- Reviewable:end -->
