### PR TITLE
proto: Re-enable catching panics in proto library

### DIFF
--- a/go/proto/cereal.go
+++ b/go/proto/cereal.go
@@ -127,14 +127,6 @@ func readRootFromReader(r io.Reader) (capnp.Struct, error) {
 	return rootPtr.Struct(), nil
 }
 
-// parseStruct parses a capnp struct into a Cerealizable instance.
-func parseStruct(c Cerealizable, s capnp.Struct) error {
-	if err := pogs.Extract(c, uint64(c.ProtoId()), s); err != nil {
-		return common.NewBasicError("Failed to extract struct from capnp message", err)
-	}
-	return nil
-}
-
 // SafeExtract calls pogs.Extract, converting panics to errors.
 func SafeExtract(val interface{}, typeID uint64, s capnp.Struct) (err error) {
 	defer func() {

--- a/go/proto/cereal.go
+++ b/go/proto/cereal.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"io"
 
-	"zombiezen.com/go/capnproto2"
+	capnp "zombiezen.com/go/capnproto2"
 	"zombiezen.com/go/capnproto2/pogs"
 
 	"github.com/scionproto/scion/go/lib/common"
@@ -110,7 +110,7 @@ func ParseFromReader(c Cerealizable, r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	return parseStruct(c, s)
+	return SafeExtract(c, uint64(c.ProtoId()), s)
 }
 
 // readRootFromReader returns the root struct from a capnp message read from r.

--- a/go/proto/cereal_test.go
+++ b/go/proto/cereal_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/stretchr/testify/require"
 	capnp "zombiezen.com/go/capnproto2"
 	"zombiezen.com/go/capnproto2/pogs"
-
-	"github.com/scionproto/scion/go/lib/common"
 )
+
+var packedASEntry, _ = PackRoot(&asEntry{})
 
 type asEntry struct{}
 
@@ -56,13 +56,10 @@ func TestParseFromRaw(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			var err error
 			a := &asEntry{}
-			raw := make(common.RawBytes, 1024)
-			n, err := WriteRoot(a, raw)
-			require.NoError(t, err)
-			raw = raw[:n]
 			wrapped := func() {
-				err = ParseFromRaw(a, raw)
+				err = ParseFromRaw(a, packedASEntry)
 			}
 			pogsExtractF = test.Extractor
 			require.NotPanics(t, wrapped)


### PR DESCRIPTION
The recover defer was removed by a code refactor in #2707.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3059)
<!-- Reviewable:end -->
