### PR TITLE
scrypto: Make map keys integers

### DIFF
--- a/go/lib/scrypto/cert/v2/base.go
+++ b/go/lib/scrypto/cert/v2/base.go
@@ -123,10 +123,10 @@ func (b *Base) checkKeyExistence(keyType KeyType, shouldExist bool) error {
 }
 
 const (
-	issuingKey    = "Issuing"
-	signingKey    = "Signing"
-	encryptionKey = "Encryption"
-	revocationKey = "Revocation"
+	IssuingKeyJSON    = "Issuing"
+	SigningKeyJSON    = "Signing"
+	EncryptionKeyJSON = "Encryption"
+	RevocationKeyJSON = "Revocation"
 )
 
 const (
@@ -141,20 +141,22 @@ const (
 	RevocationKey
 )
 
-// KeyType indicates the type of the key authenticated by the certificate. It
-// can either be "Signing", "Encryption", or "Issuing".
+// KeyType indicates the type of the key authenticated by the certificate.
+//
+// Because KeyType is used as a map key, it cannot be a string type. (see:
+// https://github.com/golang/go/issues/33298)
 type KeyType int
 
 // UnmarshalText allows KeyType to be used as a map key and do validation when parsing.
 func (t *KeyType) UnmarshalText(b []byte) error {
 	switch string(b) {
-	case issuingKey:
+	case IssuingKeyJSON:
 		*t = IssuingKey
-	case signingKey:
+	case SigningKeyJSON:
 		*t = SigningKey
-	case encryptionKey:
+	case EncryptionKeyJSON:
 		*t = EncryptionKey
-	case revocationKey:
+	case RevocationKeyJSON:
 		*t = RevocationKey
 	default:
 		return common.NewBasicError(InvalidKeyType, nil, "input", string(b))
@@ -162,17 +164,19 @@ func (t *KeyType) UnmarshalText(b []byte) error {
 	return nil
 }
 
-// MarshalText is implemented to allow KeyType to be used as JSON map key.
+// MarshalText is implemented to allow KeyType to be used as JSON map key. This
+// must be a value receiver in order for KeyType fields in a struct to marshal
+// correctly.
 func (t KeyType) MarshalText() ([]byte, error) {
 	switch t {
 	case IssuingKey:
-		return []byte(issuingKey), nil
+		return []byte(IssuingKeyJSON), nil
 	case SigningKey:
-		return []byte(signingKey), nil
+		return []byte(SigningKeyJSON), nil
 	case EncryptionKey:
-		return []byte(encryptionKey), nil
+		return []byte(EncryptionKeyJSON), nil
 	case RevocationKey:
-		return []byte(revocationKey), nil
+		return []byte(RevocationKeyJSON), nil
 	}
 	return nil, common.NewBasicError(InvalidKeyType, nil, "type", int(t))
 }

--- a/go/lib/scrypto/cert/v2/base_json_test.go
+++ b/go/lib/scrypto/cert/v2/base_json_test.go
@@ -16,6 +16,7 @@ package cert_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -102,29 +103,31 @@ func TestKeyTypeUnmarshalJSONMapKey(t *testing.T) {
 
 func TestKeyTypeMarshal(t *testing.T) {
 	tests := map[string]struct {
-		KeyType cert.KeyType
+		KeyType  cert.KeyType
+		Expected string
 	}{
 		"IssuingKey": {
-			KeyType: cert.IssuingKey,
+			KeyType:  cert.IssuingKey,
+			Expected: cert.IssuingKeyJSON,
 		},
 		"SigningKey": {
-			KeyType: cert.SigningKey,
+			KeyType:  cert.SigningKey,
+			Expected: cert.SigningKeyJSON,
 		},
 		"EncryptionKey": {
-			KeyType: cert.EncryptionKey,
+			KeyType:  cert.EncryptionKey,
+			Expected: cert.EncryptionKeyJSON,
 		},
 		"RevocationKey": {
-			KeyType: cert.RevocationKey,
+			KeyType:  cert.RevocationKey,
+			Expected: cert.RevocationKeyJSON,
 		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			b, err := json.Marshal(test.KeyType)
 			require.NoError(t, err)
-			var keyType cert.KeyType
-			err = json.Unmarshal(b, &keyType)
-			require.NoError(t, err)
-			assert.Equal(t, test.KeyType, keyType)
+			assert.Equal(t, test.Expected, strings.Trim(string(b), `"`))
 		})
 	}
 	t.Run("Invalid value", func(t *testing.T) {

--- a/go/lib/scrypto/trc/v2/primary.go
+++ b/go/lib/scrypto/trc/v2/primary.go
@@ -242,31 +242,53 @@ func (t *Attribute) UnmarshalJSON(b []byte) error {
 }
 
 const (
-	// IssuingKey is the issuing key type.
-	IssuingKey KeyType = "Issuing"
-	// OnlineKey is the online key type.
-	OnlineKey KeyType = "Online"
-	// OfflineKey is the offline key type.
-	OfflineKey KeyType = "Offline"
+	issuingKey = "Issuing"
+	onlineKey  = "Online"
+	offlineKey = "Offline"
 )
 
-var _ json.Unmarshaler = (*KeyType)(nil)
+const (
+	unknownKey KeyType = iota
+	// IssuingKey is the issuing key type.
+	IssuingKey
+	// OnlineKey is the online key type.
+	OnlineKey
+	// OfflineKey is the offline key type.
+	OfflineKey
+)
 
 // KeyType indicates the type of the key authenticated by the TRC. It can either
 // be "Online", "Offline", or "Issuing".
-type KeyType string
+//
+// Because KeyType is used as a map key, it cannot be a string type. (see:
+// https://github.com/golang/go/issues/33298)
+type KeyType int
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (t *KeyType) UnmarshalJSON(b []byte) error {
-	switch KeyType(strings.Trim(string(b), `"`)) {
-	case OnlineKey:
+// UnmarshalText allows KeyType to be used as a map key and do validation when parsing.
+func (t *KeyType) UnmarshalText(b []byte) error {
+	switch string(b) {
+	case onlineKey:
 		*t = OnlineKey
-	case OfflineKey:
+	case offlineKey:
 		*t = OfflineKey
-	case IssuingKey:
+	case issuingKey:
 		*t = IssuingKey
 	default:
 		return common.NewBasicError(InvalidKeyType, nil, "input", string(b))
 	}
 	return nil
+
+}
+
+// MarshalText is implemented to allow KeyType to be used as JSON map key.
+func (t KeyType) MarshalText() ([]byte, error) {
+	switch t {
+	case OnlineKey:
+		return []byte(onlineKey), nil
+	case OfflineKey:
+		return []byte(offlineKey), nil
+	case IssuingKey:
+		return []byte(issuingKey), nil
+	}
+	return nil, common.NewBasicError(InvalidKeyType, nil, "type", int(t))
 }

--- a/go/lib/scrypto/trc/v2/primary.go
+++ b/go/lib/scrypto/trc/v2/primary.go
@@ -242,9 +242,9 @@ func (t *Attribute) UnmarshalJSON(b []byte) error {
 }
 
 const (
-	issuingKey = "Issuing"
-	onlineKey  = "Online"
-	offlineKey = "Offline"
+	IssuingKeyJSON = "Issuing"
+	OnlineKeyJSON  = "Online"
+	OfflineKeyJSON = "Offline"
 )
 
 const (
@@ -257,8 +257,7 @@ const (
 	OfflineKey
 )
 
-// KeyType indicates the type of the key authenticated by the TRC. It can either
-// be "Online", "Offline", or "Issuing".
+// KeyType indicates the type of the key authenticated by the TRC.
 //
 // Because KeyType is used as a map key, it cannot be a string type. (see:
 // https://github.com/golang/go/issues/33298)
@@ -267,11 +266,11 @@ type KeyType int
 // UnmarshalText allows KeyType to be used as a map key and do validation when parsing.
 func (t *KeyType) UnmarshalText(b []byte) error {
 	switch string(b) {
-	case onlineKey:
+	case OnlineKeyJSON:
 		*t = OnlineKey
-	case offlineKey:
+	case OfflineKeyJSON:
 		*t = OfflineKey
-	case issuingKey:
+	case IssuingKeyJSON:
 		*t = IssuingKey
 	default:
 		return common.NewBasicError(InvalidKeyType, nil, "input", string(b))
@@ -280,15 +279,17 @@ func (t *KeyType) UnmarshalText(b []byte) error {
 
 }
 
-// MarshalText is implemented to allow KeyType to be used as JSON map key.
+// MarshalText is implemented to allow KeyType to be used as JSON map key. This
+// must be a value receiver in order for KeyType fields in a struct to marshal
+// correctly.
 func (t KeyType) MarshalText() ([]byte, error) {
 	switch t {
 	case OnlineKey:
-		return []byte(onlineKey), nil
+		return []byte(OnlineKeyJSON), nil
 	case OfflineKey:
-		return []byte(offlineKey), nil
+		return []byte(OfflineKeyJSON), nil
 	case IssuingKey:
-		return []byte(issuingKey), nil
+		return []byte(IssuingKeyJSON), nil
 	}
 	return nil, common.NewBasicError(InvalidKeyType, nil, "type", int(t))
 }

--- a/go/lib/scrypto/trc/v2/primary_json_test.go
+++ b/go/lib/scrypto/trc/v2/primary_json_test.go
@@ -16,6 +16,7 @@ package trc_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -316,26 +317,27 @@ func TestKeyTypeUnmarshalJSONMapKey(t *testing.T) {
 
 func TestKeyTypeMarshal(t *testing.T) {
 	tests := map[string]struct {
-		KeyType trc.KeyType
+		KeyType  trc.KeyType
+		Expected string
 	}{
 		"OfflineKey": {
-			KeyType: trc.OfflineKey,
+			KeyType:  trc.OfflineKey,
+			Expected: trc.OfflineKeyJSON,
 		},
 		"OnlineKey": {
-			KeyType: trc.OnlineKey,
+			KeyType:  trc.OnlineKey,
+			Expected: trc.OnlineKeyJSON,
 		},
 		"IssuingKey": {
-			KeyType: trc.IssuingKey,
+			KeyType:  trc.IssuingKey,
+			Expected: trc.IssuingKeyJSON,
 		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			b, err := json.Marshal(test.KeyType)
 			require.NoError(t, err)
-			var keyType trc.KeyType
-			err = json.Unmarshal(b, &keyType)
-			require.NoError(t, err)
-			assert.Equal(t, test.KeyType, keyType)
+			assert.Equal(t, test.Expected, strings.Trim(string(b), `"`))
 		})
 	}
 	t.Run("Invalid value", func(t *testing.T) {

--- a/go/lib/scrypto/trc/v2/signed_json_test.go
+++ b/go/lib/scrypto/trc/v2/signed_json_test.go
@@ -277,7 +277,10 @@ func TestCritUnmarshalJSON(t *testing.T) {
 }
 
 func TestCritMarshalJSON(t *testing.T) {
-	b, err := json.Marshal(trc.Protected{})
+	mockProtected := struct {
+		Crit trc.Crit `json:"crit"`
+	}{}
+	b, err := json.Marshal(mockProtected)
 	require.NoError(t, err)
 	var protected struct {
 		Crit []string `json:"crit"`


### PR DESCRIPTION
Currently some map keys are string types that implement the
`json.Unmarshaler` interface. Unfortunately, json.Unmarshal will ignore
string types' UnmarshalJSON method and simply set the string.
The same holds for the `encoding.TextUnmarshaler`.

(see: https://github.com/golang/go/issues/33298)

This PR makes those keys of integer type to ensure the parsing will
catch malformed map inputs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2927)
<!-- Reviewable:end -->
