### PR TITLE
CI: Increase e2e timeout for core-core

### DIFF
--- a/integration/e2e_integration
+++ b/integration/e2e_integration
@@ -24,7 +24,7 @@ result=0
 
 case $MODE in
     core-core|noncore-localcore)
-        run "E2E $MODE" ./bin/end2end_integration -subset "$MODE" -timeout 2s -log.console error $DOCKER_ARGS; result=$? ;;
+        run "E2E $MODE" ./bin/end2end_integration -subset "$MODE" -timeout 2500ms -log.console error $DOCKER_ARGS; result=$? ;;
     *)
         run "E2E $MODE" ./bin/end2end_integration -subset "$MODE" -log.console error $DOCKER_ARGS; result=$? ;;
 esac


### PR DESCRIPTION
Increase the timeout to 2.5 seconds, to allow enough time for
querying and verifying path and crypto material on CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2731)
<!-- Reviewable:end -->
