### PR TITLE
Exclude go/protobuf dir from gazelle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ mocks: goenv
 	./tools/gomocks
 
 gazelle:
-	bazel run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build ./go
+	bazel run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build -exclude go/protobuf ./go
 
 setcap:
 	tools/setcap cap_net_admin,cap_net_raw+ep $(BRACCEPT)


### PR DESCRIPTION
go/protobuf only contains links to generated files so we shouldn't need a BUILD.bazel file for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3000)
<!-- Reviewable:end -->
