### PR TITLE
crypto: TRC update validation

### DIFF
--- a/go/lib/scrypto/trc/v2/BUILD.bazel
+++ b/go/lib/scrypto/trc/v2/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "pop.go",
         "primary.go",
         "trc.go",
+        "update.go",
     ],
     importpath = "github.com/scionproto/scion/go/lib/scrypto/trc/v2",
     visibility = ["//visibility:public"],
@@ -25,6 +26,7 @@ go_test(
         "primary_test.go",
         "trc_json_test.go",
         "trc_test.go",
+        "update_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/go/lib/scrypto/trc/v2/keychanges.go
+++ b/go/lib/scrypto/trc/v2/keychanges.go
@@ -15,7 +15,10 @@
 package trc
 
 import (
+	"bytes"
+
 	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
 )
 
 const (
@@ -48,4 +51,52 @@ func newKeyChanges() *KeyChanges {
 		},
 	}
 	return c
+}
+
+// Sensitive indicates whether the key changes are sensitive (i.e. any offline
+// key changes).
+func (c *KeyChanges) Sensitive() bool {
+	return len(c.Fresh[OfflineKey]) != 0 || len(c.Modified[OfflineKey]) != 0
+}
+
+func (c *KeyChanges) insertAllFresh(as addr.AS, next PrimaryAS) {
+	for keyType, meta := range next.Keys {
+		c.Fresh[keyType][as] = meta
+	}
+}
+
+func (c *KeyChanges) insertModifications(as addr.AS, prev, next PrimaryAS) error {
+	for keyType, meta := range next.Keys {
+		prevMeta, ok := prev.Keys[keyType]
+		if !ok {
+			c.Fresh[keyType][as] = meta
+			continue
+		}
+		modified, err := ValidateKeyUpdate(prevMeta, meta)
+		if err != nil {
+			return common.NewBasicError(InvalidKeyMeta, err, "AS", as, "keyType", keyType)
+		}
+		if modified {
+			c.Modified[keyType][as] = meta
+		}
+	}
+	return nil
+}
+
+// ValidateKeyUpdate validates that the prev and next key meta are consistent.
+// If the algorithm and key are not modified by the update, the version must not
+// change. If they are modified, the version must be increased by one. The
+// return value indicates, whether the update is a modification.
+func ValidateKeyUpdate(prev, next KeyMeta) (bool, error) {
+	modified := next.Algorithm != prev.Algorithm || !bytes.Equal(next.Key, prev.Key)
+	// If the meta data has changed, expect a key version change.
+	expectedVersion := prev.KeyVersion
+	if modified {
+		expectedVersion = prev.KeyVersion + 1
+	}
+	if next.KeyVersion != expectedVersion {
+		return modified, common.NewBasicError(InvalidKeyVersion, nil, "modified", modified,
+			"expected", expectedVersion, "actual", next.KeyVersion)
+	}
+	return modified, nil
 }

--- a/go/lib/scrypto/trc/v2/primary.go
+++ b/go/lib/scrypto/trc/v2/primary.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package trc
 
 import (

--- a/go/lib/scrypto/trc/v2/update.go
+++ b/go/lib/scrypto/trc/v2/update.go
@@ -1,0 +1,295 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trc
+
+import (
+	"errors"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+// Update validation errors with context.
+const (
+	// ImmutableBaseVersion indicates an invalid update to the BaseVersion.
+	ImmutableBaseVersion = "BaseVersion is immutable"
+	// ImmutableISD indicates an invalid update to the ISD identifier.
+	ImmutableISD = "ISD is immutable"
+	// ImmutableTrustResetAllowed indicates an invalid update to TrustResetAllowed.
+	ImmutableTrustResetAllowed = "TrustResetAllowed is immutable"
+	// InvalidVersionIncrement indicates an invalid version increment.
+	InvalidVersionIncrement = "TRC version must be incremented by one"
+	// MissingVote indicates an AS has not cast vote during a regular update
+	// that changes its online key.
+	MissingVote = "missing vote"
+	// NotInsidePreviousValidityPeriod indicates the validity periods do not overlap.
+	NotInsidePreviousValidityPeriod = "not inside previous validity period"
+	// QuorumUnmet indicates that not enough votes have been cast.
+	QuorumUnmet = "voting quorum unmet"
+	// WrongVotingKeyType indicates the vote is cast with the wrong key type.
+	WrongVotingKeyType = "vote with wrong key type"
+	// WrongVotingKeyVersion indicates the vote is cast with the wrong key version
+	WrongVotingKeyVersion = "vote with wrong key version"
+)
+
+// Update validation error wrappers.
+const (
+	// InvalidVote indicates an invalid vote.
+	InvalidVote = "invalid vote"
+	// SanityCheckError indicates a sanity check error.
+	SanityCheckError = "sanity check error"
+)
+
+// Update validation errors.
+var (
+	// ErrBaseNotUpdate indicates that the new TRC is a base TRC.
+	ErrBaseNotUpdate = errors.New("base TRC, not update")
+	// ErrNoVotingRight indicates the vote is cast by an AS without voting rights.
+	ErrNoVotingRight = errors.New("AS has no voting rights")
+	// ErrUnexpectedVote indicates that a TRC has an unexpected vote attached.
+	ErrUnexpectedVote = errors.New("unexpected vote")
+)
+
+// UpdateInfo contains details about the TRC update.
+type UpdateInfo struct {
+	// Type indicates the TRC update type.
+	Type UpdateType
+	// KeyChanges contains all modified keys that have to show proof of possession.
+	KeyChanges *KeyChanges
+	// AttributeChanges contains all attribute changes.
+	AttributeChanges AttributeChanges
+}
+
+// UpdateValidator is used to validate TRC updates.
+type UpdateValidator struct {
+	// Prev is the previous TRC. It's version must be Next.Version - 1.
+	Prev *TRC
+	// Next is the updated TRC.
+	Next *TRC
+}
+
+// Validate validates a TRC update. In case it is valid, the key changes and
+// attribute changes are returned.
+func (v *UpdateValidator) Validate() (UpdateInfo, error) {
+	if err := v.sanity(); err != nil {
+		return UpdateInfo{}, common.NewBasicError(SanityCheckError, err)
+	}
+	keyChanges, err := v.keyChanges()
+	if err != nil {
+		return UpdateInfo{}, err
+	}
+	attrChanges := v.attrChanges()
+	info := UpdateInfo{
+		Type:             v.updateType(keyChanges, attrChanges),
+		KeyChanges:       keyChanges,
+		AttributeChanges: attrChanges,
+	}
+	if err := v.checkProofOfPossesion(keyChanges); err != nil {
+		return info, err
+	}
+	if err := v.checkVotes(info); err != nil {
+		return info, err
+	}
+	return info, nil
+}
+
+func (v *UpdateValidator) sanity() error {
+	if v.Next.Base() {
+		return ErrBaseNotUpdate
+	}
+	if err := v.Next.ValidateInvariant(); err != nil {
+		return common.NewBasicError(InvariantViolation, err)
+	}
+	if v.Next.ISD != v.Prev.ISD {
+		return common.NewBasicError(ImmutableISD, nil, "expected", v.Prev.ISD, "actual", v.Next.ISD)
+	}
+	if v.Next.TrustResetAllowed() != v.Prev.TrustResetAllowed() {
+		return common.NewBasicError(ImmutableTrustResetAllowed, nil, "expected",
+			v.Prev.TrustResetAllowed, "actual", v.Next.TrustResetAllowed)
+	}
+	if v.Next.Version != v.Prev.Version+1 {
+		return common.NewBasicError(InvalidVersionIncrement, nil, "expected", v.Prev.Version+1,
+			"actual", v.Next.Version)
+	}
+	if v.Next.BaseVersion != v.Prev.BaseVersion {
+		return common.NewBasicError(ImmutableBaseVersion, nil, "expected", v.Prev.BaseVersion,
+			"actual", v.Next.BaseVersion)
+	}
+	if !v.Prev.Validity.Contains(v.Next.Validity.NotBefore.Time) {
+		return common.NewBasicError(NotInsidePreviousValidityPeriod, nil,
+			"prevValidity", v.Prev.Validity, "NotBefore", v.Next.Validity.NotBefore)
+	}
+	return nil
+}
+
+func (v *UpdateValidator) keyChanges() (*KeyChanges, error) {
+	c := newKeyChanges()
+	for as, primary := range v.Next.PrimaryASes {
+		prev, ok := v.Prev.PrimaryASes[as]
+		if !ok {
+			c.insertAllFresh(as, primary)
+			continue
+		}
+		if err := c.insertModifications(as, prev, primary); err != nil {
+			return nil, err
+		}
+	}
+	return c, nil
+}
+
+func (v *UpdateValidator) attrChanges() AttributeChanges {
+	c := make(AttributeChanges)
+	// Check all attributes of all ASes that persist or are added.
+	for as, primary := range v.Next.PrimaryASes {
+		prev, ok := v.Prev.PrimaryASes[as]
+		if !ok {
+			c.insertAll(as, primary.Attributes, AttributeAdded)
+			continue
+		}
+		c.insertModifications(as, prev, primary)
+	}
+	// Check all attributes of all ASes that are removed.
+	for as, prev := range v.Prev.PrimaryASes {
+		if _, ok := v.Next.PrimaryASes[as]; !ok {
+			c.insertAll(as, prev.Attributes, AttributeRemoved)
+		}
+	}
+	return c
+}
+
+func (v *UpdateValidator) updateType(k *KeyChanges, a AttributeChanges) UpdateType {
+	if k.Sensitive() || a.Sensitive() || v.Next.VotingQuorum() != v.Prev.VotingQuorum() {
+		return SensitiveUpdate
+	}
+	return RegularUpdate
+}
+
+func (v *UpdateValidator) checkProofOfPossesion(keyChanges *KeyChanges) error {
+	pv := popValidator{
+		TRC:        v.Next,
+		KeyChanges: keyChanges,
+	}
+	return pv.checkProofOfPossession()
+}
+
+func (v *UpdateValidator) checkVotes(info UpdateInfo) error {
+	check := v.checkVotesSensitive
+	if info.Type == RegularUpdate {
+		check = v.checkVotesRegular
+	}
+	if err := check(info); err != nil {
+		return err
+	}
+	if len(v.Next.Votes) < v.Prev.VotingQuorum() {
+		return common.NewBasicError(QuorumUnmet, nil,
+			"min", v.Prev.VotingQuorum(), "actual", len(v.Next.Votes))
+	}
+	return nil
+}
+
+func (v *UpdateValidator) checkVotesRegular(info UpdateInfo) error {
+	// Check all votes from voting ASes with expected key.
+	for as, vote := range v.Next.Votes {
+		expectedKeyType := OnlineKey
+		if _, ok := info.KeyChanges.Modified[OnlineKey][as]; ok {
+			expectedKeyType = OfflineKey
+		}
+		if err := v.hasVotingRights(as, vote, expectedKeyType); err != nil {
+			return common.NewBasicError(InvalidVote, err, "AS", as, "vote", vote)
+		}
+	}
+	// Check all ASes with changed online key have cast a vote.
+	for as := range info.KeyChanges.Modified[OnlineKey] {
+		if _, ok := v.Next.Votes[as]; !ok {
+			return common.NewBasicError(MissingVote, nil, "AS", as)
+		}
+	}
+	return nil
+}
+
+func (v *UpdateValidator) checkVotesSensitive(info UpdateInfo) error {
+	// Check all votes from voting ASes with offline keys.
+	for as, vote := range v.Next.Votes {
+		if err := v.hasVotingRights(as, vote, OfflineKey); err != nil {
+			return common.NewBasicError(InvalidVote, err, "AS", as, "vote", vote)
+		}
+	}
+	return nil
+}
+
+func (v *UpdateValidator) hasVotingRights(as addr.AS, vote Vote, keyType KeyType) error {
+	primary, ok := v.Prev.PrimaryASes[as]
+	if !ok {
+		return ErrUnexpectedVote
+	}
+	if !primary.Is(Voting) {
+		return ErrNoVotingRight
+	}
+	if vote.Type != keyType {
+		return common.NewBasicError(WrongVotingKeyType, nil,
+			"expected", keyType, "actual", vote.Type)
+	}
+	if primary.Keys[keyType].KeyVersion != vote.KeyVersion {
+		return common.NewBasicError(WrongVotingKeyVersion, nil,
+			"expected", primary.Keys[keyType].KeyVersion, "actual", vote.KeyVersion)
+	}
+	return nil
+}
+
+const (
+	// AttributeAdded indicates an attribute is added.
+	AttributeAdded AttributeChange = iota
+	// AttributeRemoved indicates an attribute is removed.
+	AttributeRemoved
+)
+
+// AttributeChange indicates the type of attribute change in a TRC update.
+type AttributeChange int
+
+// AttributeChanges contains all attribute changes for a TRC update.
+type AttributeChanges map[addr.AS]map[Attribute]AttributeChange
+
+// Sensitive indicates whether the attribute changes are sensitive.
+func (c AttributeChanges) Sensitive() bool {
+	return len(c) != 0
+}
+
+func (c AttributeChanges) insertAll(as addr.AS, attrs Attributes, change AttributeChange) {
+	for _, attr := range attrs {
+		c.insert(as, attr, change)
+	}
+}
+
+func (c AttributeChanges) insertModifications(as addr.AS, prev, next PrimaryAS) {
+	for _, attr := range next.Attributes {
+		if !prev.Is(attr) {
+			c.insert(as, attr, AttributeAdded)
+		}
+	}
+	for _, attr := range prev.Attributes {
+		if !next.Is(attr) {
+			c.insert(as, attr, AttributeRemoved)
+		}
+	}
+}
+
+func (c AttributeChanges) insert(as addr.AS, attr Attribute, change AttributeChange) {
+	m, ok := c[as]
+	if !ok {
+		m = make(map[Attribute]AttributeChange)
+		c[as] = m
+	}
+	m[attr] = change
+}

--- a/go/lib/scrypto/trc/v2/update_test.go
+++ b/go/lib/scrypto/trc/v2/update_test.go
@@ -35,8 +35,7 @@ func TestCommonUpdate(t *testing.T) {
 		"Trust reset": {
 			Modify: func(updated, _ *trc.TRC) {
 				*updated = *newBaseTRC()
-				updated.Version = 2
-				updated.BaseVersion = 2
+				updated.BaseVersion = updated.Version
 			},
 			ExpectedErrMsg: trc.ErrBaseNotUpdate.Error(),
 		},
@@ -48,7 +47,7 @@ func TestCommonUpdate(t *testing.T) {
 		},
 		"Wrong ISD": {
 			Modify: func(updated, _ *trc.TRC) {
-				updated.ISD = 2
+				updated.ISD = updated.ISD + 1
 			},
 			ExpectedErrMsg: trc.ImmutableISD,
 		},

--- a/go/lib/scrypto/trc/v2/update_test.go
+++ b/go/lib/scrypto/trc/v2/update_test.go
@@ -1,0 +1,783 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package trc_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/scrypto"
+	trc "github.com/scionproto/scion/go/lib/scrypto/trc/v2"
+	"github.com/scionproto/scion/go/lib/util"
+)
+
+// TestCommonUpdate tests shared error cases between regular and sensitive updates.
+func TestCommonUpdate(t *testing.T) {
+	tests := map[string]struct {
+		Modify         func(updated, prev *trc.TRC)
+		ExpectedErrMsg string
+	}{
+		"Trust reset": {
+			Modify: func(updated, _ *trc.TRC) {
+				*updated = *newBaseTRC()
+				updated.Version = 2
+				updated.BaseVersion = 2
+			},
+			ExpectedErrMsg: trc.ErrBaseNotUpdate.Error(),
+		},
+		"Invariant violation": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.Validity.NotAfter = updated.Validity.NotBefore
+			},
+			ExpectedErrMsg: trc.InvalidValidityPeriod,
+		},
+		"Wrong ISD": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.ISD = 2
+			},
+			ExpectedErrMsg: trc.ImmutableISD,
+		},
+		"Wrong Version": {
+			Modify: func(updated, prev *trc.TRC) {
+				updated.Version = prev.Version + 2
+			},
+			ExpectedErrMsg: trc.InvalidVersionIncrement,
+		},
+		"Changed TrustResetAllowed": {
+			Modify: func(updated, prev *trc.TRC) {
+				*updated.TrustResetAllowedPtr = !prev.TrustResetAllowed()
+			},
+			ExpectedErrMsg: trc.ImmutableTrustResetAllowed,
+		},
+		"New NotBefore not in Validity": {
+			Modify: func(updated, prev *trc.TRC) {
+				updated.Validity = &scrypto.Validity{
+					NotBefore: util.UnixTime{Time: prev.Validity.NotAfter.Add(time.Hour)},
+					NotAfter:  util.UnixTime{Time: prev.Validity.NotAfter.Add(8760 * time.Hour)},
+				}
+			},
+			ExpectedErrMsg: trc.NotInsidePreviousValidityPeriod,
+		},
+		"Changed BaseVersion": {
+			Modify: func(updated, prev *trc.TRC) {
+				prev.Version = 5
+				updated.Version = 6
+				updated.BaseVersion = 2
+			},
+			ExpectedErrMsg: trc.ImmutableBaseVersion,
+		},
+	}
+	for name, test := range tests {
+		run := func(t *testing.T, trcs func() (*trc.TRC, *trc.TRC), updateType trc.UpdateType) {
+			updated, prev := trcs()
+			test.Modify(updated, prev)
+			v := trc.UpdateValidator{
+				Prev: prev,
+				Next: updated,
+			}
+			info, err := v.Validate()
+			if test.ExpectedErrMsg == "" {
+				require.NoError(t, err)
+				assert.Equal(t, updateType, info.Type)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.ExpectedErrMsg)
+			}
+		}
+		t.Run(name+" (regular)", func(t *testing.T) {
+			run(t, newRegularUpdate, trc.RegularUpdate)
+		})
+		sensitiveUpdate := func() (*trc.TRC, *trc.TRC) {
+			updated, prev := newSensitiveUpdate()
+			*updated.VotingQuorumPtr -= 1
+			return updated, prev
+		}
+		t.Run(name+" (sensitive)", func(t *testing.T) {
+			run(t, sensitiveUpdate, trc.SensitiveUpdate)
+		})
+	}
+}
+
+func TestSensitiveUpdate(t *testing.T) {
+	tests := map[string]struct {
+		Modify         func(updated, prev *trc.TRC)
+		Info           trc.UpdateInfo
+		ExpectedErrMsg string
+	}{
+		// Valid updates
+
+		"Votes not cast by all": {
+			Modify: func(updated, prev *trc.TRC) {
+				*prev.VotingQuorumPtr -= 1
+				delete(updated.Votes, a110)
+			},
+			Info: trc.UpdateInfo{
+				Type: trc.SensitiveUpdate,
+			},
+		},
+		"Decreased VotingQuorum": {
+			Modify: func(updated, _ *trc.TRC) {
+				*updated.VotingQuorumPtr -= 1
+			},
+			Info: trc.UpdateInfo{
+				Type: trc.SensitiveUpdate,
+			},
+		},
+		"Add new Issuing and Voting AS": {
+			Modify: func(updated, _ *trc.TRC) {
+				*updated.VotingQuorumPtr += 1
+				updated.PrimaryASes[a190] = trc.PrimaryAS{
+					Attributes: trc.Attributes{trc.Issuing, trc.Voting},
+					Keys: map[trc.KeyType]trc.KeyMeta{
+						trc.OnlineKey: {
+							KeyVersion: 1,
+							Algorithm:  scrypto.Ed25519,
+							Key:        []byte{0, 190, 1},
+						},
+						trc.OfflineKey: {
+							KeyVersion: 1,
+							Algorithm:  scrypto.Ed25519,
+							Key:        []byte{1, 190, 1},
+						},
+						trc.IssuingKey: {
+							KeyVersion: 1,
+							Algorithm:  scrypto.Ed25519,
+							Key:        []byte{2, 190, 1},
+						},
+					},
+				}
+				updated.ProofOfPossession[a190] = []trc.KeyType{
+					trc.OnlineKey, trc.OfflineKey, trc.IssuingKey}
+			},
+			Info: trc.UpdateInfo{
+				Type: trc.SensitiveUpdate,
+				KeyChanges: &trc.KeyChanges{
+					Fresh: map[trc.KeyType]trc.ASToKeyMeta{
+						trc.OnlineKey: {
+							a190: {
+								KeyVersion: 1,
+								Algorithm:  scrypto.Ed25519,
+								Key:        []byte{0, 190, 1},
+							},
+						},
+						trc.OfflineKey: {
+							a190: {
+								KeyVersion: 1,
+								Algorithm:  scrypto.Ed25519,
+								Key:        []byte{1, 190, 1},
+							},
+						},
+						trc.IssuingKey: {
+							a190: {
+								KeyVersion: 1,
+								Algorithm:  scrypto.Ed25519,
+								Key:        []byte{2, 190, 1},
+							},
+						},
+					},
+				},
+				AttributeChanges: trc.AttributeChanges{
+					a190: map[trc.Attribute]trc.AttributeChange{
+						trc.Voting:  trc.AttributeAdded,
+						trc.Issuing: trc.AttributeAdded,
+					},
+				},
+			},
+		},
+		"Remove Voting AS": {
+			Modify: func(updated, _ *trc.TRC) {
+				*updated.VotingQuorumPtr -= 1
+				delete(updated.PrimaryASes, a140)
+			},
+			Info: trc.UpdateInfo{
+				Type: trc.SensitiveUpdate,
+				AttributeChanges: trc.AttributeChanges{
+					a140: map[trc.Attribute]trc.AttributeChange{
+						trc.Voting: trc.AttributeRemoved,
+					},
+				},
+			},
+		},
+		"Promote AS to Issuing": {
+			Modify: func(updated, _ *trc.TRC) {
+				primary := updated.PrimaryASes[a150]
+				primary.Attributes = append(primary.Attributes, trc.Issuing)
+				primary.Keys = map[trc.KeyType]trc.KeyMeta{
+					trc.IssuingKey: {
+						KeyVersion: 1,
+						Algorithm:  scrypto.Ed25519,
+						Key:        []byte{2, 150, 1},
+					},
+				}
+				updated.PrimaryASes[a150] = primary
+				updated.ProofOfPossession[a150] = []trc.KeyType{trc.IssuingKey}
+			},
+			Info: trc.UpdateInfo{
+				Type: trc.SensitiveUpdate,
+				KeyChanges: &trc.KeyChanges{
+					Fresh: map[trc.KeyType]trc.ASToKeyMeta{
+						trc.IssuingKey: {
+							a150: {
+								KeyVersion: 1,
+								Algorithm:  scrypto.Ed25519,
+								Key:        []byte{2, 150, 1},
+							},
+						},
+					},
+				},
+			},
+		},
+		"Promote AS to Voting": {
+			Modify: func(updated, _ *trc.TRC) {
+				primary := updated.PrimaryASes[a130]
+				primary.Attributes = trc.Attributes{trc.Issuing, trc.Core, trc.Voting}
+				primary.Keys[trc.OnlineKey] = trc.KeyMeta{
+					KeyVersion: 1,
+					Algorithm:  scrypto.Ed25519,
+					Key:        []byte{0, 130, 1},
+				}
+				primary.Keys[trc.OfflineKey] = trc.KeyMeta{
+					KeyVersion: 1,
+					Algorithm:  scrypto.Ed25519,
+					Key:        []byte{1, 130, 1},
+				}
+				updated.PrimaryASes[a130] = primary
+				updated.ProofOfPossession[a130] = []trc.KeyType{trc.OfflineKey, trc.OnlineKey}
+			},
+			Info: trc.UpdateInfo{
+				Type: trc.SensitiveUpdate,
+				KeyChanges: &trc.KeyChanges{
+					Fresh: map[trc.KeyType]trc.ASToKeyMeta{
+						trc.OnlineKey: {
+							a130: {
+								KeyVersion: 1,
+								Algorithm:  scrypto.Ed25519,
+								Key:        []byte{0, 130, 1},
+							},
+						},
+						trc.OfflineKey: {
+							a130: {
+								KeyVersion: 1,
+								Algorithm:  scrypto.Ed25519,
+								Key:        []byte{1, 130, 1},
+							},
+						},
+					},
+				},
+				AttributeChanges: trc.AttributeChanges{
+					a130: map[trc.Attribute]trc.AttributeChange{
+						trc.Voting: trc.AttributeAdded,
+					},
+				},
+			},
+		},
+		"Demote AS from Voting": {
+			Modify: func(updated, _ *trc.TRC) {
+				*updated.VotingQuorumPtr -= 1
+				primary := updated.PrimaryASes[a110]
+				primary.Attributes = trc.Attributes{trc.Issuing, trc.Core}
+				delete(primary.Keys, trc.OnlineKey)
+				delete(primary.Keys, trc.OfflineKey)
+				updated.PrimaryASes[a110] = primary
+			},
+			Info: trc.UpdateInfo{
+				Type: trc.SensitiveUpdate,
+				AttributeChanges: trc.AttributeChanges{
+					a110: map[trc.Attribute]trc.AttributeChange{
+						trc.Voting: trc.AttributeRemoved,
+					},
+				},
+			},
+		},
+		"Demote AS from Issuing": {
+			Modify: func(updated, _ *trc.TRC) {
+				primary := updated.PrimaryASes[a110]
+				primary.Attributes = trc.Attributes{trc.Voting, trc.Core}
+				delete(primary.Keys, trc.IssuingKey)
+				updated.PrimaryASes[a110] = primary
+			},
+			Info: trc.UpdateInfo{
+				Type: trc.SensitiveUpdate,
+				AttributeChanges: trc.AttributeChanges{
+					a110: map[trc.Attribute]trc.AttributeChange{
+						trc.Issuing: trc.AttributeRemoved,
+					},
+				},
+			},
+		},
+		"Update offline key": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.PrimaryASes[a110].Keys[trc.OfflineKey] = trc.KeyMeta{
+					KeyVersion: 2,
+					Algorithm:  scrypto.Ed25519,
+					Key:        []byte{1, 110, 2},
+				}
+				updated.ProofOfPossession[a110] = []trc.KeyType{trc.OfflineKey}
+			},
+			Info: trc.UpdateInfo{
+				Type: trc.SensitiveUpdate,
+				KeyChanges: &trc.KeyChanges{
+					Modified: map[trc.KeyType]trc.ASToKeyMeta{
+						trc.OfflineKey: {
+							a110: {
+								KeyVersion: 2,
+								Algorithm:  scrypto.Ed25519,
+								Key:        []byte{1, 110, 2},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		// Invalid updates
+
+		"VotingQuorum zero": {
+			Modify: func(updated, _ *trc.TRC) {
+				*updated.VotingQuorumPtr = 0
+			},
+			ExpectedErrMsg: trc.ErrZeroVotingQuorum.Error(),
+		},
+		"VotingQuorum larger than voting ASes": {
+			Modify: func(updated, _ *trc.TRC) {
+				*updated.VotingQuorumPtr = uint8(updated.PrimaryASes.Count(trc.Voting) + 1)
+			},
+			ExpectedErrMsg: trc.VotingQuorumTooLarge,
+		},
+		"Underflow voting quorum": {
+			Modify: func(updated, _ *trc.TRC) {
+				delete(updated.PrimaryASes, a140)
+			},
+			ExpectedErrMsg: trc.VotingQuorumTooLarge,
+		},
+		"Vote quorum too small": {
+			Modify: func(updated, _ *trc.TRC) {
+				// Make sure this is a sensitive update
+				*updated.VotingQuorumPtr = 1
+				delete(updated.Votes, a120)
+				delete(updated.Votes, a140)
+			},
+			ExpectedErrMsg: trc.QuorumUnmet,
+		},
+		"New Voting AS that does not sign with offline key": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.PrimaryASes[a190] = trc.PrimaryAS{
+					Attributes: trc.Attributes{trc.Voting, trc.Core},
+					Keys: map[trc.KeyType]trc.KeyMeta{
+						trc.OnlineKey: {
+							KeyVersion: 1,
+							Algorithm:  scrypto.Ed25519,
+							Key:        []byte{0, 190, 1},
+						},
+						trc.OfflineKey: {
+							KeyVersion: 1,
+							Algorithm:  scrypto.Ed25519,
+							Key:        []byte{1, 190, 1},
+						},
+					},
+				}
+				updated.ProofOfPossession[a190] = []trc.KeyType{trc.OnlineKey}
+			},
+			ExpectedErrMsg: trc.MissingProofOfPossession,
+		},
+		"New Voting AS that does not sign with online key": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.PrimaryASes[a190] = trc.PrimaryAS{
+					Attributes: trc.Attributes{trc.Voting, trc.Core},
+					Keys: map[trc.KeyType]trc.KeyMeta{
+						trc.OnlineKey: {
+							KeyVersion: 1,
+							Algorithm:  scrypto.Ed25519,
+							Key:        []byte{0, 190, 1},
+						},
+						trc.OfflineKey: {
+							KeyVersion: 1,
+							Algorithm:  scrypto.Ed25519,
+							Key:        []byte{1, 190, 1},
+						},
+					},
+				}
+				updated.ProofOfPossession[a190] = []trc.KeyType{trc.OnlineKey}
+			},
+			ExpectedErrMsg: trc.MissingProofOfPossession,
+		},
+		"Promoted Issuing AS has no key": {
+			Modify: func(updated, _ *trc.TRC) {
+				primary := updated.PrimaryASes[a150]
+				primary.Attributes = append(primary.Attributes, trc.Issuing)
+				updated.PrimaryASes[a150] = primary
+			},
+			ExpectedErrMsg: trc.MissingKey,
+		},
+		"Demoted AS keeps offline key": {
+			Modify: func(updated, _ *trc.TRC) {
+				*updated.VotingQuorumPtr -= 1
+				primary := updated.PrimaryASes[a110]
+				primary.Attributes = trc.Attributes{trc.Issuing, trc.Core}
+				updated.PrimaryASes[a110] = primary
+			},
+			ExpectedErrMsg: trc.UnexpectedKey,
+		},
+		"Unexpected proof of possession": {
+			Modify: func(updated, _ *trc.TRC) {
+				*updated.VotingQuorumPtr -= 1
+				updated.ProofOfPossession[a110] = []trc.KeyType{trc.OnlineKey}
+			},
+			ExpectedErrMsg: trc.UnexpectedProofOfPossession,
+		},
+		"Update offline key without proof of possession": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.PrimaryASes[a110].Keys[trc.OfflineKey] = trc.KeyMeta{
+					KeyVersion: 2,
+					Algorithm:  scrypto.Ed25519,
+					Key:        []byte{1, 110, 2},
+				}
+			},
+			ExpectedErrMsg: trc.MissingProofOfPossession,
+		},
+		"Increase offline key version without modification": {
+			Modify: func(updated, _ *trc.TRC) {
+				meta := updated.PrimaryASes[a110].Keys[trc.OfflineKey]
+				meta.KeyVersion = 2
+				updated.PrimaryASes[a110].Keys[trc.OfflineKey] = meta
+				updated.ProofOfPossession[a110] = append(updated.ProofOfPossession[a110],
+					trc.OfflineKey)
+			},
+			ExpectedErrMsg: trc.InvalidKeyVersion,
+		},
+		"Modify offline key without increasing version": {
+			Modify: func(updated, _ *trc.TRC) {
+				meta := updated.PrimaryASes[a110].Keys[trc.OfflineKey]
+				meta.KeyVersion = 2
+				updated.PrimaryASes[a110].Keys[trc.OfflineKey] = meta
+				updated.ProofOfPossession[a110] = append(updated.ProofOfPossession[a110],
+					trc.OfflineKey)
+			},
+			ExpectedErrMsg: trc.InvalidKeyVersion,
+		},
+		"Increase offline key version by 2": {
+			Modify: func(updated, _ *trc.TRC) {
+				meta := updated.PrimaryASes[a110].Keys[trc.OfflineKey]
+				meta.KeyVersion += 2
+				meta.Key = []byte{1, 110, uint8(meta.KeyVersion)}
+				updated.PrimaryASes[a110].Keys[trc.OfflineKey] = meta
+				updated.ProofOfPossession[a110] = append(updated.ProofOfPossession[a110],
+					trc.OfflineKey)
+			},
+			ExpectedErrMsg: trc.InvalidKeyVersion,
+		},
+		"Signature from non-Voting AS": {
+			Modify: func(updated, _ *trc.TRC) {
+				*updated.VotingQuorumPtr -= 1
+				updated.Votes[a130] = trc.Vote{
+					Type:       trc.IssuingKey,
+					KeyVersion: 1,
+				}
+			},
+			ExpectedErrMsg: trc.ErrNoVotingRight.Error(),
+		},
+		"Signature from unknown AS": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.PrimaryASes[a190] = trc.PrimaryAS{
+					Attributes: trc.Attributes{trc.Core},
+				}
+				updated.Votes[a190] = trc.Vote{
+					Type:       trc.OnlineKey,
+					KeyVersion: 1,
+				}
+			},
+			ExpectedErrMsg: trc.ErrUnexpectedVote.Error(),
+		},
+		"Wrong KeyType on Vote": {
+			Modify: func(updated, _ *trc.TRC) {
+				*updated.VotingQuorumPtr -= 1
+				updated.Votes[a110] = trc.Vote{
+					Type:       trc.OnlineKey,
+					KeyVersion: 1,
+				}
+			},
+			ExpectedErrMsg: trc.WrongVotingKeyType,
+		},
+		"Wrong KeyVersion": {
+			Modify: func(updated, _ *trc.TRC) {
+				*updated.VotingQuorumPtr -= 1
+				updated.Votes[a110] = trc.Vote{
+					Type:       trc.OfflineKey,
+					KeyVersion: 10,
+				}
+			},
+			ExpectedErrMsg: trc.WrongVotingKeyVersion,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			updated, prev := newSensitiveUpdate()
+			test.Modify(updated, prev)
+			v := trc.UpdateValidator{
+				Prev: prev,
+				Next: updated,
+			}
+			info, err := v.Validate()
+			if test.ExpectedErrMsg == "" {
+				require.NoError(t, err)
+				assert.Equal(t, trc.SensitiveUpdate, info.Type)
+				initKeyChanges(&test.Info)
+				assert.Equal(t, test.Info.KeyChanges, info.KeyChanges)
+				//assert.Equal(t, test.Info, info)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.ExpectedErrMsg)
+			}
+		})
+	}
+}
+
+func TestRegularUpdate(t *testing.T) {
+	tests := map[string]struct {
+		Modify         func(updated, prev *trc.TRC)
+		Info           trc.UpdateInfo
+		ExpectedErrMsg string
+	}{
+		// Valid updates
+
+		"No modification": {
+			Modify: func(_, _ *trc.TRC) {},
+			Info: trc.UpdateInfo{
+				Type: trc.RegularUpdate,
+			},
+		},
+		"Update Description": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.Description = "This is the updated description"
+			},
+			Info: trc.UpdateInfo{
+				Type: trc.RegularUpdate,
+			},
+		},
+		"Update issuing key": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.PrimaryASes[a110].Keys[trc.IssuingKey] = trc.KeyMeta{
+					KeyVersion: 2,
+					Algorithm:  scrypto.Ed25519,
+					Key:        []byte{2, 110, 2},
+				}
+				updated.ProofOfPossession[a110] = []trc.KeyType{trc.IssuingKey}
+			},
+			Info: trc.UpdateInfo{
+				Type: trc.RegularUpdate,
+				KeyChanges: &trc.KeyChanges{
+					Modified: map[trc.KeyType]trc.ASToKeyMeta{
+						trc.IssuingKey: {
+							a110: {
+								KeyVersion: 2,
+								Algorithm:  scrypto.Ed25519,
+								Key:        []byte{2, 110, 2},
+							},
+						},
+					},
+				},
+			},
+		},
+		"Update online key": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.PrimaryASes[a110].Keys[trc.OnlineKey] = trc.KeyMeta{
+					KeyVersion: 2,
+					Algorithm:  scrypto.Ed25519,
+					Key:        []byte{0, 110, 2},
+				}
+				updated.ProofOfPossession[a110] = []trc.KeyType{trc.OnlineKey}
+				updated.Votes[a110] = trc.Vote{
+					Type:       trc.OfflineKey,
+					KeyVersion: 1,
+				}
+			},
+			Info: trc.UpdateInfo{
+				Type: trc.RegularUpdate,
+				KeyChanges: &trc.KeyChanges{
+					Modified: map[trc.KeyType]trc.ASToKeyMeta{
+						trc.OnlineKey: {
+							a110: {
+								KeyVersion: 2,
+								Algorithm:  scrypto.Ed25519,
+								Key:        []byte{0, 110, 2},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		// Invalid updates
+
+		"Signature from previous non-Primary AS": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.Votes[a190] = trc.Vote{
+					Type:       trc.OnlineKey,
+					KeyVersion: 1,
+				}
+			},
+			ExpectedErrMsg: trc.ErrUnexpectedVote.Error(),
+		},
+		"Signature from non-Voting AS": {
+			Modify: func(updated, prev *trc.TRC) {
+				updated.Votes[a130] = trc.Vote{
+					Type:       trc.OnlineKey,
+					KeyVersion: 1,
+				}
+			},
+			ExpectedErrMsg: trc.ErrNoVotingRight.Error(),
+		},
+		"Wrong KeyType": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.Votes[a110] = trc.Vote{
+					Type:       trc.OfflineKey,
+					KeyVersion: 1,
+				}
+			},
+			ExpectedErrMsg: trc.WrongVotingKeyType,
+		},
+		"Wrong KeyVersion": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.Votes[a110] = trc.Vote{
+					Type:       trc.OnlineKey,
+					KeyVersion: 10,
+				}
+			},
+			ExpectedErrMsg: trc.WrongVotingKeyVersion,
+		},
+		"Signature Quorum too small": {
+			Modify: func(updated, _ *trc.TRC) {
+				delete(updated.Votes, a140)
+			},
+			ExpectedErrMsg: trc.QuorumUnmet,
+		},
+		"Missing proof of possession": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.PrimaryASes[a110].Keys[trc.OnlineKey] = trc.KeyMeta{
+					KeyVersion: 2,
+					Algorithm:  scrypto.Ed25519,
+					Key:        []byte{0, 110, 2},
+				}
+				updated.Votes[a110] = trc.Vote{
+					Type:       trc.OfflineKey,
+					KeyVersion: 1,
+				}
+			},
+			ExpectedErrMsg: trc.MissingProofOfPossession,
+		},
+		"Unexpected proof of possession": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.ProofOfPossession[a110] = []trc.KeyType{trc.IssuingKey}
+			},
+			ExpectedErrMsg: trc.UnexpectedProofOfPossession,
+		},
+		"Update online key with online vote": {
+			Modify: func(updated, _ *trc.TRC) {
+				updated.PrimaryASes[a110].Keys[trc.OnlineKey] = trc.KeyMeta{
+					KeyVersion: 2,
+					Algorithm:  scrypto.Ed25519,
+					Key:        []byte{0, 110, 2},
+				}
+				updated.ProofOfPossession[a110] = []trc.KeyType{trc.OnlineKey}
+			},
+			ExpectedErrMsg: trc.WrongVotingKeyType,
+		},
+		"Update online key without any vote": {
+			Modify: func(updated, prev *trc.TRC) {
+				*prev.VotingQuorumPtr = 2
+				*updated.VotingQuorumPtr = 2
+				updated.PrimaryASes[a110].Keys[trc.OnlineKey] = trc.KeyMeta{
+					KeyVersion: 2,
+					Algorithm:  scrypto.Ed25519,
+					Key:        []byte{0, 110, 2},
+				}
+				updated.ProofOfPossession[a110] = []trc.KeyType{trc.OnlineKey}
+				delete(updated.Votes, a110)
+			},
+			ExpectedErrMsg: trc.MissingVote,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			updated, prev := newRegularUpdate()
+			test.Modify(updated, prev)
+			v := trc.UpdateValidator{
+				Prev: prev,
+				Next: updated,
+			}
+			info, err := v.Validate()
+			if test.ExpectedErrMsg == "" {
+				require.NoError(t, err)
+				assert.Equal(t, trc.RegularUpdate, info.Type)
+				initKeyChanges(&test.Info)
+				assert.Equal(t, test.Info.KeyChanges, info.KeyChanges)
+				//assert.Equal(t, test.Info, info)
+			} else {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.ExpectedErrMsg)
+			}
+		})
+	}
+}
+
+func initKeyChanges(info *trc.UpdateInfo) {
+	if info.KeyChanges == nil {
+		info.KeyChanges = &trc.KeyChanges{}
+	}
+	initModType := func(m *map[trc.KeyType]trc.ASToKeyMeta) {
+		if *m == nil {
+			*m = make(map[trc.KeyType]trc.ASToKeyMeta)
+		}
+		for _, keyType := range []trc.KeyType{trc.OnlineKey, trc.OfflineKey, trc.IssuingKey} {
+			if _, ok := (*m)[keyType]; !ok {
+				(*m)[keyType] = make(trc.ASToKeyMeta)
+			}
+		}
+	}
+	initModType(&info.KeyChanges.Fresh)
+	initModType(&info.KeyChanges.Modified)
+}
+
+func newRegularUpdate() (*trc.TRC, *trc.TRC) {
+	t := newBaseTRC()
+	t.Version = 2
+	t.GracePeriod = &trc.Period{Duration: 6 * time.Hour}
+	t.Votes = map[addr.AS]trc.Vote{
+		a110: {Type: trc.OnlineKey, KeyVersion: 1},
+		a120: {Type: trc.OnlineKey, KeyVersion: 1},
+		a140: {Type: trc.OnlineKey, KeyVersion: 1},
+	}
+	t.ProofOfPossession = make(map[addr.AS][]trc.KeyType)
+	return t, newBaseTRC()
+}
+
+// newSensitive creates an update that is signed with the offline keys.
+// The caller has to add the sensitive change.
+func newSensitiveUpdate() (*trc.TRC, *trc.TRC) {
+	t, _ := newRegularUpdate()
+	t.Version = 3
+	t.GracePeriod = &trc.Period{Duration: 6 * time.Hour}
+	t.Votes = map[addr.AS]trc.Vote{
+		a110: {Type: trc.OfflineKey, KeyVersion: 1},
+		a120: {Type: trc.OfflineKey, KeyVersion: 1},
+		a140: {Type: trc.OfflineKey, KeyVersion: 1},
+	}
+	t.ProofOfPossession = make(map[addr.AS][]trc.KeyType)
+	prev, _ := newRegularUpdate()
+	return t, prev
+}


### PR DESCRIPTION
This PR introduces TRC update validation.
The `UpdateValidator` checks that the new TRC contains valid contents
and the update is valid according to the regular/sensitive rules.

The caller has to verify the signatures itself. It must ensure that
all signatures mentioned in TRC.Votes are present and verifiable.

fixes #2849

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2860)
<!-- Reviewable:end -->
