### PR TITLE
BS: Reduce logging

### DIFF
--- a/go/beacon_srv/internal/beaconing/originator.go
+++ b/go/beacon_srv/internal/beaconing/originator.go
@@ -137,8 +137,10 @@ func (o *Originator) logSummary(s *summary, linkType proto.LinkType) {
 		log.Info("[Originator] Originated beacons", "type", linkType.String(), "egIfIds", s.IfIds())
 		return
 	}
-	log.Info("[Originator] Originated beacons on stale interfaces", "type", linkType.String(),
-		"egIfIds", s.IfIds())
+	if s.count > 0 {
+		log.Info("[Originator] Originated beacons on stale interfaces", "type", linkType.String(),
+			"egIfIds", s.IfIds())
+	}
 }
 
 // beaconOriginator originates one beacon on the given interface.

--- a/go/beacon_srv/internal/beaconing/propagator.go
+++ b/go/beacon_srv/internal/beaconing/propagator.go
@@ -169,8 +169,10 @@ func (p *Propagator) logSummary(s *summary) {
 			"egIfIds", s.IfIds())
 		return
 	}
-	log.Info("[Propagator] Propagated beacons on stale interfaces", "count", s.count,
-		"startIAs", len(s.srcs), "egIfIds", s.IfIds())
+	if s.count > 0 {
+		log.Info("[Propagator] Propagated beacons on stale interfaces", "count", s.count,
+			"startIAs", len(s.srcs), "egIfIds", s.IfIds())
+	}
 }
 
 // beaconPropagator propagates one beacon to all active interfaces.

--- a/go/beacon_srv/internal/beaconing/registrar.go
+++ b/go/beacon_srv/internal/beaconing/registrar.go
@@ -152,8 +152,10 @@ func (r *Registrar) logSummary(s *summary) {
 			"startIAs", len(s.srcs))
 		return
 	}
-	log.Info("[Registrar] Registered beacons after stale period", "type", r.segType,
-		"count", s.count, "startIAs", len(s.srcs))
+	if s.count > 0 {
+		log.Info("[Registrar] Registered beacons after stale period", "type", r.segType,
+			"count", s.count, "startIAs", len(s.srcs))
+	}
 }
 
 // segmentRegistrar registers one segment with the path server.


### PR DESCRIPTION
Before, the propagation/origination/registration tasks always logged
the summary if there are stale interfaces.

Now, these tasks only log when successfully beacon on one or multiple
stale interfaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2759)
<!-- Reviewable:end -->
