### PR TITLE
Add some fixes to the beacon db test suite

### DIFF
--- a/go/beacon_srv/internal/beacon/beacondbtest/beacondbtest.go
+++ b/go/beacon_srv/internal/beacon/beacondbtest/beacondbtest.go
@@ -80,7 +80,7 @@ var (
 		},
 	}
 
-	timeout = time.Second
+	timeout = 3 * time.Second
 )
 
 // Testable extends the beacon db interface with methods that are needed for testing.
@@ -100,7 +100,7 @@ func Test(t *testing.T, db Testable) {
 		return func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			prepareCtx, cancelF := context.WithTimeout(context.Background(), 2*timeout)
+			prepareCtx, cancelF := context.WithTimeout(context.Background(), timeout)
 			defer cancelF()
 			db.Prepare(t, prepareCtx)
 			test(t, ctrl, db)

--- a/go/beacon_srv/internal/beacon/beacondbtest/beacondbtest.go
+++ b/go/beacon_srv/internal/beacon/beacondbtest/beacondbtest.go
@@ -100,7 +100,7 @@ func Test(t *testing.T, db Testable) {
 		return func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			prepareCtx, cancelF := context.WithTimeout(context.Background(), timeout)
+			prepareCtx, cancelF := context.WithTimeout(context.Background(), 2*timeout)
 			defer cancelF()
 			db.Prepare(t, prepareCtx)
 			test(t, ctrl, db)
@@ -315,7 +315,7 @@ func testCandidateBeacons(t *testing.T, db Testable, inTx bool) {
 				InsertRevocation(t, db, sRev)
 			},
 			// last beacon (info3) is revoked
-			Expected: beacons[:1],
+			Expected: beacons[:2],
 		},
 	}
 	for name, test := range tests {
@@ -665,14 +665,16 @@ func CheckResults(t *testing.T, results <-chan beacon.BeaconOrErr,
 			t.Fatalf("Beacon %d took too long", i)
 		}
 	}
-	assert.Empty(t, results)
+	CheckEmpty(t, "", results, nil)
 }
 
 // CheckEmpty checks that no beacon is in the result channel.
 func CheckEmpty(t *testing.T, name string, results <-chan beacon.BeaconOrErr, err error) {
 	t.Helper()
 	assert.NoError(t, err, name)
-	assert.Empty(t, results, name)
+	res, more := <-results
+	assert.False(t, more)
+	assert.Zero(t, res)
 }
 
 func CheckRevs(t *testing.T, results <-chan beacon.RevocationOrErr,
@@ -691,13 +693,15 @@ func CheckRevs(t *testing.T, results <-chan beacon.RevocationOrErr,
 			t.Fatalf("Rev %d took too long", i)
 		}
 	}
-	assert.Empty(t, results)
+	CheckEmptyRevs(t, results, nil)
 }
 
 func CheckEmptyRevs(t *testing.T, results <-chan beacon.RevocationOrErr, err error) {
 	t.Helper()
 	assert.NoError(t, err)
-	assert.Empty(t, results)
+	res, more := <-results
+	assert.False(t, more)
+	assert.Zero(t, res)
 }
 
 func InsertBeacon(t *testing.T, ctrl *gomock.Controller, db beacon.DBReadWrite, ases []IfInfo,


### PR DESCRIPTION
-Give more time
-Fix revocation test it should return 2 beacons
-Use channel for empty check to make sure go routines can properly clean up after them (e.g. call rows.Close())

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3032)
<!-- Reviewable:end -->
