### PR TITLE
mock: Generate mocks for matched packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ bazel: vendor gogen
 	tar -kxf bazel-bin/scion-ci.tar -C bin
 
 mocks: goenv
-	./tools/gomocks -p "$(PKG_MATCHER)"
+	./tools/gomocks
 
 gazelle:
 	bazel run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build ./go

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ bazel: vendor gogen
 	tar -kxf bazel-bin/scion-ci.tar -C bin
 
 mocks: goenv
-	./tools/gomocks
+	./tools/gomocks -p "$(PKG_MATCHER)"
 
 gazelle:
 	bazel run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build ./go

--- a/tools/gomocks
+++ b/tools/gomocks
@@ -17,6 +17,7 @@
 ==============================================================
 """
 
+import argparse
 import os.path
 from typing import Tuple
 
@@ -69,10 +70,17 @@ MOCK_TARGETS = [
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--package-matcher", default="",
+                        help="Generate mocks for all matched packages")
+    args = parser.parse_args()
+
     mockgen = local[local.env["MOCKTOOL"]] if "MOCKTOOL" in local.env else local["mockgen"]
     print("Generating mocks using tool", mockgen)
 
     for (package, interfaces) in MOCK_TARGETS:
+        if args.package_matcher not in package:
+            continue
         (mock_dir, mock_file) = get_mock_file_path(package)
 
         mkdir("-p", mock_dir)

--- a/tools/gomocks
+++ b/tools/gomocks
@@ -71,7 +71,7 @@ MOCK_TARGETS = [
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--package-matcher", default="",
+    parser.add_argument("-p", "--package-matcher", default=os.environ.get("PKG_MATCHER", ""),
                         help="Generate mocks for all matched packages")
     args = parser.parse_args()
 


### PR DESCRIPTION
This changes allows generating the mock files for specific packages.

Sample usage: `PKG_MATCHER=svc make mocks`
generates only packages that contain `svc` in the import path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3150)
<!-- Reviewable:end -->
