### PR TITLE
Simplify trust-&path-db metrics code

### DIFF
--- a/go/lib/infra/modules/trust/trustdb/metrics.go
+++ b/go/lib/infra/modules/trust/trustdb/metrics.go
@@ -63,44 +63,15 @@ var (
 	queriesTotal *prometheus.CounterVec
 	resultsTotal *prometheus.CounterVec
 
-	allOps = []promOp{
-		promOpGetIssCert,
-		promOpGetIssCertMV,
-		promOpGetAllIssCerts,
-		promOpGetChain,
-		promOpGetChainMV,
-		promOpGetAllChains,
-		promOpGetTRC,
-		promOpGetTRCMV,
-		promOpGetAllTRCs,
-		promOpGetCustKey,
-		promOpGetAllCustKeys,
-
-		promOpInsertIssCert,
-		promOpInsertChain,
-		promOpInsertTRC,
-		promOpInsertCustKey,
-
-		promOpBeginTx,
-		promOpCommitTx,
-		promOpRollbackTx,
-	}
-
-	allResults = []string{
-		prom.ResultOk,
-		prom.ErrNotClassified,
-		prom.ErrTimeout,
-	}
-
 	initMetricsOnce sync.Once
 )
 
 func initMetrics() {
 	initMetricsOnce.Do(func() {
-		// Cardinality: X (dbName) * 18 (len(allOps))
+		// Cardinality: X (dbName) * 18 (len(all ops))
 		queriesTotal = prom.NewCounterVec(promNamespace, "", "queries_total",
 			"Total queries to the database.", []string{promDBName, prom.LabelOperation})
-		// Cardinality: X (dbName) * 18 (len(allOps)) * 3 (len(allResults))
+		// Cardinality: X (dbName) * 18 (len(all ops)) * Y (len(all results))
 		resultsTotal = prom.NewCounterVec(promNamespace, "", "results_total",
 			"Results of trustdb operations.",
 			[]string{promDBName, prom.LabelOperation, prom.LabelResult})

--- a/go/lib/infra/modules/trust/trustdb/metrics.go
+++ b/go/lib/infra/modules/trust/trustdb/metrics.go
@@ -22,7 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/infra/modules/db"
 	"github.com/scionproto/scion/go/lib/prom"
 	"github.com/scionproto/scion/go/lib/scrypto/cert"
 	"github.com/scionproto/scion/go/lib/scrypto/trc"
@@ -122,57 +122,22 @@ func WithMetrics(dbName string, trustDB TrustDB) TrustDB {
 }
 
 type counters struct {
-	opCounters     map[promOp]prometheus.Counter
-	resultCounters map[promOp]map[string]prometheus.Counter
+	queriesTotal *prometheus.CounterVec
+	resultsTotal *prometheus.CounterVec
 }
 
 func newCounters(dbName string) *counters {
+	labels := prometheus.Labels{promDBName: dbName}
 	return &counters{
-		opCounters:     opCounters(dbName),
-		resultCounters: resultCounters(dbName),
+		queriesTotal: queriesTotal.MustCurryWith(labels),
+		resultsTotal: resultsTotal.MustCurryWith(labels),
 	}
 }
 
-func opCounters(dbName string) map[promOp]prometheus.Counter {
-	opCounters := make(map[promOp]prometheus.Counter)
-	for _, op := range allOps {
-		opCounters[op] = queriesTotal.With(prometheus.Labels{
-			promDBName:          dbName,
-			prom.LabelOperation: string(op),
-		})
-	}
-	return opCounters
-}
-
-func resultCounters(dbName string) map[promOp]map[string]prometheus.Counter {
-	resultCounters := make(map[promOp]map[string]prometheus.Counter)
-	for _, op := range allOps {
-		resultCounters[op] = make(map[string]prometheus.Counter)
-		for _, res := range allResults {
-			resultCounters[op][res] = resultsTotal.With(prometheus.Labels{
-				promDBName:          dbName,
-				prom.LabelOperation: string(op),
-				prom.LabelResult:    res,
-			})
-		}
-	}
-	return resultCounters
-}
-
-func (c *counters) incOp(op promOp) {
-	c.opCounters[op].Inc()
-}
-
-func (c *counters) incResult(op promOp, err error) {
-	// TODO(lukedirtwalker): categorize error better.
-	switch {
-	case err == nil:
-		c.resultCounters[op][prom.ResultOk].Inc()
-	case common.IsTimeoutErr(err):
-		c.resultCounters[op][prom.ErrTimeout].Inc()
-	default:
-		c.resultCounters[op][prom.ErrNotClassified].Inc()
-	}
+func (c *counters) Observe(ctx context.Context, op promOp, action func(ctx context.Context) error) {
+	c.queriesTotal.WithLabelValues(string(op)).Inc()
+	err := action(ctx)
+	c.resultsTotal.WithLabelValues(string(op), db.ErrToMetricLabel(err))
 }
 
 var _ (TrustDB) = (*metricsTrustDB)(nil)
@@ -186,14 +151,18 @@ type metricsTrustDB struct {
 func (db *metricsTrustDB) BeginTransaction(ctx context.Context,
 	opts *sql.TxOptions) (Transaction, error) {
 
-	db.metricsExecutor.metrics.incOp(promOpBeginTx)
-	tx, err := db.db.BeginTransaction(ctx, opts)
-	db.metricsExecutor.metrics.incResult(promOpBeginTx, err)
+	var tx Transaction
+	var err error
+	db.metricsExecutor.metrics.Observe(ctx, promOpBeginTx, func(ctx context.Context) error {
+		tx, err = db.db.BeginTransaction(ctx, opts)
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
 	return &metricsTransaction{
-		tx: tx,
+		tx:  tx,
+		ctx: ctx,
 		metricsExecutor: &metricsExecutor{
 			rwDB:    tx,
 			metrics: db.metricsExecutor.metrics,
@@ -218,20 +187,25 @@ var _ (Transaction) = (*metricsTransaction)(nil)
 type metricsTransaction struct {
 	*metricsExecutor
 	// tx is only used for Commit and Rollback.
-	tx Transaction
+	tx  Transaction
+	ctx context.Context
 }
 
 func (tx *metricsTransaction) Commit() error {
-	tx.metrics.incOp(promOpCommitTx)
-	err := tx.tx.Commit()
-	tx.metrics.incResult(promOpCommitTx, err)
+	var err error
+	tx.metrics.Observe(tx.ctx, promOpCommitTx, func(_ context.Context) error {
+		err = tx.tx.Commit()
+		return err
+	})
 	return err
 }
 
 func (tx *metricsTransaction) Rollback() error {
-	tx.metrics.incOp(promOpRollbackTx)
-	err := tx.tx.Rollback()
-	tx.metrics.incResult(promOpRollbackTx, err)
+	var err error
+	tx.metrics.Observe(tx.ctx, promOpRollbackTx, func(_ context.Context) error {
+		err = tx.tx.Rollback()
+		return err
+	})
 	return err
 }
 
@@ -240,123 +214,168 @@ type metricsExecutor struct {
 	metrics *counters
 }
 
-// below here is very boilerplaty code that implements all DB ops and calls the inc functions.
+// below here is very boilerplaty code that implements all DB ops and calls the Observe function.
 
 func (db *metricsExecutor) InsertIssCert(ctx context.Context,
 	crt *cert.Certificate) (int64, error) {
 
-	db.metrics.incOp(promOpInsertIssCert)
-	cnt, err := db.rwDB.InsertIssCert(ctx, crt)
-	db.metrics.incResult(promOpInsertIssCert, err)
+	var cnt int64
+	var err error
+	db.metrics.Observe(ctx, promOpInsertIssCert, func(ctx context.Context) error {
+		cnt, err = db.rwDB.InsertIssCert(ctx, crt)
+		return err
+	})
 	return cnt, err
 }
 
 func (db *metricsExecutor) InsertChain(ctx context.Context, chain *cert.Chain) (int64, error) {
-	db.metrics.incOp(promOpInsertChain)
-	cnt, err := db.rwDB.InsertChain(ctx, chain)
-	db.metrics.incResult(promOpInsertChain, err)
+
+	var cnt int64
+	var err error
+	db.metrics.Observe(ctx, promOpInsertChain, func(ctx context.Context) error {
+		cnt, err = db.rwDB.InsertChain(ctx, chain)
+		return err
+	})
 	return cnt, err
 }
 
 func (db *metricsExecutor) InsertTRC(ctx context.Context, trcobj *trc.TRC) (int64, error) {
-	db.metrics.incOp(promOpInsertTRC)
-	cnt, err := db.rwDB.InsertTRC(ctx, trcobj)
-	db.metrics.incResult(promOpInsertTRC, err)
+	var cnt int64
+	var err error
+	db.metrics.Observe(ctx, promOpInsertTRC, func(ctx context.Context) error {
+		cnt, err = db.rwDB.InsertTRC(ctx, trcobj)
+		return err
+	})
 	return cnt, err
 }
 
 func (db *metricsExecutor) InsertCustKey(ctx context.Context, key *CustKey,
 	oldVersion uint64) error {
 
-	db.metrics.incOp(promOpInsertCustKey)
-	err := db.rwDB.InsertCustKey(ctx, key, oldVersion)
-	db.metrics.incResult(promOpInsertCustKey, err)
+	var err error
+	db.metrics.Observe(ctx, promOpInsertCustKey, func(ctx context.Context) error {
+		err = db.rwDB.InsertCustKey(ctx, key, oldVersion)
+		return err
+	})
 	return err
 }
 
 func (db *metricsExecutor) GetIssCertVersion(ctx context.Context, ia addr.IA,
 	version uint64) (*cert.Certificate, error) {
 
-	db.metrics.incOp(promOpGetIssCert)
-	res, err := db.rwDB.GetIssCertVersion(ctx, ia, version)
-	db.metrics.incResult(promOpGetIssCert, err)
+	var res *cert.Certificate
+	var err error
+	db.metrics.Observe(ctx, promOpGetIssCert, func(ctx context.Context) error {
+		res, err = db.rwDB.GetIssCertVersion(ctx, ia, version)
+		return err
+	})
 	return res, err
 }
 
 func (db *metricsExecutor) GetIssCertMaxVersion(ctx context.Context,
 	ia addr.IA) (*cert.Certificate, error) {
 
-	db.metrics.incOp(promOpGetIssCertMV)
-	res, err := db.rwDB.GetIssCertMaxVersion(ctx, ia)
-	db.metrics.incResult(promOpGetIssCertMV, err)
+	var res *cert.Certificate
+	var err error
+	db.metrics.Observe(ctx, promOpGetIssCertMV, func(ctx context.Context) error {
+		res, err = db.rwDB.GetIssCertMaxVersion(ctx, ia)
+		return err
+	})
 	return res, err
 }
 
 func (db *metricsExecutor) GetAllIssCerts(ctx context.Context) (<-chan CertOrErr, error) {
-	db.metrics.incOp(promOpGetAllIssCerts)
-	res, err := db.rwDB.GetAllIssCerts(ctx)
-	db.metrics.incResult(promOpGetAllIssCerts, err)
+	var res <-chan CertOrErr
+	var err error
+	db.metrics.Observe(ctx, promOpGetAllIssCerts, func(ctx context.Context) error {
+		res, err = db.rwDB.GetAllIssCerts(ctx)
+		return err
+	})
 	return res, err
 }
 
 func (db *metricsExecutor) GetChainVersion(ctx context.Context, ia addr.IA,
 	version uint64) (*cert.Chain, error) {
 
-	db.metrics.incOp(promOpGetChain)
-	res, err := db.rwDB.GetChainVersion(ctx, ia, version)
-	db.metrics.incResult(promOpGetChain, err)
+	var res *cert.Chain
+	var err error
+	db.metrics.Observe(ctx, promOpGetChain, func(ctx context.Context) error {
+		res, err = db.rwDB.GetChainVersion(ctx, ia, version)
+		return err
+	})
 	return res, err
 }
 
 func (db *metricsExecutor) GetChainMaxVersion(ctx context.Context,
 	ia addr.IA) (*cert.Chain, error) {
 
-	db.metrics.incOp(promOpGetChainMV)
-	res, err := db.rwDB.GetChainMaxVersion(ctx, ia)
-	db.metrics.incResult(promOpGetChainMV, err)
+	var res *cert.Chain
+	var err error
+	db.metrics.Observe(ctx, promOpGetChainMV, func(ctx context.Context) error {
+		res, err = db.rwDB.GetChainMaxVersion(ctx, ia)
+		return err
+	})
 	return res, err
 }
 
 func (db *metricsExecutor) GetAllChains(ctx context.Context) (<-chan ChainOrErr, error) {
-	db.metrics.incOp(promOpGetAllChains)
-	res, err := db.rwDB.GetAllChains(ctx)
-	db.metrics.incResult(promOpGetAllChains, err)
+	var res <-chan ChainOrErr
+	var err error
+	db.metrics.Observe(ctx, promOpGetAllChains, func(ctx context.Context) error {
+		res, err = db.rwDB.GetAllChains(ctx)
+		return err
+	})
 	return res, err
 }
 
 func (db *metricsExecutor) GetTRCVersion(ctx context.Context, isd addr.ISD,
 	version uint64) (*trc.TRC, error) {
 
-	db.metrics.incOp(promOpGetTRC)
-	res, err := db.rwDB.GetTRCVersion(ctx, isd, version)
-	db.metrics.incResult(promOpGetTRC, err)
+	var res *trc.TRC
+	var err error
+	db.metrics.Observe(ctx, promOpGetTRC, func(ctx context.Context) error {
+		res, err = db.rwDB.GetTRCVersion(ctx, isd, version)
+		return err
+	})
 	return res, err
 }
 
 func (db *metricsExecutor) GetTRCMaxVersion(ctx context.Context, isd addr.ISD) (*trc.TRC, error) {
-	db.metrics.incOp(promOpGetTRCMV)
-	res, err := db.rwDB.GetTRCMaxVersion(ctx, isd)
-	db.metrics.incResult(promOpGetTRCMV, err)
+	var res *trc.TRC
+	var err error
+	db.metrics.Observe(ctx, promOpGetTRCMV, func(ctx context.Context) error {
+		res, err = db.rwDB.GetTRCMaxVersion(ctx, isd)
+		return err
+	})
 	return res, err
 }
 
 func (db *metricsExecutor) GetAllTRCs(ctx context.Context) (<-chan TrcOrErr, error) {
-	db.metrics.incOp(promOpGetAllTRCs)
-	res, err := db.rwDB.GetAllTRCs(ctx)
-	db.metrics.incResult(promOpGetAllTRCs, err)
+	var res <-chan TrcOrErr
+	var err error
+	db.metrics.Observe(ctx, promOpGetAllTRCs, func(ctx context.Context) error {
+		res, err = db.rwDB.GetAllTRCs(ctx)
+		return err
+	})
 	return res, err
 }
 
 func (db *metricsExecutor) GetCustKey(ctx context.Context, ia addr.IA) (*CustKey, error) {
-	db.metrics.incOp(promOpGetCustKey)
-	res, err := db.rwDB.GetCustKey(ctx, ia)
-	db.metrics.incResult(promOpGetCustKey, err)
+	var res *CustKey
+	var err error
+	db.metrics.Observe(ctx, promOpGetCustKey, func(ctx context.Context) error {
+		res, err = db.rwDB.GetCustKey(ctx, ia)
+		return err
+	})
 	return res, err
 }
 
 func (db *metricsExecutor) GetAllCustKeys(ctx context.Context) (<-chan CustKeyOrErr, error) {
-	db.metrics.incOp(promOpGetAllCustKeys)
-	res, err := db.rwDB.GetAllCustKeys(ctx)
-	db.metrics.incResult(promOpGetAllCustKeys, err)
+	var res <-chan CustKeyOrErr
+	var err error
+	db.metrics.Observe(ctx, promOpGetAllCustKeys, func(ctx context.Context) error {
+		res, err = db.rwDB.GetAllCustKeys(ctx)
+		return err
+	})
 	return res, err
 }

--- a/go/lib/pathdb/BUILD.bazel
+++ b/go/lib/pathdb/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/ctrl/seg:go_default_library",
         "//go/lib/infra/modules/cleaner:go_default_library",
         "//go/lib/infra/modules/db:go_default_library",

--- a/go/lib/pathdb/metrics.go
+++ b/go/lib/pathdb/metrics.go
@@ -56,36 +56,15 @@ var (
 	queriesTotal *prometheus.CounterVec
 	resultsTotal *prometheus.CounterVec
 
-	allOps = []promOp{
-		promOpInsert,
-		promOpInsertHpCfg,
-		promOpDelete,
-		promOpDeleteExpired,
-		promOpGet,
-		promOpGetAll,
-		promOpInsertNextQuery,
-		promOpGetNextQuery,
-
-		promOpBeginTx,
-		promOpCommitTx,
-		promOpRollbackTx,
-	}
-
-	allResults = []string{
-		prom.ResultOk,
-		prom.ErrNotClassified,
-		prom.ErrTimeout,
-	}
-
 	initMetricsOnce sync.Once
 )
 
 func initMetrics() {
 	initMetricsOnce.Do(func() {
-		// Cardinality: X (dbName) * 11 (len(allOps))
+		// Cardinality: X (dbName) * 11 (len(all ops))
 		queriesTotal = prom.NewCounterVec(promNamespace, "", "queries_total",
 			"Total queries to the database.", []string{promDBName, prom.LabelOperation})
-		// Cardinality: X (dbNmae) * 11 (len(allOps)) * 3 (len(allResults))
+		// Cardinality: X (dbNmae) * 11 (len(all ops)) * Y (len(all results))
 		resultsTotal = prom.NewCounterVec(promNamespace, "", "results_total",
 			"The results of the pathdb ops.",
 			[]string{promDBName, prom.LabelResult, prom.LabelOperation})

--- a/go/lib/pathdb/metrics.go
+++ b/go/lib/pathdb/metrics.go
@@ -23,8 +23,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
+	"github.com/scionproto/scion/go/lib/infra/modules/db"
 	"github.com/scionproto/scion/go/lib/pathdb/query"
 	"github.com/scionproto/scion/go/lib/prom"
 )
@@ -96,63 +96,28 @@ func initMetrics() {
 // dbName will be added as a label to all metrics, so that multiple path DBs can be differentiated.
 func WithMetrics(dbName string, pathDB PathDB) PathDB {
 	initMetrics()
+	labels := prometheus.Labels{promDBName: dbName}
 	return &metricsPathDB{
 		metricsExecutor: &metricsExecutor{
 			pathDB: pathDB,
 			metrics: &dbCounters{
-				opCounters:     opCounters(dbName),
-				resultCounters: resultCounters(dbName),
+				queriesTotal: queriesTotal.MustCurryWith(labels),
+				resultsTotal: resultsTotal.MustCurryWith(labels),
 			},
 		},
 		db: pathDB,
 	}
 }
 
-func opCounters(dbName string) map[promOp]prometheus.Counter {
-	opCounters := make(map[promOp]prometheus.Counter)
-	for _, op := range allOps {
-		opCounters[op] = queriesTotal.With(prometheus.Labels{
-			promDBName:          dbName,
-			prom.LabelOperation: string(op),
-		})
-	}
-	return opCounters
-}
-
-func resultCounters(dbName string) map[promOp]map[string]prometheus.Counter {
-	resultCounters := make(map[promOp]map[string]prometheus.Counter)
-	for _, op := range allOps {
-		resultCounters[op] = make(map[string]prometheus.Counter)
-		for _, res := range allResults {
-			resultCounters[op][res] = resultsTotal.With(prometheus.Labels{
-				promDBName:          dbName,
-				prom.LabelOperation: string(op),
-				prom.LabelResult:    res,
-			})
-		}
-	}
-	return resultCounters
-}
-
 type dbCounters struct {
-	opCounters     map[promOp]prometheus.Counter
-	resultCounters map[promOp]map[string]prometheus.Counter
+	queriesTotal *prometheus.CounterVec
+	resultsTotal *prometheus.CounterVec
 }
 
-func (c *dbCounters) incOp(op promOp) {
-	c.opCounters[op].Inc()
-}
-
-func (c *dbCounters) incResult(op promOp, err error) {
-	// TODO(lukedirtwalker): categorize error better.
-	switch {
-	case err == nil:
-		c.resultCounters[op][prom.ResultOk].Inc()
-	case common.IsTimeoutErr(err):
-		c.resultCounters[op][prom.ErrTimeout].Inc()
-	default:
-		c.resultCounters[op][prom.ErrNotClassified].Inc()
-	}
+func (c *dbCounters) Observe(ctx context.Context, op promOp, action func(ctx context.Context) error) {
+	c.queriesTotal.WithLabelValues(string(op)).Inc()
+	err := action(ctx)
+	c.resultsTotal.WithLabelValues(db.ErrToMetricLabel(err), string(op)).Inc()
 }
 
 var _ (PathDB) = (*metricsPathDB)(nil)
@@ -178,14 +143,18 @@ func (db *metricsPathDB) SetMaxIdleConns(maxIdleConns int) {
 func (db *metricsPathDB) BeginTransaction(ctx context.Context,
 	opts *sql.TxOptions) (Transaction, error) {
 
-	db.metricsExecutor.metrics.incOp(promOpBeginTx)
-	tx, err := db.db.BeginTransaction(ctx, opts)
-	db.metricsExecutor.metrics.incResult(promOpBeginTx, err)
+	var tx Transaction
+	var err error
+	db.metricsExecutor.metrics.Observe(ctx, promOpBeginTx, func(ctx context.Context) error {
+		tx, err = db.db.BeginTransaction(ctx, opts)
+		return err
+	})
 	if err != nil {
 		return nil, err
 	}
 	return &metricsTransaction{
-		tx: tx,
+		tx:  tx,
+		ctx: ctx,
 		metricsExecutor: &metricsExecutor{
 			pathDB:  tx,
 			metrics: db.metricsExecutor.metrics,
@@ -197,20 +166,25 @@ var _ (Transaction) = (*metricsTransaction)(nil)
 
 type metricsTransaction struct {
 	*metricsExecutor
-	tx Transaction
+	tx  Transaction
+	ctx context.Context
 }
 
 func (tx *metricsTransaction) Commit() error {
-	tx.metrics.incOp(promOpCommitTx)
-	err := tx.tx.Commit()
-	tx.metrics.incResult(promOpCommitTx, err)
+	var err error
+	tx.metrics.Observe(tx.ctx, promOpCommitTx, func(_ context.Context) error {
+		err = tx.tx.Commit()
+		return err
+	})
 	return err
 }
 
 func (tx *metricsTransaction) Rollback() error {
-	tx.metrics.incOp(promOpRollbackTx)
-	err := tx.tx.Rollback()
-	tx.metrics.incResult(promOpRollbackTx, err)
+	var err error
+	tx.metrics.Observe(tx.ctx, promOpRollbackTx, func(_ context.Context) error {
+		err = tx.tx.Rollback()
+		return err
+	})
 	return err
 }
 
@@ -222,61 +196,85 @@ type metricsExecutor struct {
 }
 
 func (db *metricsExecutor) Insert(ctx context.Context, meta *seg.Meta) (int, error) {
-	db.metrics.incOp(promOpInsert)
-	cnt, err := db.pathDB.Insert(ctx, meta)
-	db.metrics.incResult(promOpInsert, err)
+	var cnt int
+	var err error
+	db.metrics.Observe(ctx, promOpInsert, func(ctx context.Context) error {
+		cnt, err = db.pathDB.Insert(ctx, meta)
+		return err
+	})
 	return cnt, err
 }
 
 func (db *metricsExecutor) InsertWithHPCfgIDs(ctx context.Context,
 	meta *seg.Meta, hpCfgIds []*query.HPCfgID) (int, error) {
 
-	db.metrics.incOp(promOpInsertHpCfg)
-	cnt, err := db.pathDB.InsertWithHPCfgIDs(ctx, meta, hpCfgIds)
-	db.metrics.incResult(promOpInsertHpCfg, err)
+	var cnt int
+	var err error
+	db.metrics.Observe(ctx, promOpInsertHpCfg, func(ctx context.Context) error {
+		cnt, err = db.pathDB.InsertWithHPCfgIDs(ctx, meta, hpCfgIds)
+		return err
+	})
 	return cnt, err
 }
 
 func (db *metricsExecutor) Delete(ctx context.Context, params *query.Params) (int, error) {
-	db.metrics.incOp(promOpDelete)
-	cnt, err := db.pathDB.Delete(ctx, params)
-	db.metrics.incResult(promOpDelete, err)
+	var cnt int
+	var err error
+	db.metrics.Observe(ctx, promOpDelete, func(ctx context.Context) error {
+		cnt, err = db.pathDB.Delete(ctx, params)
+		return err
+	})
 	return cnt, err
 }
 
 func (db *metricsExecutor) DeleteExpired(ctx context.Context, now time.Time) (int, error) {
-	db.metrics.incOp(promOpDeleteExpired)
-	cnt, err := db.pathDB.DeleteExpired(ctx, now)
-	db.metrics.incResult(promOpDeleteExpired, err)
+	var cnt int
+	var err error
+	db.metrics.Observe(ctx, promOpDeleteExpired, func(ctx context.Context) error {
+		cnt, err = db.pathDB.DeleteExpired(ctx, now)
+		return err
+	})
 	return cnt, err
 }
 
 func (db *metricsExecutor) Get(ctx context.Context, params *query.Params) (query.Results, error) {
-	db.metrics.incOp(promOpGet)
-	res, err := db.pathDB.Get(ctx, params)
-	db.metrics.incResult(promOpGet, err)
+	var res query.Results
+	var err error
+	db.metrics.Observe(ctx, promOpGet, func(ctx context.Context) error {
+		res, err = db.pathDB.Get(ctx, params)
+		return err
+	})
 	return res, err
 }
 
 func (db *metricsExecutor) GetAll(ctx context.Context) (<-chan query.ResultOrErr, error) {
-	db.metrics.incOp(promOpGetAll)
-	res, err := db.pathDB.GetAll(ctx)
-	db.metrics.incResult(promOpGetAll, err)
+	var res <-chan query.ResultOrErr
+	var err error
+	db.metrics.Observe(ctx, promOpGetAll, func(ctx context.Context) error {
+		res, err = db.pathDB.GetAll(ctx)
+		return err
+	})
 	return res, err
 }
 
 func (db *metricsExecutor) InsertNextQuery(ctx context.Context,
 	dst addr.IA, nextQuery time.Time) (bool, error) {
 
-	db.metrics.incOp(promOpInsertNextQuery)
-	ok, err := db.pathDB.InsertNextQuery(ctx, dst, nextQuery)
-	db.metrics.incResult(promOpInsertNextQuery, err)
+	var ok bool
+	var err error
+	db.metrics.Observe(ctx, promOpInsertNextQuery, func(ctx context.Context) error {
+		ok, err = db.pathDB.InsertNextQuery(ctx, dst, nextQuery)
+		return err
+	})
 	return ok, err
 }
 
 func (db *metricsExecutor) GetNextQuery(ctx context.Context, dst addr.IA) (*time.Time, error) {
-	db.metrics.incOp(promOpGetNextQuery)
-	t, err := db.pathDB.GetNextQuery(ctx, dst)
-	db.metrics.incResult(promOpGetNextQuery, err)
+	var t *time.Time
+	var err error
+	db.metrics.Observe(ctx, promOpGetNextQuery, func(ctx context.Context) error {
+		t, err = db.pathDB.GetNextQuery(ctx, dst)
+		return err
+	})
 	return t, err
 }


### PR DESCRIPTION
Introduce observe method instead of inc methods.
That is more flexible, it allows to add timing metrics and will make adding tracing easier.

Also do not preinitialize counters we do not use all of them in all services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2732)
<!-- Reviewable:end -->
