### PR TITLE
Reduce test sleep time

### DIFF
--- a/acceptance/cert_renewal_acceptance/test
+++ b/acceptance/cert_renewal_acceptance/test
@@ -23,16 +23,14 @@ CORE_IA_FILE="$(ia_file $CORE_IA)"
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -cs=go
-    for cfg in gen/ISD1/*/cs*/cs.toml; do
-        sed -i -e 's/Level = .*$/Level = "trace"/g' \
-            -e '/\[logging\.file\]/a FlushInterval = 1' \
-            -e '/\[cs\]/a AutomaticRenewal = true' \
-            -e "s/LeafReissueLeadTime.\+/LeafReissueLeadTime = \"$((363 * 24* 60 * 60 - 10))s\"/" \
-            -e "s/IssuerReissueLeadTime.\+/IssuerReissueLeadTime = \"$((364 * 24* 60 * 60 - 10))s\"/" \
-            -e 's/ReissueRate.\+/ReissueRate = "1s"/' \
-            -e 's/ReissueTimeout.\+/ReissueTimeout = "5s"/' "$cfg"
-    done
+    ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -t
+    sed -i -e 's/Level = .*$/Level = "trace"/g' \
+        -e '/\[logging\.file\]/a FlushInterval = 1' \
+        -e '/\[cs\]/a AutomaticRenewal = true' \
+        -e "s/LeafReissueLeadTime.\+/LeafReissueLeadTime = \"$((363 * 24* 60 * 60 - 10))s\"/" \
+        -e "s/IssuerReissueLeadTime.\+/IssuerReissueLeadTime = \"$((364 * 24* 60 * 60 - 10))s\"/" \
+        -e 's/ReissueRate.\+/ReissueRate = "1s"/' \
+        -e 's/ReissueTimeout.\+/ReissueTimeout = "5s"/' gen/ISD1/*/cs*/cs.toml
    ./scion.sh run nobuild
 }
 

--- a/acceptance/cert_renewal_acceptance/test
+++ b/acceptance/cert_renewal_acceptance/test
@@ -38,7 +38,7 @@ test_setup() {
 
 test_run() {
     set -e
-    sleep 10
+    sleep 5
     bin/end2end_integration -src $IA -dst $CORE_IA -attempts 5 -d || fail "FAIL: Traffic does not pass."
     # Make sure a reissue cycle has passed.
     sleep 10

--- a/acceptance/discovery_br_fetches_static_acceptance/test
+++ b/acceptance/discovery_br_fetches_static_acceptance/test
@@ -39,7 +39,7 @@ test_setup() {
 
 test_run() {
     set -e
-    sleep 10
+    sleep 3
     check_connectivity "initial check"
 
     # Start serving dynamic topology with invalid beacon service.

--- a/acceptance/reconnecting_acceptance/test
+++ b/acceptance/reconnecting_acceptance/test
@@ -24,7 +24,7 @@ test_run() {
     ./tools/dc start scion_disp_1-ff00_0_112 scion_disp_1-ff00_0_110
     ./tools/dc scion restart scion_bs1-ff00_0_112-1 scion_bs1-ff00_0_110-1
     sqlite3 gen-cache/sd1-ff00_0_112.path.db "delete from segments;"
-    sleep 10
+    sleep 5
     bin/end2end_integration -src 1-ff00:0:112 -dst 1-ff00:0:110 -attempts 5 -d
 }
 

--- a/acceptance/reconnecting_acceptance/test
+++ b/acceptance/reconnecting_acceptance/test
@@ -11,7 +11,7 @@ TEST_TOPOLOGY="topology/Tiny.topo"
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
+    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -t
     ./scion.sh run nobuild
     ./tools/dc start tester_1-ff00_0_112 tester_1-ff00_0_110
     docker_status

--- a/acceptance/sigutil/common.sh
+++ b/acceptance/sigutil/common.sh
@@ -11,7 +11,7 @@ test_setup() {
     ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d --sig -n 242.254.0.0/16
     ./scion.sh run nobuild
     ./tools/dc start 'tester*'
-    sleep 5
+    sleep 7
     docker_status
 }
 

--- a/acceptance/sigutil/common.sh
+++ b/acceptance/sigutil/common.sh
@@ -11,7 +11,7 @@ test_setup() {
     ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d --sig -n 242.254.0.0/16
     ./scion.sh run nobuild
     ./tools/dc start 'tester*'
-    sleep 10
+    sleep 5
     docker_status
 }
 

--- a/acceptance/topo_br_reload_util/util.sh
+++ b/acceptance/topo_br_reload_util/util.sh
@@ -32,9 +32,7 @@ base_setup() {
 
 base_gen_topo() {
     ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d
-    for sd in gen/ISD1/*/br*/br.toml; do
-        sed -i '/\[logging\.file\]/a FlushInterval = 1' "$sd"
-    done
+    sed -i '/\[logging\.file\]/a FlushInterval = 1' gen/ISD1/*/br*/br.toml
 }
 
 base_run_topo() {

--- a/acceptance/topo_invalid_reloads_acceptance/test
+++ b/acceptance/topo_invalid_reloads_acceptance/test
@@ -16,10 +16,8 @@ TOPO="gen/ISD1/AS$AS_FILE/topology.json"
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
-    for sd in gen/ISD1/*/*/*.toml; do
-        sed -i '/\[logging\.file\]/a FlushInterval = 1' "$sd"
-    done
+    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -t
+    sed -i '/\[logging\.file\]/a FlushInterval = 1' gen/ISD1/*/*/*.toml
     ./tools/dc start scion_ps$IA_FILE-1 scion_sd$IA_FILE
     docker_status
 }

--- a/acceptance/topo_ps_reloads_br_acceptance/test
+++ b/acceptance/topo_ps_reloads_br_acceptance/test
@@ -17,11 +17,8 @@ DST_IA=${DST_IA:-1-ff00:0:111}
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
-    for ps in gen/ISD1/*/ps*/ps.toml; do
-        sed -i -e 's/Level = .*$/Level = "trace"/g'\
-               -e '/\[logging\.file\]/a FlushInterval = 1' "$ps"
-    done
+    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -t
+    sed -i '/\[logging\.file\]/a FlushInterval = 1' gen/ISD1/*/ps*/ps.toml
     ./scion.sh run nobuild
     ./tools/dc start tester_$SRC_IA_FILE
     docker_status

--- a/acceptance/topo_ps_reloads_br_acceptance/test
+++ b/acceptance/topo_ps_reloads_br_acceptance/test
@@ -18,9 +18,9 @@ DST_IA=${DST_IA:-1-ff00:0:111}
 test_setup() {
     set -e
     ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
-    for sd in gen/ISD1/*/ps*/ps.toml; do
-        sed -i 's/Level = .*$/Level = "trace"/g' "$sd"
-        sed -i '/\[logging\.file\]/a FlushInterval = 1' "$sd"
+    for ps in gen/ISD1/*/ps*/ps.toml; do
+        sed -i -e 's/Level = .*$/Level = "trace"/g'\
+               -e '/\[logging\.file\]/a FlushInterval = 1' "$ps"
     done
     ./scion.sh run nobuild
     ./tools/dc start tester_$SRC_IA_FILE

--- a/acceptance/topo_ps_reloads_cs_acceptance/test
+++ b/acceptance/topo_ps_reloads_cs_acceptance/test
@@ -16,8 +16,9 @@ AS_FILE="$(as_file $IA)"
 test_setup() {
     set -e
     ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
-    for sd in gen/ISD1/*/endhost/sd.toml; do
-        sed -i '/\[logging\.file\]/a FlushInterval = 1' "$sd"
+    for ps in gen/ISD1/*/ps*/ps.toml; do
+        sed -i -e '/\[logging\.file\]/a FlushInterval = 1'\
+               -e '/\[ps\]/a\CryptoSyncInterval="1s"' "$ps"
     done
     ./scion.sh run nobuild
     docker_status
@@ -26,13 +27,13 @@ test_setup() {
 test_run() {
     set -e
     # Wait for the PS to be populated with crypto following beaconing
-    sleep 10
+    sleep 2
     local topo_file="gen/ISD1/AS$AS_FILE/ps$IA_FILE-1/topology.json"
     jq '.CertificateService[].Addrs.IPv4.Public = {Addr: "127.42.42.42", L4Port: 39999}' $topo_file | sponge $topo_file
     ./tools/dc scion kill -s HUP scion_ps$IA_FILE-1
-    # Wait for 30 (PS crypto push interval) + 1 (logging flush interval) + 30 (context timeout) + 1
-    # to guarantee a push is seen
-    sleep 62
+    # Wait for 1 (PS crypto push interval) + 1 (logging flush interval) 
+    # + 1  to guarantee a push is seen
+    sleep 3
     grep -q ".*$IA,\[127\.42\.42\.42\]:39999" "logs/ps$IA_FILE-1.log" || \
         fail "CryptoSync log entry with 127.42.42.42:39999 not found in logs"
 }

--- a/acceptance/topo_ps_reloads_cs_acceptance/test
+++ b/acceptance/topo_ps_reloads_cs_acceptance/test
@@ -15,11 +15,9 @@ AS_FILE="$(as_file $IA)"
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
-    for ps in gen/ISD1/*/ps*/ps.toml; do
-        sed -i -e '/\[logging\.file\]/a FlushInterval = 1'\
-               -e '/\[ps\]/a\CryptoSyncInterval="1s"' "$ps"
-    done
+    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -t
+    sed -i -e '/\[logging\.file\]/a FlushInterval = 1'\
+            -e '/\[ps\]/a\CryptoSyncInterval="1s"' gen/ISD1/*/ps*/ps.toml
     ./scion.sh run nobuild
     docker_status
 }

--- a/acceptance/topo_sd_reloads_br_acceptance/test
+++ b/acceptance/topo_sd_reloads_br_acceptance/test
@@ -17,11 +17,8 @@ DST_IA=${DST_IA:-1-ff00:0:110}
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
-    for sd in gen/ISD1/*/endhost/sd.toml; do
-        sed -i 's/Level = .*$/Level = "trace"/g' "$sd"
-        sed -i '/\[logging\.file\]/a FlushInterval = 1' "$sd"
-    done
+    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -t
+    sed -i '/\[logging\.file\]/a FlushInterval = 1' gen/ISD1/*/endhost/sd.toml
     ./scion.sh run nobuild
     ./tools/dc start tester_$SRC_IA_FILE
     docker_status

--- a/acceptance/topo_sd_reloads_cs_acceptance/test
+++ b/acceptance/topo_sd_reloads_cs_acceptance/test
@@ -18,8 +18,8 @@ test_setup() {
     set -e
     ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
     for sd in gen/ISD1/*/endhost/sd.toml; do
-        sed -i 's/Level = .*$/Level = "trace"/g' "$sd"
-        sed -i '/\[logging\.file\]/a FlushInterval = 1' "$sd"
+        sed -i -e 's/Level = .*$/Level = "trace"/g'\
+               -e '/\[logging\.file\]/a FlushInterval = 1' "$sd"
     done
     ./scion.sh run nobuild
     ./tools/dc start tester_$SRC_IA_FILE

--- a/acceptance/topo_sd_reloads_cs_acceptance/test
+++ b/acceptance/topo_sd_reloads_cs_acceptance/test
@@ -16,11 +16,8 @@ DST_IA=${DST_IA:-1-ff00:0:110}
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
-    for sd in gen/ISD1/*/endhost/sd.toml; do
-        sed -i -e 's/Level = .*$/Level = "trace"/g'\
-               -e '/\[logging\.file\]/a FlushInterval = 1' "$sd"
-    done
+    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -t
+    sed -i '/\[logging\.file\]/a FlushInterval = 1' gen/ISD1/*/endhost/sd.toml
     ./scion.sh run nobuild
     ./tools/dc start tester_$SRC_IA_FILE
     docker_status

--- a/acceptance/topo_sd_reloads_ps_acceptance/test
+++ b/acceptance/topo_sd_reloads_ps_acceptance/test
@@ -18,8 +18,8 @@ test_setup() {
     set -e
     ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
     for sd in gen/ISD1/*/endhost/sd.toml; do
-        sed -i 's/Level = .*$/Level = "trace"/g' "$sd"
-        sed -i '/\[logging\.file\]/a FlushInterval = 1' "$sd"
+        sed -i -e 's/Level = .*$/Level = "trace"/g'\
+               -e '/\[logging\.file\]/a FlushInterval = 1' "$sd"
     done
     ./scion.sh run nobuild
     ./tools/dc start tester_$SRC_IA_FILE

--- a/acceptance/topo_sd_reloads_ps_acceptance/test
+++ b/acceptance/topo_sd_reloads_ps_acceptance/test
@@ -16,11 +16,8 @@ DST_IA=${DST_IA:-1-ff00:0:110}
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -sd=go -ps=go
-    for sd in gen/ISD1/*/endhost/sd.toml; do
-        sed -i -e 's/Level = .*$/Level = "trace"/g'\
-               -e '/\[logging\.file\]/a FlushInterval = 1' "$sd"
-    done
+    ./scion.sh topology nobuild zkclean -c $TEST_TOPOLOGY -d -t
+    sed -i '/\[logging\.file\]/a FlushInterval = 1' gen/ISD1/*/endhost/sd.toml
     ./scion.sh run nobuild
     ./tools/dc start tester_$SRC_IA_FILE
     docker_status

--- a/go/path_srv/internal/config/config.go
+++ b/go/path_srv/internal/config/config.go
@@ -29,7 +29,8 @@ import (
 )
 
 var (
-	DefaultQueryInterval = 5 * time.Minute
+	DefaultQueryInterval      = 5 * time.Minute
+	DefaultCryptoSyncInterval = 30 * time.Second
 )
 
 var _ config.Config = (*Config)(nil)
@@ -93,11 +94,17 @@ type PSConfig struct {
 	// QueryInterval specifies after how much time segments
 	// for a destination should be refetched.
 	QueryInterval util.DurWrap
+	// CryptoSyncInterval specifies the interval of crypto pushes towards
+	// the local CS.
+	CryptoSyncInterval util.DurWrap
 }
 
 func (cfg *PSConfig) InitDefaults() {
 	if cfg.QueryInterval.Duration == 0 {
 		cfg.QueryInterval.Duration = DefaultQueryInterval
+	}
+	if cfg.CryptoSyncInterval.Duration == 0 {
+		cfg.CryptoSyncInterval.Duration = DefaultCryptoSyncInterval
 	}
 	config.InitAll(&cfg.PathDB, &cfg.RevCache)
 }

--- a/go/path_srv/internal/config/config_test.go
+++ b/go/path_srv/internal/config/config_test.go
@@ -66,4 +66,6 @@ func CheckTestPSConfig(cfg *PSConfig, id string) {
 	pathstoragetest.CheckTestRevCacheConf(&cfg.RevCache)
 	SoMsg("SegSync set", cfg.SegSync, ShouldBeFalse)
 	SoMsg("QueryInterval correct", cfg.QueryInterval.Duration, ShouldEqual, DefaultQueryInterval)
+	SoMsg("CryptoSyncInterval correct", cfg.CryptoSyncInterval.Duration,
+		ShouldEqual, DefaultCryptoSyncInterval)
 }

--- a/go/path_srv/internal/config/sample.go
+++ b/go/path_srv/internal/config/sample.go
@@ -23,4 +23,7 @@ SegSync = false
 
 # The time after which segments for a destination are refetched. (default 5m)
 QueryInterval = "5m"
+
+# The interval of crypto pushes towards the local CS. (default 30s)
+CryptoSyncInterval = "30s"
 `

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -225,7 +225,7 @@ func (t *periodicTasks) Start() {
 		DB:    t.trustDB,
 		Msger: t.msger,
 		IA:    t.args.IA,
-	}, periodic.NewTicker(30*time.Second), 30*time.Second)
+	}, periodic.NewTicker(cfg.PS.CryptoSyncInterval.Duration), cfg.PS.CryptoSyncInterval.Duration)
 	t.rcCleaner = periodic.StartPeriodicTask(revcache.NewCleaner(t.args.RevCache),
 		periodic.NewTicker(10*time.Second), 10*time.Second)
 	t.running = true

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -47,7 +47,7 @@ if is_docker_be; then
     ./tools/quiet ./tools/dc start "tester*"
 fi
 
-sleep 2
+sleep 8
 result=0
 
 # Run go integration tests

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -47,7 +47,7 @@ if is_docker_be; then
     ./tools/quiet ./tools/dc start "tester*"
 fi
 
-sleep 8
+sleep 5
 result=0
 
 # Run go integration tests

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -47,7 +47,7 @@ if is_docker_be; then
     ./tools/quiet ./tools/dc start "tester*"
 fi
 
-sleep 10
+sleep 2
 result=0
 
 # Run go integration tests

--- a/tools/ci/integration
+++ b/tools/ci/integration
@@ -50,7 +50,7 @@ if [ -n "$DOCKER_BE" ]; then
     ./docker.sh exec "set -eo pipefail; ./tools/dc start tester* |& tee -a logs/integration.run"
 fi
 
-sleep 8
+sleep 5
 
 COMMAND="$1"
 shift

--- a/tools/ci/integration
+++ b/tools/ci/integration
@@ -50,7 +50,7 @@ if [ -n "$DOCKER_BE" ]; then
     ./docker.sh exec "set -eo pipefail; ./tools/dc start tester* |& tee -a logs/integration.run"
 fi
 
-sleep 6
+sleep 8
 
 COMMAND="$1"
 shift

--- a/tools/ci/integration
+++ b/tools/ci/integration
@@ -50,7 +50,7 @@ if [ -n "$DOCKER_BE" ]; then
     ./docker.sh exec "set -eo pipefail; ./tools/dc start tester* |& tee -a logs/integration.run"
 fi
 
-sleep 20
+sleep 6
 
 COMMAND="$1"
 shift


### PR DESCRIPTION
Since the BS pushes segments way faster since #2672 we don't need to sleep that much.
Also this PR includes a CryptoSyncer config (fixes #2674) so that we can reduce the sleep in `topo_ps_reloads_cs` acceptance test.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2681)
<!-- Reviewable:end -->
