### PR TITLE
Make bazel quiet in CI.

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -77,7 +77,7 @@ RUN sudo ./install_docker && rm install_docker && sudo usermod -aG docker scion
 # Install su-exec
 ARG SU_EXEC_COMMIT=e9664105e1f0b48024e52f454c6b78d15b5daa57
 RUN set -ex; mkdir su-exec; \
-    curl -SL https://github.com/anapaya/su-exec/archive/${SU_EXEC_COMMIT}.tar.gz | tar xz -C su-exec --strip-components=1; \
+    curl -sSL https://github.com/anapaya/su-exec/archive/${SU_EXEC_COMMIT}.tar.gz | tar xz -C su-exec --strip-components=1; \
     make -C su-exec; sudo mv su-exec/su-exec /sbin/; \
     rm -r su-exec;
 

--- a/docker/perapp/base/Dockerfile.base
+++ b/docker/perapp/base/Dockerfile.base
@@ -9,7 +9,7 @@ RUN ./copy_package libcap2-bin '/usr/share'
 # Install su-exec
 ARG SU_EXEC_COMMIT=537b381606f9e455469a355b2de51ce49cd33973
 RUN set -e; mkdir su-exec; \
-    curl -SL https://github.com/anapaya/su-exec/archive/${SU_EXEC_COMMIT}.tar.gz | tar xz -C su-exec --strip-components=1; \
+    curl -sSL https://github.com/anapaya/su-exec/archive/${SU_EXEC_COMMIT}.tar.gz | tar xz -C su-exec --strip-components=1; \
     make -C su-exec; mkdir -p /rootfs/sbin; mv su-exec/su-exec /rootfs/sbin/; \
     mkdir -p /rootfs/LICENSES/su-exec; cp su-exec/LICENSE /rootfs/LICENSES/su-exec/LICENSE; \
     rm -r su-exec;

--- a/docker/perapp/base/Dockerfile.builder
+++ b/docker/perapp/base/Dockerfile.builder
@@ -1,2 +1,3 @@
 FROM scion:latest
+COPY bazelrc.quiet ~/.bazelrc
 RUN make -s all setcap && bazel clean

--- a/docker/perapp/base/Dockerfile.debug
+++ b/docker/perapp/base/Dockerfile.debug
@@ -9,7 +9,7 @@ ARG TOYBOX_SHA=62126936d400d6814c20ffe6153c5827397126b6df7cd81f54e18e7ac34a2d9f
 RUN set -ex; \
     cd /rootfs; \
     mkdir bin; \
-    curl -SL "https://landley.net/toybox/downloads/binaries/${TOYBOX_VERSION}/toybox-x86_64" > bin/toybox; \
+    curl -sSL "https://landley.net/toybox/downloads/binaries/${TOYBOX_VERSION}/toybox-x86_64" > bin/toybox; \
     echo "${TOYBOX_SHA} bin/toybox" | sha256sum -c -; \
     chmod +x bin/toybox; \
     for i in $(bin/toybox --long); do mkdir -p "$(dirname "$i")"; ln -s /bin/toybox $i; done

--- a/docker/perapp/files/bazelrc.quiet
+++ b/docker/perapp/files/bazelrc.quiet
@@ -1,0 +1,2 @@
+build --noshow_progress --color=no
+fetch --noshow_progress --color=no

--- a/env/zlog/deps
+++ b/env/zlog/deps
@@ -9,7 +9,7 @@ BASE=$(dirname "$0")
 
 tmpdir=$(mktemp -d /tmp/zlog.XXXXXXX)
 cd "${tmpdir:?}"
-curl -L $CURL_PARAM https://github.com/HardySimpson/zlog/archive/1.2.12.tar.gz | tar xzf - --strip-components=1
+curl -sSL $CURL_PARAM https://github.com/HardySimpson/zlog/archive/1.2.12.tar.gz | tar xzf - --strip-components=1
 make -sj6
 echo "ldconfig" >> postinstall-pak
 echo "ldconfig" >> postremove-pak

--- a/scion.sh
+++ b/scion.sh
@@ -267,11 +267,7 @@ py_test() {
 }
 
 bazel_test() {
-    local color_mode="auto"
-    if is_running_in_docker; then
-        color_mode="no"
-    fi
-    bazel test //go/... --print_relative_test_log_paths --color $color_mode
+    bazel test //go/... --print_relative_test_log_paths
 }
 
 cmd_coverage(){


### PR DESCRIPTION
When `bazel test` runs in CI, it outputs about 3k lines that are just
noise due to the "progress" output. This change makes bazel
build/test/run quiet in CI.

Also:
- Make curl quieter when downloading some packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3023)
<!-- Reviewable:end -->
