### PR TITLE
BR: Fix racy log

### DIFF
--- a/go/border/rctx/io.go
+++ b/go/border/rctx/io.go
@@ -100,7 +100,8 @@ func (s *Sock) Start() {
 		}
 		s.running = true
 		s.started = true
-		log.Info("Sock routines started", "addr", s.Conn.LocalAddr())
+		log.Info("Sock routines started", "addr", s.Conn.LocalAddr(), "dir", s.Dir,
+			"ifid", s.Ifid, "type", s.Type)
 	}
 }
 
@@ -108,7 +109,8 @@ func (s *Sock) Start() {
 // routines are stopped before returning to the caller.
 func (s *Sock) Stop() {
 	if s.running {
-		log.Debug("Sock routines stopping", "addr", s.Conn.LocalAddr())
+		log.Debug("Sock routines stopping", "addr", s.Conn.LocalAddr(), "dir", s.Dir,
+			"ifid", s.Ifid, "type", s.Type)
 		// The order of the sequence below is important:
 		// Close the Sock, which effectively only signals the Reader to finish.
 		close(s.stop)
@@ -127,14 +129,14 @@ func (s *Sock) Stop() {
 		}
 		// Close the posix sockets.
 		if err := s.Conn.Close(); err != nil {
-			log.Error("Error stopping socket", "err", err)
+			log.Error("Error stopping socket", "addr", s.Conn.LocalAddr(), "err", err)
 		}
 		s.running = false
 		log.Info("Sock routines stopped", "addr", s.Conn.LocalAddr())
 	} else if !s.started {
 		s.Ring.Close()
 		if err := s.Conn.Close(); err != nil {
-			log.Error("Error stopping socket", "err", err)
+			log.Error("Error stopping socket", "addr", s.Conn.LocalAddr(), "err", err)
 		}
 		log.Info("Non-started sock stopped", "addr", s.Conn.LocalAddr())
 	}

--- a/go/border/router.go
+++ b/go/border/router.go
@@ -96,11 +96,12 @@ func (r *Router) handleSock(s *rctx.Sock, stop, stopped chan struct{}) {
 	defer log.LogPanicAndExit()
 	defer close(stopped)
 	pkts := make(ringbuf.EntryList, processBufCnt)
-	log.Debug("handleSock starting", "sock", *s)
+	dst := s.Conn.LocalAddr()
+	log.Debug("handleSock starting", "addr", dst)
 	for {
 		n, _ := s.Ring.Read(pkts, true)
 		if n < 0 {
-			log.Debug("handleSock stopping", "sock", *s)
+			log.Debug("handleSock stopping", "addr", dst)
 			return
 		}
 		for i := 0; i < n; i++ {


### PR DESCRIPTION
The border router prints the socket to the logs, whil parts can still
be modified by another go routine. This shows up during race detection.

Most of the logged information is pointers, which is not really useful.
This PR reduces the logged information and makes sure no race condition
occur.

Before:
````
2019-06-20 12:21:21.468642+0000 [DBUG] Setting up new local socket. bind=[127.0.0.17]:31008
2019-06-20 12:21:21.468693+0000 [DBUG] Done setting up new local socket. conn=[127.0.0.17]:31008
2019-06-20 12:21:21.468699+0000 [DBUG] Setting up new external socket. intf="&{Id:11 IFAddr:TopoBRAddr{IPv4:{PublicOverlay: [127.0.0.5]:50000 BindOverlay: <nil>},Overlay: UDP/IPv4} RemoteAddr:[127.0.0.4]:50000 RemoteIA:1-ff00:0:110 BW:1000 MTU:1280 Type:parent}"
2019-06-20 12:21:21.468754+0000 [DBUG] Done setting up new external socket. intf="&{Id:11 IFAddr:TopoBRAddr{IPv4:{PublicOverlay: [127.0.0.5]:50000 BindOverlay: <nil>},Overlay: UDP/IPv4} RemoteAddr:[127.0.0.4]:50000 RemoteIA:1-ff00:0:110 BW:1000 MTU:1280 Type:parent}"
2019-06-20 12:21:21.468790+0000 [INFO] Sock routines started addr=[127.0.0.17]:31008
2019-06-20 12:21:21.468795+0000 [INFO] Sock routines started addr=[127.0.0.17]:31008
2019-06-20 12:21:21.468798+0000 [INFO] Sock routines started addr=[127.0.0.5]:50000
2019-06-20 12:21:21.468801+0000 [INFO] Sock routines started addr=[127.0.0.5]:50000
2019-06-20 12:21:21.468813+0000 [INFO] posixInput starting addr=[127.0.0.17]:31008
2019-06-20 12:21:21.468846+0000 [INFO] posixOutput starting addr=[127.0.0.5]:50000
2019-06-20 12:21:21.468854+0000 [DBUG] handleSock starting sock="{Ring:0xc000168240 Conn:0xc0001b2900 Dir:External Ifid:11 Labels:map[sock:intf:11] Reader:0xc1d410 Writer:0xc1d470 Type:posix stop:0xc0001b6900 readerStopped:0xc0001b6960 writerStopped:0xc0001b69c0 running:true started:true}"
2019-06-20 12:21:21.468807+0000 [DBUG] handleSock starting sock="{Ring:0xc00016dec0 Conn:0xc0001b2680 Dir:Local Ifid:0 Labels:map[sock:loc] Reader:0xc1d410 Writer:0xc1d470 Type:posix stop:0xc0001b6480 readerStopped:0xc0001b6660 writerStopped:0xc0001b6720 running:true started:true}"
2019-06-20 12:21:21.468834+0000 [INFO] posixInput starting addr=[127.0.0.5]:50000
2019-06-20 12:21:21.468838+0000 [INFO] posixOutput starting addr=[127.0.0.17]:31008
````

Now:
````
2019-06-20 12:20:44.841055+0000 [DBUG] Setting up new local socket. bind=[127.0.0.17]:31008
2019-06-20 12:20:44.841277+0000 [DBUG] Done setting up new local socket. conn=[127.0.0.17]:31008
2019-06-20 12:20:44.841316+0000 [DBUG] Setting up new external socket. intf="&{Id:11 IFAddr:TopoBRAddr{IPv4:{PublicOverlay: [127.0.0.5]:50000 BindOverlay: <nil>},Overlay: UDP/IPv4} RemoteAddr:[127.0.0.4]:50000 RemoteIA:1-ff00:0:110 BW:1000 MTU:1280 Type:parent}"
2019-06-20 12:20:44.841558+0000 [DBUG] Done setting up new external socket. intf="&{Id:11 IFAddr:TopoBRAddr{IPv4:{PublicOverlay: [127.0.0.5]:50000 BindOverlay: <nil>},Overlay: UDP/IPv4} RemoteAddr:[127.0.0.4]:50000 RemoteIA:1-ff00:0:110 BW:1000 MTU:1280 Type:parent}"
2019-06-20 12:20:44.842080+0000 [INFO] Sock routines started addr=[127.0.0.17]:31008 dir=Local ifid=0 type=posix
2019-06-20 12:20:44.842105+0000 [DBUG] handleSock starting addr=[127.0.0.17]:31008
2019-06-20 12:20:44.842231+0000 [INFO] posixOutput starting addr=[127.0.0.17]:31008
2019-06-20 12:20:44.842093+0000 [INFO] posixInput starting addr=[127.0.0.17]:31008
2019-06-20 12:20:44.842221+0000 [INFO] Sock routines started addr=[127.0.0.17]:31008 dir=Local ifid=0 type=posix
2019-06-20 12:20:44.842586+0000 [INFO] posixInput starting addr=[127.0.0.5]:50000
2019-06-20 12:20:44.842663+0000 [DBUG] handleSock starting addr=[127.0.0.5]:50000
2019-06-20 12:20:44.842654+0000 [INFO] Sock routines started addr=[127.0.0.5]:50000 dir=External ifid=11 type=posix
2019-06-20 12:20:44.842925+0000 [INFO] Sock routines started addr=[127.0.0.5]:50000 dir=External ifid=11 type=posix
2019-06-20 12:20:44.842994+0000 [INFO] posixOutput starting addr=[127.0.0.5]:50000
````

Partially addresses #2774

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2783)
<!-- Reviewable:end -->
