### PR TITLE
Fix mangling unit tests

### DIFF
--- a/go/beacon_srv/internal/revocation/handler_test.go
+++ b/go/beacon_srv/internal/revocation/handler_test.go
@@ -67,7 +67,7 @@ func TestHandler(t *testing.T) {
 	sRevInvalid, err := path_mgmt.NewSignedRevInfo(rev, signer)
 	xtest.FailOnErr(t, err)
 	// flip a bit
-	sRevInvalid.Blob[0] ^= sRevInvalid.Blob[0]
+	sRevInvalid.Blob[0] ^= 0xFF
 
 	tests := []struct {
 		Name   string

--- a/go/lib/ctrl/seg/seg_test.go
+++ b/go/lib/ctrl/seg/seg_test.go
@@ -109,14 +109,14 @@ func TestPathSegmentAddASEntry(t *testing.T) {
 			}
 		})
 		Convey("Modifying the first signature should render the segment unverifiable", func() {
-			pseg.RawASEntries[0].Sign.Signature[3] = 5
+			pseg.RawASEntries[0].Sign.Signature[3] ^= 0xFF
 			for i, keyPair := range keyPairs {
 				err := pseg.VerifyASEntry(context.Background(), keyPair, i)
 				SoMsg("Err "+asEntries[i].IA().String(), err, ShouldNotBeNil)
 			}
 		})
 		Convey("Modifying the first AS entry should render the segment unverifiable", func() {
-			pseg.RawASEntries[0].Blob[3] = 5
+			pseg.RawASEntries[0].Blob[3] ^= 0xFF
 			for i, keyPair := range keyPairs {
 				err := pseg.VerifyASEntry(context.Background(), keyPair, i)
 				SoMsg("Err "+asEntries[i].IA().String(), err, ShouldNotBeNil)

--- a/go/lib/scrypto/asym_test.go
+++ b/go/lib/scrypto/asym_test.go
@@ -116,8 +116,15 @@ func TestVerify(t *testing.T) {
 		SoMsg("err", err, ShouldBeNil)
 	})
 
-	Convey("Verify should throw an error for an invalid signature", t, func() {
+	Convey("Verify should throw an error for an invalid signature length", t, func() {
 		err := Verify(Ed25519TestMsg, Ed25519TestSignature[:63], Ed25519TestPublicKey, Ed25519)
+		SoMsg("err", err, ShouldNotBeNil)
+	})
+
+	Convey("Verify should throw an error for a mangled signature", t, func() {
+		mangled := append(common.RawBytes{}, Ed25519TestSignature...)
+		mangled[0] ^= 0xFF
+		err := Verify(Ed25519TestMsg, mangled, Ed25519TestPublicKey, Ed25519)
 		SoMsg("err", err, ShouldNotBeNil)
 	})
 


### PR DESCRIPTION
Some unit tests mangle bytes to cause invalid input.
A few do so by assigning a constant to a given byte, resulting in a
non-zero chance that the byte equals the initial one and is not altered.
This PR ensures that the bytes are always mangled to avoid unnecessary
probabilistic unit test failures.