### PR TITLE
Use MinRevTTL instead of constant

### DIFF
--- a/go/beacon_srv/internal/ifstate/revoker_test.go
+++ b/go/beacon_srv/internal/ifstate/revoker_test.go
@@ -151,7 +151,7 @@ func TestRevokedInterfaceNotRevokedImmediately(t *testing.T) {
 			RawIsdas:     ia.IAInt(),
 			LinkType:     proto.LinkType_peer,
 			RawTimestamp: util.TimeToSecs(time.Now().Add(-500 * time.Millisecond)),
-			RawTTL:       uint32(path_mgmt.MinRevTTL / time.Second),
+			RawTTL:       uint32(path_mgmt.MinRevTTL.Seconds()),
 		}, infra.NullSigner)
 		xtest.FailOnErr(t, err)
 		intfs.Get(101).Revoke(srev)

--- a/go/beacon_srv/internal/ifstate/revoker_test.go
+++ b/go/beacon_srv/internal/ifstate/revoker_test.go
@@ -151,7 +151,7 @@ func TestRevokedInterfaceNotRevokedImmediately(t *testing.T) {
 			RawIsdas:     ia.IAInt(),
 			LinkType:     proto.LinkType_peer,
 			RawTimestamp: util.TimeToSecs(time.Now().Add(-500 * time.Millisecond)),
-			RawTTL:       10,
+			RawTTL:       uint32(path_mgmt.MinRevTTL / time.Second),
 		}, infra.NullSigner)
 		xtest.FailOnErr(t, err)
 		intfs.Get(101).Revoke(srev)

--- a/go/beacon_srv/internal/revocation/handler_test.go
+++ b/go/beacon_srv/internal/revocation/handler_test.go
@@ -59,7 +59,7 @@ func TestHandler(t *testing.T) {
 		IfID:         101,
 		LinkType:     proto.LinkType_peer,
 		RawTimestamp: util.TimeToSecs(time.Now()),
-		RawTTL:       uint32(path_mgmt.MinRevTTL / time.Second),
+		RawTTL:       uint32(path_mgmt.MinRevTTL.Seconds()),
 	}
 	sRev, err := path_mgmt.NewSignedRevInfo(rev, signer)
 	xtest.FailOnErr(t, err)

--- a/go/beacon_srv/internal/revocation/handler_test.go
+++ b/go/beacon_srv/internal/revocation/handler_test.go
@@ -59,7 +59,7 @@ func TestHandler(t *testing.T) {
 		IfID:         101,
 		LinkType:     proto.LinkType_peer,
 		RawTimestamp: util.TimeToSecs(time.Now()),
-		RawTTL:       10,
+		RawTTL:       uint32(path_mgmt.MinRevTTL / time.Second),
 	}
 	sRev, err := path_mgmt.NewSignedRevInfo(rev, signer)
 	xtest.FailOnErr(t, err)


### PR DESCRIPTION
In SCIONLab, if we change the value `path_mgmt.MinRevTTL` from 10 to e.g. 20, some UTs in `beacon_srv` won't pass. Using the constant `MinRevTTL` instead of hardcoded `10` fixes them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3108)
<!-- Reviewable:end -->
