### PR TITLE
messenger: Extend RW with SendIfStateInfoReply

### DIFF
--- a/go/lib/infra/common.go
+++ b/go/lib/infra/common.go
@@ -339,6 +339,7 @@ type ResponseWriter interface {
 	SendCertChainReply(ctx context.Context, msg *cert_mgmt.Chain) error
 	SendChainIssueReply(ctx context.Context, msg *cert_mgmt.ChainIssRep) error
 	SendSegReply(ctx context.Context, msg *path_mgmt.SegReply) error
+	SendIfStateInfoReply(ctx context.Context, msg *path_mgmt.IFStateInfos) error
 }
 
 func ResponseWriterFromContext(ctx context.Context) (ResponseWriter, bool) {

--- a/go/lib/infra/messenger/udp_response_writer.go
+++ b/go/lib/infra/messenger/udp_response_writer.go
@@ -1,4 +1,4 @@
-// Copyright 2019 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,4 +52,10 @@ func (rw *UDPResponseWriter) SendChainIssueReply(ctx context.Context,
 
 func (rw *UDPResponseWriter) SendSegReply(ctx context.Context, msg *path_mgmt.SegReply) error {
 	return rw.Messenger.SendSegReply(ctx, msg, rw.Remote, rw.ID)
+}
+
+func (rw *UDPResponseWriter) SendIfStateInfoReply(ctx context.Context,
+	msg *path_mgmt.IFStateInfos) error {
+
+	return rw.Messenger.SendIfStateInfos(ctx, msg, rw.Remote, rw.ID)
 }

--- a/go/lib/infra/mock_infra/infra.go
+++ b/go/lib/infra/mock_infra/infra.go
@@ -597,6 +597,20 @@ func (mr *MockResponseWriterMockRecorder) SendChainIssueReply(arg0, arg1 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendChainIssueReply", reflect.TypeOf((*MockResponseWriter)(nil).SendChainIssueReply), arg0, arg1)
 }
 
+// SendIfStateInfoReply mocks base method
+func (m *MockResponseWriter) SendIfStateInfoReply(arg0 context.Context, arg1 *path_mgmt.IFStateInfos) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendIfStateInfoReply", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendIfStateInfoReply indicates an expected call of SendIfStateInfoReply
+func (mr *MockResponseWriterMockRecorder) SendIfStateInfoReply(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendIfStateInfoReply", reflect.TypeOf((*MockResponseWriter)(nil).SendIfStateInfoReply), arg0, arg1)
+}
+
 // SendSegReply mocks base method
 func (m *MockResponseWriter) SendSegReply(arg0 context.Context, arg1 *path_mgmt.SegReply) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Extend the response writer with SendIfStateInfoReply which is needed to implement the IfStateReq handler.
Contributes #2486

Also fix go calls in QUICResponseWrite to always defer log.LogPanicAndExit().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2626)
<!-- Reviewable:end -->
