### PR TITLE
Improve verification error output

### DIFF
--- a/go/lib/infra/modules/trust/signhelper.go
+++ b/go/lib/infra/modules/trust/signhelper.go
@@ -138,16 +138,16 @@ func (v *BasicVerifier) Verify(ctx context.Context, msg common.RawBytes, sign *p
 func (v *BasicVerifier) VerifyPld(ctx context.Context, spld *ctrl.SignedPld) (*ctrl.Pld, error) {
 	cpld, err := ctrl.NewPldFromRaw(spld.Blob)
 	if err != nil {
-		return nil, err
+		return nil, common.NewBasicError("Unable to parse payload", err)
 	}
 	if v.ignoreSign(cpld, spld.Sign) {
 		return cpld, nil
 	}
 	if err := v.sanityChecks(spld.Sign, true); err != nil {
-		return nil, err
+		return nil, common.NewBasicError("Sanity check failed", err, "pld", cpld)
 	}
 	if err := v.verify(ctx, spld.Blob, spld.Sign); err != nil {
-		return nil, err
+		return nil, common.NewBasicError("Unable to verify", err, "pld", cpld)
 	}
 	return cpld, nil
 }


### PR DESCRIPTION
This change adds the payload type information to the signature
verification error.

Before the formatted error looked something like this:
````
>  Sanity check failed
>      SignS is unset
````
Now:
````
>  Sanity check failed pld="Ctrl: Union: CertMgmt: Union: CertificateChain 1-ff00:0:130v1"
>      SignS is unset
````

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2749)
<!-- Reviewable:end -->
