### PR TITLE
SPKI: Generate templates from topology file

### DIFF
--- a/go/tools/scion-pki/internal/tmpl/BUILD.bazel
+++ b/go/tools/scion-pki/internal/tmpl/BUILD.bazel
@@ -6,13 +6,17 @@ go_library(
         "as.go",
         "cmd.go",
         "isd.go",
+        "topo.go",
     ],
     importpath = "github.com/scionproto/scion/go/tools/scion-pki/internal/tmpl",
     visibility = ["//go/tools/scion-pki:__subpackages__"],
     deps = [
         "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/util:go_default_library",
         "//go/tools/scion-pki/internal/conf:go_default_library",
         "//go/tools/scion-pki/internal/pkicmn:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@in_gopkg_yaml_v2//:go_default_library",
     ],
 )

--- a/go/tools/scion-pki/internal/tmpl/cmd.go
+++ b/go/tools/scion-pki/internal/tmpl/cmd.go
@@ -60,7 +60,22 @@ Selector:
 	},
 }
 
+var topo = &cobra.Command{
+	Use:   "topo",
+	Short: "Generate isd.ini and as.ini templates for the provided topo",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGenTopoTmpl(args)
+	},
+}
+
 func init() {
 	Cmd.AddCommand(isd)
 	Cmd.AddCommand(as)
+
+	topo.PersistentFlags().Uint32VarP(&notBefore, "notbefore", "b", 0,
+		"set not_before time in all configs")
+	topo.PersistentFlags().StringVar(&rawValidity, "validity", "365d",
+		"set the validity of all crypto material")
+	Cmd.AddCommand(topo)
 }

--- a/go/tools/scion-pki/internal/tmpl/topo.go
+++ b/go/tools/scion-pki/internal/tmpl/topo.go
@@ -49,7 +49,7 @@ func runGenTopoTmpl(args []string) error {
 		return common.NewBasicError("unable to parse topo", err, "file", args[0])
 	}
 	isdCfgs := make(map[addr.ISD]*conf.Isd)
-	for _, isd := range topo.ISDs() {
+	for isd := range topo.ISDs() {
 		isdCfg := genISDCfg(isd, topo, val)
 		isdCfgs[isd] = isdCfg
 		dir := pkicmn.GetIsdPath(pkicmn.RootDir, isd)
@@ -131,16 +131,12 @@ type topoFile struct {
 	ASes map[addr.IA]asEntry `yaml:"ASes"`
 }
 
-func (t topoFile) ISDs() []addr.ISD {
+func (t topoFile) ISDs() map[addr.ISD]struct{} {
 	m := make(map[addr.ISD]struct{})
 	for ia := range t.ASes {
 		m[ia.I] = struct{}{}
 	}
-	var isds []addr.ISD
-	for isd := range m {
-		isds = append(isds, isd)
-	}
-	return isds
+	return m
 }
 
 func (t topoFile) Cores(isd addr.ISD) []addr.IA {

--- a/go/tools/scion-pki/internal/tmpl/topo.go
+++ b/go/tools/scion-pki/internal/tmpl/topo.go
@@ -1,0 +1,159 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tmpl
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/conf"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
+)
+
+var (
+	notBefore   uint32
+	rawValidity string
+)
+
+func runGenTopoTmpl(args []string) error {
+	raw, err := ioutil.ReadFile(args[0])
+	if err != nil {
+		return common.NewBasicError("unable to read file", err, "file", args[0])
+	}
+	val, err := validityFromFlags()
+	if err != nil {
+		return err
+	}
+	var topo topoFile
+	if err := yaml.Unmarshal(raw, &topo); err != nil {
+		return common.NewBasicError("unable to parse topo", err, "file", args[0])
+	}
+	isdCfgs := make(map[addr.ISD]*conf.Isd)
+	for _, isd := range topo.ISDs() {
+		isdCfg := genISDCfg(isd, topo, val)
+		isdCfgs[isd] = isdCfg
+		dir := pkicmn.GetIsdPath(pkicmn.RootDir, isd)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return common.NewBasicError("unable to make ISD directory", err, "isd", isd)
+		}
+		if err := isdCfg.Write(filepath.Join(dir, conf.IsdConfFileName), pkicmn.Force); err != nil {
+			return common.NewBasicError("unable to write ISD config", err, "isd", isd)
+		}
+	}
+	for ia, entry := range topo.ASes {
+		asCfg := genASCfg(ia, entry, val, isdCfgs[ia.I])
+		dir := pkicmn.GetAsPath(pkicmn.RootDir, ia)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return common.NewBasicError("unable to make AS directory", err, "ia", ia)
+		}
+		if err := asCfg.Write(filepath.Join(dir, conf.AsConfFileName), pkicmn.Force); err != nil {
+			return common.NewBasicError("unable to write AS config", err, "ia", ia)
+		}
+	}
+
+	return nil
+}
+
+func genISDCfg(isd addr.ISD, topo topoFile, val validity) *conf.Isd {
+	cores := topo.Cores(isd)
+	isdCfg := &conf.Isd{
+		Desc: fmt.Sprintf("ISD %d", isd),
+		Trc: &conf.Trc{
+			Version:     1,
+			IssuingTime: val.NotBefore,
+			Validity:    val.Validity,
+			CoreIAs:     cores,
+			GracePeriod: 0,
+			// XXX(roosd): Choose quorum according to your security needs. This
+			// simply serves an example.
+			QuorumTRC: uint32(len(cores)/2 + 1),
+		},
+	}
+	return isdCfg
+}
+
+func genASCfg(ia addr.IA, entry asEntry, val validity, isdCfg *conf.Isd) *conf.As {
+	asCfg := conf.NewTemplateAsConf(ia, isdCfg.Trc.Version, pkicmn.Contains(isdCfg.Trc.CoreIAs, ia))
+	asCfg.AsCert.Comment = "AS certificate"
+	asCfg.AsCert.IssuingTime = val.NotBefore
+	asCfg.AsCert.Validity = val.Validity
+	asCfg.AsCert.RawValidity = util.FmtDuration(val.Validity)
+
+	if !entry.Issuer.IsZero() {
+		asCfg.AsCert.IssuerIA = entry.Issuer
+		asCfg.AsCert.Issuer = entry.Issuer.String()
+	}
+	if asCfg.IssuerCert != nil {
+		asCfg.IssuerCert.Comment = "Issuer certificate"
+		asCfg.IssuerCert.IssuingTime = val.NotBefore
+		asCfg.IssuerCert.Validity = val.Validity
+		asCfg.IssuerCert.RawValidity = util.FmtDuration(val.Validity)
+	}
+	return asCfg
+}
+
+// validity is a container for the provided flags.
+type validity struct {
+	NotBefore uint32
+	Validity  time.Duration
+}
+
+func validityFromFlags() (validity, error) {
+	p, err := util.ParseDuration(rawValidity)
+	if err != nil {
+		return validity{}, common.NewBasicError("invalid validity", err, "input", rawValidity)
+	}
+	return validity{NotBefore: notBefore, Validity: p}, nil
+}
+
+// topoFile is used to parse the topology description.
+type topoFile struct {
+	ASes map[addr.IA]asEntry `yaml:"ASes"`
+}
+
+func (t topoFile) ISDs() []addr.ISD {
+	m := make(map[addr.ISD]struct{})
+	for ia := range t.ASes {
+		m[ia.I] = struct{}{}
+	}
+	var isds []addr.ISD
+	for isd := range m {
+		isds = append(isds, isd)
+	}
+	return isds
+}
+
+func (t topoFile) Cores(isd addr.ISD) []addr.IA {
+	var cores []addr.IA
+	for ia, entry := range t.ASes {
+		if ia.I == isd && entry.Core {
+			cores = append(cores, ia)
+		}
+	}
+	return cores
+}
+
+type asEntry struct {
+	Core   bool    `yaml:"core"`
+	Issuer addr.IA `yaml:"cert_issuer"`
+}

--- a/go/tools/scion-pki/internal/v2/cmd/cmd.go
+++ b/go/tools/scion-pki/internal/v2/cmd/cmd.go
@@ -15,8 +15,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/keys"
@@ -27,9 +25,6 @@ import (
 var Cmd = &cobra.Command{
 	Use:   "v2",
 	Short: "Use the new format",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(args)
-	},
 }
 
 func init() {

--- a/go/tools/scion-pki/internal/v2/tmpl/BUILD.bazel
+++ b/go/tools/scion-pki/internal/v2/tmpl/BUILD.bazel
@@ -6,13 +6,17 @@ go_library(
         "as.go",
         "cmd.go",
         "isd.go",
+        "topo.go",
     ],
     importpath = "github.com/scionproto/scion/go/tools/scion-pki/internal/v2/tmpl",
     visibility = ["//go/tools/scion-pki:__subpackages__"],
     deps = [
         "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/util:go_default_library",
         "//go/tools/scion-pki/internal/pkicmn:go_default_library",
         "//go/tools/scion-pki/internal/v2/conf:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@in_gopkg_yaml_v2//:go_default_library",
     ],
 )

--- a/go/tools/scion-pki/internal/v2/tmpl/as.go
+++ b/go/tools/scion-pki/internal/v2/tmpl/as.go
@@ -34,7 +34,7 @@ func runGenAsTmpl(args []string) {
 			pkicmn.ErrorAndExit("Error reading %s: %s\n", conf.ISDCfgFileName, err)
 		}
 		for _, ia := range ases {
-			if err = genAsTmpl(ia, iconf); err != nil {
+			if err = genAndWriteASTmpl(ia, iconf); err != nil {
 				pkicmn.ErrorAndExit("Error generating %s template for %s: %s\n",
 					conf.ASConfFileName, ia, err)
 			}
@@ -42,14 +42,18 @@ func runGenAsTmpl(args []string) {
 	}
 }
 
-func genAsTmpl(ia addr.IA, isd *conf.ISDCfg) error {
-	voting := pkicmn.ContainsAS(isd.TRC.VotingASes, ia.A)
-	issuing := pkicmn.ContainsAS(isd.TRC.IssuingASes, ia.A)
-	a := conf.NewTemplateASCfg(ia, isd.TRC.Version, voting, issuing)
+func genAndWriteASTmpl(ia addr.IA, isd *conf.ISDCfg) error {
+	asCfg := genASTmpl(ia, isd)
 	dir := pkicmn.GetAsPath(pkicmn.RootDir, ia)
 	fpath := filepath.Join(dir, conf.ASConfFileName)
-	if err := a.Write(fpath, pkicmn.Force); err != nil {
+	if err := asCfg.Write(fpath, pkicmn.Force); err != nil {
 		return err
 	}
 	return nil
+}
+
+func genASTmpl(ia addr.IA, isd *conf.ISDCfg) *conf.ASCfg {
+	voting := pkicmn.ContainsAS(isd.TRC.VotingASes, ia.A)
+	issuing := pkicmn.ContainsAS(isd.TRC.IssuingASes, ia.A)
+	return conf.NewTemplateASCfg(ia, isd.TRC.Version, voting, issuing)
 }

--- a/go/tools/scion-pki/internal/v2/tmpl/cmd.go
+++ b/go/tools/scion-pki/internal/v2/tmpl/cmd.go
@@ -26,6 +26,15 @@ var Cmd = &cobra.Command{
 `,
 }
 
+var topo = &cobra.Command{
+	Use:   "topo",
+	Short: "Generate isd.ini and as.ini templates for the provided topo",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runGenTopoTmpl(args)
+	},
+}
+
 var isd = &cobra.Command{
 	Use:   "isd",
 	Short: "Generate an isd.ini template.",
@@ -63,4 +72,11 @@ Selector:
 func init() {
 	Cmd.AddCommand(isd)
 	Cmd.AddCommand(as)
+
+	topo.PersistentFlags().Uint32VarP(&notBefore, "notbefore", "b", 0,
+		"set not_before time in all configs")
+	topo.PersistentFlags().StringVar(&rawValidity, "validity", "365d",
+		"set the validity of all crypto material")
+	Cmd.AddCommand(topo)
+
 }

--- a/go/tools/scion-pki/internal/v2/tmpl/topo.go
+++ b/go/tools/scion-pki/internal/v2/tmpl/topo.go
@@ -1,0 +1,152 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tmpl
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/conf"
+)
+
+var (
+	notBefore   uint32
+	rawValidity string
+)
+
+func runGenTopoTmpl(args []string) error {
+	raw, err := ioutil.ReadFile(args[0])
+	if err != nil {
+		return common.NewBasicError("unable to read file", err, "file", args[0])
+	}
+	val, err := validityFromFlags()
+	if err != nil {
+		return err
+	}
+	var topo topoFile
+	if err := yaml.Unmarshal(raw, &topo); err != nil {
+		return common.NewBasicError("unable to parse topo", err, "file", args[0])
+	}
+	isdCfgs := make(map[addr.ISD]*conf.ISDCfg)
+	for _, isd := range topo.ISDs() {
+		isdCfg := genISDCfg(isd, topo, val)
+		isdCfgs[isd] = isdCfg
+		dir := pkicmn.GetIsdPath(pkicmn.RootDir, isd)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return common.NewBasicError("unable to make ISD directory", err, "isd", isd)
+		}
+		if err := isdCfg.Write(filepath.Join(dir, conf.ISDCfgFileName), pkicmn.Force); err != nil {
+			return common.NewBasicError("unable to write ISD config", err, "isd", isd)
+		}
+	}
+	for ia, entry := range topo.ASes {
+		asCfg := genASCfg(ia, entry, val, isdCfgs[ia.I])
+		dir := pkicmn.GetAsPath(pkicmn.RootDir, ia)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return common.NewBasicError("unable to make AS directory", err, "ia", ia)
+		}
+		if err := asCfg.Write(filepath.Join(dir, conf.ASConfFileName), pkicmn.Force); err != nil {
+			return common.NewBasicError("unable to write AS config", err, "ia", ia)
+		}
+	}
+
+	return nil
+}
+
+func genISDCfg(isd addr.ISD, topo topoFile, val validity) *conf.ISDCfg {
+	cores := topo.Cores(isd)
+	isdCfg := conf.NewTemplateISDCfg()
+	isdCfg.Desc = fmt.Sprintf("ISD %d", isd)
+	// XXX(roosd): Choose quorum according to your security needs. This simply
+	// serves an example.
+	isdCfg.VotingQuorum = len(cores)/2 + 1
+	isdCfg.NotBefore = val.NotBefore
+	isdCfg.Validity = val.Validity
+	isdCfg.AuthoritativeASes = cores
+	isdCfg.CoreASes = cores
+	isdCfg.IssuingASes = cores
+	isdCfg.VotingASes = cores
+	return isdCfg
+}
+
+func genASCfg(ia addr.IA, entry asEntry, val validity, isdCfg *conf.ISDCfg) *conf.ASCfg {
+	asCfg := genASTmpl(ia, isdCfg)
+	asCfg.AS.NotBefore = val.NotBefore
+	asCfg.AS.Validity = val.Validity
+	if !entry.Issuer.IsZero() {
+		asCfg.IssuerIA = entry.Issuer
+	}
+	if asCfg.Issuer != nil {
+		asCfg.Issuer.NotBefore = val.NotBefore
+		asCfg.Issuer.Validity = val.Validity
+	}
+	return asCfg
+
+}
+
+// validity is a container for the provided flags.
+type validity struct {
+	NotBefore uint32
+	Validity  time.Duration
+}
+
+func validityFromFlags() (validity, error) {
+	p, err := util.ParseDuration(rawValidity)
+	if err != nil {
+		return validity{}, common.NewBasicError("invalid validity", err, "input", rawValidity)
+	}
+	return validity{NotBefore: notBefore, Validity: p}, nil
+}
+
+// topoFile is used to parse the topology description.
+type topoFile struct {
+	ASes map[addr.IA]asEntry `yaml:"ASes"`
+}
+
+func (t topoFile) ISDs() []addr.ISD {
+	m := make(map[addr.ISD]struct{})
+	for ia := range t.ASes {
+		m[ia.I] = struct{}{}
+	}
+	var isds []addr.ISD
+	for isd := range m {
+		isds = append(isds, isd)
+	}
+	return isds
+}
+
+func (t topoFile) Cores(isd addr.ISD) []addr.AS {
+	var cores []addr.AS
+	for ia, entry := range t.ASes {
+		if ia.I == isd && entry.Core {
+			cores = append(cores, ia.A)
+		}
+	}
+	return cores
+}
+
+type asEntry struct {
+	Core   bool    `yaml:"core"`
+	Issuer addr.IA `yaml:"cert_issuer"`
+}

--- a/go/tools/scion-pki/internal/v2/tmpl/topo.go
+++ b/go/tools/scion-pki/internal/v2/tmpl/topo.go
@@ -49,7 +49,7 @@ func runGenTopoTmpl(args []string) error {
 		return common.NewBasicError("unable to parse topo", err, "file", args[0])
 	}
 	isdCfgs := make(map[addr.ISD]*conf.ISDCfg)
-	for _, isd := range topo.ISDs() {
+	for isd := range topo.ISDs() {
 		isdCfg := genISDCfg(isd, topo, val)
 		isdCfgs[isd] = isdCfg
 		dir := pkicmn.GetIsdPath(pkicmn.RootDir, isd)
@@ -124,16 +124,12 @@ type topoFile struct {
 	ASes map[addr.IA]asEntry `yaml:"ASes"`
 }
 
-func (t topoFile) ISDs() []addr.ISD {
+func (t topoFile) ISDs() map[addr.ISD]struct{} {
 	m := make(map[addr.ISD]struct{})
 	for ia := range t.ASes {
 		m[ia.I] = struct{}{}
 	}
-	var isds []addr.ISD
-	for isd := range m {
-		isds = append(isds, isd)
-	}
-	return isds
+	return m
 }
 
 func (t topoFile) Cores(isd addr.ISD) []addr.AS {


### PR DESCRIPTION
This PR enables templating the isd.ini and as.ini from `.topo` files.
To template the config files for the `Default.topo` run
`scion-pki v2 tmpl topo topology/Default.topo`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3079)
<!-- Reviewable:end -->
