### PR TITLE
verifier: Make acceptable TS range configurable

### DIFF
--- a/go/lib/infra/common.go
+++ b/go/lib/infra/common.go
@@ -411,6 +411,15 @@ type Signer interface {
 	Meta() SignerMeta
 }
 
+// SignatureTimestampRange configures the range a signature timestamp is
+// considered valid. This allows for small clock drifts in the network.
+type SignatureTimestampRange struct {
+	// MaxPldAge determines the maximum age of a control payload signature.
+	MaxPldAge time.Duration
+	// MaxInFuture determines the maximum time a timestamp may be in the future.
+	MaxInFuture time.Duration
+}
+
 // Verifier is used to verify payloads signed with control-plane PKI
 // certificates.
 type Verifier interface {
@@ -427,6 +436,9 @@ type Verifier interface {
 	// It verifies against the specified source, and not the value
 	// provided by the sign meta data.
 	WithSrc(src ctrl.SignSrcDef) Verifier
+	// WithSignatureTimestampRange returns a verifier that uses the specified
+	// signature timestamp range configuration.
+	WithSignatureTimestampRange(timestampRange SignatureTimestampRange) Verifier
 }
 
 // TrustStore is the interface to interact with the control-plane PKI.
@@ -566,5 +578,9 @@ func (nullSigVerifier) WithIA(_ addr.IA) Verifier {
 }
 
 func (nullSigVerifier) WithSrc(_ ctrl.SignSrcDef) Verifier {
+	return nullSigVerifier{}
+}
+
+func (nullSigVerifier) WithSignatureTimestampRange(_ SignatureTimestampRange) Verifier {
 	return nullSigVerifier{}
 }

--- a/go/lib/infra/mock_infra/infra.go
+++ b/go/lib/infra/mock_infra/infra.go
@@ -828,6 +828,20 @@ func (mr *MockVerifierMockRecorder) WithServer(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithServer", reflect.TypeOf((*MockVerifier)(nil).WithServer), arg0)
 }
 
+// WithSignatureTimestampRange mocks base method
+func (m *MockVerifier) WithSignatureTimestampRange(arg0 infra.SignatureTimestampRange) infra.Verifier {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WithSignatureTimestampRange", arg0)
+	ret0, _ := ret[0].(infra.Verifier)
+	return ret0
+}
+
+// WithSignatureTimestampRange indicates an expected call of WithSignatureTimestampRange
+func (mr *MockVerifierMockRecorder) WithSignatureTimestampRange(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithSignatureTimestampRange", reflect.TypeOf((*MockVerifier)(nil).WithSignatureTimestampRange), arg0)
+}
+
 // WithSrc mocks base method
 func (m *MockVerifier) WithSrc(arg0 ctrl.SignSrcDef) infra.Verifier {
 	m.ctrl.T.Helper()

--- a/go/lib/infra/modules/trust/BUILD.bazel
+++ b/go/lib/infra/modules/trust/BUILD.bazel
@@ -35,7 +35,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["trust_test.go"],
+    srcs = [
+        "signhelper_test.go",
+        "trust_test.go",
+    ],
     data = [
         "//go/lib/infra/modules/trust/testdata:data",
         "//go/lib/infra/modules/trust/testdata:crypto_tar",
@@ -44,6 +47,7 @@ go_test(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
+        "//go/lib/ctrl:go_default_library",
         "//go/lib/ctrl/cert_mgmt:go_default_library",
         "//go/lib/infra:go_default_library",
         "//go/lib/infra/disp:go_default_library",

--- a/go/lib/infra/modules/trust/signhelper.go
+++ b/go/lib/infra/modules/trust/signhelper.go
@@ -34,7 +34,7 @@ const (
 	// MaxPldAge indicates the maximum age of a control payload signature.
 	MaxPldAge = 2 * time.Second
 	// MaxInFuture indicates the maximum time a timestamp may be in the future.
-	MaxInFuture = 1 * time.Second
+	MaxInFuture = time.Second
 )
 
 var _ infra.Signer = (*BasicSigner)(nil)
@@ -199,13 +199,13 @@ func (v *BasicVerifier) sanityChecks(sign *proto.SignS, isPldSignature bool) err
 	}
 	now := time.Now()
 	ts := sign.Time()
-	diff := now.Sub(ts)
-	if diff < -v.tsRange.MaxInFuture {
+	signatureAge := now.Sub(ts)
+	if timeInFuture := -signatureAge; timeInFuture > v.tsRange.MaxInFuture {
 		return common.NewBasicError("Invalid timestamp. Signature from future", nil,
 			"ts", util.TimeToString(ts), "now", util.TimeToString(now),
 			"maxFuture", v.tsRange.MaxInFuture)
 	}
-	if isPldSignature && diff > v.tsRange.MaxPldAge {
+	if isPldSignature && signatureAge > v.tsRange.MaxPldAge {
 		return common.NewBasicError("Invalid timestamp. Signature expired", nil,
 			"ts", util.TimeToString(ts), "now", util.TimeToString(now),
 			"validity", v.tsRange.MaxPldAge)

--- a/go/lib/infra/modules/trust/signhelper.go
+++ b/go/lib/infra/modules/trust/signhelper.go
@@ -31,7 +31,10 @@ import (
 )
 
 const (
-	SignatureValidity = 2 * time.Second
+	// MaxPldAge indicates the maximum age of a control payload signature.
+	MaxPldAge = 2 * time.Second
+	// MaxInFuture indicates the maximum time a timestamp may be in the future.
+	MaxInFuture = 1 * time.Second
 )
 
 var _ infra.Signer = (*BasicSigner)(nil)
@@ -88,15 +91,22 @@ var _ infra.Verifier = (*BasicVerifier)(nil)
 // BasicVerifier is a verifier that ignores signatures on cert_mgmt.TRC
 // and cert_mgmt.Chain messages, to avoid dependency cycles.
 type BasicVerifier struct {
-	store  *Store
-	ia     addr.IA
-	src    ctrl.SignSrcDef
-	server net.Addr
+	tsRange infra.SignatureTimestampRange
+	store   *Store
+	ia      addr.IA
+	src     ctrl.SignSrcDef
+	server  net.Addr
 }
 
 // NewBasicVerifier creates a new verifier.
 func NewBasicVerifier(store *Store) *BasicVerifier {
-	return &BasicVerifier{store: store}
+	return &BasicVerifier{
+		tsRange: infra.SignatureTimestampRange{
+			MaxPldAge:   MaxPldAge,
+			MaxInFuture: MaxInFuture,
+		},
+		store: store,
+	}
 }
 
 // WithIA creates a verifier that is bound to the remote AS. Only
@@ -121,6 +131,16 @@ func (v *BasicVerifier) WithSrc(src ctrl.SignSrcDef) infra.Verifier {
 func (v *BasicVerifier) WithServer(server net.Addr) infra.Verifier {
 	verifier := *v
 	verifier.server = server
+	return &verifier
+}
+
+// WithSignatureTimestampRange returns a verifier that uses the specified
+// signature timestamp range configuration.
+func (v *BasicVerifier) WithSignatureTimestampRange(
+	timestampRange infra.SignatureTimestampRange) infra.Verifier {
+
+	verifier := *v
+	verifier.tsRange = timestampRange
 	return &verifier
 }
 
@@ -170,7 +190,7 @@ func (v *BasicVerifier) ignoreSign(p *ctrl.Pld, sign *proto.SignS) bool {
 	return false
 }
 
-func (v *BasicVerifier) sanityChecks(sign *proto.SignS, timeout bool) error {
+func (v *BasicVerifier) sanityChecks(sign *proto.SignS, isPldSignature bool) error {
 	if sign == nil {
 		return common.NewBasicError("SignS is unset", nil)
 	}
@@ -180,14 +200,15 @@ func (v *BasicVerifier) sanityChecks(sign *proto.SignS, timeout bool) error {
 	now := time.Now()
 	ts := sign.Time()
 	diff := now.Sub(ts)
-	if diff < 0 {
+	if diff < -v.tsRange.MaxInFuture {
 		return common.NewBasicError("Invalid timestamp. Signature from future", nil,
-			"ts", util.TimeToString(ts), "now", util.TimeToString(now))
+			"ts", util.TimeToString(ts), "now", util.TimeToString(now),
+			"maxFuture", v.tsRange.MaxInFuture)
 	}
-	if timeout && diff > SignatureValidity {
+	if isPldSignature && diff > v.tsRange.MaxPldAge {
 		return common.NewBasicError("Invalid timestamp. Signature expired", nil,
 			"ts", util.TimeToString(ts), "now", util.TimeToString(now),
-			"validity", SignatureValidity)
+			"validity", v.tsRange.MaxPldAge)
 	}
 	return nil
 }

--- a/go/lib/infra/modules/trust/signhelper_test.go
+++ b/go/lib/infra/modules/trust/signhelper_test.go
@@ -1,0 +1,92 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trust
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/go/lib/ctrl"
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/scrypto/cert"
+	"github.com/scionproto/scion/go/lib/xtest"
+	"github.com/scionproto/scion/go/proto"
+)
+
+var ia110 = xtest.MustParseIA("1-ff00:0:110")
+
+func TestBasicVerifierVerify(t *testing.T) {
+	tests := map[string]struct {
+		TSDiff    time.Duration
+		Assertion assert.ErrorAssertionFunc
+	}{
+		"valid": {
+			Assertion: assert.NoError,
+		},
+		"timestamp slightly in future": {
+			TSDiff:    500 * time.Millisecond,
+			Assertion: assert.NoError,
+		},
+		"timestamp in future": {
+			TSDiff:    time.Hour,
+			Assertion: assert.Error,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mctrl := gomock.NewController(t)
+			defer mctrl.Finish()
+			store, cancelF := initStore(t, mctrl, ia110, newMessengerMock(mctrl, nil, nil))
+			defer cancelF()
+			pub, priv, err := scrypto.GenKeyPair(scrypto.Ed25519)
+			require.NoError(t, err)
+
+			_, err = store.trustdb.InsertChain(context.Background(), &cert.Chain{
+				Leaf: &cert.Certificate{
+					Subject:        ia110,
+					Issuer:         ia110,
+					SignAlgorithm:  scrypto.Ed25519,
+					SubjectSignKey: pub,
+					Version:        1,
+					Signature:      []byte("signature"),
+				},
+				Issuer: &cert.Certificate{
+					Subject:   ia110,
+					Issuer:    ia110,
+					Version:   1,
+					Signature: []byte("signature"),
+				},
+			})
+			require.NoError(t, err)
+			verifier := NewBasicVerifier(store)
+			src := ctrl.SignSrcDef{
+				IA:       ia110,
+				ChainVer: 1,
+				TRCVer:   1,
+			}
+			sign := proto.NewSignS(proto.SignType_ed25519, src.Pack())
+			sign.SetTimestamp(time.Now().Add(test.TSDiff))
+			msg := []byte("test msg")
+			sign.Signature, err = scrypto.Sign(sign.SigInput(msg, false), priv, scrypto.Ed25519)
+			require.NoError(t, err)
+			test.Assertion(t, verifier.Verify(context.Background(), msg, sign))
+		})
+	}
+}

--- a/go/proto/sign.go
+++ b/go/proto/sign.go
@@ -51,8 +51,8 @@ func (s *SignS) Copy() *SignS {
 }
 
 // SetTimestamp sets the timestamp.
-func (s *SignS) SetTimestamp(now time.Time) {
-	s.Timestamp = util.TimeToSecs(time.Now())
+func (s *SignS) SetTimestamp(ts time.Time) {
+	s.Timestamp = util.TimeToSecs(ts)
 }
 
 // Time returns the timestamp. If the receiver is nil, the zero value is returned.


### PR DESCRIPTION
This PR makes the acceptable timestamp range for signatures
configurable.

Additionally, allow small time diffs in the future to allow for clock
drift.

fixes #3002

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3003)
<!-- Reviewable:end -->
