### PR TITLE
cert: Add base certificate

### DIFF
--- a/go/lib/scrypto/cert/v2/BUILD.bazel
+++ b/go/lib/scrypto/cert/v2/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//go/lib/addr:go_default_library",
         "//go/lib/scrypto:go_default_library",
         "//go/lib/util:go_default_library",
         "//go/lib/xtest:go_default_library",

--- a/go/lib/scrypto/cert/v2/BUILD.bazel
+++ b/go/lib/scrypto/cert/v2/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["base.go"],
+    importpath = "github.com/scionproto/scion/go/lib/scrypto/cert/v2",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/scrypto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "base_json_test.go",
+        "base_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/lib/scrypto:go_default_library",
+        "//go/lib/util:go_default_library",
+        "//go/lib/xtest:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
+)

--- a/go/lib/scrypto/cert/v2/base.go
+++ b/go/lib/scrypto/cert/v2/base.go
@@ -30,10 +30,10 @@ import (
 const (
 	// InvalidKeyType indicates an inexistent key type.
 	InvalidKeyType = "invalid key type"
-	// InvalidVersion indicates an invalid TRC version.
-	InvalidVersion = "Invalid TRC version"
-	// UnsupportedFormat indicates an invalid TRC format.
-	UnsupportedFormat = "Unsupported TRC format"
+	// InvalidVersion indicates an invalid certificate version.
+	InvalidVersion = "Invalid certificate version"
+	// UnsupportedFormat indicates an invalid certificate format.
+	UnsupportedFormat = "Unsupported certificate format"
 )
 
 // Validation errors
@@ -170,8 +170,8 @@ const (
 
 var _ json.Unmarshaler = (*KeyType)(nil)
 
-// KeyType indicates the type of the key authenticated by the TRC. It can either
-// be "Signing", "Encryption", or "Issuing".
+// KeyType indicates the type of the key authenticated by the certificate. It
+// can either be "Signing", "Encryption", or "Issuing".
 type KeyType string
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -189,7 +189,7 @@ func (t *KeyType) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Version identifies the version of a TRC. It cannot be
+// Version identifies the version of a certificate. It cannot be
 // marshalled/unmarshalled to/from scrypto.LatestVer.
 type Version uint64
 
@@ -214,7 +214,7 @@ func (v Version) MarshalJSON() ([]byte, error) {
 	return json.Marshal(uint64(v))
 }
 
-// FormatVersion indicates the TRC format version. Currently, only format
+// FormatVersion indicates the certificate format version. Currently, only format
 // version 1 is supported.
 type FormatVersion uint8
 

--- a/go/lib/scrypto/cert/v2/base.go
+++ b/go/lib/scrypto/cert/v2/base.go
@@ -1,0 +1,232 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cert
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/scrypto"
+)
+
+// Parsing errors with context.
+const (
+	// InvalidKeyType indicates an inexistent key type.
+	InvalidKeyType = "invalid key type"
+	// InvalidVersion indicates an invalid TRC version.
+	InvalidVersion = "Invalid TRC version"
+	// UnsupportedFormat indicates an invalid TRC format.
+	UnsupportedFormat = "Unsupported TRC format"
+)
+
+// Validation errors
+const (
+	// InvalidValidityPeriod indicates an invalid validity period.
+	InvalidValidityPeriod = "invalid validity period"
+	// InvalidSubject indicates that the subject contains a wildcard.
+	InvalidSubject = "subject contains wildcard"
+	// UnexpectedKey indicates that the certificate holds an excess key.
+	UnexpectedKey = "unexpected key"
+	// MissingKey indicates that the certificate is missing a key.
+	MissingKey = "missing key"
+)
+
+var (
+	// ErrAlgorithmNotSet indicates the key algorithm is not set.
+	ErrAlgorithmNotSet = errors.New("algorithm not set")
+	// ErrKeyNotSet indicates the key is not set.
+	ErrKeyNotSet = errors.New("key not set")
+	// ErrKeyVersionNotSet indicates KeyVersion is not set.
+	ErrKeyVersionNotSet = errors.New("key version not set")
+)
+
+// Base contains the shared fields between the issuer and AS certificate.
+type Base struct {
+	// Subject identifies the subject of the certificate.
+	Subject addr.IA `json:"Subject"`
+	// Version indicates the certificate version.
+	Version Version `json:"Version"`
+	// FormatVersion is the certificate format version.
+	FormatVersion FormatVersion `json:"FormatVersion"`
+	// Description is a human-readable description of the certificate.
+	Description string `json:"Description"`
+	// Validity defines the validity period of the certificate.
+	Validity *scrypto.Validity `json:"Validity"`
+	// Keys holds all keys authenticated by this certificate.
+	Keys map[KeyType]KeyMeta `json:"Keys"`
+}
+
+// Validate validates the shared fields are set correctly.
+func (b *Base) Validate() error {
+	if b.Subject.IsWildcard() {
+		return common.NewBasicError(InvalidSubject, nil, "subject", b.Subject)
+	}
+	if err := b.Validity.Validate(); err != nil {
+		return common.NewBasicError(InvalidValidityPeriod, err, "validity", b.Validity)
+	}
+	return nil
+}
+
+func (b *Base) validateKeys(issuerCertificate bool) error {
+	if err := b.checkKeyExistence(IssuingKey, issuerCertificate); err != nil {
+		return err
+	}
+	if err := b.checkKeyExistence(SigningKey, !issuerCertificate); err != nil {
+		return err
+	}
+	if err := b.checkKeyExistence(EncryptionKey, !issuerCertificate); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (b *Base) checkKeyExistence(keyType KeyType, shouldExist bool) error {
+	_, ok := b.Keys[keyType]
+	if ok && !shouldExist {
+		return common.NewBasicError(UnexpectedKey, nil, "type", keyType)
+	}
+	if !ok && shouldExist {
+		return common.NewBasicError(MissingKey, nil, "type", keyType)
+	}
+	return nil
+}
+
+// KeyMeta holds the key with metadata.
+type KeyMeta struct {
+	// KeyVersion identifies the key. It must change if the key changes, and
+	// stay the same if the key does not change.
+	KeyVersion KeyVersion `json:"KeyVersion"`
+	// Algorithm indicates the algorithm associated with the key.
+	Algorithm string `json:"Algorithm"`
+	// Key is the raw public key.
+	Key common.RawBytes `json:"Key"`
+}
+
+// UnmarshalJSON checks that all fields are set.
+func (m *KeyMeta) UnmarshalJSON(b []byte) error {
+	var alias keyMetaAlias
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&alias); err != nil {
+		return err
+	}
+	if err := alias.checkAllSet(); err != nil {
+		return err
+	}
+	*m = KeyMeta{
+		KeyVersion: *alias.KeyVersion,
+		Algorithm:  *alias.Algorithm,
+		Key:        *alias.Key,
+	}
+	return nil
+}
+
+type keyMetaAlias struct {
+	KeyVersion *KeyVersion      `json:"KeyVersion"`
+	Algorithm  *string          `json:"Algorithm"`
+	Key        *common.RawBytes `json:"Key"`
+}
+
+func (m *keyMetaAlias) checkAllSet() error {
+	switch {
+	case m.KeyVersion == nil:
+		return ErrKeyVersionNotSet
+	case m.Algorithm == nil:
+		return ErrAlgorithmNotSet
+	case m.Key == nil:
+		return ErrKeyNotSet
+	}
+	return nil
+}
+
+// KeyVersion identifies a key for a given KeyType and ISD-AS.
+type KeyVersion uint64
+
+const (
+	// IssuingKey is the issuing key type. It must only appear in issuer certificates.
+	IssuingKey KeyType = "Issuing"
+	// SigningKey is the signing key type. It must only appear in AS certificates.
+	SigningKey KeyType = "Signing"
+	// EncryptionKey is the encryption key type. It must only appear in AS certificates.
+	EncryptionKey KeyType = "Encryption"
+)
+
+var _ json.Unmarshaler = (*KeyType)(nil)
+
+// KeyType indicates the type of the key authenticated by the TRC. It can either
+// be "Signing", "Encryption", or "Issuing".
+type KeyType string
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (t *KeyType) UnmarshalJSON(b []byte) error {
+	switch KeyType(strings.Trim(string(b), `"`)) {
+	case SigningKey:
+		*t = SigningKey
+	case EncryptionKey:
+		*t = EncryptionKey
+	case IssuingKey:
+		*t = IssuingKey
+	default:
+		return common.NewBasicError(InvalidKeyType, nil, "input", string(b))
+	}
+	return nil
+}
+
+// Version identifies the version of a TRC. It cannot be
+// marshalled/unmarshalled to/from scrypto.LatestVer.
+type Version uint64
+
+// UnmarshalJSON checks that the value is not scrypto.LatestVer.
+func (v *Version) UnmarshalJSON(b []byte) error {
+	parsed, err := strconv.ParseUint(string(b), 10, 64)
+	if err != nil {
+		return err
+	}
+	if parsed == scrypto.LatestVer {
+		return common.NewBasicError(InvalidVersion, nil, "ver", parsed)
+	}
+	*v = Version(parsed)
+	return nil
+}
+
+// MarshalJSON checks that the value is not scrypto.LatestVer.
+func (v Version) MarshalJSON() ([]byte, error) {
+	if uint64(v) == scrypto.LatestVer {
+		return nil, common.NewBasicError(InvalidVersion, nil, "ver", v)
+	}
+	return json.Marshal(uint64(v))
+}
+
+// FormatVersion indicates the TRC format version. Currently, only format
+// version 1 is supported.
+type FormatVersion uint8
+
+// UnmarshalJSON checks that the FormatVersion is supported.
+func (v *FormatVersion) UnmarshalJSON(b []byte) error {
+	parsed, err := strconv.ParseUint(string(b), 10, 8)
+	if err != nil {
+		return err
+	}
+	if parsed != 1 {
+		return common.NewBasicError(UnsupportedFormat, nil, "fmt", parsed)
+	}
+	*v = FormatVersion(parsed)
+	return nil
+}

--- a/go/lib/scrypto/cert/v2/base.go
+++ b/go/lib/scrypto/cert/v2/base.go
@@ -68,13 +68,13 @@ type Base struct {
 	FormatVersion FormatVersion `json:"FormatVersion"`
 	// Description is a human-readable description of the certificate.
 	Description string `json:"Description"`
+	// OptionalDistributionPoints contains optional certificate revocation
+	// distribution points.
+	OptionalDistributionPoints []addr.IA `json:"OptionalDistributionPoints"`
 	// Validity defines the validity period of the certificate.
 	Validity *scrypto.Validity `json:"Validity"`
 	// Keys holds all keys authenticated by this certificate.
 	Keys map[KeyType]scrypto.KeyMeta `json:"Keys"`
-	// OptionalDistributionPoints contains optional certificate revocation
-	// distribution points.
-	OptionalDistributionPoints []addr.IA `json:"OptionalDistributionPoints"`
 }
 
 // Validate validates the shared fields are set correctly.

--- a/go/lib/scrypto/cert/v2/base_json_test.go
+++ b/go/lib/scrypto/cert/v2/base_json_test.go
@@ -1,0 +1,241 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cert_test
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/scrypto/cert/v2"
+	"github.com/scionproto/scion/go/lib/xtest"
+)
+
+func TestKeyMetaUnmarshalJSON(t *testing.T) {
+	tests := map[string]struct {
+		Input          string
+		Meta           cert.KeyMeta
+		ExpectedErrMsg string
+	}{
+		"Valid": {
+			Input: `
+			{
+				"KeyVersion": 1,
+				"Algorithm": "ed25519",
+				"Key": "YW5hcGF5YSDinaQgIHNjaW9u"
+			}`,
+			Meta: cert.KeyMeta{
+				KeyVersion: 1,
+				Algorithm:  scrypto.Ed25519,
+				Key:        xtest.MustParseHexString("616e617061796120e29da420207363696f6e"),
+			},
+		},
+		"KeyVersion not set": {
+			Input: `
+			{
+				"Algorithm": "ed25519",
+				"Key": "YW5hcGF5YSDinaQgIHNjaW9u"
+			}`,
+			ExpectedErrMsg: cert.ErrKeyVersionNotSet.Error(),
+		},
+		"Algorithm not set": {
+			Input: `
+			{
+				"KeyVersion": 1,
+				"Key": "YW5hcGF5YSDinaQgIHNjaW9u"
+			}`,
+			ExpectedErrMsg: cert.ErrAlgorithmNotSet.Error(),
+		},
+		"Key not set": {
+			Input: `
+			{
+				"KeyVersion": 1,
+				"Algorithm": "ed25519"
+			}`,
+			ExpectedErrMsg: cert.ErrKeyNotSet.Error(),
+		},
+		"Unknown field": {
+			Input: `
+			{
+				"UnknownField": "UNKNOWN"
+			}`,
+			ExpectedErrMsg: `json: unknown field "UnknownField"`,
+		},
+		"invalid json": {
+			Input: `
+			{
+				"KeyVersion": 1,
+				"Algorithm": "ed25519"
+			`,
+			ExpectedErrMsg: "unexpected end of JSON input",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var meta cert.KeyMeta
+			err := json.Unmarshal([]byte(test.Input), &meta)
+			if test.ExpectedErrMsg == "" {
+				require.NoError(t, err)
+				assert.Equal(t, test.Meta, meta)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.ExpectedErrMsg)
+			}
+		})
+	}
+}
+
+func TestKeyTypeUnmarshalJSON(t *testing.T) {
+	tests := map[string]struct {
+		Input     string
+		Assertion assert.ErrorAssertionFunc
+		Expected  cert.KeyType
+	}{
+		"Garbage": {
+			Input:     `"test"`,
+			Assertion: assert.Error,
+		},
+		"Integer": {
+			Input:     `42`,
+			Assertion: assert.Error,
+		},
+		"Wrong case": {
+			Input:     `"offline"`,
+			Assertion: assert.Error,
+		},
+		"SigningKey": {
+			Input:     `"Signing"`,
+			Assertion: assert.NoError,
+			Expected:  cert.SigningKey,
+		},
+		"EncryptionKey": {
+			Input:     `"Encryption"`,
+			Assertion: assert.NoError,
+			Expected:  cert.EncryptionKey,
+		},
+		"IssuingKey": {
+			Input:     `"Issuing"`,
+			Assertion: assert.NoError,
+			Expected:  cert.IssuingKey,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var keyType cert.KeyType
+			test.Assertion(t, json.Unmarshal([]byte(test.Input), &keyType))
+			assert.Equal(t, test.Expected, keyType)
+		})
+	}
+}
+
+func TestFormatVersionUnmarshalJSON(t *testing.T) {
+	tests := map[string]struct {
+		Input     []byte
+		Expected  cert.FormatVersion
+		Assertion assert.ErrorAssertionFunc
+	}{
+		"Valid": {
+			Input:     []byte("1"),
+			Expected:  1,
+			Assertion: assert.NoError,
+		},
+		"Unsupported": {
+			Input:     []byte("0"),
+			Assertion: assert.Error,
+		},
+		"String": {
+			Input:     []byte(`"0"`),
+			Assertion: assert.Error,
+		},
+		"Garbage": {
+			Input:     []byte(`"Garbage"`),
+			Assertion: assert.Error,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var v cert.FormatVersion
+			test.Assertion(t, json.Unmarshal(test.Input, &v))
+			assert.Equal(t, test.Expected, v)
+
+		})
+	}
+}
+
+func TestVersionUnmarshalJSON(t *testing.T) {
+	tests := map[string]struct {
+		Input     []byte
+		Expected  cert.Version
+		Assertion assert.ErrorAssertionFunc
+	}{
+		"Valid": {
+			Input:     []byte("1"),
+			Expected:  1,
+			Assertion: assert.NoError,
+		},
+		"Reserved": {
+			Input:     []byte(strconv.FormatUint(scrypto.LatestVer, 10)),
+			Assertion: assert.Error,
+		},
+		"String": {
+			Input:     []byte(`"1"`),
+			Assertion: assert.Error,
+		},
+		"Garbage": {
+			Input:     []byte(`"Garbage"`),
+			Assertion: assert.Error,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var v cert.Version
+			test.Assertion(t, json.Unmarshal(test.Input, &v))
+			assert.Equal(t, test.Expected, v)
+		})
+	}
+}
+
+func TestVersionMarshalJSON(t *testing.T) {
+	type mockCert struct {
+		Version cert.Version
+	}
+	tests := map[string]struct {
+		// Use a struct to simulate TRC marshaling. Pointer vs value receiver.
+		Input     mockCert
+		Expected  []byte
+		Assertion assert.ErrorAssertionFunc
+	}{
+		"Valid": {
+			Input:     mockCert{Version: 1},
+			Expected:  []byte(`{"Version":1}`),
+			Assertion: assert.NoError,
+		},
+		"Reserved": {
+			Input:     mockCert{Version: cert.Version(scrypto.LatestVer)},
+			Assertion: assert.Error,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			b, err := json.Marshal(test.Input)
+			test.Assertion(t, err)
+			assert.Equal(t, test.Expected, b)
+		})
+	}
+}

--- a/go/lib/scrypto/cert/v2/base_json_test.go
+++ b/go/lib/scrypto/cert/v2/base_json_test.go
@@ -38,7 +38,7 @@ func TestKeyTypeUnmarshalJSON(t *testing.T) {
 			Assertion: assert.Error,
 		},
 		"Wrong case": {
-			Input:     `"offline"`,
+			Input:     `"signing"`,
 			Assertion: assert.Error,
 		},
 		"SigningKey": {

--- a/go/lib/scrypto/cert/v2/base_json_test.go
+++ b/go/lib/scrypto/cert/v2/base_json_test.go
@@ -216,7 +216,7 @@ func TestVersionMarshalJSON(t *testing.T) {
 		Version cert.Version
 	}
 	tests := map[string]struct {
-		// Use a struct to simulate TRC marshaling. Pointer vs value receiver.
+		// Use a struct to simulate certificate marshaling. Pointer vs value receiver.
 		Input     mockCert
 		Expected  []byte
 		Assertion assert.ErrorAssertionFunc

--- a/go/lib/scrypto/cert/v2/base_test.go
+++ b/go/lib/scrypto/cert/v2/base_test.go
@@ -1,0 +1,87 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cert_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/scrypto/cert/v2"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/lib/xtest"
+)
+
+var ia110 = xtest.MustParseIA("1-ff00:0:110")
+
+func TestBaseValidate(t *testing.T) {
+	tests := map[string]struct {
+		Modify         func(*cert.Base)
+		ExpectedErrMsg string
+	}{
+		"Valid": {
+			Modify: func(_ *cert.Base) {},
+		},
+		"Subject wildcard AS": {
+			Modify: func(c *cert.Base) {
+				c.Subject.A = 0
+			},
+			ExpectedErrMsg: cert.InvalidSubject,
+		},
+		"Subject wildcard ISD": {
+			Modify: func(c *cert.Base) {
+				c.Subject.I = 0
+			},
+			ExpectedErrMsg: cert.InvalidSubject,
+		},
+		"Wrong validity period": {
+			Modify: func(c *cert.Base) {
+				c.Validity.NotAfter.Time = c.Validity.NotBefore.Time
+			},
+			ExpectedErrMsg: cert.InvalidValidityPeriod,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := newBaseCert()
+			test.Modify(&c)
+			err := c.Validate()
+			if test.ExpectedErrMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.ExpectedErrMsg)
+			}
+		})
+	}
+}
+
+func newBaseCert() cert.Base {
+	now := time.Now().Round(time.Second)
+	c := cert.Base{
+		Subject:       ia110,
+		Version:       1,
+		FormatVersion: 1,
+		Description:   "This is a base certificate",
+		Validity: &scrypto.Validity{
+			NotBefore: util.UnixTime{Time: now},
+			NotAfter:  util.UnixTime{Time: now.Add(8760 * time.Hour)},
+		},
+	}
+	return c
+}

--- a/go/lib/scrypto/cert/v2/base_test.go
+++ b/go/lib/scrypto/cert/v2/base_test.go
@@ -21,13 +21,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/scrypto/cert/v2"
 	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
-var ia110 = xtest.MustParseIA("1-ff00:0:110")
+var (
+	ia110 = xtest.MustParseIA("1-ff00:0:110")
+	ia210 = xtest.MustParseIA("2-ff00:0:210")
+)
 
 func TestBaseValidate(t *testing.T) {
 	tests := map[string]struct {
@@ -48,6 +52,12 @@ func TestBaseValidate(t *testing.T) {
 				c.Subject.I = 0
 			},
 			ExpectedErrMsg: cert.InvalidSubject,
+		},
+		"DistributionPoint wildcard": {
+			Modify: func(c *cert.Base) {
+				c.OptionalDistributionPoints = append(c.OptionalDistributionPoints, addr.IA{I: 1})
+			},
+			ExpectedErrMsg: cert.InvalidDistributionPoint,
 		},
 		"Wrong validity period": {
 			Modify: func(c *cert.Base) {
@@ -82,6 +92,7 @@ func newBaseCert() cert.Base {
 			NotBefore: util.UnixTime{Time: now},
 			NotAfter:  util.UnixTime{Time: now.Add(8760 * time.Hour)},
 		},
+		OptionalDistributionPoints: []addr.IA{ia210},
 	}
 	return c
 }

--- a/go/lib/scrypto/trc/v2/trc.go
+++ b/go/lib/scrypto/trc/v2/trc.go
@@ -158,9 +158,8 @@ func (t *TRC) Base() bool {
 
 // ValidateInvariant ensures that the TRC invariant holds.
 func (t *TRC) ValidateInvariant() error {
-	if !t.Validity.NotAfter.After(t.Validity.NotBefore.Time) {
-		return common.NewBasicError(InvalidValidityPeriod, nil,
-			"NotBefore", t.Validity.NotBefore, "NotAfter", t.Validity.NotAfter)
+	if err := t.Validity.Validate(); err != nil {
+		return common.NewBasicError(InvalidValidityPeriod, err, "validity", t.Validity)
 	}
 	if t.VotingQuorum() <= 0 {
 		return ErrZeroVotingQuorum

--- a/go/lib/scrypto/validity.go
+++ b/go/lib/scrypto/validity.go
@@ -17,12 +17,16 @@ package scrypto
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/util"
 )
+
+// ErrInvalidValidityPeriod indicates an invalid validity period.
+var ErrInvalidValidityPeriod = errors.New("NotAfter before NotBefore")
 
 // Validity indicates a validity period.
 type Validity struct {
@@ -34,6 +38,13 @@ type Validity struct {
 func (v *Validity) Contains(t time.Time) bool {
 	return !t.Before(v.NotBefore.Time) && !t.After(v.NotAfter.Time)
 }
+
+// Validate checks that NotAfter is after NotBefore.
+func (v *Validity) Validate() error {
+	if !v.NotAfter.After(v.NotBefore.Time) {
+		return ErrInvalidValidityPeriod
+	}
+	return nil
 
 // UnmarshalJSON checks that both NotBefore and NotAfter are set.
 func (v *Validity) UnmarshalJSON(b []byte) error {

--- a/go/lib/scrypto/validity.go
+++ b/go/lib/scrypto/validity.go
@@ -45,6 +45,7 @@ func (v *Validity) Validate() error {
 		return ErrInvalidValidityPeriod
 	}
 	return nil
+}
 
 // UnmarshalJSON checks that both NotBefore and NotAfter are set.
 func (v *Validity) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
This change introduces the base certificate struct that holds the shared fields between the issuer an AS certificates. 

(Contributes to #2853)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2910)
<!-- Reviewable:end -->
