### PR TITLE
Add python3-pyasn1 to dependencies.

### DIFF
--- a/.buildkite/scripts/build_scion_img
+++ b/.buildkite/scripts/build_scion_img
@@ -2,7 +2,7 @@
 
 set -e
 
-BASE_IMG=${BASE_IMG:-4cd7f3aa80d177ac03b54441e95eec0f0c7b3ef65def5d4337b679252320228c}
+BASE_IMG=${BASE_IMG:-c6fe9bb142388719db2a654c7b3876748e4f0c467086f23a27a15883c6dc2420}
 
 docker pull scionproto/scion_base@sha256:$BASE_IMG
 docker tag scionproto/scion_base@sha256:$BASE_IMG scion_base:latest

--- a/env/debian/pkgs.txt
+++ b/env/debian/pkgs.txt
@@ -39,6 +39,7 @@ python3-nose
 python3-nose-cov
 python3-openssl
 python3-pip
+python3-pyasn1
 python3-pygments
 python3-setuptools
 python3-wheel


### PR DESCRIPTION
It's needed by python3-openssl to handle subjectAltName's on certs.

(It's marked as 'recommended' by python3-openssl, but we use
`--no-install-recommends` to reduce the amount of unnecessary packages
installed.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2823)
<!-- Reviewable:end -->
