### PR TITLE
BS: Ignore inactive interfaces in Propagator/Registrar

### DIFF
--- a/go/beacon_srv/internal/beaconing/extender.go
+++ b/go/beacon_srv/internal/beaconing/extender.go
@@ -185,3 +185,9 @@ func (s *segExtender) createHopF(inIfid, egIfid common.IFIDType, prev common.Raw
 	hop.Mac = hop.CalcMac(s.cfg.Mac, util.TimeToSecs(ts), prev)
 	return hop, nil
 }
+
+// IntfActive returns whether the interface is active.
+func (s *segExtender) IntfActive(ifid common.IFIDType) bool {
+	intf := s.cfg.Intfs.Get(ifid)
+	return intf != nil && intf.State() == ifstate.Active
+}

--- a/go/beacon_srv/internal/beaconing/propagator.go
+++ b/go/beacon_srv/internal/beaconing/propagator.go
@@ -114,9 +114,6 @@ func (p *Propagator) run(ctx context.Context) error {
 		logger.Debug("[beaconing.Propagator] Ignore non-active peering interfaces",
 			"ifids", nonActivePeers)
 	}
-	if len(intfs) == 0 {
-		return nil
-	}
 	beacons, err := p.provider.BeaconsToPropagate(ctx)
 	if err != nil {
 		p.metrics.IncInternalErr()
@@ -128,6 +125,9 @@ func (p *Propagator) run(ctx context.Context) error {
 		if bOrErr.Err != nil {
 			logger.Error("[beaconing.Propagator] Unable to get beacon", "err", bOrErr.Err)
 			p.metrics.IncInternalErr()
+			continue
+		}
+		if !p.IntfActive(bOrErr.Beacon.InIfId) {
 			continue
 		}
 		b := beaconPropagator{

--- a/go/beacon_srv/internal/beaconing/propagator.go
+++ b/go/beacon_srv/internal/beaconing/propagator.go
@@ -114,6 +114,9 @@ func (p *Propagator) run(ctx context.Context) error {
 		logger.Debug("[beaconing.Propagator] Ignore non-active peering interfaces",
 			"ifids", nonActivePeers)
 	}
+	if len(intfs) == 0 {
+		return nil
+	}
 	beacons, err := p.provider.BeaconsToPropagate(ctx)
 	if err != nil {
 		p.metrics.IncInternalErr()

--- a/go/beacon_srv/internal/beaconing/registrar.go
+++ b/go/beacon_srv/internal/beaconing/registrar.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/scionproto/scion/go/beacon_srv/internal/beacon"
 	"github.com/scionproto/scion/go/beacon_srv/internal/beaconing/metrics"
-	"github.com/scionproto/scion/go/beacon_srv/internal/ifstate"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
@@ -132,8 +131,7 @@ func (r *Registrar) run(ctx context.Context) error {
 			r.metrics.IncInternalErr(r.segType)
 			continue
 		}
-		intf := r.cfg.Intfs.Get(bOrErr.Beacon.InIfId)
-		if intf == nil || intf.State() != ifstate.Active {
+		if !r.IntfActive(bOrErr.Beacon.InIfId) {
 			continue
 		}
 		expected++

--- a/go/beacon_srv/internal/beaconing/registrar.go
+++ b/go/beacon_srv/internal/beaconing/registrar.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/scionproto/scion/go/beacon_srv/internal/beacon"
 	"github.com/scionproto/scion/go/beacon_srv/internal/beaconing/metrics"
+	"github.com/scionproto/scion/go/beacon_srv/internal/ifstate"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
@@ -129,6 +130,10 @@ func (r *Registrar) run(ctx context.Context) error {
 		if bOrErr.Err != nil {
 			logger.Error("[beaconing.Registrar] Unable to get beacon", "err", err)
 			r.metrics.IncInternalErr(r.segType)
+			continue
+		}
+		intf := r.cfg.Intfs.Get(bOrErr.Beacon.InIfId)
+		if intf == nil || intf.State() != ifstate.Active {
 			continue
 		}
 		expected++


### PR DESCRIPTION
Currently, the propagator and registrar attempt to execute their
operations even if no interface is active.
This leads to a lot of noise output.

This PR introduces the following changes:
- Propagator: Early return when no interfaces are active.
- Registrar: Ignore all beacons with inactive ingress interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2921)
<!-- Reviewable:end -->
