### PR TITLE
jaeger: Fix storing segments

### DIFF
--- a/python/topology/jaeger.py
+++ b/python/topology/jaeger.py
@@ -57,10 +57,13 @@ class JaegerGenerator(object):
                     ],
                     'environment': [
                         'SPAN_STORAGE_TYPE=badger',
+                        'BADGER_EPHEMERAL=false',
+                        'BADGER_DIRECTORY_VALUE=/badger/data',
+                        'BADGER_DIRECTORY_KEY=/badger/key',
                         'BADGER_CONSISTENCY=true',
                     ],
                     'volumes': [
-                        '%s:/tmp' % self.docker_jaeger_dir,
+                        '%s:/badger:rw' % self.docker_jaeger_dir,
                     ],
                 }
             }

--- a/scion.sh
+++ b/scion.sh
@@ -424,7 +424,7 @@ cmd_traces() {
         -e BADGER_CONSISTENCY=true \
         -v "$trace_dir:/badger" \
         -p "$port":16686 \
-        jaegertracing/all-in-one:1.12.0
+        jaegertracing/all-in-one:1.14.0
     sleep 3
     x-www-browser "http://localhost:$port"
 }


### PR DESCRIPTION
In #3128 we switched to temp storage, but that is deleted after calling down on the container.
That would mean on CI we can't access the traces, therefore switch back to the old storage approach.

Also update the version in scion.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3131)
<!-- Reviewable:end -->
