### PR TITLE
segfetcher: Consider revocations in resolver

### DIFF
--- a/go/lib/infra/modules/segfetcher/BUILD.bazel
+++ b/go/lib/infra/modules/segfetcher/BUILD.bazel
@@ -51,6 +51,8 @@ go_test(
         "//go/lib/mocks/net/mock_net:go_default_library",
         "//go/lib/pathdb/mock_pathdb:go_default_library",
         "//go/lib/pathdb/query:go_default_library",
+        "//go/lib/revcache:go_default_library",
+        "//go/lib/revcache/mock_revcache:go_default_library",
         "//go/lib/xtest:go_default_library",
         "//go/lib/xtest/graph:go_default_library",
         "//go/lib/xtest/matchers:go_default_library",

--- a/go/lib/infra/modules/segfetcher/requester_test.go
+++ b/go/lib/infra/modules/segfetcher/requester_test.go
@@ -43,6 +43,7 @@ var (
 	non_core_111 = xtest.MustParseIA("1-ff00:0:111")
 	non_core_112 = xtest.MustParseIA("1-ff00:0:112")
 	non_core_211 = xtest.MustParseIA("2-ff00:0:211")
+	non_core_212 = xtest.MustParseIA("2-ff00:0:212")
 
 	req_111_1   = segfetcher.Request{Src: non_core_111, Dst: isd1}
 	req_1_111   = segfetcher.Request{Src: isd1, Dst: non_core_111}

--- a/go/lib/infra/modules/segfetcher/resolver_test.go
+++ b/go/lib/infra/modules/segfetcher/resolver_test.go
@@ -16,18 +16,24 @@ package segfetcher_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
+	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/modules/segfetcher"
 	"github.com/scionproto/scion/go/lib/pathdb/mock_pathdb"
 	"github.com/scionproto/scion/go/lib/pathdb/query"
+	"github.com/scionproto/scion/go/lib/revcache"
+	"github.com/scionproto/scion/go/lib/revcache/mock_revcache"
 	"github.com/scionproto/scion/go/lib/xtest/graph"
 	"github.com/scionproto/scion/go/lib/xtest/matchers"
 	"github.com/scionproto/scion/go/proto"
@@ -41,9 +47,11 @@ type testGraph struct {
 	seg130_111 *seg.PathSegment
 	seg120_111 *seg.PathSegment
 
-	seg210_120 *seg.PathSegment
-	seg210_130 *seg.PathSegment
-	seg210_211 *seg.PathSegment
+	seg210_120   *seg.PathSegment
+	seg210_130   *seg.PathSegment
+	seg210_130_2 *seg.PathSegment
+	seg210_211   *seg.PathSegment
+	seg210_212   *seg.PathSegment
 }
 
 func newTestGraph(ctrl *gomock.Controller) *testGraph {
@@ -58,7 +66,10 @@ func newTestGraph(ctrl *gomock.Controller) *testGraph {
 
 		seg210_120: g.Beacon([]common.IFIDType{graph.If_210_X_110_X, graph.If_110_X_120_A}),
 		seg210_130: g.Beacon([]common.IFIDType{graph.If_210_X_110_X, graph.If_110_X_130_A}),
+		seg210_130_2: g.Beacon([]common.IFIDType{graph.If_210_X_220_X,
+			graph.If_220_X_120_B, graph.If_120_A_130_B}),
 		seg210_211: g.Beacon([]common.IFIDType{graph.If_210_X_211_A}),
+		seg210_212: g.Beacon([]common.IFIDType{graph.If_210_X_211_A, graph.If_211_A_212_X}),
 	}
 }
 
@@ -66,6 +77,7 @@ type resolverTest struct {
 	Req              segfetcher.RequestSet
 	Segs             segfetcher.Segments
 	ExpectCalls      func(db *mock_pathdb.MockPathDB)
+	ExpectRevcache   func(t *testing.T, revCache *mock_revcache.MockRevCache)
 	ExpectedSegments segfetcher.Segments
 	ExpectedReqSet   segfetcher.RequestSet
 }
@@ -76,7 +88,13 @@ func (rt resolverTest) run(t *testing.T) {
 
 	db := mock_pathdb.NewMockPathDB(ctrl)
 	rt.ExpectCalls(db)
-	resolver := segfetcher.NewResolver(db)
+	var revCache revcache.RevCache
+	if rt.ExpectRevcache != nil {
+		mRevCache := mock_revcache.NewMockRevCache(ctrl)
+		rt.ExpectRevcache(t, mRevCache)
+		revCache = mRevCache
+	}
+	resolver := segfetcher.NewResolver(db, revCache, revCache == nil)
 	segs, remainingReqs, err := resolver.Resolve(context.Background(), rt.Segs, rt.Req)
 	assert.Equal(t, rt.ExpectedSegments, segs)
 	assert.Equal(t, rt.ExpectedReqSet, remainingReqs)
@@ -208,6 +226,47 @@ func TestResolver(t *testing.T) {
 				Cores: []segfetcher.Request{
 					{Src: core_120, Dst: core_110},
 				},
+			},
+		},
+		"Up down": {
+			Req: segfetcher.RequestSet{
+				Up:    segfetcher.Request{Src: non_core_211, Dst: isd2},
+				Cores: []segfetcher.Request{{Src: isd2, Dst: isd2}},
+				Down:  segfetcher.Request{Src: isd2, Dst: non_core_212},
+			},
+			ExpectCalls: func(db *mock_pathdb.MockPathDB) {
+				db.EXPECT().GetNextQuery(gomock.Any(), non_core_211, isd2, gomock.Any())
+				db.EXPECT().GetNextQuery(gomock.Any(), isd2, non_core_212, gomock.Any())
+			},
+			ExpectedReqSet: segfetcher.RequestSet{
+				Up:    segfetcher.Request{Src: non_core_211, Dst: isd2},
+				Cores: []segfetcher.Request{{Src: isd2, Dst: isd2}},
+				Down:  segfetcher.Request{Src: isd2, Dst: non_core_212},
+			},
+		},
+		"Up(cached) down(cached)": {
+			Req: segfetcher.RequestSet{
+				Up:    segfetcher.Request{Src: non_core_211, Dst: isd2},
+				Cores: []segfetcher.Request{{Src: isd2, Dst: isd2}},
+				Down:  segfetcher.Request{Src: isd2, Dst: non_core_212},
+			},
+			ExpectCalls: func(db *mock_pathdb.MockPathDB) {
+				db.EXPECT().GetNextQuery(gomock.Any(), non_core_211, isd2, gomock.Any()).
+					Return(futureT, nil)
+				db.EXPECT().GetNextQuery(gomock.Any(), isd2, non_core_212, gomock.Any()).
+					Return(futureT, nil)
+				db.EXPECT().Get(gomock.Any(), matchers.EqParams(&query.Params{
+					SegTypes: []proto.PathSegType{proto.PathSegType_up},
+					StartsAt: []addr.IA{isd2}, EndsAt: []addr.IA{non_core_211},
+				})).Return(resultsFromSegs(tg.seg210_211), nil)
+				db.EXPECT().Get(gomock.Any(), matchers.EqParams(&query.Params{
+					SegTypes: []proto.PathSegType{proto.PathSegType_down},
+					StartsAt: []addr.IA{isd2}, EndsAt: []addr.IA{non_core_212},
+				})).Return(resultsFromSegs(tg.seg210_212), nil)
+			},
+			ExpectedSegments: segfetcher.Segments{
+				Up:   seg.Segments{tg.seg210_211},
+				Down: seg.Segments{tg.seg210_212},
 			},
 		},
 		"Up Core Down": {
@@ -369,6 +428,42 @@ func TestResolver(t *testing.T) {
 				Core: seg.Segments{tg.seg210_130},
 			},
 		},
+		"Core (cached) with revocations": {
+			Req: segfetcher.RequestSet{
+				Cores: []segfetcher.Request{
+					{Src: core_210, Dst: core_110},
+					{Src: core_210, Dst: core_120},
+					{Src: core_210, Dst: core_130},
+				},
+			},
+			ExpectCalls: func(db *mock_pathdb.MockPathDB) {
+				db.EXPECT().GetNextQuery(gomock.Any(), gomock.Eq(core_210),
+					gomock.Eq(core_110), gomock.Any()).Return(futureT, nil)
+				db.EXPECT().GetNextQuery(gomock.Any(), gomock.Eq(core_210),
+					gomock.Eq(core_120), gomock.Any()).Return(futureT, nil)
+				db.EXPECT().GetNextQuery(gomock.Any(), gomock.Eq(core_210),
+					gomock.Eq(core_130), gomock.Any()).Return(futureT, nil)
+				db.EXPECT().Get(gomock.Any(), matchers.EqParams(&query.Params{
+					SegTypes: []proto.PathSegType{proto.PathSegType_core},
+					StartsAt: []addr.IA{core_110, core_120, core_130}, EndsAt: []addr.IA{core_210},
+				})).Return(resultsFromSegs(tg.seg210_130, tg.seg210_130_2), nil)
+			},
+			// Revoke the shorter path via 110, so it should only return the
+			// longer path via 120.
+			ExpectRevcache: func(t *testing.T, revCache *mock_revcache.MockRevCache) {
+				key110 := revcache.Key{IA: core_110, IfId: graph.If_110_X_130_A}
+				ksMatcher := keySetContains{keys: []revcache.Key{key110}}
+				srev, err := path_mgmt.NewSignedRevInfo(&path_mgmt.RevInfo{}, infra.NullSigner)
+				require.NoError(t, err)
+				revCache.EXPECT().Get(gomock.Any(), ksMatcher).Return(revcache.Revocations{
+					key110: srev,
+				}, nil)
+				revCache.EXPECT().Get(gomock.Any(), gomock.Any()).AnyTimes()
+			},
+			ExpectedSegments: segfetcher.Segments{
+				Core: seg.Segments{tg.seg210_130_2},
+			},
+		},
 		"Core Down": {
 			Req: segfetcher.RequestSet{
 				Cores: []segfetcher.Request{{Src: core_110, Dst: isd2}},
@@ -495,4 +590,25 @@ func resultsFromSegs(segs ...*seg.PathSegment) query.Results {
 		})
 	}
 	return results
+}
+
+type keySetContains struct {
+	keys []revcache.Key
+}
+
+func (m keySetContains) Matches(other interface{}) bool {
+	ks, ok := other.(revcache.KeySet)
+	if !ok {
+		return false
+	}
+	for _, k := range m.keys {
+		if _, ok := ks[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (m keySetContains) String() string {
+	return fmt.Sprintf("revcache.KeySet containing %v", m.keys)
 }


### PR DESCRIPTION
For sciond we don't want to return segments that are revoked.

Also test some more cases in the resolver tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3045)
<!-- Reviewable:end -->
