### PR TITLE
PS: Request missing TRC from core CS

### DIFF
--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -55,11 +55,24 @@ func (h *segReqHandler) isValidDst(segReq *path_mgmt.SegReq) bool {
 	return true
 }
 
-func (h *segReqHandler) isCoreDst(ctx context.Context, segReq *path_mgmt.SegReq) (bool, error) {
+func (h *segReqHandler) isCoreDst(ctx context.Context, segReq *path_mgmt.SegReq,
+	resolver func() (net.Addr, error)) (bool, error) {
+
 	if segReq.DstIA().A == 0 {
 		return true, nil
 	}
-	dstTRC, err := h.trustStore.GetTRC(ctx, segReq.DstIA().I, scrypto.LatestVer)
+	// Try local trust store first.
+	if dstTrc, err := h.trustStore.GetValidCachedTRC(ctx, segReq.DstIA().I); err == nil {
+		return dstTrc.CoreASes.Contains(segReq.DstIA()), nil
+	}
+	var remote net.Addr
+	if resolver != nil {
+		var err error
+		if remote, err = resolver(); err != nil {
+			return false, common.NewBasicError("Unable to resolve remote", err)
+		}
+	}
+	dstTRC, err := h.trustStore.GetValidTRC(ctx, segReq.DstIA().I, remote)
 	if err != nil {
 		return false, common.NewBasicError("Failed to get TRC for dst", err)
 	}

--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -64,13 +64,13 @@ func (h *segReqHandler) isCoreDst(ctx context.Context, segReq *path_mgmt.SegReq,
 	// Try local trust store first.
 	if dstTrc, err := h.trustStore.GetValidCachedTRC(ctx, segReq.DstIA().I); err == nil {
 		return dstTrc.CoreASes.Contains(segReq.DstIA()), nil
+	} else if resolver == nil {
+		return false, common.NewBasicError("Destination TRC not found", err,
+			"isd", segReq.DstIA().I)
 	}
-	var remote net.Addr
-	if resolver != nil {
-		var err error
-		if remote, err = resolver(); err != nil {
-			return false, common.NewBasicError("Unable to resolve remote", err)
-		}
+	remote, err := resolver()
+	if err != nil {
+		return false, common.NewBasicError("Unable to resolve remote", err)
 	}
 	dstTRC, err := h.trustStore.GetValidTRC(ctx, segReq.DstIA().I, remote)
 	if err != nil {

--- a/go/path_srv/internal/handlers/segreqcore.go
+++ b/go/path_srv/internal/handlers/segreqcore.go
@@ -83,7 +83,7 @@ func (h *segReqCoreHandler) handleReq(ctx context.Context, rw infra.ResponseWrit
 		rw.SendSegReply(ctx, &path_mgmt.SegReply{Req: segReq})
 		return
 	}
-	dstCore, err := h.isCoreDst(ctx, segReq)
+	dstCore, err := h.isCoreDst(ctx, segReq, nil)
 	if err != nil {
 		logger.Error("[segReqCoreHandler] Failed to determine dest type", "err", err)
 		rw.SendSegReply(ctx, &path_mgmt.SegReply{Req: segReq})

--- a/go/path_srv/internal/handlers/segreqnoncore_test.go
+++ b/go/path_srv/internal/handlers/segreqnoncore_test.go
@@ -331,6 +331,11 @@ func TestSegReqLocal(t *testing.T) {
 				return trcs[isd], nil
 			},
 		)
+		ts.EXPECT().GetValidCachedTRC(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
+			func(_ context.Context, isd addr.ISD) (*trc.TRC, error) {
+				return trcs[isd], nil
+			},
+		)
 		for _, tc := range testCases {
 			Convey(tc.Name, func() {
 				db := setupDB(t, tc)


### PR DESCRIPTION
The path server determines whether an AS in a remote ISD is core or
not using the TRC. If the TRC is missing locally, the path server
currently queries the local certificate service for the TRC.

In a non-core AS, the certificate server discovers TRCs for remote ISDs
through the path server. Thus, it is highly unlikely that it already has
the TRC. This causes the certificate server to request a path to the
local core from the path server, leading to many rpc calls and a loop
in addressed services.

With this change, a path server in a non-core AS immediately fetches
the TRC from a local core certificate server to avoid rpc calls
and reduce latency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2723)
<!-- Reviewable:end -->
