### PR TITLE
sciond socket file mode.

### DIFF
--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -53,6 +53,8 @@ const (
 	SVCInfoTTL = 10 * time.Second
 	// DefaultSCIONDPath contains the system default for a SCIOND socket.
 	DefaultSCIONDPath = "/run/shm/sciond/default.sock"
+	// DefaultSocketFileMode allows read/write to the user and group only.
+	DefaultSocketFileMode = 0770
 )
 
 // Service describes a SCIOND endpoint. New connections to SCIOND can be

--- a/go/sciond/internal/config/config.go
+++ b/go/sciond/internal/config/config.go
@@ -17,6 +17,8 @@ package config
 
 import (
 	"io"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/scionproto/scion/go/lib/common"
@@ -100,6 +102,8 @@ type SDConfig struct {
 	// Address to listen on for normal unixgram messages. If empty, a
 	// unixgram server on the default socket is started.
 	Unix string
+	// Socket files (both Reliable and Unix) permissions when created; read from octal (e.g. 0755).
+	SocketFileMode FileMode
 	// If set to True, the socket is removed before being created
 	DeleteSocket bool
 	// Public is the local address to listen on for SCION messages (if Bind is
@@ -124,6 +128,9 @@ func (cfg *SDConfig) InitDefaults() {
 	if cfg.Unix == "" {
 		cfg.Unix = "/run/shm/sciond/default-unix.sock"
 	}
+	if cfg.SocketFileMode == 0 {
+		cfg.SocketFileMode = sciond.DefaultSocketFileMode
+	}
 	if cfg.QueryInterval.Duration == 0 {
 		cfg.QueryInterval.Duration = DefaultQueryInterval
 	}
@@ -136,6 +143,9 @@ func (cfg *SDConfig) Validate() error {
 	}
 	if cfg.Unix == "" {
 		return common.NewBasicError("Unix must be set", nil)
+	}
+	if cfg.SocketFileMode == 0 {
+		return common.NewBasicError("SocketFileMode must be set", nil)
 	}
 	if cfg.QueryInterval.Duration == 0 {
 		return common.NewBasicError("QueryInterval must not be zero", nil)
@@ -160,4 +170,12 @@ func (cfg *SDConfig) CreateSocketDirs() error {
 		return common.NewBasicError("Cannot create unix socket dir", err)
 	}
 	return nil
+}
+
+type FileMode os.FileMode
+
+func (f *FileMode) UnmarshalText(text []byte) error {
+	perm, err := strconv.ParseUint(string(text), 8, 32)
+	*f = FileMode(perm)
+	return err
 }

--- a/go/sciond/internal/config/config_test.go
+++ b/go/sciond/internal/config/config_test.go
@@ -67,6 +67,7 @@ func CheckTestSDConfig(cfg *SDConfig, id string) {
 	pathstoragetest.CheckTestRevCacheConf(&cfg.RevCache)
 	SoMsg("Reliable correct", cfg.Reliable, ShouldEqual, sciond.DefaultSCIONDPath)
 	SoMsg("Unix correct", cfg.Unix, ShouldEqual, "/run/shm/sciond/default-unix.sock")
+	SoMsg("File permissions correct", cfg.SocketFileMode, ShouldEqual, 0755)
 	SoMsg("Public correct", cfg.Public.String(), ShouldEqual,
 		"1-ff00:0:110,[127.0.0.1]:0 (UDP)")
 	SoMsg("QueryInterval correct", cfg.QueryInterval.Duration, ShouldEqual, DefaultQueryInterval)

--- a/go/sciond/internal/config/config_test.go
+++ b/go/sciond/internal/config/config_test.go
@@ -67,7 +67,7 @@ func CheckTestSDConfig(cfg *SDConfig, id string) {
 	pathstoragetest.CheckTestRevCacheConf(&cfg.RevCache)
 	SoMsg("Reliable correct", cfg.Reliable, ShouldEqual, sciond.DefaultSCIONDPath)
 	SoMsg("Unix correct", cfg.Unix, ShouldEqual, "/run/shm/sciond/default-unix.sock")
-	SoMsg("File permissions correct", cfg.SocketFileMode, ShouldEqual, 0755)
+	SoMsg("File permissions correct", cfg.SocketFileMode, ShouldEqual, sciond.DefaultSocketFileMode)
 	SoMsg("Public correct", cfg.Public.String(), ShouldEqual,
 		"1-ff00:0:110,[127.0.0.1]:0 (UDP)")
 	SoMsg("QueryInterval correct", cfg.QueryInterval.Duration, ShouldEqual, DefaultQueryInterval)

--- a/go/sciond/internal/config/sample.go
+++ b/go/sciond/internal/config/sample.go
@@ -25,8 +25,8 @@ Reliable = "/run/shm/sciond/default.sock"
 # unixgram server on the default socket is started.
 Unix = "/run/shm/sciond/default-unix.sock"
 
-# File permissions of both the Reliable and Unix socket files, in octal.
-SocketFileMode = "0755"
+# File permissions of both the Reliable and Unix socket files, in octal. (default "0770")
+SocketFileMode = "0770"
 
 # If set to True, the socket is removed before being created. (default false)
 DeleteSocket = false

--- a/go/sciond/internal/config/sample.go
+++ b/go/sciond/internal/config/sample.go
@@ -25,6 +25,9 @@ Reliable = "/run/shm/sciond/default.sock"
 # unixgram server on the default socket is started.
 Unix = "/run/shm/sciond/default-unix.sock"
 
+# File permissions of both the Reliable and Unix socket files, in octal.
+SocketFileMode = "0755"
+
 # If set to True, the socket is removed before being created. (default false)
 DeleteSocket = false
 

--- a/go/sciond/internal/servers/server.go
+++ b/go/sciond/internal/servers/server.go
@@ -50,7 +50,9 @@ type Server struct {
 // HandlerMap. To start listening on the address, call ListenAndServe.
 //
 // Network must be "unixpacket" or "rsock".
-func NewServer(network string, address string, filemode os.FileMode, handlers HandlerMap, logger log.Logger) *Server {
+func NewServer(network string, address string, filemode os.FileMode, handlers HandlerMap,
+	logger log.Logger) *Server {
+
 	return &Server{
 		network:  network,
 		address:  address,

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -222,7 +222,7 @@ func startDiscovery() error {
 func NewServer(network string, rsockPath string, handlers servers.HandlerMap,
 	logger log.Logger) (*servers.Server, func()) {
 
-	server := servers.NewServer(network, rsockPath, handlers, logger)
+	server := servers.NewServer(network, rsockPath, os.FileMode(cfg.SD.SocketFileMode), handlers, logger)
 	shutdownF := func() {
 		ctx, cancelF := context.WithTimeout(context.Background(), ShutdownWaitTimeout)
 		server.Shutdown(ctx)

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -222,7 +222,8 @@ func startDiscovery() error {
 func NewServer(network string, rsockPath string, handlers servers.HandlerMap,
 	logger log.Logger) (*servers.Server, func()) {
 
-	server := servers.NewServer(network, rsockPath, os.FileMode(cfg.SD.SocketFileMode), handlers, logger)
+	server := servers.NewServer(network, rsockPath, os.FileMode(cfg.SD.SocketFileMode), handlers,
+		logger)
 	shutdownF := func() {
 		ctx, cancelF := context.WithTimeout(context.Background(), ShutdownWaitTimeout)
 		server.Shutdown(ctx)


### PR DESCRIPTION
sciond sets the file mode for both its Reliable and Unix socket files.
The file mode comes from the configuration value SocketFileMode,
specified in octal as a string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3099)
<!-- Reviewable:end -->
