### PR TITLE
prom: Remove custom registry

### DIFF
--- a/go/beacon_srv/BUILD.bazel
+++ b/go/beacon_srv/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//go/lib/keyconf:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/periodic:go_default_library",
+        "//go/lib/prom:go_default_library",
         "//go/lib/scrypto:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/sock/reliable:go_default_library",

--- a/go/beacon_srv/BUILD.bazel
+++ b/go/beacon_srv/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//go/beacon_srv/internal/config:go_default_library",
         "//go/beacon_srv/internal/ifstate:go_default_library",
         "//go/beacon_srv/internal/keepalive:go_default_library",
-        "//go/beacon_srv/internal/metrics:go_default_library",
         "//go/beacon_srv/internal/onehop:go_default_library",
         "//go/beacon_srv/internal/revocation:go_default_library",
         "//go/lib/addr:go_default_library",

--- a/go/beacon_srv/internal/metrics/BUILD.bazel
+++ b/go/beacon_srv/internal/metrics/BUILD.bazel
@@ -5,5 +5,4 @@ go_library(
     srcs = ["metrics.go"],
     importpath = "github.com/scionproto/scion/go/beacon_srv/internal/metrics",
     visibility = ["//go/beacon_srv:__subpackages__"],
-    deps = ["//go/lib/prom:go_default_library"],
 )

--- a/go/beacon_srv/internal/metrics/metrics.go
+++ b/go/beacon_srv/internal/metrics/metrics.go
@@ -14,15 +14,5 @@
 
 package metrics
 
-import (
-	"github.com/scionproto/scion/go/lib/prom"
-)
-
-const (
-	namespace = "beacon_srv"
-)
-
-// Init initializes the metrics for the beacon server.
-func Init(elem string) {
-	prom.UseDefaultRegWithElem(elem)
-}
+// Namespace is the metrics namespace for the beacon server.
+const namespace = "bs"

--- a/go/beacon_srv/main.go
+++ b/go/beacon_srv/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/scionproto/scion/go/lib/keyconf"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/periodic"
+	"github.com/scionproto/scion/go/lib/prom"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/sock/reliable"
@@ -543,6 +544,7 @@ func setupBasic() error {
 	if err := env.InitLogging(&cfg.Logging); err != nil {
 		return err
 	}
+	prom.ExportElementID(cfg.General.ID)
 	return env.LogAppStarted(common.BS, cfg.General.ID)
 }
 

--- a/go/beacon_srv/main.go
+++ b/go/beacon_srv/main.go
@@ -36,7 +36,6 @@ import (
 	"github.com/scionproto/scion/go/beacon_srv/internal/config"
 	"github.com/scionproto/scion/go/beacon_srv/internal/ifstate"
 	"github.com/scionproto/scion/go/beacon_srv/internal/keepalive"
-	"github.com/scionproto/scion/go/beacon_srv/internal/metrics"
 	"github.com/scionproto/scion/go/beacon_srv/internal/onehop"
 	"github.com/scionproto/scion/go/beacon_srv/internal/revocation"
 	"github.com/scionproto/scion/go/lib/addr"
@@ -544,7 +543,6 @@ func setupBasic() error {
 	if err := env.InitLogging(&cfg.Logging); err != nil {
 		return err
 	}
-	metrics.Init(cfg.General.ID)
 	return env.LogAppStarted(common.BS, cfg.General.ID)
 }
 

--- a/go/border/BUILD.bazel
+++ b/go/border/BUILD.bazel
@@ -62,7 +62,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/border/brconf:go_default_library",
-        "//go/border/metrics:go_default_library",
         "//go/border/rctx:go_default_library",
         "//go/border/rpkt:go_default_library",
         "//go/lib/addr:go_default_library",

--- a/go/border/main.go
+++ b/go/border/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/scionproto/scion/go/lib/fatal"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/profile"
+	"github.com/scionproto/scion/go/lib/prom"
 )
 
 var (
@@ -104,6 +105,7 @@ func setupBasic() error {
 	if err := env.InitLogging(&cfg.Logging); err != nil {
 		return err
 	}
+	prom.ExportElementID(cfg.General.ID)
 	return env.LogAppStarted(common.BR, cfg.General.ID)
 }
 

--- a/go/border/metrics/metrics.go
+++ b/go/border/metrics/metrics.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Namespace is the metrics namespace for the border router.
-const Namespace = "border"
+const Namespace = "br"
 
 // Declare prometheus metrics to export.
 var (

--- a/go/border/metrics/metrics.go
+++ b/go/border/metrics/metrics.go
@@ -24,6 +24,9 @@ import (
 	"github.com/scionproto/scion/go/lib/ringbuf"
 )
 
+// Namespace is the metrics namespace for the border router.
+const Namespace = "border"
+
 // Declare prometheus metrics to export.
 var (
 	// High-level input stats
@@ -56,23 +59,22 @@ var (
 )
 
 func init() {
-	namespace := "br"
 	sockLabels := []string{"sock"}
 
 	// Some closures to reduce boiler-plate.
 	newCVec := func(name, help string, lNames []string) *prometheus.CounterVec {
-		return prom.NewCounterVec(namespace, "", name, help, lNames)
+		return prom.NewCounterVec(Namespace, "", name, help, lNames)
 	}
 	newG := func(name, help string) prometheus.Gauge {
-		return prom.NewGauge(namespace, "", name, help)
+		return prom.NewGauge(Namespace, "", name, help)
 	}
 	newGVec := func(name, help string, lNames []string) *prometheus.GaugeVec {
-		return prom.NewGaugeVec(namespace, "", name, help, lNames)
+		return prom.NewGaugeVec(Namespace, "", name, help, lNames)
 	}
 	newHVec := func(name, help string,
 		lNames []string, buckets []float64) *prometheus.HistogramVec {
 
-		return prom.NewHistogramVec(namespace, "", name, help, lNames, buckets)
+		return prom.NewHistogramVec(Namespace, "", name, help, lNames, buckets)
 	}
 
 	InputPkts = newCVec("input_pkts_total", "Total number of input packets received.", sockLabels)
@@ -114,5 +116,5 @@ func init() {
 	IFState = newGVec("interface_active", "Interface is active.", sockLabels)
 
 	// Initialize ringbuf metrics.
-	ringbuf.InitMetrics("border", []string{"ringId"})
+	ringbuf.InitMetrics(Namespace, []string{"ringId"})
 }

--- a/go/border/metrics/metrics.go
+++ b/go/border/metrics/metrics.go
@@ -55,12 +55,10 @@ var (
 	IFState *prometheus.GaugeVec
 )
 
-// Init ensures all metrics are registered.
-func Init(elem string) {
-	namespace := "border"
+func init() {
+	namespace := "br"
 	sockLabels := []string{"sock"}
 
-	prom.UseDefaultRegWithElem(elem)
 	// Some closures to reduce boiler-plate.
 	newCVec := func(name, help string, lNames []string) *prometheus.CounterVec {
 		return prom.NewCounterVec(namespace, "", name, help, lNames)

--- a/go/border/router.go
+++ b/go/border/router.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/scionproto/scion/go/border/brconf"
-	"github.com/scionproto/scion/go/border/metrics"
 	"github.com/scionproto/scion/go/border/rcmn"
 	"github.com/scionproto/scion/go/border/rctrl"
 	"github.com/scionproto/scion/go/border/rctx"
@@ -55,7 +54,6 @@ type Router struct {
 }
 
 func NewRouter(id, confDir string) (*Router, error) {
-	metrics.Init(id)
 	r := &Router{Id: id, confDir: confDir}
 	if err := r.setup(); err != nil {
 		return nil, err

--- a/go/border/setup_test.go
+++ b/go/border/setup_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/scionproto/scion/go/border/brconf"
-	"github.com/scionproto/scion/go/border/metrics"
 	"github.com/scionproto/scion/go/border/rctx"
 	"github.com/scionproto/scion/go/border/rpkt"
 	"github.com/scionproto/scion/go/lib/common"
@@ -304,7 +303,6 @@ func setupTestRouter(t *testing.T) (*Router, *rctx.Ctx) {
 func initTestRouter(maxNumPosixInput int) *Router {
 	// Init metrics.
 	testInitOnce.Do(func() {
-		metrics.Init("br1-ff00_0_111-1")
 		// Reduce output displayed in goconvey.
 		log.Root().SetHandler(log.DiscardHandler())
 	})

--- a/go/cert_srv/BUILD.bazel
+++ b/go/cert_srv/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//go/lib/infra/modules/trust/trustdb:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/periodic:go_default_library",
+        "//go/lib/prom:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/topology:go_default_library",
         "//go/proto:go_default_library",

--- a/go/cert_srv/BUILD.bazel
+++ b/go/cert_srv/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//go/cert_srv/internal/config:go_default_library",
-        "//go/cert_srv/internal/metrics:go_default_library",
         "//go/cert_srv/internal/reiss:go_default_library",
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",

--- a/go/cert_srv/internal/metrics/BUILD.bazel
+++ b/go/cert_srv/internal/metrics/BUILD.bazel
@@ -5,5 +5,4 @@ go_library(
     srcs = ["metrics.go"],
     importpath = "github.com/scionproto/scion/go/cert_srv/internal/metrics",
     visibility = ["//go/cert_srv:__subpackages__"],
-    deps = ["//go/lib/prom:go_default_library"],
 )

--- a/go/cert_srv/internal/metrics/metrics.go
+++ b/go/cert_srv/internal/metrics/metrics.go
@@ -15,4 +15,4 @@
 package metrics
 
 // Namespace is the metrics namespace for the certificate server.
-const namespace = "cs"
+const Namespace = "cs"

--- a/go/cert_srv/internal/metrics/metrics.go
+++ b/go/cert_srv/internal/metrics/metrics.go
@@ -14,15 +14,5 @@
 
 package metrics
 
-import (
-	"github.com/scionproto/scion/go/lib/prom"
-)
-
-const (
-	namespace = "cert_srv"
-)
-
-// Init initializes the metrics for the CS.
-func Init(elem string) {
-	prom.UseDefaultRegWithElem(elem)
-}
+// Namespace is the metrics namespace for the certificate server.
+const namespace = "cs"

--- a/go/cert_srv/setup.go
+++ b/go/cert_srv/setup.go
@@ -22,7 +22,6 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/scionproto/scion/go/cert_srv/internal/config"
-	"github.com/scionproto/scion/go/cert_srv/internal/metrics"
 	"github.com/scionproto/scion/go/cert_srv/internal/reiss"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
@@ -57,7 +56,6 @@ func setupBasic() error {
 	if err := env.InitLogging(&cfg.Logging); err != nil {
 		return err
 	}
-	metrics.Init(cfg.General.ID)
 	return env.LogAppStarted(common.CS, cfg.General.ID)
 }
 

--- a/go/cert_srv/setup.go
+++ b/go/cert_srv/setup.go
@@ -33,6 +33,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra/modules/trust"
 	"github.com/scionproto/scion/go/lib/infra/modules/trust/trustdb"
 	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/prom"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/proto"
@@ -56,6 +57,7 @@ func setupBasic() error {
 	if err := env.InitLogging(&cfg.Logging); err != nil {
 		return err
 	}
+	prom.ExportElementID(cfg.General.ID)
 	return env.LogAppStarted(common.CS, cfg.General.ID)
 }
 

--- a/go/godispatcher/BUILD.bazel
+++ b/go/godispatcher/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//go/godispatcher/internal/config:go_default_library",
-        "//go/godispatcher/internal/metrics:go_default_library",
         "//go/godispatcher/network:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/env:go_default_library",
@@ -30,7 +29,6 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//go/godispatcher/internal/metrics:go_default_library",
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/hpkt:go_default_library",

--- a/go/godispatcher/internal/metrics/metrics.go
+++ b/go/godispatcher/internal/metrics/metrics.go
@@ -15,8 +15,6 @@
 package metrics
 
 import (
-	"sync"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/scionproto/scion/go/lib/addr"
@@ -24,9 +22,8 @@ import (
 	"github.com/scionproto/scion/go/lib/ringbuf"
 )
 
-const (
-	namespace = "dispatcher"
-)
+// Namespace is the metrics namespace for the dispatcher.
+const Namespace = "dispatcher"
 
 // Label descriptions
 const (
@@ -58,26 +55,16 @@ func GetOpenConnectionLabel(svc addr.HostSVC) string {
 	return svc.BaseString()
 }
 
-var initSentinel sync.Once
-
-// Init initializes the metrics for the dispatcher.
-func Init(elem string) {
-	initSentinel.Do(func() {
-		initMetrics(elem)
-	})
-}
-
-func initMetrics(elem string) {
-	prom.UseDefaultRegWithElem(elem)
+func init() {
 	ringbuf.InitMetrics("dispatcher", nil)
-	OutgoingBytesTotal = prom.NewCounter(namespace, "", "outgoing_bytes_total",
+	OutgoingBytesTotal = prom.NewCounter(Namespace, "", "outgoing_bytes_total",
 		"Total bytes sent on the network.")
-	OutgoingPacketsTotal = prom.NewCounter(namespace, "", "outgoing_packets_total",
+	OutgoingPacketsTotal = prom.NewCounter(Namespace, "", "outgoing_packets_total",
 		"Total packets sent on the network.")
-	IncomingBytesTotal = prom.NewCounter(namespace, "", "incoming_bytes_total",
+	IncomingBytesTotal = prom.NewCounter(Namespace, "", "incoming_bytes_total",
 		"Total bytes received from the network irrespective of packet outcome.")
-	IncomingPackets = prom.NewCounterVec(namespace, "", "incoming_packets_total",
+	IncomingPackets = prom.NewCounterVec(Namespace, "", "incoming_packets_total",
 		"Total packets received from the network.", []string{IncomingPacketOutcome})
-	OpenSockets = prom.NewGaugeVec(namespace, "", "open_application_connections",
+	OpenSockets = prom.NewGaugeVec(Namespace, "", "open_application_connections",
 		"Number of sockets currently opened by applications.", []string{OpenConnectionType})
 }

--- a/go/godispatcher/internal/metrics/metrics.go
+++ b/go/godispatcher/internal/metrics/metrics.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Namespace is the metrics namespace for the dispatcher.
-const Namespace = "dispatcher"
+const Namespace = "disp"
 
 // Label descriptions
 const (
@@ -56,7 +56,7 @@ func GetOpenConnectionLabel(svc addr.HostSVC) string {
 }
 
 func init() {
-	ringbuf.InitMetrics("dispatcher", nil)
+	ringbuf.InitMetrics(Namespace, nil)
 	OutgoingBytesTotal = prom.NewCounter(Namespace, "", "outgoing_bytes_total",
 		"Total bytes sent on the network.")
 	OutgoingPacketsTotal = prom.NewCounter(Namespace, "", "outgoing_packets_total",

--- a/go/godispatcher/main.go
+++ b/go/godispatcher/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/scionproto/scion/go/godispatcher/internal/config"
-	"github.com/scionproto/scion/go/godispatcher/internal/metrics"
 	"github.com/scionproto/scion/go/godispatcher/network"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/env"
@@ -124,7 +123,6 @@ func setupBasic() error {
 	if err := env.InitLogging(&cfg.Logging); err != nil {
 		return err
 	}
-	metrics.Init(cfg.Dispatcher.ID)
 	return env.LogAppStarted("Dispatcher", cfg.Dispatcher.ID)
 }
 

--- a/go/godispatcher/main_test.go
+++ b/go/godispatcher/main_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/scionproto/scion/go/godispatcher/internal/metrics"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/hpkt"
@@ -519,9 +518,6 @@ func MustPackQuotedSCMPL4Header(header *scmp.Hdr, meta *scmp.Meta, info scmp.Inf
 }
 
 func TestMain(m *testing.M) {
-	// If the prometheus package is not initialized, dispatcher internals panic
-	// because the counters are nil.
-	metrics.Init("dispatcher")
 	log.Root().SetHandler(log.DiscardHandler())
 	os.Exit(m.Run())
 }

--- a/go/lib/infra/messenger/metrics.go
+++ b/go/lib/infra/messenger/metrics.go
@@ -127,7 +127,7 @@ func errorToResultLabel(ctx context.Context, err error) string {
 	// TODO(lukedirtwalker): categorize error better.
 	switch {
 	case err == nil:
-		return prom.ResultOk
+		return prom.Success
 	case common.IsTimeoutErr(err):
 		return prom.ErrTimeout
 	default:

--- a/go/lib/infra/metrics.go
+++ b/go/lib/infra/metrics.go
@@ -52,7 +52,7 @@ var (
 	metricsErrRevCache   = &HandlerResult{Result: "err_revcache", Status: prom.StatusErr}
 	metricsErrRevCacheTo = &HandlerResult{Result: "err_revcache_to", Status: prom.StatusTimeout}
 
-	MetricsResultOk = &HandlerResult{Result: prom.ResultOk, Status: prom.StatusOk}
+	MetricsResultOk = &HandlerResult{Result: prom.Success, Status: prom.StatusOk}
 )
 
 func MetricsErrTrustDB(err error) *HandlerResult {

--- a/go/lib/infra/modules/db/metrics.go
+++ b/go/lib/infra/modules/db/metrics.go
@@ -23,7 +23,7 @@ import (
 func ErrToMetricLabel(err error) string {
 	switch {
 	case err == nil:
-		return prom.ResultOk
+		return prom.Success
 	case common.IsTimeoutErr(err):
 		return prom.ErrTimeout
 	default:

--- a/go/lib/prom/prom.go
+++ b/go/lib/prom/prom.go
@@ -61,6 +61,12 @@ var (
 		1.28, 2.56, 5.12, 10.24}
 )
 
+// ExportElementID exports the element ID as configured in the config file.
+func ExportElementID(id string) {
+	NewGaugeVec("scion", "", "elem_id",
+		"The element ID from the config file", []string{"cfg"}).WithLabelValues(id).Set(1)
+}
+
 // FIXME(roosd): remove.
 func CopyLabels(labels prometheus.Labels) prometheus.Labels {
 	l := make(prometheus.Labels)
@@ -68,14 +74,6 @@ func CopyLabels(labels prometheus.Labels) prometheus.Labels {
 		l[k] = v
 	}
 	return l
-}
-
-// UseDefaultRegWithElem changes the default prometheus registry
-// to one that always adds the element id label.
-// Note this should be called before any other interaction with prometheus.
-// See also: https://github.com/prometheus/client_golang/issues/515
-func UseDefaultRegWithElem(elemId string) {
-
 }
 
 // NewCounter creates a new prometheus counter that is registered with the default registry.

--- a/go/lib/prom/prom.go
+++ b/go/lib/prom/prom.go
@@ -22,25 +22,34 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// Common label values.
 const (
 	// LabelResult is the label for result classifications.
 	LabelResult = "result"
 	// LabelStatus for latency status classifications, possible values are prefixed with Status*.
 	LabelStatus = "status"
-	// LabelElem is the label for the element id that is added to all metrics.
-	LabelElem = "elem"
 	// LabelOperation is the label for the name of an executed operation.
 	LabelOperation = "op"
 	// LabelSrc is the label for the src of a request.
 	LabelSrc = "src"
+)
 
-	// ResultOk is no error.
-	ResultOk = "ok"
+// Common result values.
+const (
+	// Success is no error.
+	Success = "success"
 	// ErrNotClassified is an error that is not further classified.
 	ErrNotClassified = "err_not_classified"
 	// ErrTimeout is a timeout error.
 	ErrTimeout = "err_timeout"
+	// ErrInternal is an internal error.
+	ErrInternal = "err_internal"
+	// ErrInvalidReq is an invalid request.
+	ErrInvalidReq = "err_invalid_request"
+)
 
+// FIXME(roosd): remove when moving messenger to new metrics style.
+const (
 	StatusOk      = "ok"
 	StatusErr     = "err"
 	StatusTimeout = "err_timeout"
@@ -52,6 +61,7 @@ var (
 		1.28, 2.56, 5.12, 10.24}
 )
 
+// FIXME(roosd): remove.
 func CopyLabels(labels prometheus.Labels) prometheus.Labels {
 	l := make(prometheus.Labels)
 	for k, v := range labels {
@@ -65,12 +75,7 @@ func CopyLabels(labels prometheus.Labels) prometheus.Labels {
 // Note this should be called before any other interaction with prometheus.
 // See also: https://github.com/prometheus/client_golang/issues/515
 func UseDefaultRegWithElem(elemId string) {
-	labels := prometheus.Labels{LabelElem: elemId}
-	reg := prometheus.NewRegistry()
-	prometheus.DefaultRegisterer = prometheus.WrapRegistererWith(labels, reg)
-	prometheus.DefaultGatherer = reg
-	prometheus.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
-	prometheus.MustRegister(prometheus.NewGoCollector())
+
 }
 
 // NewCounter creates a new prometheus counter that is registered with the default registry.

--- a/go/path_srv/BUILD.bazel
+++ b/go/path_srv/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//go/path_srv/internal/config:go_default_library",
         "//go/path_srv/internal/cryptosyncer:go_default_library",
         "//go/path_srv/internal/handlers:go_default_library",
-        "//go/path_srv/internal/metrics:go_default_library",
         "//go/path_srv/internal/segreq:go_default_library",
         "//go/path_srv/internal/segsyncer:go_default_library",
         "//go/proto:go_default_library",

--- a/go/path_srv/BUILD.bazel
+++ b/go/path_srv/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//go/lib/pathdb:go_default_library",
         "//go/lib/pathstorage:go_default_library",
         "//go/lib/periodic:go_default_library",
+        "//go/lib/prom:go_default_library",
         "//go/lib/revcache:go_default_library",
         "//go/lib/topology:go_default_library",
         "//go/path_srv/internal/config:go_default_library",

--- a/go/path_srv/internal/metrics/BUILD.bazel
+++ b/go/path_srv/internal/metrics/BUILD.bazel
@@ -5,5 +5,4 @@ go_library(
     srcs = ["metrics.go"],
     importpath = "github.com/scionproto/scion/go/path_srv/internal/metrics",
     visibility = ["//go/path_srv:__subpackages__"],
-    deps = ["//go/lib/prom:go_default_library"],
 )

--- a/go/path_srv/internal/metrics/metrics.go
+++ b/go/path_srv/internal/metrics/metrics.go
@@ -14,15 +14,5 @@
 
 package metrics
 
-import (
-	"github.com/scionproto/scion/go/lib/prom"
-)
-
-const (
-	namespace = "path_srv"
-)
-
-// Init initializes the metrics for the PS.
-func Init(elem string) {
-	prom.UseDefaultRegWithElem(elem)
-}
+// Namespace is the metrics namespace for the path server.
+const Namespace = "ps"

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -47,7 +47,6 @@ import (
 	"github.com/scionproto/scion/go/path_srv/internal/config"
 	"github.com/scionproto/scion/go/path_srv/internal/cryptosyncer"
 	"github.com/scionproto/scion/go/path_srv/internal/handlers"
-	"github.com/scionproto/scion/go/path_srv/internal/metrics"
 	"github.com/scionproto/scion/go/path_srv/internal/segreq"
 	"github.com/scionproto/scion/go/path_srv/internal/segsyncer"
 	"github.com/scionproto/scion/go/proto"
@@ -264,7 +263,6 @@ func setupBasic() error {
 	if err := env.InitLogging(&cfg.Logging); err != nil {
 		return err
 	}
-	metrics.Init(cfg.General.ID)
 	return env.LogAppStarted(common.PS, cfg.General.ID)
 }
 

--- a/go/path_srv/main.go
+++ b/go/path_srv/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/scionproto/scion/go/lib/pathdb"
 	"github.com/scionproto/scion/go/lib/pathstorage"
 	"github.com/scionproto/scion/go/lib/periodic"
+	"github.com/scionproto/scion/go/lib/prom"
 	"github.com/scionproto/scion/go/lib/revcache"
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/path_srv/internal/config"
@@ -263,6 +264,7 @@ func setupBasic() error {
 	if err := env.InitLogging(&cfg.Logging); err != nil {
 		return err
 	}
+	prom.ExportElementID(cfg.General.ID)
 	return env.LogAppStarted(common.PS, cfg.General.ID)
 }
 

--- a/go/sciond/BUILD.bazel
+++ b/go/sciond/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//go/proto:go_default_library",
         "//go/sciond/internal/config:go_default_library",
         "//go/sciond/internal/fetcher:go_default_library",
-        "//go/sciond/internal/metrics:go_default_library",
         "//go/sciond/internal/servers:go_default_library",
         "@com_github_burntsushi_toml//:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",

--- a/go/sciond/BUILD.bazel
+++ b/go/sciond/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//go/lib/pathdb:go_default_library",
         "//go/lib/pathstorage:go_default_library",
         "//go/lib/periodic:go_default_library",
+        "//go/lib/prom:go_default_library",
         "//go/lib/revcache:go_default_library",
         "//go/lib/topology:go_default_library",
         "//go/proto:go_default_library",

--- a/go/sciond/internal/metrics/BUILD.bazel
+++ b/go/sciond/internal/metrics/BUILD.bazel
@@ -5,5 +5,4 @@ go_library(
     srcs = ["metrics.go"],
     importpath = "github.com/scionproto/scion/go/sciond/internal/metrics",
     visibility = ["//go/sciond:__subpackages__"],
-    deps = ["//go/lib/prom:go_default_library"],
 )

--- a/go/sciond/internal/metrics/metrics.go
+++ b/go/sciond/internal/metrics/metrics.go
@@ -15,4 +15,4 @@
 package metrics
 
 // Namespace is the metrics namespace for sciond.
-const Namespace = "sciond"
+const Namespace = "sd"

--- a/go/sciond/internal/metrics/metrics.go
+++ b/go/sciond/internal/metrics/metrics.go
@@ -14,15 +14,5 @@
 
 package metrics
 
-import (
-	"github.com/scionproto/scion/go/lib/prom"
-)
-
-const (
-	namespace = "sciond"
-)
-
-// Init initializes the metrics for sciond.
-func Init(elem string) {
-	prom.UseDefaultRegWithElem(elem)
-}
+// Namespace is the metrics namespace for sciond.
+const Namespace = "sciond"

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -46,7 +46,6 @@ import (
 	"github.com/scionproto/scion/go/proto"
 	"github.com/scionproto/scion/go/sciond/internal/config"
 	"github.com/scionproto/scion/go/sciond/internal/fetcher"
-	"github.com/scionproto/scion/go/sciond/internal/metrics"
 	"github.com/scionproto/scion/go/sciond/internal/servers"
 )
 
@@ -192,7 +191,6 @@ func setupBasic() error {
 	if err := env.InitLogging(&cfg.Logging); err != nil {
 		return err
 	}
-	metrics.Init(cfg.General.ID)
 	return env.LogAppStarted("SD", cfg.General.ID)
 }
 

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/scionproto/scion/go/lib/pathdb"
 	"github.com/scionproto/scion/go/lib/pathstorage"
 	"github.com/scionproto/scion/go/lib/periodic"
+	"github.com/scionproto/scion/go/lib/prom"
 	"github.com/scionproto/scion/go/lib/revcache"
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/proto"
@@ -191,6 +192,7 @@ func setupBasic() error {
 	if err := env.InitLogging(&cfg.Logging); err != nil {
 		return err
 	}
+	prom.ExportElementID(cfg.General.ID)
 	return env.LogAppStarted("SD", cfg.General.ID)
 }
 

--- a/go/sig/BUILD.bazel
+++ b/go/sig/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//go/lib/env:go_default_library",
         "//go/lib/fatal:go_default_library",
         "//go/lib/log:go_default_library",
+        "//go/lib/prom:go_default_library",
         "//go/sig/base:go_default_library",
         "//go/sig/config:go_default_library",
         "//go/sig/disp:go_default_library",

--- a/go/sig/egress/worker/BUILD.bazel
+++ b/go/sig/egress/worker/BUILD.bazel
@@ -36,7 +36,6 @@ go_test(
         "//go/sig/egress/iface:go_default_library",
         "//go/sig/egress/iface/mock_iface:go_default_library",
         "//go/sig/egress/worker/mock_worker:go_default_library",
-        "//go/sig/metrics:go_default_library",
         "//go/sig/mgmt:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",

--- a/go/sig/egress/worker/worker_test.go
+++ b/go/sig/egress/worker/worker_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/scionproto/scion/go/sig/egress/iface"
 	"github.com/scionproto/scion/go/sig/egress/iface/mock_iface"
 	"github.com/scionproto/scion/go/sig/egress/worker/mock_worker"
-	"github.com/scionproto/scion/go/sig/metrics"
 	"github.com/scionproto/scion/go/sig/mgmt"
 )
 
@@ -127,7 +126,6 @@ func (wt *WorkerTester) Finish() {
 }
 
 func TestParsing(t *testing.T) {
-	metrics.Init("")
 	iface.Init()
 
 	t.Run("simple packet", func(t *testing.T) {

--- a/go/sig/ingress/BUILD.bazel
+++ b/go/sig/ingress/BUILD.bazel
@@ -34,7 +34,6 @@ go_test(
     deps = [
         "//go/lib/ringbuf:go_default_library",
         "//go/lib/snet:go_default_library",
-        "//go/sig/metrics:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/go/sig/ingress/worker_test.go
+++ b/go/sig/ingress/worker_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/scionproto/scion/go/lib/ringbuf"
 	"github.com/scionproto/scion/go/lib/snet"
-	"github.com/scionproto/scion/go/sig/metrics"
 )
 
 type MockTun struct {
@@ -62,7 +61,6 @@ func SendFrame(t *testing.T, w *Worker, data []byte) {
 }
 
 func TestParsing(t *testing.T) {
-	metrics.Init("")
 	addr, err := snet.AddrFromString("1-ff00:0:300,[192.168.1.1]:80")
 	assert.NoError(t, err)
 	mt := &MockTun{}

--- a/go/sig/main.go
+++ b/go/sig/main.go
@@ -78,8 +78,6 @@ func realMain() int {
 		log.Crit("Unable to create & configure TUN device", "err", err)
 		return 1
 	}
-	// Export prometheus metrics.
-	metrics.Init(cfg.Sig.ID)
 	if err := sigcmn.Init(cfg.Sig, cfg.Sciond); err != nil {
 		log.Crit("Error during initialization", err)
 		return 1

--- a/go/sig/main.go
+++ b/go/sig/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/scionproto/scion/go/lib/env"
 	"github.com/scionproto/scion/go/lib/fatal"
 	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/prom"
 	"github.com/scionproto/scion/go/sig/base"
 	"github.com/scionproto/scion/go/sig/config"
 	"github.com/scionproto/scion/go/sig/disp"
@@ -121,6 +122,7 @@ func setupBasic() error {
 	if err := env.InitLogging(&cfg.Logging); err != nil {
 		return err
 	}
+	prom.ExportElementID(cfg.Sig.ID)
 	return env.LogAppStarted("SIG", cfg.Sig.ID)
 }
 

--- a/go/sig/metrics/metrics.go
+++ b/go/sig/metrics/metrics.go
@@ -30,6 +30,9 @@ import (
 	"github.com/scionproto/scion/go/sig/mgmt"
 )
 
+// Namespace is the metrics namespace for the SIG.
+const Namespace = "sig"
+
 // Declare prometheus metrics to export.
 var (
 	PktsRecv              *prometheus.CounterVec
@@ -54,18 +57,15 @@ var (
 // Version number of loaded config, atomic
 var ConfigVersion uint64
 
-// Ensure all metrics are registered.
-func Init(elem string) {
-	namespace := "sig"
+func init() {
 	iaLabels := []string{"IA", "sessId"}
-	prom.UseDefaultRegWithElem(elem)
 
 	// Some closures to reduce boiler-plate.
 	newC := func(name, help string) prometheus.Counter {
-		return prom.NewCounter(namespace, "", name, help)
+		return prom.NewCounter(Namespace, "", name, help)
 	}
 	newCVec := func(name, help string, lNames []string) *prometheus.CounterVec {
-		return prom.NewCounterVec(namespace, "", name, help, lNames)
+		return prom.NewCounterVec(Namespace, "", name, help, lNames)
 	}
 	// FIXME(kormat): these metrics should probably have more informative labels
 	PktsRecv = newCVec("pkts_recv_total", "Number of packets received.", iaLabels)


### PR DESCRIPTION
This change renames namespaces and removes the `elem_id` label from all metrics.
The element ID configured in the config is exposed through `scion_elem_id`.

namespace renames:
- `beacon_srv` -> `bs`
- `border` -> `br`
- `cert_srv` -> `cs`
- `dispatcher` -> `disp`
- `path_srv` -> `ps`
- `sciond` -> `sd`


fixes #3160


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3161)
<!-- Reviewable:end -->
