### PR TITLE
Ordered topology start

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -67,6 +67,10 @@ cmd_run() {
     fi
     run_setup
     echo "Running the network..."
+    # Start dispatcher first, as it is requrired by the border routers.
+    ./tools/quiet ./scion.sh mstart '*disp*'
+    # Start border routers before all other services to provide connectivity.
+    ./tools/quiet ./scion.sh mstart '*br*'
     # Run with docker-compose or supervisor
     if is_docker_be; then
         ./tools/quiet ./tools/dc start 'scion*'


### PR DESCRIPTION
This PR first starts the dispatcher and border routers to ensure
initial connectivity.

Currently, some tests fail because the beacon server are started
before the border routers and the ifid keepalives are not delivered.
By the time the border router has started, the interface is already
revoked. The introduced ordering will avoid this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2717)
<!-- Reviewable:end -->
