### PR TITLE
serrors: Add serrors package

### DIFF
--- a/go/lib/serrors/BUILD.bazel
+++ b/go/lib/serrors/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["errors.go"],
+    importpath = "github.com/scionproto/scion/go/lib/serrors",
+    visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_xerrors//:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["errors_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@org_golang_x_xerrors//:go_default_library",
+    ],
+)

--- a/go/lib/serrors/errors.go
+++ b/go/lib/serrors/errors.go
@@ -1,0 +1,205 @@
+// Copyright 2016 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serrors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/xerrors"
+)
+
+// ErrorWrapper allows recursing into nested errrors.
+type ErrorWrapper interface {
+	error
+	xerrors.Wrapper
+	// TopError should return the top level error without the wrapped ones.
+	TopError() string
+}
+
+type errOrMsg struct {
+	str string
+	err error
+}
+
+type basicError struct {
+	msg    errOrMsg
+	logCtx []interface{}
+	cause  error
+}
+
+func (e basicError) Error() string {
+	return FmtError(e)
+}
+
+func (e basicError) Is(err error) bool {
+	switch other := err.(type) {
+	case basicError:
+		return e.msg == other.msg
+	default:
+		if e.msg.err != nil {
+			return e.msg.err == err
+		}
+		return false
+	}
+}
+
+// TODO do we need self ASing? that would mean the type would need to be public.
+func (e basicError) As(as interface{}) bool {
+	if e.msg.err != nil {
+		return xerrors.As(e.msg.err, as)
+	}
+	return false
+}
+
+func (e basicError) Unwrap() error {
+	return e.cause
+}
+
+func (e basicError) TopError() string {
+	s := make([]string, 0, 1+(len(e.logCtx)/2))
+	s = append(s, e.msgString())
+	for i := 0; i < len(e.logCtx); i += 2 {
+		s = append(s, fmt.Sprintf("%s=\"%v\"", e.logCtx[i], e.logCtx[i+1]))
+	}
+	return strings.Join(s, " ")
+}
+
+func (e basicError) msgString() string {
+	if e.msg.err != nil {
+		return e.msg.err.Error()
+	}
+	return e.msg.str
+}
+
+// IsTimeout returns whether err is or is caused by a timeout error.
+func IsTimeout(err error) bool {
+	var t interface{ Timeout() bool }
+	return xerrors.As(err, &t) && t.Timeout()
+}
+
+// IsTemporary returns whether err is or is caused by a temporary error.
+func IsTemporary(err error) bool {
+	var t interface{ Temporary() bool }
+	return xerrors.As(err, &t) && t.Temporary()
+}
+
+// WithCtx returns an error that is the same as the given error but contains the
+// additional context. The additional context is printed in the Error method.
+func WithCtx(err error, logCtx ...interface{}) error {
+	return basicError{
+		msg:    errOrMsg{err: err},
+		logCtx: logCtx,
+	}
+}
+
+// Wrap wraps the cause with the msg error and adds context to the resulting
+// error.
+func Wrap(msg, cause error, logCtx ...interface{}) error {
+	return basicError{
+		msg:    errOrMsg{err: msg},
+		cause:  cause,
+		logCtx: logCtx,
+	}
+}
+
+// WrapStr wraps the cause with an error that has msg in the error message and
+// adds the addtional context.
+func WrapStr(msg string, cause error, logCtx ...interface{}) error {
+	return basicError{
+		msg:    errOrMsg{str: msg},
+		cause:  cause,
+		logCtx: logCtx,
+	}
+}
+
+// New creates a new error with the given message and context. If no context is
+// used prefer using the standard libs New function.
+func New(msg string, logCtx ...interface{}) error {
+	if len(logCtx) == 0 {
+		return errors.New(msg)
+	}
+	return &basicError{
+		msg:    errOrMsg{str: msg},
+		logCtx: logCtx,
+	}
+}
+
+// List is a slice of errors
+type List []error
+
+// ToError returns the object as error interface implementation.
+func (e List) ToError() error {
+	if len(e) == 0 {
+		return nil
+	}
+	return errList(e)
+}
+
+// errList is the internal error interface implementation of MultiError.
+type errList []error
+
+func (e errList) Error() string {
+	return fmtErrors(e)
+}
+
+// FmtError formats e for logging. It walks through all nested errors, putting each on a new line,
+// and indenting multi-line errors.
+func FmtError(e error) string {
+	var s, ns []string
+	for {
+		ns, e = innerFmtError(e)
+		s = append(s, ns...)
+		if e == nil {
+			break
+		}
+	}
+	return strings.Join(s, "\n    ")
+}
+
+func innerFmtError(e error) ([]string, error) {
+	var s []string
+	var lines []string
+	switch e := e.(type) {
+	case ErrorWrapper:
+		lines = strings.Split(e.TopError(), "\n")
+	default:
+		lines = strings.Split(e.Error(), "\n")
+	}
+	for i, line := range lines {
+		if i == len(lines)-1 && len(line) == 0 {
+			// Don't output an empty line if caused by a trailing newline in
+			// the input.
+			break
+		}
+		if i == 0 {
+			s = append(s, line)
+		} else {
+			s = append(s, ">   "+line)
+		}
+	}
+	return s, xerrors.Unwrap(e)
+}
+
+// fmtErrors formats a slice of errors for logging.
+func fmtErrors(errs []error) string {
+	s := make([]string, 0, len(errs))
+	for _, e := range errs {
+		s = append(s, e.Error())
+	}
+	return strings.Join(s, "\n")
+}

--- a/go/lib/serrors/errors_test.go
+++ b/go/lib/serrors/errors_test.go
@@ -1,0 +1,229 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serrors_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"github.com/scionproto/scion/go/lib/serrors"
+)
+
+type testErrType struct {
+	msg string
+}
+
+func (e *testErrType) Error() string {
+	return e.msg
+}
+
+type testToTempErr struct {
+	msg       string
+	timeout   bool
+	temporary bool
+	cause     error
+}
+
+func (e *testToTempErr) Error() string {
+	return e.msg
+}
+
+func (e *testToTempErr) Timeout() bool {
+	return e.timeout
+}
+
+func (e *testToTempErr) Temporary() bool {
+	return e.temporary
+}
+
+func (e *testToTempErr) Unwrap() error {
+	return e.cause
+}
+
+func TestIsTimeout(t *testing.T) {
+	err := serrors.New("no timeout")
+	assert.False(t, serrors.IsTimeout(err))
+	wrappedErr := serrors.WrapStr("timeout",
+		&testToTempErr{msg: "to", timeout: true})
+	assert.True(t, serrors.IsTimeout(wrappedErr))
+	timeoutWrappingNoTimeout := serrors.WrapStr("notimeout", &testToTempErr{
+		msg:   "wraps timeout",
+		cause: &testToTempErr{msg: "timeout", timeout: true},
+	})
+	assert.False(t, serrors.IsTimeout(timeoutWrappingNoTimeout))
+}
+
+func TestIsTemporary(t *testing.T) {
+	err := serrors.New("not temp")
+	assert.False(t, serrors.IsTemporary(err))
+	wrappedErr := serrors.WrapStr("temp",
+		&testToTempErr{msg: "to", temporary: true})
+	assert.True(t, serrors.IsTemporary(wrappedErr))
+	tempWrappingNoTemp := serrors.WrapStr("notemp", &testToTempErr{
+		msg:   "wraps temp",
+		cause: &testToTempErr{msg: "timeout", temporary: true},
+	})
+	assert.False(t, serrors.IsTemporary(tempWrappingNoTemp))
+}
+
+func TestWithCtx(t *testing.T) {
+	t.Run("Is", func(t *testing.T) {
+		err := serrors.New("simple err")
+		errWithCtx := serrors.WithCtx(err, "someCtx", "someValue")
+		assert.True(t, xerrors.Is(errWithCtx, err))
+		assert.True(t, xerrors.Is(errWithCtx, errWithCtx))
+	})
+	t.Run("As", func(t *testing.T) {
+		err := &testErrType{msg: "test err"}
+		errWithCtx := serrors.WithCtx(err, "someCtx", "someVal")
+		var errAs *testErrType
+		require.True(t, xerrors.As(errWithCtx, &errAs))
+		assert.Equal(t, err, errAs)
+	})
+	t.Run("Fmt", func(t *testing.T) {
+		err := serrors.New("simple err")
+		errWithCtx := serrors.WithCtx(err, "someCtx", "someValue")
+		expectedMsg := `simple err someCtx="someValue"`
+		assert.Equal(t, expectedMsg, errWithCtx.Error())
+	})
+}
+
+func TestWrap(t *testing.T) {
+	t.Run("Is", func(t *testing.T) {
+		err := serrors.New("simple err")
+		msg := serrors.New("msg err")
+		wrappedErr := serrors.Wrap(msg, err, "someCtx", "someValue")
+		assert.True(t, xerrors.Is(wrappedErr, err))
+		assert.True(t, xerrors.Is(wrappedErr, msg))
+		assert.True(t, xerrors.Is(wrappedErr, wrappedErr))
+	})
+	t.Run("As", func(t *testing.T) {
+		err := &testErrType{msg: "test err"}
+		msg := serrors.New("msg err")
+		wrappedErr := serrors.Wrap(msg, err, "someCtx", "someValue")
+		var errAs *testErrType
+		require.True(t, xerrors.As(wrappedErr, &errAs))
+		assert.Equal(t, err, errAs)
+
+	})
+	t.Run("Fmt", func(t *testing.T) {
+		err := serrors.New("level0\nlevel0.1")
+		cause := serrors.New("level1\nlevel1.1")
+		wrappedErr := serrors.Wrap(err, cause, "k0", "v0", "k1", 1)
+		expedtedMsg := strings.Join([]string{
+			"level0",
+			`    >   level0.1 k0="v0" k1="1"`,
+			"    level1",
+			"    >   level1.1",
+		}, "\n")
+		assert.Equal(t, expedtedMsg, wrappedErr.Error())
+	})
+}
+
+func TestWrapStr(t *testing.T) {
+	t.Run("Is", func(t *testing.T) {
+		err := serrors.New("simple err")
+		msg := "msg"
+		wrappedErr := serrors.WrapStr(msg, err, "someCtx", "someValue")
+		assert.True(t, xerrors.Is(wrappedErr, err))
+		assert.True(t, xerrors.Is(wrappedErr, wrappedErr))
+	})
+	t.Run("As", func(t *testing.T) {
+		err := &testErrType{msg: "test err"}
+		msg := "msg"
+		wrappedErr := serrors.WrapStr(msg, err, "someCtx", "someValue")
+		var errAs *testErrType
+		require.True(t, xerrors.As(wrappedErr, &errAs))
+		assert.Equal(t, err, errAs)
+
+	})
+	t.Run("Fmt", func(t *testing.T) {
+		msg := "level0\nlevel0.1"
+		cause := serrors.New("level1\nlevel1.1")
+		wrappedErr := serrors.WrapStr(msg, cause, "k0", "v0", "k1", 1)
+		expedtedMsg := strings.Join([]string{
+			"level0",
+			`    >   level0.1 k0="v0" k1="1"`,
+			"    level1",
+			"    >   level1.1",
+		}, "\n")
+		assert.Equal(t, expedtedMsg, wrappedErr.Error())
+	})
+}
+
+func TestNew(t *testing.T) {
+	t.Run("Is", func(t *testing.T) {
+		err1 := serrors.New("err msg")
+		err2 := serrors.New("err msg")
+		assert.True(t, xerrors.Is(err1, err1))
+		assert.True(t, xerrors.Is(err2, err2))
+		assert.False(t, xerrors.Is(err1, err2))
+		assert.False(t, xerrors.Is(err2, err1))
+		err1 = serrors.New("err msg", "someCtx", "value")
+		err2 = serrors.New("err msg", "someCtx", "value")
+		assert.True(t, xerrors.Is(err1, err1))
+		assert.True(t, xerrors.Is(err2, err2))
+		assert.False(t, xerrors.Is(err1, err2))
+		assert.False(t, xerrors.Is(err2, err1))
+	})
+	t.Run("Fmt", func(t *testing.T) {
+		err := serrors.New("err msg\n", "k0", "v0", "k1", 1)
+		expedtedMsg := strings.Join([]string{
+			"err msg",
+			`    >    k0="v0" k1="1"`,
+		}, "\n")
+		assert.Equal(t, expedtedMsg, err.Error())
+	})
+}
+
+func TestList(t *testing.T) {
+	var errors serrors.List
+	assert.Nil(t, errors.ToError())
+	errors = serrors.List{serrors.New("err1"), serrors.New("err2")}
+	combinedErr := errors.ToError()
+	assert.NotNil(t, combinedErr)
+	assert.Equal(t, "err1\nerr2", combinedErr.Error())
+}
+
+func ExampleWrapStr() {
+	// ErrNoSpace is an error defined at package scope.
+	var ErrNoSpace = serrors.New("no space")
+
+	fmt.Println(xerrors.Is(serrors.WrapStr("wrap with more context", ErrNoSpace, "ctx", 1), ErrNoSpace))
+	// Output: true
+}
+
+func ExampleWrap() {
+	// ErrNoSpace is an error defined at package scope.
+	var ErrNoSpace = serrors.New("no space")
+	// ErrDB is an error defined at package scope.
+	var ErrDB = serrors.New("db")
+
+	wrapped := serrors.Wrap(ErrDB, ErrNoSpace, "ctx", 1)
+	// Now we can identify specific errors:
+	fmt.Println(xerrors.Is(wrapped, ErrNoSpace))
+
+	// But we can also identify the broader error class ErrDB:
+	fmt.Println(xerrors.Is(wrapped, ErrDB))
+
+	// Output:
+	// true
+	// true
+}

--- a/go/lib/serrors/errors_test.go
+++ b/go/lib/serrors/errors_test.go
@@ -63,11 +63,12 @@ func TestIsTimeout(t *testing.T) {
 	wrappedErr := serrors.WrapStr("timeout",
 		&testToTempErr{msg: "to", timeout: true})
 	assert.True(t, serrors.IsTimeout(wrappedErr))
-	timeoutWrappingNoTimeout := serrors.WrapStr("notimeout", &testToTempErr{
-		msg:   "wraps timeout",
-		cause: &testToTempErr{msg: "timeout", timeout: true},
+	noTimeoutWrappingTimeout := serrors.WrapStr("notimeout", &testToTempErr{
+		msg:     "non timeout wraps timeout",
+		timeout: false,
+		cause:   &testToTempErr{msg: "timeout", timeout: true},
 	})
-	assert.False(t, serrors.IsTimeout(timeoutWrappingNoTimeout))
+	assert.False(t, serrors.IsTimeout(noTimeoutWrappingTimeout))
 }
 
 func TestIsTemporary(t *testing.T) {
@@ -76,11 +77,12 @@ func TestIsTemporary(t *testing.T) {
 	wrappedErr := serrors.WrapStr("temp",
 		&testToTempErr{msg: "to", temporary: true})
 	assert.True(t, serrors.IsTemporary(wrappedErr))
-	tempWrappingNoTemp := serrors.WrapStr("notemp", &testToTempErr{
-		msg:   "wraps temp",
-		cause: &testToTempErr{msg: "timeout", temporary: true},
+	noTempWrappingTemp := serrors.WrapStr("notemp", &testToTempErr{
+		msg:       "non temp wraps temp",
+		temporary: false,
+		cause:     &testToTempErr{msg: "temp", temporary: true},
 	})
-	assert.False(t, serrors.IsTemporary(tempWrappingNoTemp))
+	assert.False(t, serrors.IsTemporary(noTempWrappingTemp))
 }
 
 func TestWithCtx(t *testing.T) {
@@ -202,11 +204,30 @@ func TestList(t *testing.T) {
 	assert.Equal(t, "err1\nerr2", combinedErr.Error())
 }
 
+func ExampleNew() {
+	err1 := serrors.New("errtxt")
+	err2 := serrors.New("errtxt")
+
+	// Self equality always works:
+	fmt.Println(xerrors.Is(err1, err1))
+	fmt.Println(xerrors.Is(err2, err2))
+	// On the other hand different errors with same text should not be "equal".
+	// That is to prevent that errors with same message in different packages
+	// with same text are seen as the same thing:
+	fmt.Println(xerrors.Is(err1, err2))
+
+	// Output:
+	// true
+	// true
+	// false
+}
+
 func ExampleWrapStr() {
 	// ErrNoSpace is an error defined at package scope.
 	var ErrNoSpace = serrors.New("no space")
 
-	fmt.Println(xerrors.Is(serrors.WrapStr("wrap with more context", ErrNoSpace, "ctx", 1), ErrNoSpace))
+	wrappedErr := serrors.WrapStr("wrap with more context", ErrNoSpace, "ctx", 1)
+	fmt.Println(xerrors.Is(wrappedErr, ErrNoSpace))
 	// Output: true
 }
 


### PR DESCRIPTION
This should in the long term replace:
-errors.New
-common.NewBasicError

The package is ready to be used with Go1.13 (or xerrors) Is and As.

Also it provides all the functionality that was provided by common.BasicError/common.MultiError.

By putting it in a serrors package we can make the API slightly nicer to use.

Contributes #3042

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3159)
<!-- Reviewable:end -->
