### PR TITLE
BS: Add metrics for the keepalive messages

### DIFF
--- a/go/beacon_srv/internal/keepalive/BUILD.bazel
+++ b/go/beacon_srv/internal/keepalive/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//go/beacon_srv:__subpackages__"],
     deps = [
         "//go/beacon_srv/internal/ifstate:go_default_library",
+        "//go/beacon_srv/internal/metrics:go_default_library",
         "//go/beacon_srv/internal/onehop:go_default_library",
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
@@ -50,6 +51,7 @@ go_test(
         "//go/lib/topology:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/beacon_srv/internal/metrics/BUILD.bazel
+++ b/go/beacon_srv/internal/metrics/BUILD.bazel
@@ -2,7 +2,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["metrics.go"],
+    srcs = [
+        "keepalive.go",
+        "metrics.go",
+    ],
     importpath = "github.com/scionproto/scion/go/beacon_srv/internal/metrics",
     visibility = ["//go/beacon_srv:__subpackages__"],
+    deps = [
+        "//go/lib/common:go_default_library",
+        "//go/lib/prom:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+    ],
 )

--- a/go/beacon_srv/internal/metrics/keepalive.go
+++ b/go/beacon_srv/internal/metrics/keepalive.go
@@ -1,0 +1,66 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/prom"
+)
+
+// KeepaliveLabels is used by clients to pass in a safe way labels
+// values to prometheus metric types (e.g. counter).
+type KeepaliveLabels struct {
+	IfID   common.IFIDType
+	Result string
+}
+
+// Labels returns the name of the labels in correct order.
+func (l KeepaliveLabels) Labels() []string {
+	return []string{"ifid", prom.LabelResult}
+}
+
+// Values returns the values of the label in correct order.
+func (l *KeepaliveLabels) Values() []string {
+	return []string{l.IfID.String(), l.Result}
+}
+
+type exporter struct {
+	out, in prometheus.CounterVec
+}
+
+func newKeepalive() exporter {
+	sub := "keepalive"
+	labels := KeepaliveLabels{}.Labels()
+
+	return exporter{
+		out: *prom.NewCounterVec(Namespace, sub, "transmit_msgs_total",
+			"Total number of transmitted keepalive msgs.", labels),
+		in: *prom.NewCounterVec(Namespace, sub, "receive_msgs_total",
+			"Total number of received keepalive msgs.", labels),
+	}
+
+}
+
+// Transmits returns transmit counter.
+func (e *exporter) Transmits(l KeepaliveLabels) prometheus.Counter {
+	return e.out.WithLabelValues(l.Values()...)
+}
+
+// Receives returns the receive counter.
+func (e *exporter) Receives(l KeepaliveLabels) prometheus.Counter {
+	return e.in.WithLabelValues(l.Values()...)
+}

--- a/go/beacon_srv/internal/metrics/metrics.go
+++ b/go/beacon_srv/internal/metrics/metrics.go
@@ -14,5 +14,19 @@
 
 package metrics
 
-// Namespace is the metrics namespace for the beacon server.
-const namespace = "bs"
+import "github.com/scionproto/scion/go/lib/prom"
+
+const (
+	// Namespace is the metrics namespace for the beacon server.
+	Namespace = "bs"
+
+	// Success indicates a successful result.
+	Success string = prom.Success
+	// ErrProcess indicates an error during processing.
+	ErrProcess string = prom.ErrProcess
+)
+
+var (
+	// Keepalive the single-instance struct to get prometheus counters
+	Keepalive = newKeepalive()
+)

--- a/go/lib/prom/prom.go
+++ b/go/lib/prom/prom.go
@@ -46,6 +46,8 @@ const (
 	ErrInternal = "err_internal"
 	// ErrInvalidReq is an invalid request.
 	ErrInvalidReq = "err_invalid_request"
+	// ErrProcess is an error during processing e.g. parsing failed.
+	ErrProcess = "err_process"
 )
 
 // FIXME(roosd): remove when moving messenger to new metrics style.


### PR DESCRIPTION
This PR works the first bullet on https://github.com/scionproto/scion/issues/3104
```
# HELP bs_keepalive_receive_msgs_total Total number of received keepalive msgs.
# TYPE bs_keepalive_receive_msgs_total counter
bs_keepalive_receive_msgs_total{ifid="1",result="success"} 118
bs_keepalive_receive_msgs_total{ifid="2",result="success"} 118
# HELP bs_keepalive_transmit_msgs_total Total number of transmitted keepalive msgs.
# TYPE bs_keepalive_transmit_msgs_total counter
bs_keepalive_transmit_msgs_total{ifid="1",result="process_err"} 118
bs_keepalive_transmit_msgs_total{ifid="2",result="process_err"} 118
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3151)
<!-- Reviewable:end -->
