### PR TITLE
Update jaeger all-in-one image to 1.14

### DIFF
--- a/python/topology/jaeger.py
+++ b/python/topology/jaeger.py
@@ -48,7 +48,7 @@ class JaegerGenerator(object):
             'version': '2',
             'services': {
                 'jaeger': {
-                    'image': 'jaegertracing/all-in-one:1.12.0',
+                    'image': 'jaegertracing/all-in-one:1.14.0',
                     'container_name': name,
                     'user': '%s:%s' % (str(os.getuid()), str(os.getgid())),
                     'ports': [
@@ -57,13 +57,10 @@ class JaegerGenerator(object):
                     ],
                     'environment': [
                         'SPAN_STORAGE_TYPE=badger',
-                        'BADGER_EPHEMERAL=false',
-                        'BADGER_DIRECTORY_VALUE=/badger/data',
-                        'BADGER_DIRECTORY_KEY=/badger/key',
                         'BADGER_CONSISTENCY=true',
                     ],
                     'volumes': [
-                        '%s:/badger' % self.docker_jaeger_dir,
+                        '%s:/tmp' % self.docker_jaeger_dir,
                     ],
                 }
             }


### PR DESCRIPTION
Version 1.12 for me tried to allocate all the ram which would result in the machine no longer reacting.
With 1.14 I no longer saw this behavior.

Also use the new tmp volume (see https://github.com/jaegertracing/jaeger/pull/1571)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3128)
<!-- Reviewable:end -->
