### PR TITLE
BS: Make ifstate metric useful

### DIFF
--- a/go/beacon_srv/internal/ifstate/metrics.go
+++ b/go/beacon_srv/internal/ifstate/metrics.go
@@ -35,8 +35,8 @@ func NewCollector(intfs *Interfaces, subsystemName string) *Collector {
 	return &Collector{
 		desc: prometheus.NewDesc(
 			prometheus.BuildFQName("beacon_srv", subsystemName, "ifstate"),
-			"Interface state, 0 means down, 1 up. More details in labels (ifid, state)",
-			[]string{"ifid", "state"},
+			"Interface state, 0==inactive/expired/revoked, 1==active",
+			[]string{"ifid"},
 			prometheus.Labels{},
 		),
 		intfs: intfs,
@@ -45,13 +45,12 @@ func NewCollector(intfs *Interfaces, subsystemName string) *Collector {
 
 func (c *Collector) Collect(mc chan<- prometheus.Metric) {
 	for ifid, intf := range c.intfs.All() {
-		state := intf.State()
-		var up float64
-		if state == Active {
+		up := float64(0)
+		if intf.State() == Active {
 			up = 1
 		}
 		mc <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, up,
-			strconv.FormatUint(uint64(ifid), 10), string(state))
+			strconv.FormatUint(uint64(ifid), 10))
 	}
 }
 


### PR DESCRIPTION
Remove the state label from the ifstate metric.

before:
````
# HELP beacon_srv_ifstate Interface state, 0 means down, 1 up. More details in labels (ifid, state)
# TYPE beacon_srv_ifstate gauge
beacon_srv_ifstate{elem="bs1-ff00_0_110-1",ifid="1",state="Active"} 1
````

now:
````
# HELP beacon_srv_ifstate Interface state, 0==inactive/expired/revoked, 1==active
# TYPE beacon_srv_ifstate gauge
beacon_srv_ifstate{elem="bs1-ff00_0_110-1",ifid="1"} 0
````

fixes #3103

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3105)
<!-- Reviewable:end -->
