### PR TITLE
PS: Remove superfluous handler timeout

### DIFF
--- a/go/path_srv/internal/handlers/common.go
+++ b/go/path_srv/internal/handlers/common.go
@@ -38,8 +38,6 @@ import (
 )
 
 const (
-	HandlerTimeout = 30 * time.Second
-
 	NoSegmentsErr = "No segments"
 )
 

--- a/go/path_srv/internal/handlers/ifstateinfo.go
+++ b/go/path_srv/internal/handlers/ifstateinfo.go
@@ -39,7 +39,8 @@ func NewIfStateInfoHandler(args HandlerArgs) infra.Handler {
 }
 
 func (h *ifStateInfoHandler) Handle() *infra.HandlerResult {
-	logger := log.FromCtx(h.request.Context())
+	ctx := h.request.Context()
+	logger := log.FromCtx(ctx)
 	ifStateInfo, ok := h.request.Message.(*path_mgmt.IFStateInfos)
 	if !ok {
 		logger.Error("[ifStateHandler] wrong message type, expected path_mgmt.IFStateInfos",
@@ -47,12 +48,10 @@ func (h *ifStateInfoHandler) Handle() *infra.HandlerResult {
 		return infra.MetricsErrInternal
 	}
 	logger.Debug("[ifStateHandler] Received IfStateInfo", "ifStateInfo", ifStateInfo)
-	subCtx, cancelF := context.WithTimeout(h.request.Context(), HandlerTimeout)
-	defer cancelF()
 	// TODO(lukedirtwalker): if all verifications fail we should reflect that in metrics.
 	for _, info := range ifStateInfo.Infos {
 		if !info.Active && info.SRevInfo != nil {
-			h.verifyAndStore(subCtx, info.SRevInfo)
+			h.verifyAndStore(ctx, info.SRevInfo)
 		}
 	}
 	logger.Debug("[ifStateHandler] done processing ifStateInfo")

--- a/go/path_srv/internal/segreq/handler.go
+++ b/go/path_srv/internal/segreq/handler.go
@@ -15,7 +15,6 @@
 package segreq
 
 import (
-	"context"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/common"
@@ -53,7 +52,8 @@ func NewHandler(args handlers.HandlerArgs) infra.Handler {
 }
 
 func (h *handler) Handle(request *infra.Request) *infra.HandlerResult {
-	logger := log.FromCtx(request.Context())
+	ctx := request.Context()
+	logger := log.FromCtx(ctx)
 	segReq, ok := request.Message.(*path_mgmt.SegReq)
 	if !ok {
 		logger.Error("[segReqHandler] wrong message type, expected path_mgmt.SegReq",
@@ -61,13 +61,11 @@ func (h *handler) Handle(request *infra.Request) *infra.HandlerResult {
 		return infra.MetricsErrInternal
 	}
 	logger.Debug("[segReqHandler] Received", "segReq", segReq)
-	rw, ok := infra.ResponseWriterFromContext(request.Context())
+	rw, ok := infra.ResponseWriterFromContext(ctx)
 	if !ok {
 		logger.Warn("[segReqHandler] Unable to reply to client, no response writer found")
 		return infra.MetricsErrInternal
 	}
-	ctx, cancelF := context.WithTimeout(request.Context(), handlers.HandlerTimeout)
-	defer cancelF()
 
 	segs, err := h.fetcher.FetchSegs(ctx,
 		segfetcher.Request{Src: segReq.SrcIA(), Dst: segReq.DstIA()})


### PR DESCRIPTION
The messenger already creates a context with a timeout, which is by default smaller (10s).
So we just use that one instead of creating a superfluous context with deadline.

Fixes #3077

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3080)
<!-- Reviewable:end -->
