### PR TITLE
scrypto: Fix flaky tests

### DIFF
--- a/go/lib/scrypto/cert/v2/as_json_test.go
+++ b/go/lib/scrypto/cert/v2/as_json_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -103,7 +104,7 @@ func TestASUnmarshalJSON(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			g := newGenASCert()
+			expected, g := newGenASCert(time.Now())
 			test.Modify(g)
 			b, err := json.Marshal(g)
 			require.NoError(t, err)
@@ -111,7 +112,6 @@ func TestASUnmarshalJSON(t *testing.T) {
 			err = json.Unmarshal(b, &as)
 			if test.ExpectedErrMsg == "" {
 				require.NoError(t, err)
-				expected := newASCert()
 				if test.ModifyExpected != nil {
 					test.ModifyExpected(&expected)
 				}
@@ -221,8 +221,8 @@ func TestTypeASMarshalSameASString(t *testing.T) {
 	assert.Equal(t, cert.TypeASJSON, strings.Trim(string(b), `"`))
 }
 
-func newGenASCert() *genCert {
-	c := newASCert()
+func newGenASCert(now time.Time) (cert.AS, *genCert) {
+	c := newASCert(now)
 	g := &genCert{
 		Subject:         &c.Subject,
 		Version:         &c.Version,
@@ -237,12 +237,12 @@ func newGenASCert() *genCert {
 		"ia":                  c.Issuer.IA,
 		"certificate_version": c.Issuer.CertificateVersion,
 	}
-	return g
+	return c, g
 }
 
-func newASCert() cert.AS {
+func newASCert(now time.Time) cert.AS {
 	c := cert.AS{
-		Base: newBaseCert(),
+		Base: newBaseCert(now),
 		Issuer: cert.IssuerCertID{
 			IA:                 ia110,
 			CertificateVersion: 2,

--- a/go/lib/scrypto/cert/v2/as_signed_test.go
+++ b/go/lib/scrypto/cert/v2/as_signed_test.go
@@ -16,6 +16,7 @@ package cert_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func TestEncodeAS(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			base := newASCert()
+			base := newASCert(time.Now())
 			test.Modify(&base)
 			packed, err := cert.EncodeAS(&base)
 			test.Assertion(t, err)
@@ -57,7 +58,7 @@ func TestEncodeAS(t *testing.T) {
 }
 
 func TestEncodedASDecode(t *testing.T) {
-	base := newASCert()
+	base := newASCert(time.Now())
 	valid, err := cert.EncodeAS(&base)
 	require.NoError(t, err)
 

--- a/go/lib/scrypto/cert/v2/as_test.go
+++ b/go/lib/scrypto/cert/v2/as_test.go
@@ -16,6 +16,7 @@ package cert_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,7 +85,7 @@ func TestASValidate(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			c := newASCert()
+			c := newASCert(time.Now())
 			test.Modify(&c)
 			err := c.Validate()
 			if test.ExpectedErrMsg == "" {

--- a/go/lib/scrypto/cert/v2/base_test.go
+++ b/go/lib/scrypto/cert/v2/base_test.go
@@ -82,7 +82,7 @@ func TestBaseValidate(t *testing.T) {
 }
 
 func newBaseCert(notBefore time.Time) cert.Base {
-	now := notBefore.Round(time.Second)
+	now := notBefore.Truncate(time.Second)
 	c := cert.Base{
 		Subject:       ia110,
 		Version:       1,

--- a/go/lib/scrypto/cert/v2/base_test.go
+++ b/go/lib/scrypto/cert/v2/base_test.go
@@ -68,7 +68,7 @@ func TestBaseValidate(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			c := newBaseCert()
+			c := newBaseCert(time.Now())
 			test.Modify(&c)
 			err := c.Validate()
 			if test.ExpectedErrMsg == "" {
@@ -81,8 +81,8 @@ func TestBaseValidate(t *testing.T) {
 	}
 }
 
-func newBaseCert() cert.Base {
-	now := time.Now().Round(time.Second)
+func newBaseCert(notBefore time.Time) cert.Base {
+	now := notBefore.Round(time.Second)
 	c := cert.Base{
 		Subject:       ia110,
 		Version:       1,

--- a/go/lib/scrypto/cert/v2/issuer_json_test.go
+++ b/go/lib/scrypto/cert/v2/issuer_json_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,7 +96,7 @@ func TestIssuerUnmarshalJSON(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			g := newGenIssuerCert()
+			expected, g := newGenIssuerCert(time.Now())
 			test.Modify(g)
 			b, err := json.Marshal(g)
 			require.NoError(t, err)
@@ -103,7 +104,6 @@ func TestIssuerUnmarshalJSON(t *testing.T) {
 			err = json.Unmarshal(b, &iss)
 			if test.ExpectedErrMsg == "" {
 				require.NoError(t, err)
-				expected := newIssuerCert()
 				if test.ModifyExpected != nil {
 					test.ModifyExpected(&expected)
 				}
@@ -196,8 +196,8 @@ func TestTypeIssuerMarshalSameASString(t *testing.T) {
 	assert.Equal(t, cert.TypeIssuerJSON, strings.Trim(string(b), `"`))
 }
 
-func newGenIssuerCert() *genCert {
-	c := newIssuerCert()
+func newGenIssuerCert(now time.Time) (cert.Issuer, *genCert) {
+	c := newIssuerCert(now)
 	g := &genCert{
 		Subject:         &c.Subject,
 		Version:         &c.Version,
@@ -211,12 +211,12 @@ func newGenIssuerCert() *genCert {
 	g.Issuer = &map[string]interface{}{
 		"trc_version": c.Issuer.TRCVersion,
 	}
-	return g
+	return c, g
 }
 
-func newIssuerCert() cert.Issuer {
+func newIssuerCert(now time.Time) cert.Issuer {
 	c := cert.Issuer{
-		Base: newBaseCert(),
+		Base: newBaseCert(now),
 		Issuer: cert.IssuerTRC{
 			TRCVersion: 4,
 		},

--- a/go/lib/scrypto/cert/v2/issuer_signed_test.go
+++ b/go/lib/scrypto/cert/v2/issuer_signed_test.go
@@ -16,6 +16,7 @@ package cert_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,7 +43,7 @@ func TestEncodeIssuer(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			base := newIssuerCert()
+			base := newIssuerCert(time.Now())
 			test.Modify(&base)
 			packed, err := cert.EncodeIssuer(&base)
 			test.Assertion(t, err)
@@ -57,7 +58,7 @@ func TestEncodeIssuer(t *testing.T) {
 }
 
 func TestEncodedIssuerDecode(t *testing.T) {
-	base := newIssuerCert()
+	base := newIssuerCert(time.Now())
 	valid, err := cert.EncodeIssuer(&base)
 	require.NoError(t, err)
 

--- a/go/lib/scrypto/cert/v2/issuer_test.go
+++ b/go/lib/scrypto/cert/v2/issuer_test.go
@@ -16,6 +16,7 @@ package cert_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,7 +77,7 @@ func TestIssuerValidate(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			c := newIssuerCert()
+			c := newIssuerCert(time.Now())
 			test.Modify(&c)
 			err := c.Validate()
 			if test.ExpectedErrMsg == "" {

--- a/go/lib/scrypto/cert/v2/verify_test.go
+++ b/go/lib/scrypto/cert/v2/verify_test.go
@@ -97,8 +97,8 @@ func TestASVerifierVerify(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			as := newASCert()
-			issuer := newIssuerCert()
+			as := newASCert(time.Now())
+			issuer := newIssuerCert(time.Now())
 			pub, priv, err := scrypto.GenKeyPair(scrypto.Ed25519)
 			require.NoError(t, err)
 
@@ -213,7 +213,7 @@ func TestIssuerVerifierVerify(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			issuer := newIssuerCert()
+			issuer := newIssuerCert(time.Now())
 			pub, priv, err := scrypto.GenKeyPair(scrypto.Ed25519)
 			require.NoError(t, err)
 			trc_ := trc.TRC{

--- a/go/lib/scrypto/trc/v2/signed_test.go
+++ b/go/lib/scrypto/trc/v2/signed_test.go
@@ -16,6 +16,7 @@ package trc_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,7 +45,7 @@ func TestEncode(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			base := newBaseTRC()
+			base := newBaseTRC(time.Now())
 			test.Modify(base)
 			packed, err := trc.Encode(base)
 			test.Assertion(t, err)
@@ -59,7 +60,7 @@ func TestEncode(t *testing.T) {
 }
 
 func TestEncodedDecode(t *testing.T) {
-	valid, err := trc.Encode(newBaseTRC())
+	valid, err := trc.Encode(newBaseTRC(time.Now()))
 	require.NoError(t, err)
 
 	tests := map[string]struct {

--- a/go/lib/scrypto/trc/v2/trc_json_test.go
+++ b/go/lib/scrypto/trc/v2/trc_json_test.go
@@ -47,12 +47,10 @@ type genTRC struct {
 func TestTRCUnmarshalJSON(t *testing.T) {
 	tests := map[string]struct {
 		Modify         func(*genTRC)
-		TRC            *trc.TRC
 		ExpectedErrMsg string
 	}{
 		"valid": {
 			Modify: func(*genTRC) {},
-			TRC:    newBaseTRC(),
 		},
 		"ISD not set": {
 			Modify: func(g *genTRC) {
@@ -135,7 +133,7 @@ func TestTRCUnmarshalJSON(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			g := newGenTRC()
+			trcObj, g := newGenTRC(time.Now())
 			test.Modify(g)
 			b, err := json.Marshal(g)
 			require.NoError(t, err)
@@ -143,7 +141,7 @@ func TestTRCUnmarshalJSON(t *testing.T) {
 			err = json.Unmarshal(b, &parsed)
 			if test.ExpectedErrMsg == "" {
 				require.NoError(t, err)
-				assert.Equal(t, test.TRC, &parsed)
+				assert.Equal(t, trcObj, &parsed)
 			} else {
 				require.Error(t, err)
 				assert.Equal(t, err.Error(), test.ExpectedErrMsg)
@@ -310,8 +308,8 @@ func TestPeriodMarshalJSON(t *testing.T) {
 	}
 }
 
-func newGenTRC() *genTRC {
-	b := newBaseTRC()
+func newGenTRC(now time.Time) (*trc.TRC, *genTRC) {
+	b := newBaseTRC(now)
 	t := &genTRC{
 		ISD:               &b.ISD,
 		Version:           &b.Version,
@@ -326,5 +324,5 @@ func newGenTRC() *genTRC {
 		Votes:             &b.Votes,
 		ProofOfPossession: &b.ProofOfPossession,
 	}
-	return t
+	return b, t
 }

--- a/go/lib/scrypto/trc/v2/trc_test.go
+++ b/go/lib/scrypto/trc/v2/trc_test.go
@@ -131,7 +131,7 @@ func TestTRCValidateInvariant(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			base := newBaseTRC()
+			base := newBaseTRC(time.Now())
 			test.Modify(base)
 			err := base.ValidateInvariant()
 			if test.ExpectedErrMsg == "" {
@@ -144,8 +144,8 @@ func TestTRCValidateInvariant(t *testing.T) {
 	}
 }
 
-func newBaseTRC() *trc.TRC {
-	now := time.Now().Round(time.Second)
+func newBaseTRC(notBefore time.Time) *trc.TRC {
+	now := notBefore.Round(time.Second)
 	quorum := uint8(3)
 	trustResetAllowed := true
 	t := &trc.TRC{

--- a/go/lib/scrypto/trc/v2/trc_test.go
+++ b/go/lib/scrypto/trc/v2/trc_test.go
@@ -145,7 +145,7 @@ func TestTRCValidateInvariant(t *testing.T) {
 }
 
 func newBaseTRC(notBefore time.Time) *trc.TRC {
-	now := notBefore.Round(time.Second)
+	now := notBefore.Truncate(time.Second)
 	quorum := uint8(3)
 	trustResetAllowed := true
 	t := &trc.TRC{

--- a/go/lib/scrypto/trc/v2/verify_test.go
+++ b/go/lib/scrypto/trc/v2/verify_test.go
@@ -16,6 +16,7 @@ package trc_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -179,7 +180,7 @@ func TestUpdateVerifierVerify(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			next, prev := newRegularUpdate()
+			next, prev := newRegularUpdate(time.Now())
 			meta := next.PrimaryASes[a110].Keys[trc.OnlineKey]
 			meta.KeyVersion += 1
 			next.PrimaryASes[a110].Keys[trc.OnlineKey] = meta


### PR DESCRIPTION
Always provide the not_before time of the validity period to avoid
flaky tests at second boundaries.

fixes #2993

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3022)
<!-- Reviewable:end -->
