### PR TITLE
BK: Add automatic retry for jobs that lost their agent

### DIFF
--- a/.buildkite/acceptance-pipeline.sh
+++ b/.buildkite/acceptance-pipeline.sh
@@ -45,9 +45,10 @@ for test in ./acceptance/*_acceptance; do
     echo "  timeout_in_minutes: 10"
     echo "  retry:"
     echo "    automatic:"
-    echo "      - exit_status: 5"  # Pull failed
+    echo "      - exit_status: 5"   # Pull failed
     echo "        limit: 2"
-    echo "      - exit_status: -1" # Agent was lost
+    echo "      - exit_status: -1"  # Agent was lost
+    echo "      - exit_status: 255" # Forced agent shutdown
     echo "  artifact_paths:"
     echo "  - \"artifacts.out/**/*\""
 done

--- a/.buildkite/acceptance-pipeline.sh
+++ b/.buildkite/acceptance-pipeline.sh
@@ -47,6 +47,7 @@ for test in ./acceptance/*_acceptance; do
     echo "    automatic:"
     echo "      - exit_status: 5"  # Pull failed
     echo "        limit: 2"
+    echo "      - exit_status: -1" # Agent was lost
     echo "  artifact_paths:"
     echo "  - \"artifacts.out/**/*\""
 done

--- a/.buildkite/steps/build_all.yml
+++ b/.buildkite/steps/build_all.yml
@@ -15,5 +15,5 @@
     - "artifacts.out/**/*"
   retry:
     automatic:
-      exit_status: 255
+      exit_status: -1
   timeout_in_minutes: 10

--- a/.buildkite/steps/build_all.yml
+++ b/.buildkite/steps/build_all.yml
@@ -15,5 +15,6 @@
     - "artifacts.out/**/*"
   retry:
     automatic:
-      exit_status: -1
+      - exit_status: -1  # Agent was lost
+      - exit_status: 255 # Forced agent shutdown
   timeout_in_minutes: 10

--- a/.buildkite/steps/docker-integration.yml
+++ b/.buildkite/steps/docker-integration.yml
@@ -4,7 +4,8 @@
   - $BASE/run_step integration -d -a
   retry:
     automatic:
-      exit_status: -1
+      - exit_status: -1  # Agent was lost
+      - exit_status: 255 # Forced agent shutdown
   timeout_in_minutes: 10
   artifact_paths:
   - "artifacts.out/**/*"

--- a/.buildkite/steps/docker-integration.yml
+++ b/.buildkite/steps/docker-integration.yml
@@ -2,6 +2,9 @@
   command:
   - $BASE/scripts/all_images pull
   - $BASE/run_step integration -d -a
+  retry:
+    automatic:
+      exit_status: -1
   timeout_in_minutes: 10
   artifact_paths:
   - "artifacts.out/**/*"

--- a/.buildkite/steps/integration
+++ b/.buildkite/steps/integration
@@ -12,6 +12,9 @@ run_test() {
     fi
     echo "  command:"
     echo "  - $BASE/run_step integration $1 $2"
+    echo "  retry:"
+    echo "    automatic:"
+    echo "      exit_status: -1"
     echo "  timeout_in_minutes: 10"
     echo "  artifact_paths:"
     echo "  - \"artifacts.out/**/*\""

--- a/.buildkite/steps/integration
+++ b/.buildkite/steps/integration
@@ -14,7 +14,8 @@ run_test() {
     echo "  - $BASE/run_step integration $1 $2"
     echo "  retry:"
     echo "    automatic:"
-    echo "      exit_status: -1"
+    echo "      - exit_status: -1"  # Agent was lost
+    echo "      - exit_status: 255" # Forced agent shutdown
     echo "  timeout_in_minutes: 10"
     echo "  artifact_paths:"
     echo "  - \"artifacts.out/**/*\""

--- a/.buildkite/steps/setup.yml
+++ b/.buildkite/steps/setup.yml
@@ -8,6 +8,6 @@
     - "artifacts.out/**/*"
   retry:
     automatic:
-      exit_status: 255
+      exit_status: -1
   timeout_in_minutes: 10
 - wait

--- a/.buildkite/steps/setup.yml
+++ b/.buildkite/steps/setup.yml
@@ -8,6 +8,7 @@
     - "artifacts.out/**/*"
   retry:
     automatic:
-      exit_status: -1
+      - exit_status: -1  # Agent was lost
+      - exit_status: 255 # Forced agent shutdown
   timeout_in_minutes: 10
 - wait

--- a/.buildkite/steps/test.yml
+++ b/.buildkite/steps/test.yml
@@ -1,5 +1,8 @@
 - label: "Check generated go/proto files in git"
   command: $BASE/run_step checkgogen
+  retry:
+    automatic:
+      exit_status: -1
   timeout_in_minutes: 10
 - label: "Unit tests :bazel:"
   command: $BASE/run_step test
@@ -7,7 +10,7 @@
       - "artifacts.out/**/*"
   retry:
     automatic:
-      exit_status: 255
+      exit_status: -1
   timeout_in_minutes: 10
 - label: "Lint :bazel:"
   command: $BASE/run_step lint
@@ -15,5 +18,5 @@
     - "artifacts.out/**/*"
   retry:
     automatic:
-      exit_status: 255
+      exit_status: -1
   timeout_in_minutes: 10

--- a/.buildkite/steps/test.yml
+++ b/.buildkite/steps/test.yml
@@ -2,7 +2,8 @@
   command: $BASE/run_step checkgogen
   retry:
     automatic:
-      exit_status: -1
+      - exit_status: -1  # Agent was lost
+      - exit_status: 255 # Forced agent shutdown
   timeout_in_minutes: 10
 - label: "Unit tests :bazel:"
   command: $BASE/run_step test
@@ -10,7 +11,8 @@
       - "artifacts.out/**/*"
   retry:
     automatic:
-      exit_status: -1
+      - exit_status: -1  # Agent was lost
+      - exit_status: 255 # Forced agent shutdown
   timeout_in_minutes: 10
 - label: "Lint :bazel:"
   command: $BASE/run_step lint
@@ -18,5 +20,6 @@
     - "artifacts.out/**/*"
   retry:
     automatic:
-      exit_status: -1
+      - exit_status: -1  # Agent was lost
+      - exit_status: 255 # Forced agent shutdown
   timeout_in_minutes: 10


### PR DESCRIPTION
Jobs where the agent is lost are not automatically retried, see https://github.com/buildkite/docs/pull/355. And docs: https://buildkite.com/docs/pipelines/command-step#automatic-retry-attributes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3156)
<!-- Reviewable:end -->
