### PR TITLE
Do not print millis for timestamps with secs only

### DIFF
--- a/go/cert_srv/internal/reiss/requester.go
+++ b/go/cert_srv/internal/reiss/requester.go
@@ -68,7 +68,7 @@ func (r *Requester) run(ctx context.Context) (bool, error) {
 	now := time.Now()
 	if now.After(exp) {
 		return true, common.NewBasicError("Certificate expired without being reissued", nil,
-			"chain", chain, "expTime", util.TimeToStringSec(exp), "now", util.TimeToString(now))
+			"chain", chain, "expTime", util.TimeToCompact(exp), "now", util.TimeToString(now))
 	}
 	if now.Add(r.LeafTime).Before(exp) {
 		return false, nil

--- a/go/cert_srv/internal/reiss/requester.go
+++ b/go/cert_srv/internal/reiss/requester.go
@@ -68,7 +68,7 @@ func (r *Requester) run(ctx context.Context) (bool, error) {
 	now := time.Now()
 	if now.After(exp) {
 		return true, common.NewBasicError("Certificate expired without being reissued", nil,
-			"chain", chain, "expTime", util.TimeToString(exp), "now", util.TimeToString(now))
+			"chain", chain, "expTime", util.TimeToStringSec(exp), "now", util.TimeToString(now))
 	}
 	if now.Add(r.LeafTime).Before(exp) {
 		return false, nil

--- a/go/lib/common/defs.go
+++ b/go/lib/common/defs.go
@@ -1,5 +1,5 @@
 // Copyright 2016 ETH Zurich
-// Copyrgiht 2018 ETH Zurich, Anapaya Systems
+// Copyright 2018 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,10 +22,11 @@ import (
 
 const (
 	// LineLen is the number of bytes that all SCION headers are padded to a multiple of.
-	LineLen = 8
-	MinMTU  = 1280
-	MaxMTU  = (1 << 16) - 1
-	TimeFmt = "2006-01-02 15:04:05.000000-0700"
+	LineLen     = 8
+	MinMTU      = 1280
+	MaxMTU      = (1 << 16) - 1
+	TimeFmt     = "2006-01-02 15:04:05.000000-0700"
+	TimeFmtSecs = "2006-01-02 15:04:05-0700"
 )
 
 const (

--- a/go/lib/ctrl/path_mgmt/rev_info.go
+++ b/go/lib/ctrl/path_mgmt/rev_info.go
@@ -37,7 +37,7 @@ type RevTimeError string
 func NewRevTimeError(r *RevInfo) RevTimeError {
 	return RevTimeError(fmt.Sprintf(
 		"Revocation is expired, timestamp: %s, TTL %s.",
-		util.TimeToString(r.Timestamp()), r.TTL()))
+		util.SecsToTime(r.RawTimestamp), r.TTL()))
 }
 
 func (ee RevTimeError) Timeout() bool {
@@ -95,7 +95,7 @@ func (r *RevInfo) Active() error {
 	}
 	if r.Timestamp().After(now.Add(time.Second)) {
 		return common.NewBasicError("Revocation timestamp is in the future.", nil,
-			"timestamp", util.TimeToString(r.Timestamp()))
+			"timestamp", util.SecsToTimeString(r.RawTimestamp))
 	}
 	return nil
 }
@@ -110,7 +110,7 @@ func (r *RevInfo) Pack() (common.RawBytes, error) {
 
 func (r *RevInfo) String() string {
 	return fmt.Sprintf("IA: %s IfID: %d Link type: %s Timestamp: %s TTL: %s", r.IA(), r.IfID,
-		r.LinkType, util.TimeToString(r.Timestamp()), r.TTL())
+		r.LinkType, util.SecsToTimeString(r.RawTimestamp), r.TTL())
 }
 
 // RelativeTTL returns the duration r is still valid for, relative to

--- a/go/lib/ctrl/path_mgmt/rev_info.go
+++ b/go/lib/ctrl/path_mgmt/rev_info.go
@@ -37,7 +37,7 @@ type RevTimeError string
 func NewRevTimeError(r *RevInfo) RevTimeError {
 	return RevTimeError(fmt.Sprintf(
 		"Revocation is expired, timestamp: %s, TTL %s.",
-		util.SecsToTime(r.RawTimestamp), r.TTL()))
+		util.TimeToCompact(r.Timestamp()), r.TTL()))
 }
 
 func (ee RevTimeError) Timeout() bool {

--- a/go/lib/ctrl/path_mgmt/rev_info.go
+++ b/go/lib/ctrl/path_mgmt/rev_info.go
@@ -95,7 +95,7 @@ func (r *RevInfo) Active() error {
 	}
 	if r.Timestamp().After(now.Add(time.Second)) {
 		return common.NewBasicError("Revocation timestamp is in the future.", nil,
-			"timestamp", util.SecsToTimeString(r.RawTimestamp))
+			"timestamp", util.TimeToCompact(r.Timestamp()))
 	}
 	return nil
 }
@@ -110,7 +110,7 @@ func (r *RevInfo) Pack() (common.RawBytes, error) {
 
 func (r *RevInfo) String() string {
 	return fmt.Sprintf("IA: %s IfID: %d Link type: %s Timestamp: %s TTL: %s", r.IA(), r.IfID,
-		r.LinkType, util.SecsToTimeString(r.RawTimestamp), r.TTL())
+		r.LinkType, util.TimeToCompact(r.Timestamp()), r.TTL())
 }
 
 // RelativeTTL returns the duration r is still valid for, relative to

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -444,7 +444,7 @@ func (ps *PathSegment) String() string {
 	info, _ := ps.InfoF()
 	desc := []string{
 		ps.GetLoggingID(),
-		util.TimeToString(info.Timestamp()),
+		util.SecsToTimeString(info.TsInt),
 		ps.getHopsDescription(),
 	}
 	return strings.Join(desc, " ")

--- a/go/lib/ctrl/seg/seg.go
+++ b/go/lib/ctrl/seg/seg.go
@@ -444,7 +444,7 @@ func (ps *PathSegment) String() string {
 	info, _ := ps.InfoF()
 	desc := []string{
 		ps.GetLoggingID(),
-		util.SecsToTimeString(info.TsInt),
+		util.TimeToCompact(info.Timestamp()),
 		ps.getHopsDescription(),
 	}
 	return strings.Join(desc, " ")

--- a/go/lib/scrypto/cert/cert.go
+++ b/go/lib/scrypto/cert/cert.go
@@ -115,13 +115,13 @@ func (c *Certificate) Verify(subject addr.IA, verifyKey common.RawBytes, signAlg
 func (c *Certificate) VerifyTime(ts uint32) error {
 	if ts < c.IssuingTime {
 		return common.NewBasicError(EarlyUsage, nil,
-			"IssuingTime", util.SecsToTimeString(c.IssuingTime),
-			"current", util.SecsToTimeString(ts))
+			"IssuingTime", util.SecsToCompact(c.IssuingTime),
+			"current", util.SecsToCompact(ts))
 	}
 	if ts > c.ExpirationTime {
 		return common.NewBasicError(Expired, nil,
-			"ExpirationTime", util.SecsToTimeString(c.ExpirationTime),
-			"current", util.SecsToTimeString(ts))
+			"ExpirationTime", util.SecsToCompact(c.ExpirationTime),
+			"current", util.SecsToCompact(ts))
 	}
 	return nil
 }

--- a/go/lib/scrypto/cert/cert.go
+++ b/go/lib/scrypto/cert/cert.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -114,13 +115,13 @@ func (c *Certificate) Verify(subject addr.IA, verifyKey common.RawBytes, signAlg
 func (c *Certificate) VerifyTime(ts uint32) error {
 	if ts < c.IssuingTime {
 		return common.NewBasicError(EarlyUsage, nil,
-			"IssuingTime", util.TimeToString(util.SecsToTime(c.IssuingTime)),
-			"current", util.TimeToString(util.SecsToTime(ts)))
+			"IssuingTime", util.SecsToTimeString(c.IssuingTime),
+			"current", util.SecsToTimeString(ts))
 	}
 	if ts > c.ExpirationTime {
 		return common.NewBasicError(Expired, nil,
-			"ExpirationTime", util.TimeToString(util.SecsToTime(c.ExpirationTime)),
-			"current", util.TimeToString(util.SecsToTime(ts)))
+			"ExpirationTime", util.SecsToTimeString(c.ExpirationTime),
+			"current", util.SecsToTimeString(ts))
 	}
 	return nil
 }

--- a/go/lib/scrypto/cert/chain.go
+++ b/go/lib/scrypto/cert/chain.go
@@ -158,13 +158,13 @@ func ChainFromSlice(certs []*Certificate) (*Chain, error) {
 func (c *Chain) Verify(subject addr.IA, t *trc.TRC) error {
 	if c.Leaf.IssuingTime < c.Issuer.IssuingTime {
 		return common.NewBasicError(LeafIssuedBefore, nil,
-			"leaf", util.TimeToString(util.SecsToTime(c.Leaf.IssuingTime)),
-			"issuer", util.TimeToString(util.SecsToTime(c.Issuer.IssuingTime)))
+			"leaf", util.SecsToTimeString(c.Leaf.IssuingTime),
+			"issuer", util.SecsToTimeString(c.Issuer.IssuingTime))
 	}
 	if c.Leaf.ExpirationTime > c.Issuer.ExpirationTime {
 		return common.NewBasicError(LeafExpiresAfter, nil,
-			"leaf", util.TimeToString(util.SecsToTime(c.Leaf.ExpirationTime)),
-			"issuer", util.TimeToString(util.SecsToTime(c.Issuer.ExpirationTime)))
+			"leaf", util.SecsToTimeString(c.Leaf.ExpirationTime),
+			"issuer", util.SecsToTimeString(c.Issuer.ExpirationTime))
 	}
 	if !c.Issuer.CanIssue {
 		return common.NewBasicError(IssCertInvalid, nil, "CanIssue", false)
@@ -174,8 +174,8 @@ func (c *Chain) Verify(subject addr.IA, t *trc.TRC) error {
 	}
 	if c.Issuer.ExpirationTime > t.ExpirationTime {
 		return common.NewBasicError(IssExpiresAfter, nil,
-			"issuer", util.TimeToString(util.SecsToTime(c.Issuer.ExpirationTime)),
-			"TRC", util.TimeToString(util.SecsToTime(t.ExpirationTime)))
+			"issuer", util.SecsToTimeString(c.Issuer.ExpirationTime),
+			"TRC", util.SecsToTimeString(t.ExpirationTime))
 	}
 	coreAS, ok := t.CoreASes[c.Issuer.Issuer]
 	if !ok {

--- a/go/lib/scrypto/cert/chain.go
+++ b/go/lib/scrypto/cert/chain.go
@@ -158,13 +158,13 @@ func ChainFromSlice(certs []*Certificate) (*Chain, error) {
 func (c *Chain) Verify(subject addr.IA, t *trc.TRC) error {
 	if c.Leaf.IssuingTime < c.Issuer.IssuingTime {
 		return common.NewBasicError(LeafIssuedBefore, nil,
-			"leaf", util.SecsToTimeString(c.Leaf.IssuingTime),
-			"issuer", util.SecsToTimeString(c.Issuer.IssuingTime))
+			"leaf", util.SecsToCompact(c.Leaf.IssuingTime),
+			"issuer", util.SecsToCompact(c.Issuer.IssuingTime))
 	}
 	if c.Leaf.ExpirationTime > c.Issuer.ExpirationTime {
 		return common.NewBasicError(LeafExpiresAfter, nil,
-			"leaf", util.SecsToTimeString(c.Leaf.ExpirationTime),
-			"issuer", util.SecsToTimeString(c.Issuer.ExpirationTime))
+			"leaf", util.SecsToCompact(c.Leaf.ExpirationTime),
+			"issuer", util.SecsToCompact(c.Issuer.ExpirationTime))
 	}
 	if !c.Issuer.CanIssue {
 		return common.NewBasicError(IssCertInvalid, nil, "CanIssue", false)
@@ -174,8 +174,8 @@ func (c *Chain) Verify(subject addr.IA, t *trc.TRC) error {
 	}
 	if c.Issuer.ExpirationTime > t.ExpirationTime {
 		return common.NewBasicError(IssExpiresAfter, nil,
-			"issuer", util.SecsToTimeString(c.Issuer.ExpirationTime),
-			"TRC", util.SecsToTimeString(t.ExpirationTime))
+			"issuer", util.SecsToCompact(c.Issuer.ExpirationTime),
+			"TRC", util.SecsToCompact(t.ExpirationTime))
 	}
 	coreAS, ok := t.CoreASes[c.Issuer.Issuer]
 	if !ok {

--- a/go/lib/scrypto/trc/trc.go
+++ b/go/lib/scrypto/trc/trc.go
@@ -233,12 +233,12 @@ func (t *TRC) IsActive(maxTRC *TRC) error {
 	currTime := util.TimeToSecs(time.Now())
 	if currTime < t.CreationTime {
 		return common.NewBasicError(EarlyUsage, nil,
-			"now", util.SecsToTimeString(currTime),
-			"creation", util.SecsToTimeString(t.CreationTime))
+			"now", util.SecsToCompact(currTime),
+			"creation", util.SecsToCompact(t.CreationTime))
 	} else if currTime > t.ExpirationTime {
 		return common.NewBasicError(Expired, nil,
-			"now", util.SecsToTimeString(currTime),
-			"expiration", util.SecsToTimeString(t.ExpirationTime))
+			"now", util.SecsToCompact(currTime),
+			"expiration", util.SecsToCompact(t.ExpirationTime))
 	} else if t.Version == maxTRC.Version {
 		return nil
 	} else if t.Version+1 != maxTRC.Version {
@@ -248,8 +248,8 @@ func (t *TRC) IsActive(maxTRC *TRC) error {
 			"actual", t.Version,
 		)
 	} else if currTime > maxTRC.CreationTime+maxTRC.GracePeriod {
-		return common.NewBasicError(GracePeriodPassed, nil, "now", util.SecsToTimeString(currTime),
-			"expiration", util.SecsToTimeString(maxTRC.CreationTime+maxTRC.GracePeriod))
+		return common.NewBasicError(GracePeriodPassed, nil, "now", util.SecsToCompact(currTime),
+			"expiration", util.SecsToCompact(maxTRC.CreationTime+maxTRC.GracePeriod))
 	}
 	return nil
 }
@@ -289,8 +289,8 @@ func (t *TRC) verifyUpdate(old *TRC) (*TRCVerResult, error) {
 	if t.CreationTime < old.CreationTime+old.GracePeriod {
 		return nil, common.NewBasicError(
 			InvalidCreationTime, nil,
-			"expected >", util.SecsToTimeString(old.CreationTime+old.GracePeriod),
-			"actual", util.SecsToTimeString(t.CreationTime),
+			"expected >", util.SecsToCompact(old.CreationTime+old.GracePeriod),
+			"actual", util.SecsToCompact(t.CreationTime),
 		)
 	}
 	if t.Quarantine || old.Quarantine {

--- a/go/lib/scrypto/trc/trc.go
+++ b/go/lib/scrypto/trc/trc.go
@@ -233,10 +233,12 @@ func (t *TRC) IsActive(maxTRC *TRC) error {
 	currTime := util.TimeToSecs(time.Now())
 	if currTime < t.CreationTime {
 		return common.NewBasicError(EarlyUsage, nil,
-			"now", timeToString(currTime), "creation", timeToString(t.CreationTime))
+			"now", util.SecsToTimeString(currTime),
+			"creation", util.SecsToTimeString(t.CreationTime))
 	} else if currTime > t.ExpirationTime {
 		return common.NewBasicError(Expired, nil,
-			"now", timeToString(currTime), "expiration", timeToString(t.ExpirationTime))
+			"now", util.SecsToTimeString(currTime),
+			"expiration", util.SecsToTimeString(t.ExpirationTime))
 	} else if t.Version == maxTRC.Version {
 		return nil
 	} else if t.Version+1 != maxTRC.Version {
@@ -246,8 +248,8 @@ func (t *TRC) IsActive(maxTRC *TRC) error {
 			"actual", t.Version,
 		)
 	} else if currTime > maxTRC.CreationTime+maxTRC.GracePeriod {
-		return common.NewBasicError(GracePeriodPassed, nil, "now", timeToString(currTime),
-			"expiration", timeToString(maxTRC.CreationTime+maxTRC.GracePeriod))
+		return common.NewBasicError(GracePeriodPassed, nil, "now", util.SecsToTimeString(currTime),
+			"expiration", util.SecsToTimeString(maxTRC.CreationTime+maxTRC.GracePeriod))
 	}
 	return nil
 }
@@ -287,8 +289,8 @@ func (t *TRC) verifyUpdate(old *TRC) (*TRCVerResult, error) {
 	if t.CreationTime < old.CreationTime+old.GracePeriod {
 		return nil, common.NewBasicError(
 			InvalidCreationTime, nil,
-			"expected >", timeToString(old.CreationTime+old.GracePeriod),
-			"actual", timeToString(t.CreationTime),
+			"expected >", util.SecsToTimeString(old.CreationTime+old.GracePeriod),
+			"actual", util.SecsToTimeString(t.CreationTime),
 		)
 	}
 	if t.Quarantine || old.Quarantine {
@@ -417,8 +419,4 @@ func (t *TRC) String() string {
 		return "TRC <nil>"
 	}
 	return fmt.Sprintf("TRC %dv%d", t.ISD, t.Version)
-}
-
-func timeToString(t uint32) string {
-	return util.TimeToString(util.SecsToTime(t))
 }

--- a/go/lib/spath/info.go
+++ b/go/lib/spath/info.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/util"
 )
 
 const (
@@ -91,12 +92,12 @@ func (inf *InfoField) Write(b common.RawBytes) {
 
 func (inf *InfoField) String() string {
 	return fmt.Sprintf("ISD: %v TS: %v Hops: %v ConsDir: %v Shortcut: %v Peer: %v",
-		inf.ISD, inf.Timestamp(), inf.Hops, inf.ConsDir, inf.Shortcut, inf.Peer)
+		inf.ISD, util.TimeToStringSec(inf.Timestamp()), inf.Hops, inf.ConsDir, inf.Shortcut, inf.Peer)
 }
 
 // Timestamp returns TsInt as a time.Time.
 func (inf *InfoField) Timestamp() time.Time {
-	return time.Unix(int64(inf.TsInt), 0)
+	return util.SecsToTime(inf.TsInt)
 }
 
 // WriteTo implements the io.WriterTo interface.

--- a/go/lib/spath/info.go
+++ b/go/lib/spath/info.go
@@ -92,7 +92,8 @@ func (inf *InfoField) Write(b common.RawBytes) {
 
 func (inf *InfoField) String() string {
 	return fmt.Sprintf("ISD: %v TS: %v Hops: %v ConsDir: %v Shortcut: %v Peer: %v",
-		inf.ISD, util.TimeToStringSec(inf.Timestamp()), inf.Hops, inf.ConsDir, inf.Shortcut, inf.Peer)
+		inf.ISD, util.TimeToStringSec(inf.Timestamp()),
+		inf.Hops, inf.ConsDir, inf.Shortcut, inf.Peer)
 }
 
 // Timestamp returns TsInt as a time.Time.

--- a/go/lib/spath/info.go
+++ b/go/lib/spath/info.go
@@ -92,7 +92,7 @@ func (inf *InfoField) Write(b common.RawBytes) {
 
 func (inf *InfoField) String() string {
 	return fmt.Sprintf("ISD: %v TS: %v Hops: %v ConsDir: %v Shortcut: %v Peer: %v",
-		inf.ISD, util.TimeToStringSec(inf.Timestamp()),
+		inf.ISD, util.TimeToCompact(inf.Timestamp()),
 		inf.Hops, inf.ConsDir, inf.Shortcut, inf.Peer)
 }
 

--- a/go/lib/util/time.go
+++ b/go/lib/util/time.go
@@ -36,13 +36,16 @@ func TimeToString(t time.Time) string {
 	return t.UTC().Format(common.TimeFmt)
 }
 
-// SecsToTimeString converts seconds to a formatted time string.
-func SecsToTimeString(t uint32) string {
-	return TimeToStringSec(SecsToTime(t))
+// SecsToCompact creates a compact string representation from the seconds.
+func SecsToCompact(t uint32) string {
+	return TimeToCompact(SecsToTime(t))
 }
 
-// TimeToStringSec converts the given time to a string but only prints up to
-// seconds accurracy.
-func TimeToStringSec(t time.Time) string {
-	return t.UTC().Format(common.TimeFmtSecs)
+// TimeToCompact formats the time as a compat string, e.g. it discards the
+// milliseconds parts if the time only has second resolution.
+func TimeToCompact(t time.Time) string {
+	if t.Nanosecond() == 0 {
+		return t.UTC().Format(common.TimeFmtSecs)
+	}
+	return TimeToString(t)
 }

--- a/go/lib/util/time.go
+++ b/go/lib/util/time.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +31,18 @@ func TimeToSecs(t time.Time) uint32 {
 	return uint32(t.Unix())
 }
 
+// TimeToString formats the time as a string.
 func TimeToString(t time.Time) string {
 	return t.UTC().Format(common.TimeFmt)
+}
+
+// SecsToTimeString converts seconds to a formatted time string.
+func SecsToTimeString(t uint32) string {
+	return TimeToStringSec(SecsToTime(t))
+}
+
+// TimeToStringSec converts the given time to a string but only prints up to
+// seconds accurracy.
+func TimeToStringSec(t time.Time) string {
+	return t.UTC().Format(common.TimeFmtSecs)
 }


### PR DESCRIPTION
This only makes the log noisy.
Example segment before:
`Type: up, Segment: 41187899827c 2019-06-17 12:12:59.000000+0000 1-ff00:0:120 4>3 1-ff00:0:121`
After:
`Type: up, Segment: 41187899827c 2019-06-17 12:11:29+0000 1-ff00:0:120 4>3 1-ff00:0:121`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2763)
<!-- Reviewable:end -->
