### PR TITLE
trust store: Reduce log level of push received message

### DIFF
--- a/go/lib/infra/modules/trust/handlers.go
+++ b/go/lib/infra/modules/trust/handlers.go
@@ -204,8 +204,6 @@ func (h *trcPushHandler) Handle() *infra.HandlerResult {
 			"msg", h.request.Message, "type", common.TypeOf(h.request.Message))
 		return infra.MetricsErrInternal
 	}
-	logger.Debug("[TrustStore:trcPushHandler] Received push", "trcPush", trcPush,
-		"peer", h.request.Peer)
 	rw, ok := infra.ResponseWriterFromContext(h.request.Context())
 	if !ok {
 		logger.Warn("[TrustStore:trcPushHandler] Unable to service request, no Messenger found")
@@ -233,8 +231,9 @@ func (h *trcPushHandler) Handle() *infra.HandlerResult {
 		sendAck(proto.Ack_ErrCode_retry, messenger.AckRetryDBError)
 		return infra.MetricsErrTrustDB(err)
 	}
-	if n != 0 {
-		logger.Debug("[TrustStore:trcPushHandler] Inserted TRC into DB", "trc", trcObj)
+	if n > 0 {
+		logger.Info("[TrustStore:trcPushHandler] Inserted TRC into DB",
+			"trc", trcObj, "peer", h.request.Peer)
 	}
 	sendAck(proto.Ack_ErrCode_ok, "")
 	return infra.MetricsResultOk
@@ -253,8 +252,6 @@ func (h *chainPushHandler) Handle() *infra.HandlerResult {
 			"msg", h.request.Message, "type", common.TypeOf(h.request.Message))
 		return infra.MetricsErrInternal
 	}
-	logger.Debug("[TrustStore:chainPushHandler] Received push", "chainPush", chainPush,
-		"peer", h.request.Peer)
 	rw, ok := infra.ResponseWriterFromContext(h.request.Context())
 	if !ok {
 		logger.Warn("[TrustStore:chainPushHandler] Unable to service request, no Messenger found")
@@ -282,8 +279,9 @@ func (h *chainPushHandler) Handle() *infra.HandlerResult {
 		sendAck(proto.Ack_ErrCode_retry, messenger.AckRetryDBError)
 		return infra.MetricsErrTrustDB(err)
 	}
-	if n != 0 {
-		logger.Debug("[TrustStore:chainPushHandler] Inserted chain into DB", "chain", chain)
+	if n > 0 {
+		logger.Info("[TrustStore:chainPushHandler] Inserted chain into DB",
+			"chain", chain, "peer", h.request.Peer)
 	}
 	sendAck(proto.Ack_ErrCode_ok, "")
 	return infra.MetricsResultOk

--- a/go/lib/infra/modules/trust/handlers.go
+++ b/go/lib/infra/modules/trust/handlers.go
@@ -204,6 +204,8 @@ func (h *trcPushHandler) Handle() *infra.HandlerResult {
 			"msg", h.request.Message, "type", common.TypeOf(h.request.Message))
 		return infra.MetricsErrInternal
 	}
+	logger.Trace("[TrustStore:trcPushHandler] Received push", "trcPush", trcPush,
+		"peer", h.request.Peer)
 	rw, ok := infra.ResponseWriterFromContext(h.request.Context())
 	if !ok {
 		logger.Warn("[TrustStore:trcPushHandler] Unable to service request, no Messenger found")
@@ -252,6 +254,8 @@ func (h *chainPushHandler) Handle() *infra.HandlerResult {
 			"msg", h.request.Message, "type", common.TypeOf(h.request.Message))
 		return infra.MetricsErrInternal
 	}
+	logger.Trace("[TrustStore:chainPushHandler] Received push", "chainPush", chainPush,
+		"peer", h.request.Peer)
 	rw, ok := infra.ResponseWriterFromContext(h.request.Context())
 	if !ok {
 		logger.Warn("[TrustStore:chainPushHandler] Unable to service request, no Messenger found")

--- a/go/lib/infra/modules/trust/trustdb/trustdbtest/trustdbtest.go
+++ b/go/lib/infra/modules/trust/trustdb/trustdbtest/trustdbtest.go
@@ -294,6 +294,9 @@ func testChain(t *testing.T, db trustdb.ReadWrite) {
 			rows, err := db.InsertChain(ctx, chain)
 			SoMsg("err", err, ShouldBeNil)
 			SoMsg("rows", rows, ShouldNotEqual, 0)
+			rows, err = db.InsertChain(ctx, chain)
+			SoMsg("err", err, ShouldBeNil)
+			SoMsg("rows", rows, ShouldEqual, 0)
 			Convey("Get certificate chain from database", func() {
 				newChain, err := db.GetChainVersion(ctx, ia, 1)
 				SoMsg("err", err, ShouldBeNil)


### PR DESCRIPTION
Chain and TRC push handlers log that they received a msg only at trace level.
On the other hand a new TRC or Chain that was received is logged at info level.

Also make sure that a double insert of a chain in the trustdb return 0 modified rows.

Fixes #2866

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2869)
<!-- Reviewable:end -->
