### PR TITLE
Acceptance: Reduce query interval on sciond

### DIFF
--- a/.buildkite/acceptance-pipeline.sh
+++ b/.buildkite/acceptance-pipeline.sh
@@ -16,7 +16,7 @@ fi
 
 host_acceptance="br_multi br_child br_parent br_peer br_core_multi br_core_childIf br_core_coreIf"
 
-for test in ./acceptance/sig_short*_acceptance; do
+for test in ./acceptance/*_acceptance; do
     name="$(basename ${test%_acceptance})"
     if [[ ! "$name" =~ "$ACCEPTANCE_TEST" ]]; then
         continue
@@ -43,7 +43,6 @@ for test in ./acceptance/sig_short*_acceptance; do
         echo "  - $BASE/run_step run_acceptance $name"
     fi
     echo "  timeout_in_minutes: 10"
-    echo "  parallelism: 10"
     echo "  retry:"
     echo "    automatic:"
     echo "      - exit_status: 5"  # Pull failed

--- a/.buildkite/acceptance-pipeline.sh
+++ b/.buildkite/acceptance-pipeline.sh
@@ -16,7 +16,7 @@ fi
 
 host_acceptance="br_multi br_child br_parent br_peer br_core_multi br_core_childIf br_core_coreIf"
 
-for test in ./acceptance/*_acceptance; do
+for test in ./acceptance/sig_short*_acceptance; do
     name="$(basename ${test%_acceptance})"
     if [[ ! "$name" =~ "$ACCEPTANCE_TEST" ]]; then
         continue
@@ -43,6 +43,7 @@ for test in ./acceptance/*_acceptance; do
         echo "  - $BASE/run_step run_acceptance $name"
     fi
     echo "  timeout_in_minutes: 10"
+    echo "  parallelism: 10"
     echo "  retry:"
     echo "    automatic:"
     echo "      - exit_status: 5"  # Pull failed

--- a/acceptance/sig_short_exp_time_acceptance/test
+++ b/acceptance/sig_short_exp_time_acceptance/test
@@ -54,6 +54,7 @@ class TestSetup(Base):
 
         self.scion.topology('topology/Tiny.topo', '--sig', '-t', '-n', '242.254.0.0/16')
         self.set_bs_policies()
+        self.set_sd_policies()
         self.scion.run()
         if not self.no_docker:
             self.tools_dc('start', 'tester*')
@@ -71,6 +72,12 @@ class TestSetup(Base):
             }, [path])
             with open(os.path.join(path.dirname, 'policy.yml'), 'w') as outfile:
                 yaml.dump({'MaxExpTime': 0}, outfile, default_flow_style=False)
+
+    def set_sd_policies(self):
+        for path in local.path('gen') // 'ISD*/AS*/endhost/sd.toml':
+            self.scion.set_configs({
+                'sd.QueryInterval': "1m",
+            }, [path])
 
 
 @Test.subcommand("run")


### PR DESCRIPTION
Currently, the next query does not consider path expiration time. (see #2979)
This PR reduces the query interval for sciond in the `sig_short_exp_time` expiration test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3089)
<!-- Reviewable:end -->
