### PR TITLE
CS: Force cancel core pusher

### DIFF
--- a/go/cert_srv/internal/reiss/corepush.go
+++ b/go/cert_srv/internal/reiss/corepush.go
@@ -115,7 +115,6 @@ func (p *CorePusher) syncCores(ctx context.Context, chain *cert.Chain, cores *ia
 }
 
 // asyncPush pushes the certificate chain to the core if it does not have it already.
-// Errors while checking are
 func (p *CorePusher) asyncPush(ctx context.Context, chain *cert.Chain, cores *iaMap,
 	core addr.IA, checkErrs *iaList, wg *sync.WaitGroup) {
 

--- a/go/cert_srv/internal/reiss/corepush.go
+++ b/go/cert_srv/internal/reiss/corepush.go
@@ -16,6 +16,7 @@ package reiss
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
@@ -34,6 +35,9 @@ var (
 	// SleepAfterFailure is the base time to sleep after a failed attempt to push the chain.
 	// The actual sleep time is: attempts * SleepAfterFailure.
 	SleepAfterFailure = time.Second
+	// DefaultTryTimeout is the default timeout for one sync try if the context
+	// has no deadline set.
+	DefaultTryTimeout = 20 * time.Second
 )
 
 var _ periodic.Task = (*CorePusher)(nil)
@@ -53,64 +57,84 @@ func (p *CorePusher) Run(ctx context.Context) {
 		log.Error("[corePusher] Failed to get local chain from DB", "err", err)
 		return
 	}
-	allCores, err := p.coreASes(ctx)
+	cores, err := p.coreASes(ctx)
 	if err != nil {
 		log.Error("[corePusher] Failed to determine core ASes", "err", err)
 		return
 	}
-	cores := allCores
+	numCores := len(cores.ias)
+	tryTimeout := DefaultTryTimeout
+	if deadline, ok := ctx.Deadline(); ok {
+		tryTimeout = deadline.Sub(time.Now()) / 3
+	}
 	for syncTries := 0; syncTries < 3 && ctx.Err() == nil; syncTries++ {
-		time.Sleep(time.Duration(syncTries) * SleepAfterFailure)
-		cores, err = p.syncCores(ctx, chain, cores)
+		tryCtx, cancelF := context.WithTimeout(ctx, tryTimeout)
+		err = p.syncCores(tryCtx, chain, cores)
+		cancelF()
 		if err == nil {
-			log.Info("[corePusher] Successfully pushed chain to cores", "cores", len(allCores))
+			log.Info("[corePusher] Successfully pushed chain to cores", "cores", numCores)
 			return
 		}
 		log.Error("[corePusher] Failed to sync all cores", "err", err)
+		select {
+		case <-time.After(time.Duration(syncTries) * SleepAfterFailure):
+		case <-ctx.Done():
+		}
 	}
 }
 
-// syncCores tries to sync to the given cores and returns the cores for which the syncing failed.
-func (p *CorePusher) syncCores(ctx context.Context, chain *cert.Chain,
-	cores []addr.IA) ([]addr.IA, error) {
-
-	var checkErrors []addr.IA
-	var remainingCores []addr.IA
-	for _, coreIA := range cores {
-		hasChain, err := p.hasChain(ctx, coreIA, chain)
-		if err != nil {
-			checkErrors = append(checkErrors, coreIA)
-			// fall-through explicitly, we just assume the core doesn't have it and send it.
-		}
-		if !hasChain {
-			if err = p.sendChain(ctx, coreIA, chain); err != nil {
-				remainingCores = append(remainingCores, coreIA)
-			}
-		}
-	}
-	if len(checkErrors) > 0 || len(remainingCores) > 0 {
-		return remainingCores, common.NewBasicError("Sync error", nil,
-			"checkErrors", checkErrors, "remainingCores", remainingCores)
-	}
-	return nil, nil
-}
-
-func (p *CorePusher) coreASes(ctx context.Context) ([]addr.IA, error) {
+func (p *CorePusher) coreASes(ctx context.Context) (*iaMap, error) {
 	trc, err := p.TrustDB.GetTRCMaxVersion(ctx, p.LocalIA.I)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to get TRC for local ISD", err)
 	}
-	return p.filterLocalIA(trc.CoreASes.ASList()), nil
-}
-
-func (p *CorePusher) filterLocalIA(allCores []addr.IA) []addr.IA {
-	cores := make([]addr.IA, 0, len(allCores))
-	for _, coreIA := range allCores {
-		if !p.LocalIA.Equal(coreIA) {
-			cores = append(cores, coreIA)
+	cores := make(map[addr.IA]struct{})
+	for _, ia := range trc.CoreASes.ASList() {
+		if !p.LocalIA.Equal(ia) {
+			cores[ia] = struct{}{}
 		}
 	}
-	return cores
+	return &iaMap{ias: cores}, nil
+}
+
+// syncCores tries to sync to the given cores and returns the cores for which the syncing failed.
+func (p *CorePusher) syncCores(ctx context.Context, chain *cert.Chain, cores *iaMap) error {
+
+	wg := &sync.WaitGroup{}
+	wg.Add(len(cores.ias))
+	checkErrs := &iaList{}
+	for coreIA := range cores.ias {
+		p.asyncPush(ctx, chain, cores, coreIA, checkErrs, wg)
+	}
+	wg.Wait()
+	if len(checkErrs.ias) > 0 || len(cores.ias) > 0 {
+		return common.NewBasicError("Sync error", nil, "checkErrors", checkErrs.ias,
+			"remainingCores", cores.list())
+	}
+	return nil
+}
+
+// asyncPush pushes the certificate chain to the core if it does not have it already.
+// Errors while checking are
+func (p *CorePusher) asyncPush(ctx context.Context, chain *cert.Chain, cores *iaMap,
+	core addr.IA, checkErrs *iaList, wg *sync.WaitGroup) {
+
+	go func() {
+		defer log.LogPanicAndExit()
+		defer wg.Done()
+		hasChain, err := p.hasChain(ctx, core, chain)
+		if err != nil {
+			checkErrs.append(core)
+			// fall-through explicitly, we just assume the core doesn't have it and send it.
+		}
+		var sendErr error
+		if !hasChain {
+			sendErr = p.sendChain(ctx, core, chain)
+		}
+		if sendErr == nil {
+			cores.delete(core)
+		}
+	}()
 }
 
 func (p *CorePusher) hasChain(ctx context.Context, coreAS addr.IA,
@@ -142,4 +166,36 @@ func (p *CorePusher) sendChain(ctx context.Context, coreAS addr.IA, chain *cert.
 	coreAddr := &snet.Addr{IA: coreAS, Host: addr.NewSVCUDPAppAddr(addr.SvcCS)}
 	// TODO(lukedirtwalker): Expect Acks.
 	return p.Msger.SendCertChain(ctx, msg, coreAddr, messenger.NextId())
+}
+
+type iaList struct {
+	mu  sync.Mutex
+	ias []addr.IA
+}
+
+func (l *iaList) append(ia addr.IA) {
+	l.mu.Lock()
+	l.ias = append(l.ias, ia)
+	l.mu.Unlock()
+}
+
+type iaMap struct {
+	mu  sync.Mutex
+	ias map[addr.IA]struct{}
+}
+
+func (m *iaMap) delete(ia addr.IA) {
+	m.mu.Lock()
+	delete(m.ias, ia)
+	m.mu.Unlock()
+}
+
+func (m *iaMap) list() []addr.IA {
+	m.mu.Lock()
+	l := make([]addr.IA, 0, len(m.ias))
+	for ia := range m.ias {
+		l = append(l, ia)
+	}
+	m.mu.Unlock()
+	return l
 }

--- a/go/cert_srv/main.go
+++ b/go/cert_srv/main.go
@@ -183,7 +183,7 @@ func startDiscovery() {
 
 func stopReissRunner() {
 	if corePusher != nil {
-		corePusher.Stop()
+		corePusher.Kill()
 	}
 	if reissRunner != nil {
 		reissRunner.Stop()
@@ -192,7 +192,7 @@ func stopReissRunner() {
 
 func stop() {
 	stopReissRunner()
-	discRunners.Stop()
+	discRunners.Kill()
 	msgr.CloseServer()
 	trustDB.Close()
 }

--- a/go/lib/infra/modules/idiscovery/idiscovery.go
+++ b/go/lib/infra/modules/idiscovery/idiscovery.go
@@ -143,19 +143,6 @@ func StartRunners(cfg Config, file discovery.File, handlers TopoHandlers,
 	return r, nil
 }
 
-// Stop stops all runners.
-func (r *Runners) Stop() {
-	if r.Static != nil {
-		r.Static.Stop()
-	}
-	if r.Dynamic != nil {
-		r.Dynamic.Stop()
-	}
-	if r.Cleaner != nil {
-		r.Cleaner.Stop()
-	}
-}
-
 // Kill kills all runners.
 func (r *Runners) Kill() {
 	if r.Static != nil {
@@ -186,26 +173,14 @@ type Runner struct {
 	fetched flag
 }
 
-// Stop stops the periodic execution of the Runner. If the task is currently running
-// this method will block until it is done.
-func (r *Runner) Stop() {
-	r.fetcherMtx.Lock()
-	defer r.fetcherMtx.Unlock()
-	r.stopping = true
-	close(r.stop)
-	if r.fetcher != nil {
-		r.fetcher.Stop()
-	}
-}
-
-// Kill is like stop but it also cancels the context of the current running method.
+// Kill stops the periodic execution of the Runner.
 func (r *Runner) Kill() {
 	r.fetcherMtx.Lock()
 	defer r.fetcherMtx.Unlock()
 	r.stopping = true
 	close(r.stop)
 	if r.fetcher != nil {
-		r.fetcher.Stop()
+		r.fetcher.Kill()
 	}
 }
 


### PR DESCRIPTION
The core pusher in the certificate server can block up to a minute if there are no paths available.
This can delay the shutdown of the whole certificate server if the task is in blocking state.

This PR fixes this by killing the task instead of waiting for it to finish.

Additionally, the SegPusher now uses go routines to avoid head of line blocking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2660)
<!-- Reviewable:end -->
