### PR TITLE
Control-plane clients use QUIC for inter-AS SVC traffic

### DIFF
--- a/.buildkite/scripts/build_scion_img
+++ b/.buildkite/scripts/build_scion_img
@@ -2,7 +2,7 @@
 
 set -e
 
-BASE_IMG=${BASE_IMG:-4990cb291246224acb70265c5e3ecafba54db156ab0b5b688bab932c463d5bcc}
+BASE_IMG=${BASE_IMG:-ff849f26412c979bc8150ceb83898cd0e59f369de0f57a60cf9030adf5b773ab}
 
 docker pull scionproto/scion_base@sha256:$BASE_IMG
 docker tag scionproto/scion_base@sha256:$BASE_IMG scion_base:latest

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -253,7 +253,7 @@ go_repository(
 
 go_repository(
     name = "com_github_lucas_clemente_quic_go",
-    commit = "deffae864a3363cf4cd4a0030fc8106e16ec5723",
+    commit = "fd7246d7ed6eeb79eb4dc8b7b1bfa8a13047105a",
     importpath = "github.com/lucas-clemente/quic-go",
 )
 

--- a/acceptance/topo_ps_reloads_cs_acceptance/test
+++ b/acceptance/topo_ps_reloads_cs_acceptance/test
@@ -32,8 +32,8 @@ test_run() {
     ./tools/dc scion kill -s HUP scion_ps$IA_FILE-1
     # Wait for 30 (PS crypto push interval) + 1 (logging flush interval) seconds to guarantee a push is seen
     sleep 31
-    grep -q "\[INFO\].*Sent crypto to CS.*$IA,\[127\.42\.42\.42\]:39999" "logs/ps$IA_FILE-1.log" || \
-        fail "Crypto material push to 127.42.42.42:39999 not found in logs"
+    grep -q ".*CryptoSync.*$IA,\[127\.42\.42\.42\]:39999" "logs/ps$IA_FILE-1.log" || \
+        fail "CryptoSync log entry with 127.42.42.42:39999 not found in logs"
 }
 
 print_help() {

--- a/acceptance/topo_ps_reloads_cs_acceptance/test
+++ b/acceptance/topo_ps_reloads_cs_acceptance/test
@@ -30,9 +30,10 @@ test_run() {
     local topo_file="gen/ISD1/AS$AS_FILE/ps$IA_FILE-1/topology.json"
     jq '.CertificateService[].Addrs.IPv4.Public = {Addr: "127.42.42.42", L4Port: 39999}' $topo_file | sponge $topo_file
     ./tools/dc scion kill -s HUP scion_ps$IA_FILE-1
-    # Wait for 30 (PS crypto push interval) + 1 (logging flush interval) seconds to guarantee a push is seen
-    sleep 31
-    grep -q ".*$IA,\[127\.42\.42\.42\]:39999" "logs/ps$IA_FILE-1.log" || \
+    # Wait for 30 (PS crypto push interval) + 1 (logging flush interval) + allow context timeout
+	# to guarantee a push is seen
+    sleep 40
+    grep -q ".*\[127\.42\.42\.42\]:39999" "logs/ps$IA_FILE-1.log" || \
         fail "CryptoSync log entry with 127.42.42.42:39999 not found in logs"
 }
 

--- a/acceptance/topo_ps_reloads_cs_acceptance/test
+++ b/acceptance/topo_ps_reloads_cs_acceptance/test
@@ -32,7 +32,7 @@ test_run() {
     ./tools/dc scion kill -s HUP scion_ps$IA_FILE-1
     # Wait for 30 (PS crypto push interval) + 1 (logging flush interval) seconds to guarantee a push is seen
     sleep 31
-    grep -q ".*CryptoSync.*$IA,\[127\.42\.42\.42\]:39999" "logs/ps$IA_FILE-1.log" || \
+    grep -q ".*$IA,\[127\.42\.42\.42\]:39999" "logs/ps$IA_FILE-1.log" || \
         fail "CryptoSync log entry with 127.42.42.42:39999 not found in logs"
 }
 

--- a/acceptance/topo_ps_reloads_cs_acceptance/test
+++ b/acceptance/topo_ps_reloads_cs_acceptance/test
@@ -30,10 +30,10 @@ test_run() {
     local topo_file="gen/ISD1/AS$AS_FILE/ps$IA_FILE-1/topology.json"
     jq '.CertificateService[].Addrs.IPv4.Public = {Addr: "127.42.42.42", L4Port: 39999}' $topo_file | sponge $topo_file
     ./tools/dc scion kill -s HUP scion_ps$IA_FILE-1
-    # Wait for 30 (PS crypto push interval) + 1 (logging flush interval) + allow context timeout
-	# to guarantee a push is seen
-    sleep 40
-    grep -q ".*\[127\.42\.42\.42\]:39999" "logs/ps$IA_FILE-1.log" || \
+    # Wait for 30 (PS crypto push interval) + 1 (logging flush interval) + 30 (context timeout) + 1
+    # to guarantee a push is seen
+    sleep 62
+    grep -q ".*$IA,\[127\.42\.42\.42\]:39999" "logs/ps$IA_FILE-1.log" || \
         fail "CryptoSync log entry with 127.42.42.42:39999 not found in logs"
 }
 

--- a/go/examples/pingpong/BUILD.bazel
+++ b/go/examples/pingpong/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//go/lib/sock/reliable:go_default_library",
         "//go/lib/spath:go_default_library",
         "@com_github_lucas_clemente_quic_go//:go_default_library",
-        "@com_github_lucas_clemente_quic_go//qerr:go_default_library",
     ],
 )
 

--- a/go/lib/infra/messenger/addr.go
+++ b/go/lib/infra/messenger/addr.go
@@ -124,7 +124,7 @@ func (r AddressRewriter) buildFullAddress(ctx context.Context, a net.Addr) (*sne
 
 // resolveIfSvc performs SVC resolution and returns an UDP/IP address if the
 // input address is an SVC destination. If the UDP/IP address is for a
-// QUIC-compatible server , the returned boolean value is set to true. If the
+// QUIC-compatible server, the returned boolean value is set to true. If the
 // address does not have an SVC destination, it is returned unchanged. If
 // address is not a well-formed application address (all fields set, non-nil,
 // supported protocols), the function's behavior is undefined. The returned

--- a/go/lib/infra/messenger/addr.go
+++ b/go/lib/infra/messenger/addr.go
@@ -57,26 +57,32 @@ type AddressRewriter struct {
 	SVCResolutionFraction float64
 }
 
-// Rewrite takes an address and adds a path (if one does not already exist but
-// is required), and replaces SVC destinations with unicast ones, if desired.
-func (r AddressRewriter) Rewrite(ctx context.Context, a net.Addr) (net.Addr, error) {
+// RedirectToQUIC takes an address and adds a path (if one does not already
+// exist but is required), and replaces SVC destinations with QUIC unicast
+// ones, if possible.
+//
+// The returned boolean value is set to true if the remote server is
+// QUIC-compatible and we have successfully discovered its address.
+//
+// If the address is already unicast, no redirection to QUIC is attempted.
+func (r AddressRewriter) RedirectToQUIC(ctx context.Context, a net.Addr) (net.Addr, bool, error) {
 	// FIXME(scrye): This is not legitimate use. It's only included for
 	// compatibility with older unit tests. See
 	// https://github.com/scionproto/scion/issues/2611.
 	if a == nil {
-		return nil, nil
+		return nil, false, nil
 	}
-	address, err := r.buildFullAddress(ctx, a)
+	fullAddress, err := r.buildFullAddress(ctx, a)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	path, err := address.GetPath()
+	path, err := fullAddress.GetPath()
 	if err != nil {
-		return nil, common.NewBasicError("bad path", err)
+		return nil, false, common.NewBasicError("bad path", err)
 	}
-	address.Host, err = r.resolveIfSVC(ctx, path, address.Host)
-	return address, err
-
+	var quicRedirect bool
+	fullAddress.Host, quicRedirect, err = r.resolveIfSVC(ctx, path, fullAddress.Host)
+	return fullAddress, quicRedirect, err
 }
 
 // buildFullAddress checks that a is a well-formed address (all fields set,
@@ -117,19 +123,21 @@ func (r AddressRewriter) buildFullAddress(ctx context.Context, a net.Addr) (*sne
 }
 
 // resolveIfSvc performs SVC resolution and returns an UDP/IP address if the
-// input address is an SVC destination. If the address does not have an SVC
-// destination, it is returned unchanged. If address is not a well-formed
-// application address (all fields set, non-nil, supported protocols), the
-// function's behavior is undefined. The returned address is always a copy.
+// input address is an SVC destination. If the UDP/IP address is for a
+// QUIC-compatible server , the returned boolean value is set to true. If the
+// address does not have an SVC destination, it is returned unchanged. If
+// address is not a well-formed application address (all fields set, non-nil,
+// supported protocols), the function's behavior is undefined. The returned
+// address is always a copy.
 func (r AddressRewriter) resolveIfSVC(ctx context.Context, p snet.Path,
-	address *addr.AppAddr) (*addr.AppAddr, error) {
+	address *addr.AppAddr) (*addr.AppAddr, bool, error) {
 
 	svcAddress, ok := address.L3.(addr.HostSVC)
 	if !ok {
-		return address.Copy(), nil
+		return address.Copy(), false, nil
 	}
 	if r.SVCResolutionFraction <= 0.0 {
-		return address.Copy(), nil
+		return address.Copy(), false, nil
 	}
 
 	if r.SVCResolutionFraction < 1.0 {
@@ -147,14 +155,19 @@ func (r AddressRewriter) resolveIfSVC(ctx context.Context, p snet.Path,
 			// fraction of the timeout left for data transfers, so return
 			// address with SVC destination still set
 			logger.Trace("SVC resolution failed, falling back to legacy mode", "err", err)
-			return address.Copy(), nil
+			return address.Copy(), false, nil
 		}
 		// Legacy behavior is disallowed, so propagate a hard failure back to the app.
 		logger.Trace("SVC resolution failed and legacy mode disabled", "err", err)
-		return nil, err
+		return nil, false, err
 	}
 	logger.Trace("SVC resolution successful", "reply", reply)
-	return parseReply(reply)
+
+	appAddr, err := parseReply(reply)
+	if err != nil {
+		return nil, false, err
+	}
+	return appAddr, true, nil
 }
 
 func (r AddressRewriter) resolutionCtx(ctx context.Context) (context.Context, context.CancelFunc) {
@@ -168,7 +181,7 @@ func (r AddressRewriter) resolutionCtx(ctx context.Context) (context.Context, co
 	return context.WithTimeout(ctx, timeout)
 }
 
-// parseReply searches for a UDP server on the remote address. If one is not
+// parseReply searches for a QUIC server on the remote address. If one is not
 // found, an error is returned.
 func parseReply(reply *svc.Reply) (*addr.AppAddr, error) {
 	if reply == nil {
@@ -177,9 +190,9 @@ func parseReply(reply *svc.Reply) (*addr.AppAddr, error) {
 	if reply.Transports == nil {
 		return nil, common.NewBasicError("empty reply", nil)
 	}
-	addressStr, ok := reply.Transports[svc.UDP]
+	addressStr, ok := reply.Transports[svc.QUIC]
 	if !ok {
-		return nil, common.NewBasicError("UDP server address not found", nil)
+		return nil, common.NewBasicError("QUIC server address not found", nil)
 	}
 	udpAddr, err := net.ResolveUDPAddr("udp", addressStr)
 	if err != nil {

--- a/go/lib/infra/rpc/rpc.go
+++ b/go/lib/infra/rpc/rpc.go
@@ -156,7 +156,7 @@ func (c *Client) Request(ctx context.Context, request *Request, address net.Addr
 	}
 	go func() {
 		<-ctx.Done()
-		// it is safe to cancel the write even after the stream is closed
+		stream.CancelRead(CtxTimedOutError)
 		stream.CancelWrite(CtxTimedOutError)
 	}()
 
@@ -180,7 +180,7 @@ func (c *Client) Request(ctx context.Context, request *Request, address net.Addr
 	if err := stream.Close(); err != nil {
 		return nil, err
 	}
-	if err := session.Close(nil); err != nil {
+	if err := session.Close(); err != nil {
 		return nil, err
 	}
 	return &Reply{SignedPld: signedPld}, nil

--- a/go/path_srv/internal/cryptosyncer/cryptosyncer.go
+++ b/go/path_srv/internal/cryptosyncer/cryptosyncer.go
@@ -99,7 +99,7 @@ func (c *Syncer) sendTRC(ctx context.Context, cs net.Addr, trcObj *trc.TRC) {
 		RawTRC: rawTRC,
 	}, cs, messenger.NextId())
 	if err != nil {
-		log.Error("[CryptoSync] Failed to send TRC", "err", err)
+		log.Error("[CryptoSync] Failed to send TRC", "err", err, "cs", cs)
 	}
 }
 
@@ -128,6 +128,6 @@ func (c *Syncer) sendChain(ctx context.Context, cs net.Addr, chain *cert.Chain) 
 		RawChain: rawChain,
 	}, cs, messenger.NextId())
 	if err != nil {
-		log.Error("[CryptoSync] Failed to send Chain", "err", err)
+		log.Error("[CryptoSync] Failed to send Chain", "err", err, "cs", cs)
 	}
 }

--- a/nogo.json
+++ b/nogo.json
@@ -26,5 +26,10 @@
       "/com_github_mattn_go_sqlite3/": "",
       "/com_github_google_gopacket/afpacket/": ""
     }
+  },
+  "shift": {
+    "exclude_files": {
+      "/com_github_lucas_clemente_quic_go/": ""
+    }
   }
 }


### PR DESCRIPTION
 QUIC is used only if the clients discover that the server supports it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2664)
<!-- Reviewable:end -->
