### PR TITLE
Update bazel go rules to work with 0.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ Necessary steps in order to run SCION:
 
 1. Make sure that you are using a clean and recently updated **Ubuntu 16.04**.
 
-1. Install [Bazel](https://bazel.build).
+1. Install [Bazel](https://bazel.build) version 0.27.0:
+   ```
+   wget https://github.com/bazelbuild/bazel/releases/download/0.27.0/bazel-0.27.0-installer-linux-x86_64.sh
+   bash ./bazel-0.27.0-installer-linux-x86_64.sh --user
+   rm ./bazel-0.27.0-installer-linux-x86_64.sh
+   ```
 
 1. Make sure that you have a
    [Go workspace](https://golang.org/doc/code.html#GOPATH) setup, and that

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,7 +6,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.18.1",
+    tag = "0.18.6",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_rules_dependencies", "go_register_toolchains")


### PR DESCRIPTION
Also change the documentation to recommend that people install this
specific version of bazel, and not just the latest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2766)
<!-- Reviewable:end -->
