### PR TITLE
sciond: Make sure maxpaths is always respected

### DIFF
--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -134,10 +134,10 @@ func (f *fetcherHandler) GetPaths(ctx context.Context, req *sciond.PathReq,
 		paths, err := f.buildPathsFromDB(ctx, req)
 		switch {
 		case ctx.Err() != nil:
-			return f.buildSCIONDReply(nil, 0, sciond.ErrorNoPaths), nil
+			return f.buildSCIONDReply(nil, req.MaxPaths, sciond.ErrorNoPaths), nil
 		case err != nil && common.GetErrorMsg(err) == trust.ErrNotFoundLocally:
 		case err != nil:
-			return f.buildSCIONDReply(nil, 0, sciond.ErrorInternal), err
+			return f.buildSCIONDReply(nil, req.MaxPaths, sciond.ErrorInternal), err
 		case err == nil && len(paths) > 0:
 			return f.buildSCIONDReply(paths, req.MaxPaths, sciond.ErrorOk), nil
 		}
@@ -176,11 +176,11 @@ func (f *fetcherHandler) GetPaths(ctx context.Context, req *sciond.PathReq,
 	paths, err := f.buildPathsFromDB(ctx, req)
 	switch {
 	case ctx.Err() != nil:
-		return f.buildSCIONDReply(nil, 0, sciond.ErrorNoPaths), nil
+		return f.buildSCIONDReply(nil, req.MaxPaths, sciond.ErrorNoPaths), nil
 	case err != nil:
-		return f.buildSCIONDReply(nil, 0, sciond.ErrorInternal), err
+		return f.buildSCIONDReply(nil, req.MaxPaths, sciond.ErrorInternal), err
 	case err == nil && len(paths) > 0:
-		return f.buildSCIONDReply(paths, 0, sciond.ErrorOk), nil
+		return f.buildSCIONDReply(paths, req.MaxPaths, sciond.ErrorOk), nil
 	}
 	// If we reached this point because the early reply fired but we still
 	// weren't able to build and paths, wait as much as possible for new
@@ -193,15 +193,15 @@ func (f *fetcherHandler) GetPaths(ctx context.Context, req *sciond.PathReq,
 		paths, err := f.buildPathsFromDB(ctx, req)
 		switch {
 		case ctx.Err() != nil:
-			return f.buildSCIONDReply(nil, 0, sciond.ErrorNoPaths), nil
+			return f.buildSCIONDReply(nil, req.MaxPaths, sciond.ErrorNoPaths), nil
 		case err != nil:
-			return f.buildSCIONDReply(nil, 0, sciond.ErrorInternal), err
+			return f.buildSCIONDReply(nil, req.MaxPaths, sciond.ErrorInternal), err
 		case err == nil && len(paths) > 0:
 			return f.buildSCIONDReply(paths, req.MaxPaths, sciond.ErrorOk), nil
 		}
 	}
 	// Your paths are in another castle
-	return f.buildSCIONDReply(nil, 0, sciond.ErrorNoPaths), nil
+	return f.buildSCIONDReply(nil, req.MaxPaths, sciond.ErrorNoPaths), nil
 }
 
 // buildSCIONDReply constructs a fresh SCIOND PathReply from the information


### PR DESCRIPTION
Instead of passing 0 to buildSCIONDReply sometimes just always pass req.MaxPaths.
This prevents errors, also there was one OK case where 0 was wrongly passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2718)
<!-- Reviewable:end -->
