### PR TITLE
HP: HiddenPathDB interface and PathDB Adapter

### DIFF
--- a/go/hidden_path_srv/internal/hiddenpathdb/BUILD.bazel
+++ b/go/hidden_path_srv/internal/hiddenpathdb/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["hiddenpathdb.go"],
+    importpath = "github.com/scionproto/scion/go/hidden_path_srv/internal/hiddenpathdb",
+    visibility = ["//go/hidden_path_srv:__subpackages__"],
+    deps = [
+        "//go/hidden_path_srv/internal/hpsegreq:go_default_library",
+        "//go/lib/addr:go_default_library",
+        "//go/lib/ctrl/seg:go_default_library",
+        "//go/lib/pathdb/query:go_default_library",
+    ],
+)

--- a/go/hidden_path_srv/internal/hiddenpathdb/adapter/BUILD.bazel
+++ b/go/hidden_path_srv/internal/hiddenpathdb/adapter/BUILD.bazel
@@ -28,7 +28,9 @@ go_test(
         "//go/lib/pathdb/mock_pathdb:go_default_library",
         "//go/lib/pathdb/pathdbtest:go_default_library",
         "//go/lib/pathdb/query:go_default_library",
+        "//go/lib/xtest/matchers:go_default_library",
         "//go/proto:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/hidden_path_srv/internal/hiddenpathdb/adapter/BUILD.bazel
+++ b/go/hidden_path_srv/internal/hiddenpathdb/adapter/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["pathdb_adapter.go"],
+    importpath = "github.com/scionproto/scion/go/hidden_path_srv/internal/hiddenpathdb/adapter",
+    visibility = ["//go/hidden_path_srv:__subpackages__"],
+    deps = [
+        "//go/hidden_path_srv/internal/hiddenpathdb:go_default_library",
+        "//go/hidden_path_srv/internal/hpsegreq:go_default_library",
+        "//go/lib/addr:go_default_library",
+        "//go/lib/ctrl/seg:go_default_library",
+        "//go/lib/pathdb:go_default_library",
+        "//go/lib/pathdb/query:go_default_library",
+        "//go/lib/pathdb/sqlite:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["pathdb_adapter_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/hidden_path_srv/internal/hiddenpathdb:go_default_library",
+        "//go/hidden_path_srv/internal/hpsegreq:go_default_library",
+        "//go/lib/addr:go_default_library",
+        "//go/lib/ctrl/seg:go_default_library",
+        "//go/lib/hiddenpath:go_default_library",
+        "//go/lib/pathdb/mock_pathdb:go_default_library",
+        "//go/lib/pathdb/pathdbtest:go_default_library",
+        "//go/lib/pathdb/query:go_default_library",
+        "//go/proto:go_default_library",
+        "@com_github_golang_mock//gomock:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
+)

--- a/go/hidden_path_srv/internal/hiddenpathdb/adapter/BUILD.bazel
+++ b/go/hidden_path_srv/internal/hiddenpathdb/adapter/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//go/lib/ctrl/seg:go_default_library",
         "//go/lib/pathdb:go_default_library",
         "//go/lib/pathdb/query:go_default_library",
-        "//go/lib/pathdb/sqlite:go_default_library",
     ],
 )
 
@@ -31,7 +30,5 @@ go_test(
         "//go/lib/pathdb/query:go_default_library",
         "//go/proto:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
-        "@com_github_stretchr_testify//assert:go_default_library",
-        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/hidden_path_srv/internal/hiddenpathdb/adapter/pathdb_adapter.go
+++ b/go/hidden_path_srv/internal/hiddenpathdb/adapter/pathdb_adapter.go
@@ -25,7 +25,6 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
 	"github.com/scionproto/scion/go/lib/pathdb"
 	"github.com/scionproto/scion/go/lib/pathdb/query"
-	"github.com/scionproto/scion/go/lib/pathdb/sqlite"
 )
 
 var _ hiddenpathdb.HiddenPathDB = (*PathDBAdapter)(nil)
@@ -41,16 +40,12 @@ type readWriter struct {
 	backend pathdb.ReadWrite
 }
 
-// New returns a new PathDBAdapter with an SQLite backend opening a database at the given path.
-// If no database exists a new database is created. If the schema version of the
-// stored database is different from the one in schema.go, an error is returned.
-func New(path string) (*PathDBAdapter, error) {
-	backend, err := sqlite.New(path)
-	if err != nil {
-		return nil, err
+// New returns a new PathDBAdapter with an implementation of PathDB as backend.
+func New(db pathdb.PathDB) *PathDBAdapter {
+	return &PathDBAdapter{
+		backend:    db,
+		readWriter: &readWriter{db},
 	}
-	return &PathDBAdapter{backend: backend,
-		readWriter: &readWriter{backend}}, nil
 }
 
 // Get fetches all the hidden path segments matching the given parameters

--- a/go/hidden_path_srv/internal/hiddenpathdb/adapter/pathdb_adapter.go
+++ b/go/hidden_path_srv/internal/hiddenpathdb/adapter/pathdb_adapter.go
@@ -41,10 +41,10 @@ type readWriter struct {
 }
 
 // New returns a new PathDBAdapter with an implementation of PathDB as backend.
-func New(db pathdb.PathDB) *PathDBAdapter {
+func New(pdb pathdb.PathDB) *PathDBAdapter {
 	return &PathDBAdapter{
-		backend:    db,
-		readWriter: &readWriter{db},
+		backend:    pdb,
+		readWriter: &readWriter{pdb},
 	}
 }
 

--- a/go/hidden_path_srv/internal/hiddenpathdb/adapter/pathdb_adapter.go
+++ b/go/hidden_path_srv/internal/hiddenpathdb/adapter/pathdb_adapter.go
@@ -1,0 +1,140 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/scionproto/scion/go/hidden_path_srv/internal/hiddenpathdb"
+	"github.com/scionproto/scion/go/hidden_path_srv/internal/hpsegreq"
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/ctrl/seg"
+	"github.com/scionproto/scion/go/lib/pathdb"
+	"github.com/scionproto/scion/go/lib/pathdb/query"
+	"github.com/scionproto/scion/go/lib/pathdb/sqlite"
+)
+
+var _ hiddenpathdb.HiddenPathDB = (*PathDBAdapter)(nil)
+
+// PathDBAdapter implements the HiddenPathDB interface.
+// It wraps an implementation of PathDB.
+type PathDBAdapter struct {
+	backend pathdb.PathDB
+	*readWriter
+}
+
+type readWriter struct {
+	backend pathdb.ReadWrite
+}
+
+// New returns a new PathDBAdapter with an SQLite backend opening a database at the given path.
+// If no database exists a new database is created. If the schema version of the
+// stored database is different from the one in schema.go, an error is returned.
+func New(path string) (*PathDBAdapter, error) {
+	backend, err := sqlite.New(path)
+	if err != nil {
+		return nil, err
+	}
+	return &PathDBAdapter{backend: backend,
+		readWriter: &readWriter{backend}}, nil
+}
+
+// Get fetches all the hidden path segments matching the given parameters
+func (rw *readWriter) Get(ctx context.Context, params *hiddenpathdb.Params) (query.Results, error) {
+	var queryParams *query.Params
+	if params != nil {
+		queryParams = &query.Params{
+			HpCfgIDs: convertIds(params.GroupIds),
+			EndsAt:   []addr.IA{params.EndsAt},
+		}
+	}
+	return rw.backend.Get(ctx, queryParams)
+}
+
+// Insert inserts a hidden path segment into the the underlying PathDB
+func (rw *readWriter) Insert(ctx context.Context, seg *seg.Meta,
+	ids hpsegreq.GroupIdSet) (int, error) {
+
+	return rw.backend.InsertWithHPCfgIDs(ctx, seg, convertIds(ids))
+}
+
+// Delete deletes all path segments that match the given query,
+// returning the number of deleted segments
+func (rw *readWriter) Delete(ctx context.Context, params *hiddenpathdb.Params) (int, error) {
+	var queryParams *query.Params
+	if params != nil {
+		queryParams = &query.Params{
+			HpCfgIDs: convertIds(params.GroupIds),
+			EndsAt:   []addr.IA{params.EndsAt},
+		}
+	}
+	return rw.backend.Delete(ctx, queryParams)
+}
+
+// DeleteExpired deletes all hidden path segments that are expired, using now as a reference.
+// Returns the number of deleted segments.
+func (rw *readWriter) DeleteExpired(ctx context.Context, now time.Time) (int, error) {
+	return rw.backend.DeleteExpired(ctx, now)
+}
+
+// BeginTransaction begins a database read-write transacation
+func (a *PathDBAdapter) BeginTransaction(ctx context.Context, opts *sql.TxOptions) (
+	hiddenpathdb.Transaction, error) {
+
+	tx, err := a.backend.BeginTransaction(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &transaction{
+		backend:    tx,
+		readWriter: &readWriter{tx},
+	}, nil
+}
+
+// Close closes the backend database
+func (a *PathDBAdapter) Close() error {
+	return a.backend.Close()
+}
+
+var _ hiddenpathdb.Transaction = (*transaction)(nil)
+
+type transaction struct {
+	backend pathdb.Transaction
+	*readWriter
+}
+
+func (tx *transaction) Commit() error {
+	return tx.backend.Commit()
+}
+
+func (tx *transaction) Rollback() error {
+	return tx.backend.Rollback()
+}
+
+func convertIds(ids hpsegreq.GroupIdSet) []*query.HPCfgID {
+	queryIds := make([]*query.HPCfgID, 0, len(ids))
+	for id := range ids {
+		queryId := &query.HPCfgID{
+			IA: addr.IA{
+				A: id.OwnerAS,
+			},
+			ID: uint64(id.Suffix),
+		}
+		queryIds = append(queryIds, queryId)
+	}
+	return queryIds
+}

--- a/go/hidden_path_srv/internal/hiddenpathdb/adapter/pathdb_adapter_test.go
+++ b/go/hidden_path_srv/internal/hiddenpathdb/adapter/pathdb_adapter_test.go
@@ -1,0 +1,190 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package adapter
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/go/hidden_path_srv/internal/hiddenpathdb"
+	"github.com/scionproto/scion/go/hidden_path_srv/internal/hpsegreq"
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/ctrl/seg"
+	"github.com/scionproto/scion/go/lib/hiddenpath"
+	"github.com/scionproto/scion/go/lib/pathdb/mock_pathdb"
+	"github.com/scionproto/scion/go/lib/pathdb/pathdbtest"
+	"github.com/scionproto/scion/go/lib/pathdb/query"
+	"github.com/scionproto/scion/go/proto"
+)
+
+var (
+	owner    = addr.IA{I: 0, A: 0xff0000000330}
+	end      = addr.IA{I: 5, A: 0xff0000000440}
+	suffix   = uint16(1337)
+	ifs      = []uint64{0, 5, 2, 3, 6, 3, 1, 0}
+	ctx      = context.Background()
+	groupIds = hpsegreq.GroupIdSet{
+		hiddenpath.GroupId{}:               struct{}{},
+		{OwnerAS: owner.A, Suffix: suffix}: struct{}{},
+	}
+	hpCfgIDs = []*query.HPCfgID{
+		&query.NullHpCfgID,
+		{
+			IA: owner,
+			ID: uint64(suffix),
+		},
+	}
+	params = &hiddenpathdb.Params{
+		EndsAt:   end,
+		GroupIds: groupIds,
+	}
+	queryParams = &query.Params{
+		EndsAt:   []addr.IA{end},
+		HpCfgIDs: hpCfgIDs,
+	}
+)
+
+func newTestDB(t *testing.T) (*gomock.Controller,
+	*PathDBAdapter, *mock_pathdb.MockPathDB) {
+
+	ctrl := gomock.NewController(t)
+	mockBackend := mock_pathdb.NewMockPathDB(ctrl)
+	return ctrl, &PathDBAdapter{
+		backend:    mockBackend,
+		readWriter: &readWriter{mockBackend},
+	}, mockBackend
+}
+
+func newTestTransaction(t *testing.T) (*gomock.Controller,
+	*transaction, *mock_pathdb.MockTransaction) {
+
+	ctrl := gomock.NewController(t)
+	mockBackend := mock_pathdb.NewMockTransaction(ctrl)
+	return ctrl, &transaction{
+		backend:    mockBackend,
+		readWriter: &readWriter{mockBackend},
+	}, mockBackend
+}
+
+// TestOpenExisting tests that New does not overwrite an existing database if
+// versions match.
+func TestOpenExisting(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	db, tmpF := setupDB(t)
+	defer os.Remove(tmpF)
+	TS := uint32(10)
+	pseg, _ := pathdbtest.AllocPathSegment(t, ctrl, ifs, TS)
+	db.Insert(ctx, getSeg(pseg), groupIds)
+	db.Close()
+	// Call
+	db, err := New(tmpF)
+	require.NoError(t, err)
+	// Test
+	// Check that path segment is still there.
+	res, err := db.Get(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(res), "Segment still exists")
+}
+
+func TestGet(t *testing.T) {
+	ctrl, db, mockBackend := newTestDB(t)
+	defer ctrl.Finish()
+	mockBackend.EXPECT().Get(ctx, queryParams).Times(1)
+	mockBackend.EXPECT().Get(ctx, nil).Times(1)
+	db.Get(ctx, params)
+	// handles nil params
+	db.Get(ctx, nil)
+}
+
+func TestInsert(t *testing.T) {
+	ctrl, db, mockBackend := newTestDB(t)
+	defer ctrl.Finish()
+	TS := uint32(10)
+	pseg, _ := pathdbtest.AllocPathSegment(t, ctrl, ifs, TS)
+	mockBackend.EXPECT().InsertWithHPCfgIDs(ctx, getSeg(pseg), hpCfgIDs).Times(1)
+	db.Insert(ctx, getSeg(pseg), groupIds)
+}
+
+func TestDelete(t *testing.T) {
+	ctrl, db, mockBackend := newTestDB(t)
+	defer ctrl.Finish()
+	mockBackend.EXPECT().Delete(ctx, queryParams).Times(1)
+	mockBackend.EXPECT().Delete(ctx, nil).Times(1)
+	db.Delete(ctx, params)
+	// handles nil params
+	db.Delete(ctx, nil)
+}
+
+func TestDeleteExpired(t *testing.T) {
+	ctrl, db, mockBackend := newTestDB(t)
+	defer ctrl.Finish()
+	timeNow := time.Now()
+	mockBackend.EXPECT().DeleteExpired(ctx, timeNow).Times(1)
+	db.DeleteExpired(ctx, timeNow)
+}
+
+func TestBeginTransaction(t *testing.T) {
+	ctrl, db, mockBackend := newTestDB(t)
+	defer ctrl.Finish()
+	mockBackend.EXPECT().BeginTransaction(ctx, nil).Times(1)
+	db.BeginTransaction(ctx, nil)
+}
+
+func TestClose(t *testing.T) {
+	ctrl, db, mockBackend := newTestDB(t)
+	defer ctrl.Finish()
+	mockBackend.EXPECT().Close().Times(1)
+	db.Close()
+}
+
+func TestCommit(t *testing.T) {
+	ctrl, tx, mockBackend := newTestTransaction(t)
+	defer ctrl.Finish()
+	mockBackend.EXPECT().Commit().Times(1)
+	tx.Commit()
+}
+
+func TestRollback(t *testing.T) {
+	ctrl, tx, mockBackend := newTestTransaction(t)
+	defer ctrl.Finish()
+	mockBackend.EXPECT().Rollback().Times(1)
+	tx.Rollback()
+}
+
+func getSeg(pseg *seg.PathSegment) *seg.Meta {
+	return seg.NewMeta(pseg, proto.PathSegType_down)
+}
+
+func setupDB(t *testing.T) (hiddenpathdb.HiddenPathDB, string) {
+	tmpFile := tempFilename(t)
+	b, err := New(tmpFile)
+	require.NoError(t, err, "Failed to open DB")
+	return b, tmpFile
+}
+
+func tempFilename(t *testing.T) string {
+	dir, err := ioutil.TempDir("", "pathdb-sqlite")
+	require.NoError(t, err)
+	return path.Join(dir, t.Name())
+}

--- a/go/hidden_path_srv/internal/hiddenpathdb/adapter/pathdb_adapter_test.go
+++ b/go/hidden_path_srv/internal/hiddenpathdb/adapter/pathdb_adapter_test.go
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package adapter
+package adapter_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/go/hidden_path_srv/internal/hiddenpathdb"
+	"github.com/scionproto/scion/go/hidden_path_srv/internal/hiddenpathdb/adapter"
 	"github.com/scionproto/scion/go/hidden_path_srv/internal/hpsegreq"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
@@ -29,6 +32,7 @@ import (
 	"github.com/scionproto/scion/go/lib/pathdb/mock_pathdb"
 	"github.com/scionproto/scion/go/lib/pathdb/pathdbtest"
 	"github.com/scionproto/scion/go/lib/pathdb/query"
+	"github.com/scionproto/scion/go/lib/xtest/matchers"
 	"github.com/scionproto/scion/go/proto"
 )
 
@@ -65,51 +69,72 @@ func TestAdapter(t *testing.T) {
 		"Get with params": func(t *testing.T, ctx context.Context, pdb *mock_pathdb.MockPathDB,
 			_ *gomock.Controller) {
 
-			pdb.EXPECT().Get(ctx, queryParams)
-			New(pdb).Get(ctx, params)
+			pdb.EXPECT().Get(ctx, matchers.EqParams(queryParams))
+			adapter.New(pdb).Get(ctx, params)
 		},
 		"Get no params": func(t *testing.T, ctx context.Context, pdb *mock_pathdb.MockPathDB,
 			_ *gomock.Controller) {
 
 			pdb.EXPECT().Get(ctx, nil)
-			New(pdb).Get(ctx, nil)
+			adapter.New(pdb).Get(ctx, nil)
 		},
 		"Insert": func(t *testing.T, ctx context.Context, pdb *mock_pathdb.MockPathDB,
 			ctrl *gomock.Controller) {
 
 			pseg, _ := pathdbtest.AllocPathSegment(t, ctrl, ifs, uint32(10))
-			pdb.EXPECT().InsertWithHPCfgIDs(ctx, getSeg(pseg), hpCfgIDs)
-			New(pdb).Insert(ctx, getSeg(pseg), groupIds)
+			pdb.EXPECT().InsertWithHPCfgIDs(ctx, getSeg(pseg), matchers.EqHPCfgIDs(hpCfgIDs))
+			fmt.Println("want")
+			adapter.New(pdb).Insert(ctx, getSeg(pseg), groupIds)
 		},
 		"Delete with params": func(t *testing.T, ctx context.Context, pdb *mock_pathdb.MockPathDB,
 			_ *gomock.Controller) {
 
-			pdb.EXPECT().Delete(ctx, queryParams)
-			New(pdb).Delete(ctx, params)
+			pdb.EXPECT().Delete(ctx, matchers.EqParams(queryParams))
+			adapter.New(pdb).Delete(ctx, params)
 		},
 		"Delete no params": func(t *testing.T, ctx context.Context, pdb *mock_pathdb.MockPathDB,
 			_ *gomock.Controller) {
 
 			pdb.EXPECT().Delete(ctx, nil)
-			New(pdb).Delete(ctx, nil)
+			adapter.New(pdb).Delete(ctx, nil)
 		},
 		"DeleteExpired": func(t *testing.T, ctx context.Context, pdb *mock_pathdb.MockPathDB,
 			_ *gomock.Controller) {
 
 			timeNow := time.Now()
 			pdb.EXPECT().DeleteExpired(ctx, timeNow)
-			New(pdb).DeleteExpired(ctx, timeNow)
+			adapter.New(pdb).DeleteExpired(ctx, timeNow)
 		},
 		"BeginTransaction": func(t *testing.T, ctx context.Context, pdb *mock_pathdb.MockPathDB,
 			_ *gomock.Controller) {
 
 			pdb.EXPECT().BeginTransaction(ctx, nil)
-			New(pdb).BeginTransaction(ctx, nil)
+			adapter.New(pdb).BeginTransaction(ctx, nil)
 		},
 		"Close": func(t *testing.T, ctx context.Context, pdb *mock_pathdb.MockPathDB,
 			_ *gomock.Controller) {
 			pdb.EXPECT().Close()
-			New(pdb).Close()
+			adapter.New(pdb).Close()
+		},
+		"Commit": func(t *testing.T, ctx context.Context, pdb *mock_pathdb.MockPathDB,
+			ctrl *gomock.Controller) {
+
+			tx := mock_pathdb.NewMockTransaction(ctrl)
+			pdb.EXPECT().BeginTransaction(ctx, gomock.Any()).Return(tx, nil)
+			tx.EXPECT().Commit()
+			pdbTx, err := adapter.New(pdb).BeginTransaction(ctx, nil)
+			require.NoError(t, err)
+			pdbTx.Commit()
+		},
+		"Rollback": func(t *testing.T, ctx context.Context, pdb *mock_pathdb.MockPathDB,
+			ctrl *gomock.Controller) {
+
+			tx := mock_pathdb.NewMockTransaction(ctrl)
+			pdb.EXPECT().BeginTransaction(ctx, gomock.Any()).Return(tx, nil)
+			tx.EXPECT().Rollback()
+			pdbTx, err := adapter.New(pdb).BeginTransaction(ctx, nil)
+			require.NoError(t, err)
+			pdbTx.Rollback()
 		},
 	}
 	for name, test := range tests {
@@ -119,30 +144,6 @@ func TestAdapter(t *testing.T) {
 			ctx := context.Background()
 			pdb := mock_pathdb.NewMockPathDB(ctrl)
 			test(t, ctx, pdb, ctrl)
-		})
-	}
-}
-
-func TestTransaction(t *testing.T) {
-	tests := map[string]func(*testing.T, context.Context, *mock_pathdb.MockTransaction){
-		"Commit": func(t *testing.T, ctx context.Context, txPdb *mock_pathdb.MockTransaction) {
-			txPdb.EXPECT().Commit()
-			tx := &transaction{backend: txPdb}
-			tx.Commit()
-		},
-		"Rollback": func(t *testing.T, ctx context.Context, txPdb *mock_pathdb.MockTransaction) {
-			txPdb.EXPECT().Rollback()
-			tx := &transaction{backend: txPdb}
-			tx.Rollback()
-		},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			ctx := context.Background()
-			tx := mock_pathdb.NewMockTransaction(ctrl)
-			test(t, ctx, tx)
 		})
 	}
 }

--- a/go/hidden_path_srv/internal/hiddenpathdb/adapter/pathdb_adapter_test.go
+++ b/go/hidden_path_srv/internal/hiddenpathdb/adapter/pathdb_adapter_test.go
@@ -16,7 +16,6 @@ package adapter_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -83,7 +82,6 @@ func TestAdapter(t *testing.T) {
 
 			pseg, _ := pathdbtest.AllocPathSegment(t, ctrl, ifs, uint32(10))
 			pdb.EXPECT().InsertWithHPCfgIDs(ctx, getSeg(pseg), matchers.EqHPCfgIDs(hpCfgIDs))
-			fmt.Println("want")
 			adapter.New(pdb).Insert(ctx, getSeg(pseg), groupIds)
 		},
 		"Delete with params": func(t *testing.T, ctx context.Context, pdb *mock_pathdb.MockPathDB,

--- a/go/hidden_path_srv/internal/hiddenpathdb/hiddenpathdb.go
+++ b/go/hidden_path_srv/internal/hiddenpathdb/hiddenpathdb.go
@@ -1,0 +1,71 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hiddenpathdb
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"time"
+
+	"github.com/scionproto/scion/go/hidden_path_srv/internal/hpsegreq"
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/ctrl/seg"
+	"github.com/scionproto/scion/go/lib/pathdb/query"
+)
+
+// Read defines all read operations of the hidden path DB.
+type Read interface {
+	// Get returns all path segment(s) matching the parameters specified.
+	Get(context.Context, *Params) (query.Results, error)
+}
+
+// Write defines all write operations of the hidden path DB.
+type Write interface {
+	// Insert inserts or updates a hidden path segment. It returns the number of path segments
+	// that have been inserted/updated.
+	Insert(context.Context, *seg.Meta, hpsegreq.GroupIdSet) (int, error)
+	// Delete deletes all path segments that match the given query,
+	// returning the number of deleted segments
+	Delete(context.Context, *Params) (int, error)
+	// DeleteExpired deletes all hidden path segments that are expired, using now as a reference.
+	// Returns the number of deleted segments.
+	DeleteExpired(context.Context, time.Time) (int, error)
+}
+
+// ReadWrite defines all read an write operations of the hidden path DB.
+type ReadWrite interface {
+	Read
+	Write
+}
+
+type Transaction interface {
+	ReadWrite
+	Commit() error
+	Rollback() error
+}
+
+// HiddenPathDB defines the interface that all HiddenPathDB backends have to implement
+type HiddenPathDB interface {
+	ReadWrite
+	BeginTransaction(ctx context.Context, opts *sql.TxOptions) (Transaction, error)
+	io.Closer
+}
+
+// Params contains the parameters with which the database can be queried.
+type Params struct {
+	GroupIds hpsegreq.GroupIdSet
+	EndsAt   addr.IA
+}

--- a/go/lib/xtest/matchers/matchers.go
+++ b/go/lib/xtest/matchers/matchers.go
@@ -163,3 +163,32 @@ func (m *QueryParams) Matches(x interface{}) bool {
 func (m *QueryParams) String() string {
 	return fmt.Sprintf("is query.Params = %v", m.query)
 }
+
+// EqHPCfgIDs returns a matcher for the given slice of HPCfgIDs.
+func EqHPCfgIDs(ids []*query.HPCfgID) *QueryHPCfgIDs {
+	return &QueryHPCfgIDs{ids: ids}
+}
+
+// QueryHPCfgIDs is a matcher for HPCfgIDs.
+type QueryHPCfgIDs struct {
+	ids []*query.HPCfgID
+}
+
+// Matches returns whether x matches the defined HPCfgIDs ignoring the
+// order of the slice elements.
+func (m *QueryHPCfgIDs) Matches(x interface{}) bool {
+	ids, ok := x.([]*query.HPCfgID)
+	if !ok {
+		return false
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return (ids[i].IA.IAInt() < ids[j].IA.IAInt()) ||
+			(ids[i].IA.IAInt() == ids[j].IA.IAInt() &&
+				ids[i].ID < ids[j].ID)
+	})
+	return reflect.DeepEqual(m.ids, ids)
+}
+
+func (m *QueryHPCfgIDs) String() string {
+	return fmt.Sprintf("is []*query.HPCfgID = %v", m.ids)
+}


### PR DESCRIPTION
Adds a HiddenPathDB interface to HPS together with an adapter implementation for the existing PathDB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3044)
<!-- Reviewable:end -->
