### PR TITLE
BK: remove command because it's now unnecessary

### DIFF
--- a/.buildkite/steps/setup.yml
+++ b/.buildkite/steps/setup.yml
@@ -1,7 +1,6 @@
 - label: "Scion image :docker: "
   command:
     - $BASE/scripts/build_scion_img
-    - mkdir docker/_build && touch docker/_build/scion.stamp
     - make -C docker/perapp app_builder
     - docker tag scion_app_builder "$SCION_IMG"
     - $BASE/scripts/registry_login


### PR DESCRIPTION
build_scion_img actually calls docker.sh which creates docker/_build/scion.stamp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2811)
<!-- Reviewable:end -->
