### PR TITLE
Buildkite: Acceptance in separate pipeline

### DIFF
--- a/.buildkite/acceptance-pipeline.sh
+++ b/.buildkite/acceptance-pipeline.sh
@@ -4,14 +4,13 @@ set -e
 
 export BASE=".buildkite"
 STEPS="$BASE/steps"
-TRIGGERS="$BASE/triggers"
-RUN_DOCKER_BUILD=${RUN_DOCKER_BUILD:-true}
+RUN_DOCKER_BUILD="${RUN_DOCKER_BUILD:-true}"
 
-${BASE}/common.sh
+"${BASE}/common.sh"
 echo "steps:"
 
 if [[ "$RUN_DOCKER_BUILD" = true ]]; then
-    cat ${STEPS}/build_all.yml
+    cat "=${STEPS}/build_all.yml"
     echo "- wait"
 fi
 

--- a/.buildkite/acceptance-pipeline.sh
+++ b/.buildkite/acceptance-pipeline.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+set -e
+
+export BASE=".buildkite"
+STEPS="$BASE/steps"
+TRIGGERS="$BASE/triggers"
+RUN_DOCKER_BUILD=${RUN_DOCKER_BUILD:-true}
+
+${BASE}/common.sh
+echo "steps:"
+
+if [[ "$RUN_DOCKER_BUILD" = true ]]; then
+    cat ${STEPS}/build_all.yml
+    echo "- wait"
+fi
+
 host_acceptance="br_multi br_child br_parent br_peer br_core_multi br_core_childIf br_core_coreIf"
 
 for test in ./acceptance/*_acceptance; do

--- a/.buildkite/acceptance-pipeline.sh
+++ b/.buildkite/acceptance-pipeline.sh
@@ -10,7 +10,7 @@ RUN_DOCKER_BUILD="${RUN_DOCKER_BUILD:-true}"
 echo "steps:"
 
 if [[ "$RUN_DOCKER_BUILD" = true ]]; then
-    cat "=${STEPS}/build_all.yml"
+    cat "${STEPS}/build_all.yml"
     echo "- wait"
 fi
 

--- a/.buildkite/common.sh
+++ b/.buildkite/common.sh
@@ -12,11 +12,12 @@ BUILD="build-${BUILDKITE_BUILD_NUMBER}"
 [ -n "$NIGHTLY" ] && BUILD=nightly-"$(date +%s)"
 
 REGISTRY=${REGISTRY:-ci-registry.scionproto.net}
+TAG=${TAG:-$BUILDKITE_BUILD_NUMBER}
 
 echo "env:"
 echo "  SCION_MOUNT: /tmp/scion_out.$BUILDKITE_BUILD_NUMBER"
 echo "  SCION_CNTR: scion_ci_$BUILDKITE_BUILD_NUMBER"
-echo "  SCION_IMG: $REGISTRY/scion_ci:${BUILDKITE_BUILD_NUMBER}"
+echo "  SCION_IMG: $REGISTRY/scion_ci:${TAG}"
 echo "  ARTIFACTS: buildkite.${BUILDKITE_ORGANIZATION_SLUG}.${TARGET}.${BUILD}"
 echo "  BASE: $BASE"
 echo "  REGISTRY: $REGISTRY"

--- a/.buildkite/files/acceptance_trigger_instructions
+++ b/.buildkite/files/acceptance_trigger_instructions
@@ -9,7 +9,7 @@ curl -X POST -H "Authorization: Bearer ${DOLLAR}{ACCEPTANCE_ACCESS_TOKEN}" "http
     }
   }'
 
-# Or open 'https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/acceptance-tests' and create a new build with 
+# Or open \033]1339;url='https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/acceptance-tests' and create a new build with 
 # Commit: $BUILDKITE_COMMIT
 # Branch: $BUILDKITE_BRANCH
 # Env:    TAG=${BUILDKITE_BUILD_NUMBER}

--- a/.buildkite/files/acceptance_trigger_instructions
+++ b/.buildkite/files/acceptance_trigger_instructions
@@ -9,7 +9,7 @@ curl -X POST -H "Authorization: Bearer ${DOLLAR}{ACCEPTANCE_ACCESS_TOKEN}" "http
     }
   }'
 
-# Or open \033]1339;url='https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/acceptance-tests' and create a new build with 
+# Or open 'https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/acceptance-tests' and create a new build with 
 # Commit: $BUILDKITE_COMMIT
 # Branch: $BUILDKITE_BRANCH
 # Env:    TAG=${BUILDKITE_BUILD_NUMBER}

--- a/.buildkite/files/acceptance_trigger_instructions
+++ b/.buildkite/files/acceptance_trigger_instructions
@@ -1,4 +1,4 @@
-# Run the following curl command to execute acceptance tests for this commit. Use A buildkite token with the "Modify Builds" scope
+# Run the following curl command to execute acceptance tests for this commit. Use A Buildkite token with the "Modify Builds" scope
 curl -X POST -H "Authorization: Bearer ${DOLLAR}{ACCEPTANCE_ACCESS_TOKEN}" "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/acceptance-tests/builds" \
   -d '{
     "commit": "$BUILDKITE_COMMIT",
@@ -9,4 +9,7 @@ curl -X POST -H "Authorization: Bearer ${DOLLAR}{ACCEPTANCE_ACCESS_TOKEN}" "http
     }
   }'
 
-#Or open 'https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/acceptance-tests' and create a new build with Commit: $BUILDKITE_COMMIT, Branch: $BUILDKITE_BRANCH and env var TAG=${BUILDKITE_BUILD_NUMBER}
+# Or open 'https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/acceptance-tests' and create a new build with 
+# Commit: $BUILDKITE_COMMIT
+# Branch: $BUILDKITE_BRANCH
+# Env:    TAG=${BUILDKITE_BUILD_NUMBER}

--- a/.buildkite/files/acceptance_trigger_instructions
+++ b/.buildkite/files/acceptance_trigger_instructions
@@ -1,5 +1,5 @@
-# Run the following curl command to execute acceptance tests for this commit. Use A Buildkite token with the "Modify Builds" scope
-curl -X POST -H "Authorization: Bearer ${DOLLAR}{ACCEPTANCE_ACCESS_TOKEN}" "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/acceptance-tests/builds" \
+# Run the following curl command to execute acceptance tests for this commit. Use a Buildkite token with the "Modify Builds" scope
+curl -X POST -H "Authorization: Bearer ${DOLLAR}{ACCEPTANCE_ACCESS_TOKEN}" "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/acceptance/builds" \
   -d '{
     "commit": "$BUILDKITE_COMMIT",
     "branch": "$BUILDKITE_BRANCH",

--- a/.buildkite/files/acceptance_trigger_instructions
+++ b/.buildkite/files/acceptance_trigger_instructions
@@ -3,7 +3,7 @@ curl -X POST -H "Authorization: Bearer ${DOLLAR}{ACCEPTANCE_ACCESS_TOKEN}" "http
   -d '{
     "commit": "${BUILDKITE_COMMIT}",
     "branch": "${BUILDKITE_BRANCH}",
-    "message": "Triggered from curl, brach: ${BUILDKITE_BRANCH}, commit: ${BUILDKITE_COMMIT}",
+    "message": "Triggered from curl, branch: ${BUILDKITE_BRANCH}, commit: ${BUILDKITE_COMMIT}",
     "env": {
       "TAG": "${BUILDKITE_BUILD_NUMBER}"
     }

--- a/.buildkite/files/acceptance_trigger_instructions
+++ b/.buildkite/files/acceptance_trigger_instructions
@@ -1,9 +1,9 @@
 # Run the following curl command to execute acceptance tests for this commit. Use a Buildkite token with the "Modify Builds" scope
 curl -X POST -H "Authorization: Bearer ${DOLLAR}{ACCEPTANCE_ACCESS_TOKEN}" "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/acceptance/builds" \
   -d '{
-    "commit": "$BUILDKITE_COMMIT",
-    "branch": "$BUILDKITE_BRANCH",
-    "message": "Manually triggered acceptence tests",
+    "commit": "${BUILDKITE_COMMIT}",
+    "branch": "${BUILDKITE_BRANCH}",
+    "message": "Triggered from curl, brach: ${BUILDKITE_BRANCH}, commit: ${BUILDKITE_COMMIT}",
     "env": {
       "TAG": "${BUILDKITE_BUILD_NUMBER}"
     }

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -20,7 +20,7 @@ cat "$STEPS/setup.yml"
 
 # Print instructions for manual build
 echo "- label: 'Manually trigger acceptance tests'"
-echo "  command: 'envsubst < $BASE/file/acceptance_trigger_instructions'"
+echo "  command: 'envsubst < $BASE/files/acceptance_trigger_instructions'"
 echo "  env:"
 echo "    DOLLAR: '$'"
 # build images together with unit tests

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -22,7 +22,7 @@ cat "$STEPS/setup.yml"
 echo "- label: 'Print instructions to trigger acceptance tests as user'"
 echo "  command: 'envsubst < $BASE/files/acceptance_trigger_instructions'"
 echo "  env:"
-#The DOLLAR variable is used to create a $ in the output of envsubst. https://stackoverflow.com/questions/24963705/is-there-an-escape-character-for-envsubst
+# The DOLLAR variable is used to create a $ in the output of envsubst. https://stackoverflow.com/questions/24963705/is-there-an-escape-character-for-envsubst
 echo "    DOLLAR: '$'"
 # build images together with unit tests
 if [ "$RUN_ALL_TESTS" = "y" ]; then

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -19,8 +19,8 @@ echo "steps:"
 cat "$STEPS/setup.yml"
 
 # Print instructions for manual build
-echo "- label: 'Print curl command to trigger acceptance tests'"
-echo "  command: 'envsubst < $BASE/scripts/run_acceptence_test_curl_command'"
+echo "- label: 'Manually trigger acceptance tests'"
+echo "  command: 'envsubst < $BASE/file/acceptance_trigger_instructions'"
 echo "  env:"
 echo "    DOLLAR: '$'"
 # build images together with unit tests

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -19,7 +19,7 @@ echo "steps:"
 cat "$STEPS/setup.yml"
 
 # Print instructions for manual build
-echo "- label: 'Manually trigger acceptance tests'"
+echo "- label: 'Print instructions to trigger acceptance tests as user'"
 echo "  command: 'envsubst < $BASE/files/acceptance_trigger_instructions'"
 echo "  env:"
 echo "    DOLLAR: '$'"

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -4,6 +4,7 @@ set -e
 
 export BASE=".buildkite"
 STEPS="$BASE/steps"
+TRIGGERS="$BASE/triggers"
 
 # if the pipeline is triggered from a PR, run a reduced pipeline
 if [ -z "$RUN_ALL_TESTS" ]; then
@@ -17,6 +18,11 @@ echo "steps:"
 # build scion image and binaries
 cat "$STEPS/setup.yml"
 
+# Print instructions for manual build
+echo "- label: 'Print curl command to trigger acceptance tests'"
+echo "  command: 'envsubst < $BASE/scripts/run_acceptence_test_curl_command'"
+echo "  env:"
+echo "    DOLLAR: '$'"
 # build images together with unit tests
 if [ "$RUN_ALL_TESTS" = "y" ]; then
     cat "$STEPS/build_all.yml"
@@ -38,7 +44,7 @@ if [ "$RUN_ALL_TESTS" = "y" ]; then
     # docker integration testing
     cat "$STEPS/docker-integration.yml"
     # acceptance testing
-    "$STEPS/acceptance"
+    cat "$TRIGGERS/acceptance-trigger.yml"
 fi
 
 # deploy

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -22,6 +22,7 @@ cat "$STEPS/setup.yml"
 echo "- label: 'Print instructions to trigger acceptance tests as user'"
 echo "  command: 'envsubst < $BASE/files/acceptance_trigger_instructions'"
 echo "  env:"
+#The DOLLAR variable is used to create a $ in the output of envsubst. https://stackoverflow.com/questions/24963705/is-there-an-escape-character-for-envsubst
 echo "    DOLLAR: '$'"
 # build images together with unit tests
 if [ "$RUN_ALL_TESTS" = "y" ]; then

--- a/.buildkite/scripts/all_images
+++ b/.buildkite/scripts/all_images
@@ -2,9 +2,10 @@
 
 . $BASE/steps/common.sh
 
-set -eu
+set -exu
 
-TAG="$BUILDKITE_BUILD_NUMBER"
+#Set tag only in not already set in environment
+TAG=${TAG:-$BUILDKITE_BUILD_NUMBER}
 
 $BASE/scripts/registry_login &>/dev/null
 

--- a/.buildkite/scripts/all_images
+++ b/.buildkite/scripts/all_images
@@ -4,7 +4,7 @@
 
 set -eu
 
-#Set tag if not already set in environment
+# Set tag if not already set in environment
 TAG=${TAG:-$BUILDKITE_BUILD_NUMBER}
 
 $BASE/scripts/registry_login &>/dev/null

--- a/.buildkite/scripts/all_images
+++ b/.buildkite/scripts/all_images
@@ -2,9 +2,9 @@
 
 . $BASE/steps/common.sh
 
-set -exu
+set -eu
 
-#Set tag only in not already set in environment
+#Set tag if not already set in environment
 TAG=${TAG:-$BUILDKITE_BUILD_NUMBER}
 
 $BASE/scripts/registry_login &>/dev/null

--- a/.buildkite/scripts/run_acceptence_test_curl_command
+++ b/.buildkite/scripts/run_acceptence_test_curl_command
@@ -1,0 +1,12 @@
+# Run the following curl command to execute acceptance tests for this commit. Use A buildkite token with the "Modify Builds" scope
+curl -X POST -H "Authorization: Bearer ${DOLLAR}{ACCEPTANCE_ACCESS_TOKEN}" "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/acceptance-tests/builds" \
+  -d '{
+    "commit": "$BUILDKITE_COMMIT",
+    "branch": "$BUILDKITE_BRANCH",
+    "message": "Manually triggered acceptence tests",
+    "env": {
+      "TAG": "${BUILDKITE_BUILD_NUMBER}"
+    }
+  }'
+
+#Or open 'https://buildkite.com/${BUILDKITE_ORGANIZATION_SLUG}/acceptance-tests' and create a new build with Commit: $BUILDKITE_COMMIT, Branch: $BUILDKITE_BRANCH and env var TAG=${BUILDKITE_BUILD_NUMBER}

--- a/.buildkite/triggers/acceptance-trigger.yml
+++ b/.buildkite/triggers/acceptance-trigger.yml
@@ -1,0 +1,8 @@
+- trigger: "acceptance-tests"
+  label: "Run acceptance tests"
+  build:
+    commit: "${BUILDKITE_COMMIT}"
+    branch: "${BUILDKITE_BRANCH}"
+    env:
+      TAG: "${BUILDKITE_BUILD_NUMBER}"
+      RUN_DOCKER_BUILD: "false"

--- a/.buildkite/triggers/acceptance-trigger.yml
+++ b/.buildkite/triggers/acceptance-trigger.yml
@@ -1,5 +1,5 @@
 - trigger: "acceptance-tests"
-  label: "Run acceptance tests"
+  label: "Acceptance"
   build:
     commit: "${BUILDKITE_COMMIT}"
     branch: "${BUILDKITE_BRANCH}"

--- a/.buildkite/triggers/acceptance-trigger.yml
+++ b/.buildkite/triggers/acceptance-trigger.yml
@@ -1,5 +1,5 @@
-- trigger: "acceptance-tests"
-  label: "Acceptance"
+- trigger: "acceptance"
+  label: "Acceptance tests"
   build:
     commit: "${BUILDKITE_COMMIT}"
     branch: "${BUILDKITE_BRANCH}"


### PR DESCRIPTION
The acceptance tests will be triggered for master pushes. Also the pipeline prints instructions how to start the acceptance tests manually or with a curl command.
https://github.com/scionproto/scion/wiki/Buildkite for updated documentation

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2781)
<!-- Reviewable:end -->
