### PR TITLE
Accept: Refactor command structure

### DIFF
--- a/acceptance/bs_add_link_acceptance/test
+++ b/acceptance/bs_add_link_acceptance/test
@@ -27,14 +27,14 @@ from plumbum import local
 from plumbum.path.local import LocalPath
 
 from acceptance.common.log import LogExec, init_log
-from acceptance.common.base import Base, set_name
+from acceptance.common.base import CmdBase, set_name, TestBase
 from acceptance.common.scion import svc_names_from_path
 
 set_name(__file__)
 logger = logging.getLogger(__name__)
 
 
-class Test(Base):
+class Test(TestBase):
     """
     Test that an interface can be added to the topology and the
     beacon server starts beaconing on that interface.
@@ -49,13 +49,16 @@ class Test(Base):
     checks that end2end connectivity is established.
     """
 
+class Base(CmdBase):
+
     @staticmethod
     def topology_files() -> LocalPath:
         return local.path('gen/ISD1') // 'ASff00_0_11[0,1]/bs*/topology.json'
 
 
 @Test.subcommand('setup')
-class TestSetup(Test):
+class TestSetup(Base):
+    """ Setup topology with missing link between 1-ff00:0:110 and 1-ff00:0:111. """
     @LogExec(logger, 'setup')
     def main(self):
         self.cmd_setup()
@@ -112,7 +115,9 @@ class TestSetup(Test):
 
 
 @Test.subcommand('run')
-class TestRun(Test):
+class TestRun(Base):
+    """ Run the test. """
+
     @LogExec(logger, 'run')
     def main(self):
         self.scion.run_end2end(expect_fail=True)

--- a/acceptance/bs_add_link_acceptance/test
+++ b/acceptance/bs_add_link_acceptance/test
@@ -52,7 +52,7 @@ class Test(TestBase):
 
 def topology_files() -> LocalPath:
     """
-    Retrun the paths to all topology files for beacon servers in
+    Return the paths to all topology files for beacon servers in
     AS 1-ff00:0:110 and 1-ff00:0:111.
     """
     return local.path('gen/ISD1') // 'ASff00_0_11[0,1]/bs*/topology.json'

--- a/acceptance/bs_add_link_acceptance/test
+++ b/acceptance/bs_add_link_acceptance/test
@@ -49,15 +49,17 @@ class Test(TestBase):
     checks that end2end connectivity is established.
     """
 
-class Base(CmdBase):
 
-    @staticmethod
-    def topology_files() -> LocalPath:
-        return local.path('gen/ISD1') // 'ASff00_0_11[0,1]/bs*/topology.json'
+def topology_files() -> LocalPath:
+    """
+    Retrun the paths to all topology files for beacon servers in
+    AS 1-ff00:0:110 and 1-ff00:0:111.
+    """
+    return local.path('gen/ISD1') // 'ASff00_0_11[0,1]/bs*/topology.json'
 
 
 @Test.subcommand('setup')
-class TestSetup(Base):
+class TestSetup(CmdBase):
     """ Setup topology with missing link between 1-ff00:0:110 and 1-ff00:0:111. """
     @LogExec(logger, 'setup')
     def main(self):
@@ -74,7 +76,7 @@ class TestSetup(Base):
             self.docker_status()
 
     def modify_topologies(self):
-        files = self.topology_files()
+        files = topology_files()
         self.backup_topologies(files)
         topos = self.load_topologies(files)
         filtered = self.filter_interfaces(topos, ['1-ff00:0:110', '1-ff00:0:111'])
@@ -115,15 +117,16 @@ class TestSetup(Base):
 
 
 @Test.subcommand('run')
-class TestRun(Base):
+class TestRun(CmdBase):
     """ Run the test. """
 
     @LogExec(logger, 'run')
     def main(self):
         self.scion.run_end2end(expect_fail=True)
         logger.info('Initial end2end failed as expected, restoring topologies')
-        self.restore_topologies(self.topology_files())
-        names = svc_names_from_path(self.topology_files())
+        files = topology_files()
+        self.restore_topologies(files)
+        names = svc_names_from_path(files)
         logging.info('Reloading services: %s' % names)
         self.scion.reload_svc(names)
         time.sleep(2)

--- a/acceptance/common/README.md
+++ b/acceptance/common/README.md
@@ -6,21 +6,28 @@ This module provides a simple acceptance testing library.
 
 An acceptance test is structured fairly simple. It exposes a way
 to implement the necessary sub-commands for `acceptance/run`.
-At the core is the `Base` class. It implements the `name` and `teardown`
-sub-commands. The `setup` and `run` command must be implemented by
-each test individually.
+At the core are the `TestBase` and `CmdBase` classes. A test should
+have multiple classes. One class `Test` that sub-classes `common.TestBase`,
+with only a doc string. This doc comment used in the output when running the
+command with `--help` flag.
 
-`Base` registers two flags that also can be set using environment variables:
+`TestBase` registers two flags that also can be set using environment variables:
 - `--artifacts/ACCEPTANCE_ARTIFACTS` defines the directory for artifacts
   (required)
 - `--disable-docker/DISABLE_DOCKER` disables the dockerized topology.
   This allows for faster development cycle.
 
-Additionally, the base stores utility classes that help
-interacting with the infrastructure in fields:
+The sub-commands should sub-class `common.CmdBase`. `CmdBase` has defined some
+common properties and methods that are useful for test writing and interacting
+with the infrastructure, such as:
 - `scion` can be used to start and stop the scion infrastructure,
    or interact with individual service processes.
 - `dc` can be used to interact with docker compose.
+
+Sub-commands are registered with the `@Test.subcommand` decorator.
+By default, the `name` and `teardown` sub-command are already implemented.
+The `setup` and `run` command must be implemented by each test individually.
+
 
 ### Writing Your Own Test
 
@@ -40,7 +47,7 @@ import logging
 from plumbum import local
 
 from acceptance.common.log import LogExec, init_log
-from acceptance.common.base import Base, set_name
+from acceptance.common.base import CmdBase, TestBase, set_name
 
 # Set the name of the test. It is inferred from the file path.
 set_name(__file__)
@@ -48,7 +55,7 @@ set_name(__file__)
 logger = logging.getLogger(__name__)
 
 
-class Test(Base):
+class Test(TestBase):
     """
     Fill in the test description here. Plumbum will use it as output
     in if the --help flag is set, or the provided flags are invalid.
@@ -57,7 +64,9 @@ class Test(Base):
 
 # This decorator defines the sub-command setup.
 @Test.subcommand('setup')
-class TestSetup(Test):
+class TestSetup(CmdBase):
+    """ This doc string is used in the sub-command help. """
+
     # This decorator logs start and end of the call.
     @LogExec(logger, 'setup')
     def main(self):
@@ -78,7 +87,9 @@ class TestSetup(Test):
 
 # This decorator defines the sub-command run.
 @Test.subcommand('run')
-class TestRun(Test):
+class TestRun(CmdBase):
+    """ This doc string is used in the sub-command help. """
+
     # This decorator logs start and end of the call.
     @LogExec(logger, 'run')
     def main(self):

--- a/acceptance/common/README.md
+++ b/acceptance/common/README.md
@@ -9,7 +9,8 @@ to implement the necessary sub-commands for `acceptance/run`.
 At the core are the `TestBase` and `CmdBase` classes. A test should
 have multiple classes. One class `Test` that sub-classes `common.TestBase`,
 with only a doc string. This doc comment used in the output when running the
-command with `--help` flag.
+command with `--help` flag. Furthermore, a test should have one class per
+sub-command that sub-classes `common.CmdBase` (see below).
 
 `TestBase` registers two flags that also can be set using environment variables:
 - `--artifacts/ACCEPTANCE_ARTIFACTS` defines the directory for artifacts


### PR DESCRIPTION
As it turns out, plumbum expects every sub-command to be their
own cli.Application. This PR refactors the acceptance framework
and introduces 2 base classes. One for the test definition and
doc string, and one for the sub-commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2710)
<!-- Reviewable:end -->
