### PR TITLE
Gen: Leaf certificate issuing time workaround

### DIFF
--- a/python/lib/crypto/certificate.py
+++ b/python/lib/crypto/certificate.py
@@ -152,7 +152,7 @@ class Certificate(object):
 
     @classmethod
     def from_values(cls, subject, issuer, trc_version, version, comment, can_issue, validity_period,
-                    subject_enc_key, subject_sig_key, iss_priv_key):
+                    subject_enc_key, subject_sig_key, iss_priv_key, issuing_time=0):
         """
         Generate a Certificate instance.
 
@@ -170,10 +170,13 @@ class Certificate(object):
             the issuer's signing key. It is used to sign the certificate.
         :param bytes subject_sig_key: the public key of the subject.
         :param bytes subject_enc_key: the public part of the encryption key.
+        :param int issuing_time: the certificate issuing time.
+            In case of 0, the current time is used.
         :returns: the newly created Certificate instance.
         :rtype: :class:`Certificate`
         """
-        now = int(time.time())
+        if not issuing_time:
+            issuing_time = int(time.time())
         cert_dict = {
             SUBJECT_STRING: subject,
             ISSUER_STRING: issuer,
@@ -181,8 +184,8 @@ class Certificate(object):
             VERSION_STRING: version,
             COMMENT_STRING: comment,
             CAN_ISSUE_STRING: can_issue,
-            ISSUING_TIME_STRING: now,
-            EXPIRATION_TIME_STRING: now + validity_period,
+            ISSUING_TIME_STRING: issuing_time,
+            EXPIRATION_TIME_STRING: issuing_time + validity_period,
             ENC_ALGORITHM_STRING: cls.ENC_ALGORITHM,
             SUBJECT_ENC_KEY_STRING:
                 base64.b64encode(subject_enc_key).decode("utf-8"),

--- a/python/topology/cert.py
+++ b/python/topology/cert.py
@@ -19,6 +19,7 @@
 # Stdlib
 import base64
 import os
+import time
 from collections import defaultdict
 
 # SCION
@@ -165,7 +166,7 @@ class CertGenerator(object):
         self.certs[topo_id] = Certificate.from_values(
             str(topo_id), str(issuer), INITIAL_TRC_VERSION, INITIAL_CERT_VERSION,
             comment, can_issue, DEFAULT_LEAF_CERT_VALIDITY, self.enc_pub_keys[topo_id],
-            self.sig_pub_keys[topo_id], signing_key
+            self.sig_pub_keys[topo_id], signing_key, issuing_time=int(time.time())+2,
         )
 
     def _build_chains(self):


### PR DESCRIPTION
The generator occasionally issues leaf certificates that are valid
before the issuing Issuer certificate. This can happen, since the
granularity is one second, and the issuing time is simply current time
without considering the enclosing Issuer validity period.

This PR is a "hacky" attempt of solving the problem. As it will not take
any machine that is capable of running the topology more than a second
to generate the certificates, we simply add 2 seconds to the current
time for leaf certificates. This guarantees that the leaf certificates
validity period is covered by the Issuer certificate (given our
reasonable assumption)

To cleanly fix the issue, we should consider addressing #1491, but
this is good enough for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2801)
<!-- Reviewable:end -->
