### PR TITLE
Run apt-get without user interaction

### DIFF
--- a/env/debian/deps
+++ b/env/debian/deps
@@ -10,4 +10,4 @@ APTARGS=${APTARGS:---no-remove}
 pkgs="$($BASE/check)"
 [ -z "$pkgs" ] && exit
 
-sudo DEBIAN_FRONTEND=noninteractive apt-get install $APTARGS --no-install-recommends $pkgs
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y install $APTARGS --no-install-recommends $pkgs


### PR DESCRIPTION
Currently apt-get will require a user confirmation if there are changes to be applied. This change makes apt-get assume "yes" as an answer to all the prompts.

Closes-bug: #3065

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3066)
<!-- Reviewable:end -->
