### PR TITLE
Don't prompt for sudo password on every build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ vendor:
 bazel: vendor
 	bazel build //:scion --workspace_status_command=./tools/bazel-build-env
 	tar -xf bazel-bin/scion.tar -C bin
-	@sudo -p "go:braccept [sudo] password for %p: " true
-	sudo setcap cap_net_admin,cap_net_raw+ep bin/braccept
 
 gazelle:
 	bazel run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build ./go

--- a/acceptance/brutil/common.sh
+++ b/acceptance/brutil/common.sh
@@ -14,6 +14,11 @@ BRCONF_DIR=${BRUTIL}/conf
 test_setup() {
     set -e
 
+    if [ -n "$(getcap bin/braccept)" ]; then
+        sudo -p "go:braccept [sudo] password for %p: " true
+        sudo setcap cap_net_admin,cap_net_raw+ep bin/braccept
+    fi
+
     local disp_dir="/run/shm/dispatcher"
     [ -d "$disp_dir" ] || mkdir "$disp_dir"
     [ $(stat -c "%U" "$disp_dir") == "$LOGNAME" ] || { sudo -p "Fixing ownership of $disp_dir - [sudo] password for %p: " chown $LOGNAME: "$disp_dir"; }


### PR DESCRIPTION
`bin/braccept` is only needed for the br acceptance tests, so check/set
capabilities there instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2793)
<!-- Reviewable:end -->
