### PR TITLE
pathdb: Add next query deletion methods

### DIFF
--- a/go/lib/pathdb/BUILD.bazel
+++ b/go/lib/pathdb/BUILD.bazel
@@ -33,8 +33,7 @@ go_test(
     deps = [
         "//go/lib/pathdb/pathdbtest:go_default_library",
         "//go/lib/pathdb/sqlite:go_default_library",
-        "//go/lib/xtest:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/lib/pathdb/metrics_test.go
+++ b/go/lib/pathdb/metrics_test.go
@@ -18,12 +18,11 @@ import (
 	"context"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/go/lib/pathdb"
 	"github.com/scionproto/scion/go/lib/pathdb/pathdbtest"
 	"github.com/scionproto/scion/go/lib/pathdb/sqlite"
-	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 type TestPathDB struct {
@@ -34,15 +33,15 @@ func (b *TestPathDB) Prepare(t *testing.T, _ context.Context) {
 	b.PathDB = setupDB(t)
 }
 
+// TestMetricWrapperFunctionality tests that the metrics wrapper succeeds the
+// normal path db test suite.
 func TestMetricWrapperFunctionality(t *testing.T) {
 	tdb := &TestPathDB{}
-	Convey("Test metrics wrapper functions normally", t, func() {
-		pathdbtest.TestPathDB(t, tdb)
-	})
+	pathdbtest.TestPathDB(t, tdb)
 }
 
 func setupDB(t *testing.T) pathdb.PathDB {
 	db, err := sqlite.New(":memory:")
-	xtest.FailOnErr(t, err)
+	require.NoError(t, err)
 	return pathdb.WithMetrics("testdb", db)
 }

--- a/go/lib/pathdb/mock_pathdb/pathdb.go
+++ b/go/lib/pathdb/mock_pathdb/pathdb.go
@@ -99,6 +99,36 @@ func (mr *MockPathDBMockRecorder) DeleteExpired(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExpired", reflect.TypeOf((*MockPathDB)(nil).DeleteExpired), arg0, arg1)
 }
 
+// DeleteExpiredNQ mocks base method
+func (m *MockPathDB) DeleteExpiredNQ(arg0 context.Context, arg1 time.Time) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteExpiredNQ", arg0, arg1)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteExpiredNQ indicates an expected call of DeleteExpiredNQ
+func (mr *MockPathDBMockRecorder) DeleteExpiredNQ(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExpiredNQ", reflect.TypeOf((*MockPathDB)(nil).DeleteExpiredNQ), arg0, arg1)
+}
+
+// DeleteNQ mocks base method
+func (m *MockPathDB) DeleteNQ(arg0 context.Context, arg1, arg2 addr.IA, arg3 *pathpol.Policy) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNQ", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteNQ indicates an expected call of DeleteNQ
+func (mr *MockPathDBMockRecorder) DeleteNQ(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNQ", reflect.TypeOf((*MockPathDB)(nil).DeleteNQ), arg0, arg1, arg2, arg3)
+}
+
 // Get mocks base method
 func (m *MockPathDB) Get(arg0 context.Context, arg1 *query.Params) (query.Results, error) {
 	m.ctrl.T.Helper()
@@ -280,6 +310,36 @@ func (mr *MockTransactionMockRecorder) DeleteExpired(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExpired", reflect.TypeOf((*MockTransaction)(nil).DeleteExpired), arg0, arg1)
 }
 
+// DeleteExpiredNQ mocks base method
+func (m *MockTransaction) DeleteExpiredNQ(arg0 context.Context, arg1 time.Time) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteExpiredNQ", arg0, arg1)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteExpiredNQ indicates an expected call of DeleteExpiredNQ
+func (mr *MockTransactionMockRecorder) DeleteExpiredNQ(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExpiredNQ", reflect.TypeOf((*MockTransaction)(nil).DeleteExpiredNQ), arg0, arg1)
+}
+
+// DeleteNQ mocks base method
+func (m *MockTransaction) DeleteNQ(arg0 context.Context, arg1, arg2 addr.IA, arg3 *pathpol.Policy) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNQ", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteNQ indicates an expected call of DeleteNQ
+func (mr *MockTransactionMockRecorder) DeleteNQ(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNQ", reflect.TypeOf((*MockTransaction)(nil).DeleteNQ), arg0, arg1, arg2, arg3)
+}
+
 // Get mocks base method
 func (m *MockTransaction) Get(arg0 context.Context, arg1 *query.Params) (query.Results, error) {
 	m.ctrl.T.Helper()
@@ -435,6 +495,36 @@ func (m *MockReadWrite) DeleteExpired(arg0 context.Context, arg1 time.Time) (int
 func (mr *MockReadWriteMockRecorder) DeleteExpired(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExpired", reflect.TypeOf((*MockReadWrite)(nil).DeleteExpired), arg0, arg1)
+}
+
+// DeleteExpiredNQ mocks base method
+func (m *MockReadWrite) DeleteExpiredNQ(arg0 context.Context, arg1 time.Time) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteExpiredNQ", arg0, arg1)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteExpiredNQ indicates an expected call of DeleteExpiredNQ
+func (mr *MockReadWriteMockRecorder) DeleteExpiredNQ(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExpiredNQ", reflect.TypeOf((*MockReadWrite)(nil).DeleteExpiredNQ), arg0, arg1)
+}
+
+// DeleteNQ mocks base method
+func (m *MockReadWrite) DeleteNQ(arg0 context.Context, arg1, arg2 addr.IA, arg3 *pathpol.Policy) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNQ", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteNQ indicates an expected call of DeleteNQ
+func (mr *MockReadWriteMockRecorder) DeleteNQ(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNQ", reflect.TypeOf((*MockReadWrite)(nil).DeleteNQ), arg0, arg1, arg2, arg3)
 }
 
 // Get mocks base method

--- a/go/lib/pathdb/pathdb.go
+++ b/go/lib/pathdb/pathdb.go
@@ -65,6 +65,20 @@ type Write interface {
 	// false if the stored timestamp is already newer.
 	InsertNextQuery(ctx context.Context, src, dst addr.IA, policy *pathpol.Policy,
 		nextQuery time.Time) (bool, error)
+	NextQueryDeleter
+}
+
+// NextQueryDeleter contains functions to delete NextQuery entries.
+type NextQueryDeleter interface {
+	// DeleteExpiredNQ deletes all expired next query entries, i.e. all entries
+	// which have a next query time that is in the past.
+	DeleteExpiredNQ(ctx context.Context, now time.Time) (int, error)
+	// DeleteNQ deletes all entries that match the given parameters. Note that
+	// only parameters with non-zero value are considered, i.e. calling this
+	// function with all zero values deletes all next query entries. Calling
+	// with only a non-zero src value will delete all next query entries where
+	// the source matches the given src parameter.
+	DeleteNQ(ctx context.Context, src, dst addr.IA, policy *pathpol.Policy) (int, error)
 }
 
 // ReadWrite defines all read an write operations of the path DB.

--- a/go/lib/pathdb/pathdbtest/pathdbtest.go
+++ b/go/lib/pathdb/pathdbtest/pathdbtest.go
@@ -89,15 +89,15 @@ func TestPathDB(t *testing.T, db TestablePathDB) {
 			test(t, ctrl, db)
 		}
 	}
-	deleteWrapper := func(inTx bool) func(t *testing.T) {
+	tableWrapper := func(inTx bool, test func(t *testing.T, db TestablePathDB,
+		inTx bool)) func(t *testing.T) {
+
 		return func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			testDelete(t, ctrl, db, inTx)
+			test(t, db, inTx)
 		}
 	}
 	t.Run("Delete",
-		deleteWrapper(false))
+		tableWrapper(false, testDelete))
 	t.Run("InsertWithHpCfgID should correctly insert a new segment",
 		testWrapper(testInsertWithHpCfgIDsFull))
 	t.Run("InsertWithHpCfgID should correctly update a new segment",
@@ -124,6 +124,10 @@ func TestPathDB(t *testing.T, db TestablePathDB) {
 		testWrapper(testGetModifiedIDs))
 	t.Run("NextQuery",
 		testWrapper(testNextQuery))
+	t.Run("DeleteExpiredNQ",
+		tableWrapper(false, testNextQueryDeleteExpired))
+	t.Run("DeleteNQ",
+		tableWrapper(false, testDeleteNQ))
 
 	txTestWrapper := func(test func(*testing.T, *gomock.Controller,
 		pathdb.ReadWrite)) func(t *testing.T) {
@@ -143,7 +147,7 @@ func TestPathDB(t *testing.T, db TestablePathDB) {
 	}
 	t.Run("WithTransaction", func(t *testing.T) {
 		t.Run("Delete",
-			deleteWrapper(true))
+			tableWrapper(true, testDelete))
 		t.Run("InsertWithHpCfgID should correctly insert a new segment",
 			txTestWrapper(testInsertWithHpCfgIDsFull))
 		t.Run("InsertWithHpCfgID should correctly update a new segment",
@@ -170,6 +174,10 @@ func TestPathDB(t *testing.T, db TestablePathDB) {
 			txTestWrapper(testGetModifiedIDs))
 		t.Run("NextQuery",
 			txTestWrapper(testNextQuery))
+		t.Run("DeleteExpiredNQ",
+			tableWrapper(true, testNextQueryDeleteExpired))
+		t.Run("DeleteNQ",
+			tableWrapper(true, testDeleteNQ))
 		t.Run("Rollback", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -181,7 +189,7 @@ func TestPathDB(t *testing.T, db TestablePathDB) {
 	})
 }
 
-func testDelete(t *testing.T, ctrl *gomock.Controller, pathDB TestablePathDB, inTx bool) {
+func testDelete(t *testing.T, pathDB TestablePathDB, inTx bool) {
 	tests := map[string]struct {
 		Setup func(ctx context.Context, t *testing.T, ctrl *gomock.Controller,
 			pathDB pathdb.PathDB) *query.Params
@@ -214,6 +222,8 @@ func testDelete(t *testing.T, ctrl *gomock.Controller, pathDB TestablePathDB, in
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 			ctx, cancelF := context.WithTimeout(context.Background(), timeout)
 			defer cancelF()
 			pathDB.Prepare(t, ctx)
@@ -575,6 +585,181 @@ func testNextQuery(t *testing.T, _ *gomock.Controller, pathDB pathdb.ReadWrite) 
 	defer cancelF()
 	_, err = pathDB.GetNextQuery(ctx, src, xtest.MustParseIA("1-ff00:0:122"), nil)
 	assert.Error(t, err)
+}
+
+// nqDescriptor describes a next query entry.
+type nqDescriptor struct {
+	Src    addr.IA
+	Dst    addr.IA
+	Policy *pathpol.Policy
+}
+
+func testNextQueryDeleteExpired(t *testing.T, pathDB TestablePathDB, inTx bool) {
+	ia110 := xtest.MustParseIA("1-ff00:0:110")
+	ia120 := xtest.MustParseIA("1-ff00:0:120")
+	ia130 := xtest.MustParseIA("1-ff00:0:130")
+
+	tests := map[string]struct {
+		PrepareDB func(t *testing.T, ctx context.Context,
+			now time.Time, pathDB pathdb.ReadWrite)
+		ExpectedDeleted   int
+		ExpectedRemaining []nqDescriptor
+	}{
+		"Empty table, no deletions": {
+			PrepareDB: func(t *testing.T, ctx context.Context,
+				now time.Time, pathDB pathdb.ReadWrite) {
+			},
+		},
+		"Table with non expired entry no deletions": {
+			PrepareDB: func(t *testing.T, ctx context.Context,
+				now time.Time, pathDB pathdb.ReadWrite) {
+
+				_, err := pathDB.InsertNextQuery(ctx, ia110, ia110, nil, now.Add(time.Minute))
+				require.NoError(t, err)
+			},
+			ExpectedRemaining: []nqDescriptor{{ia110, ia110, nil}},
+		},
+		"Table with 2 old entries and 1 new entry -> 2 deletions": {
+			PrepareDB: func(t *testing.T, ctx context.Context,
+				now time.Time, pathDB pathdb.ReadWrite) {
+
+				_, err := pathDB.InsertNextQuery(ctx, ia110, ia110, nil, now.Add(-time.Minute))
+				require.NoError(t, err)
+				_, err = pathDB.InsertNextQuery(ctx, ia110, ia120, nil, now.Add(-time.Minute))
+				require.NoError(t, err)
+				_, err = pathDB.InsertNextQuery(ctx, ia110, ia130, nil, now)
+				require.NoError(t, err)
+			},
+			ExpectedDeleted:   2,
+			ExpectedRemaining: []nqDescriptor{{ia110, ia130, nil}},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancelF := context.WithTimeout(context.Background(), timeout)
+			defer cancelF()
+			pathDB.Prepare(t, ctx)
+
+			now := time.Now()
+			var deleted int
+			test.PrepareDB(t, ctx, now, pathDB)
+			if inTx {
+				tx, err := pathDB.BeginTransaction(ctx, nil)
+				require.NoError(t, err)
+				deleted, err = tx.DeleteExpiredNQ(ctx, now)
+				require.NoError(t, err)
+				require.NoError(t, tx.Commit())
+			} else {
+				var err error
+				deleted, err = pathDB.DeleteExpiredNQ(ctx, now)
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.ExpectedDeleted, deleted)
+			for _, nq := range test.ExpectedRemaining {
+				nextQuery, err := pathDB.GetNextQuery(ctx, nq.Src, nq.Dst, nq.Policy)
+				assert.NoError(t, err, "Expected NQ %v to be in DB", nq)
+				assert.NotZero(t, nextQuery, "Expected NQ %v to be in DB", nq)
+			}
+		})
+	}
+}
+
+func testDeleteNQ(t *testing.T, pathDB TestablePathDB, inTx bool) {
+	ia110 := xtest.MustParseIA("1-ff00:0:110")
+	ia120 := xtest.MustParseIA("1-ff00:0:120")
+	ia130 := xtest.MustParseIA("1-ff00:0:130")
+	pol := policy(t)
+
+	insertStdEntries := func(t *testing.T, ctx context.Context, pathDB pathdb.ReadWrite) {
+		now := time.Now()
+		_, err := pathDB.InsertNextQuery(ctx, ia110, ia110, nil, now.Add(time.Minute))
+		require.NoError(t, err)
+		_, err = pathDB.InsertNextQuery(ctx, ia110, ia120, nil, now.Add(time.Minute))
+		require.NoError(t, err)
+		_, err = pathDB.InsertNextQuery(ctx, ia120, ia130, nil, now.Add(time.Minute))
+		require.NoError(t, err)
+		_, err = pathDB.InsertNextQuery(ctx, ia120, ia130, pol, now.Add(time.Minute))
+		require.NoError(t, err)
+	}
+
+	tests := map[string]struct {
+		PrepareDB         func(t *testing.T, ctx context.Context, pathDB pathdb.ReadWrite)
+		Src               addr.IA
+		Dst               addr.IA
+		Policy            *pathpol.Policy
+		ExpectedDeleted   int
+		ExpectedRemaining []nqDescriptor
+	}{
+		"Empty DB -> no deletions": {
+			PrepareDB: func(t *testing.T, ctx context.Context, pathDB pathdb.ReadWrite) {},
+		},
+		"Full DB, delete all -> deletes all": {
+			PrepareDB:       insertStdEntries,
+			ExpectedDeleted: 4,
+		},
+		"Full DB, delete src -> deletes all with matching src": {
+			PrepareDB:         insertStdEntries,
+			Src:               ia120,
+			ExpectedDeleted:   2,
+			ExpectedRemaining: []nqDescriptor{{ia110, ia110, nil}, {ia110, ia120, nil}},
+		},
+		"Full DB, delete dst -> deletes all with matching dst": {
+			PrepareDB:       insertStdEntries,
+			Dst:             ia120,
+			ExpectedDeleted: 1,
+			ExpectedRemaining: []nqDescriptor{
+				{ia110, ia110, nil}, {ia120, ia130, nil}, {ia120, ia130, pol}},
+		},
+		"Full DB, delete pol -> deletes all with matching policy": {
+			PrepareDB:       insertStdEntries,
+			Policy:          pol,
+			ExpectedDeleted: 1,
+			ExpectedRemaining: []nqDescriptor{
+				{ia110, ia110, nil}, {ia110, ia120, nil}, {ia120, ia130, nil}},
+		},
+		"Full DB, delete src,dst -> deletes all with matching src & dst": {
+			PrepareDB:       insertStdEntries,
+			Src:             ia110,
+			Dst:             ia110,
+			ExpectedDeleted: 1,
+			ExpectedRemaining: []nqDescriptor{
+				{ia110, ia120, nil}, {ia120, ia130, nil}, {ia120, ia130, pol}},
+		},
+		"Not matching query -> deletes nothing": {
+			PrepareDB: insertStdEntries,
+			Src:       ia110,
+			Policy:    pol,
+			ExpectedRemaining: []nqDescriptor{
+				{ia110, ia110, nil}, {ia110, ia120, nil}, {ia120, ia130, nil}, {ia120, ia130, pol}},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancelF := context.WithTimeout(context.Background(), timeout)
+			defer cancelF()
+			pathDB.Prepare(t, ctx)
+
+			var deleted int
+			test.PrepareDB(t, ctx, pathDB)
+			if inTx {
+				tx, err := pathDB.BeginTransaction(ctx, nil)
+				require.NoError(t, err)
+				deleted, err = tx.DeleteNQ(ctx, test.Src, test.Dst, test.Policy)
+				require.NoError(t, err)
+				require.NoError(t, tx.Commit())
+			} else {
+				var err error
+				deleted, err = pathDB.DeleteNQ(ctx, test.Src, test.Dst, test.Policy)
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.ExpectedDeleted, deleted)
+			for _, nq := range test.ExpectedRemaining {
+				nextQuery, err := pathDB.GetNextQuery(ctx, nq.Src, nq.Dst, nq.Policy)
+				assert.NoError(t, err, "Expected NQ %v to be in DB", nq)
+				assert.NotZero(t, nextQuery, "Expected NQ %v to be in DB", nq)
+			}
+		})
+	}
 }
 
 func testRollback(t *testing.T, ctrl *gomock.Controller, pathDB pathdb.PathDB) {


### PR DESCRIPTION
This is needed for the new path lookup strategy and for the policy integration in path lookup.

Contributes #2454

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/2990)
<!-- Reviewable:end -->
