### PR TITLE
disp: Fix SVC multicast and nil panic

### DIFF
--- a/go/godispatcher/internal/registration/BUILD.bazel
+++ b/go/godispatcher/internal/registration/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "bench_test.go",
         "generators_test.go",
         "iatable_test.go",
+        "portlist_test.go",
         "scmp_table_test.go",
         "svctable_test.go",
         "table_test.go",

--- a/go/godispatcher/internal/registration/portlist.go
+++ b/go/godispatcher/internal/registration/portlist.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,12 +44,18 @@ func (l *portList) Insert(port int, v interface{}) *ring.Ring {
 // The objects are returned in round-robin fashion. Removing an element from
 // the list can make the round-robin selection reset from the start.
 func (l *portList) Get() interface{} {
+	if l.list == nil {
+		return nil
+	}
 	v := l.list.Value
 	l.list = l.list.Next()
 	return v.(*listItem).value
 }
 
 func (l *portList) Find(port int) bool {
+	if l.list == nil {
+		return false
+	}
 	var found bool
 	l.list.Do(
 		func(p interface{}) {
@@ -64,11 +71,16 @@ func (l *portList) Remove(element *ring.Ring) {
 	if element.Len() == 1 {
 		l.list = nil
 	} else {
-		element.Prev().Unlink(1)
+		// always change the l.list since it could be that l.list == element.
+		l.list = element.Prev()
+		l.list.Unlink(1)
 	}
 }
 
 func (l *portList) Len() int {
+	if l.list == nil {
+		return 0
+	}
 	return l.list.Len()
 }
 

--- a/go/godispatcher/internal/registration/portlist.go
+++ b/go/godispatcher/internal/registration/portlist.go
@@ -53,9 +53,6 @@ func (l *portList) Get() interface{} {
 }
 
 func (l *portList) Find(port int) bool {
-	if l.list == nil {
-		return false
-	}
 	var found bool
 	l.list.Do(
 		func(p interface{}) {

--- a/go/godispatcher/internal/registration/portlist_test.go
+++ b/go/godispatcher/internal/registration/portlist_test.go
@@ -22,13 +22,10 @@ import (
 
 func TestEmptyPortList(t *testing.T) {
 	pl := newPortList()
-	// Test empty list actions.
 	expectGet(t, pl, nil)
-	if pl.Find(1) {
-		t.Fatalf("Empty list should not find anything but found")
-	}
+	expectFind(t, pl, 1, false)
 	expectLen(t, pl, 0)
-	// Remove can't be called without a ring element.
+	// Remove can't be tested on empty port list since we don't have a ring to remove.
 }
 
 func TestRemoval(t *testing.T) {
@@ -52,7 +49,6 @@ func TestRemoval(t *testing.T) {
 
 	pl.Remove(r3)
 	expectList(t, pl, "1", "2")
-	r3 = pl.Insert(3, "3")
 }
 
 func expectGet(t *testing.T, pl *portList, expected interface{}) {

--- a/go/godispatcher/internal/registration/portlist_test.go
+++ b/go/godispatcher/internal/registration/portlist_test.go
@@ -1,0 +1,89 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registration
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestEmptyPortList(t *testing.T) {
+	pl := newPortList()
+	// Test empty list actions.
+	expectGet(t, pl, nil)
+	if pl.Find(1) {
+		t.Fatalf("Empty list should not find anything but found")
+	}
+	expectLen(t, pl, 0)
+	// Remove can't be called without a ring element.
+}
+
+func TestRemoval(t *testing.T) {
+	pl := newPortList()
+	r1 := pl.Insert(1, "1")
+	pl.Remove(r1)
+	expectLen(t, pl, 0)
+	r2 := pl.Insert(2, "2")
+	expectGet(t, pl, "2")
+	r1 = pl.Insert(1, "1")
+	r3 := pl.Insert(3, "3")
+	expectList(t, pl, "1", "2", "3")
+
+	pl.Remove(r2)
+	expectList(t, pl, "1", "3")
+	r2 = pl.Insert(2, "2")
+
+	pl.Remove(r1)
+	expectList(t, pl, "2", "3")
+	r1 = pl.Insert(1, "1")
+
+	pl.Remove(r3)
+	expectList(t, pl, "1", "2")
+	r3 = pl.Insert(3, "3")
+}
+
+func expectGet(t *testing.T, pl *portList, expected interface{}) {
+	if v := pl.Get(); v != expected {
+		t.Fatalf("Expected %s in Get but returned %s", expected, v)
+	}
+}
+
+func expectList(t *testing.T, pl *portList, expected ...string) {
+	var actual []string
+	for i := 0; i < pl.Len(); i++ {
+		actual = append(actual, pl.Get().(string))
+	}
+	sort.Slice(actual, func(i, j int) bool { return actual[i] < actual[j] })
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("Expected list to be %v but was %v", expected, actual)
+	}
+}
+
+func expectLen(t *testing.T, pl *portList, expectedLen int) {
+	if l := pl.Len(); l != expectedLen {
+		t.Fatalf("List should have length %d but has %d", expectedLen, l)
+	}
+}
+
+func expectFind(t *testing.T, pl *portList, val int, expectedFound bool) {
+	if pl.Find(val) != expectedFound {
+		if expectedFound {
+			t.Fatalf("Expected %d to be found but wasn't", val)
+		} else {
+			t.Fatalf("Expected %d to not be found but was", val)
+		}
+	}
+}

--- a/go/godispatcher/internal/registration/svctable_test.go
+++ b/go/godispatcher/internal/registration/svctable_test.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -229,21 +230,44 @@ func TestSVCTableFree(t *testing.T) {
 			ip := net.IP{10, 2, 3, 4}
 			table := NewSVCTable()
 			addressOne := &net.UDPAddr{IP: ip, Port: 10080}
-			_, err := table.Register(addr.SvcCS, addressOne, "1")
+			refOne, err := table.Register(addr.SvcCS, addressOne, "1")
 			xtest.FailOnErr(t, err)
 			addressTwo := &net.UDPAddr{IP: ip, Port: 10081}
 			refTwo, err := table.Register(addr.SvcCS, addressTwo, "2")
 			xtest.FailOnErr(t, err)
 			addressThree := &net.UDPAddr{IP: ip, Port: 10082}
-			_, err = table.Register(addr.SvcCS, addressThree, "3")
+			refThree, err := table.Register(addr.SvcCS, addressThree, "3")
 			xtest.FailOnErr(t, err)
-			Convey("if the second address is removed", func() {
+			Convey("if the second address is removed, 1 and 3 should stay", func() {
 				refTwo.Free()
-				Convey("anycasting cycles between addresses one and three", func() {
-					retValuesOne := table.Lookup(addr.SvcCS, ip)
-					SoMsg("retValuesOne", retValuesOne, ShouldResemble, []interface{}{"1"})
-					retValueThree := table.Lookup(addr.SvcCS, ip)
-					SoMsg("retValuesThree", retValueThree, ShouldResemble, []interface{}{"3"})
+				retValues := table.Lookup(addr.SvcCS.Multicast(), ip)
+				sort.Slice(retValues, func(i, j int) bool {
+					return retValues[i].(string) < retValues[j].(string)
+				})
+				So(retValues, ShouldResemble, []interface{}{"1", "3"})
+			})
+			Convey("if the first address is removed, 2 and 3 should stay", func() {
+				refOne.Free()
+				retValues := table.Lookup(addr.SvcCS.Multicast(), ip)
+				sort.Slice(retValues, func(i, j int) bool {
+					return retValues[i].(string) < retValues[j].(string)
+				})
+				So(retValues, ShouldResemble, []interface{}{"2", "3"})
+			})
+			Convey("if the third address is removed, 1 and 2 should stay", func() {
+				refThree.Free()
+				retValues := table.Lookup(addr.SvcCS.Multicast(), ip)
+				sort.Slice(retValues, func(i, j int) bool {
+					return retValues[i].(string) < retValues[j].(string)
+				})
+				So(retValues, ShouldResemble, []interface{}{"1", "2"})
+				Convey("removing the 1st as well should only leave 2", func() {
+					refOne.Free()
+					retValues := table.Lookup(addr.SvcCS.Multicast(), ip)
+					sort.Slice(retValues, func(i, j int) bool {
+						return retValues[i].(string) < retValues[j].(string)
+					})
+					So(retValues, ShouldResemble, []interface{}{"2"})
 				})
 			})
 		})


### PR DESCRIPTION
Removing the first entry in the port list wasn't doing the correct action,
which lead to SVC multicast errors.
Portlist was not always nil save which lead to dispatcher panics.

Co-authored-by: Oncilla <roos@anapaya.net>
Co-authored-by: Sergio Gonzalez Monroy <sgmonroy@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2696)
<!-- Reviewable:end -->
