### PR TITLE
BS: Load policies

### DIFF
--- a/go/beacon_srv/BUILD.bazel
+++ b/go/beacon_srv/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//go/proto:go_default_library",
         "@com_github_burntsushi_toml//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@in_gopkg_yaml_v2//:go_default_library",
         "@org_golang_x_crypto//pbkdf2:go_default_library",
     ],
 )

--- a/go/beacon_srv/internal/config/config.go
+++ b/go/beacon_srv/internal/config/config.go
@@ -124,6 +124,8 @@ type BSConfig struct {
 	// ExpiredCheckInterval is the interval between checking whether interfaces
 	// have expired and should be revoked.
 	ExpiredCheckInterval util.DurWrap
+	// Policies contains the policy files.
+	Policies Policies
 }
 
 // InitDefaults the default values for the durations that are equal to zero.
@@ -162,6 +164,7 @@ func (cfg *BSConfig) Validate() error {
 // Sample generates a sample for the beacon server specific configuration.
 func (cfg *BSConfig) Sample(dst io.Writer, path config.Path, ctx config.CtxMap) {
 	config.WriteString(dst, bsconfigSample)
+	config.WriteSample(dst, path, ctx, &cfg.Policies)
 }
 
 // ConfigName is the toml key for the beacon server specific configuration.
@@ -173,4 +176,37 @@ func initDurWrap(w *util.DurWrap, def time.Duration) {
 	if w.Duration == 0 {
 		w.Duration = def
 	}
+}
+
+var _ config.Config = (*Policies)(nil)
+
+// Policies contains the file paths of the policies.
+type Policies struct {
+	config.NoDefaulter
+	config.NoValidator
+	//	Propagation contains the file path for the propagation policy. If this
+	//	is the empty string, the default policy is used.
+	Propagation string
+	// CoreRegistration contains the file path for the core registration
+	// policy. If this is the empty string, the default policy is used. In a
+	// non-core beacon server, this field is ignored.
+	CoreRegistration string
+	// UpRegistration contains the file path for the up registration policy. If
+	// this is the empty string, the default policy is used. In a core beacon
+	// server, this field is ignored.
+	UpRegistration string
+	// DownRegistration contains the file path for the down registration policy.
+	// If this is the empty string, the default policy is used. In a core beacon
+	// server, this field is ignored.
+	DownRegistration string
+}
+
+// Sample generates a sample for the beacon server specific configuration.
+func (cfg *Policies) Sample(dst io.Writer, _ config.Path, _ config.CtxMap) {
+	config.WriteString(dst, policiesSample)
+}
+
+// ConfigName is the toml key for the beacon server specific configuration.
+func (cfg *Policies) ConfigName() string {
+	return "policies"
 }

--- a/go/beacon_srv/internal/config/config.go
+++ b/go/beacon_srv/internal/config/config.go
@@ -184,8 +184,8 @@ var _ config.Config = (*Policies)(nil)
 type Policies struct {
 	config.NoDefaulter
 	config.NoValidator
-	//	Propagation contains the file path for the propagation policy. If this
-	//	is the empty string, the default policy is used.
+	// Propagation contains the file path for the propagation policy. If this
+	// is the empty string, the default policy is used.
 	Propagation string
 	// CoreRegistration contains the file path for the core registration
 	// policy. If this is the empty string, the default policy is used. In a

--- a/go/beacon_srv/internal/config/config_test.go
+++ b/go/beacon_srv/internal/config/config_test.go
@@ -49,7 +49,16 @@ func InitTestConfig(cfg *Config) {
 	InitTestBSConfig(&cfg.BS)
 }
 
-func InitTestBSConfig(cfg *BSConfig) {}
+func InitTestBSConfig(cfg *BSConfig) {
+	InitTestPolicies(&cfg.Policies)
+}
+
+func InitTestPolicies(cfg *Policies) {
+	cfg.Propagation = "test"
+	cfg.CoreRegistration = "test"
+	cfg.UpRegistration = "test"
+	cfg.DownRegistration = "test"
+}
 
 func CheckTestConfig(cfg *Config, id string) {
 	envtest.CheckTest(&cfg.General, &cfg.Logging, &cfg.Metrics, nil, id)
@@ -71,4 +80,12 @@ func CheckTestBSConfig(cfg *BSConfig) {
 		DefaultRegistrationInterval)
 	SoMsg("ExpiredCheckInterval", cfg.ExpiredCheckInterval.Duration, ShouldEqual,
 		DefaultExpiredCheckInterval)
+	CheckTestPolicies(&cfg.Policies)
+}
+
+func CheckTestPolicies(cfg *Policies) {
+	SoMsg("Propagation", cfg.Propagation, ShouldEqual, "")
+	SoMsg("CoreRegistration", cfg.CoreRegistration, ShouldEqual, "")
+	SoMsg("UpRegistration", cfg.UpRegistration, ShouldEqual, "")
+	SoMsg("DownRegistration", cfg.DownRegistration, ShouldEqual, "")
 }

--- a/go/beacon_srv/internal/config/sample.go
+++ b/go/beacon_srv/internal/config/sample.go
@@ -36,3 +36,24 @@ RegistrationInterval = "5s"
 # The interval between checking for expired interfaces to revoke. (default 200ms)
 ExpiredCheckInterval = "200ms"
 `
+
+const policiesSample = `
+# The file path for the propagation policy. In case of the empty string, 
+# the default policy is used. (default "")
+Propagation = ""
+
+# The file path for the core registration policy. In case of the empty string, 
+# the default policy is used. In a non-core beacon server, this field is ignored.
+# (default "")
+CoreRegistration = ""
+
+# The file path for the up registration policy. In case of the empty string, 
+# the default policy is used. In a core beacon server, this field is ignored.
+# (default "")
+UpRegistration = ""
+
+# The file path for the down registration policy. In case of the empty string, 
+# the default policy is used. In a core beacon server, this field is ignored.
+# (default "")
+DownRegistration = ""
+`


### PR DESCRIPTION
This PR enables policy loading from file.
The policy file paths are specified in the config toml.
A sample policy can be printed with the `-help-policy` flag.

fixes #2661

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2680)
<!-- Reviewable:end -->
