### PR TITLE
BS: Reduce logging and refactor registrar/originator/propagator tasks

### DIFF
--- a/go/beacon_srv/internal/beaconing/handler.go
+++ b/go/beacon_srv/internal/beaconing/handler.go
@@ -76,7 +76,7 @@ func (h *handler) handle(logger log.Logger) (*infra.HandlerResult, error) {
 	if err != nil {
 		return res, err
 	}
-	logger.Debug("[BeaconHandler] Received", "beacon", b)
+	logger.Trace("[BeaconHandler] Received", "beacon", b)
 	if err := h.inserter.PreFilter(b); err != nil {
 		logger.Trace("[BeaconHandler] Beacon pre-filtered", "err", err)
 		return infra.MetricsResultOk, nil
@@ -87,7 +87,7 @@ func (h *handler) handle(logger log.Logger) (*infra.HandlerResult, error) {
 	if err := h.inserter.InsertBeacons(h.request.Context(), b); err != nil {
 		return infra.MetricsErrInternal, common.NewBasicError("Unable to insert beacon", err)
 	}
-	logger.Debug("[BeaconHandler] Successfully inserted", "beacon", b)
+	logger.Trace("[BeaconHandler] Successfully inserted", "beacon", b)
 	return infra.MetricsResultOk, nil
 }
 

--- a/go/beacon_srv/internal/beaconing/originator.go
+++ b/go/beacon_srv/internal/beaconing/originator.go
@@ -76,17 +76,29 @@ func (o *Originator) Run(_ context.Context) {
 func (o *Originator) originateBeacons(linkType proto.LinkType) {
 	active, nonActive := sortedIntfs(o.cfg.Intfs, linkType)
 	if len(nonActive) > 0 && o.tick.passed() {
-		log.Debug("[Originator] Ignore non-active interfaces", "intfs", nonActive)
+		log.Debug("[Originator] Ignore non-active interfaces", "ifids", nonActive)
+	}
+	intfs := o.needBeacon(active)
+	if len(intfs) == 0 {
+		return
 	}
 	infoF := o.createInfoF(o.tick.now)
-	for _, ifid := range o.needBeacon(active) {
-		if err := o.originateBeacon(ifid, infoF); err != nil {
+	s := newSummary()
+	for _, ifid := range intfs {
+		b := beaconOriginator{
+			Originator: o,
+			ifId:       ifid,
+			infoF:      infoF,
+			summary:    s,
+		}
+		if err := b.originateBeacon(); err != nil {
 			log.Error("[Originator] Unable to originate on interface", "ifid", ifid, "err", err)
 		}
 	}
+
 }
 
-// crateInfoF creates the info field.
+// createInfoF creates the info field.
 func (o *Originator) createInfoF(now time.Time) spath.InfoField {
 	infoF := spath.InfoField{
 		ConsDir: true,
@@ -114,14 +126,31 @@ func (o *Originator) needBeacon(active []common.IFIDType) []common.IFIDType {
 	return stale
 }
 
+func (o *Originator) logSummary(s *summary, linkType proto.LinkType) {
+	if o.tick.passed() {
+		log.Info("[Originator] Originated beacons", "type", linkType.String(), "egIfIds", s.IfIds())
+		return
+	}
+	log.Info("[Originator] Originated beacons on stale interfaces", "type", linkType.String(),
+		"egIfIds", s.IfIds())
+}
+
+// beaconOriginator originates one beacon on the given interface.
+type beaconOriginator struct {
+	*Originator
+	ifId    common.IFIDType
+	infoF   spath.InfoField
+	summary *summary
+}
+
 // originateBeacon originates a beacon on the given ifid.
-func (o *Originator) originateBeacon(ifid common.IFIDType, infoF spath.InfoField) error {
-	intf := o.cfg.Intfs.Get(ifid)
+func (o *beaconOriginator) originateBeacon() error {
+	intf := o.cfg.Intfs.Get(o.ifId)
 	if intf == nil {
 		return common.NewBasicError("Interface does not exist", nil)
 	}
 	topoInfo := intf.TopoInfo()
-	msg, err := o.createBeaconMsg(ifid, infoF, topoInfo.ISD_AS)
+	msg, err := o.createBeaconMsg(topoInfo.ISD_AS)
 	if err != nil {
 		return err
 	}
@@ -130,29 +159,27 @@ func (o *Originator) originateBeacon(ifid common.IFIDType, infoF spath.InfoField
 		return common.NewBasicError("Unable to send packet", err)
 	}
 	intf.Originate(o.tick.now)
+	o.summary.AddIfid(o.ifId)
+	o.summary.Inc()
 	return nil
 }
 
 // createBeaconMsg creates a beacon for the given interface, signs it and
 // wraps it in a one-hop message.
-func (o *Originator) createBeaconMsg(ifid common.IFIDType, infoF spath.InfoField,
-	remoteIA addr.IA) (*onehop.Msg, error) {
-
-	bseg, err := o.createBeacon(ifid, infoF)
+func (o *beaconOriginator) createBeaconMsg(remoteIA addr.IA) (*onehop.Msg, error) {
+	bseg, err := o.createBeacon()
 	if err != nil {
-		return nil, common.NewBasicError("Unable to create beacon", err, "ifid", ifid)
+		return nil, common.NewBasicError("Unable to create beacon", err, "ifid", o.ifId)
 	}
-	return packBeaconMsg(bseg, remoteIA, ifid, o.cfg.Signer)
+	return packBeaconMsg(bseg, remoteIA, o.ifId, o.cfg.Signer)
 }
 
-func (o *Originator) createBeacon(ifid common.IFIDType,
-	infoF spath.InfoField) (*seg.Beacon, error) {
-
-	bseg, err := seg.NewSeg(&infoF)
+func (o *beaconOriginator) createBeacon() (*seg.Beacon, error) {
+	bseg, err := seg.NewSeg(&o.infoF)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to create segment", err)
 	}
-	if err := o.extend(bseg, 0, ifid, nil); err != nil {
+	if err := o.extend(bseg, 0, o.ifId, nil); err != nil {
 		return nil, common.NewBasicError("Unable to extend segment", err)
 	}
 	return &seg.Beacon{Segment: bseg}, nil

--- a/go/beacon_srv/internal/beaconing/originator.go
+++ b/go/beacon_srv/internal/beaconing/originator.go
@@ -95,7 +95,7 @@ func (o *Originator) originateBeacons(linkType proto.LinkType) {
 			log.Error("[Originator] Unable to originate on interface", "ifid", ifid, "err", err)
 		}
 	}
-
+	o.logSummary(s, linkType)
 }
 
 // createInfoF creates the info field.

--- a/go/beacon_srv/internal/beaconing/propagator.go
+++ b/go/beacon_srv/internal/beaconing/propagator.go
@@ -97,21 +97,30 @@ func (p *Propagator) run(ctx context.Context) error {
 	}
 	peers, nonActivePeers := sortedIntfs(p.cfg.Intfs, proto.LinkType_peer)
 	if len(nonActivePeers) > 0 && p.tick.passed() {
-		log.Debug("[Propagator] Ignore inactive peer links", "ifids", nonActivePeers)
+		log.Debug("[Propagator] Ignore non-active peering interfaces", "ifids", nonActivePeers)
 	}
 	beacons, err := p.provider.BeaconsToPropagate(ctx)
 	if err != nil {
 		return err
 	}
-	wg := &sync.WaitGroup{}
+	s := newSummary()
+	var wg sync.WaitGroup
 	for bOrErr := range beacons {
 		if bOrErr.Err != nil {
 			log.Error("[Propagator] Unable to get beacon", "err", err)
 			continue
 		}
-		p.startPropagate(bOrErr.Beacon, intfs, peers, wg)
+		b := beaconPropagator{
+			Propagator:  p,
+			beacon:      bOrErr.Beacon,
+			activeIntfs: intfs,
+			peers:       peers,
+			summary:     s,
+		}
+		b.start(&wg)
 	}
 	wg.Wait()
+	p.logSummary(s)
 	return nil
 }
 
@@ -126,7 +135,10 @@ func (p *Propagator) needsBeacons() []common.IFIDType {
 		activeIntfs, nonActiveIntfs = sortedIntfs(p.cfg.Intfs, proto.LinkType_child)
 	}
 	if len(nonActiveIntfs) > 0 && p.tick.passed() {
-		log.Debug("[Propagator] Ignore inactive links", "ifids", nonActiveIntfs)
+		log.Debug("[Propagator] Ignore non-active interfaces", "ifids", nonActiveIntfs)
+	}
+	if p.tick.passed() {
+		return activeIntfs
 	}
 	stale := make([]common.IFIDType, 0, len(activeIntfs))
 	for _, ifid := range activeIntfs {
@@ -141,65 +153,80 @@ func (p *Propagator) needsBeacons() []common.IFIDType {
 	return stale
 }
 
-// startPropagate adds to the wait group and starts propagation of the beacon on
-// all active interfaces.
-func (p *Propagator) startPropagate(origBeacon beacon.Beacon, activeIntfs,
-	peers []common.IFIDType, wg *sync.WaitGroup) {
+func (p *Propagator) logSummary(s *summary) {
+	if p.tick.passed() {
+		log.Info("[Propagator] Propagated beacons", "count", s.count, "startIAs", len(s.srcs),
+			"egIfIds", s.IfIds())
+		return
+	}
+	log.Info("[Propagator] Propagated beacons on stale interfaces", "count", s.count,
+		"startIAs", len(s.srcs), "egIfIds", s.IfIds())
+}
 
+// beaconPropagator propagates one beacon to all active interfaces.
+type beaconPropagator struct {
+	*Propagator
+	wg          sync.WaitGroup
+	beacon      beacon.Beacon
+	activeIntfs []common.IFIDType
+	peers       []common.IFIDType
+	success     ctr
+	summary     *summary
+}
+
+// start adds to the wait group and starts propagation of the beacon on
+// all active interfaces.
+func (p *beaconPropagator) start(wg *sync.WaitGroup) {
 	wg.Add(1)
 	go func() {
 		defer log.LogPanicAndExit()
 		defer wg.Done()
-		if err := p.propagate(origBeacon, activeIntfs, peers); err != nil {
-			log.Error("[Propagator] Unable to propagate", "beacon", origBeacon, "err", err)
+		if err := p.propagate(); err != nil {
+			log.Error("[Propagator] Unable to propagate", "beacon", p.beacon, "err", err)
 			return
 		}
 	}()
 }
 
-func (p *Propagator) propagate(origBeacon beacon.Beacon, activeIntfs,
-	peers []common.IFIDType) error {
-
-	raw, err := origBeacon.Segment.Pack()
+func (p *beaconPropagator) propagate() error {
+	raw, err := p.beacon.Segment.Pack()
 	if err != nil {
 		return err
 	}
-	var success ctr
 	var expected int
-	wg := sync.WaitGroup{}
-	for _, egIfid := range activeIntfs {
-		if p.shouldIgnore(origBeacon, egIfid) {
+	for _, egIfid := range p.activeIntfs {
+		if p.shouldIgnore(p.beacon, egIfid) {
 			continue
 		}
 		expected++
-		bseg := origBeacon
+		bseg := p.beacon
 		if bseg.Segment, err = seg.NewBeaconFromRaw(raw); err != nil {
 			return common.NewBasicError("Unable to unpack beacon", err)
 		}
-		p.extendAndSend(bseg, egIfid, peers, &success, &wg)
+		p.extendAndSend(bseg, egIfid)
 	}
-	wg.Wait()
+	p.wg.Wait()
 	if expected == 0 {
 		return nil
 	}
-	if success.c <= 0 {
+	if p.success.c <= 0 {
 		return common.NewBasicError("None propagated", nil, "expected", expected)
 	}
-	log.Trace("[Propagator] Successfully propagated", "beacon", origBeacon,
-		"expected", expected, "count", success.c)
+	p.summary.AddSrc(p.beacon.Segment.FirstIA())
+	p.summary.Inc()
+	log.Trace("[Propagator] Successfully propagated", "beacon", p.beacon,
+		"expected", expected, "count", p.success.c)
 	return nil
 }
 
 // extendAndSend extends the path segment with the AS entry and sends it on the
 // egress interface, all done in a goroutine to avoid head-of-line blocking.
-func (p *Propagator) extendAndSend(bseg beacon.Beacon, egIfid common.IFIDType,
-	peers []common.IFIDType, success *ctr, wg *sync.WaitGroup) {
-
-	wg.Add(1)
+func (p *beaconPropagator) extendAndSend(bseg beacon.Beacon, egIfid common.IFIDType) {
+	p.wg.Add(1)
 	go func() {
 		defer log.LogPanicAndExit()
-		defer wg.Done()
-		if err := p.extend(bseg.Segment, bseg.InIfId, egIfid, peers); err != nil {
+		defer p.wg.Done()
+		if err := p.extend(bseg.Segment, bseg.InIfId, egIfid, p.peers); err != nil {
 			log.Error("[Propagator] Unable to extend beacon", "beacon", bseg, "err", err)
 			return
 		}
@@ -220,13 +247,14 @@ func (p *Propagator) extendAndSend(bseg beacon.Beacon, egIfid common.IFIDType,
 			return
 		}
 		intf.Propagate(p.tick.now)
-		success.Inc()
+		p.success.Inc()
+		p.summary.AddIfid(egIfid)
 	}()
 }
 
 // shouldIgnore indicates whether a beacon should not be sent on the egress
 // interface because it creates a loop.
-func (p *Propagator) shouldIgnore(bseg beacon.Beacon, egIfid common.IFIDType) bool {
+func (p *beaconPropagator) shouldIgnore(bseg beacon.Beacon, egIfid common.IFIDType) bool {
 	intf := p.cfg.Intfs.Get(egIfid)
 	if intf == nil {
 		return true

--- a/go/beacon_srv/internal/beaconing/propagator.go
+++ b/go/beacon_srv/internal/beaconing/propagator.go
@@ -182,7 +182,7 @@ func (p *Propagator) propagate(origBeacon beacon.Beacon, activeIntfs,
 	if success.c <= 0 && expected > 0 {
 		return common.NewBasicError("None propagated", nil, "expected", expected)
 	}
-	log.Info("[Propagator] Successfully propagated", "beacon", origBeacon,
+	log.Trace("[Propagator] Successfully propagated", "beacon", origBeacon,
 		"expected", expected, "count", success.c)
 	return nil
 }

--- a/go/beacon_srv/internal/beaconing/propagator.go
+++ b/go/beacon_srv/internal/beaconing/propagator.go
@@ -179,7 +179,10 @@ func (p *Propagator) propagate(origBeacon beacon.Beacon, activeIntfs,
 		p.extendAndSend(bseg, egIfid, peers, &success, &wg)
 	}
 	wg.Wait()
-	if success.c <= 0 && expected > 0 {
+	if expected == 0 {
+		return nil
+	}
+	if success.c <= 0 {
 		return common.NewBasicError("None propagated", nil, "expected", expected)
 	}
 	log.Trace("[Propagator] Successfully propagated", "beacon", origBeacon,

--- a/go/beacon_srv/internal/beaconing/registrar.go
+++ b/go/beacon_srv/internal/beaconing/registrar.go
@@ -96,7 +96,7 @@ func (r *Registrar) Run(ctx context.Context) {
 }
 
 func (r *Registrar) run(ctx context.Context) error {
-	if r.tick.now.Sub(r.lastSucc) < r.tick.period {
+	if r.tick.now.Sub(r.lastSucc) < r.tick.period && !r.tick.passed() {
 		return nil
 	}
 	segments, err := r.segProvider.SegmentsToRegister(ctx, r.segType)
@@ -108,79 +108,109 @@ func (r *Registrar) run(ctx context.Context) error {
 		log.Debug("[Registrar] Ignore non-active peer interfaces", "type", r.segType,
 			"intfs", nonActivePeers)
 	}
-	var success, segErr, sendErr ctr
-	wg := &sync.WaitGroup{}
+	s := newSummary()
+	var expected int
+	var wg sync.WaitGroup
 	for bOrErr := range segments {
-		reg, saddr, err := r.segToRegister(ctx, peers, bOrErr)
-		if err != nil {
-			log.Error("[Registrar] Unable to create segment", "type", r.segType, "err", err)
-			segErr.Inc()
+		if bOrErr.Err != nil {
+			log.Error("[Registrar] Unable to get beacon", "err", err)
 			continue
 		}
+		expected++
+		s := segmentRegistrar{
+			Registrar: r,
+			beacon:    bOrErr.Beacon,
+			peers:     peers,
+			summary:   s,
+		}
 		// Avoid head-of-line blocking when sending message to slow servers.
-		r.startSendSegReg(ctx, reg, saddr, wg, &success, &sendErr)
+		s.start(ctx, &wg)
 	}
 	wg.Wait()
-	total := success.c + segErr.c + sendErr.c
-	if total == 0 {
+	if expected == 0 {
 		return nil
 	}
-	if success.c <= 0 {
-		return common.NewBasicError("No beacons propagated", nil, "candidates", total,
-			"segCreationErrs", segErr.c, "sendErrs", sendErr.c)
+	if s.count <= 0 {
+		return common.NewBasicError("No beacons propagated", nil, "candidates", expected)
 	}
-	log.Trace("[Registrar] Successfully registered segments", "type", r.segType, "success",
-		success.c, "candidates", total, "segCreationErrs", segErr.c, "sendErrs", sendErr.c)
+	r.lastSucc = r.tick.now
+	r.logSummary(s)
+	return nil
+}
+
+func (r *Registrar) logSummary(s *summary) {
+	if r.tick.passed() {
+		log.Info("[Registrar] Registered beacons", "count", s.count, "startIAs", len(s.srcs))
+		return
+	}
+	log.Info("[Registrar] Registered beacons after stale period", "count", s.count,
+		"startIAs", len(s.srcs))
+}
+
+// segmentRegistrar registers one segment with the path server.
+type segmentRegistrar struct {
+	*Registrar
+	beacon  beacon.Beacon
+	peers   []common.IFIDType
+	summary *summary
+
+	// mutable
+	reg  *path_mgmt.SegReg
+	addr net.Addr
+}
+
+// start extends the beacon and starts a go routine that registers the beacon
+// with the path server.
+func (r *segmentRegistrar) start(ctx context.Context, wg *sync.WaitGroup) {
+	if err := r.setSegToRegister(); err != nil {
+		log.Error("[Registrar] Unable to create segment", "type", r.segType, "err", err)
+		return
+	}
+	r.startSendSegReg(ctx, wg)
+}
+
+// setSegToRegister sets the segment to register and the address to send to.
+func (r *segmentRegistrar) setSegToRegister() error {
+	if err := r.extend(r.beacon.Segment, r.beacon.InIfId, 0, r.peers); err != nil {
+		return common.NewBasicError("Unable to terminate", err, "beacon", r.beacon)
+	}
+	r.reg = &path_mgmt.SegReg{
+		SegRecs: &path_mgmt.SegRecs{
+			Recs: []*seg.Meta{
+				{
+					Type:    r.segType,
+					Segment: r.beacon.Segment,
+				},
+			},
+		},
+	}
+	var err error
+	r.addr, err = r.chooseServer(r.beacon.Segment)
+	if err != nil {
+		return common.NewBasicError("Unable to choose server", err)
+	}
 	return nil
 }
 
 // startSendSegReg adds to the wait group and starts a goroutine that sends the
 // registration message to the peer.
-func (r *Registrar) startSendSegReg(ctx context.Context, reg *path_mgmt.SegReg, saddr net.Addr,
-	wg *sync.WaitGroup, success, sendErr *ctr) {
-
+func (r *segmentRegistrar) startSendSegReg(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	go func() {
 		defer log.LogPanicAndExit()
 		defer wg.Done()
-		if err := r.msgr.SendSegReg(ctx, reg, saddr, messenger.NextId()); err != nil {
-			log.Error("[Registrar] Unable to register segment", "addr", saddr, "err", err)
-			sendErr.Inc()
+		if err := r.msgr.SendSegReg(ctx, r.reg, r.addr, messenger.NextId()); err != nil {
+			log.Error("[Registrar] Unable to register segment", "addr", r.addr, "err", err)
 			return
 		}
-		log.Trace("[Registrar] Successfully registered segment", "type", r.segType, "addr", saddr,
-			"seg", reg.Recs[0].Segment)
-		success.Inc()
+		r.summary.AddSrc(r.beacon.Segment.FirstIA())
+		r.summary.Inc()
+		log.Trace("[Registrar] Successfully registered segment", "type", r.segType, "addr", r.addr,
+			"seg", r.beacon.Segment)
 	}()
 }
 
-func (r *Registrar) segToRegister(ctx context.Context, peers []common.IFIDType,
-	bOrErr beacon.BeaconOrErr) (*path_mgmt.SegReg, net.Addr, error) {
-	if bOrErr.Err != nil {
-		return nil, nil, bOrErr.Err
-	}
-	pseg := bOrErr.Beacon.Segment
-	if err := r.extend(pseg, bOrErr.Beacon.InIfId, 0, peers); err != nil {
-		return nil, nil, common.NewBasicError("Unable to terminate", err, "beacon", bOrErr.Beacon)
-	}
-	reg := &path_mgmt.SegReg{
-		SegRecs: &path_mgmt.SegRecs{
-			Recs: []*seg.Meta{
-				{
-					Type:    r.segType,
-					Segment: pseg,
-				},
-			},
-		},
-	}
-	saddr, err := r.chooseServer(pseg)
-	if err != nil {
-		return nil, nil, common.NewBasicError("Unable to choose server", err)
-	}
-	return reg, saddr, nil
-}
-
-func (r *Registrar) chooseServer(pseg *seg.PathSegment) (net.Addr, error) {
+func (r *segmentRegistrar) chooseServer(pseg *seg.PathSegment) (net.Addr, error) {
 	if r.segType != proto.PathSegType_down {
 		topo := r.topoProvider.Get()
 		return &snet.Addr{IA: topo.ISD_AS, Host: addr.NewSVCUDPAppAddr(addr.SvcPS)}, nil

--- a/go/beacon_srv/internal/beaconing/registrar.go
+++ b/go/beacon_srv/internal/beaconing/registrar.go
@@ -122,7 +122,10 @@ func (r *Registrar) run(ctx context.Context) error {
 	}
 	wg.Wait()
 	total := success.c + segErr.c + sendErr.c
-	if total > 0 && success.c <= 0 {
+	if total == 0 {
+		return nil
+	}
+	if success.c <= 0 {
 		return common.NewBasicError("No beacons propagated", nil, "candidates", total,
 			"segCreationErrs", segErr.c, "sendErrs", sendErr.c)
 	}

--- a/go/beacon_srv/internal/beaconing/registrar.go
+++ b/go/beacon_srv/internal/beaconing/registrar.go
@@ -122,7 +122,7 @@ func (r *Registrar) run(ctx context.Context) error {
 	}
 	wg.Wait()
 	total := success.c + segErr.c + sendErr.c
-	if success.c <= 0 {
+	if total > 0 && success.c <= 0 {
 		return common.NewBasicError("No beacons propagated", nil, "candidates", total,
 			"segCreationErrs", segErr.c, "sendErrs", sendErr.c)
 	}

--- a/go/beacon_srv/internal/beaconing/registrar.go
+++ b/go/beacon_srv/internal/beaconing/registrar.go
@@ -140,11 +140,12 @@ func (r *Registrar) run(ctx context.Context) error {
 
 func (r *Registrar) logSummary(s *summary) {
 	if r.tick.passed() {
-		log.Info("[Registrar] Registered beacons", "count", s.count, "startIAs", len(s.srcs))
+		log.Info("[Registrar] Registered beacons", "type", r.segType, "count", s.count,
+			"startIAs", len(s.srcs))
 		return
 	}
-	log.Info("[Registrar] Registered beacons after stale period", "count", s.count,
-		"startIAs", len(s.srcs))
+	log.Info("[Registrar] Registered beacons after stale period", "type", r.segType,
+		"count", s.count, "startIAs", len(s.srcs))
 }
 
 // segmentRegistrar registers one segment with the path server.

--- a/go/beacon_srv/internal/beaconing/registrar.go
+++ b/go/beacon_srv/internal/beaconing/registrar.go
@@ -105,7 +105,8 @@ func (r *Registrar) run(ctx context.Context) error {
 	}
 	peers, nonActivePeers := sortedIntfs(r.cfg.Intfs, proto.LinkType_peer)
 	if len(nonActivePeers) > 0 {
-		log.Debug("[Registrar] Ignore non-active peer interfaces", "intfs", nonActivePeers)
+		log.Debug("[Registrar] Ignore non-active peer interfaces", "type", r.segType,
+			"intfs", nonActivePeers)
 	}
 	var success, segErr, sendErr ctr
 	wg := &sync.WaitGroup{}
@@ -125,9 +126,8 @@ func (r *Registrar) run(ctx context.Context) error {
 		return common.NewBasicError("No beacons propagated", nil, "candidates", total,
 			"segCreationErrs", segErr.c, "sendErrs", sendErr.c)
 	}
-	log.Info("[Registrar] Successfully registered segments", "success", success.c,
-		"candidates", total, "segCreationErrs", segErr.c, "sendErrs", sendErr.c)
-	r.lastSucc = r.tick.now
+	log.Trace("[Registrar] Successfully registered segments", "type", r.segType, "success",
+		success.c, "candidates", total, "segCreationErrs", segErr.c, "sendErrs", sendErr.c)
 	return nil
 }
 
@@ -145,7 +145,7 @@ func (r *Registrar) startSendSegReg(ctx context.Context, reg *path_mgmt.SegReg, 
 			sendErr.Inc()
 			return
 		}
-		log.Debug("[Registrar] Successfully registered segment", "addr", saddr,
+		log.Trace("[Registrar] Successfully registered segment", "type", r.segType, "addr", saddr,
 			"seg", reg.Recs[0].Segment)
 		success.Inc()
 	}()

--- a/go/beacon_srv/internal/beaconing/util.go
+++ b/go/beacon_srv/internal/beaconing/util.go
@@ -120,6 +120,7 @@ func (s *summary) IfIds() []common.IFIDType {
 	for ifId := range s.ifIds {
 		list = append(list, ifId)
 	}
+	sort.Slice(list, func(i, j int) bool { return list[i] < list[j] })
 	return list
 }
 

--- a/go/beacon_srv/internal/beaconing/util.go
+++ b/go/beacon_srv/internal/beaconing/util.go
@@ -81,6 +81,48 @@ func sortedIntfs(intfs *ifstate.Interfaces, linkType proto.LinkType) ([]common.I
 	return active, nonActive
 }
 
+type summary struct {
+	mu    sync.Mutex
+	srcs  map[addr.IA]struct{}
+	ifIds map[common.IFIDType]struct{}
+	count int
+}
+
+func newSummary() *summary {
+	return &summary{
+		srcs:  make(map[addr.IA]struct{}),
+		ifIds: make(map[common.IFIDType]struct{}),
+	}
+}
+
+func (s *summary) AddSrc(ia addr.IA) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.srcs[ia] = struct{}{}
+}
+
+func (s *summary) AddIfid(ifid common.IFIDType) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ifIds[ifid] = struct{}{}
+}
+
+func (s *summary) Inc() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.count++
+}
+
+func (s *summary) IfIds() []common.IFIDType {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list := make([]common.IFIDType, 0, len(s.ifIds))
+	for ifId := range s.ifIds {
+		list = append(list, ifId)
+	}
+	return list
+}
+
 type ctr struct {
 	sync.Mutex
 	c int

--- a/go/beacon_srv/main.go
+++ b/go/beacon_srv/main.go
@@ -504,7 +504,7 @@ func setupBasic() error {
 		return err
 	}
 	metrics.Init(cfg.General.ID)
-	return env.LogAppStarted(common.CS, cfg.General.ID)
+	return env.LogAppStarted(common.BS, cfg.General.ID)
 }
 
 func setup() error {

--- a/go/beacon_srv/main.go
+++ b/go/beacon_srv/main.go
@@ -526,7 +526,6 @@ func setup() error {
 
 func handleTopoUpdate() {
 	if intfs == nil {
-		log.Warn("intfs not set, ignoring static update")
 		return
 	}
 	intfs.Update(itopo.Get().IFInfoMap)


### PR DESCRIPTION
Refactor registrar/originator/propagator to reduce the method signatures and declutter the code.

Additionally, reduce logging statements for normal operation in the BS to be less
verbose by moving many of them to `TRACE`. This allows us to focus
on the errors instead. A summary of all operations is printed at the and of each run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2665)
<!-- Reviewable:end -->
