### PR TITLE
SPKI: Generate prototype TRC

### DIFF
--- a/go/lib/scrypto/asym.go
+++ b/go/lib/scrypto/asym.go
@@ -71,6 +71,15 @@ func GenKeyPair(algo string) (common.RawBytes, common.RawBytes, error) {
 	}
 }
 
+// GetPubKey generates the public key for the provided private key.
+func GetPubKey(privKey []byte, algo string) ([]byte, error) {
+	switch strings.ToLower(algo) {
+	case Ed25519:
+		return ed25519.PrivateKey(privKey).Public().(ed25519.PublicKey), nil
+	}
+	return nil, common.NewBasicError("unsupported key type", nil)
+}
+
 // Sign takes a signature input and a signing key to create a signature. Currently only
 // ed25519 is supported.
 func Sign(sigInput, signKey common.RawBytes, signAlgo string) (common.RawBytes, error) {

--- a/go/tools/scion-pki/internal/pkicmn/pkicmn.go
+++ b/go/tools/scion-pki/internal/pkicmn/pkicmn.go
@@ -31,6 +31,8 @@ const (
 	CertNameFmt        = "ISD%d-AS%s-V%d.crt"
 	CoreCertNameFmt    = "ISD%d-AS%s-V%d-core.crt"
 	TrcNameFmt         = "ISD%d-V%d.trc"
+	TRCPartsDirFmt     = "ISD%d-V%d.parts"
+	TRCProtoNameFmt    = "ISD%d-V%d.proto"
 	ErrInvalidSelector = "Invalid selector."
 	ErrNoISDDirFound   = "No ISD directories found"
 	ErrNoASDirFound    = "No AS directories found"
@@ -142,7 +144,21 @@ func ContainsAS(ases []addr.AS, as addr.AS) bool {
 	return false
 }
 
-func WriteToFile(raw common.RawBytes, path string, perm os.FileMode) error {
+// CreateDir creates a directory if it does not already exist.
+func CreateDir(dir string, perm os.FileMode) error {
+	_, err := os.Stat(dir)
+	switch {
+	case os.IsNotExist(err):
+		if err := os.MkdirAll(dir, perm); err != nil {
+			return common.NewBasicError("cannot create output dir", err, "path", dir)
+		}
+	case err != nil:
+		return common.NewBasicError("unable to stat dir", err, "dir", dir)
+	}
+	return nil
+}
+
+func WriteToFile(raw []byte, path string, perm os.FileMode) error {
 	// Check if file already exists.
 	if _, err := os.Stat(path); err == nil {
 		if !Force {

--- a/go/tools/scion-pki/internal/pkicmn/pkicmn.go
+++ b/go/tools/scion-pki/internal/pkicmn/pkicmn.go
@@ -144,20 +144,6 @@ func ContainsAS(ases []addr.AS, as addr.AS) bool {
 	return false
 }
 
-// CreateDir creates a directory if it does not already exist.
-func CreateDir(dir string, perm os.FileMode) error {
-	_, err := os.Stat(dir)
-	switch {
-	case os.IsNotExist(err):
-		if err := os.MkdirAll(dir, perm); err != nil {
-			return common.NewBasicError("cannot create output dir", err, "path", dir)
-		}
-	case err != nil:
-		return common.NewBasicError("unable to stat dir", err, "dir", dir)
-	}
-	return nil
-}
-
 func WriteToFile(raw []byte, path string, perm os.FileMode) error {
 	// Check if file already exists.
 	if _, err := os.Stat(path); err == nil {

--- a/go/tools/scion-pki/internal/v2/cmd/BUILD.bazel
+++ b/go/tools/scion-pki/internal/v2/cmd/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//go/tools/scion-pki/internal/v2/keys:go_default_library",
         "//go/tools/scion-pki/internal/v2/tmpl:go_default_library",
+        "//go/tools/scion-pki/internal/v2/trc:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )

--- a/go/tools/scion-pki/internal/v2/cmd/cmd.go
+++ b/go/tools/scion-pki/internal/v2/cmd/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/keys"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/tmpl"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/trc"
 )
 
 var Cmd = &cobra.Command{
@@ -34,4 +35,5 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(tmpl.Cmd)
 	Cmd.AddCommand(keys.Cmd)
+	Cmd.AddCommand(trc.Cmd)
 }

--- a/go/tools/scion-pki/internal/v2/conf/isd.go
+++ b/go/tools/scion-pki/internal/v2/conf/isd.go
@@ -67,6 +67,9 @@ func LoadISDCfg(dir string) (*ISDCfg, error) {
 	if err = cfg.MapTo(i); err != nil {
 		return nil, err
 	}
+	if len(i.Desc) == 0 {
+		return nil, common.NewBasicError("description not set", nil)
+	}
 	if err = i.TRC.Validate(); err != nil {
 		return nil, err
 	}

--- a/go/tools/scion-pki/internal/v2/keys/gen.go
+++ b/go/tools/scion-pki/internal/v2/keys/gen.go
@@ -89,7 +89,7 @@ func (a *as) gen() error {
 			keyconf.TRCOfflineKeyFile: a.cfg.PrimaryKeyAlgorithms.Offline,
 		})
 	}
-	if err := pkicmn.CreateDir(a.outDir, 0700); err != nil {
+	if err := os.MkdirAll(a.outDir, 0700); err != nil {
 		return nil
 	}
 	for file, keyType := range keys {

--- a/go/tools/scion-pki/internal/v2/keys/gen.go
+++ b/go/tools/scion-pki/internal/v2/keys/gen.go
@@ -89,14 +89,8 @@ func (a *as) gen() error {
 			keyconf.TRCOfflineKeyFile: a.cfg.PrimaryKeyAlgorithms.Offline,
 		})
 	}
-	// Check if out directory exists and if not create it.
-	_, err := os.Stat(a.outDir)
-	if os.IsNotExist(err) {
-		if err = os.MkdirAll(a.outDir, 0700); err != nil {
-			return common.NewBasicError("Cannot create output dir", err)
-		}
-	} else if err != nil {
-		return common.NewBasicError("Error checking output dir", err)
+	if err := pkicmn.CreateDir(a.outDir, 0700); err != nil {
+		return nil
 	}
 	for file, keyType := range keys {
 		if err := a.genKey(file, keyType); err != nil {

--- a/go/tools/scion-pki/internal/v2/trc/BUILD.bazel
+++ b/go/tools/scion-pki/internal/v2/trc/BUILD.bazel
@@ -5,7 +5,7 @@ go_library(
     srcs = [
         "ases.go",
         "cmd.go",
-        "proto.go",
+        "prototype.go",
         "util.go",
     ],
     importpath = "github.com/scionproto/scion/go/tools/scion-pki/internal/v2/trc",

--- a/go/tools/scion-pki/internal/v2/trc/BUILD.bazel
+++ b/go/tools/scion-pki/internal/v2/trc/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "ases.go",
+        "cmd.go",
+        "proto.go",
+        "util.go",
+    ],
+    importpath = "github.com/scionproto/scion/go/tools/scion-pki/internal/v2/trc",
+    visibility = ["//go/tools/scion-pki:__subpackages__"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/keyconf:go_default_library",
+        "//go/lib/scrypto:go_default_library",
+        "//go/lib/scrypto/trc/v2:go_default_library",
+        "//go/lib/util:go_default_library",
+        "//go/tools/scion-pki/internal/pkicmn:go_default_library",
+        "//go/tools/scion-pki/internal/v2/conf:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)

--- a/go/tools/scion-pki/internal/v2/trc/ases.go
+++ b/go/tools/scion-pki/internal/v2/trc/ases.go
@@ -1,0 +1,103 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trc
+
+import (
+	"path/filepath"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/keyconf"
+	"github.com/scionproto/scion/go/lib/scrypto/trc/v2"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/conf"
+)
+
+// asCfg holds the AS configuration including the from file system loaded
+// private keys.
+type asCfg struct {
+	ASCfg *conf.ASCfg
+	Keys  map[trc.KeyType][]byte
+}
+
+// KeyTypeToAlgo determines the algorithm for the key type.
+func (cfg *asCfg) KeyTypeToAlgo(keyType trc.KeyType) string {
+	switch keyType {
+	case trc.OnlineKey:
+		return cfg.ASCfg.Online
+	case trc.OfflineKey:
+		return cfg.ASCfg.Offline
+	case trc.IssuingKey:
+		return cfg.ASCfg.Issuing
+	}
+	return "none"
+}
+
+// loadPrimaryASes loads the primary ASes with their keys for the ASes in the
+// whitelist. If the whitelist is empty, all primary ASes are loaded.
+func loadPrimaryASes(isd addr.ISD, isdCfg *conf.ISDCfg, wl []addr.IA) (map[addr.AS]*asCfg, error) {
+	ases := make(map[addr.AS][]trc.KeyType)
+	for _, as := range isdCfg.VotingASes {
+		ases[as] = []trc.KeyType{trc.OnlineKey, trc.OfflineKey}
+	}
+	for _, as := range isdCfg.IssuingASes {
+		ases[as] = append(ases[as], trc.IssuingKey)
+	}
+	primaryASes := make(map[addr.AS]*asCfg)
+	for as, keys := range ases {
+		if len(wl) != 0 && !pkicmn.Contains(wl, addr.IA{I: isd, A: as}) {
+			continue
+		}
+		ia := addr.IA{I: isd, A: as}
+		cfg, err := loadASCfg(ia)
+		if err != nil {
+			return nil, err
+		}
+		for _, keyType := range keys {
+			if cfg.Keys[keyType], err = loadKey(ia, keyType, cfg); err != nil {
+				return nil, err
+			}
+		}
+		primaryASes[as] = cfg
+	}
+	return primaryASes, nil
+}
+
+func loadASCfg(ia addr.IA) (*asCfg, error) {
+	cfgPath := filepath.Join(pkicmn.GetAsPath(pkicmn.RootDir, ia), conf.ASConfFileName)
+	cfg, err := conf.LoadASCfg(filepath.Dir(cfgPath))
+	if err != nil {
+		return nil, err
+	}
+	return &asCfg{ASCfg: cfg, Keys: make(map[trc.KeyType][]byte)}, nil
+}
+
+func loadKey(ia addr.IA, keyType trc.KeyType, cfg *asCfg) ([]byte, error) {
+	var file string
+	switch keyType {
+	case trc.OnlineKey:
+		file = keyconf.TRCOnlineKeyFile
+	case trc.OfflineKey:
+		file = keyconf.TRCOfflineKeyFile
+	case trc.IssuingKey:
+		file = keyconf.TRCIssuingKeyFile
+	}
+	key, err := keyconf.LoadKey(filepath.Join(pkicmn.GetAsPath(pkicmn.OutDir, ia),
+		pkicmn.KeysDir, file), cfg.KeyTypeToAlgo(keyType))
+	if err != nil {
+		return nil, common.NewBasicError("unable to load key", err, "keyType", keyType)
+	}
+	return key, nil
+}

--- a/go/tools/scion-pki/internal/v2/trc/ases.go
+++ b/go/tools/scion-pki/internal/v2/trc/ases.go
@@ -25,8 +25,7 @@ import (
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/conf"
 )
 
-// asCfg holds the AS configuration including the from file system loaded
-// private keys.
+// asCfg holds the AS configuration including the private keys loaded from file system.
 type asCfg struct {
 	ASCfg *conf.ASCfg
 	Keys  map[trc.KeyType][]byte
@@ -55,11 +54,9 @@ func loadPrimaryASes(isd addr.ISD, isdCfg *conf.ISDCfg, wl []addr.IA) (map[addr.
 	for _, as := range isdCfg.IssuingASes {
 		ases[as] = append(ases[as], trc.IssuingKey)
 	}
+	filter(isd, ases, wl)
 	primaryASes := make(map[addr.AS]*asCfg)
 	for as, keys := range ases {
-		if len(wl) != 0 && !pkicmn.Contains(wl, addr.IA{I: isd, A: as}) {
-			continue
-		}
 		ia := addr.IA{I: isd, A: as}
 		cfg, err := loadASCfg(ia)
 		if err != nil {
@@ -73,6 +70,18 @@ func loadPrimaryASes(isd addr.ISD, isdCfg *conf.ISDCfg, wl []addr.IA) (map[addr.
 		primaryASes[as] = cfg
 	}
 	return primaryASes, nil
+}
+
+// filter deletes all entries that are not on the whitelist.
+func filter(isd addr.ISD, ases map[addr.AS][]trc.KeyType, wl []addr.IA) {
+	if len(wl) == 0 {
+		return
+	}
+	for as := range ases {
+		if !pkicmn.Contains(wl, addr.IA{I: isd, A: as}) {
+			delete(ases, as)
+		}
+	}
 }
 
 func loadASCfg(ia addr.IA) (*asCfg, error) {
@@ -94,10 +103,10 @@ func loadKey(ia addr.IA, keyType trc.KeyType, cfg *asCfg) ([]byte, error) {
 	case trc.IssuingKey:
 		file = keyconf.TRCIssuingKeyFile
 	}
-	key, err := keyconf.LoadKey(filepath.Join(pkicmn.GetAsPath(pkicmn.OutDir, ia),
-		pkicmn.KeysDir, file), cfg.KeyTypeToAlgo(keyType))
+	path := filepath.Join(pkicmn.GetAsPath(pkicmn.OutDir, ia), pkicmn.KeysDir, file)
+	key, err := keyconf.LoadKey(path, cfg.KeyTypeToAlgo(keyType))
 	if err != nil {
-		return nil, common.NewBasicError("unable to load key", err, "keyType", keyType)
+		return nil, common.NewBasicError("unable to load key", err, "type", keyType, "file", path)
 	}
 	return key, nil
 }

--- a/go/tools/scion-pki/internal/v2/trc/cmd.go
+++ b/go/tools/scion-pki/internal/v2/trc/cmd.go
@@ -1,0 +1,108 @@
+// Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trc
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "trc",
+	Short: "Generate TRCs for the SCION control plane PKI",
+	Long: `
+'trc' can be used to generate Trust Root Configuration (TRC) files used in the SCION control
+plane PKI.
+
+Generating a TRC can be split into three phases:
+1. 'proto': Generate the prototype TRC that contains the payload part of the signed TRC.
+2. 'sign': Sign the payload with the respective private keys.
+3. 'combine': Combine the signatures and the payload to a fully signed TRC.
+
+In case the caller has access to all private keys, the caller can use a short-cut command
+that generates the signed TRC in one call: 'gen'.
+
+Selector:
+	*
+		All ISDs under the root directory.
+	X
+		ISD X.
+'trc' needs to be pointed to the root directory where all keys and certificates are
+stored on disk (-d flag). It expects the contents of the root directory to follow
+a predefined structure:
+	<root>/
+		ISD1/
+			isd.ini
+			AS1/
+			AS2/
+			...
+		ISD2/
+			isd.ini
+			AS1/
+			...
+		...
+isd.ini contains the preconfigured parameters according to which 'trc' generates
+the TRCs. It follows the ini format and can contain only the default section with
+the following values:
+	Description [required]
+		arbitrary non-empty string used to describe the ISD/TRC
+and a section 'TRC' with the following values:
+	Version [required]
+		integer representing the version of the TRC
+	BaseVersion [required]
+		integer representing the base version of the TRC
+	VotingQuorum [required]
+		integer representing the number of voting ASes needed to sign an updated TRC.
+	GracePeriod [required]
+		duration string indicating how long the previous TRC is still valid.
+		Must be 0s for base TRC.
+	TrustResetAllowed [required]
+		boolean indicating whether trust resets are allowed for this ISD.
+	NotBefore [optional]
+		integer representing the not_before time in the TRC represented as seconds
+		since UNIX epoch. If 0 will be set to now.
+	Validity [required]
+		duration string determining the validity of the TRC, e.g., 180d or 36h.
+	AuthoritativeASes [required]
+		comma-separated list of AS identifiers representing the authoritative
+		ASes of the ISD, e.g., ff00:0:110,ff00:0:120.
+	CoreASes [required]
+		comma-separated list of AS identifiers representing the core
+		ASes of the ISD, e.g., ff00:0:110,ff00:0:120.
+	IssuingASes [required]
+		comma-separated list of AS identifiers representing the issuing
+		ASes of the ISD, e.g., ff00:0:110,ff00:0:120.
+	VotingASes [required]
+		comma-separated list of AS identifiers representing the voting
+		ASes of the ISD, e.g., ff00:0:110,ff00:0:120.
+`,
+}
+
+var proto = &cobra.Command{
+	Use:   "proto",
+	Short: "Generate new proto TRCs",
+	Long: `
+	'proto' generates new prototype TRCs from the ISD configs. They need to be signed
+	using the sign command.
+`,
+	Args: cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		runProto(args)
+	},
+}
+
+func init() {
+	Cmd.AddCommand(proto)
+}

--- a/go/tools/scion-pki/internal/v2/trc/proto.go
+++ b/go/tools/scion-pki/internal/v2/trc/proto.go
@@ -1,0 +1,169 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trc
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/scrypto/trc/v2"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/conf"
+)
+
+func runProto(args []string) {
+	asMap, err := pkicmn.ProcessSelector(args[0])
+	if err != nil {
+		pkicmn.ErrorAndExit("Error: %s\n", err)
+	}
+	for isd := range asMap {
+		if err = genAndWriteProto(isd); err != nil {
+			pkicmn.ErrorAndExit("Error generating proto TRC for ISD %d: %s\n", isd, err)
+		}
+	}
+	os.Exit(0)
+}
+
+func genAndWriteProto(isd addr.ISD) error {
+	isdCfg, err := conf.LoadISDCfg(pkicmn.GetIsdPath(pkicmn.RootDir, isd))
+	if err != nil {
+		return common.NewBasicError("error loading ISD config", err)
+	}
+	t, encoded, err := genProto(isd, isdCfg)
+	if err != nil {
+		return common.NewBasicError("unable to generate TRC", err)
+	}
+	signed := &trc.Signed{EncodedTRC: encoded}
+	raw, err := json.Marshal(signed)
+	if err != nil {
+		return common.NewBasicError("unable to marshal", err)
+	}
+	if err := pkicmn.CreateDir(PartsDir(isd, uint64(t.Version)), 0755); err != nil {
+		return err
+	}
+	return pkicmn.WriteToFile(raw, ProtoFile(isd, uint64(t.Version)), 0644)
+}
+
+func genProto(isd addr.ISD, isdCfg *conf.ISDCfg) (*trc.TRC, trc.Encoded, error) {
+	pkicmn.QuietPrint("Generating proto TRC for ISD %d\n", isd)
+	primaryASes, err := loadPrimaryASes(isd, isdCfg, nil)
+	if err != nil {
+		return nil, nil, common.NewBasicError("error loading primary ASes configs", err)
+	}
+	t, err := newTRC(isd, isdCfg, primaryASes)
+	if err != nil {
+		return nil, nil, err
+	}
+	encoded, err := trc.Encode(t)
+	if err != nil {
+		return nil, nil, common.NewBasicError("unable to encode TRC", err)
+	}
+	return t, encoded, nil
+}
+
+func newTRC(isd addr.ISD, isdCfg *conf.ISDCfg, primaryASes map[addr.AS]*asCfg) (*trc.TRC, error) {
+	quorum := uint8(isdCfg.TRC.VotingQuorum)
+	reset := isdCfg.TRC.TrustResetAllowed
+	t := &trc.TRC{
+		ISD:                  isd,
+		Version:              scrypto.Version(isdCfg.TRC.Version),
+		BaseVersion:          scrypto.Version(isdCfg.TRC.BaseVersion),
+		Description:          isdCfg.Desc,
+		VotingQuorumPtr:      &quorum,
+		FormatVersion:        1,
+		GracePeriod:          &trc.Period{Duration: isdCfg.TRC.GracePeriod},
+		TrustResetAllowedPtr: &reset,
+		Validity:             createValidity(isdCfg.TRC.NotBefore, isdCfg.TRC.Validity),
+		PrimaryASes:          make(trc.PrimaryASes),
+		Votes:                make(map[addr.AS]trc.Vote),
+		ProofOfPossession:    make(map[addr.AS][]trc.KeyType),
+	}
+	if !t.Base() {
+		return nil, common.NewBasicError("TRC updates not supported yet", nil,
+			"version", t.Version, "base", t.BaseVersion)
+	}
+	for as, cfg := range primaryASes {
+		t.PrimaryASes[as] = trc.PrimaryAS{
+			Attributes: getAttributes(isdCfg, as),
+			Keys:       getKeys(cfg),
+		}
+		t.ProofOfPossession[as] = getKeyTypes(cfg)
+	}
+	if err := t.ValidateInvariant(); err != nil {
+		return nil, common.NewBasicError("invariant violated", err)
+	}
+	return t, nil
+}
+
+func createValidity(notBefore uint32, validity time.Duration) *scrypto.Validity {
+	val := &scrypto.Validity{
+		NotBefore: util.UnixTime{Time: util.SecsToTime(notBefore)},
+	}
+	if notBefore == 0 {
+		val.NotBefore.Time = time.Now()
+	}
+	val.NotAfter = util.UnixTime{Time: val.NotBefore.Add(validity)}
+	return val
+}
+
+func getAttributes(isdCfg *conf.ISDCfg, as addr.AS) []trc.Attribute {
+	var a []trc.Attribute
+	m := map[trc.Attribute][]addr.AS{
+		trc.Authoritative: isdCfg.AuthoritativeASes,
+		trc.Core:          isdCfg.CoreASes,
+		trc.Issuing:       isdCfg.IssuingASes,
+		trc.Voting:        isdCfg.VotingASes,
+	}
+	for attr, list := range m {
+		if pkicmn.ContainsAS(list, as) {
+			a = append(a, attr)
+		}
+	}
+	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
+	return a
+}
+
+func getKeys(cfg *asCfg) map[trc.KeyType]scrypto.KeyMeta {
+	// FIXME(roosd): allow for different key versions.
+	m := make(map[trc.KeyType]scrypto.KeyMeta)
+	for keyType, key := range cfg.Keys {
+		algo := cfg.KeyTypeToAlgo(keyType)
+		pubKey, err := scrypto.GetPubKey(key, algo)
+		if err != nil {
+			pkicmn.ErrorAndExit("unsupported algorithm passed validation algo=%s", algo)
+		}
+		m[keyType] = scrypto.KeyMeta{
+			Algorithm:  algo,
+			Key:        pubKey,
+			KeyVersion: 1,
+		}
+	}
+	return m
+}
+
+func getKeyTypes(cfg *asCfg) []trc.KeyType {
+	keyTypes := make([]trc.KeyType, 0, len(cfg.Keys))
+	for keyType := range cfg.Keys {
+		keyTypes = append(keyTypes, keyType)
+	}
+	sort.Slice(keyTypes, func(i, j int) bool { return keyTypes[i] < keyTypes[j] })
+	return keyTypes
+}

--- a/go/tools/scion-pki/internal/v2/trc/prototype.go
+++ b/go/tools/scion-pki/internal/v2/trc/prototype.go
@@ -56,7 +56,7 @@ func genAndWriteProto(isd addr.ISD) error {
 	if err != nil {
 		return common.NewBasicError("unable to marshal", err)
 	}
-	if err := pkicmn.CreateDir(PartsDir(isd, uint64(t.Version)), 0755); err != nil {
+	if err := os.MkdirAll(PartsDir(isd, uint64(t.Version)), 0755); err != nil {
 		return err
 	}
 	return pkicmn.WriteToFile(raw, ProtoFile(isd, uint64(t.Version)), 0644)

--- a/go/tools/scion-pki/internal/v2/trc/util.go
+++ b/go/tools/scion-pki/internal/v2/trc/util.go
@@ -1,0 +1,38 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trc
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
+)
+
+// Dir returns the directory where TRCs are written to.
+func Dir(isd addr.ISD) string {
+	return filepath.Join(pkicmn.GetIsdPath(pkicmn.OutDir, isd), pkicmn.TRCsDir)
+}
+
+// PartsDir returns the directory where the partially signed TRC is written to.
+func PartsDir(isd addr.ISD, ver uint64) string {
+	return filepath.Join(Dir(isd), fmt.Sprintf(pkicmn.TRCPartsDirFmt, isd, ver))
+}
+
+// ProtoFile returns the file path for the prototype TRC.
+func ProtoFile(isd addr.ISD, ver uint64) string {
+	return filepath.Join(PartsDir(isd, ver), fmt.Sprintf(pkicmn.TRCProtoNameFmt, isd, ver))
+}


### PR DESCRIPTION
This change allows generating prototype TRC payloads.
A prototype TRC will be signed and then combined to a signed TRC.
Signing and combining is left for a future PR.

For convenience, a 'gen' command will also be added in the future that
executes the three phases in a single call.

contributes to #2983

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3049)
<!-- Reviewable:end -->
