### PR TITLE
CS: Use path to wildcard AS directly

### DIFF
--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -670,7 +670,12 @@ func (store *Store) ChooseServer(ctx context.Context, destination addr.IA) (net.
 		return nil, common.NewBasicError("Unable to find path to any core AS", err,
 			"isd", destISD)
 	}
-	a := &snet.Addr{IA: path.Destination(), Host: addr.NewSVCUDPAppAddr(addr.SvcCS)}
+	a := &snet.Addr{
+		IA:      path.Destination(),
+		Host:    addr.NewSVCUDPAppAddr(addr.SvcCS),
+		Path:    path.Path(),
+		NextHop: path.OverlayNextHop(),
+	}
 	return a, nil
 }
 


### PR DESCRIPTION
If we do a routing to a dest ISD we get a path to a specific AS.
So instead of only setting the IA from this path, use directly the whole path.
This saves a request to sciond.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2720)
<!-- Reviewable:end -->
