### PR TITLE
crypto: Introduce validity period

### DIFF
--- a/go/lib/scrypto/BUILD.bazel
+++ b/go/lib/scrypto/BUILD.bazel
@@ -7,11 +7,13 @@ go_library(
         "defs.go",
         "mac.go",
         "rand.go",
+        "validity.go",
     ],
     importpath = "github.com/scionproto/scion/go/lib/scrypto",
     visibility = ["//visibility:public"],
     deps = [
         "//go/lib/common:go_default_library",
+        "//go/lib/util:go_default_library",
         "@com_github_dchest_cmac//:go_default_library",
         "@org_golang_x_crypto//ed25519:go_default_library",
         "@org_golang_x_crypto//nacl/box:go_default_library",
@@ -23,12 +25,16 @@ go_test(
     srcs = [
         "asym_test.go",
         "rand_test.go",
+        "validity_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
         "//go/lib/common:go_default_library",
+        "//go/lib/util:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
         "@org_golang_x_crypto//ed25519:go_default_library",
     ],
 )

--- a/go/lib/scrypto/validity.go
+++ b/go/lib/scrypto/validity.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scrypto
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/util"
+)
+
+// Validity indicates a validity period.
+type Validity struct {
+	NotBefore util.UnixTime `json:"NotBefore"`
+	NotAfter  util.UnixTime `json:"NotAfter"`
+}
+
+type validity struct {
+	NotBefore *util.UnixTime `json:"NotBefore"`
+	NotAfter  *util.UnixTime `json:"NotAfter"`
+}
+
+// UnmarshalJSON checks that both NotBefore and NotAfter are set.
+func (v *Validity) UnmarshalJSON(b []byte) error {
+	var p validity
+	if err := json.Unmarshal(b, &p); err != nil {
+		return err
+	}
+	if p.NotBefore == nil {
+		return common.NewBasicError("NotBefore unset", nil)
+	}
+	if p.NotAfter == nil {
+		return common.NewBasicError("NotBefore unset", nil)
+	}
+	*v = Validity{
+		NotBefore: *p.NotBefore,
+		NotAfter:  *p.NotAfter,
+	}
+	return nil
+}
+
+// Contains indicates whether the provided time is inside the validity period.
+func (v *Validity) Contains(t time.Time) bool {
+	return !t.Before(v.NotBefore.Time) && !t.After(v.NotAfter.Time)
+}
+
+func (v *Validity) String() string {
+	return fmt.Sprintf("[%s, %s]", v.NotBefore, v.NotAfter)
+}

--- a/go/lib/scrypto/validity_test.go
+++ b/go/lib/scrypto/validity_test.go
@@ -1,0 +1,116 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scrypto_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/util"
+)
+
+func TestValidityContains(t *testing.T) {
+	now := time.Now()
+	validity := scrypto.Validity{
+		NotBefore: util.UnixTime{Time: now},
+		NotAfter:  util.UnixTime{Time: now.Add(time.Minute)},
+	}
+	tests := map[string]struct {
+		Time      time.Time
+		Contained bool
+	}{
+		"Before": {
+			Time: now.Add(-time.Minute),
+		},
+		"Same as NotBefore": {
+			Time:      now,
+			Contained: true,
+		},
+		"Between NotBefore and NotAfter": {
+			Time:      now.Add(30 * time.Second),
+			Contained: true,
+		},
+		"Same as NotAfter": {
+			Time:      now.Add(time.Minute),
+			Contained: true,
+		},
+		"After": {
+			Time: now.Add(time.Hour),
+		},
+	}
+	for name, test := range tests {
+		assert.Equal(t, test.Contained, validity.Contains(test.Time), name)
+	}
+}
+
+func TestValidityUnmarshal(t *testing.T) {
+	tests := map[string]struct {
+		Input  string
+		Assert assert.ErrorAssertionFunc
+	}{
+		"invalid type": {
+			Input:  `{"a": 10}`,
+			Assert: assert.Error,
+		},
+		"NotBefore missing": {
+			Input:  `{"NotAfter": 1356134400}`,
+			Assert: assert.Error,
+		},
+		"NotAfter missing": {
+			Input:  `{"NotBefore": 1356048000}`,
+			Assert: assert.Error,
+		},
+		"correct": {
+			Input: `
+			{
+				"NotBefore": 1356048000,
+				"NotAfter": 1356134400
+			}
+			`,
+			Assert: assert.NoError,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var v scrypto.Validity
+			err := json.Unmarshal([]byte(test.Input), &v)
+			test.Assert(t, err)
+			if err != nil {
+				return
+			}
+			assert.Equal(t, util.SecsToTime(1356048000), v.NotBefore.Time)
+			assert.Equal(t, util.SecsToTime(1356134400), v.NotAfter.Time)
+		})
+	}
+}
+
+func TestValidityMarshal(t *testing.T) {
+	s := struct {
+		Validity scrypto.Validity
+	}{
+		Validity: scrypto.Validity{
+			NotBefore: util.UnixTime{Time: util.SecsToTime(1356048000)},
+			NotAfter:  util.UnixTime{Time: util.SecsToTime(1356134400)},
+		},
+	}
+	raw, err := json.Marshal(s)
+	require.NoError(t, err)
+	assert.Equal(t, `{"Validity":{"NotBefore":1356048000,"NotAfter":1356134400}}`, string(raw))
+}

--- a/go/lib/util/BUILD.bazel
+++ b/go/lib/util/BUILD.bazel
@@ -34,12 +34,15 @@ go_test(
         "checksum_test.go",
         "duration_test.go",
         "padding_test.go",
+        "time_test.go",
         "yaml_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
         "//go/lib/common:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
     ],
 )

--- a/go/lib/util/time.go
+++ b/go/lib/util/time.go
@@ -16,10 +16,40 @@
 package util
 
 import (
+	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/common"
 )
+
+var _ json.Marshaler = (*UnixTime)(nil)
+var _ json.Unmarshaler = (*UnixTime)(nil)
+
+// UnixTime allows parsing and packing timestamps in seconds since epoch.
+type UnixTime struct {
+	time.Time
+}
+
+func (t *UnixTime) UnmarshalJSON(b []byte) error {
+	var seconds uint64
+	seconds, err := strconv.ParseUint(string(b), 10, 64)
+	if err != nil {
+		return err
+	}
+	t.Time = time.Unix(int64(seconds), 0)
+	return nil
+}
+
+// MarshalJSON marshals the time as seconds since unix epoch. This must be a
+// value receiver.
+func (t UnixTime) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.FormatUint(uint64(t.Unix()), 10)), nil
+}
+
+func (t *UnixTime) String() string {
+	return TimeToString(t.Time)
+}
 
 // SecsToTime takes seconds stored in a uint32.
 func SecsToTime(t uint32) time.Time {

--- a/go/lib/util/time.go
+++ b/go/lib/util/time.go
@@ -49,7 +49,7 @@ func (t UnixTime) MarshalJSON() ([]byte, error) {
 }
 
 func (t *UnixTime) String() string {
-	return TimeToString(t.Time)
+	return TimeToCompact(t.Time)
 }
 
 // SecsToTime takes seconds stored in a uint32.

--- a/go/lib/util/time.go
+++ b/go/lib/util/time.go
@@ -33,7 +33,8 @@ type UnixTime struct {
 
 func (t *UnixTime) UnmarshalJSON(b []byte) error {
 	var seconds uint64
-	seconds, err := strconv.ParseUint(string(b), 10, 64)
+	// Only allow up to 63-bit to avoid wrap around.
+	seconds, err := strconv.ParseUint(string(b), 10, 63)
 	if err != nil {
 		return err
 	}

--- a/go/lib/util/time_test.go
+++ b/go/lib/util/time_test.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnixTimeUnmarshal(t *testing.T) {
+	tests := map[string]struct {
+		Input  string
+		Assert assert.ErrorAssertionFunc
+	}{
+		"invalid type": {
+			Input:  `{"a": 10}`,
+			Assert: assert.Error,
+		},
+		"invalid string": {
+			Input:  "111a",
+			Assert: assert.Error,
+		},
+		"negative": {
+			Input:  "-1",
+			Assert: assert.Error,
+		},
+		"correct": {
+			Input:  "1356091932",
+			Assert: assert.NoError,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var u UnixTime
+			err := json.Unmarshal([]byte(test.Input), &u)
+			test.Assert(t, err)
+			if err != nil {
+				return
+			}
+			assert.Equal(t, SecsToTime(1356091932), u.Time)
+		})
+	}
+}
+
+func TestUnixTimeMarshal(t *testing.T) {
+	s := struct {
+		Unix UnixTime
+	}{
+		Unix: UnixTime{
+			Time: SecsToTime(1356091932),
+		},
+	}
+	raw, err := json.Marshal(s)
+	require.NoError(t, err)
+	assert.Equal(t, `{"Unix":1356091932}`, string(raw))
+
+}

--- a/go/lib/util/time_test.go
+++ b/go/lib/util/time_test.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"encoding/json"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,10 @@ func TestUnixTimeUnmarshal(t *testing.T) {
 		},
 		"negative": {
 			Input:  "-1",
+			Assert: assert.Error,
+		},
+		"wrap around": {
+			Input:  strconv.FormatUint(1<<63, 10),
 			Assert: assert.Error,
 		},
 		"correct": {


### PR DESCRIPTION
This change introduces the validity period.
This will be used for the new TRC and certificate format.

Additionally, adds unix time that marshals and unmarshals in the correct
format (64 bit uint seconds since epoch).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2842)
<!-- Reviewable:end -->
