### PR TITLE
Default QUIC address in SD,PS,BS and CS

### DIFF
--- a/go/beacon_srv/main.go
+++ b/go/beacon_srv/main.go
@@ -131,6 +131,12 @@ func realMain() int {
 		log.Crit("Unable to find topo address")
 		return 1
 	}
+	// If QUIC bind address is not specified we'll use UDP bind address and
+	// an ephemeral port.
+	if cfg.QUIC.Address == "" {
+		addr := topoAddress.IPv4.BindOrPublic().L3.IP()
+		cfg.QUIC.Address = fmt.Sprintf("%s:0", addr.String())
+	}
 	nc := infraenv.NetworkConfig{
 		IA:                    topo.ISD_AS,
 		Public:                env.GetPublicSnetAddress(topo.ISD_AS, topoAddress),

--- a/go/cert_srv/setup.go
+++ b/go/cert_srv/setup.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -151,6 +152,12 @@ func setMessenger(cfg *config.Config, router snet.Router) error {
 	topoAddress := topo.CS.GetById(cfg.General.ID)
 	if topoAddress == nil {
 		return common.NewBasicError("Unable to find topo address", nil)
+	}
+	// If QUIC bind address is not specified we'll use UDP bind address and
+	// an ephemeral port.
+	if cfg.QUIC.Address == "" {
+		addr := topoAddress.IPv4.BindOrPublic().L3.IP()
+		cfg.QUIC.Address = fmt.Sprintf("%s:0", addr.String())
 	}
 	nc := infraenv.NetworkConfig{
 		IA:                    topo.ISD_AS,

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -118,6 +118,12 @@ func realMain() int {
 		log.Crit("Unable to find topo address")
 		return 1
 	}
+	// If QUIC bind address is not specified we'll use UDP bind address and
+	// an ephemeral port.
+	if cfg.QUIC.Address == "" {
+		addr := topoAddress.IPv4.BindOrPublic().L3.IP()
+		cfg.QUIC.Address = fmt.Sprintf("%s:0", addr.String())
+	}
 	nc := infraenv.NetworkConfig{
 		IA:                    topo.ISD_AS,
 		Public:                env.GetPublicSnetAddress(topo.ISD_AS, topoAddress),

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -111,6 +111,15 @@ func realMain() int {
 		log.Crit("TRC error", "err", err)
 		return 1
 	}
+	// If QUIC bind address is not specified we'll use UDP bind address and
+	// an ephemeral port.
+	if cfg.QUIC.Address == "" {
+		addr := cfg.SD.Bind.Host.L3.IP()
+		if addr == nil {
+			addr = cfg.SD.Public.Host.L3.IP()
+		}
+		cfg.QUIC.Address = fmt.Sprintf("%s:0", addr.String())
+	}
 	nc := infraenv.NetworkConfig{
 		IA:                    itopo.Get().ISD_AS,
 		Public:                cfg.SD.Public,


### PR DESCRIPTION
If QUIC listening address is not specified in the config file it will be
constructed from the UDP address (retrieved from the topology file) and
an ephemeral port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2741)
<!-- Reviewable:end -->
