### PR TITLE
PS: Revocation handler should not query BR

### DIFF
--- a/go/path_srv/internal/handlers/segrevoc.go
+++ b/go/path_srv/internal/handlers/segrevoc.go
@@ -68,8 +68,7 @@ func (h *revocHandler) Handle() *infra.HandlerResult {
 	logger = logger.New("revInfo", revInfo)
 	logger.Debug("[revocHandler] Received revocation")
 
-	err = segverifier.VerifyRevInfo(subCtx, h.trustStore.NewVerifier(), h.request.Peer,
-		revocation)
+	err = segverifier.VerifyRevInfo(subCtx, h.trustStore.NewVerifier(), nil, revocation)
 	if err != nil {
 		logger.Warn("Couldn't verify revocation", "err", err)
 		sendAck(proto.Ack_ErrCode_reject, messenger.AckRejectFailedToVerify)


### PR DESCRIPTION
When the border router forks a revocation, the PS will
try to fetch the crypto from the border router that happily
drops these kinds of requests.

By setting nil, the certificate server is queried which makes sense in all cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2729)
<!-- Reviewable:end -->
