### PR TITLE
Allow snet users to customize SCMP behavior

### DIFF
--- a/go/beacon_srv/main.go
+++ b/go/beacon_srv/main.go
@@ -182,7 +182,9 @@ func realMain() int {
 		msgr.ListenAndServe()
 	}()
 	ovAddr := &addr.AppAddr{L3: topoAddress.PublicAddr(topoAddress.Overlay).L3}
-	pktDisp := snet.NewDefaultPacketDispatcherService(reliable.NewDispatcherService(""))
+	pktDisp := &snet.DefaultPacketDispatcherService{
+		Dispatcher: reliable.NewDispatcherService(""),
+	}
 	// We do not need to drain the connection, since the src address is spoofed
 	// to contain the topo address.
 	conn, _, err := pktDisp.RegisterTimeout(topo.ISD_AS, ovAddr, nil, addr.SvcNone, time.Second)
@@ -199,9 +201,9 @@ func realMain() int {
 		topoProvider: itopo.Provider(),
 		addressRewriter: nc.AddressRewriter(
 			&onehop.OHPPacketDispatcherService{
-				PacketDispatcherService: snet.NewDefaultPacketDispatcherService(
-					reliable.NewDispatcherService(""),
-				),
+				PacketDispatcherService: &snet.DefaultPacketDispatcherService{
+					Dispatcher: reliable.NewDispatcherService(""),
+				},
 			},
 		),
 	}

--- a/go/lib/infra/infraenv/infraenv.go
+++ b/go/lib/infra/infraenv/infraenv.go
@@ -141,9 +141,9 @@ func (nc *NetworkConfig) AddressRewriter(
 		router = &snet.BaseRouter{IA: nc.IA}
 	}
 	if connFactory == nil {
-		connFactory = snet.NewDefaultPacketDispatcherService(
-			reliable.NewDispatcherService(""),
-		)
+		connFactory = &snet.DefaultPacketDispatcherService{
+			Dispatcher: reliable.NewDispatcherService(""),
+		}
 	}
 
 	return &messenger.AddressRewriter{
@@ -181,9 +181,9 @@ func (nc *NetworkConfig) initUDPSocket(quicAddress string) (net.PacketConn, erro
 	}
 
 	packetDispatcher := svc.NewResolverPacketDispatcher(
-		snet.NewDefaultPacketDispatcherService(
-			reliable.NewDispatcherService(""),
-		),
+		&snet.DefaultPacketDispatcherService{
+			Dispatcher: reliable.NewDispatcherService(""),
+		},
 		&LegacyForwardingHandler{
 			BaseHandler: &svc.BaseHandler{
 				Message: udpAddressStr.Bytes(),

--- a/go/lib/infra/infraenv/infraenv.go
+++ b/go/lib/infra/infraenv/infraenv.go
@@ -209,9 +209,10 @@ func (nc *NetworkConfig) initUDPSocket(quicAddress string) (net.PacketConn, erro
 func (nc *NetworkConfig) initQUICSocket() (net.PacketConn, error) {
 	var network snet.Network
 	network, err := snet.NewCustomNetwork(nc.IA, "",
-		snet.NewDefaultPacketDispatcherService(
-			reliable.NewDispatcherService(""),
-		),
+		&snet.DefaultPacketDispatcherService{
+			Dispatcher:  reliable.NewDispatcherService(""),
+			SCMPHandler: ignoreSCMP{},
+		},
 	)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to create network", err)
@@ -344,4 +345,16 @@ func InitInfraEnvironmentFunc(topologyPath string, f func()) *env.Env {
 			}
 		},
 	)
+}
+
+// ignoreSCMP ignores all received SCMP packets.
+//
+// FIXME(scrye): Different services will want to process SCMP revocations in
+// different ways, for example, to update their custom path stores (PS) or
+// inform local SCION state (CS informing the local SD).
+type ignoreSCMP struct{}
+
+func (ignoreSCMP) Handle(pkt *snet.SCIONPacket) error {
+	// Always reattempt reads from the socket.
+	return nil
 }

--- a/go/lib/snet/dispatcher.go
+++ b/go/lib/snet/dispatcher.go
@@ -47,15 +47,6 @@ type DefaultPacketDispatcherService struct {
 	SCMPHandler SCMPHandler
 }
 
-func NewDefaultPacketDispatcherService(
-	dispatcherService reliable.DispatcherService) *DefaultPacketDispatcherService {
-
-	return &DefaultPacketDispatcherService{
-		Dispatcher:  dispatcherService,
-		SCMPHandler: &scmpHandler{},
-	}
-}
-
 func (s *DefaultPacketDispatcherService) RegisterTimeout(ia addr.IA, public *addr.AppAddr,
 	bind *overlay.OverlayAddr, svc addr.HostSVC,
 	timeout time.Duration) (PacketConn, uint16, error) {
@@ -81,6 +72,18 @@ type SCMPHandler interface {
 	// If the handler mutates the packet, the changes are seen by snet
 	// connection method callers.
 	Handle(pkt *SCIONPacket) error
+}
+
+// NewSCMPHandler creates a default SCMP handler that forwards revocations to
+// the path resolver. SCMP packets are also forwarded to snet callers via
+// errors returned by Read calls.
+//
+// If the resolver is nil, revocations are not forwarded to any resolver.
+// However, they are still sent back to the caller during read operations.
+func NewSCMPHandler(pr pathmgr.Resolver) SCMPHandler {
+	return &scmpHandler{
+		pathResolver: pr,
+	}
 }
 
 // scmpHandler handles SCMP messages received from the network.

--- a/go/lib/snet/reader.go
+++ b/go/lib/snet/reader.go
@@ -90,11 +90,12 @@ func (c *scionConnReader) read(b []byte) (int, *Addr, error) {
 	if c.base.net == "udp4" {
 		// Extract remote address
 		remote = &Addr{
-			IA:   pkt.Source.IA,
-			Path: pkt.Path,
+			IA: pkt.Source.IA,
 		}
+
 		// Extract path
-		if remote.Path != nil {
+		if pkt.Path != nil {
+			remote.Path = pkt.Path.Copy()
 			if err = remote.Path.Reverse(); err != nil {
 				return 0, nil,
 					common.NewBasicError("Unable to reverse path on received packet", err)

--- a/go/lib/snet/reader.go
+++ b/go/lib/snet/reader.go
@@ -15,7 +15,6 @@
 package snet
 
 import (
-	"context"
 	"net"
 	"sync"
 	"time"
@@ -23,7 +22,6 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/l4"
-	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/scmp"
 )
@@ -71,6 +69,7 @@ func (c *scionConnReader) read(b []byte) (int, *Addr, error) {
 
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
+
 	pkt := SCIONPacket{
 		Bytes: Bytes(c.buffer),
 	}
@@ -113,8 +112,6 @@ func (c *scionConnReader) read(b []byte) (int, *Addr, error) {
 			l4i = addr.NewL4UDPInfo(hdr.SrcPort)
 		case *scmp.Hdr:
 			l4i = addr.NewL4SCMPInfo()
-			c.handleSCMP(hdr, &pkt)
-			err = &OpError{scmp: hdr}
 		default:
 			err = common.NewBasicError("Unexpected SCION L4 protocol", nil,
 				"expected", "UDP or SCMP", "actual", pkt.L4Header.L4Type())
@@ -125,30 +122,6 @@ func (c *scionConnReader) read(b []byte) (int, *Addr, error) {
 		return n, remote, err
 	}
 	return 0, nil, common.NewBasicError("Unknown network", nil, "net", c.base.net)
-}
-
-func (c *scionConnReader) handleSCMP(hdr *scmp.Hdr, pkt *SCIONPacket) {
-	// Only handle revocations for now
-	if hdr.Class == scmp.C_Path && hdr.Type == scmp.T_P_RevokedIF {
-		c.handleSCMPRev(hdr, pkt)
-	}
-}
-
-func (c *scionConnReader) handleSCMPRev(hdr *scmp.Hdr, pkt *SCIONPacket) {
-	scmpPayload, ok := pkt.Payload.(*scmp.Payload)
-	if !ok {
-		log.Error("Unable to type assert payload to SCMP payload",
-			"type", common.TypeOf(pkt.Payload))
-	}
-	info, ok := scmpPayload.Info.(*scmp.InfoRevocation)
-	if !ok {
-		log.Error("Unable to type assert SCMP Info to SCMP Revocation Info",
-			"type", common.TypeOf(scmpPayload.Info))
-	}
-	log.Info("Received SCMP revocation", "header", hdr.String(), "payload", scmpPayload.String())
-	if c.base.scionNet.pathResolver != nil {
-		c.base.scionNet.pathResolver.RevokeRaw(context.TODO(), info.RawSRev)
-	}
 }
 
 func (c *scionConnReader) SetReadDeadline(t time.Time) error {


### PR DESCRIPTION
Also, QUIC sockets for infra RPC no longer propagate SCMP errors back to
the app.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2734)
<!-- Reviewable:end -->
