### PR TITLE
sciond: Only insert next query if we got a reply

### DIFF
--- a/go/lib/pathdb/pathdb.go
+++ b/go/lib/pathdb/pathdb.go
@@ -59,8 +59,9 @@ type Write interface {
 	// DeleteExpired deletes all paths segments that are expired, using now as a reference.
 	// Returns the number of deleted segments.
 	DeleteExpired(ctx context.Context, now time.Time) (int, error)
-	// Get returns all path segment(s) matching the parameters specified.
-	// InsertNextQuery inserts or updates the timestamp nextQuery for the given dst.
+	// InsertNextQuery inserts or updates the timestamp nextQuery for the given
+	// dst. Returns true if an insert/update happened or false if the stored
+	// timestamp is already newer.
 	InsertNextQuery(ctx context.Context, dst addr.IA, nextQuery time.Time) (bool, error)
 }
 

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -166,13 +166,6 @@ func (f *fetcherHandler) GetPaths(ctx context.Context, req *sciond.PathReq,
 	case <-subCtx.Done():
 	case <-ctx.Done():
 	}
-	if ctx.Err() == nil {
-		_, err = f.pathDB.InsertNextQuery(ctx, req.Dst.IA(),
-			time.Now().Add(f.config.QueryInterval.Duration))
-		if err != nil {
-			f.logger.Warn("Failed to update nextQuery", "err", err)
-		}
-	}
 	paths, err := f.buildPathsFromDB(ctx, req)
 	switch {
 	case ctx.Err() != nil:
@@ -471,6 +464,11 @@ func (f *fetcherHandler) fetchAndVerify(ctx context.Context, cancelF context.Can
 		verifiedSeg, verifiedRev, segErr, revErr)
 	if len(insertedSegmentIDs) > 0 {
 		f.logger.Debug("Segments inserted in DB", "segments", insertedSegmentIDs)
+		_, err = f.pathDB.InsertNextQuery(ctx, req.Dst.IA(),
+			time.Now().Add(f.config.QueryInterval.Duration))
+		if err != nil {
+			f.logger.Warn("Failed to update nextQuery", "err", err)
+		}
 	}
 }
 


### PR DESCRIPTION
It doens't make sense to insert the NextQuery if we dind't get a reply,
otherwise we wouldn't request again for a long time eventhough the initial request failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2761)
<!-- Reviewable:end -->
