### PR TITLE
Downgrade to bazel 0.26.1

### DIFF
--- a/.buildkite/scripts/build_scion_img
+++ b/.buildkite/scripts/build_scion_img
@@ -2,7 +2,7 @@
 
 set -e
 
-BASE_IMG=${BASE_IMG:-fde166653ffe010abbb40bcb48210814f992ce09592952f7c01e92096b1b8fb6}
+BASE_IMG=${BASE_IMG:-5a5d0d37bbf9d9ca9bb64bfbbdc6a22d23e77a4429c6d00b3754cfa9baa253c6}
 
 docker pull scionproto/scion_base@sha256:$BASE_IMG
 docker tag scionproto/scion_base@sha256:$BASE_IMG scion_base:latest

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Necessary steps in order to run SCION:
 
 1. Make sure that you are using a clean and recently updated **Ubuntu 16.04**.
 
-1. Install [Bazel](https://bazel.build) version 0.27.0:
+1. Install [Bazel](https://bazel.build) version 0.26.1:
    ```
-   wget https://github.com/bazelbuild/bazel/releases/download/0.27.0/bazel-0.27.0-installer-linux-x86_64.sh
-   bash ./bazel-0.27.0-installer-linux-x86_64.sh --user
-   rm ./bazel-0.27.0-installer-linux-x86_64.sh
+   wget https://github.com/bazelbuild/bazel/releases/download/0.26.1/bazel-0.26.1-installer-linux-x86_64.sh
+   bash ./bazel-0.26.1-installer-linux-x86_64.sh --user
+   rm ./bazel-0.26.1-installer-linux-x86_64.sh
    ```
 
 1. Make sure that you have a

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 ENV HOME /home/scion
 ENV BASE /home/scion/go/src/github.com/scionproto/scion
 ENV GOPATH $HOME/go
-ENV PATH /usr/local/go/bin:$GOPATH/bin:$HOME/.local/bin:$PATH
+ENV PATH $HOME/bin:/usr/local/go/bin:$GOPATH/bin:$HOME/.local/bin:$PATH
 
 WORKDIR $BASE
 

--- a/tools/install_bazel
+++ b/tools/install_bazel
@@ -2,19 +2,19 @@
 
 set -ex
 
-[ $(id -u) -eq 0 ] || { echo "Error: this script should be run as root" && exit 1; }
 
-# OpenJDK is mentioned as a prereq here:
-# https://docs.bazel.build/versions/master/install-ubuntu.html#install-on-ubuntu
-# However, it seems that it's not really needed.
-# DEBIAN_FRONTEND=noninteractive apt-get install -y openjdk-8-jdk
+BAZEL_VER=0.26.1
+BAZEL_CKSUM=6c50e142a0a405d3d8598050d6c1b3920c8cdb82a7ffca6fc067cb474275148f
 
-# Add bazel apt repo.
-if ! grep -Rq "http://storage.googleapis.com/bazel-apt" /etc/apt/sources.list.d/; then
-    curl -fsSL https://bazel.build/bazel-release.pub.gpg | apt-key add -
-    add-apt-repository "deb [arch=$(dpkg --print-architecture)] http://storage.googleapis.com/bazel-apt stable jdk1.8"
-    apt-get update
-fi
+BAZEL_MACH="$(uname -m)"
+BAZEL_FILE="bazel-${BAZEL_VER}-linux-${BAZEL_MACH}"
 
-# Install the package
-DEBIAN_FRONTEND=noninteractive apt-get install -y bazel
+[ "$BAZEL_MACH" == "x86_64" ] || { echo "Error: bazel does not provide binaries for $BAZEL_MACH"; exit 1; }
+# If ~/bin/bazel already has the expected checksum, no need to continue.
+[ -e ~/bin/bazel ] && echo ${BAZEL_CKSUM} ~/bin/bazel | sha256sum --check --status && exit 0
+
+curl -sSL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VER}/${BAZEL_FILE} -o /tmp/${BAZEL_FILE}
+echo ${BAZEL_CKSUM} /tmp/${BAZEL_FILE} | sha256sum --check --quiet -
+
+install -m 0755 -D /tmp/${BAZEL_FILE} ~/bin/bazel
+rm /tmp/${BAZEL_FILE}


### PR DESCRIPTION
Fixes https://github.com/scionproto/scion/issues/2769

Bazel 0.27.0 breaks some of our dependencies. E.g.:
   https://github.com/GoogleContainerTools/distroless/pull/373

Bazel 0.26.1 seems to work just fine, so let's go back to it.

Also:
- Update tools/install_bazel to install the correct version of bazel
  from github, not apt, so it doesn't get auto-upgraded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2778)
<!-- Reviewable:end -->
