### PR TITLE
Add path policies in path lookup design

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,18 @@ Internet architecture.
   containers.
 * [go/](/go): parts of the implementation that are written in
   [Go](http://golang.org).
-  * [border_router](/go/border): Border Router
-  * [certificate_server](/go/cert_srv): Certificate Server
-  * [scion_ip_gateway](/go/sig): SCION IP Gateway
-  * [lib](/go/lib): shared SCION Go libraries
+    * [border_router](/go/border): Border Router
+    * [certificate_server](/go/cert_srv): Certificate Server
+    * [scion_ip_gateway](/go/sig): SCION IP Gateway
+    * [lib](/go/lib): shared SCION Go libraries
 * [python/](/python): the parts of the infrastructure
   implemented in Python.
-  * [beacon_server](/python/beacon_server): Beacon Server
-  * [certificate_server](/python/cert_server): Certificate Server
-  * [path_server](/python/path_server): Path Server
-  * [lib/](/python/lib): shared SCION Python libraries
-  * [topology](/python/topology): generator for generating a local topology,
-    including all the necessary configuration, key, and certificate files
+    * [beacon_server](/python/beacon_server): Beacon Server
+    * [certificate_server](/python/cert_server): Certificate Server
+    * [path_server](/python/path_server): Path Server
+    * [lib/](/python/lib): shared SCION Python libraries
+    * [topology](/python/topology): generator for generating a local topology,
+        including all the necessary configuration, key, and certificate files
 * [proto/](/proto): the protocol definitions for use with [Cap’n
   Proto](https://capnproto.org/).
 * [supervisor/](/supervisor): the configuration for

--- a/doc/ControlPlanePKI.md
+++ b/doc/ControlPlanePKI.md
@@ -248,10 +248,9 @@ This is an object that maps primary AS identifiers to their attributes and keys:
 
 - __Keys__: Object that maps key types (`Issuing`, `Online` or `Offline`) to an object with the
   following fields:
-  - __KeyVersion__: 64-bit integer. Starts at 1, incremented every time this key is
-    replaced.
-  - __Algorithm__: string. Identifies the algorithm this key is used with.
-  - __Key__: Base64-encoded string representation of the public key.
+    - __KeyVersion__: 64-bit integer. Starts at 1, incremented every time this key is replaced.
+    - __Algorithm__: string. Identifies the algorithm this key is used with.
+    - __Key__: Base64-encoded string representation of the public key.
 
 An AS that has no core links must not be a core AS. An authoritative AS must be a core AS (this
 ensures it is reachable by other core ASes for bootstrap purposes). A voting AS is required to have
@@ -583,10 +582,9 @@ This is an object that maps the type of key (`Issuing`, `Encryption`, `Signing`,
 the algorithm and the key.
 
 - __Keys__: Object that maps key types to an object with the following fields:
-  - __Algorithm__: string. Identifies the algorithm this key is used with.
-  - __Key__: Base64-encoded string representation of the public key.
-  - __KeyVersion__: 64-bit integer. Starts at 1, incremented every time the key is
-    replaced.
+    - __Algorithm__: string. Identifies the algorithm this key is used with.
+    - __Key__: Base64-encoded string representation of the public key.
+    - __KeyVersion__: 64-bit integer. Starts at 1, incremented every time the key is replaced.
 
 The following table shows what keys are authenticated by the different certificate types. The key
 notation is the same as in the [private keys table](#table-private-keys).

--- a/doc/PathPolicy.md
+++ b/doc/PathPolicy.md
@@ -212,8 +212,8 @@ third option which denies only hops in AS _1-ff00:0:133_, is used.
 ### Path lookup flow
 
 1. Client sends request towards sciond with a policy in the request.
-1. Sciond checks if it has cached segments for the destination
-    1. Cached segments present: build paths and filter with policy, return result to client.
+1. Sciond checks if it has recently done a request with the same policy for the destination
+    1. Recent request done: build path from cache and filter with policy, return result to client.
     1. Cached segments not present: continue with steps below.
 1. Sciond sends request with policy to local PS
 1. PS checks if it has cached segments for the destination
@@ -223,6 +223,12 @@ third option which denies only hops in AS _1-ff00:0:133_, is used.
    paths should be returned.
 1. PS stores reply in its DB and filters segments with policy and returns it to sciond.
 1. Sciond builds paths and filters them with policy and return them to the client.
+
+Note that for the request caching in sciond we need to remember which policies were used in a
+request. For that we use a time & space limited cache. It caches a result for a destination and a
+certain policy up to x seconds. But it also starts to drop items once there are more than y requests
+with different policies. To differentiate policies the hash of the serialized policy is used, so two
+policies with the same effect but different representation will count separately.
 
 ### API changes
 

--- a/doc/PathPolicy.md
+++ b/doc/PathPolicy.md
@@ -55,7 +55,7 @@ A policy is defined by a policy object. It can have the following attributes:
 - [`acl`](#ACL) (list of HPs, preceded by `+` or `-`)
 - [`sequence`](#Sequence) (space separated list of HPs, may contain operators)
 - [`options`](#Options) (list of option policies)
-  - `weight` (importance level, only valid under `options`)
+    - `weight` (importance level, only valid under `options`)
 
 Planned:
 
@@ -195,3 +195,44 @@ third option which denies only hops in AS _1-ff00:0:133_, is used.
     - "- 1-ff00:0:133#0"
     - "+"
 ```
+
+## Path policies in path lookup
+
+### Requirements
+
+1. The path lookup path policy languages has to be at least as expressive as what we offer to
+   clients. Otherwise we will need to have a middle man which requests all the required segments
+   until a request can be fulfilled.
+1. The path lookup path policy can only contain static properties of a path. Static are the acl and
+   sequence parts of the policy and everything that does not contain information that can
+   dynamically change, like latency (note that min latency of a link is probably a helpful static
+   property).
+1. The path lookup result caching should, if possible, not be affected by this change.
+
+### Path lookup flow
+
+1. Client sends request towards sciond with a policy in the request.
+1. Sciond checks if it has cached segments for the destination
+    1. Cached segments present: build paths and filter with policy, return result to client.
+    1. Cached segments not present: continue with steps below.
+1. Sciond sends request with policy to local PS
+1. PS checks if it has cached segments for the destination
+    1. Cached segments present: filter segments with policy, return result to client.
+    1. Cached segments not present: continue with steps below.
+1. PS sends request to relevant core PS (according to current rules) with a flag indicating that all
+   paths should be returned.
+1. PS stores reply in its DB and filters segments with policy and returns it to sciond.
+1. Sciond builds paths and filters them with policy and return them to the client.
+
+### API changes
+
+We have to change the sciond `PathReq` and the PS `SegReq` to include at policy field. The field
+should encapsulate the `pathpol.PolicyMap` go type. Preferably a capnproto type would be used to
+model it and if that is not possible we should serialize the type to JSON and send it as text field.
+
+### Possible implementation shortcuts
+
+It would be possible for the local PS to just return all the segments without filtering since sciond
+has to do filtering anyway. Since the API of the PS will already accept policies we can just forward
+the policy from sciond to the PS and the PS can either filter segments or just return all segments
+without filtering.

--- a/doc/PathService.md
+++ b/doc/PathService.md
@@ -72,8 +72,8 @@ Local means in the same ISD as the current PS, remote means in a different ISD.
 * For non-core PS: Check source (R.RawSrcIA): must either be unset, or set to the local IA otherwise
   return an error/empty reply
 * Check destination (R.RawDstIA):
-  * If the R.RawDstIA is not set or invalid (i.e., ISD is 0) or represents the local IA, immediately
-    return an error/empty reply
+    * If the R.RawDstIA is not set or invalid (i.e., ISD is 0) or represents the local IA,
+      immediately return an error/empty reply
 * Define `GetCached(Seg, cPS)` := if last lookup Seg.Dst is longer than a configured time ago (Note
   comments on the cache refresh interval in chapter below), request at cPS and save result in cache,
   then return cached version. If we currently do not have a path to cPS we should hold the request
@@ -84,35 +84,35 @@ Local means in the same ISD as the current PS, remote means in a different ISD.
 #### Non-core PS
 
 * If Dst == Core-AS:
-  * For each local core-AS x, for which an up segment exists && isNot(dst):
-    * GetCached(coreSeg{dst->x}, x)
-  * Return up-segments, which have a connecting core segment or which end in dst, and the core
-    segments.
+    * For each local core-AS x, for which an up segment exists && isNot(dst):
+        * GetCached(coreSeg{dst->x}, x)
+    * Return up-segments, which have a connecting core segment or which end in dst, and the core
+        segments.
 * Else // Dst == Non-Core-AS:
-  * GetCached(downSeg{*->dst}, any local cPS)
-  * Filter down segments, remove revoked ones.
-  * For each core AS x, that is at the start of a down segment:
-    * For each local core AS y, for which an up segment exists && x != y: GetCached(coreSeg{x->y},
-      y)
-  * Filter down segments, only keep reachable ones
-  * Return the down, core, and up segments.
+    * GetCached(downSeg{*->dst}, any local cPS)
+    * Filter down segments, remove revoked ones.
+    * For each core AS x, that is at the start of a down segment:
+        * For each local core AS y, for which an up segment exists && x != y:
+          GetCached(coreSeg{x->y}, y)
+    * Filter down segments, only keep reachable ones
+    * Return the down, core, and up segments.
 
 #### Core PS
 
 * If destination is local:
-  * If Dest is ISD-0: return empty
-  * Else if Dest is core AS: return coreSeg{dst->self}
-  * Else
-    * If request from different AS: return downSeg{*->dst} (from DB)
-    * Else return downSeg{*->dst} (from DB) and for each core AS x, that is at the start of a down
-      segment return the coreSegs{x->self}
+    * If Dest is ISD-0: return empty
+    * Else if Dest is core AS: return coreSeg{dst->self}
+    * Else
+        * If request from different AS: return downSeg{*->dst} (from DB)
+        * Else return downSeg{*->dst} (from DB) and for each core AS x, that is at the start of a
+          down segment return the coreSegs{x->self}
 * If destination is remote:
-  * If Dest is ISD-0 return any coreSeg{ISD-*->self}
-  * Else if Dest is core AS: return coreSeg{dst->self}
-  * Else
-    * If request from different AS: return GetCached(downSeg{*->dst}, any cPS in DestISD)
-    * Else return GetCached(downSeg{*->dst}, any cPS in DestISD) and for each core AS x, that is at
-      the start of a down segment return the coreSegs{x->self}
+    * If Dest is ISD-0 return any coreSeg{ISD-*->self}
+    * Else if Dest is core AS: return coreSeg{dst->self}
+    * Else
+        * If request from different AS: return GetCached(downSeg{*->dst}, any cPS in DestISD)
+        * Else return GetCached(downSeg{*->dst}, any cPS in DestISD) and for each core AS x, that is
+          at the start of a down segment return the coreSegs{x->self}
 
 ### Cache refresh interval
 
@@ -156,16 +156,16 @@ segment. Instead we only filter when using path segments.
 
 * Receive revocation R
 * If R is a CtrlPld.PathMgmt.SRevInfo && source is not in same ISD
-  * Ignore R // SRevInfo should only come from within the same ISD.
+    * Ignore R // SRevInfo should only come from within the same ISD.
 * Verify R, if invalid drop it and return.
 * Save R in the revocation cache
 * Forward revocation in non-core PS:
-  * If revoked interface belongs to this AS OR revocation is from a different ISD:
-    * Inform all core PSes in the local ISD
+    * If revoked interface belongs to this AS OR revocation is from a different ISD:
+        * Inform all core PSes in the local ISD
 * Forward revocation in core PS:
-  * If revoked interface belongs to this AS OR Revocation is from a BR and it originated from a
+    * If revoked interface belongs to this AS OR Revocation is from a BR and it originated from a
       different ISD
-    * Inform all other core ASes.
-  * Note that if a cPS queries a cPS of another ISD for down segments it should also get the
-    relevant revocations for the segments. These revocations do not need to be forwarded to other
-    cPSes.
+        * Inform all other core ASes.
+    * Note that if a cPS queries a cPS of another ISD for down segments it should also get the
+      relevant revocations for the segments. These revocations do not need to be forwarded to other
+      cPSes.

--- a/tools/md/mdlintstyle.rb
+++ b/tools/md/mdlintstyle.rb
@@ -2,4 +2,5 @@ all
 rule 'MD013', :line_length => 100
 rule 'MD013', :code_blocks => false
 rule 'MD013', :tables => false
+rule 'MD007', :indent => 4 # see https://github.com/markdownlint/markdownlint/issues/139
 rule 'MD024', :allow_different_nesting => true


### PR DESCRIPTION
Note that this PR also changes the configuration of the md linter, therefore some other documents changed as well (whitespace only).

The problem is with rule MD007, there is an upstream issue: https://github.com/markdownlint/markdownlint/issues/139
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2839)
<!-- Reviewable:end -->
