### PR TITLE
Add goenv (and helper) target(s).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean clibs libscion libfilter dispatcher uninstall tags vendor
+.PHONY: all clean goenv gogenlinks gogenlinks_clean vendor bazel gazelle clibs libscion libfilter dispatcher uninstall tags
 
 GAZELLE_MODE?=fix
 
@@ -6,10 +6,20 @@ SRC_DIRS = c/lib/scion c/lib/filter c/dispatcher
 
 all: tags clibs dispatcher bazel
 
-clean:
+clean: gogenlinks_clean
 	$(foreach var,$(SRC_DIRS),$(MAKE) -C $(var) clean || exit 1;)
 	bazel clean
 	rm -f bin/* tags
+	if [ -e go/vendor ]; then rm -r go/vendor; fi
+
+goenv: vendor gogenlinks
+
+gogenlinks: gogenlinks_clean
+	bazel build //go/proto:go_default_library
+	find bazel-genfiles/go/proto -maxdepth 1 -type f -exec ln -snf ../../{} go/proto \;
+
+gogenlinks_clean:
+	find ./go/proto -maxdepth 1 -type l -exec rm {} +
 
 vendor:
 	./tools/vendor.sh


### PR DESCRIPTION
The new `goenv` make target will generate the go/vendor links, as well as
in-tree links to generated files.

Also:
- Fix up the phony target list
- Remove go/vendor in the `clean` target.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2740)
<!-- Reviewable:end -->
