### PR TITLE
BS: Improve unit test for recentness of revocation

### DIFF
--- a/go/beacon_srv/internal/ifstate/revoker_test.go
+++ b/go/beacon_srv/internal/ifstate/revoker_test.go
@@ -297,7 +297,8 @@ func checkRevocation(t *testing.T, srev *path_mgmt.SignedRevInfo,
 		SoMsg("correct linkType", revInfo.LinkType,
 			ShouldEqual, topoProvider.Get().IFInfoMap[revokedIfId].LinkType)
 		rawNow := util.TimeToSecs(time.Now())
-		SoMsg("recent revocation", revInfo.RawTimestamp, ShouldBeBetween, rawNow-1, rawNow+1)
+		SoMsg("recent revocation", revInfo.RawTimestamp,
+			ShouldBeBetweenOrEqual, rawNow-1, rawNow)
 		SoMsg("minTTL", revInfo.RawTTL, ShouldEqual, uint32(path_mgmt.MinRevTTL.Seconds()))
 	})
 }


### PR DESCRIPTION
ShouldBeBetween doesn't include the bound.
In case the revocation was issued the second before the test creates the now value,
the test would fail on the lower bound.
(see https://buildkite.com/scionproto/scionproto-nightly/builds/228#e8f2c1cb-6d69-4852-89fa-d88953df795b)

Fix the check: The revocation can either have
- A timestamp with a second value 1 less than now, or
- A timestamp with the same second value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2663)
<!-- Reviewable:end -->
