### PR TITLE
Remove 4GB memory limit and 1GB shared memory limit from docker.sh 

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -82,8 +82,7 @@ cmd_clean() {
 }
 
 common_args() {
-    # Limit to 4G of ram, don't allow swapping.
-    local args="-h scion -m 4GB --memory-swap=4GB --shm-size=1024M $DOCKER_ARGS"
+    local args="-h scion $DOCKER_ARGS"
     args+=" -v /var/run/docker.sock:/var/run/docker.sock"
     args+=" -v $SCION_MOUNT/gen:/home/scion/go/src/github.com/scionproto/scion/gen"
     args+=" -v $SCION_MOUNT/logs:/home/scion/go/src/github.com/scionproto/scion/logs"


### PR DESCRIPTION
Fixes integration tests running out of memory (on CI)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2828)
<!-- Reviewable:end -->
