### PR TITLE
sciond: Fix TRC not found locally error logic

### DIFF
--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -19,6 +19,7 @@ package fetcher
 import (
 	"bytes"
 	"context"
+	"strings"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -204,7 +205,7 @@ func (f *fetcherHandler) buildReplyFromDB(ctx context.Context,
 	switch {
 	case ctx.Err() != nil:
 		return f.buildSCIONDReply(paths, req.MaxPaths, sciond.ErrorNoPaths), nil
-	case ignoreTrustNotFoundLocally && common.GetErrorMsg(err) == trust.ErrNotFoundLocally:
+	case ignoreTrustNotFoundLocally && f.isTrustNotFoundLocally(err):
 		return nil, nil
 	case err != nil:
 		return f.buildSCIONDReply(paths, req.MaxPaths, sciond.ErrorInternal), err
@@ -212,6 +213,10 @@ func (f *fetcherHandler) buildReplyFromDB(ctx context.Context,
 		return f.buildSCIONDReply(paths, req.MaxPaths, sciond.ErrorOk), nil
 	}
 	return nil, nil
+}
+
+func (f *fetcherHandler) isTrustNotFoundLocally(err error) bool {
+	return err != nil && strings.Contains(err.Error(), trust.ErrNotFoundLocally)
 }
 
 // buildSCIONDReply constructs a fresh SCIOND PathReply from the information


### PR DESCRIPTION
The error handling for remote TRCs not found locally is brittle.
By simply checking the error message with `common.GetErrMsg`, catching
wrapped errors is not possible.

fixes #3037

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3043)
<!-- Reviewable:end -->
