### PR TITLE
acceptance: Fix build order

### DIFF
--- a/acceptance/common/tools.py
+++ b/acceptance/common/tools.py
@@ -50,5 +50,6 @@ class DC(object):
         mkdir('-p', out_p)
         for svc in self('config', '--services').splitlines():
             dst_f = out_p / '%s.log' % svc
-            with open(dst_f, 'w') as log_f:
-                log_f.write(self('logs', svc))
+            with local.env(BASE_DIR=self.base_dir, COMPOSE_FILE=self.compose_file):
+                with redirect_stderr(sys.stdout):
+                    (docker_compose['-p', 'acceptance_scion', '--no-ansi', 'logs', svc] > dst_f)()

--- a/acceptance/lib.sh
+++ b/acceptance/lib.sh
@@ -62,10 +62,10 @@ global_setup() {
     run_command build_docker_base ${out_dir:+$out_dir/global_setup_docker_base.out}
     print_green "[---->-----]" "Building scion docker image"
     run_command build_docker_scion ${out_dir:+$out_dir/global_setup_docker_scion.out}
-    print_green "[----->----]" "Building tester docker images"
-    run_command build_docker_tester ${out_dir:+$out_dir/global_setup_docker_scion.out}
-    print_green "[------>---]" "Building per-app docker images"
+    print_green "[----->----]" "Building per-app docker images"
     run_command build_docker_perapp ${out_dir:+$out_dir/global_setup_docker_perapp.out}
+    print_green "[------>---]" "Building tester docker images"
+    run_command build_docker_tester ${out_dir:+$out_dir/global_setup_docker_scion.out}
     print_green "[>>>>>>>>>>]" "Global test environment set-up finished"
     set +e
 }


### PR DESCRIPTION
The scion tester image depends on scion_app_builder container,
thus we should build per-app images first since that also build the scion_app_builder container.

Also use a pipe to collect logs so that we don't have create a file manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2743)
<!-- Reviewable:end -->
