### PR TITLE
BS: Add revoker for IFs with missing keepalive

### DIFF
--- a/go/beacon_srv/internal/ifstate/BUILD.bazel
+++ b/go/beacon_srv/internal/ifstate/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "ifstate.go",
         "revoker.go",
     ],
@@ -13,7 +14,6 @@ go_library(
         "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/infra:go_default_library",
         "//go/lib/infra/messenger:go_default_library",
-        "//go/lib/infra/modules/itopo:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/periodic:go_default_library",
         "//go/lib/snet:go_default_library",
@@ -37,8 +37,8 @@ go_test(
         "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/infra:go_default_library",
         "//go/lib/infra/mock_infra:go_default_library",
-        "//go/lib/infra/modules/itopo:go_default_library",
         "//go/lib/infra/modules/trust:go_default_library",
+        "//go/lib/log:go_default_library",
         "//go/lib/scrypto:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/topology:go_default_library",

--- a/go/beacon_srv/internal/ifstate/BUILD.bazel
+++ b/go/beacon_srv/internal/ifstate/BUILD.bazel
@@ -2,23 +2,50 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["ifstate.go"],
+    srcs = [
+        "ifstate.go",
+        "revoker.go",
+    ],
     importpath = "github.com/scionproto/scion/go/beacon_srv/internal/ifstate",
     visibility = ["//go/beacon_srv:__subpackages__"],
     deps = [
         "//go/lib/common:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
+        "//go/lib/infra:go_default_library",
+        "//go/lib/infra/messenger:go_default_library",
+        "//go/lib/infra/modules/itopo:go_default_library",
+        "//go/lib/log:go_default_library",
+        "//go/lib/periodic:go_default_library",
+        "//go/lib/snet:go_default_library",
         "//go/lib/topology:go_default_library",
+        "//go/lib/util:go_default_library",
+        "//go/proto:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["ifstate_test.go"],
+    srcs = [
+        "ifstate_test.go",
+        "revoker_test.go",
+    ],
+    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
+        "//go/lib/common:go_default_library",
+        "//go/lib/ctrl:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
+        "//go/lib/infra:go_default_library",
+        "//go/lib/infra/mock_infra:go_default_library",
+        "//go/lib/infra/modules/itopo:go_default_library",
+        "//go/lib/infra/modules/trust:go_default_library",
+        "//go/lib/scrypto:go_default_library",
+        "//go/lib/snet:go_default_library",
         "//go/lib/topology:go_default_library",
+        "//go/lib/util:go_default_library",
+        "//go/lib/xtest:go_default_library",
+        "//go/proto:go_default_library",
+        "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
     ],
 )

--- a/go/beacon_srv/internal/ifstate/doc.go
+++ b/go/beacon_srv/internal/ifstate/doc.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ifstate implements the interface state in memory structure as well
+// as related tasks and handlers.
+//
+// Interface state
+//
+// The interface state is stored in the Interfaces struct it can be created by
+// calling the NewInterfaces constructor. The state of a specific interface is
+// stored in the Interface struct.
+//
+// Revoker
+//
+// The revoker is a periodic task that revokes interfaces that have timed out
+// and renews revocations of already revoked interfaces. Create it with the
+// NewRevoker costructor.
+package ifstate

--- a/go/beacon_srv/internal/ifstate/revoker.go
+++ b/go/beacon_srv/internal/ifstate/revoker.go
@@ -1,0 +1,206 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ifstate
+
+import (
+	"context"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/periodic"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/proto"
+)
+
+// DefaultRevOverlap specifies the default for how long before the expiry of an existing revocation
+// the revoker can reissue a new revocation.
+const DefaultRevOverlap = path_mgmt.MinRevTTL / 2
+
+// RevConfig configures the revoker.
+type RevConfig struct {
+	RevOverlap time.Duration
+}
+
+// InitDefaults initializes the config fields that are not set to the default values.
+func (c *RevConfig) InitDefaults() {
+	if c.RevOverlap == 0 {
+		c.RevOverlap = DefaultRevOverlap
+	}
+}
+
+var _ periodic.Task = (*Revoker)(nil)
+
+// Revoker revokes interfaces for which we didn't receive an ifid keepalive message for too long.
+type Revoker struct {
+	intfs  *Interfaces
+	msger  infra.Messenger
+	cfg    RevConfig
+	signer infra.Signer
+}
+
+func NewRevoker(intfs *Interfaces, msger infra.Messenger,
+	signer infra.Signer, cfg RevConfig) *Revoker {
+
+	cfg.InitDefaults()
+	return &Revoker{
+		intfs:  intfs,
+		msger:  msger,
+		cfg:    cfg,
+		signer: signer,
+	}
+}
+
+func (r *Revoker) Run(ctx context.Context) {
+	if err := r.run(ctx); err != nil {
+		log.Error("[Revoker] Failed to run revoker", "err", err)
+	}
+}
+
+func (r *Revoker) run(ctx context.Context) error {
+	var revIfIds []common.IFIDType
+	for ifid, intf := range r.intfs.All() {
+		if intf.Expire() {
+			var existingRevInfo *path_mgmt.RevInfo
+			if existingRev := intf.Revocation(); existingRev != nil {
+				var err error
+				existingRevInfo, err = existingRev.RevInfo()
+				if err != nil {
+					log.Warn("[Revoker] couldn't extract rev info from existing revocation", "err", err)
+				}
+			}
+			if existingRevInfo == nil {
+				log.Info("[Revoker] interface went down", "ifid", ifid)
+			}
+			if sendRevocation := existingRevInfo == nil ||
+				existingRevInfo.RelativeTTL(time.Now()) < r.cfg.RevOverlap; sendRevocation {
+				revIfIds = append(revIfIds, ifid)
+			}
+		}
+	}
+	if len(revIfIds) > 0 {
+		revs := r.createRevocations(revIfIds)
+		r.revokeInterfaces(revs)
+		r.pushRevocationsToBRs(ctx, revs)
+		r.pushRevocationsToPS(ctx, revs)
+	}
+	return nil
+}
+
+func (r *Revoker) createRevocations(
+	ifids []common.IFIDType) map[common.IFIDType]*path_mgmt.SignedRevInfo {
+
+	revs := make(map[common.IFIDType]*path_mgmt.SignedRevInfo)
+	for _, ifid := range ifids {
+		srev, err := r.signedRevInfo(ifid)
+		if err != nil {
+			log.Error("[Revoker] Failed to create revocation", "ifid", ifid, "err", err)
+			continue
+		}
+		revs[ifid] = srev
+	}
+	return revs
+}
+
+func (r *Revoker) signedRevInfo(ifid common.IFIDType) (*path_mgmt.SignedRevInfo, error) {
+	now := util.TimeToSecs(time.Now())
+	revInfo := &path_mgmt.RevInfo{
+		IfID:         ifid,
+		RawIsdas:     itopo.Get().ISD_AS.IAInt(),
+		LinkType:     itopo.Get().IFInfoMap[ifid].LinkType,
+		RawTimestamp: now,
+		RawTTL:       uint32(path_mgmt.MinRevTTL.Seconds()),
+	}
+	rawRevInfo, err := revInfo.Pack()
+	if err != nil {
+		return nil, err
+	}
+	sign, err := r.signer.Sign(rawRevInfo)
+	if err != nil {
+		return nil, err
+	}
+	return path_mgmt.NewSignedRevInfo(revInfo, sign)
+}
+
+func (r *Revoker) revokeInterfaces(revs map[common.IFIDType]*path_mgmt.SignedRevInfo) {
+	for ifid, srev := range revs {
+		if intf := r.intfs.Get(ifid); intf != nil {
+			if err := intf.Revoke(srev); err != nil {
+				// interface activated in the meantime, so delete it from the map.
+				delete(revs, ifid)
+			}
+		} else {
+			// interface deleted in the meantime, so delete it from the map.
+			delete(revs, ifid)
+		}
+	}
+}
+
+func (r *Revoker) pushRevocationsToBRs(ctx context.Context,
+	revs map[common.IFIDType]*path_mgmt.SignedRevInfo) {
+
+	topo := itopo.Get()
+	msg := &path_mgmt.IFStateInfos{
+		Infos: make([]*path_mgmt.IFStateInfo, 0, len(revs)),
+	}
+	for ifid, srev := range revs {
+		msg.Infos = append(msg.Infos, &path_mgmt.IFStateInfo{
+			IfID:     uint64(ifid),
+			Active:   false,
+			SRevInfo: srev,
+		})
+	}
+	for brId, br := range topo.BR {
+		a := &snet.Addr{
+			IA:      topo.ISD_AS,
+			Host:    br.CtrlAddrs.PublicAddr(topo.Overlay),
+			NextHop: br.CtrlAddrs.OverlayAddr(topo.Overlay),
+		}
+		if err := r.msger.SendIfStateInfos(ctx, msg, a, messenger.NextId()); err != nil {
+			log.Error("[Revoker] Failed to send revocations to BR", "br", brId, "err", err)
+		}
+	}
+}
+
+func (r *Revoker) pushRevocationsToPS(ctx context.Context,
+	revs map[common.IFIDType]*path_mgmt.SignedRevInfo) {
+
+	topo := itopo.Get()
+	svcInfo, err := topo.GetSvcInfo(proto.ServiceType_ps)
+	if err != nil {
+		log.Error("[Revoker] Failed to get svcInfo for PS", "err", err)
+		return
+	}
+	topoAddr := svcInfo.GetAnyTopoAddr()
+	if topoAddr == nil {
+		log.Error("[Revoker] No PS found in topology")
+		return
+	}
+	a := &snet.Addr{
+		IA:      topo.ISD_AS,
+		Host:    topoAddr.PublicAddr(topo.Overlay),
+		NextHop: topoAddr.OverlayAddr(topo.Overlay),
+	}
+	for ifid, srev := range revs {
+		if err := r.msger.SendRev(ctx, srev, a, messenger.NextId()); err != nil {
+			log.Error("[Revoker] Failed to send revocation to PS", "ifid", ifid, "err", err)
+		}
+	}
+}

--- a/go/beacon_srv/internal/ifstate/revoker.go
+++ b/go/beacon_srv/internal/ifstate/revoker.go
@@ -83,7 +83,8 @@ func (r *Revoker) run(ctx context.Context) error {
 				var err error
 				existingRevInfo, err = existingRev.RevInfo()
 				if err != nil {
-					log.Warn("[Revoker] couldn't extract rev info from existing revocation", "err", err)
+					log.Warn("[Revoker] couldn't extract rev info from existing revocation",
+						"err", err)
 				}
 			}
 			if existingRevInfo == nil {

--- a/go/beacon_srv/internal/ifstate/revoker.go
+++ b/go/beacon_srv/internal/ifstate/revoker.go
@@ -16,6 +16,7 @@ package ifstate
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/common"
@@ -26,6 +27,7 @@ import (
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/periodic"
 	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/proto"
 )
@@ -48,7 +50,8 @@ func (c *RevConfig) InitDefaults() {
 
 var _ periodic.Task = (*Revoker)(nil)
 
-// Revoker revokes interfaces for which we didn't receive an ifid keepalive message for too long.
+// Revoker issues revocations for interfaces that have timed out.
+// Revocations for already revoked interfaces are renewed periodically.
 type Revoker struct {
 	intfs  *Interfaces
 	msger  infra.Messenger
@@ -56,6 +59,7 @@ type Revoker struct {
 	signer infra.Signer
 }
 
+// NewRevoker creates a new revoker from the given arguments.
 func NewRevoker(intfs *Interfaces, msger infra.Messenger,
 	signer infra.Signer, cfg RevConfig) *Revoker {
 
@@ -68,59 +72,42 @@ func NewRevoker(intfs *Interfaces, msger infra.Messenger,
 	}
 }
 
+// Run issues revocations for interfaces that have timed out
+// and renews revocations for revoked interfaces.
 func (r *Revoker) Run(ctx context.Context) {
-	if err := r.run(ctx); err != nil {
-		log.Error("[Revoker] Failed to run revoker", "err", err)
-	}
-}
-
-func (r *Revoker) run(ctx context.Context) error {
-	var revIfIds []common.IFIDType
-	for ifid, intf := range r.intfs.All() {
-		if intf.Expire() {
-			var existingRevInfo *path_mgmt.RevInfo
-			if existingRev := intf.Revocation(); existingRev != nil {
-				var err error
-				existingRevInfo, err = existingRev.RevInfo()
-				if err != nil {
-					log.Warn("[Revoker] couldn't extract rev info from existing revocation",
-						"err", err)
-				}
-			}
-			if existingRevInfo == nil {
-				log.Info("[Revoker] interface went down", "ifid", ifid)
-			}
-			if sendRevocation := existingRevInfo == nil ||
-				existingRevInfo.RelativeTTL(time.Now()) < r.cfg.RevOverlap; sendRevocation {
-				revIfIds = append(revIfIds, ifid)
-			}
-		}
-	}
-	if len(revIfIds) > 0 {
-		revs := r.createRevocations(revIfIds)
-		r.revokeInterfaces(revs)
-		r.pushRevocationsToBRs(ctx, revs)
-		r.pushRevocationsToPS(ctx, revs)
-	}
-	return nil
-}
-
-func (r *Revoker) createRevocations(
-	ifids []common.IFIDType) map[common.IFIDType]*path_mgmt.SignedRevInfo {
-
 	revs := make(map[common.IFIDType]*path_mgmt.SignedRevInfo)
-	for _, ifid := range ifids {
-		srev, err := r.signedRevInfo(ifid)
-		if err != nil {
-			log.Error("[Revoker] Failed to create revocation", "ifid", ifid, "err", err)
-			continue
+	for ifid, intf := range r.intfs.All() {
+		if intf.Expire() && !r.hasValidRevocation(intf) {
+			log.Info("[Revoker] interface went down", "ifid", ifid)
+			srev, err := r.createSignedRev(ifid)
+			if err != nil {
+				log.Error("[Revoker] Failed to create revocation", "ifid", ifid, "err", err)
+				continue
+			}
+			if err := intf.Revoke(srev); err == nil {
+				revs[ifid] = srev
+			} else {
+				log.Error("Failed to revoke!", "err", err)
+			}
 		}
-		revs[ifid] = srev
 	}
-	return revs
+	if len(revs) > 0 {
+		wg := &sync.WaitGroup{}
+		r.pushRevocationsToBRs(ctx, revs, wg)
+		r.pushRevocationsToPS(ctx, revs)
+		wg.Wait()
+	}
 }
 
-func (r *Revoker) signedRevInfo(ifid common.IFIDType) (*path_mgmt.SignedRevInfo, error) {
+func (r *Revoker) hasValidRevocation(intf *Interface) bool {
+	if srev := intf.Revocation(); srev != nil {
+		rev, err := srev.RevInfo()
+		return err == nil && rev.RelativeTTL(time.Now()) >= r.cfg.RevOverlap
+	}
+	return false
+}
+
+func (r *Revoker) createSignedRev(ifid common.IFIDType) (*path_mgmt.SignedRevInfo, error) {
 	now := util.TimeToSecs(time.Now())
 	revInfo := &path_mgmt.RevInfo{
 		IfID:         ifid,
@@ -140,22 +127,8 @@ func (r *Revoker) signedRevInfo(ifid common.IFIDType) (*path_mgmt.SignedRevInfo,
 	return path_mgmt.NewSignedRevInfo(revInfo, sign)
 }
 
-func (r *Revoker) revokeInterfaces(revs map[common.IFIDType]*path_mgmt.SignedRevInfo) {
-	for ifid, srev := range revs {
-		if intf := r.intfs.Get(ifid); intf != nil {
-			if err := intf.Revoke(srev); err != nil {
-				// interface activated in the meantime, so delete it from the map.
-				delete(revs, ifid)
-			}
-		} else {
-			// interface deleted in the meantime, so delete it from the map.
-			delete(revs, ifid)
-		}
-	}
-}
-
 func (r *Revoker) pushRevocationsToBRs(ctx context.Context,
-	revs map[common.IFIDType]*path_mgmt.SignedRevInfo) {
+	revs map[common.IFIDType]*path_mgmt.SignedRevInfo, wg *sync.WaitGroup) {
 
 	topo := itopo.Get()
 	msg := &path_mgmt.IFStateInfos{
@@ -169,14 +142,7 @@ func (r *Revoker) pushRevocationsToBRs(ctx context.Context,
 		})
 	}
 	for brId, br := range topo.BR {
-		a := &snet.Addr{
-			IA:      topo.ISD_AS,
-			Host:    br.CtrlAddrs.PublicAddr(topo.Overlay),
-			NextHop: br.CtrlAddrs.OverlayAddr(topo.Overlay),
-		}
-		if err := r.msger.SendIfStateInfos(ctx, msg, a, messenger.NextId()); err != nil {
-			log.Error("[Revoker] Failed to send revocations to BR", "br", brId, "err", err)
-		}
+		r.sendToBr(ctx, brId, br, msg, wg)
 	}
 }
 
@@ -204,4 +170,24 @@ func (r *Revoker) pushRevocationsToPS(ctx context.Context,
 			log.Error("[Revoker] Failed to send revocation to PS", "ifid", ifid, "err", err)
 		}
 	}
+}
+
+func (r *Revoker) sendToBr(ctx context.Context, brId string, br topology.BRInfo,
+	msg *path_mgmt.IFStateInfos, wg *sync.WaitGroup) {
+
+	wg.Add(1)
+	go func() {
+		defer log.LogPanicAndExit()
+		defer wg.Done()
+
+		topo := itopo.Get()
+		a := &snet.Addr{
+			IA:      topo.ISD_AS,
+			Host:    br.CtrlAddrs.PublicAddr(topo.Overlay),
+			NextHop: br.CtrlAddrs.OverlayAddr(topo.Overlay),
+		}
+		if err := r.msger.SendIfStateInfos(ctx, msg, a, messenger.NextId()); err != nil {
+			log.Error("[Revoker] Failed to send revocations to BR", "br", brId, "err", err)
+		}
+	}()
 }

--- a/go/beacon_srv/internal/ifstate/revoker_test.go
+++ b/go/beacon_srv/internal/ifstate/revoker_test.go
@@ -1,0 +1,354 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ifstate
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/mock_infra"
+	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust"
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/topology"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/lib/xtest"
+	"github.com/scionproto/scion/go/proto"
+)
+
+var (
+	timeout     = time.Second
+	overlapTime = path_mgmt.MinRevTTL / 2
+	expireTime  = time.Second + DefaultKeepaliveTimeout
+	ia          = xtest.MustParseIA("1-ff00:0:111")
+)
+
+type brMsg struct {
+	msg *path_mgmt.IFStateInfos
+	a   net.Addr
+}
+
+func TestMain(m *testing.M) {
+	itopo.Init("", proto.ServiceType_unset, itopo.Callbacks{})
+	os.Exit(m.Run())
+}
+
+// TestNoRevocationIssued tests that if all interfaces receive if keepalives the revoker should do
+// nothing.
+func TestNoRevocationIssued(t *testing.T) {
+	setupItopo(t)
+	_, priv, err := scrypto.GenKeyPair(scrypto.Ed25519)
+	xtest.FailOnErr(t, err)
+	signer := createTestSigner(t, priv)
+	Convey("TestNoRevocationIssued", t, func() {
+		ctx, cancelF := context.WithTimeout(context.Background(), timeout)
+		defer cancelF()
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		msger := mock_infra.NewMockMessenger(mctrl)
+		intfs := NewInterfaces(itopo.Get().IFInfoMap, Config{})
+		activateAll(intfs)
+		revoker := testRevoker(intfs, msger, signer)
+		revoker.Run(ctx)
+		// gomock tests that no calls to the messenger are made.
+		Convey("Check interface state didn't change", func() {
+			for ifid, intf := range intfs.All() {
+				SoMsg(fmt.Sprintf("Intf %d should be active", ifid),
+					intf.State(), ShouldEqual, Active)
+			}
+		})
+	})
+}
+
+// TestRevokeInterface tests that if a keepalive didn't arrive for an interface it should be
+// revoked.
+func TestRevokeInterface(t *testing.T) {
+	setupItopo(t)
+	pub, priv, err := scrypto.GenKeyPair(scrypto.Ed25519)
+	xtest.FailOnErr(t, err)
+	signer := createTestSigner(t, priv)
+	verifier := revVerifier(pub)
+	Convey("TestRevokeInterface", t, func() {
+		ctx, cancelF := context.WithTimeout(context.Background(), timeout)
+		defer cancelF()
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		msger := mock_infra.NewMockMessenger(mctrl)
+		intfs := NewInterfaces(itopo.Get().IFInfoMap, Config{})
+		activateAll(intfs)
+		intfs.Get(101).lastActivate = time.Now().Add(-expireTime)
+		checkSentMessages := expectMessengerCalls(msger, 101)
+		revoker := testRevoker(intfs, msger, signer)
+		revoker.Run(ctx)
+		Convey("Check interface state", func() {
+			for ifid, intf := range intfs.All() {
+				if ifid == 101 {
+					SoMsg(fmt.Sprintf("Intf %d should be revoked", ifid),
+						intf.State(), ShouldEqual, Revoked)
+				} else {
+					SoMsg(fmt.Sprintf("Intf %d should be active", ifid),
+						intf.State(), ShouldEqual, Active)
+				}
+			}
+		})
+		checkSentMessages(t, verifier)
+	})
+}
+
+// TestRevokedInterfaceNotRevokedImmediately tests that if an interface was revoked recently it
+// shouldn't be revoked again.
+func TestRevokedInterfaceNotRevokedImmediately(t *testing.T) {
+	setupItopo(t)
+	_, priv, err := scrypto.GenKeyPair(scrypto.Ed25519)
+	xtest.FailOnErr(t, err)
+	signer := createTestSigner(t, priv)
+	Convey("TestRevokedInterfaceNotRevokedImmediately", t, func() {
+		ctx, cancelF := context.WithTimeout(context.Background(), timeout)
+		defer cancelF()
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		msger := mock_infra.NewMockMessenger(mctrl)
+		intfs := NewInterfaces(itopo.Get().IFInfoMap, Config{})
+		activateAll(intfs)
+		intfs.Get(101).state = Expired
+		intfs.Get(101).Revoke(toSigned(t, &path_mgmt.RevInfo{
+			IfID:         101,
+			RawIsdas:     ia.IAInt(),
+			LinkType:     proto.LinkType_peer,
+			RawTimestamp: util.TimeToSecs(time.Now().Add(-500 * time.Millisecond)),
+			RawTTL:       10,
+		}))
+		revoker := testRevoker(intfs, msger, signer)
+		revoker.Run(ctx)
+		// gomock tests that no calls to the messenger are made.
+		Convey("Check interface state didn't change", func() {
+			for ifid, intf := range intfs.All() {
+				if ifid == 101 {
+					SoMsg(fmt.Sprintf("Intf %d should be revoked", ifid),
+						intf.State(), ShouldEqual, Revoked)
+				} else {
+					SoMsg(fmt.Sprintf("Intf %d should be active", ifid),
+						intf.State(), ShouldEqual, Active)
+				}
+			}
+		})
+	})
+}
+
+// TestRevokedInterfaceRevokedAgain test that if an interface was revoked and the overlap period
+// started it should be revoked again.
+func TestRevokedInterfaceRevokedAgain(t *testing.T) {
+	setupItopo(t)
+	pub, priv, err := scrypto.GenKeyPair(scrypto.Ed25519)
+	xtest.FailOnErr(t, err)
+	signer := createTestSigner(t, priv)
+	verifier := revVerifier(pub)
+	Convey("TestRevokedInterfaceRevokedAgain", t, func() {
+		ctx, cancelF := context.WithTimeout(context.Background(), timeout)
+		defer cancelF()
+		mctrl := gomock.NewController(t)
+		defer mctrl.Finish()
+		msger := mock_infra.NewMockMessenger(mctrl)
+		intfs := NewInterfaces(itopo.Get().IFInfoMap, Config{})
+		activateAll(intfs)
+		intfs.Get(101).state = Expired
+		intfs.Get(101).Revoke(toSigned(t, &path_mgmt.RevInfo{
+			IfID:         101,
+			RawIsdas:     ia.IAInt(),
+			LinkType:     proto.LinkType_peer,
+			RawTimestamp: util.TimeToSecs(time.Now().Add(-6 * time.Second)),
+			RawTTL:       10,
+		}))
+		checkSentMessages := expectMessengerCalls(msger, 101)
+		revoker := testRevoker(intfs, msger, signer)
+		revoker.Run(ctx)
+		// gomock tests that no calls to the messenger are made.
+		Convey("Check interface state didn't change", func() {
+			for ifid, intf := range intfs.All() {
+				if ifid == 101 {
+					SoMsg(fmt.Sprintf("Intf %d should be revoked", ifid),
+						intf.State(), ShouldEqual, Revoked)
+				} else {
+					SoMsg(fmt.Sprintf("Intf %d should be active", ifid),
+						intf.State(), ShouldEqual, Active)
+				}
+			}
+		})
+		checkSentMessages(t, verifier)
+	})
+}
+
+// TODO(lukedirtwalker): test revoking multiple interfaces at once.
+
+func expectMessengerCalls(msger *mock_infra.MockMessenger,
+	revokedIfId common.IFIDType) func(*testing.T, revVerifier) {
+
+	var brMsgs []brMsg
+	var brMsgsMtx sync.Mutex
+	msger.EXPECT().SendIfStateInfos(gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any()).Times(brCount()).DoAndReturn(
+		func(_ context.Context, msg *path_mgmt.IFStateInfos, a net.Addr, _ uint64) error {
+			brMsgsMtx.Lock()
+			defer brMsgsMtx.Unlock()
+			brMsgs = append(brMsgs, brMsg{msg: msg, a: a})
+			return nil
+		})
+	var psAddr net.Addr
+	var psMsg *path_mgmt.SignedRevInfo
+	msger.EXPECT().SendRev(gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any()).DoAndReturn(
+		func(_ context.Context, msg *path_mgmt.SignedRevInfo, a net.Addr, _ uint64) error {
+			psAddr = a
+			psMsg = msg
+			return nil
+		})
+	return func(t *testing.T, verifier revVerifier) {
+		Convey("Check sent BR messages", func() {
+			SoMsg("Should send correct amount of messages", len(brMsgs), ShouldEqual, brCount())
+			sentBRs := expectedBRs()
+			for _, brMsg := range brMsgs {
+				brName := brId(t, brMsg.a.(*snet.Addr))
+				delete(sentBRs, brName)
+				checkBRMessage(t, brName, brMsg.msg, revokedIfId, verifier)
+			}
+			SoMsg("Should have sent to all brs", sentBRs, ShouldBeEmpty)
+		})
+		Convey("Check sent PS message", func() {
+			saddr := psAddr.(*snet.Addr)
+			SoMsg("Should send to local IA", saddr.IA, ShouldResemble, ia)
+			topo := itopo.Get()
+			isPsAddr := false
+			for _, tAddr := range topo.PS {
+				if tAddr.PublicAddr(topo.Overlay).Equal(saddr.Host) {
+					isPsAddr = true
+					break
+				}
+			}
+			SoMsg("Should send to PS", isPsAddr, ShouldBeTrue)
+			checkRevocation(t, psMsg, revokedIfId, verifier)
+		})
+	}
+}
+
+func checkBRMessage(t *testing.T, brId string, infos *path_mgmt.IFStateInfos,
+	revokedIfId common.IFIDType, verifier revVerifier) {
+
+	Convey(fmt.Sprintf("Check ifstateinfo for %s", brId), func() {
+		SoMsg("Should contain correct amount of infos", len(infos.Infos), ShouldEqual, 1)
+		SoMsg("Correct ifid", infos.Infos[0].IfID, ShouldEqual, revokedIfId)
+		SoMsg("Not active", infos.Infos[0].Active, ShouldBeFalse)
+		checkRevocation(t, infos.Infos[0].SRevInfo, revokedIfId, verifier)
+	})
+}
+
+func checkRevocation(t *testing.T, srev *path_mgmt.SignedRevInfo,
+	revokedIfId common.IFIDType, verifier revVerifier) {
+
+	Convey("Check revocation", func() {
+		verifier.Verify(t, srev)
+		revInfo, err := srev.RevInfo()
+		xtest.FailOnErr(t, err)
+		SoMsg("correct ifId", revInfo.IfID, ShouldEqual, revokedIfId)
+		SoMsg("correct IA", revInfo.RawIsdas, ShouldEqual, ia.IAInt())
+		SoMsg("correct linkType", revInfo.LinkType,
+			ShouldEqual, itopo.Get().IFInfoMap[revokedIfId].LinkType)
+		rawNow := util.TimeToSecs(time.Now())
+		SoMsg("recent revocation", revInfo.RawTimestamp, ShouldBeBetween, rawNow-1, rawNow+1)
+		SoMsg("minTTL", revInfo.RawTTL, ShouldEqual, uint32(path_mgmt.MinRevTTL.Seconds()))
+	})
+}
+
+func brId(t *testing.T, saddr *snet.Addr) string {
+	topo := itopo.Get()
+	for brId, brInfo := range topo.BR {
+		if brInfo.CtrlAddrs.PublicAddr(topo.Overlay).Equal(saddr.Host) {
+			return brId
+		}
+	}
+	t.Fatalf("Didn't find br ID for %s", saddr.Host)
+	return "" // meh, makes the compiler happy.
+}
+
+// expectedBRs return a set of BR ids for which we expect a if state update push.
+func expectedBRs() map[string]struct{} {
+	brIds := make(map[string]struct{})
+	for brId := range itopo.Get().BR {
+		brIds[brId] = struct{}{}
+	}
+	return brIds
+}
+
+func toSigned(t *testing.T, r *path_mgmt.RevInfo) *path_mgmt.SignedRevInfo {
+	t.Helper()
+	sr, err := path_mgmt.NewSignedRevInfo(r, nil)
+	xtest.FailOnErr(t, err)
+	return sr
+}
+
+func brCount() int {
+	return len(itopo.Get().BR)
+}
+
+func activateAll(intfs *Interfaces) {
+	for _, intf := range intfs.All() {
+		intf.Activate(42)
+	}
+}
+
+func testRevoker(intfs *Interfaces, msger infra.Messenger, signer infra.Signer) *Revoker {
+	return NewRevoker(intfs, msger, signer, RevConfig{RevOverlap: overlapTime})
+}
+
+func setupItopo(t *testing.T) {
+	topo, err := topology.LoadFromFile("testdata/topology.json")
+	xtest.FailOnErr(t, err)
+	_, _, err = itopo.SetStatic(topo, true)
+	xtest.FailOnErr(t, err)
+}
+
+func createTestSigner(t *testing.T, key common.RawBytes) infra.Signer {
+	signer, err := trust.NewBasicSigner(key, infra.SignerMeta{
+		Src: ctrl.SignSrcDef{
+			IA:       xtest.MustParseIA("1-ff00:0:84"),
+			ChainVer: 42,
+			TRCVer:   21,
+		},
+		Algo: scrypto.Ed25519,
+	})
+	xtest.FailOnErr(t, err)
+	return signer
+}
+
+type revVerifier common.RawBytes
+
+func (v revVerifier) Verify(t *testing.T, srev *path_mgmt.SignedRevInfo) {
+	sign := srev.Sign
+	err := scrypto.Verify(sign.SigInput(srev.Blob, false), sign.Signature,
+		common.RawBytes(v), scrypto.Ed25519)
+	xtest.FailOnErr(t, err)
+}

--- a/go/beacon_srv/internal/ifstate/testdata/topology.json
+++ b/go/beacon_srv/internal/ifstate/testdata/topology.json
@@ -1,0 +1,170 @@
+{
+  "Overlay": "UDP/IPv4",
+  "MTU": 1472,
+  "ISD_AS": "1-ff00:0:111",
+  "Core": false,
+  "BorderRouters": {
+    "br1-ff00_0_111-2": {
+      "CtrlAddr": {
+        "IPv4": {
+          "Public": {
+            "L4Port": 31031,
+            "Addr": "127.0.0.82"
+          }
+        }
+      },
+      "InternalAddrs": {
+        "IPv4": {
+          "PublicOverlay": {
+            "OverlayPort": 31032,
+            "Addr": "127.0.0.82"
+          }
+        }
+      },
+      "Interfaces": {
+        "105": {
+          "Bandwidth": 1000,
+          "RemoteOverlay": {
+            "OverlayPort": 50000,
+            "Addr": "127.0.0.17"
+          },
+          "Overlay": "UDP/IPv4",
+          "ISD_AS": "1-ff00:0:130",
+          "PublicOverlay": {
+            "OverlayPort": 50000,
+            "Addr": "127.0.0.16"
+          },
+          "LinkTo": "PARENT",
+          "MTU": 1472
+        },
+        "103": {
+          "Bandwidth": 1000,
+          "RemoteOverlay": {
+            "OverlayPort": 50000,
+            "Addr": "127.0.0.15"
+          },
+          "Overlay": "UDP/IPv4",
+          "ISD_AS": "1-ff00:0:112",
+          "PublicOverlay": {
+            "OverlayPort": 50000,
+            "Addr": "127.0.0.14"
+          },
+          "LinkTo": "CHILD",
+          "MTU": 1472
+        }
+      }
+    },
+    "br1-ff00_0_111-3": {
+      "CtrlAddr": {
+        "IPv4": {
+          "Public": {
+            "L4Port": 31033,
+            "Addr": "127.0.0.83"
+          }
+        }
+      },
+      "InternalAddrs": {
+        "IPv4": {
+          "PublicOverlay": {
+            "OverlayPort": 31034,
+            "Addr": "127.0.0.83"
+          }
+        }
+      },
+      "Interfaces": {
+        "100": {
+          "Bandwidth": 1000,
+          "RemoteOverlay": {
+            "OverlayPort": 50000,
+            "Addr": "127.0.0.19"
+          },
+          "Overlay": "UDP/IPv4",
+          "ISD_AS": "1-ff00:0:121",
+          "PublicOverlay": {
+            "OverlayPort": 50000,
+            "Addr": "127.0.0.18"
+          },
+          "LinkTo": "PEER",
+          "MTU": 1472
+        },
+        "102": {
+          "Bandwidth": 1000,
+          "RemoteOverlay": {
+            "OverlayPort": 50000,
+            "Addr": "127.0.0.21"
+          },
+          "Overlay": "UDP/IPv4",
+          "ISD_AS": "2-ff00:0:211",
+          "PublicOverlay": {
+            "OverlayPort": 50000,
+            "Addr": "127.0.0.20"
+          },
+          "LinkTo": "PEER",
+          "MTU": 1472
+        }
+      }
+    },
+    "br1-ff00_0_111-1": {
+      "CtrlAddr": {
+        "IPv4": {
+          "Public": {
+            "L4Port": 31029,
+            "Addr": "127.0.0.81"
+          }
+        }
+      },
+      "InternalAddrs": {
+        "IPv4": {
+          "PublicOverlay": {
+            "OverlayPort": 31030,
+            "Addr": "127.0.0.81"
+          }
+        }
+      },
+      "Interfaces": {
+        "104": {
+          "Bandwidth": 1000,
+          "RemoteOverlay": {
+            "OverlayPort": 50000,
+            "Addr": "127.0.0.11"
+          },
+          "Overlay": "UDP/IPv4",
+          "ISD_AS": "1-ff00:0:120",
+          "PublicOverlay": {
+            "OverlayPort": 50000,
+            "Addr": "127.0.0.10"
+          },
+          "LinkTo": "PARENT",
+          "MTU": 1472
+        },
+        "101": {
+          "Bandwidth": 1000,
+          "RemoteOverlay": {
+            "OverlayPort": 50000,
+            "Addr": "127.0.0.13"
+          },
+          "Overlay": "UDP/IPv4",
+          "ISD_AS": "2-ff00:0:211",
+          "PublicOverlay": {
+            "OverlayPort": 50000,
+            "Addr": "127.0.0.12"
+          },
+          "LinkTo": "PEER",
+          "MTU": 1472
+        }
+      }
+    }
+  },
+  "PathService": {
+    "ps1-ff00_0_111-1": {
+      "Addrs": {
+        "IPv4": {
+          "Public": {
+            "L4Port": 31028,
+            "Addr": "127.0.0.86"
+          }
+        }
+      }
+    }
+  }
+}

--- a/go/lib/xtest/BUILD.bazel
+++ b/go/lib/xtest/BUILD.bazel
@@ -6,12 +6,14 @@ go_library(
         "convey.go",
         "helpers.go",
         "mocking.go",
+        "topo.go",
     ],
     importpath = "github.com/scionproto/scion/go/lib/xtest",
     visibility = ["//visibility:public"],
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
+        "//go/lib/topology:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
     ],
 )

--- a/go/lib/xtest/topo.go
+++ b/go/lib/xtest/topo.go
@@ -1,0 +1,40 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xtest
+
+import (
+	"testing"
+
+	"github.com/scionproto/scion/go/lib/topology"
+)
+
+// TestTopoProvider is a provider for a specific topology object.
+type TestTopoProvider struct {
+	*topology.Topo
+}
+
+// TopoProviderFromFile creates a topo provider from a topology file.
+// It fails the test if loading the file fails.
+func TopoProviderFromFile(t *testing.T, fName string) *TestTopoProvider {
+	t.Helper()
+	topo, err := topology.LoadFromFile("testdata/topology.json")
+	FailOnErr(t, err)
+	return &TestTopoProvider{Topo: topo}
+}
+
+// Get returns the stored topology.
+func (t *TestTopoProvider) Get() *topology.Topo {
+	return t.Topo
+}


### PR DESCRIPTION
Adds a Revoker task that issues revocations for interfaces that have timed
and renews evocations for already revoked interfaces periodically.

Fixes #2566

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2625)
<!-- Reviewable:end -->
