### PR TITLE
Cleaner: Make safe against double registration

### DIFF
--- a/go/lib/infra/modules/cleaner/BUILD.bazel
+++ b/go/lib/infra/modules/cleaner/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -11,4 +11,10 @@ go_library(
         "//go/lib/prom:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["cleaner_test.go"],
+    embed = [":go_default_library"],
 )

--- a/go/lib/infra/modules/cleaner/cleaner.go
+++ b/go/lib/infra/modules/cleaner/cleaner.go
@@ -16,6 +16,7 @@ package cleaner
 
 import (
 	"context"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -30,6 +31,8 @@ const (
 	MetricsNamespace = "cleaner"
 )
 
+var registry = metricsRegistry{registered: make(map[string]*metric)}
+
 // ExpiredDeleter is used to delete expired data.
 type ExpiredDeleter func(ctx context.Context) (int, error)
 
@@ -39,35 +42,54 @@ var _ periodic.Task = (*Cleaner)(nil)
 type Cleaner struct {
 	deleter ExpiredDeleter
 	logger  log.Logger
-
-	resultsTotal *prometheus.CounterVec
-	deletedTotal prometheus.Counter
+	metric  *metric
 }
 
 // New returns a new cleaner task that delete expired data from deleter.
-func New(deleter ExpiredDeleter, label string) *Cleaner {
+func New(deleter ExpiredDeleter, subsystem string) *Cleaner {
 	return &Cleaner{
 		deleter: deleter,
-		logger:  log.New("label", label),
-		resultsTotal: prom.NewCounterVec(MetricsNamespace, label, "results_total",
-			"Results of running the cleaner, either ok or err", []string{"result"}),
-		deletedTotal: prom.NewCounter(MetricsNamespace, label, "deleted_total",
-			"Number of deleted entries total."),
+		logger:  log.New("subsystem", subsystem),
+		metric:  registry.register(subsystem),
 	}
 }
 
 // Run deletes expired entries using the deleter func.
 func (c *Cleaner) Run(ctx context.Context) {
-	result := "ok"
-	defer c.resultsTotal.WithLabelValues(result).Inc()
 	count, err := c.deleter(ctx)
 	if err != nil {
 		c.logger.Error("[Cleaner] Failed to delete", "err", err)
-		result = "err"
+		c.metric.resultsTotal.WithLabelValues("err").Inc()
 		return
 	}
 	if count > 0 {
 		c.logger.Info("[Cleaner] Deleted expired", "count", count)
-		c.deletedTotal.Add(float64(count))
+		c.metric.deletedTotal.Add(float64(count))
 	}
+	c.metric.resultsTotal.WithLabelValues("ok").Inc()
+}
+
+type metricsRegistry struct {
+	mu         sync.Mutex
+	registered map[string]*metric
+}
+
+func (m *metricsRegistry) register(subsystem string) *metric {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if metric, ok := m.registered[subsystem]; ok {
+		return metric
+	}
+	m.registered[subsystem] = &metric{
+		resultsTotal: *prom.NewCounterVec(MetricsNamespace, subsystem, "results_total",
+			"Results of running the cleaner, either ok or err", []string{"result"}),
+		deletedTotal: prom.NewCounter(MetricsNamespace, subsystem, "deleted_total",
+			"Number of deleted entries total."),
+	}
+	return m.registered[subsystem]
+}
+
+type metric struct {
+	resultsTotal prometheus.CounterVec
+	deletedTotal prometheus.Counter
 }

--- a/go/lib/infra/modules/cleaner/cleaner.go
+++ b/go/lib/infra/modules/cleaner/cleaner.go
@@ -45,7 +45,7 @@ type Cleaner struct {
 	metric  *metric
 }
 
-// New returns a new cleaner task that delete expired data from deleter.
+// New returns a new cleaner task that deletes expired data using deleter.
 func New(deleter ExpiredDeleter, subsystem string) *Cleaner {
 	return &Cleaner{
 		deleter: deleter,

--- a/go/lib/infra/modules/cleaner/cleaner_test.go
+++ b/go/lib/infra/modules/cleaner/cleaner_test.go
@@ -1,0 +1,30 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleaner_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/scionproto/scion/go/lib/infra/modules/cleaner"
+)
+
+// TestDoubleNew checks that two cleaning tasks with the same subsystem can be
+// initialized.
+func TestDoubleNew(t *testing.T) {
+	dummy := func(context.Context) (int, error) { return 0, nil }
+	cleaner.New(dummy, "same")
+	cleaner.New(dummy, "same")
+}


### PR DESCRIPTION
Previously, registering the cleaner with the same sub-system would
cause a panic.

Now, the cleaner registers metrics pointers and provides them as
appropriate.

fixes #2701

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2703)
<!-- Reviewable:end -->
