### PR TITLE
Fix sciond logging for processing path replies.

### DIFF
--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -183,3 +183,12 @@ func innerFmtError(e error) ([]string, error) {
 	}
 	return s, GetNestedError(e)
 }
+
+// FmtErrors formats a slice of errors for logging.
+func FmtErrors(es []error) string {
+	s := make([]string, 0)
+	for _, e := range es {
+		s = append(s, e.Error())
+	}
+	return strings.Join(s, "\n")
+}

--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -186,9 +186,9 @@ func innerFmtError(e error) ([]string, error) {
 
 // FmtErrors formats a slice of errors for logging.
 func FmtErrors(es []error) string {
-	s := make([]string, 0)
-	for _, e := range es {
-		s = append(s, e.Error())
+	s := make([]string, len(es))
+	for i, e := range es {
+		s[i] = e.Error()
 	}
 	return strings.Join(s, "\n")
 }

--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -186,9 +186,9 @@ func innerFmtError(e error) ([]string, error) {
 
 // FmtErrors formats a slice of errors for logging.
 func FmtErrors(es []error) string {
-	s := make([]string, len(es))
-	for i, e := range es {
-		s[i] = e.Error()
+	s := make([]string, 0, len(es))
+	for _, e := range es {
+		s = append(s, e.Error())
 	}
 	return strings.Join(s, "\n")
 }

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -183,10 +183,11 @@ func (f *fetcherHandler) GetPaths(ctx context.Context, req *sciond.PathReq,
 	case <-processedResult.FullReplyProcessed():
 	}
 	if processedResult.Err() != nil {
-		f.logger.Error("Failed to store segments", nil, "err", err)
+		f.logger.Error("Failed to store segments", "err", err)
 	}
 	if processedResult.VerificationErrors() != nil {
-		f.logger.Warn("Failed to verify reply", nil, "errors", processedResult.VerificationErrors())
+		f.logger.Warn("Failed to verify reply",
+			"errors", common.FmtErrors(processedResult.VerificationErrors()))
 	}
 	if reply, err := f.buildReplyFromDB(ctx, req, false); reply != nil {
 		return reply, err


### PR DESCRIPTION
- The logger does not expect an `error` after the string, so removing
  `nil`.
- The logger does not do a good job with `[]error`, so created
  `common.FmtErrors` to handle this.

Before:
```
2019-08-21 09:01:33.830842+0000 [WARN] Failed to verify reply debug_id=747f80c4 trace_id=64dc60702aa9bf7 LOG15_ERROR="Key(<nil>) is not a string: <nil>" LOG15_ERROR="Key([]error) is not a string: [Failed to verify seg seg="55c11074ec66 2019-08-21 09:01:31+0000 1-ff00:0:110 1>41 1-ff00:0:111"
    DEBUGTHISTHING 2 Failed to verify seg seg="55c11074ec66 2019-08-21 09:01:31+0000 1-ff00:0:110 1>41 1-ff00:0:111"
    DEBUGTHISTHING 2]" LOG15_ERROR="Normalized odd number of arguments by adding nil"
```

After:
```
2019-08-20 15:59:05.693430+0000 [WARN] Failed to verify reply debug_id=e544675c trace_id=6963201a9432fbae errors=
>  Failed to verify seg seg="55c11074ec66 2019-08-20 15:59:01+0000 1-ff00:0:110 1>41 1-ff00:0:111"
>      DEBUGTHISTHING 2
>  Failed to verify seg seg="55c11074ec66 2019-08-20 15:59:01+0000 1-ff00:0:110 1>41 1-ff00:0:111"
>      DEBUGTHISTHING 2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3021)
<!-- Reviewable:end -->
