### PR TITLE
path-policy: Change Act method signature

### DIFF
--- a/go/lib/infra/modules/combinator/combinator.go
+++ b/go/lib/infra/modules/combinator/combinator.go
@@ -232,8 +232,8 @@ func FilterLongPaths(paths []*Path) []*Path {
 		long := false
 		iaCounts := make(map[addr.IA]int)
 		for _, iface := range path.Interfaces {
-			iaCounts[iface.ISD_AS()]++
-			if iaCounts[iface.ISD_AS()] > 2 {
+			iaCounts[iface.IA()]++
+			if iaCounts[iface.IA()] > 2 {
 				long = true
 				break
 			}

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -160,7 +160,11 @@ func (r *resolver) QueryFilter(ctx context.Context, src, dst addr.IA,
 	if policy == nil {
 		return aps
 	}
-	return policy.Act(aps).(spathmeta.AppPathSet)
+	ps := make(pathpol.PathSet, len(aps))
+	for key, path := range aps {
+		ps[key.String()] = path
+	}
+	return policy.Act2(aps)
 }
 
 func (r *resolver) WatchFilter(ctx context.Context, src, dst addr.IA,

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -160,11 +160,7 @@ func (r *resolver) QueryFilter(ctx context.Context, src, dst addr.IA,
 	if policy == nil {
 		return aps
 	}
-	ps := make(pathpol.PathSet, len(aps))
-	for key, path := range aps {
-		ps[key.String()] = path
-	}
-	return policy.Act2(aps)
+	return psToAps(policy.Act(apsToPs(aps)))
 }
 
 func (r *resolver) WatchFilter(ctx context.Context, src, dst addr.IA,
@@ -172,7 +168,7 @@ func (r *resolver) WatchFilter(ctx context.Context, src, dst addr.IA,
 
 	aps := r.Query(ctx, src, dst, sciond.PathReqFlags{})
 	if filter != nil {
-		aps = filter.Act(aps).(spathmeta.AppPathSet)
+		aps = psToAps(filter.Act(apsToPs(aps)))
 	}
 	sp := NewSyncPaths()
 	sp.update(aps)
@@ -272,4 +268,35 @@ func matches(path *spathmeta.AppPath, predicatePI sciond.PathInterface) bool {
 		}
 	}
 	return false
+}
+
+type pathWrap struct {
+	*spathmeta.AppPath
+}
+
+func (p pathWrap) Key() string     { return p.AppPath.Key().String() }
+func (p pathWrap) IsPartial() bool { return false }
+func (p pathWrap) Interfaces() []pathpol.PathInterface {
+	intfs := make([]pathpol.PathInterface, 0, len(p.Entry.Path.Interfaces))
+	for _, intf := range p.Entry.Path.Interfaces {
+		intfs = append(intfs, intf)
+	}
+	return intfs
+}
+
+func apsToPs(aps spathmeta.AppPathSet) pathpol.PathSet {
+	ps := make(pathpol.PathSet, len(aps))
+	for key, path := range aps {
+		ps[key.String()] = pathWrap{AppPath: path}
+	}
+	return ps
+}
+
+func psToAps(ps pathpol.PathSet) spathmeta.AppPathSet {
+	aps := make(spathmeta.AppPathSet)
+	for _, path := range ps {
+		ap := path.(pathWrap).AppPath
+		aps[ap.Key()] = ap
+	}
+	return aps
 }

--- a/go/lib/pathmgr/watch.go
+++ b/go/lib/pathmgr/watch.go
@@ -1,4 +1,4 @@
-// Copyright 2019 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -153,7 +153,7 @@ type queryConfig struct {
 func (bq *queryConfig) Do(ctx context.Context, flags sciond.PathReqFlags) spathmeta.AppPathSet {
 	aps := bq.querier.Query(ctx, bq.src, bq.dst, flags)
 	if bq.filter != nil {
-		aps = bq.filter.Act(aps).(spathmeta.AppPathSet)
+		aps = psToAps(bq.filter.Act(apsToPs(aps)))
 	}
 	return aps
 }

--- a/go/lib/pathpol/BUILD.bazel
+++ b/go/lib/pathpol/BUILD.bazel
@@ -16,8 +16,6 @@ go_library(
         "//go/lib/common:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/pathpol/sequence:go_default_library",
-        "//go/lib/sciond:go_default_library",
-        "//go/lib/spath/spathmeta:go_default_library",
         "@com_github_antlr_antlr4//runtime/Go/antlr:go_default_library",
     ],
 )
@@ -36,7 +34,6 @@ go_test(
         "//go/lib/xtest:go_default_library",
         "//go/lib/xtest/graph:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/go/lib/pathpol/BUILD.bazel
+++ b/go/lib/pathpol/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "acl.go",
         "hop_pred.go",
+        "pathset.go",
         "policy.go",
         "sequence.go",
     ],
@@ -32,11 +33,10 @@ go_test(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
-        "//go/lib/sciond:go_default_library",
-        "//go/lib/spath/spathmeta:go_default_library",
         "//go/lib/xtest:go_default_library",
         "//go/lib/xtest/graph:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/go/lib/pathpol/acl.go
+++ b/go/lib/pathpol/acl.go
@@ -69,7 +69,7 @@ func (a *ACL) evalPath(path Path) ACLAction {
 
 func (a *ACL) evalInterface(iface PathInterface, ingress bool) ACLAction {
 	for _, aclEntry := range a.Entries {
-		if aclEntry.Rule == nil || aclEntry.Rule.pathIFMatch2(iface, ingress) {
+		if aclEntry.Rule == nil || aclEntry.Rule.pathIFMatch(iface, ingress) {
 			return aclEntry.Action
 		}
 	}

--- a/go/lib/pathpol/hop_pred.go
+++ b/go/lib/pathpol/hop_pred.go
@@ -108,10 +108,10 @@ func (hp *HopPredicate) pathIFMatch(pi sciond.PathInterface, in bool) bool {
 }
 
 func (hp *HopPredicate) pathIFMatch2(pi PathInterface, in bool) bool {
-	if hp.ISD != 0 && pi.IA.I != hp.ISD {
+	if hp.ISD != 0 && pi.IA().I != hp.ISD {
 		return false
 	}
-	if hp.AS != 0 && pi.IA.A != hp.AS {
+	if hp.AS != 0 && pi.IA().A != hp.AS {
 		return false
 	}
 	ifInd := 0
@@ -121,7 +121,7 @@ func (hp *HopPredicate) pathIFMatch2(pi PathInterface, in bool) bool {
 	if len(hp.IfIDs) == 2 && !in {
 		ifInd = 1
 	}
-	if hp.IfIDs[ifInd] != 0 && hp.IfIDs[ifInd] != pi.IfId {
+	if hp.IfIDs[ifInd] != 0 && hp.IfIDs[ifInd] != pi.IfId() {
 		return false
 	}
 	return true

--- a/go/lib/pathpol/hop_pred.go
+++ b/go/lib/pathpol/hop_pred.go
@@ -85,7 +85,7 @@ func HopPredicateFromString(str string) (*HopPredicate, error) {
 
 // pathIFMatch takes a PathInterface and a bool indicating if the ingress
 // interface needs to be matching. It returns true if the HopPredicate matches the PathInterface
-func (hp *HopPredicate) pathIFMatch2(pi PathInterface, in bool) bool {
+func (hp *HopPredicate) pathIFMatch(pi PathInterface, in bool) bool {
 	if hp.ISD != 0 && pi.IA().I != hp.ISD {
 		return false
 	}

--- a/go/lib/pathpol/hop_pred.go
+++ b/go/lib/pathpol/hop_pred.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -101,6 +102,26 @@ func (hp *HopPredicate) pathIFMatch(pi sciond.PathInterface, in bool) bool {
 		ifInd = 1
 	}
 	if hp.IfIDs[ifInd] != 0 && hp.IfIDs[ifInd] != pi.IfID {
+		return false
+	}
+	return true
+}
+
+func (hp *HopPredicate) pathIFMatch2(pi PathInterface, in bool) bool {
+	if hp.ISD != 0 && pi.IA.I != hp.ISD {
+		return false
+	}
+	if hp.AS != 0 && pi.IA.A != hp.AS {
+		return false
+	}
+	ifInd := 0
+	// the IF index is set to 1 if
+	// - there are two IFIDs and
+	// - the ingress interface should not be matched
+	if len(hp.IfIDs) == 2 && !in {
+		ifInd = 1
+	}
+	if hp.IfIDs[ifInd] != 0 && hp.IfIDs[ifInd] != pi.IfId {
 		return false
 	}
 	return true

--- a/go/lib/pathpol/hop_pred.go
+++ b/go/lib/pathpol/hop_pred.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/sciond"
 )
 
 // A HopPredicate specifies a hop in the ACL or Sequence of the path policy,
@@ -86,27 +85,6 @@ func HopPredicateFromString(str string) (*HopPredicate, error) {
 
 // pathIFMatch takes a PathInterface and a bool indicating if the ingress
 // interface needs to be matching. It returns true if the HopPredicate matches the PathInterface
-func (hp *HopPredicate) pathIFMatch(pi sciond.PathInterface, in bool) bool {
-	piIA := pi.ISD_AS()
-	if hp.ISD != 0 && piIA.I != hp.ISD {
-		return false
-	}
-	if hp.AS != 0 && piIA.A != hp.AS {
-		return false
-	}
-	ifInd := 0
-	// the IF index is set to 1 if
-	// - there are two IFIDs and
-	// - the ingress interface should not be matched
-	if len(hp.IfIDs) == 2 && !in {
-		ifInd = 1
-	}
-	if hp.IfIDs[ifInd] != 0 && hp.IfIDs[ifInd] != pi.IfID {
-		return false
-	}
-	return true
-}
-
 func (hp *HopPredicate) pathIFMatch2(pi PathInterface, in bool) bool {
 	if hp.ISD != 0 && pi.IA().I != hp.ISD {
 		return false

--- a/go/lib/pathpol/hop_pred_test.go
+++ b/go/lib/pathpol/hop_pred_test.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,175 +19,145 @@ import (
 	"encoding/json"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/scionproto/scion/go/lib/common"
 )
 
 func TestNewHopPredicate(t *testing.T) {
-	testCases := []struct {
-		Name  string
+	tests := map[string]struct {
 		In    string
 		HP    *HopPredicate
 		Valid bool
 	}{
-		{
-			Name:  "ISD wildcard",
+		"ISD wildcard": {
 			In:    "0",
 			HP:    &HopPredicate{ISD: 0, AS: 0, IfIDs: []common.IFIDType{0}},
 			Valid: true,
 		},
-		{
-			Name:  "AS, IF wildcard omitted",
+		"AS, IF wildcard omitted": {
 			In:    "1",
 			HP:    &HopPredicate{ISD: 1, AS: 0, IfIDs: []common.IFIDType{0}},
 			Valid: true,
 		},
-		{
-			Name:  "IF wildcard omitted",
+		"IF wildcard omitted": {
 			In:    "1-0",
 			HP:    &HopPredicate{ISD: 1, AS: 0, IfIDs: []common.IFIDType{0}},
 			Valid: true,
 		},
-		{
-			Name:  "basic wildcard",
+		"basic wildcard": {
 			In:    "1-0#0",
 			HP:    &HopPredicate{ISD: 1, AS: 0, IfIDs: []common.IFIDType{0}},
 			Valid: true,
 		},
-		{
-			Name:  "AS wildcard, interface set",
+		"AS wildcard, interface set": {
 			In:    "1-0#1",
 			Valid: false,
 		},
-		{
-			Name:  "ISD wildcard, AS set",
+		"ISD wildcard, AS set": {
 			In:    "0-1#0",
 			HP:    &HopPredicate{ISD: 0, AS: 1, IfIDs: []common.IFIDType{0}},
 			Valid: true,
 		},
-		{
-			Name:  "ISD wildcard, AS set, interface set",
+		"ISD wildcard, AS set, interface set": {
 			In:    "0-1#2",
 			HP:    &HopPredicate{ISD: 0, AS: 1, IfIDs: []common.IFIDType{2}},
 			Valid: true,
 		},
-		{
-			Name:  "ISD wildcard, AS set and interface omitted",
+		"ISD wildcard, AS set and interface omitted": {
 			In:    "0-1",
 			HP:    &HopPredicate{ISD: 0, AS: 1, IfIDs: []common.IFIDType{0}},
 			Valid: true,
 		},
-		{
-			Name:  "IF wildcard omitted, AS set",
+		"IF wildcard omitted, AS set": {
 			In:    "1-2",
 			HP:    &HopPredicate{ISD: 1, AS: 2, IfIDs: []common.IFIDType{0}},
 			Valid: true,
 		},
-		{
-			Name:  "two IfIDs",
+		"two IfIDs": {
 			In:    "1-2#3,4",
 			HP:    &HopPredicate{ISD: 1, AS: 2, IfIDs: []common.IFIDType{3, 4}},
 			Valid: true,
 		},
-		{
-			Name:  "three IfIDs",
+		"three IfIDs": {
 			In:    "1-2#3,4,5",
 			Valid: false,
 		},
-		{
-			Name:  "bad -",
+		"bad -": {
 			In:    "1-1-0",
 			Valid: false,
 		},
-		{
-			Name:  "missing AS",
+		"missing AS": {
 			In:    "1#2",
 			Valid: false,
 		},
-		{
-			Name:  "bad #",
+		"bad #": {
 			In:    "1-1#0#",
 			Valid: false,
 		},
-		{
-			Name:  "bad IF",
+		"bad IF": {
 			In:    "1-1#e",
 			Valid: false,
 		},
-		{
-			Name:  "bad second IF",
+		"bad second IF": {
 			In:    "1-2#1,3a",
 			Valid: false,
 		},
-		{
-			Name:  "AS wildcard, second IF defined",
+		"AS wildcard, second IF defined": {
 			In:    "1-0#1,3",
 			Valid: false,
 		},
-		{
-			Name:  "bad AS",
+		"bad AS": {
 			In:    "1-12323433243534#0",
 			Valid: false,
 		},
-		{
-			Name:  "bad ISD",
+		"bad ISD": {
 			In:    "1123212-23#0",
 			Valid: false,
 		},
 	}
-
-	Convey("TestNewHopPredicate", t, func() {
-		for _, tc := range testCases {
-			Convey(tc.Name, func() {
-				hp, err := HopPredicateFromString(tc.In)
-				if tc.Valid {
-					SoMsg("err", err, ShouldBeNil)
-					SoMsg("hp", hp, ShouldResemble, tc.HP)
-				} else {
-					SoMsg("err", err, ShouldNotBeNil)
-				}
-			})
-		}
-	})
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			hp, err := HopPredicateFromString(test.In)
+			if test.Valid {
+				assert.NoError(t, err)
+				assert.Equal(t, test.HP, hp)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
 }
 
 func TestHopPredicateString(t *testing.T) {
-	Convey("TestString", t, func() {
-		hp, _ := HopPredicateFromString("1-2#3,4")
-		SoMsg("hp", hp.String(), ShouldEqual, "1-2#3,4")
-	})
+	hp, _ := HopPredicateFromString("1-2#3,4")
+	assert.Equal(t, "1-2#3,4", hp.String())
 }
 
 func TestJsonConversion(t *testing.T) {
-	testCases := []struct {
+	tests := map[string]struct {
 		Name string
 		HP   *HopPredicate
 	}{
-		{
-			Name: "Normal predicate",
-			HP:   &HopPredicate{ISD: 1, AS: 2, IfIDs: []common.IFIDType{1, 2}},
+		"Normal predicate": {
+			HP: &HopPredicate{ISD: 1, AS: 2, IfIDs: []common.IFIDType{1, 2}},
 		},
-		{
-			Name: "wildcard predicate",
-			HP:   &HopPredicate{ISD: 1, AS: 2, IfIDs: []common.IFIDType{0}},
+		"wildcard predicate": {
+			HP: &HopPredicate{ISD: 1, AS: 2, IfIDs: []common.IFIDType{0}},
 		},
-		{
-			Name: "only ifids",
-			HP:   &HopPredicate{IfIDs: []common.IFIDType{0}},
+		"only ifids": {
+			HP: &HopPredicate{IfIDs: []common.IFIDType{0}},
 		},
 	}
-	Convey("TestJsonConversion", t, func() {
-		for _, tc := range testCases {
-			Convey(tc.Name, func() {
-				jsonHP, err := json.Marshal(tc.HP)
-				SoMsg("err", err, ShouldBeNil)
-
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			jsonHP, err := json.Marshal(test.HP)
+			if assert.NoError(t, err) {
 				var hp HopPredicate
 				err = json.Unmarshal(jsonHP, &hp)
-				SoMsg("err", err, ShouldBeNil)
-				SoMsg("predicate", tc.HP, ShouldResemble, &hp)
-			})
-		}
-	})
+				assert.NoError(t, err)
+				assert.Equal(t, test.HP, &hp)
+			}
+		})
+	}
 }

--- a/go/lib/pathpol/pathset.go
+++ b/go/lib/pathpol/pathset.go
@@ -33,9 +33,9 @@ type Path interface {
 }
 
 // PathInterface is an interface on the path.
-type PathInterface struct {
+type PathInterface interface {
 	// IfId is the id of the interface.
-	IfId common.IFIDType
+	IfId() common.IFIDType
 	// IA is the ISD AS identifier of the interface.
-	IA addr.IA
+	IA() addr.IA
 }

--- a/go/lib/pathpol/pathset.go
+++ b/go/lib/pathpol/pathset.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pathpol
+
+import (
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+// PathSet is a set of paths. PathSet is used for policy filtering.
+type PathSet map[string]Path
+
+// Path describes a path or a partial path, e.g. a segment.
+type Path interface {
+	// Interfaces returns all the interfaces of this path.
+	Interfaces() []PathInterface
+	// IsPartial returns whether this is a partial path.
+	IsPartial() bool
+	// Returns a string that uniquely identifies this path.
+	Key() string
+}
+
+// PathInterface is an interface on the path.
+type PathInterface struct {
+	// IfId is the id of the interface.
+	IfId common.IFIDType
+	// IA is the ISD AS identifier of the interface.
+	IA addr.IA
+}

--- a/go/lib/pathpol/policy.go
+++ b/go/lib/pathpol/policy.go
@@ -63,7 +63,7 @@ func (p *Policy) Act(paths PathSet) PathSet {
 	}
 	// Filter on sub policies
 	if len(p.Options) > 0 {
-		resultSet = p.evalOptions2(resultSet)
+		resultSet = p.evalOptions(resultSet)
 	}
 	return resultSet
 }
@@ -119,7 +119,7 @@ func (p *Policy) applyExtended(extends []string, exPolicies []*ExtPolicy) error 
 
 // evalOptions evaluates the options of a policy and returns the pathSet that matches the option
 // with the highest weight
-func (p *Policy) evalOptions2(inputSet PathSet) PathSet {
+func (p *Policy) evalOptions(inputSet PathSet) PathSet {
 	subPolicySet := make(PathSet)
 	currWeight := p.Options[0].Weight
 	// Go through sub policies

--- a/go/lib/pathpol/policy_test.go
+++ b/go/lib/pathpol/policy_test.go
@@ -790,7 +790,7 @@ func (p PathProvider) GetPaths(src, dst addr.IA) PathSet {
 		var key strings.Builder
 		for _, ifid := range ifids {
 			ia := p.g.GetParent(ifid)
-			pathIntfs = append(pathIntfs, PathInterface{IA: ia, IfId: ifid})
+			pathIntfs = append(pathIntfs, testPathIntf{ia: ia, ifid: ifid})
 			key.WriteString(fmt.Sprintf("%s-%d", ia, ifid))
 		}
 		result[key.String()] = &testPath{interfaces: pathIntfs, key: key.String()}
@@ -810,6 +810,14 @@ func (p *testPath) Interfaces() []PathInterface {
 func (p *testPath) IsPartial() bool { return false }
 
 func (p *testPath) Key() string { return p.key }
+
+type testPathIntf struct {
+	ia   addr.IA
+	ifid common.IFIDType
+}
+
+func (i testPathIntf) IfId() common.IFIDType { return i.ifid }
+func (i testPathIntf) IA() addr.IA           { return i.ia }
 
 func mustHopPredicate(t *testing.T, str string) *HopPredicate {
 	hp, err := HopPredicateFromString(str)

--- a/go/lib/pathpol/policy_test.go
+++ b/go/lib/pathpol/policy_test.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,354 +16,299 @@
 package pathpol
 
 import (
-	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/sciond"
-	"github.com/scionproto/scion/go/lib/spath/spathmeta"
 	"github.com/scionproto/scion/go/lib/xtest"
 	"github.com/scionproto/scion/go/lib/xtest/graph"
 )
 
 func TestBasicPolicy(t *testing.T) {
-	testCases := []struct {
+	tests := map[string]struct {
 		Name       string
 		Policy     *Policy
 		Src        addr.IA
 		Dst        addr.IA
 		ExpPathNum int
 	}{
-		{
-			Name:       "Empty policy",
+		"Empty policy": {
 			Policy:     &Policy{},
 			Src:        xtest.MustParseIA("2-ff00:0:212"),
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
 	}
-
-	Convey("TestPolicy", t, func() {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-		conn := testGetSCIONDConn(t, ctrl)
-		for _, tc := range testCases {
-			Convey(tc.Name, func() {
-				paths, err := conn.Paths(context.Background(), tc.Dst, tc.Src, 5,
-					sciond.PathReqFlags{})
-				SoMsg("sciond err", err, ShouldBeNil)
-
-				inAPS := spathmeta.NewAppPathSet(paths)
-				outAPS := tc.Policy.Act(inAPS).(spathmeta.AppPathSet)
-				SoMsg("paths", len(outAPS), ShouldEqual, tc.ExpPathNum)
-			})
-		}
-	})
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	pp := NewPathProvider(ctrl)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			paths := pp.GetPaths(test.Src, test.Dst)
+			outPaths := test.Policy.Act2(paths)
+			assert.Equal(t, test.ExpPathNum, len(outPaths))
+		})
+	}
 }
 
 func TestSequenceEval(t *testing.T) {
-	testCases := []struct {
-		Name       string
+	tests := map[string]struct {
 		Seq        *Sequence
 		Src        addr.IA
 		Dst        addr.IA
 		ExpPathNum int
 	}{
-		{
-			Name:       "Empty path",
+		"Empty path": {
 			Seq:        newSequence(t, "0-0#0"),
 			Src:        xtest.MustParseIA("2-ff00:0:212"),
 			Dst:        xtest.MustParseIA("2-ff00:0:212"),
 			ExpPathNum: 0,
 		},
-		{
-			Name:       "Length not matching",
+		"Length not matching": {
 			Seq:        newSequence(t, "0-0#0"),
 			Src:        xtest.MustParseIA("2-ff00:0:212"),
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 0,
 		},
-		{
-			Name:       "Two Wildcard matching",
+		"Two Wildcard matching": {
 			Seq:        newSequence(t, "0-0#0 0-0#0"),
 			Src:        xtest.MustParseIA("2-ff00:0:212"),
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
-		{
-			Name:       "Longer Wildcard matching",
+		"Longer Wildcard matching": {
 			Seq:        newSequence(t, "0-0#0 0-0#0 0-0#0 0-0#0"),
 			Src:        xtest.MustParseIA("1-ff00:0:122"),
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 2,
 		},
-		{
-			Name:       "Two Explicit matching",
+		"Two Explicit matching": {
 			Seq:        newSequence(t, "1-ff00:0:133#1019 1-ff00:0:132#1910"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:132"),
 			ExpPathNum: 1,
 		},
-		{
-			Name:       "AS double IF matching",
+		"AS double IF matching": {
 			Seq:        newSequence(t, "0 1-ff00:0:132#1910,1916 0"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:131"),
 			ExpPathNum: 1,
 		},
-		{
-			Name:       "AS IF matching, first wildcard",
+		"AS IF matching, first wildcard": {
 			Seq:        newSequence(t, "0 1-ff00:0:132#0,1916 0"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:131"),
 			ExpPathNum: 1,
 		},
-		{
-			Name: "Longer Explicit matching",
+		"Longer Explicit matching": {
 			Seq: newSequence(t, "1-ff00:0:122#1815 1-ff00:0:121#1518,1530 "+
 				"1-ff00:0:120#3015,3122 2-ff00:0:220#2231,2224 2-ff00:0:221#2422"),
 			Src:        xtest.MustParseIA("1-ff00:0:122"),
 			Dst:        xtest.MustParseIA("2-ff00:0:221"),
 			ExpPathNum: 1,
 		},
-		{
-			Name: "Longer Explicit matching, single wildcard",
+		"Longer Explicit matching, single wildcard": {
 			Seq: newSequence(t, "1-ff00:0:133#1018 1-ff00:0:122#1810,1815 "+
 				"1-ff00:0:121#0,1530 1-ff00:0:120#3015,2911 1-ff00:0:110#1129"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:110"),
 			ExpPathNum: 1,
 		},
-		{
-			Name: "Longer Explicit matching, reverse single wildcard",
+		"Longer Explicit matching, reverse single wildcard": {
 			Seq: newSequence(t, "1-ff00:0:133#1018 1-ff00:0:122#1810,1815 "+
 				"1-ff00:0:121#1530,0 1-ff00:0:120#3015,2911 1-ff00:0:110#1129"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:110"),
 			ExpPathNum: 0,
 		},
-		{
-			Name: "Longer Explicit matching, multiple wildcard",
+		"Longer Explicit matching, multiple wildcard": {
 			Seq: newSequence(t, "1-ff00:0:133#1018 1-ff00:0:122#0,1815 "+
 				"1-ff00:0:121#0,1530 1-ff00:0:120#3015,0 1-ff00:0:110#1129"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:110"),
 			ExpPathNum: 1,
 		},
-		{
-			Name: "Longer Explicit matching, mixed wildcard types",
+		"Longer Explicit matching, mixed wildcard types": {
 			Seq: newSequence(t, "1-ff00:0:133#0 1 "+
 				"0-0#0 1-ff00:0:120#0 1-ff00:0:110#1129"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:110"),
 			ExpPathNum: 1,
 		},
-		{
-			Name: "Longer Explicit matching, mixed wildcard types, two paths",
+		"Longer Explicit matching, mixed wildcard types, two paths": {
 			Seq: newSequence(t, "1-ff00:0:133#0 1-0#0 "+
 				"0-0#0 1-0#0 1-ff00:0:110#0"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:110"),
 			ExpPathNum: 2,
 		},
-		{
-			Name:       "Nil sequence does not filter",
+		"Nil sequence does not filter": {
 			Seq:        nil,
 			Src:        xtest.MustParseIA("2-ff00:0:212"),
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
-		{
-			Name:       "Asterisk matches multiple hops",
+		"Asterisk matches multiple hops": {
 			Seq:        newSequence(t, "0*"),
 			Src:        xtest.MustParseIA("2-ff00:0:212"),
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
-		{
-			Name:       "Asterisk matches zero hops",
+		"Asterisk matches zero hops": {
 			Seq:        newSequence(t, "0 0 0*"),
 			Src:        xtest.MustParseIA("2-ff00:0:212"),
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
-		{
-			Name:       "Plus matches multiple hops",
+		"Plus matches multiple hops": {
 			Seq:        newSequence(t, "0+"),
 			Src:        xtest.MustParseIA("2-ff00:0:212"),
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
-		{
-			Name:       "Plus doesn't match zero hops",
+		"Plus doesn't match zero hops": {
 			Seq:        newSequence(t, "0 0 0+"),
 			Src:        xtest.MustParseIA("2-ff00:0:212"),
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 0,
 		},
-		{
-			Name:       "Question mark matches zero hops",
+		"Question mark matches zero hops": {
 			Seq:        newSequence(t, "0 0 0?"),
 			Src:        xtest.MustParseIA("2-ff00:0:212"),
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
-		{
-			Name:       "Question mark matches one hop",
+		"Question mark matches one hop": {
 			Seq:        newSequence(t, "0 0?"),
 			Src:        xtest.MustParseIA("2-ff00:0:212"),
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
-		{
-			Name:       "Question mark doesn't match two hops",
+		"Question mark doesn't match two hops": {
 			Seq:        newSequence(t, "0?"),
 			Src:        xtest.MustParseIA("2-ff00:0:212"),
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 0,
 		},
-		{
-			Name:       "Successful match on hop count",
+		"Successful match on hop count": {
 			Seq:        newSequence(t, "0 0 0"),
 			Src:        xtest.MustParseIA("2-ff00:0:211"),
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 3,
 		},
-		{
-			Name:       "Failed match on hop count",
+		"Failed match on hop count": {
 			Seq:        newSequence(t, "0 0"),
 			Src:        xtest.MustParseIA("2-ff00:0:211"),
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 0,
 		},
-		{
-			Name:       "Select one of the intermediate ASes",
+		"Select one of the intermediate ASes": {
 			Seq:        newSequence(t, "0 2-ff00:0:221 0"),
 			Src:        xtest.MustParseIA("2-ff00:0:211"),
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 1,
 		},
-		{
-			Name:       "Select two alternative intermediate ASes",
+		"Select two alternative intermediate ASes": {
 			Seq:        newSequence(t, "0 (2-ff00:0:221 | 2-ff00:0:210) 0"),
 			Src:        xtest.MustParseIA("2-ff00:0:211"),
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 3,
 		},
-		{
-			Name:       "Alternative intermediate ASes, but one doesn't exist",
+		"Alternative intermediate ASes, but one doesn't exist": {
 			Seq:        newSequence(t, "0 (2-ff00:0:221 |64-12345) 0"),
 			Src:        xtest.MustParseIA("2-ff00:0:211"),
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 1,
 		},
-		{
-			Name:       "Or has higher priority than concatenation",
+		"Or has higher priority than concatenation": {
 			Seq:        newSequence(t, "0 2-ff00:0:221|64-12345 0"),
 			Src:        xtest.MustParseIA("2-ff00:0:211"),
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 1,
 		},
-		{
-			Name:       "Question mark has higher priority than concatenation",
+		"Question mark has higher priority than concatenation": {
 			Seq:        newSequence(t, "0 0 0 ?  "),
 			Src:        xtest.MustParseIA("2-ff00:0:211"),
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 3,
 		},
-		{
-			Name:       "Parentheses change priority",
+		"Parentheses change priority": {
 			Seq:        newSequence(t, "(0 0)?"),
 			Src:        xtest.MustParseIA("2-ff00:0:211"),
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 0,
 		},
-		{
-			Name:       "Single interface matches inbound interface",
+		"Single interface matches inbound interface": {
 			Seq:        newSequence(t, "0 1-ff00:0:132#1910 0"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:131"),
 			ExpPathNum: 1,
 		},
-		{
-			Name:       "Single interface matches outbound interface",
+		"Single interface matches outbound interface": {
 			Seq:        newSequence(t, "0 1-ff00:0:132#1916 0"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:131"),
 			ExpPathNum: 1,
 		},
-		{
-			Name:       "Single non-matching interface",
+		"Single non-matching interface": {
 			Seq:        newSequence(t, "0 1-ff00:0:132#1917 0"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:131"),
 			ExpPathNum: 0,
 		},
-		{
-			Name:       "Left interface matches inbound",
+		"Left interface matches inbound": {
 			Seq:        newSequence(t, "0 1-ff00:0:132#1910,0 0"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:131"),
 			ExpPathNum: 1,
 		},
-		{
-			Name:       "Left interface doesn't match outbound",
+		"Left interface doesn't match outbound": {
 			Seq:        newSequence(t, "0 1-ff00:0:132#1916,0 0"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:131"),
 			ExpPathNum: 0,
 		},
-		{
-			Name:       "Right interface matches outbound",
+		"Right interface matches outbound": {
 			Seq:        newSequence(t, "0 1-ff00:0:132#0,1916 0"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:131"),
 			ExpPathNum: 1,
 		},
-		{
-			Name:       "Right interface doesn't match inbound",
+		"Right interface doesn't match inbound": {
 			Seq:        newSequence(t, "0 1-ff00:0:132#0,1910 0"),
 			Src:        xtest.MustParseIA("1-ff00:0:133"),
 			Dst:        xtest.MustParseIA("1-ff00:0:131"),
 			ExpPathNum: 0,
 		},
 	}
-
-	Convey("TestSeq", t, func() {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-		conn := testGetSCIONDConn(t, ctrl)
-		for _, tc := range testCases {
-			Convey(tc.Name, func() {
-				paths, err := conn.Paths(context.Background(), tc.Dst, tc.Src, 5,
-					sciond.PathReqFlags{})
-				SoMsg("sciond err", err, ShouldBeNil)
-
-				inAPS := spathmeta.NewAppPathSet(paths)
-				outAPS := tc.Seq.Eval(inAPS)
-				SoMsg("paths", len(outAPS), ShouldEqual, tc.ExpPathNum)
-			})
-		}
-	})
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	pp := NewPathProvider(ctrl)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			paths := pp.GetPaths(test.Src, test.Dst)
+			outPaths := test.Seq.Eval2(paths)
+			assert.Equal(t, test.ExpPathNum, len(outPaths))
+		})
+	}
 }
 
 var allowEntry = &ACLEntry{ACLAction(true), NewHopPredicate()}
 var denyEntry = &ACLEntry{ACLAction(false), NewHopPredicate()}
 
 func TestACLEval(t *testing.T) {
-	testCases := []struct {
-		Name       string
+	tests := map[string]struct {
 		ACL        *ACL
 		Src        addr.IA
 		Dst        addr.IA
 		ExpPathNum int
 	}{
-		{
-			Name: "allow everything",
+		"allow everything": {
 			ACL: &ACL{Entries: []*ACLEntry{
 				{Action: Allow, Rule: mustHopPredicate(t, "0-0#0")},
 				denyEntry}},
@@ -370,8 +316,7 @@ func TestACLEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
-		{
-			Name: "allow 2-0#0, deny rest",
+		"allow 2-0#0, deny rest": {
 			ACL: &ACL{Entries: []*ACLEntry{
 				{Action: Allow, Rule: mustHopPredicate(t, "2-0#0")},
 				denyEntry}},
@@ -379,8 +324,7 @@ func TestACLEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
-		{
-			Name: "allow 2-ff00:0:212#0 and 2-ff00:0:211, deny rest",
+		"allow 2-ff00:0:212#0 and 2-ff00:0:211, deny rest": {
 			ACL: &ACL{Entries: []*ACLEntry{
 				{Action: Allow, Rule: mustHopPredicate(t, "2-ff00:0:212#0")},
 				{Action: Allow, Rule: mustHopPredicate(t, "2-ff00:0:211#0")},
@@ -389,8 +333,7 @@ func TestACLEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
-		{
-			Name: "allow 2-ff00:0:212#0, deny rest",
+		"allow 2-ff00:0:212#0, deny rest": {
 			ACL: &ACL{Entries: []*ACLEntry{
 				{Action: Allow, Rule: mustHopPredicate(t, "2-ff00:0:212#0")},
 				denyEntry}},
@@ -398,8 +341,7 @@ func TestACLEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 0,
 		},
-		{
-			Name: "deny 1-ff00:0:110#0, 1-ff00:0:120#0, allow rest",
+		"deny 1-ff00:0:110#0, 1-ff00:0:120#0, allow rest": {
 			ACL: &ACL{Entries: []*ACLEntry{
 				{Action: Deny, Rule: mustHopPredicate(t, "1-ff00:0:110#0")},
 				{Action: Deny, Rule: mustHopPredicate(t, "1-ff00:0:120#0")},
@@ -408,8 +350,7 @@ func TestACLEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:222"),
 			ExpPathNum: 2,
 		},
-		{
-			Name: "deny 1-ff00:0:110#0, 1-ff00:0:120#0 and 1-ff00:0:111#2823, allow rest",
+		"deny 1-ff00:0:110#0, 1-ff00:0:120#0 and 1-ff00:0:111#2823, allow rest": {
 			ACL: &ACL{Entries: []*ACLEntry{
 				{Action: Deny, Rule: mustHopPredicate(t, "1-ff00:0:110#0")},
 				{Action: Deny, Rule: mustHopPredicate(t, "1-ff00:0:120#0")},
@@ -419,8 +360,7 @@ func TestACLEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:222"),
 			ExpPathNum: 1,
 		},
-		{
-			Name: "deny ISD1, allow certain ASes",
+		"deny ISD1, allow certain ASes": {
 			ACL: &ACL{Entries: []*ACLEntry{
 				{Action: Allow, Rule: mustHopPredicate(t, "1-ff00:0:120#0")},
 				{Action: Allow, Rule: mustHopPredicate(t, "1-ff00:0:130#0")},
@@ -430,8 +370,7 @@ func TestACLEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 2,
 		},
-		{
-			Name: "deny ISD1, allow certain ASes - wrong oder",
+		"deny ISD1, allow certain ASes - wrong oder": {
 			ACL: &ACL{Entries: []*ACLEntry{
 				{Action: Deny, Rule: mustHopPredicate(t, "1-0#0")},
 				{Action: Allow, Rule: mustHopPredicate(t, "1-ff00:0:130#0")},
@@ -441,8 +380,7 @@ func TestACLEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 0,
 		},
-		{
-			Name: "nil rule should match all the paths",
+		"nil rule should match all the paths": {
 			ACL: &ACL{Entries: []*ACLEntry{
 				{Action: Deny, Rule: nil},
 				allowEntry}},
@@ -451,23 +389,16 @@ func TestACLEval(t *testing.T) {
 			ExpPathNum: 0,
 		},
 	}
-
-	Convey("TestPolicy", t, func() {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-		conn := testGetSCIONDConn(t, ctrl)
-		for _, tc := range testCases {
-			Convey(tc.Name, func() {
-				paths, err := conn.Paths(context.Background(), tc.Dst, tc.Src, 5,
-					sciond.PathReqFlags{})
-				SoMsg("sciond err", err, ShouldBeNil)
-
-				inAPS := spathmeta.NewAppPathSet(paths)
-				outAPS := tc.ACL.Eval(inAPS)
-				SoMsg("paths", len(outAPS), ShouldEqual, tc.ExpPathNum)
-			})
-		}
-	})
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	pp := NewPathProvider(ctrl)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			paths := pp.GetPaths(test.Src, test.Dst)
+			outPaths := test.ACL.Eval2(paths)
+			assert.Equal(t, test.ExpPathNum, len(outPaths))
+		})
+	}
 }
 
 func TestACLPanic(t *testing.T) {
@@ -475,47 +406,39 @@ func TestACLPanic(t *testing.T) {
 		Action: Allow,
 		Rule:   mustHopPredicate(t, "1-0#0")}}}
 
-	Convey("TestACLPanic", t, func() {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-		conn := testGetSCIONDConn(t, ctrl)
-		paths, err := conn.Paths(context.Background(), xtest.MustParseIA("2-ff00:0:211"),
-			xtest.MustParseIA("2-ff00:0:212"), 5, sciond.PathReqFlags{})
-		SoMsg("sciond err", err, ShouldBeNil)
-
-		inAPS := spathmeta.NewAppPathSet(paths)
-		So(func() { acl.Eval(inAPS) }, ShouldPanic)
-	})
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	pp := NewPathProvider(ctrl)
+	paths := pp.GetPaths(xtest.MustParseIA("2-ff00:0:212"), xtest.MustParseIA("2-ff00:0:211"))
+	assert.Panics(t, func() { acl.Eval2(paths) })
 }
 
 func TestACLConstructor(t *testing.T) {
-	Convey("TestACLConstructor", t, func() {
-		_, err := NewACL(&ACLEntry{
-			Action: Allow,
-			Rule:   mustHopPredicate(t, "1-0#0")})
-		SoMsg("constructor", err, ShouldResemble,
-			common.NewBasicError("ACL does not have a default", nil))
-		acl, err := NewACL(&ACLEntry{
-			Action: Allow,
-			Rule:   mustHopPredicate(t, "1-0#0")},
-			&ACLEntry{
-				Action: Deny,
-				Rule:   mustHopPredicate(t, "0-0#0")})
-		SoMsg("err", err, ShouldBeNil)
-		SoMsg("acl", acl, ShouldNotBeNil)
-	})
+	_, err := NewACL(&ACLEntry{
+		Action: Allow,
+		Rule:   mustHopPredicate(t, "1-0#0")})
+	if assert.Error(t, err) {
+		assert.Equal(t, common.NewBasicError("ACL does not have a default", nil), err)
+	}
+	acl, err := NewACL(&ACLEntry{
+		Action: Allow,
+		Rule:   mustHopPredicate(t, "1-0#0")},
+		&ACLEntry{
+			Action: Deny,
+			Rule:   mustHopPredicate(t, "0-0#0")})
+	if assert.NoError(t, err) {
+		assert.NotNil(t, acl)
+	}
 }
 
 func TestOptionsEval(t *testing.T) {
-	testCases := []struct {
-		Name       string
+	tests := map[string]struct {
 		Policy     *Policy
 		Src        addr.IA
 		Dst        addr.IA
 		ExpPathNum int
 	}{
-		{
-			Name: "one option, allow everything",
+		"one option, allow everything": {
 			Policy: NewPolicy("", nil, nil, []Option{
 				{
 					Policy: &Policy{
@@ -530,8 +453,7 @@ func TestOptionsEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
-		{
-			Name: "two options, deny everything",
+		"two options, deny everything": {
 			Policy: NewPolicy("", nil, nil, []Option{
 				{
 					Policy: &Policy{
@@ -552,8 +474,7 @@ func TestOptionsEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:211"),
 			ExpPathNum: 2,
 		},
-		{
-			Name: "two options, first: allow everything, second: allow one path",
+		"two options, first: allow everything, second: allow one path": {
 			Policy: NewPolicy("", nil, nil, []Option{
 				{Policy: &Policy{ACL: &ACL{Entries: []*ACLEntry{
 					{Action: Allow, Rule: mustHopPredicate(t, "0-0#0")},
@@ -570,8 +491,7 @@ func TestOptionsEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:222"),
 			ExpPathNum: 1,
 		},
-		{
-			Name: "two options, combined",
+		"two options, combined": {
 			Policy: NewPolicy("", nil, nil, []Option{
 				{Policy: &Policy{ACL: &ACL{Entries: []*ACLEntry{
 					{Action: Deny, Rule: mustHopPredicate(t, "1-ff00:0:120#0")},
@@ -586,8 +506,7 @@ func TestOptionsEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 3,
 		},
-		{
-			Name: "two options, take first",
+		"two options, take first": {
 			Policy: NewPolicy("", nil, nil, []Option{
 				{Policy: &Policy{ACL: &ACL{Entries: []*ACLEntry{
 					{Action: Deny, Rule: mustHopPredicate(t, "1-ff00:0:120#0")},
@@ -602,8 +521,7 @@ func TestOptionsEval(t *testing.T) {
 			Dst:        xtest.MustParseIA("2-ff00:0:220"),
 			ExpPathNum: 1,
 		},
-		{
-			Name: "two options, take second",
+		"two options, take second": {
 			Policy: NewPolicy("", nil, nil, []Option{
 				{Policy: &Policy{ACL: &ACL{Entries: []*ACLEntry{
 					{Action: Deny, Rule: mustHopPredicate(t, "1-ff00:0:120#0")},
@@ -619,34 +537,25 @@ func TestOptionsEval(t *testing.T) {
 			ExpPathNum: 2,
 		},
 	}
-
-	Convey("TestPolicy", t, func() {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-		conn := testGetSCIONDConn(t, ctrl)
-		for _, tc := range testCases {
-			Convey(tc.Name, func() {
-				paths, err := conn.Paths(context.Background(), tc.Dst, tc.Src, 5,
-					sciond.PathReqFlags{})
-				SoMsg("sciond err", err, ShouldBeNil)
-
-				inAPS := spathmeta.NewAppPathSet(paths)
-				outAPS := tc.Policy.Act(inAPS).(spathmeta.AppPathSet)
-				SoMsg("paths", len(outAPS), ShouldEqual, tc.ExpPathNum)
-			})
-		}
-	})
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	pp := NewPathProvider(ctrl)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			paths := pp.GetPaths(test.Src, test.Dst)
+			outPaths := test.Policy.Act2(paths)
+			assert.Equal(t, test.ExpPathNum, len(outPaths))
+		})
+	}
 }
 
 func TestExtends(t *testing.T) {
-	testCases := []struct {
-		Name           string
+	tests := map[string]struct {
 		Policy         *ExtPolicy
 		Extended       []*ExtPolicy
 		ExtendedPolicy *Policy
 	}{
-		{
-			Name: "one extends, use sub acl",
+		"one extends, use sub acl": {
 			Policy: &ExtPolicy{
 				Extends: []string{"policy1"}},
 			Extended: []*ExtPolicy{
@@ -663,8 +572,7 @@ func TestExtends(t *testing.T) {
 					Rule:   mustHopPredicate(t, "0-0#0")},
 					denyEntry}}},
 		},
-		{
-			Name: "use option of extended policy",
+		"use option of extended policy": {
 			Policy: &ExtPolicy{
 				Extends: []string{"policy1"}},
 			Extended: []*ExtPolicy{
@@ -691,8 +599,7 @@ func TestExtends(t *testing.T) {
 			},
 			},
 		},
-		{
-			Name:   "two extends, use sub acl and list",
+		"two extends, use sub acl and list": {
 			Policy: &ExtPolicy{Extends: []string{"policy1"}},
 			Extended: []*ExtPolicy{
 				{
@@ -710,8 +617,7 @@ func TestExtends(t *testing.T) {
 				denyEntry}},
 				Sequence: newSequence(t, "1-ff00:0:133#1019 1-ff00:0:132#1910")},
 		},
-		{
-			Name: "two extends, only use acl",
+		"two extends, only use acl": {
 			Policy: &ExtPolicy{
 				Policy: &Policy{
 					Sequence: newSequence(t, "1-ff00:0:133#0 1-ff00:0:132#0")},
@@ -731,8 +637,7 @@ func TestExtends(t *testing.T) {
 				denyEntry}},
 				Sequence: newSequence(t, "1-ff00:0:133#0 1-ff00:0:132#0")},
 		},
-		{
-			Name: "three extends, use last list",
+		"three extends, use last list": {
 			Policy: &ExtPolicy{
 				Extends: []string{"p1", "p2", "p3"}},
 			Extended: []*ExtPolicy{
@@ -752,8 +657,7 @@ func TestExtends(t *testing.T) {
 			ExtendedPolicy: &Policy{
 				Sequence: newSequence(t, "1-ff00:0:133#1013 1-ff00:0:132#1913")},
 		},
-		{
-			Name: "nested extends",
+		"nested extends": {
 			Policy: &ExtPolicy{
 				Extends: []string{"policy1"}},
 			Extended: []*ExtPolicy{
@@ -772,8 +676,7 @@ func TestExtends(t *testing.T) {
 			ExtendedPolicy: &Policy{
 				Sequence: newSequence(t, "1-ff00:0:133#1011 1-ff00:0:132#1911")},
 		},
-		{
-			Name: "nested extends, evaluating order",
+		"nested extends, evaluating order": {
 			Policy: &ExtPolicy{
 				Extends: []string{"policy3"}},
 			Extended: []*ExtPolicy{
@@ -793,8 +696,7 @@ func TestExtends(t *testing.T) {
 			ExtendedPolicy: &Policy{
 				Sequence: newSequence(t, "1-ff00:0:133#1010 1-ff00:0:132#1910")},
 		},
-		{
-			Name: "different nested extends, evaluating order",
+		"different nested extends, evaluating order": {
 			Policy: &ExtPolicy{
 				Extends: []string{"policy6"}},
 			Extended: []*ExtPolicy{
@@ -819,17 +721,16 @@ func TestExtends(t *testing.T) {
 		},
 	}
 
-	Convey("TestPolicy Extend", t, func() {
-		for _, tc := range testCases {
-			Convey(tc.Name, func() {
-				pol, err := PolicyFromExtPolicy(tc.Policy, tc.Extended)
-				SoMsg("err", err, ShouldBeNil)
-				SoMsg("policies", pol, ShouldResemble, tc.ExtendedPolicy)
-			})
-		}
-	})
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			pol, err := PolicyFromExtPolicy(test.Policy, test.Extended)
+			if assert.NoError(t, err) {
+				assert.Equal(t, test.ExtendedPolicy, pol)
+			}
+		})
+	}
 
-	Convey("TestPolicy Extend not found", t, func() {
+	t.Run("TestPolicy Extend not found", func(t *testing.T) {
 		extPolicy := &ExtPolicy{Extends: []string{"policy1"}}
 		extended := []*ExtPolicy{
 			{
@@ -845,27 +746,24 @@ func TestExtends(t *testing.T) {
 			},
 		}
 		_, err := PolicyFromExtPolicy(extPolicy, extended)
-		SoMsg("error", err, ShouldNotBeNil)
+		assert.Error(t, err)
 	})
 }
 
 func TestSequenceConstructor(t *testing.T) {
-	Convey("TestSequenceConstructor", t, func() {
-		_, err := NewSequence("0-0-0#0")
-		SoMsg("err1", err, ShouldNotBeNil)
-
-		_, err = NewSequence("0#0#0")
-		SoMsg("err2", err, ShouldNotBeNil)
-
-		_, err = NewSequence("0")
-		SoMsg("err3", err, ShouldBeNil)
-
-		_, err = NewSequence("1#0")
-		SoMsg("err4", err, ShouldNotBeNil)
-
-		_, err = NewSequence("1-0")
-		SoMsg("err5", err, ShouldBeNil)
-	})
+	tests := map[string]assert.ErrorAssertionFunc{
+		"0-0-0#0": assert.Error,
+		"0#0#0":   assert.Error,
+		"0":       assert.NoError,
+		"1#0":     assert.Error,
+		"1-0":     assert.NoError,
+	}
+	for seq, assertion := range tests {
+		t.Run(seq, func(t *testing.T) {
+			_, err := NewSequence(seq)
+			assertion(t, err, seq)
+		})
+	}
 }
 
 func newSequence(t *testing.T, str string) *Sequence {
@@ -874,23 +772,44 @@ func newSequence(t *testing.T, str string) *Sequence {
 	return seq
 }
 
-func testGetSCIONDConn(t *testing.T, ctrl *gomock.Controller) sciond.Connector {
-	t.Helper()
+type PathProvider struct {
+	g *graph.Graph
+}
 
-	g := graph.NewDefaultGraph(ctrl)
-	service := sciond.NewMockService(g)
-	conn, err := service.Connect()
-	if err != nil {
-		t.Fatalf("sciond init error: %s", err)
+func NewPathProvider(ctrl *gomock.Controller) PathProvider {
+	return PathProvider{
+		g: graph.NewDefaultGraph(ctrl),
 	}
-	return conn
 }
 
-func mustPolicyFromExtPolicy(t *testing.T, extPolicy *ExtPolicy, extended []*ExtPolicy) *Policy {
-	pol, err := PolicyFromExtPolicy(extPolicy, extended)
-	xtest.FailOnErr(t, err)
-	return pol
+func (p PathProvider) GetPaths(src, dst addr.IA) PathSet {
+	result := make(PathSet)
+	paths := p.g.GetPaths(src.String(), dst.String())
+	for _, ifids := range paths {
+		pathIntfs := make([]PathInterface, 0, len(ifids))
+		var key strings.Builder
+		for _, ifid := range ifids {
+			ia := p.g.GetParent(ifid)
+			pathIntfs = append(pathIntfs, PathInterface{IA: ia, IfId: ifid})
+			key.WriteString(fmt.Sprintf("%s-%d", ia, ifid))
+		}
+		result[key.String()] = &testPath{interfaces: pathIntfs, key: key.String()}
+	}
+	return result
 }
+
+type testPath struct {
+	interfaces []PathInterface
+	key        string
+}
+
+func (p *testPath) Interfaces() []PathInterface {
+	return p.interfaces
+}
+
+func (p *testPath) IsPartial() bool { return false }
+
+func (p *testPath) Key() string { return p.key }
 
 func mustHopPredicate(t *testing.T, str string) *HopPredicate {
 	hp, err := HopPredicateFromString(str)

--- a/go/lib/pathpol/policy_test.go
+++ b/go/lib/pathpol/policy_test.go
@@ -50,7 +50,7 @@ func TestBasicPolicy(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			paths := pp.GetPaths(test.Src, test.Dst)
-			outPaths := test.Policy.Act2(paths)
+			outPaths := test.Policy.Act(paths)
 			assert.Equal(t, test.ExpPathNum, len(outPaths))
 		})
 	}
@@ -292,7 +292,7 @@ func TestSequenceEval(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			paths := pp.GetPaths(test.Src, test.Dst)
-			outPaths := test.Seq.Eval2(paths)
+			outPaths := test.Seq.Eval(paths)
 			assert.Equal(t, test.ExpPathNum, len(outPaths))
 		})
 	}
@@ -395,7 +395,7 @@ func TestACLEval(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			paths := pp.GetPaths(test.Src, test.Dst)
-			outPaths := test.ACL.Eval2(paths)
+			outPaths := test.ACL.Eval(paths)
 			assert.Equal(t, test.ExpPathNum, len(outPaths))
 		})
 	}
@@ -410,7 +410,7 @@ func TestACLPanic(t *testing.T) {
 	defer ctrl.Finish()
 	pp := NewPathProvider(ctrl)
 	paths := pp.GetPaths(xtest.MustParseIA("2-ff00:0:212"), xtest.MustParseIA("2-ff00:0:211"))
-	assert.Panics(t, func() { acl.Eval2(paths) })
+	assert.Panics(t, func() { acl.Eval(paths) })
 }
 
 func TestACLConstructor(t *testing.T) {
@@ -543,7 +543,7 @@ func TestOptionsEval(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			paths := pp.GetPaths(test.Src, test.Dst)
-			outPaths := test.Policy.Act2(paths)
+			outPaths := test.Policy.Act(paths)
 			assert.Equal(t, test.ExpPathNum, len(outPaths))
 		})
 	}

--- a/go/lib/pathpol/sequence.go
+++ b/go/lib/pathpol/sequence.go
@@ -126,13 +126,13 @@ func (s *Sequence) Eval2(inputSet PathSet) PathSet {
 		// one element in form <IA>#<inbound-interface>,<outbound-interface>,
 		// e.g. 64-ff00:0:112#3,5. For the source AS, the inbound interface will be
 		// zero. For destination AS, outbound interface will be zero.
-		p := fmt.Sprintf("%s#0,%d ", ifaces[0].IA, ifaces[0].IfId)
+		p := fmt.Sprintf("%s#0,%d ", ifaces[0].IA(), ifaces[0].IfId())
 		for i := 1; i < len(ifaces)-1; i += 2 {
-			p += fmt.Sprintf("%s#%d,%d ", ifaces[i].IA,
-				ifaces[i].IfId, ifaces[i+1].IfId)
+			p += fmt.Sprintf("%s#%d,%d ", ifaces[i].IA(),
+				ifaces[i].IfId(), ifaces[i+1].IfId())
 		}
-		p += fmt.Sprintf("%s#%d,0 ", ifaces[len(ifaces)-1].IA,
-			ifaces[len(ifaces)-1].IfId)
+		p += fmt.Sprintf("%s#%d,0 ", ifaces[len(ifaces)-1].IA(),
+			ifaces[len(ifaces)-1].IfId())
 		// Check whether the string matches the sequence regexp.
 		//fmt.Printf("EVAL: %s\n", p)
 		if s.re.MatchString(p) {

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -272,6 +272,14 @@ func (iface *PathInterface) ISD_AS() addr.IA {
 	return iface.RawIsdas.IA()
 }
 
+func (iface PathInterface) IA() addr.IA {
+	return iface.RawIsdas.IA()
+}
+
+func (iface PathInterface) IfId() common.IFIDType {
+	return iface.IfID
+}
+
 func (iface *PathInterface) Equal(other *PathInterface) bool {
 	if iface == nil || other == nil {
 		return iface == other

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -193,7 +193,7 @@ func (fpm *FwdPathMeta) SrcIA() addr.IA {
 	if len(ifaces) == 0 {
 		return addr.IA{}
 	}
-	return ifaces[0].ISD_AS()
+	return ifaces[0].IA()
 }
 
 func (fpm *FwdPathMeta) DstIA() addr.IA {
@@ -201,7 +201,7 @@ func (fpm *FwdPathMeta) DstIA() addr.IA {
 	if len(ifaces) == 0 {
 		return addr.IA{}
 	}
-	return ifaces[len(ifaces)-1].ISD_AS()
+	return ifaces[len(ifaces)-1].IA()
 }
 
 func (fpm *FwdPathMeta) Expiry() time.Time {
@@ -232,14 +232,14 @@ func (fpm *FwdPathMeta) fmtIfaces() []string {
 		return hops
 	}
 	intf := fpm.Interfaces[0]
-	hops = append(hops, fmt.Sprintf("%s %d", intf.ISD_AS(), intf.IfID))
+	hops = append(hops, fmt.Sprintf("%s %d", intf.IA(), intf.IfID))
 	for i := 1; i < len(fpm.Interfaces)-1; i += 2 {
 		inIntf := fpm.Interfaces[i]
 		outIntf := fpm.Interfaces[i+1]
-		hops = append(hops, fmt.Sprintf("%d %s %d", inIntf.IfID, inIntf.ISD_AS(), outIntf.IfID))
+		hops = append(hops, fmt.Sprintf("%d %s %d", inIntf.IfID, inIntf.IA(), outIntf.IfID))
 	}
 	intf = fpm.Interfaces[len(fpm.Interfaces)-1]
-	hops = append(hops, fmt.Sprintf("%d %s", intf.IfID, intf.ISD_AS()))
+	hops = append(hops, fmt.Sprintf("%d %s", intf.IfID, intf.IA()))
 	return hops
 }
 
@@ -268,10 +268,6 @@ func NewPathInterface(str string) (PathInterface, error) {
 	return iface, nil
 }
 
-func (iface *PathInterface) ISD_AS() addr.IA {
-	return iface.RawIsdas.IA()
-}
-
 func (iface PathInterface) IA() addr.IA {
 	return iface.RawIsdas.IA()
 }
@@ -288,7 +284,7 @@ func (iface *PathInterface) Equal(other *PathInterface) bool {
 }
 
 func (iface PathInterface) String() string {
-	return fmt.Sprintf("%s#%d", iface.ISD_AS(), iface.IfID)
+	return fmt.Sprintf("%s#%d", iface.IA(), iface.IfID)
 }
 
 type ASInfoReq struct {

--- a/go/lib/spath/spathmeta/apppath.go
+++ b/go/lib/spath/spathmeta/apppath.go
@@ -91,7 +91,7 @@ type AppPath struct {
 func (ap *AppPath) Key() PathKey {
 	h := sha256.New()
 	for _, iface := range ap.Entry.Path.Interfaces {
-		binary.Write(h, common.Order, iface.ISD_AS().IAInt())
+		binary.Write(h, common.Order, iface.RawIsdas)
 		binary.Write(h, common.Order, iface.IfID)
 	}
 	return PathKey(h.Sum(nil))

--- a/go/lib/spath/spathmeta/apppath.go
+++ b/go/lib/spath/spathmeta/apppath.go
@@ -97,14 +97,6 @@ func (ap *AppPath) Key() PathKey {
 	return PathKey(h.Sum(nil))
 }
 
-func (ap *AppPath) Interfaces() []*sciond.PathInterface {
-	return nil
-}
-
-func (ap *AppPath) IsPartial() bool {
-	return false
-}
-
 func (ap *AppPath) Copy() *AppPath {
 	// FIXME(scrye): this might need deep copying as well
 	return &AppPath{

--- a/go/lib/spath/spathmeta/apppath.go
+++ b/go/lib/spath/spathmeta/apppath.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -94,6 +95,14 @@ func (ap *AppPath) Key() PathKey {
 		binary.Write(h, common.Order, iface.IfID)
 	}
 	return PathKey(h.Sum(nil))
+}
+
+func (ap *AppPath) Interfaces() []*sciond.PathInterface {
+	return nil
+}
+
+func (ap *AppPath) IsPartial() bool {
+	return false
 }
 
 func (ap *AppPath) Copy() *AppPath {

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -399,7 +399,7 @@ func (f *fetcherHandler) filterRevokedPaths(ctx context.Context,
 		for _, iface := range path.Interfaces {
 			// cache automatically expires outdated revocations every second,
 			// so a cache hit implies revocation is still active.
-			revs, err := f.revocationCache.Get(ctx, revcache.SingleKey(iface.ISD_AS(), iface.IfID))
+			revs, err := f.revocationCache.Get(ctx, revcache.SingleKey(iface.IA(), iface.IfID))
 			if err != nil {
 				f.logger.Error("Failed to get revocation", "err", err)
 				// continue, the client might still get some usable paths like this.


### PR DESCRIPTION
Instead of accepting an interface{} which must be a spathmeta.AppPathSet, define a type in the pathpol package that must be given as an input.

This way we will get more flexibility in what we pass in.
Everything that implements the accepted type can now be filtered by the policy.

Also remove goconvey dependency from pathpol testing.

Fixes #2939

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2943)
<!-- Reviewable:end -->
