### PR TITLE
Test: Make bazel output useful

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -268,7 +268,9 @@ py_test() {
 
 bazel_test() {
     local color_mode="auto"
-    [ "$CI" == "true" ] && color_mode="no"
+    if is_running_in_docker; then
+        color_mode="no"
+    fi
     bazel test //go/... --print_relative_test_log_paths --color $color_mode
 }
 

--- a/scion.sh
+++ b/scion.sh
@@ -267,7 +267,8 @@ py_test() {
 }
 
 bazel_test() {
-    local color_mode=$([ "$CI" == "true" ] && echo "no" || echo "auto")
+    local color_mode="auto"
+    [ "$CI" == "true" ] && color_mode="no"
     bazel test //go/... --print_relative_test_log_paths --color $color_mode
 }
 

--- a/scion.sh
+++ b/scion.sh
@@ -267,7 +267,8 @@ py_test() {
 }
 
 bazel_test() {
-    bazel test //go/... --print_relative_test_log_paths --color no
+    local color_mode=$([ "$CI" == "true" ] && echo "no" || echo "auto")
+    bazel test //go/... --print_relative_test_log_paths --color $color_mode
 }
 
 cmd_coverage(){


### PR DESCRIPTION
With this PR, no-color mode is only enabled on CI.
This reduces the output of `./scion.sh test` to the relevant parts
and makes it useful for humans again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2954)
<!-- Reviewable:end -->
