### PR TITLE
BS: Create beacon store through beaconstorage

### DIFF
--- a/go/beacon_srv/internal/beacon/policy.go
+++ b/go/beacon_srv/internal/beacon/policy.go
@@ -46,6 +46,96 @@ const (
 	DefaultMaxHopsLength = 10
 )
 
+// Policies keeps track of all policies for a non-core beacon store.
+type Policies struct {
+	// Prop is the propagation policy.
+	Prop Policy
+	// UpReg is the up segment policy.
+	UpReg Policy
+	// DownReg is the down segment policy.
+	DownReg Policy
+}
+
+// InitDefaults sets the defaults for all policies.
+func (p *Policies) InitDefaults() {
+	p.Prop.initDefaults(PropPolicy)
+	p.UpReg.initDefaults(UpRegPolicy)
+	p.DownReg.initDefaults(DownRegPolicy)
+}
+
+// Validate checks that each policy is of the correct type.
+func (p *Policies) Validate() error {
+	if p.Prop.Type != PropPolicy {
+		return common.NewBasicError("Invalid policy type", nil,
+			"expected", PropPolicy, "actual", p.Prop.Type)
+	}
+	if p.UpReg.Type != UpRegPolicy {
+		return common.NewBasicError("Invalid policy type", nil,
+			"expected", UpRegPolicy, "actual", p.UpReg.Type)
+	}
+	if p.DownReg.Type != DownRegPolicy {
+		return common.NewBasicError("Invalid policy type", nil,
+			"expected", DownRegPolicy, "actual", p.DownReg.Type)
+	}
+	return nil
+}
+
+// Usage returns the allowed usage of the beacon based on all available
+// policies. For missing policies, the usage is not permitted.
+func (p *Policies) Usage(beacon Beacon) Usage {
+	var u Usage
+	if p.Prop.Filter.Apply(beacon) == nil {
+		u |= UsageProp
+	}
+	if p.UpReg.Filter.Apply(beacon) == nil {
+		u |= UsageUpReg
+	}
+	if p.DownReg.Filter.Apply(beacon) == nil {
+		u |= UsageDownReg
+	}
+	return u
+}
+
+// CorePolicies keeps track of all policies for a core beacon store.
+type CorePolicies struct {
+	// Prop is the propagation policy.
+	Prop Policy
+	// CoreReg is the core segment policy.
+	CoreReg Policy
+}
+
+// InitDefaults sets the defaults for all policies.
+func (p *CorePolicies) InitDefaults() {
+	p.Prop.initDefaults(PropPolicy)
+	p.CoreReg.initDefaults(CoreRegPolicy)
+}
+
+// Validate checks that each policy is of the correct type.
+func (p *CorePolicies) Validate() error {
+	if p.Prop.Type != PropPolicy {
+		return common.NewBasicError("Invalid policy type", nil,
+			"expected", PropPolicy, "actual", p.Prop.Type)
+	}
+	if p.CoreReg.Type != CoreRegPolicy {
+		return common.NewBasicError("Invalid policy type", nil,
+			"expected", CoreRegPolicy, "actual", p.CoreReg.Type)
+	}
+	return nil
+}
+
+// Usage returns the allowed usage of the beacon based on all available
+// policies. For missing policies, the usage is not permitted.
+func (p *CorePolicies) Usage(beacon Beacon) Usage {
+	var u Usage
+	if p.Prop.Filter.Apply(beacon) == nil {
+		u |= UsageProp
+	}
+	if p.CoreReg.Filter.Apply(beacon) == nil {
+		u |= UsageCoreReg
+	}
+	return u
+}
+
 // Policy contains the policy parameters when handling beacons.
 type Policy struct {
 	// BestSetSize is the number of segments to propagate or register.

--- a/go/beacon_srv/internal/beacon/policy.go
+++ b/go/beacon_srv/internal/beacon/policy.go
@@ -70,6 +70,13 @@ func (p *Policy) InitDefaults() {
 	p.Filter.InitDefaults()
 }
 
+func (p *Policy) initDefaults(t PolicyType) {
+	p.InitDefaults()
+	if p.Type == "" {
+		p.Type = t
+	}
+}
+
 // ParseYaml parses the policy in yaml format and initializes the default values.
 func ParseYaml(b common.RawBytes, t PolicyType) (*Policy, error) {
 	p := &Policy{}

--- a/go/beacon_srv/internal/beacon/store_test.go
+++ b/go/beacon_srv/internal/beacon/store_test.go
@@ -322,10 +322,9 @@ func testCoreStoreSelection(t *testing.T,
 			defer mctrl.Finish()
 			db := mock_beacon.NewMockDB(mctrl)
 			tx := mock_beacon.NewMockTransaction(mctrl)
-			policies := beacon.Policies{
+			policies := beacon.CorePolicies{
 				Prop:    beacon.Policy{BestSetSize: test.bestSize},
 				CoreReg: beacon.Policy{BestSetSize: test.bestSize},
-				Core:    true,
 			}
 			store, err := beacon.NewCoreBeaconStore(policies, db)
 			xtest.FailOnErr(t, err)

--- a/go/beacon_srv/internal/beacon/store_test.go
+++ b/go/beacon_srv/internal/beacon/store_test.go
@@ -157,7 +157,8 @@ func testStoreSelection(t *testing.T,
 			prop := beacon.Policy{BestSetSize: test.bestSize, Type: beacon.PropPolicy}
 			up := beacon.Policy{BestSetSize: test.bestSize, Type: beacon.UpRegPolicy}
 			down := beacon.Policy{BestSetSize: test.bestSize, Type: beacon.DownRegPolicy}
-			store := beacon.NewBeaconStore(prop, up, down, db)
+			store, err := beacon.NewBeaconStore(prop, up, down, db)
+			xtest.FailOnErr(t, err)
 			db.EXPECT().CandidateBeacons(gomock.Any(), gomock.Any(), gomock.Any(),
 				addr.IA{}).DoAndReturn(
 				func(_ ...interface{}) (<-chan beacon.BeaconOrErr, error) {
@@ -321,7 +322,8 @@ func testCoreStoreSelection(t *testing.T,
 			tx := mock_beacon.NewMockTransaction(mctrl)
 			prop := beacon.Policy{BestSetSize: test.bestSize, Type: beacon.PropPolicy}
 			reg := beacon.Policy{BestSetSize: test.bestSize, Type: beacon.CoreRegPolicy}
-			store := beacon.NewCoreBeaconStore(prop, reg, db)
+			store, err := beacon.NewCoreBeaconStore(prop, reg, db)
+			xtest.FailOnErr(t, err)
 			// respFunc serves beacons on the returned channel.
 			type respFunc func(_ ...interface{}) (<-chan beacon.BeaconOrErr, error)
 			// responder is a factory that generates a function serving the specified beacons.

--- a/go/beacon_srv/internal/beacon/store_test.go
+++ b/go/beacon_srv/internal/beacon/store_test.go
@@ -154,10 +154,12 @@ func testStoreSelection(t *testing.T,
 			mctrl := gomock.NewController(t)
 			defer mctrl.Finish()
 			db := mock_beacon.NewMockDB(mctrl)
-			prop := beacon.Policy{BestSetSize: test.bestSize, Type: beacon.PropPolicy}
-			up := beacon.Policy{BestSetSize: test.bestSize, Type: beacon.UpRegPolicy}
-			down := beacon.Policy{BestSetSize: test.bestSize, Type: beacon.DownRegPolicy}
-			store, err := beacon.NewBeaconStore(prop, up, down, db)
+			policies := beacon.Policies{
+				Prop:    beacon.Policy{BestSetSize: test.bestSize},
+				UpReg:   beacon.Policy{BestSetSize: test.bestSize},
+				DownReg: beacon.Policy{BestSetSize: test.bestSize},
+			}
+			store, err := beacon.NewBeaconStore(policies, db)
 			xtest.FailOnErr(t, err)
 			db.EXPECT().CandidateBeacons(gomock.Any(), gomock.Any(), gomock.Any(),
 				addr.IA{}).DoAndReturn(
@@ -320,9 +322,12 @@ func testCoreStoreSelection(t *testing.T,
 			defer mctrl.Finish()
 			db := mock_beacon.NewMockDB(mctrl)
 			tx := mock_beacon.NewMockTransaction(mctrl)
-			prop := beacon.Policy{BestSetSize: test.bestSize, Type: beacon.PropPolicy}
-			reg := beacon.Policy{BestSetSize: test.bestSize, Type: beacon.CoreRegPolicy}
-			store, err := beacon.NewCoreBeaconStore(prop, reg, db)
+			policies := beacon.Policies{
+				Prop:    beacon.Policy{BestSetSize: test.bestSize},
+				CoreReg: beacon.Policy{BestSetSize: test.bestSize},
+				Core:    true,
+			}
+			store, err := beacon.NewCoreBeaconStore(policies, db)
 			xtest.FailOnErr(t, err)
 			// respFunc serves beacons on the returned channel.
 			type respFunc func(_ ...interface{}) (<-chan beacon.BeaconOrErr, error)

--- a/go/beacon_srv/internal/beaconstorage/config.go
+++ b/go/beacon_srv/internal/beaconstorage/config.go
@@ -160,10 +160,16 @@ func (cfg *BeaconDBConf) NewStore(ia addr.IA, policies beacon.Policies) (Store, 
 	if err != nil {
 		return nil, err
 	}
-	if policies.Core {
-		return beacon.NewCoreBeaconStore(policies, db)
-	}
 	return beacon.NewBeaconStore(policies, db)
+}
+
+// NewCoreStore creates a new core beacon store backed by the configured database.
+func (cfg *BeaconDBConf) NewCoreStore(ia addr.IA, policies beacon.CorePolicies) (Store, error) {
+	db, err := cfg.New(ia)
+	if err != nil {
+		return nil, err
+	}
+	return beacon.NewCoreBeaconStore(policies, db)
 }
 
 func setConnLimits(cfg *BeaconDBConf, db beacon.DB) {

--- a/go/beacon_srv/internal/beaconstorage/config.go
+++ b/go/beacon_srv/internal/beaconstorage/config.go
@@ -154,6 +154,26 @@ func (cfg *BeaconDBConf) New(ia addr.IA) (beacon.DB, error) {
 	return db, nil
 }
 
+// NewStore creates a new beacon store backed by the configured database.
+func (cfg *BeaconDBConf) NewStore(core bool, ia addr.IA, policies Policies) (Store, error) {
+	db, err := cfg.New(ia)
+	if err != nil {
+		return nil, err
+	}
+	if core {
+		return beacon.NewCoreBeaconStore(policies.Prop, policies.CoreReg, db)
+	}
+	return beacon.NewBeaconStore(policies.Prop, policies.UpReg, policies.DownReg, db)
+}
+
+// Policies holds the policies to initialize the beacon store.
+type Policies struct {
+	Prop    beacon.Policy
+	UpReg   beacon.Policy
+	DownReg beacon.Policy
+	CoreReg beacon.Policy
+}
+
 func setConnLimits(cfg *BeaconDBConf, db beacon.DB) {
 	if m, ok := cfg.MaxOpenConns(); ok {
 		db.SetMaxOpenConns(m)

--- a/go/beacon_srv/internal/beaconstorage/config.go
+++ b/go/beacon_srv/internal/beaconstorage/config.go
@@ -155,23 +155,15 @@ func (cfg *BeaconDBConf) New(ia addr.IA) (beacon.DB, error) {
 }
 
 // NewStore creates a new beacon store backed by the configured database.
-func (cfg *BeaconDBConf) NewStore(core bool, ia addr.IA, policies Policies) (Store, error) {
+func (cfg *BeaconDBConf) NewStore(ia addr.IA, policies beacon.Policies) (Store, error) {
 	db, err := cfg.New(ia)
 	if err != nil {
 		return nil, err
 	}
-	if core {
-		return beacon.NewCoreBeaconStore(policies.Prop, policies.CoreReg, db)
+	if policies.Core {
+		return beacon.NewCoreBeaconStore(policies, db)
 	}
-	return beacon.NewBeaconStore(policies.Prop, policies.UpReg, policies.DownReg, db)
-}
-
-// Policies holds the policies to initialize the beacon store.
-type Policies struct {
-	Prop    beacon.Policy
-	UpReg   beacon.Policy
-	DownReg beacon.Policy
-	CoreReg beacon.Policy
+	return beacon.NewBeaconStore(policies, db)
 }
 
 func setConnLimits(cfg *BeaconDBConf, db beacon.DB) {


### PR DESCRIPTION
This PR makes `beacon.{Core}Store` implement the `beaconstorage.Store`
interface.
This allows us to create the beacon store backed by the configured
database in `BeaconDBConf`.

fixes  #2560

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2648)
<!-- Reviewable:end -->
