### PR TITLE
SPKI: Use RunE in cobra commands

### DIFF
--- a/go/lib/keyconf/keyconf.go
+++ b/go/lib/keyconf/keyconf.go
@@ -54,7 +54,7 @@ const (
 	// FIXME(roosd): removed unused keys above.
 
 	ASSigKeyFile = "as-signing.key"
-	ASDecKeyFile = "as-decrypt.ley"
+	ASDecKeyFile = "as-decrypt.key"
 	ASRevKeyFile = "as-revocation.key"
 
 	IssuerRevKeyFile  = "issuer-revocation.key"

--- a/go/tools/scion-pki/internal/cmd/BUILD.bazel
+++ b/go/tools/scion-pki/internal/cmd/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/scionproto/scion/go/tools/scion-pki/internal/cmd",
     visibility = ["//go/tools/scion-pki:__subpackages__"],
     deps = [
+        "//go/lib/common:go_default_library",
         "//go/tools/scion-pki/internal/certs:go_default_library",
         "//go/tools/scion-pki/internal/keys:go_default_library",
         "//go/tools/scion-pki/internal/pkicmn:go_default_library",

--- a/go/tools/scion-pki/internal/cmd/cmd.go
+++ b/go/tools/scion-pki/internal/cmd/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/certs"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/keys"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
@@ -41,6 +42,8 @@ root configuration files used in the SCION control plane PKI.`,
 			pkicmn.OutDir = pkicmn.RootDir
 		}
 	},
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 const (
@@ -82,8 +85,14 @@ var autoCompleteCmd = &cobra.Command{
 }
 
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+	err := RootCmd.Execute()
+	switch err.(type) {
+	case common.BasicError:
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(2)
+	case error:
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		RootCmd.Usage()
 		os.Exit(1)
 	}
 }

--- a/go/tools/scion-pki/internal/v2/cmd/BUILD.bazel
+++ b/go/tools/scion-pki/internal/v2/cmd/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     deps = [
         "//go/tools/scion-pki/internal/v2/keys:go_default_library",
         "//go/tools/scion-pki/internal/v2/tmpl:go_default_library",
-        "//go/tools/scion-pki/internal/v2/trc:go_default_library",
+        "//go/tools/scion-pki/internal/v2/trcs:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )

--- a/go/tools/scion-pki/internal/v2/cmd/cmd.go
+++ b/go/tools/scion-pki/internal/v2/cmd/cmd.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/keys"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/tmpl"
-	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/trc"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/trcs"
 )
 
 var Cmd = &cobra.Command{
@@ -30,5 +30,5 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(tmpl.Cmd)
 	Cmd.AddCommand(keys.Cmd)
-	Cmd.AddCommand(trc.Cmd)
+	Cmd.AddCommand(trcs.Cmd)
 }

--- a/go/tools/scion-pki/internal/v2/conf/as.go
+++ b/go/tools/scion-pki/internal/v2/conf/as.go
@@ -106,8 +106,7 @@ func NewTemplateASCfg(subject addr.IA, trcVer uint64, voting, issuing bool) *ASC
 
 // LoadASCfg loads the AS configuration from a directory.
 func LoadASCfg(dir string) (*ASCfg, error) {
-	cname := filepath.Join(dir, ASConfFileName)
-	cfg, err := ini.Load(cname)
+	cfg, err := ini.Load(ASCfgPath(dir))
 	if err != nil {
 		return nil, err
 	}
@@ -119,6 +118,11 @@ func LoadASCfg(dir string) (*ASCfg, error) {
 		return nil, err
 	}
 	return as, nil
+}
+
+// ASCfgPath returns the path to the AS config file given a directory.
+func ASCfgPath(dir string) string {
+	return filepath.Join(dir, ASConfFileName)
 }
 
 // Validate parses the raw values and validates that the AS config is correct.

--- a/go/tools/scion-pki/internal/v2/conf/isd.go
+++ b/go/tools/scion-pki/internal/v2/conf/isd.go
@@ -58,8 +58,7 @@ func NewTemplateISDCfg() *ISDCfg {
 
 // LoadISDCfg loads the ISD configuration from a directory.
 func LoadISDCfg(dir string) (*ISDCfg, error) {
-	cname := filepath.Join(dir, ISDCfgFileName)
-	cfg, err := ini.Load(cname)
+	cfg, err := ini.Load(ISDCfgPath(dir))
 	if err != nil {
 		return nil, err
 	}
@@ -74,6 +73,11 @@ func LoadISDCfg(dir string) (*ISDCfg, error) {
 		return nil, err
 	}
 	return i, nil
+}
+
+// ISDCfgPath returns the path to the ISD config file given a directory.
+func ISDCfgPath(dir string) string {
+	return filepath.Join(dir, ISDCfgFileName)
 }
 
 // Write writes the ISD config to the provided path.

--- a/go/tools/scion-pki/internal/v2/keys/cmd.go
+++ b/go/tools/scion-pki/internal/v2/keys/cmd.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/scionproto/scion/go/lib/common"
 )
 
 var Cmd = &cobra.Command{
@@ -40,9 +42,12 @@ Selector:
 var genCmd = &cobra.Command{
 	Use:   "gen",
 	Short: "Generate new keys",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		runGenKey(args)
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := runGenKey(args[0]); err != nil {
+			return common.NewBasicError("unable to generate keys", err)
+		}
+		return nil
 	},
 }
 

--- a/go/tools/scion-pki/internal/v2/tmpl/cmd.go
+++ b/go/tools/scion-pki/internal/v2/tmpl/cmd.go
@@ -16,6 +16,8 @@ package tmpl
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/scionproto/scion/go/lib/common"
 )
 
 var Cmd = &cobra.Command{
@@ -31,7 +33,11 @@ var topo = &cobra.Command{
 	Short: "Generate isd.ini and as.ini templates for the provided topo",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runGenTopoTmpl(args)
+		if err := runGenTopoTmpl(args[0]); err != nil {
+			return common.NewBasicError("unable to generate templates from topo", err,
+				"file", args[0])
+		}
+		return nil
 	},
 }
 
@@ -45,9 +51,13 @@ Selector:
 	X
 		A specific ISD X.
 `,
-	Args: cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		runGenIsdTmpl(args)
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := runGenISDTmpl(args[0]); err != nil {
+			return common.NewBasicError("unable to generate ISD templates", err,
+				"selector", args[0])
+		}
+		return nil
 	},
 }
 
@@ -63,9 +73,12 @@ Selector:
 	X-Y
 		A specific AS X-Y, e.g. AS 1-ff00:0:300
 `,
-	Args: cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		runGenAsTmpl(args)
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := runGenASTmpl(args[0]); err != nil {
+			return common.NewBasicError("unable to generate AS templates", err, "selector", args[0])
+		}
+		return nil
 	},
 }
 

--- a/go/tools/scion-pki/internal/v2/tmpl/isd.go
+++ b/go/tools/scion-pki/internal/v2/tmpl/isd.go
@@ -19,22 +19,26 @@ import (
 	"path/filepath"
 
 	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/conf"
 )
 
-func runGenIsdTmpl(args []string) {
-	asMap, err := pkicmn.ProcessSelector(args[0])
+func runGenISDTmpl(selector string) error {
+	asMap, err := pkicmn.ProcessSelector(selector)
 	if err != nil {
-		pkicmn.ErrorAndExit("Error: %s\n", err)
+		return err
 	}
 	pkicmn.QuietPrint("Generating trc config templates.\n")
 	for isd := range asMap {
-		genIsdTmpl(isd)
+		if err := genISDTmpl(isd); err != nil {
+			return common.NewBasicError("error generating isd.ini template", err, "isd", isd)
+		}
 	}
+	return nil
 }
 
-func genIsdTmpl(isd addr.ISD) error {
+func genISDTmpl(isd addr.ISD) error {
 	dir := pkicmn.GetIsdPath(pkicmn.RootDir, isd)
 	pkicmn.QuietPrint("Generating configuration template for ISD%d\n", isd)
 	i := conf.NewTemplateISDCfg()

--- a/go/tools/scion-pki/internal/v2/tmpl/topo.go
+++ b/go/tools/scion-pki/internal/v2/tmpl/topo.go
@@ -35,10 +35,10 @@ var (
 	rawValidity string
 )
 
-func runGenTopoTmpl(args []string) error {
-	raw, err := ioutil.ReadFile(args[0])
+func runGenTopoTmpl(path string) error {
+	raw, err := ioutil.ReadFile(path)
 	if err != nil {
-		return common.NewBasicError("unable to read file", err, "file", args[0])
+		return common.NewBasicError("unable to read file", err)
 	}
 	val, err := validityFromFlags()
 	if err != nil {
@@ -46,7 +46,7 @@ func runGenTopoTmpl(args []string) error {
 	}
 	var topo topoFile
 	if err := yaml.Unmarshal(raw, &topo); err != nil {
-		return common.NewBasicError("unable to parse topo", err, "file", args[0])
+		return common.NewBasicError("unable to parse topo", err)
 	}
 	isdCfgs := make(map[addr.ISD]*conf.ISDCfg)
 	for isd := range topo.ISDs() {
@@ -70,7 +70,6 @@ func runGenTopoTmpl(args []string) error {
 			return common.NewBasicError("unable to write AS config", err, "ia", ia)
 		}
 	}
-
 	return nil
 }
 

--- a/go/tools/scion-pki/internal/v2/trcs/BUILD.bazel
+++ b/go/tools/scion-pki/internal/v2/trcs/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "sign.go",
         "util.go",
     ],
-    importpath = "github.com/scionproto/scion/go/tools/scion-pki/internal/v2/trc",
+    importpath = "github.com/scionproto/scion/go/tools/scion-pki/internal/v2/trcs",
     visibility = ["//go/tools/scion-pki:__subpackages__"],
     deps = [
         "//go/lib/addr:go_default_library",

--- a/go/tools/scion-pki/internal/v2/trcs/ases.go
+++ b/go/tools/scion-pki/internal/v2/trcs/ases.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trc
+package trcs
 
 import (
 	"path/filepath"

--- a/go/tools/scion-pki/internal/v2/trcs/cmd.go
+++ b/go/tools/scion-pki/internal/v2/trcs/cmd.go
@@ -13,14 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trc
+package trcs
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/scionproto/scion/go/lib/common"
 )
 
 var Cmd = &cobra.Command{
-	Use:   "trc",
+	Use:   "trcs",
 	Short: "Generate TRCs for the SCION control plane PKI",
 	Long: `
 'trc' can be used to generate Trust Root Configuration (TRC) files used in the SCION control
@@ -97,9 +99,12 @@ var proto = &cobra.Command{
 	'proto' generates new prototype TRCs from the ISD configs. They need to be signed
 	using the sign command.
 `,
-	Args: cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		runProto(args)
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := runProto(args[0]); err != nil {
+			return common.NewBasicError("unable to generate prototype TRC", err)
+		}
+		return nil
 	},
 }
 
@@ -109,9 +114,12 @@ var sign = &cobra.Command{
 	Long: `
 	'sign' generates new signatures for the proto TRCs.
 `,
-	Args: cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		runSign(args)
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := runSign(args[0]); err != nil {
+			return common.NewBasicError("unable to sign TRC", err)
+		}
+		return nil
 	},
 }
 

--- a/go/tools/scion-pki/internal/v2/trcs/human.go
+++ b/go/tools/scion-pki/internal/v2/trcs/human.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trc
+package trcs
 
 import (
 	"encoding/json"
@@ -22,16 +22,15 @@ import (
 
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/scrypto/trc/v2"
-	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
 )
 
-func runHuman(args []string) {
-	for _, file := range args {
+func runHuman(files []string) error {
+	for _, file := range files {
 		if err := genHuman(file); err != nil {
-			pkicmn.ErrorAndExit("Error: %s\n", err)
+			return common.NewBasicError("unable to generate human output", err, "file", file)
 		}
 	}
-	os.Exit(0)
+	return nil
 }
 
 func genHuman(file string) error {

--- a/go/tools/scion-pki/internal/v2/trcs/prototype.go
+++ b/go/tools/scion-pki/internal/v2/trcs/prototype.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trc
+package trcs
 
 import (
 	"encoding/json"
@@ -29,17 +29,17 @@ import (
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/conf"
 )
 
-func runProto(args []string) {
-	asMap, err := pkicmn.ProcessSelector(args[0])
+func runProto(selector string) error {
+	asMap, err := pkicmn.ProcessSelector(selector)
 	if err != nil {
-		pkicmn.ErrorAndExit("Error: %s\n", err)
+		return err
 	}
 	for isd := range asMap {
 		if err = genAndWriteProto(isd); err != nil {
-			pkicmn.ErrorAndExit("Error generating proto TRC for ISD %d: %s\n", isd, err)
+			return common.NewBasicError("unable to generating prototype TRC", err, "isd", isd)
 		}
 	}
-	os.Exit(0)
+	return nil
 }
 
 func genAndWriteProto(isd addr.ISD) error {
@@ -63,7 +63,7 @@ func genAndWriteProto(isd addr.ISD) error {
 }
 
 func genProto(isd addr.ISD, isdCfg *conf.ISDCfg) (*trc.TRC, trc.Encoded, error) {
-	pkicmn.QuietPrint("Generating proto TRC for ISD %d\n", isd)
+	pkicmn.QuietPrint("Generating prototype TRC for ISD %d\n", isd)
 	primaryASes, err := loadPrimaryASes(isd, isdCfg, nil)
 	if err != nil {
 		return nil, nil, common.NewBasicError("error loading primary ASes configs", err)

--- a/go/tools/scion-pki/internal/v2/trcs/sign.go
+++ b/go/tools/scion-pki/internal/v2/trcs/sign.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trc
+package trcs
 
 import (
 	"encoding/json"
@@ -27,21 +27,21 @@ import (
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/v2/conf"
 )
 
-func runSign(args []string) {
-	_, selector, err := pkicmn.ParseSelector(args[0])
+func runSign(selector string) error {
+	_, asSelector, err := pkicmn.ParseSelector(selector)
 	if err != nil {
-		pkicmn.ErrorAndExit("error: %s\n", err)
+		return err
 	}
-	asMap, err := pkicmn.ProcessSelector(args[0])
+	asMap, err := pkicmn.ProcessSelector(selector)
 	if err != nil {
-		pkicmn.ErrorAndExit("error: %s\n", err)
+		return err
 	}
 	for isd, ases := range asMap {
-		if err = genAndWriteSignatures(isd, ases, selector); err != nil {
-			pkicmn.ErrorAndExit("error signing TRC for ISD %d: %s\n", isd, err)
+		if err = genAndWriteSignatures(isd, ases, asSelector); err != nil {
+			return common.NewBasicError("unable to sign TRC", err, "isd", isd)
 		}
 	}
-	os.Exit(0)
+	return nil
 }
 
 func genAndWriteSignatures(isd addr.ISD, ases []addr.IA, selector string) error {

--- a/go/tools/scion-pki/internal/v2/trcs/util.go
+++ b/go/tools/scion-pki/internal/v2/trcs/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package trc
+package trcs
 
 import (
 	"fmt"


### PR DESCRIPTION
This PR is in preparation to the scion-pki testing pipeline.
Instead of calling os.Exit() the tests now use cobra to return errors.
With this change, unit tests can check the exit codes of the application
without building and running the binary by directly invoking the
commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3102)
<!-- Reviewable:end -->
