### PR TITLE
errors: add support for Is and Unwrap

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -442,13 +442,13 @@ go_repository(
 go_repository(
     name = "com_github_buildkite_go_buildkite",
     commit = "568b6651b687ccf6893ada08086ce58b072538b6",
-    importpath = "github.com/buildkite/go-buildkite", # buildkite
+    importpath = "github.com/buildkite/go-buildkite",  # buildkite
 )
 
 go_repository(
     name = "com_github_google_go_querystring",
     commit = "c8c88dbee036db4e4808d1f2ec8c2e15e11c3f80",
-    importpath = "github.com/google/go-querystring", # query
+    importpath = "github.com/google/go-querystring",  # query
 )
 
 go_repository(
@@ -466,11 +466,17 @@ go_repository(
 go_repository(
     name = "com_github_uber_jaeger_lib",
     commit = "0e30338a695636fe5bcf7301e8030ce8dd2a8530",
-    importpath = "github.com/uber/jaeger-lib", # metrics
+    importpath = "github.com/uber/jaeger-lib",  # metrics
 )
 
 go_repository(
     name = "com_github_pkg_errors",
     commit = "27936f6d90f9c8e1145f11ed52ffffbfdb9e0af7",
     importpath = "github.com/pkg/errors",
+)
+
+go_repository(
+    name = "org_golang_x_xerrors",
+    commit = "a985d3407aa71f30cf86696ee0a2f409709f22e1",
+    importpath = "golang.org/x/xerrors",
 )

--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -62,8 +62,7 @@ func ISDFromString(s string) (ISD, error) {
 func ISDFromFileFmt(s string, prefix bool) (ISD, error) {
 	if prefix {
 		if !strings.HasPrefix(s, ISDFmtPrefix) {
-			return 0, common.NewBasicError(
-				fmt.Sprintf("'%s' prefix missing", ISDFmtPrefix), nil, "raw", s)
+			return 0, common.NewBasicError("prefix missing", nil, "prefix", ISDFmtPrefix, "raw", s)
 		}
 		s = s[len(ISDFmtPrefix):]
 	}
@@ -89,8 +88,7 @@ func ASFromString(s string) (AS, error) {
 func ASFromFileFmt(s string, prefix bool) (AS, error) {
 	if prefix {
 		if !strings.HasPrefix(s, ASFmtPrefix) {
-			return 0, common.NewBasicError(
-				fmt.Sprintf("'%s' prefix missing", ASFmtPrefix), nil, "raw", s)
+			return 0, common.NewBasicError("prefix missing", nil, "prefix", ASFmtPrefix, "raw", s)
 		}
 		s = s[len(ASFmtPrefix):]
 	}
@@ -109,9 +107,8 @@ func asParse(s string, sep string) (AS, error) {
 	}
 	parts := strings.Split(s, sep)
 	if len(parts) != asParts {
-		return 0, common.NewBasicError(
-			fmt.Sprintf("Unable to parse AS: wrong number of %s separators", sep), nil,
-			"expected", asParts, "actual", len(parts), "raw", s)
+		return 0, common.NewBasicError("unable to parse AS: wrong number of separators", nil,
+			"expected", asParts, "actual", len(parts), "sep", sep, "raw", s)
 	}
 	var as AS
 	for i := 0; i < asParts; i++ {
@@ -193,7 +190,7 @@ func IAFromRaw(b common.RawBytes) IA {
 	return *ia
 }
 
-/// IAFromString parses an IA from a string of the format 'ia-as'.
+// IAFromString parses an IA from a string of the format 'ia-as'.
 func IAFromString(s string) (IA, error) {
 	parts := strings.Split(s, "-")
 	if len(parts) != 2 {
@@ -231,7 +228,7 @@ func (ia IA) MarshalText() ([]byte, error) {
 	return []byte(ia.String()), nil
 }
 
-// allows IA to be used as a map key in JSON.
+// UnmarshalText allows IA to be used as a map key in JSON.
 func (ia *IA) UnmarshalText(text []byte) error {
 	if len(text) == 0 {
 		*ia = IA{}
@@ -285,7 +282,7 @@ func (ia IA) FileFmt(prefixes bool) string {
 	return fmt.Sprintf(fmts, ia.I, ia.A.FileFmt())
 }
 
-// This method implements flag.Value interface
+// Set implements flag.Value interface
 func (ia *IA) Set(s string) error {
 	pIA, err := IAFromString(s)
 	if err != nil {

--- a/go/lib/common/BUILD.bazel
+++ b/go/lib/common/BUILD.bazel
@@ -24,5 +24,9 @@ go_test(
         "errors_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["@com_github_smartystreets_goconvey//convey:go_default_library"],
+    deps = [
+        "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@org_golang_x_xerrors//:go_default_library",
+    ],
 )

--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -97,11 +97,11 @@ func IsTimeoutErr(e error) bool {
 	return false
 }
 
-// SimpleError should be used for error string constants. The constant can then
-// be used for Is checking in the calling code.
-type SimpleError string
+// ErrMsg should be used for error string constants. The constant can then be
+// used for Is checking in the calling code.
+type ErrMsg string
 
-func (e SimpleError) Error() string {
+func (e ErrMsg) Error() string {
 	return string(e)
 }
 
@@ -112,7 +112,7 @@ var _ ErrorNester = BasicError{}
 // and can contain context (slice of [string, val, string, val...]) for logging purposes.
 type BasicError struct {
 	// Error message
-	Msg SimpleError
+	Msg ErrMsg
 	// Error context, for logging purposes only
 	logCtx []interface{}
 	// Nested error, if any.
@@ -125,7 +125,7 @@ func (be BasicError) Is(err error) bool {
 	switch other := err.(type) {
 	case BasicError:
 		return be.Msg == other.Msg
-	case SimpleError:
+	case ErrMsg:
 		return be.Msg == other
 	default:
 		return false
@@ -140,7 +140,7 @@ func (be BasicError) Unwrap() error {
 // NewBasicError creates a new BasicError, with e as the embedded error (can be nil), with logCtx
 // being a list of string/val pairs. These key/value pairs should contain all context-dependent
 // information: 'msg' argument itself should be a constant string.
-func NewBasicError(msg SimpleError, e error, logCtx ...interface{}) error {
+func NewBasicError(msg ErrMsg, e error, logCtx ...interface{}) error {
 	if assert.On {
 		assert.Must(len(logCtx)%2 == 0, "Log context must have an even number of elements")
 		for i := 0; i < len(logCtx); i += 2 {

--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -120,7 +120,7 @@ type BasicError struct {
 }
 
 // Is returns whether this error is the same error as err, or in case err is a
-// SimpleError whether the message is equal.
+// ErrMsg whether the message is equal.
 func (be BasicError) Is(err error) bool {
 	switch other := err.(type) {
 	case BasicError:

--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -1,4 +1,5 @@
 // Copyright 2016 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -78,7 +79,7 @@ func IsTemporaryErr(e error) bool {
 	return false
 }
 
-// Temporary allows signalling of a timeout error. Based on https://golang.org/pkg/net/#Error
+// Timeout allows signalling of a timeout error. Based on https://golang.org/pkg/net/#Error
 type Timeout interface {
 	error
 	Timeout() bool
@@ -96,6 +97,14 @@ func IsTimeoutErr(e error) bool {
 	return false
 }
 
+// SimpleError should be used for error string constants. The constant can then
+// be used for Is checking in the calling code.
+type SimpleError string
+
+func (e SimpleError) Error() string {
+	return string(e)
+}
+
 var _ ErrorMsger = BasicError{}
 var _ ErrorNester = BasicError{}
 
@@ -103,17 +112,35 @@ var _ ErrorNester = BasicError{}
 // and can contain context (slice of [string, val, string, val...]) for logging purposes.
 type BasicError struct {
 	// Error message
-	Msg string
+	Msg SimpleError
 	// Error context, for logging purposes only
 	logCtx []interface{}
 	// Nested error, if any.
 	Err error
 }
 
+// Is returns whether this error is the same error as err, or in case err is a
+// SimpleError whether the message is equal.
+func (be BasicError) Is(err error) bool {
+	switch other := err.(type) {
+	case BasicError:
+		return be.Msg == other.Msg
+	case SimpleError:
+		return be.Msg == other
+	default:
+		return false
+	}
+}
+
+// Unwrap returns the next error in the error chain, or nil if there is none.
+func (be BasicError) Unwrap() error {
+	return be.GetErr()
+}
+
 // NewBasicError creates a new BasicError, with e as the embedded error (can be nil), with logCtx
 // being a list of string/val pairs. These key/value pairs should contain all context-dependent
 // information: 'msg' argument itself should be a constant string.
-func NewBasicError(msg string, e error, logCtx ...interface{}) error {
+func NewBasicError(msg SimpleError, e error, logCtx ...interface{}) error {
 	if assert.On {
 		assert.Must(len(logCtx)%2 == 0, "Log context must have an even number of elements")
 		for i := 0; i < len(logCtx); i += 2 {
@@ -126,8 +153,8 @@ func NewBasicError(msg string, e error, logCtx ...interface{}) error {
 
 func (be BasicError) TopError() string {
 	s := make([]string, 0, 1+(len(be.logCtx)/2))
-	s = append(s, be.Msg)
-	s[0] = be.Msg
+	s = append(s, string(be.Msg))
+	s[0] = string(be.Msg)
 	for i := 0; i < len(be.logCtx); i += 2 {
 		s = append(s, fmt.Sprintf("%s=\"%v\"", be.logCtx[i], be.logCtx[i+1]))
 	}
@@ -139,7 +166,7 @@ func (be BasicError) Error() string {
 }
 
 func (be BasicError) GetMsg() string {
-	return be.Msg
+	return string(be.Msg)
 }
 
 func (be BasicError) GetErr() error {

--- a/go/lib/common/errors_test.go
+++ b/go/lib/common/errors_test.go
@@ -39,7 +39,7 @@ func TestFmtError(t *testing.T) {
 
 func TestSimpleError(t *testing.T) {
 	errText := "test error string"
-	err := SimpleError(errText)
+	err := ErrMsg(errText)
 	assert.Equal(t, errText, err.Error())
 }
 
@@ -71,16 +71,16 @@ func TestIs(t *testing.T) {
 	assert.True(t, xerrors.Is(wrapWrapBaseErr, baseErr))
 	assert.True(t, xerrors.Is(wrapWrapBaseErr, wrapBaseErr))
 
-	assert.True(t, xerrors.Is(noWrapErr, SimpleError("test no wrap")))
-	assert.True(t, xerrors.Is(wrapWrapBaseErr, SimpleError("wrapping base once")))
-	assert.True(t, xerrors.Is(wrapNoWrapErr, SimpleError("test no wrap")))
+	assert.True(t, xerrors.Is(noWrapErr, ErrMsg("test no wrap")))
+	assert.True(t, xerrors.Is(wrapWrapBaseErr, ErrMsg("wrapping base once")))
+	assert.True(t, xerrors.Is(wrapNoWrapErr, ErrMsg("test no wrap")))
 
-	assert.True(t, xerrors.Is(SimpleError("foo"), SimpleError("foo")))
+	assert.True(t, xerrors.Is(ErrMsg("foo"), ErrMsg("foo")))
 }
 
 func ExampleSimpleError() {
-	var ErrMsg SimpleError = "this is the error msg"
+	var SomeErr ErrMsg = "this is the error msg"
 
-	fmt.Println(xerrors.Is(NewBasicError(ErrMsg, nil, "ctx", 1), ErrMsg))
+	fmt.Println(xerrors.Is(NewBasicError(SomeErr, nil, "ctx", 1), SomeErr))
 	// Output: true
 }

--- a/go/lib/common/errors_test.go
+++ b/go/lib/common/errors_test.go
@@ -37,7 +37,7 @@ func TestFmtError(t *testing.T) {
 	assert.Equal(t, expedtedMsg, FmtError(err))
 }
 
-func TestSimpleError(t *testing.T) {
+func TestErrMsg(t *testing.T) {
 	errText := "test error string"
 	err := ErrMsg(errText)
 	assert.Equal(t, errText, err.Error())
@@ -57,9 +57,11 @@ func TestUnwrap(t *testing.T) {
 
 func TestIs(t *testing.T) {
 	baseErr := errors.New("base err")
+	var baseErrMsg ErrMsg = "base err msg"
 	noWrapErr := NewBasicError("test no wrap", nil)
 	wrapNoWrapErr := NewBasicError("wrapping basic error", noWrapErr)
 	wrapBaseErr := NewBasicError("wrapping base once", baseErr)
+	wrapBaseErrMsg := NewBasicError("wrapping base msg once", baseErrMsg)
 	wrapWrapBaseErr := NewBasicError("wrapping wrapper of base", wrapBaseErr)
 
 	assert.False(t, xerrors.Is(baseErr, wrapBaseErr))
@@ -70,6 +72,7 @@ func TestIs(t *testing.T) {
 	assert.True(t, xerrors.Is(wrapNoWrapErr, noWrapErr))
 	assert.True(t, xerrors.Is(wrapWrapBaseErr, baseErr))
 	assert.True(t, xerrors.Is(wrapWrapBaseErr, wrapBaseErr))
+	assert.True(t, xerrors.Is(wrapBaseErrMsg, baseErrMsg))
 
 	assert.True(t, xerrors.Is(noWrapErr, ErrMsg("test no wrap")))
 	assert.True(t, xerrors.Is(wrapWrapBaseErr, ErrMsg("wrapping base once")))
@@ -78,7 +81,7 @@ func TestIs(t *testing.T) {
 	assert.True(t, xerrors.Is(ErrMsg("foo"), ErrMsg("foo")))
 }
 
-func ExampleSimpleError() {
+func ExampleErrMsg() {
 	var SomeErr ErrMsg = "this is the error msg"
 
 	fmt.Println(xerrors.Is(NewBasicError(SomeErr, nil, "ctx", 1), SomeErr))

--- a/go/lib/env/env.go
+++ b/go/lib/env/env.go
@@ -111,8 +111,7 @@ func (cfg *General) checkDir() error {
 			return err
 		}
 		if !info.IsDir() {
-			return common.NewBasicError(
-				fmt.Sprintf("%v is not a directory", cfg.ConfigDir), nil)
+			return common.NewBasicError("Not a directory", nil, "dir", cfg.ConfigDir)
 		}
 	}
 	return nil

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -955,8 +955,8 @@ func (m *Messenger) getQUICRequester(signer ctrl.Signer) *QUICRequester {
 }
 
 func newTypeAssertErr(typeStr string, msg interface{}) error {
-	errStr := fmt.Sprintf("Unable to type assert disp.Message to %s", typeStr)
-	return common.NewBasicError(errStr, nil, "msg", msg)
+	return common.NewBasicError("Unable to type assert disp.Message", nil,
+		"msg", msg, "type", typeStr)
 }
 
 // pathingRequester resolves the SCION path and constructs complete snet

--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -46,7 +46,7 @@ const (
 	HandlerTimeout = 3 * time.Second
 )
 
-var (
+const (
 	ErrNotFoundLocally      = "Chain/TRC not found locally"
 	ErrMissingAuthoritative = "Trust store is authoritative for requested object," +
 		" and object was not found"

--- a/go/lib/overlay/conn/conn.go
+++ b/go/lib/overlay/conn/conn.go
@@ -273,7 +273,7 @@ func (cc *connUDPBase) initConnUDP(network string, listen, remote *overlay.Overl
 		ctx := []interface{}{"expected", ReceiveBufferSize, "actual", after / 2,
 			"before", before / 2}
 		if !*sizeIgnore {
-			return common.NewBasicError(msg, nil, ctx...)
+			return common.NewBasicError(common.SimpleError(msg), nil, ctx...)
 		}
 		log.Warn(msg, ctx...)
 	}

--- a/go/lib/overlay/conn/conn.go
+++ b/go/lib/overlay/conn/conn.go
@@ -273,7 +273,7 @@ func (cc *connUDPBase) initConnUDP(network string, listen, remote *overlay.Overl
 		ctx := []interface{}{"expected", ReceiveBufferSize, "actual", after / 2,
 			"before", before / 2}
 		if !*sizeIgnore {
-			return common.NewBasicError(common.SimpleError(msg), nil, ctx...)
+			return common.NewBasicError(common.ErrMsg(msg), nil, ctx...)
 		}
 		log.Warn(msg, ctx...)
 	}

--- a/go/lib/pathpol/policy.go
+++ b/go/lib/pathpol/policy.go
@@ -20,7 +20,6 @@
 package pathpol
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/scionproto/scion/go/lib/common"
@@ -98,8 +97,8 @@ func (p *Policy) applyExtended(extends []string, exPolicies []*ExtPolicy) error 
 			}
 		}
 		if policy == nil {
-			return common.NewBasicError(
-				fmt.Sprintf("Extended policy '%s' could not be found", extends[i]), nil)
+			return common.NewBasicError("Extended policy could not be found", nil,
+				"policy", extends[i])
 		}
 		// Replace ACL
 		if p.ACL == nil && policy.ACL != nil {

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -236,11 +236,11 @@ func StartServer(name, sockPath string, server *servers.Server) {
 		defer log.LogPanicAndExit()
 		if cfg.SD.DeleteSocket {
 			if err := os.Remove(sockPath); err != nil && !os.IsNotExist(err) {
-				fatal.Fatal(common.NewBasicError(name+" SocketRemoval error", err))
+				fatal.Fatal(common.NewBasicError("SocketRemoval error", err, "name", name))
 			}
 		}
 		if err := server.ListenAndServe(); err != nil {
-			fatal.Fatal(common.NewBasicError(name+" ListenAndServe error", err))
+			fatal.Fatal(common.NewBasicError("ListenAndServe error", err, "name", name))
 		}
 	}()
 }

--- a/go/tools/scion-pki/internal/conf/as.go
+++ b/go/tools/scion-pki/internal/conf/as.go
@@ -233,7 +233,7 @@ func validateEncAlgorithm(algorithm string) error {
 	return validateAlgorithm(algorithm, validEncAlgorithms, ErrInvalidEncAlgorithm)
 }
 
-func validateAlgorithm(algorithm string, valid []string, errMsg common.SimpleError) error {
+func validateAlgorithm(algorithm string, valid []string, errMsg common.ErrMsg) error {
 	for _, a := range valid {
 		if a == algorithm {
 			return nil

--- a/go/tools/scion-pki/internal/conf/as.go
+++ b/go/tools/scion-pki/internal/conf/as.go
@@ -233,7 +233,7 @@ func validateEncAlgorithm(algorithm string) error {
 	return validateAlgorithm(algorithm, validEncAlgorithms, ErrInvalidEncAlgorithm)
 }
 
-func validateAlgorithm(algorithm string, valid []string, errMsg string) error {
+func validateAlgorithm(algorithm string, valid []string, errMsg common.SimpleError) error {
 	for _, a := range valid {
 		if a == algorithm {
 			return nil

--- a/go/tools/scion-pki/internal/v2/conf/as.go
+++ b/go/tools/scion-pki/internal/v2/conf/as.go
@@ -312,7 +312,7 @@ func defaultAndValidateEncAlgorithm(algo *string) error {
 	return validateAlgorithm(*algo, validEncAlgorithms, ErrInvalidEncAlgorithm)
 }
 
-func validateAlgorithm(algorithm string, valid []string, errMsg common.SimpleError) error {
+func validateAlgorithm(algorithm string, valid []string, errMsg common.ErrMsg) error {
 	for _, a := range valid {
 		if a == algorithm {
 			return nil

--- a/go/tools/scion-pki/internal/v2/conf/as.go
+++ b/go/tools/scion-pki/internal/v2/conf/as.go
@@ -312,7 +312,7 @@ func defaultAndValidateEncAlgorithm(algo *string) error {
 	return validateAlgorithm(*algo, validEncAlgorithms, ErrInvalidEncAlgorithm)
 }
 
-func validateAlgorithm(algorithm string, valid []string, errMsg string) error {
+func validateAlgorithm(algorithm string, valid []string, errMsg common.SimpleError) error {
 	for _, a := range valid {
 		if a == algorithm {
 			return nil


### PR DESCRIPTION
This commit adds Unwrap and Is methods to the BasicError type.
It also adds a SimpleError type that can be used for error string constants.
This will allow us to get rid of brittle error checks with GetErrorMsg=="some string".

Contributes #3042

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3048)
<!-- Reviewable:end -->
