### PR TITLE
PS: Return immediately if sending the reply failed

### DIFF
--- a/go/path_srv/internal/handlers/segreq.go
+++ b/go/path_srv/internal/handlers/segreq.go
@@ -202,6 +202,7 @@ func (h *segReqHandler) sendReply(ctx context.Context, rw infra.ResponseWriter,
 	}
 	if err := rw.SendSegReply(ctx, reply); err != nil {
 		logger.Error("[segReqHandler] Failed to send reply!", "err", err)
+		return
 	}
 	logger.Debug("[segReqHandler] reply sent", "id", h.request.ID,
 		"ups", len(upSegs), "cores", len(coreSegs), "downs", len(downSegs))


### PR DESCRIPTION
Currently, the PS logs that it sent a reply even if it fails sending.

This is the log output currently:
````
2019-06-17 10:34:32.850597+0000 [EROR] [segReqHandler] Failed to send reply! debug_id=185fc30b err="Stream 0 was reset with error code 1"
2019-06-17 10:34:32.850610+0000 [DBUG] [segReqHandler] reply sent debug_id=185fc30b id=8141298586611935543 ups=0 cores=0 downs=4
````

With the change, the PS does not log the second line.



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2762)
<!-- Reviewable:end -->
