### PR TITLE
Remove goconvey from {pathdb,periodic,util} tests

### DIFF
--- a/go/lib/pathdb/pathdbtest/BUILD.bazel
+++ b/go/lib/pathdb/pathdbtest/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//go/lib/xtest:go_default_library",
         "//go/proto:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/lib/pathdb/sqlite/sqlite_test.go
+++ b/go/lib/pathdb/sqlite/sqlite_test.go
@@ -59,9 +59,7 @@ func (b *TestPathDB) Prepare(t *testing.T, _ context.Context) {
 
 func TestPathDBSuite(t *testing.T) {
 	tdb := &TestPathDB{}
-	Convey("PathDBSuite", t, func() {
-		pathdbtest.TestPathDB(t, tdb)
-	})
+	pathdbtest.TestPathDB(t, tdb)
 }
 
 func TestOpenExisting(t *testing.T) {

--- a/go/lib/periodic/BUILD.bazel
+++ b/go/lib/periodic/BUILD.bazel
@@ -17,6 +17,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/xtest:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/go/lib/periodic/periodic_test.go
+++ b/go/lib/periodic/periodic_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/scionproto/scion/go/lib/xtest"
 )
@@ -48,89 +48,81 @@ func (t *testTicker) Chan() <-chan time.Time {
 func (t *testTicker) Stop() {}
 
 func TestPeriodicExecution(t *testing.T) {
-	Convey("Test periodic execution", t, func() {
-		done := make(chan struct{})
-		cnt := 0
-		fn := taskFunc(func(ctx context.Context) {
-			cnt++
-			done <- struct{}{}
-		})
-		tickC := make(chan time.Time)
-		ticker := &testTicker{C: tickC}
-		r := StartPeriodicTask(fn, ticker, time.Microsecond)
-		tickC <- time.Now()
-		xtest.AssertReadReturnsBefore(t, done, 50*time.Millisecond)
-		tickC <- time.Now()
-		xtest.AssertReadReturnsBefore(t, done, 50*time.Millisecond)
-		tickC <- time.Now()
-		xtest.AssertReadReturnsBefore(t, done, 50*time.Millisecond)
-		r.Stop()
-		SoMsg("Must have executed 3 times", cnt, ShouldEqual, 3)
+	done := make(chan struct{})
+	cnt := 0
+	fn := taskFunc(func(ctx context.Context) {
+		cnt++
+		done <- struct{}{}
 	})
+	tickC := make(chan time.Time)
+	ticker := &testTicker{C: tickC}
+	r := StartPeriodicTask(fn, ticker, time.Microsecond)
+	tickC <- time.Now()
+	xtest.AssertReadReturnsBefore(t, done, 50*time.Millisecond)
+	tickC <- time.Now()
+	xtest.AssertReadReturnsBefore(t, done, 50*time.Millisecond)
+	tickC <- time.Now()
+	xtest.AssertReadReturnsBefore(t, done, 50*time.Millisecond)
+	r.Stop()
+	assert.Equal(t, 3, cnt, "Must have executed 3 times")
 }
 
 func TestKillExitsLongRunningFunc(t *testing.T) {
-	Convey("Test kill cancels the context of the run function", t, func() {
-		errChan := make(chan error, 1)
-		fn := taskFunc(func(ctx context.Context) {
-			// Simulate long work by blocking on the done channel.
-			xtest.AssertReadReturnsBefore(t, ctx.Done(), time.Second)
-			errChan <- ctx.Err()
-		})
-		tickC := make(chan time.Time)
-		ticker := &testTicker{C: tickC}
-		r := StartPeriodicTask(fn, ticker, time.Second)
-		// trigger the periodic method.
-		tickC <- time.Now()
-		r.Kill()
-		var err error
-		select {
-		case err = <-errChan:
-		case <-time.After(time.Second):
-			t.Fatalf("time out while waiting on err")
-		}
-		SoMsg("Context should have been canceled", err, ShouldEqual, context.Canceled)
+	errChan := make(chan error, 1)
+	fn := taskFunc(func(ctx context.Context) {
+		// Simulate long work by blocking on the done channel.
+		xtest.AssertReadReturnsBefore(t, ctx.Done(), time.Second)
+		errChan <- ctx.Err()
 	})
+	tickC := make(chan time.Time)
+	ticker := &testTicker{C: tickC}
+	r := StartPeriodicTask(fn, ticker, time.Second)
+	// trigger the periodic method.
+	tickC <- time.Now()
+	r.Kill()
+	var err error
+	select {
+	case err = <-errChan:
+	case <-time.After(time.Second):
+		t.Fatalf("time out while waiting on err")
+	}
+	assert.Equal(t, context.Canceled, err, "Context should have been canceled")
 }
 
 func TestTaskDoesntRunAfterKill(t *testing.T) {
-	Convey("Test task doesn't run after the periodic runner was killed.", t, func() {
-		fn := taskFunc(func(ctx context.Context) {
-			t.Fatalf("Should not have executed")
-		})
-		tickC := make(chan time.Time)
-		ticker := &testTicker{C: tickC}
-		// Try to make sure tick channel is full.
-		go func() {
-			tickC <- time.Now()
-		}()
-		runtime.Gosched()
-		// Now start the task and immediately kill it.
-		r := StartPeriodicTask(fn, ticker, time.Second)
-		r.Kill()
+	fn := taskFunc(func(ctx context.Context) {
+		t.Fatalf("Should not have executed")
 	})
+	tickC := make(chan time.Time)
+	ticker := &testTicker{C: tickC}
+	// Try to make sure tick channel is full.
+	go func() {
+		tickC <- time.Now()
+	}()
+	runtime.Gosched()
+	// Now start the task and immediately kill it.
+	r := StartPeriodicTask(fn, ticker, time.Second)
+	r.Kill()
 }
 
 func TestTriggerNow(t *testing.T) {
-	Convey("TestTriggerNow", t, func() {
-		done := make(chan struct{})
-		cnt := 0
-		fn := taskFunc(func(ctx context.Context) {
-			cnt++
-			done <- struct{}{}
-		})
-		tickC := make(chan time.Time)
-		ticker := &testTicker{C: tickC}
-		r := StartPeriodicTask(fn, ticker, time.Microsecond)
-		r.TriggerRun()
-		xtest.AssertReadReturnsBefore(t, done, 50*time.Millisecond)
-		tickC <- time.Now()
-		xtest.AssertReadReturnsBefore(t, done, 50*time.Millisecond)
-		r.TriggerRun()
-		xtest.AssertReadReturnsBefore(t, done, 50*time.Millisecond)
-		r.Stop()
-		// check that a trigger after stop doesn't do anything.
-		r.TriggerRun()
-		SoMsg("Must have executed 3 times", cnt, ShouldEqual, 3)
+	done := make(chan struct{})
+	cnt := 0
+	fn := taskFunc(func(ctx context.Context) {
+		cnt++
+		done <- struct{}{}
 	})
+	tickC := make(chan time.Time)
+	ticker := &testTicker{C: tickC}
+	r := StartPeriodicTask(fn, ticker, time.Microsecond)
+	r.TriggerRun()
+	xtest.AssertReadReturnsBefore(t, done, 50*time.Millisecond)
+	tickC <- time.Now()
+	xtest.AssertReadReturnsBefore(t, done, 50*time.Millisecond)
+	r.TriggerRun()
+	xtest.AssertReadReturnsBefore(t, done, 50*time.Millisecond)
+	r.Stop()
+	// check that a trigger after stop doesn't do anything.
+	r.TriggerRun()
+	assert.Equal(t, 3, cnt, "Must have executed 3 times")
 }

--- a/go/lib/util/BUILD.bazel
+++ b/go/lib/util/BUILD.bazel
@@ -40,7 +40,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/common:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",

--- a/go/lib/util/checksum_test.go
+++ b/go/lib/util/checksum_test.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/scionproto/scion/go/lib/common"
 )
@@ -40,17 +41,13 @@ func TestChecksum(t *testing.T) {
 			{0xb1, 0xb2, 0xb3},
 			{0x10, 0x20}}, [2]byte{0x45, 0xe5}},
 	}
-
-	Convey("Test checksum", t, func() {
-		for _, test := range tests {
-			checksum := make([]byte, 2)
-			binary.BigEndian.PutUint16(checksum, Checksum(test.Input...))
-			Convey(fmt.Sprintf("Input %v", test.Input), func() {
-				So(checksum[0], ShouldEqual, test.Output[0])
-				So(checksum[1], ShouldEqual, test.Output[1])
-			})
-		}
-	})
+	for _, test := range tests {
+		checksum := make([]byte, 2)
+		binary.BigEndian.PutUint16(checksum, Checksum(test.Input...))
+		t.Run(fmt.Sprintf("Input %v", test.Input), func(t *testing.T) {
+			assert.Equal(t, test.Output[:], checksum)
+		})
+	}
 }
 
 func BenchmarkChecksum(b *testing.B) {

--- a/go/lib/util/duration_test.go
+++ b/go/lib/util/duration_test.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,42 +20,36 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_ParseDuration(t *testing.T) {
 	tests := []struct {
-		input  string
-		output time.Duration
-		isOk   bool
+		input          string
+		output         time.Duration
+		errorAssertion assert.ErrorAssertionFunc
 	}{
-		{"", 0, false},      // Empty string
-		{"0", 0, false},     // No unit provided
-		{"1d12h", 0, false}, // Multiple units
-		{"2ns", 2 * time.Nanosecond, true},
-		{"33us", 33 * time.Microsecond, true},
-		{"4444µs", 4444 * time.Microsecond, true},
-		{"55555ms", 55555 * time.Millisecond, true},
-		{"101s", 101 * time.Second, true},
-		{"102m", 102 * time.Minute, true},
-		{"103h", 103 * time.Hour, true},
-		{"104d", 104 * 24 * time.Hour, true},
-		{"105w", 105 * 7 * 24 * time.Hour, true},
-		{"106y", 106 * 365 * 24 * time.Hour, true},
+		{"", 0, assert.Error},      // Empty string
+		{"0", 0, assert.Error},     // No unit provided
+		{"1d12h", 0, assert.Error}, // Multiple units
+		{"2ns", 2 * time.Nanosecond, assert.NoError},
+		{"33us", 33 * time.Microsecond, assert.NoError},
+		{"4444µs", 4444 * time.Microsecond, assert.NoError},
+		{"55555ms", 55555 * time.Millisecond, assert.NoError},
+		{"101s", 101 * time.Second, assert.NoError},
+		{"102m", 102 * time.Minute, assert.NoError},
+		{"103h", 103 * time.Hour, assert.NoError},
+		{"104d", 104 * 24 * time.Hour, assert.NoError},
+		{"105w", 105 * 7 * 24 * time.Hour, assert.NoError},
+		{"106y", 106 * 365 * 24 * time.Hour, assert.NoError},
 	}
-	Convey("Test ParseDuration", t, func() {
-		for _, test := range tests {
-			Convey(fmt.Sprintf("Input: %q", test.input), func() {
-				ret, err := ParseDuration(test.input)
-				if test.isOk {
-					SoMsg("No error", err, ShouldBeNil)
-					SoMsg("Result should be correct", ret, ShouldEqual, test.output)
-				} else {
-					SoMsg("Error", err, ShouldNotBeNil)
-				}
-			})
-		}
-	})
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Input: %q", test.input), func(t *testing.T) {
+			ret, err := ParseDuration(test.input)
+			test.errorAssertion(t, err)
+			assert.Equal(t, test.output, ret)
+		})
+	}
 }
 
 func Test_FmtDuration(t *testing.T) {
@@ -73,13 +68,10 @@ func Test_FmtDuration(t *testing.T) {
 		{35 * day, "5w"},
 		{101 * year, "101y"},
 	}
-	Convey("Test FmtDuration", t, func() {
-		for _, test := range tests {
-			Convey(fmt.Sprintf("Input: %v", test.output), func() {
-				ret := FmtDuration(test.input)
-				SoMsg("Result should be correct", ret, ShouldEqual, test.output)
-			})
-		}
-	})
-
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Input: %v", test.output), func(t *testing.T) {
+			ret := FmtDuration(test.input)
+			assert.Equal(t, test.output, ret)
+		})
+	}
 }

--- a/go/lib/util/padding_test.go
+++ b/go/lib/util/padding_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,20 +19,19 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_CalcPadding(t *testing.T) {
-	Convey("CalcPadding should calculate the correct padding (8B block size)", t, func() {
-		cases := map[int]int{
-			0: 0, 1: 7, 2: 6, 3: 5, 4: 4, 5: 3, 6: 2, 7: 1,
-			8: 0, 9: 7, 10: 6, 11: 5, 12: 4, 13: 3, 14: 2, 15: 1,
-			16: 0,
-		}
-		for input, expected := range cases {
-			Convey(fmt.Sprintf("Padding for %v should be %v", input, expected), func() {
-				So(CalcPadding(input, 8), ShouldEqual, expected)
-			})
-		}
-	})
+	cases := map[int]int{
+		0: 0, 1: 7, 2: 6, 3: 5, 4: 4, 5: 3, 6: 2, 7: 1,
+		8: 0, 9: 7, 10: 6, 11: 5, 12: 4, 13: 3, 14: 2, 15: 1,
+		16: 0,
+	}
+	for input, expected := range cases {
+		t.Run(fmt.Sprintf("Padding for %v should be %v", input, expected), func(t *testing.T) {
+			assert.Equal(t, expected, CalcPadding(input, 8),
+				"CalcPadding should calculate the correct padding (8B block size)")
+		})
+	}
 }

--- a/go/lib/util/yaml_test.go
+++ b/go/lib/util/yaml_test.go
@@ -1,4 +1,5 @@
 // Copyright 2016 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +18,7 @@ package util
 import (
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v2"
 )
 
@@ -26,40 +27,35 @@ var _ yaml.Marshaler = (*B64Bytes)(nil)
 var _ yaml.Unmarshaler = (*B64Bytes)(nil)
 
 func Test_B64B_String(t *testing.T) {
-	Convey("String() should return hex-encoded string", t, func() {
-		b := B64Bytes{00, 01, 02, 03}
-		So(b.String(), ShouldEqual, "00010203")
-	})
+	b := B64Bytes{00, 01, 02, 03}
+	assert.Equal(t, "00010203", b.String(), "String() should return hex-encoded string")
 }
 
 func Test_B64B_MarshalYAML(t *testing.T) {
-	Convey("Should marshal to a base64-encoded yaml entry", t, func() {
-		b := B64Bytes("hello, world")
-		out, _ := yaml.Marshal(&b)
-		So(string(out), ShouldEqual, "aGVsbG8sIHdvcmxk\n")
-	})
+	b := B64Bytes("hello, world")
+	out, _ := yaml.Marshal(&b)
+	assert.Equal(t, "aGVsbG8sIHdvcmxk\n", string(out),
+		"Should marshal to a base64-encoded yaml entry")
 }
 
 func Test_B64B_UnmarshalYAML_YAMLParseError(t *testing.T) {
-	Convey("YAML parse error", t, func() {
-		var b B64Bytes
-		So(yaml.Unmarshal([]byte("a: b"), &b), ShouldNotBeNil)
-		So(b, ShouldBeZeroValue)
-	})
+	var b B64Bytes
+	err := yaml.Unmarshal([]byte("a: b"), &b)
+	assert.Error(t, err, "YAML parse error")
+	assert.Zero(t, b)
 }
 
 func Test_B64B_UnmarshalYAML_B64DecodeError(t *testing.T) {
-	Convey("Base64 decode error", t, func() {
-		var b B64Bytes
-		So(yaml.Unmarshal([]byte("_"), &b), ShouldNotBeNil)
-		So(b, ShouldBeZeroValue)
-	})
+	var b B64Bytes
+	err := yaml.Unmarshal([]byte("_"), &b)
+	assert.Error(t, err, "Base64 decode error")
+	assert.Zero(t, b)
 }
 
 func Test_B64B_UnmarshalYAML_Success(t *testing.T) {
-	Convey("Valid sequence unmarshaled", t, func() {
-		var b B64Bytes
-		So(yaml.Unmarshal([]byte("aGVsbG8sIHdvcmxk"), &b), ShouldBeNil)
-		So(b, ShouldResemble, B64Bytes("hello, world"))
-	})
+	var b B64Bytes
+	err := yaml.Unmarshal([]byte("aGVsbG8sIHdvcmxk"), &b)
+	if assert.NoError(t, err, "Valid sequence unmarshaled") {
+		assert.Equal(t, B64Bytes("hello, world"), b)
+	}
 }


### PR DESCRIPTION
Remove goconvey from
-pathdb
-periodic
-util
tests.

Without convey we have better insights into failures that happen in CI.

Contributes #2986

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2988)
<!-- Reviewable:end -->
