### PR TITLE
Added missing dependency for be64toh

### DIFF
--- a/c/lib/filter/filter.c
+++ b/c/lib/filter/filter.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
+#include <endian.h>
 
 #include <zlog.h>
 


### PR DESCRIPTION
In file `c/lib/filter/filter.c`, there was a missing dependency for the function `be64toh`.  
Including `<endian.h>` fixes this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2657)
<!-- Reviewable:end -->
