### PR TITLE
PS,SD: Use revocations from SegReply to invalidate NextQuery

### DIFF
--- a/.buildkite/steps/integration
+++ b/.buildkite/steps/integration
@@ -13,6 +13,9 @@ run_test() {
     echo "  command:"
     echo "  - $BASE/run_step integration $1 $2"
     echo "  timeout_in_minutes: 10"
+    if [ "$1" = "revocation" ]; then
+        echo "  parallelism: 40"
+    fi
     echo "  artifact_paths:"
     echo "  - \"artifacts.out/**/*\""
 }

--- a/.buildkite/steps/integration
+++ b/.buildkite/steps/integration
@@ -13,9 +13,6 @@ run_test() {
     echo "  command:"
     echo "  - $BASE/run_step integration $1 $2"
     echo "  timeout_in_minutes: 10"
-    if [ "$1" = "revocation" ]; then
-        echo "  parallelism: 40"
-    fi
     echo "  artifact_paths:"
     echo "  - \"artifacts.out/**/*\""
 }

--- a/go/lib/infra/modules/segfetcher/fetcher.go
+++ b/go/lib/infra/modules/segfetcher/fetcher.go
@@ -100,19 +100,21 @@ func (f *Fetcher) FetchSegs(ctx context.Context, req Request) (Segments, error) 
 	var segs Segments
 	i := 0
 	for {
-		log.FromCtx(ctx).Trace("Request to process", "req", reqSet, "segs", segs)
+		log.FromCtx(ctx).Trace("Request to process",
+			"req", reqSet, "segs", segs, "iteration", i+1)
 		segs, reqSet, err = f.Resolver.Resolve(ctx, segs, reqSet)
 		if err != nil {
 			return Segments{}, err
 		}
-		log.FromCtx(ctx).Trace("After resolving", "req", reqSet, "segs", segs)
+		log.FromCtx(ctx).Trace("After resolving",
+			"req", reqSet, "segs", segs, "iteration", i+1)
 		if reqSet.IsEmpty() {
 			break
 		}
 		if i > 3 {
 			log.FromCtx(ctx).Error("No convergence in lookup", "iteration", i+1)
 			return segs, common.NewBasicError("Segment lookup doesn't converge", nil,
-				"iterations", i)
+				"iterations", i+1)
 		}
 		// XXX(lukedirtwalker): Optimally we wouldn't need a different timeout
 		// here. The problem is that revocations can't be differentiated from

--- a/go/lib/infra/modules/segfetcher/revocation.go
+++ b/go/lib/infra/modules/segfetcher/revocation.go
@@ -55,6 +55,7 @@ func (c *NextQueryCleaner) ResetQueryCache(ctx context.Context, revInfo *path_mg
 func DeleteNextQueryEntries(ctx context.Context, tx pathdb.Transaction,
 	results query.Results) error {
 
+	logger := log.FromCtx(ctx)
 	nextQueriesToDelete := make(map[Request]struct{})
 	for _, r := range results {
 		var req Request
@@ -66,13 +67,13 @@ func DeleteNextQueryEntries(ctx context.Context, tx pathdb.Transaction,
 		case proto.PathSegType_down:
 			req = Request{Src: addr.IA{I: r.Seg.FirstIA().I}, Dst: r.Seg.LastIA()}
 		default:
-			log.Error("Invalid seg type", "segType", r.Type)
+			logger.Error("Invalid seg type", "segType", r.Type)
 			continue
 		}
 		nextQueriesToDelete[req] = struct{}{}
 	}
 	for nq := range nextQueriesToDelete {
-		log.Trace("Delete NQ", "src", nq.Src, "dst", nq.Dst)
+		logger.Trace("Delete NQ", "src", nq.Src, "dst", nq.Dst)
 		if _, err := tx.DeleteNQ(ctx, nq.Src, nq.Dst, nil); err != nil {
 			return err
 		}

--- a/go/lib/infra/modules/segfetcher/segreplyhandler_test.go
+++ b/go/lib/infra/modules/segfetcher/segreplyhandler_test.go
@@ -126,7 +126,7 @@ func TestReplyHandlerErrors(t *testing.T) {
 }
 
 // TestReplyHandlerNoErrors tests the happy case of the reply handler: 3
-// segments and 1 revocation are succesfully verified and stored.
+// segments and 1 revocation are successfully verified and stored.
 func TestReplyHandlerNoErrors(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
In the PS and SD we invalidate the NextQuery for all segments that have received a revocation. But currently we only do this for explicit revocations that come in as Revocation message, we should also do it for revocations that we receive in a SegReply from another PS.
This commit also invalidates NextQuery cache for revocations received in the SegReply.

Fixes #3057 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3058)
<!-- Reviewable:end -->
