### PR TITLE
BS: Filter ISD loops

### DIFF
--- a/go/beacon_srv/internal/beacon/policy.go
+++ b/go/beacon_srv/internal/beacon/policy.go
@@ -306,15 +306,10 @@ func filterLoops(hops []addr.IA, allowIsdLoop bool) error {
 
 func filterAsLoop(hops []addr.IA) addr.IA {
 	seen := make(map[addr.IA]struct{})
-	var last addr.IA
 	for _, ia := range hops {
-		if last.Equal(ia) {
-			return ia
-		}
 		if _, ok := seen[ia]; ok {
 			return ia
 		}
-		last = ia
 		seen[ia] = struct{}{}
 	}
 	return addr.IA{}

--- a/go/beacon_srv/internal/beacon/policy.go
+++ b/go/beacon_srv/internal/beacon/policy.go
@@ -80,6 +80,25 @@ func (p *Policies) Validate() error {
 	return nil
 }
 
+// Filter applies all filters and returns an error if all of them filter the
+// beacon. If at least one does not filter, no error is returned.
+func (p *Policies) Filter(beacon Beacon) error {
+	var errors []error
+	if err := p.Prop.Filter.Apply(beacon); err != nil {
+		errors = append(errors, err)
+	}
+	if err := p.UpReg.Filter.Apply(beacon); err != nil {
+		errors = append(errors, err)
+	}
+	if err := p.DownReg.Filter.Apply(beacon); err != nil {
+		errors = append(errors, err)
+	}
+	if len(errors) == 3 {
+		return common.NewBasicError("Filtered by all policies", nil, "errs", errors)
+	}
+	return nil
+}
+
 // Usage returns the allowed usage of the beacon based on all available
 // policies. For missing policies, the usage is not permitted.
 func (p *Policies) Usage(beacon Beacon) Usage {
@@ -119,6 +138,22 @@ func (p *CorePolicies) Validate() error {
 	if p.CoreReg.Type != CoreRegPolicy {
 		return common.NewBasicError("Invalid policy type", nil,
 			"expected", CoreRegPolicy, "actual", p.CoreReg.Type)
+	}
+	return nil
+}
+
+// Filter applies all filters and returns an error if all of them filter the
+// beacon. If at least one does not filter, no error is returned.
+func (p *CorePolicies) Filter(beacon Beacon) error {
+	var errors []error
+	if err := p.Prop.Filter.Apply(beacon); err != nil {
+		errors = append(errors, err)
+	}
+	if err := p.CoreReg.Filter.Apply(beacon); err != nil {
+		errors = append(errors, err)
+	}
+	if len(errors) == 2 {
+		return common.NewBasicError("Filtered by all policies", nil, "errs", errors)
 	}
 	return nil
 }
@@ -202,6 +237,8 @@ type Filter struct {
 	AsBlackList []addr.AS `yaml:"AsBlackList"`
 	// IsdBlackList contains all ISD that may not appear in a segment.
 	IsdBlackList []addr.ISD `yaml:"IsdBlackList"`
+	// AllowIsdLoop indicates whether ISD loops should not be filtered.
+	AllowIsdLoop bool
 }
 
 // InitDefaults initializes the default values for unset fields.
@@ -217,8 +254,11 @@ func (f Filter) Apply(beacon Beacon) error {
 		return common.NewBasicError("MaxHopsLength exceeded", nil, "max", f.MaxHopsLength,
 			"actual", len(beacon.Segment.ASEntries))
 	}
-	for _, entry := range beacon.Segment.ASEntries {
-		ia := entry.IA()
+	hops := buildHops(beacon)
+	if err := filterLoops(hops, f.AllowIsdLoop); err != nil {
+		return err
+	}
+	for _, ia := range hops {
 		for _, as := range f.AsBlackList {
 			if ia.A == as {
 				return common.NewBasicError("Contains blacklisted AS", nil, "ia", ia)
@@ -231,4 +271,55 @@ func (f Filter) Apply(beacon Beacon) error {
 		}
 	}
 	return nil
+}
+
+// FilterLoop returns an error if the beacon contains an AS or ISD loop. If ISD
+// loops are allowed, an error is returned only on AS loops.
+func FilterLoop(beacon Beacon, next addr.IA, allowIsdLoop bool) error {
+	hops := buildHops(beacon)
+	if !next.IsZero() {
+		hops = append(hops, next)
+	}
+	return filterLoops(hops, allowIsdLoop)
+}
+
+func buildHops(beacon Beacon) []addr.IA {
+	hops := make([]addr.IA, 0, len(beacon.Segment.ASEntries)+1)
+	for _, asEntry := range beacon.Segment.ASEntries {
+		hops = append(hops, asEntry.IA())
+	}
+	return hops
+}
+
+func filterLoops(hops []addr.IA, allowIsdLoop bool) error {
+	if !allowIsdLoop {
+		if ia := filterLoop(hops, true); !ia.IsZero() {
+			return common.NewBasicError("ISD loop", nil, "isd", ia.I)
+		}
+	}
+	if ia := filterLoop(hops, false); !ia.IsZero() {
+		return common.NewBasicError("AS loop", nil, "ia", ia)
+	}
+	return nil
+}
+
+func filterLoop(hops []addr.IA, ignoreAs bool) addr.IA {
+	seen := make(map[addr.IA]struct{})
+	var last addr.IA
+	for _, ia := range hops {
+		if last.Equal(ia) {
+			return ia
+		}
+		if ignoreAs {
+			ia.A = 0
+		}
+		if !last.Equal(ia) {
+			if _, ok := seen[ia]; ok {
+				return ia
+			}
+			last = ia
+			seen[ia] = struct{}{}
+		}
+	}
+	return addr.IA{}
 }

--- a/go/beacon_srv/internal/beacon/policy_test.go
+++ b/go/beacon_srv/internal/beacon/policy_test.go
@@ -43,6 +43,7 @@ func TestLoadFromYaml(t *testing.T) {
 		SoMsg("MaxHopsLength", p.Filter.MaxHopsLength, ShouldEqual, 8)
 		SoMsg("AsBlackList", p.Filter.AsBlackList, ShouldResemble, []addr.AS{ia110.A, ia111.A})
 		SoMsg("IsdBlackList", p.Filter.IsdBlackList, ShouldResemble, []addr.ISD{1, 2, 3})
+		SoMsg("AllowIsdLoop", p.Filter.AllowIsdLoop, ShouldBeTrue)
 
 	}
 	Convey("Given a policy file with policy type set", t, func() {
@@ -125,9 +126,9 @@ func TestFilterApply(t *testing.T) {
 			},
 			{
 				Name:         "ISD/AS Loop [1-ff00:0:110, 3-ff00:0:311, 1-ff00:0:110]",
-				Beacon:       newTestBeacon(ia110, ia311, ia111),
+				Beacon:       newTestBeacon(ia110, ia311, ia110),
 				Filter:       &beacon.Filter{MaxHopsLength: 8, AllowIsdLoop: true},
-				ShouldFilter: false,
+				ShouldFilter: true,
 			},
 			{
 				Name:         "ISD Loop allowed [1-ff00:0:110, 3-ff00:0:311, 1-ff00:0:111]",
@@ -175,9 +176,9 @@ func TestFilterLoop(t *testing.T) {
 		},
 		{
 			Name:         "ISD/AS Loop [1-ff00:0:110, 3-ff00:0:311, 1-ff00:0:110]",
-			Beacon:       newTestBeacon(ia110, ia311, ia111),
+			Beacon:       newTestBeacon(ia110, ia311, ia110),
 			AllowIsdLoop: true,
-			ShouldFilter: false,
+			ShouldFilter: true,
 		},
 		{
 			Name:         "ISD Loop allowed [1-ff00:0:110, 3-ff00:0:311, 1-ff00:0:111]",

--- a/go/beacon_srv/internal/beacon/store.go
+++ b/go/beacon_srv/internal/beacon/store.go
@@ -30,6 +30,7 @@ import (
 const maxResultChanSize = 32
 
 type usager interface {
+	Filter(beacon Beacon) error
 	Usage(beacon Beacon) Usage
 }
 
@@ -193,6 +194,13 @@ type baseStore struct {
 	db     DB
 	usager usager
 	algo   selectionAlgorithm
+}
+
+// PreFilter indicates whether the beacon will be filtered on insert by
+// returning an error with the reason. This allows the caller to drop
+// ignored beacons.
+func (s *baseStore) PreFilter(beacon Beacon) error {
+	return s.usager.Filter(beacon)
 }
 
 // InsertBeacons adds verified beacons to the store. Beacons that

--- a/go/beacon_srv/internal/beacon/testdata/policy.yml
+++ b/go/beacon_srv/internal/beacon/testdata/policy.yml
@@ -5,4 +5,5 @@ Filter:
   MaxHopsLength: 8
   AsBlackList: ["ff00:0:110", "ff00:0:111"]
   IsdBlackList: [1, 2, 3]
+  AllowIsdLoop: true
 

--- a/go/beacon_srv/internal/beacon/testdata/typedPolicy.yml
+++ b/go/beacon_srv/internal/beacon/testdata/typedPolicy.yml
@@ -5,4 +5,5 @@ Filter:
   MaxHopsLength: 8
   AsBlackList: ["ff00:0:110", "ff00:0:111"]
   IsdBlackList: [1, 2, 3]
+  AllowIsdLoop: true
 Type: Propagation

--- a/go/beacon_srv/internal/beaconing/handler.go
+++ b/go/beacon_srv/internal/beaconing/handler.go
@@ -31,6 +31,7 @@ import (
 
 // BeaconInserter inserts beacons into the beacon store.
 type BeaconInserter interface {
+	PreFilter(beacon beacon.Beacon) error
 	InsertBeacons(ctx context.Context, beacon ...beacon.Beacon) error
 }
 
@@ -76,6 +77,10 @@ func (h *handler) handle(logger log.Logger) (*infra.HandlerResult, error) {
 		return res, err
 	}
 	logger.Debug("[BeaconHandler] Received", "beacon", b)
+	if err := h.inserter.PreFilter(b); err != nil {
+		logger.Trace("[BeaconHandler] Beacon pre-filtered", "err", err)
+		return infra.MetricsResultOk, nil
+	}
 	if err := h.verifyBeacon(b); err != nil {
 		return infra.MetricsErrInvalid, err
 	}

--- a/go/beacon_srv/internal/beaconing/handler_test.go
+++ b/go/beacon_srv/internal/beaconing/handler_test.go
@@ -61,6 +61,7 @@ func TestNewHandler(t *testing.T) {
 			inserter := mock_beaconing.NewMockBeaconInserter(mctrl)
 			expectedBeacon := beacon.Beacon{Segment: pseg, InIfId: localIF}
 			inserter.EXPECT().InsertBeacons(gomock.Any(), expectedBeacon).Return(nil)
+			inserter.EXPECT().PreFilter(gomock.Any()).Return(nil)
 
 			verifier := mock_infra.NewMockVerifier(mctrl)
 			verifier.EXPECT().WithServer(gomock.Any()).MaxTimes(2).Return(verifier)
@@ -74,6 +75,7 @@ func TestNewHandler(t *testing.T) {
 		})
 		Convey("Invalid requests cause an error", func() {
 			inserter := mock_beaconing.NewMockBeaconInserter(mctrl)
+			inserter.EXPECT().PreFilter(gomock.Any()).AnyTimes().Return(nil)
 			verifier := mock_infra.NewMockVerifier(mctrl)
 
 			intfs := testInterfaces(topoProvider.Get())
@@ -164,6 +166,7 @@ func TestNewHandler(t *testing.T) {
 				})
 				Convey("Insertion error", func() {
 					inserter := mock_beaconing.NewMockBeaconInserter(mctrl)
+					inserter.EXPECT().PreFilter(gomock.Any()).Return(nil)
 					inserter.EXPECT().InsertBeacons(gomock.Any(),
 						gomock.Any()).Return(common.NewBasicError("failed", nil))
 

--- a/go/beacon_srv/internal/beaconing/mock_beaconing/beaconing.go
+++ b/go/beacon_srv/internal/beaconing/mock_beaconing/beaconing.go
@@ -54,6 +54,20 @@ func (mr *MockBeaconInserterMockRecorder) InsertBeacons(arg0 interface{}, arg1 .
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBeacons", reflect.TypeOf((*MockBeaconInserter)(nil).InsertBeacons), varargs...)
 }
 
+// PreFilter mocks base method
+func (m *MockBeaconInserter) PreFilter(arg0 beacon.Beacon) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PreFilter", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PreFilter indicates an expected call of PreFilter
+func (mr *MockBeaconInserterMockRecorder) PreFilter(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreFilter", reflect.TypeOf((*MockBeaconInserter)(nil).PreFilter), arg0)
+}
+
 // MockBeaconProvider is a mock of BeaconProvider interface
 type MockBeaconProvider struct {
 	ctrl     *gomock.Controller

--- a/go/beacon_srv/internal/beaconstorage/store.go
+++ b/go/beacon_srv/internal/beaconstorage/store.go
@@ -27,6 +27,10 @@ import (
 
 // Store is the interface to interact with the beacon store.
 type Store interface {
+	// PreFilter indicates whether the beacon will be filtered on insert by
+	// returning an error with the reason. This allows the caller to drop
+	// ignored beacons.
+	PreFilter(beacon beacon.Beacon) error
 	// BeaconsToPropagate returns a channel that provides all beacons to
 	// propagate at the time of the call. The selection is based on the
 	// configured propagation policy.

--- a/go/beacon_srv/main.go
+++ b/go/beacon_srv/main.go
@@ -222,6 +222,7 @@ type periodicTasks struct {
 	store        beaconstorage.Store
 	msgr         infra.Messenger
 	topoProvider topology.Provider
+	allowIsdLoop bool
 
 	keepalive  *periodic.Runner
 	originator *periodic.Runner
@@ -360,6 +361,7 @@ func (t *periodicTasks) startPropagator(a *topology.TopoAddr) (*periodic.Runner,
 	}
 	p, err := beaconing.PropagatorConf{
 		BeaconProvider: t.store,
+		AllowIsdLoop:   t.allowIsdLoop,
 		Core:           topo.Core,
 		Sender: &onehop.Sender{
 			Conn: t.conn,


### PR DESCRIPTION
Add ISD loop filtering to the policy.
By default, ISD loops are not allowed. If desired, they can be allowed
in the policy.

Additionally, add pre-check to beacon store to indicate whether a beacon
will be ingored, so that the caller does not have to spend resources on
further processing the beacon.

fixes #2658

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2662)
<!-- Reviewable:end -->
