### PR TITLE
topology: fix panic and make overBindAddr public

### DIFF
--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -65,13 +65,13 @@ func mkPBO(ip string, port int, bindip string, bindport int, op int) *pubBindAdd
 	return pbo
 }
 
-func mkOB(ip string, port int, bindip string) *overBindAddr {
+func mkOB(ip string, port int, bindip string) *OverBindAddr {
 	overlay := addr.HostFromIPStr(ip)
 	var bind addr.HostAddr
 	if bindip != "" {
 		bind = addr.HostFromIPStr(bindip)
 	}
-	return &overBindAddr{
+	return &OverBindAddr{
 		PublicOverlay: mkO(overlay, port),
 		BindOverlay:   mkO(bind, port),
 	}


### PR DESCRIPTION
Both PublicOverlay and BindOverlay methods on TopoBRAddr would panic
there is no address set for the requested overlay type.

This change fixes that and also makes OverBindAddr a public type so it
is easier to work with it as the only way to get such objects is by
parsing a topology file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3034)
<!-- Reviewable:end -->
