### PR TITLE
CI: Fix build by making app_builder dependency explicit

### DIFF
--- a/.buildkite/steps/build_all.yml
+++ b/.buildkite/steps/build_all.yml
@@ -6,7 +6,7 @@
   # docker.sh tester depends on scion:latest (needs to be tagged)
   - docker tag $SCION_IMG scion:latest
   - echo "$(date -u +"%F %T.%6N%z") Build perapp images"
-  - ./docker.sh run -c "mkdir docker/_build && touch docker/_build/scion.stamp && make -C docker/perapp apps"
+  - ./docker.sh run -c "mkdir docker/_build && touch docker/_build/scion.stamp && make -C docker/perapp app_builder apps"
   - echo "$(date -u +"%F %T.%6N%z") Build tester image"
   - ./docker.sh tester
   - $BASE/scripts/all_images push

--- a/docker/perapp/debug/Dockerfile.beacon
+++ b/docker/perapp/debug/Dockerfile.beacon
@@ -1,2 +1,0 @@
-FROM scion_beacon:latest
-COPY --from=scion_debug_base:latest / /

--- a/docker/perapp/debug/Dockerfile.border
+++ b/docker/perapp/debug/Dockerfile.border
@@ -1,2 +1,0 @@
-FROM scion_border:latest
-COPY --from=scion_debug_base:latest / /

--- a/docker/perapp/debug/Dockerfile.cert
+++ b/docker/perapp/debug/Dockerfile.cert
@@ -1,2 +1,0 @@
-FROM scion_cert:latest
-COPY --from=scion_debug_base:latest / /

--- a/docker/perapp/debug/Dockerfile.dispatcher_go
+++ b/docker/perapp/debug/Dockerfile.dispatcher_go
@@ -1,2 +1,0 @@
-FROM scion_dispatcher:latest
-COPY --from=scion_debug_base:latest / /

--- a/docker/perapp/debug/Dockerfile.path
+++ b/docker/perapp/debug/Dockerfile.path
@@ -1,2 +1,0 @@
-FROM scion_path:latest
-COPY --from=scion_debug_base:latest / /

--- a/docker/perapp/debug/Dockerfile.sciond
+++ b/docker/perapp/debug/Dockerfile.sciond
@@ -1,2 +1,0 @@
-FROM scion_sciond:latest
-COPY --from=scion_debug_base:latest / /


### PR DESCRIPTION
Previously app_builder was built as a dependency of the dispatcher docker image, this is no longer the case, therefore we need to explicitly pull it to be able to build the tester image.

Also remove old unused docker files.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3155)
<!-- Reviewable:end -->
