### PR TITLE
Start removing GetErrMsg == "xx" tests

### DIFF
--- a/go/border/rpkt/BUILD.bazel
+++ b/go/border/rpkt/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//go/lib/util:go_default_library",
         "//go/proto:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/go/border/rpkt/BUILD.bazel
+++ b/go/border/rpkt/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//go/lib/overlay:go_default_library",
         "//go/lib/ringbuf:go_default_library",
         "//go/lib/scmp:go_default_library",
+        "//go/lib/serrors:go_default_library",
         "//go/lib/spath:go_default_library",
         "//go/lib/spkt:go_default_library",
         "//go/lib/spse:go_default_library",

--- a/go/border/rpkt/l4.go
+++ b/go/border/rpkt/l4.go
@@ -20,11 +20,12 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/l4"
 	"github.com/scionproto/scion/go/lib/scmp"
+	"github.com/scionproto/scion/go/lib/serrors"
 )
 
-const (
+var (
 	// ErrUnsupportedL4 indicates an unsupported L4 header type.
-	ErrUnsupportedL4 common.ErrMsg = "unsupported L4 header type"
+	ErrUnsupportedL4 = serrors.New("unsupported L4 header type")
 )
 
 // L4Hdr finds, parses and returns the layer 4 header, if any. The verify
@@ -56,7 +57,7 @@ func (rp *RtrPkt) L4Hdr(verify bool) (l4.L4Header, error) {
 		*/
 		default:
 			// Can't return an SCMP error as we don't understand the L4 header
-			return nil, common.NewBasicError(ErrUnsupportedL4, nil, "type", rp.L4Type)
+			return nil, serrors.WithCtx(ErrUnsupportedL4, "type", rp.L4Type)
 		}
 	}
 	if verify {

--- a/go/border/rpkt/l4.go
+++ b/go/border/rpkt/l4.go
@@ -1,4 +1,5 @@
 // Copyright 2016 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +23,8 @@ import (
 )
 
 const (
-	UnsupportedL4 = "Unsupported L4 header type"
+	// ErrUnsupportedL4 indicates an unsupported L4 header type.
+	ErrUnsupportedL4 common.ErrMsg = "unsupported L4 header type"
 )
 
 // L4Hdr finds, parses and returns the layer 4 header, if any. The verify
@@ -54,7 +56,7 @@ func (rp *RtrPkt) L4Hdr(verify bool) (l4.L4Header, error) {
 		*/
 		default:
 			// Can't return an SCMP error as we don't understand the L4 header
-			return nil, common.NewBasicError(UnsupportedL4, nil, "type", rp.L4Type)
+			return nil, common.NewBasicError(ErrUnsupportedL4, nil, "type", rp.L4Type)
 		}
 	}
 	if verify {

--- a/go/border/rpkt/parse.go
+++ b/go/border/rpkt/parse.go
@@ -1,4 +1,5 @@
 // Copyright 2016 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +19,8 @@
 package rpkt
 
 import (
+	"golang.org/x/xerrors"
+
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/scmp"
@@ -75,7 +78,7 @@ func (rp *RtrPkt) parseBasic() error {
 	// Set index for destination host address and calculate its length.
 	rp.idxs.dstHost = rp.idxs.srcIA + addr.IABytes
 	if dstLen, err = addr.HostLen(rp.CmnHdr.DstType); err != nil {
-		if common.GetErrorMsg(err) == addr.ErrorBadHostAddrType {
+		if xerrors.Is(err, addr.ErrBadHostAddrType) {
 			err = scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadDstType, nil, err)
 		}
 		return err
@@ -83,7 +86,7 @@ func (rp *RtrPkt) parseBasic() error {
 	// Set index for source host address and calculate its length.
 	rp.idxs.srcHost = rp.idxs.dstHost + int(dstLen)
 	if srcLen, err = addr.HostLen(rp.CmnHdr.SrcType); err != nil {
-		if common.GetErrorMsg(err) == addr.ErrorBadHostAddrType {
+		if xerrors.Is(err, addr.ErrBadHostAddrType) {
 			err = scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadSrcType, nil, err)
 		}
 		return err

--- a/go/border/rpkt/path.go
+++ b/go/border/rpkt/path.go
@@ -21,6 +21,8 @@ import (
 	"hash"
 	"time"
 
+	"golang.org/x/xerrors"
+
 	"github.com/scionproto/scion/go/border/ifstate"
 	"github.com/scionproto/scion/go/border/rcmn"
 	"github.com/scionproto/scion/go/lib/assert"
@@ -68,7 +70,7 @@ func (rp *RtrPkt) validatePath(dirFrom rcmn.Dir) error {
 	hfmac := rp.Ctx.HFMacPool.Get().(hash.Hash)
 	err := rp.hopF.Verify(hfmac, rp.infoF.TsInt, rp.getHopFVer(dirFrom))
 	rp.Ctx.HFMacPool.Put(hfmac)
-	if err != nil && common.GetErrorMsg(err) == spath.ErrorHopFBadMac {
+	if err != nil && xerrors.Is(err, spath.ErrorHopFBadMac) {
 		err = scmp.NewError(scmp.C_Path, scmp.T_P_BadMac,
 			rp.mkInfoPathOffsets(rp.CmnHdr.CurrInfoF, rp.CmnHdr.CurrHopF), err)
 	}

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -303,11 +303,10 @@ func (rp *RtrPkt) ToScnPkt(verify bool) (*spkt.ScnPkt, error) {
 	}
 	// L4 header was parsed without error, then parse payload
 	if sp.Pld, err = rp.Payload(verify); err != nil {
-		if xerrors.Is(err, ErrUnsupportedL4) {
-			// See comment above for why we return here.
-			return sp, nil
+		if !xerrors.Is(err, ErrUnsupportedL4) {
+			// See comment above for why we special case ErrUnsupportedL4.
+			return nil, err
 		}
-		return nil, err
 	}
 	return sp, nil
 }

--- a/go/border/rpkt/rpkt.go
+++ b/go/border/rpkt/rpkt.go
@@ -1,4 +1,5 @@
 // Copyright 2016 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +24,8 @@ import (
 	"fmt"
 	"sync/atomic"
 	"time"
+
+	"golang.org/x/xerrors"
 
 	"github.com/scionproto/scion/go/border/rcmn"
 	"github.com/scionproto/scion/go/border/rctx"
@@ -289,17 +292,22 @@ func (rp *RtrPkt) ToScnPkt(verify bool) (*spkt.ScnPkt, error) {
 	}
 	// Try to parse L4 and Payload, but we might fail to do so, ie. unsupported L4 protocol
 	if sp.L4, err = rp.L4Hdr(verify); err != nil {
-		if common.GetErrorMsg(err) != UnsupportedL4 {
-			return nil, err
+		if xerrors.Is(err, ErrUnsupportedL4) {
+			// In case of an unsupported L4 protocol return the sp we have so far.
+			// scion packets are created either in error scenarios, where we
+			// don't need L4, or in SCMP replies where we shouldn't reach this
+			// code here since the packet was already parsed before.
+			return sp, nil
 		}
+		return nil, err
 	}
-	if err == nil {
-		// L4 header was parsed without error, then parse payload
-		if sp.Pld, err = rp.Payload(verify); err != nil {
-			if common.GetErrorMsg(err) != UnsupportedL4 {
-				return nil, err
-			}
+	// L4 header was parsed without error, then parse payload
+	if sp.Pld, err = rp.Payload(verify); err != nil {
+		if xerrors.Is(err, ErrUnsupportedL4) {
+			// See comment above for why we return here.
+			return sp, nil
 		}
+		return nil, err
 	}
 	return sp, nil
 }

--- a/go/lib/addr/BUILD.bazel
+++ b/go/lib/addr/BUILD.bazel
@@ -12,7 +12,10 @@ go_library(
     ],
     importpath = "github.com/scionproto/scion/go/lib/addr",
     visibility = ["//visibility:public"],
-    deps = ["//go/lib/common:go_default_library"],
+    deps = [
+        "//go/lib/common:go_default_library",
+        "//go/lib/serrors:go_default_library",
+    ],
 )
 
 go_test(

--- a/go/lib/addr/host.go
+++ b/go/lib/addr/host.go
@@ -55,8 +55,10 @@ const (
 )
 
 const (
-	ErrorBadHostAddrType       = "Unsupported host address type"
-	ErrorMalformedHostAddrType = "Malformed host address type"
+	// ErrBadHostAddrType indicates an invalid host address type.
+	ErrBadHostAddrType common.ErrMsg = "unsupported host address type"
+	// ErrMalformedHostAddrType indicates a malformed host address type.
+	ErrMalformedHostAddrType common.ErrMsg = "malformed host address type"
 )
 
 const (
@@ -284,18 +286,18 @@ func HostFromRaw(b common.RawBytes, htype HostAddrType) (HostAddr, error) {
 		return HostNone{}, nil
 	case HostTypeIPv4:
 		if len(b) < HostLenIPv4 {
-			return nil, common.NewBasicError(ErrorMalformedHostAddrType, nil, "type", htype)
+			return nil, common.NewBasicError(ErrMalformedHostAddrType, nil, "type", htype)
 		}
 		return HostIPv4(b[:HostLenIPv4]), nil
 	case HostTypeIPv6:
 		if len(b) < HostLenIPv6 {
-			return nil, common.NewBasicError(ErrorMalformedHostAddrType, nil, "type", htype)
+			return nil, common.NewBasicError(ErrMalformedHostAddrType, nil, "type", htype)
 		}
 		return HostIPv6(b[:HostLenIPv6]), nil
 	case HostTypeSVC:
 		return HostSVC(binary.BigEndian.Uint16(b)), nil
 	default:
-		return nil, common.NewBasicError(ErrorBadHostAddrType, nil, "type", htype)
+		return nil, common.NewBasicError(ErrBadHostAddrType, nil, "type", htype)
 	}
 }
 
@@ -326,7 +328,7 @@ func HostLen(htype HostAddrType) (uint8, error) {
 	case HostTypeSVC:
 		length = HostLenSVC
 	default:
-		return 0, common.NewBasicError(ErrorBadHostAddrType, nil, "type", htype)
+		return 0, common.NewBasicError(ErrBadHostAddrType, nil, "type", htype)
 	}
 	return length, nil
 }

--- a/go/lib/addr/host.go
+++ b/go/lib/addr/host.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/serrors"
 )
 
 type HostAddrType uint8
@@ -54,11 +55,11 @@ const (
 	HostLenSVC  = 2
 )
 
-const (
+var (
 	// ErrBadHostAddrType indicates an invalid host address type.
-	ErrBadHostAddrType common.ErrMsg = "unsupported host address type"
+	ErrBadHostAddrType = serrors.New("unsupported host address type")
 	// ErrMalformedHostAddrType indicates a malformed host address type.
-	ErrMalformedHostAddrType common.ErrMsg = "malformed host address type"
+	ErrMalformedHostAddrType = serrors.New("malformed host address type")
 )
 
 const (
@@ -286,18 +287,18 @@ func HostFromRaw(b common.RawBytes, htype HostAddrType) (HostAddr, error) {
 		return HostNone{}, nil
 	case HostTypeIPv4:
 		if len(b) < HostLenIPv4 {
-			return nil, common.NewBasicError(ErrMalformedHostAddrType, nil, "type", htype)
+			return nil, serrors.WithCtx(ErrMalformedHostAddrType, "type", htype)
 		}
 		return HostIPv4(b[:HostLenIPv4]), nil
 	case HostTypeIPv6:
 		if len(b) < HostLenIPv6 {
-			return nil, common.NewBasicError(ErrMalformedHostAddrType, nil, "type", htype)
+			return nil, serrors.WithCtx(ErrMalformedHostAddrType, "type", htype)
 		}
 		return HostIPv6(b[:HostLenIPv6]), nil
 	case HostTypeSVC:
 		return HostSVC(binary.BigEndian.Uint16(b)), nil
 	default:
-		return nil, common.NewBasicError(ErrBadHostAddrType, nil, "type", htype)
+		return nil, serrors.WithCtx(ErrBadHostAddrType, "type", htype)
 	}
 }
 
@@ -328,7 +329,7 @@ func HostLen(htype HostAddrType) (uint8, error) {
 	case HostTypeSVC:
 		length = HostLenSVC
 	default:
-		return 0, common.NewBasicError(ErrBadHostAddrType, nil, "type", htype)
+		return 0, serrors.WithCtx(ErrBadHostAddrType, "type", htype)
 	}
 	return length, nil
 }

--- a/go/lib/infra/modules/db/BUILD.bazel
+++ b/go/lib/infra/modules/db/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//go/lib/common:go_default_library",
         "//go/lib/prom:go_default_library",
+        "//go/lib/serrors:go_default_library",
         "@org_golang_x_xerrors//:go_default_library",
     ],
 )

--- a/go/lib/infra/modules/db/BUILD.bazel
+++ b/go/lib/infra/modules/db/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//go/lib/common:go_default_library",
         "//go/lib/prom:go_default_library",
+        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/go/lib/infra/modules/db/errors.go
+++ b/go/lib/infra/modules/db/errors.go
@@ -15,43 +15,43 @@
 package db
 
 import (
-	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/serrors"
 )
 
-const (
+var (
 	// ErrInvalidInputData indicates invalid data was tried to input in the DB.
-	ErrInvalidInputData common.ErrMsg = "db: input data invalid"
+	ErrInvalidInputData = serrors.New("db: input data invalid")
 	// ErrDataInvalid indicates invalid data is stored in the DB.
-	ErrDataInvalid common.ErrMsg = "db: db data invalid"
+	ErrDataInvalid = serrors.New("db: db data invalid")
 	// ErrReadFailed indicates that reading from the DB failed.
-	ErrReadFailed common.ErrMsg = "db: read failed"
+	ErrReadFailed = serrors.New("db: read failed")
 	// ErrWriteFailed indicates that writing to the DB failed.
-	ErrWriteFailed common.ErrMsg = "db: write failed"
+	ErrWriteFailed = serrors.New("db: write failed")
 	// ErrTx indicates a transaction error.
-	ErrTx common.ErrMsg = "db: transaction error"
+	ErrTx = serrors.New("db: transaction error")
 )
 
 func NewTxError(msg string, err error, logCtx ...interface{}) error {
-	return common.NewBasicError(ErrTx, err,
+	return serrors.Wrap(ErrTx, err,
 		append([]interface{}{"detailMsg", msg}, logCtx...)...)
 }
 
 func NewInputDataError(msg string, err error, logCtx ...interface{}) error {
-	return common.NewBasicError(ErrInvalidInputData, err,
+	return serrors.Wrap(ErrInvalidInputData, err,
 		append([]interface{}{"detailMsg", msg}, logCtx...)...)
 }
 
 func NewDataError(msg string, err error, logCtx ...interface{}) error {
-	return common.NewBasicError(ErrDataInvalid, err,
+	return serrors.Wrap(ErrDataInvalid, err,
 		append([]interface{}{"detailMsg", msg}, logCtx...)...)
 }
 
 func NewReadError(msg string, err error, logCtx ...interface{}) error {
-	return common.NewBasicError(ErrReadFailed, err,
+	return serrors.Wrap(ErrReadFailed, err,
 		append([]interface{}{"detailMsg", msg}, logCtx...)...)
 }
 
 func NewWriteError(msg string, err error, logCtx ...interface{}) error {
-	return common.NewBasicError(ErrWriteFailed, err,
+	return serrors.Wrap(ErrWriteFailed, err,
 		append([]interface{}{"detailMsg", msg}, logCtx...)...)
 }

--- a/go/lib/infra/modules/db/errors.go
+++ b/go/lib/infra/modules/db/errors.go
@@ -19,34 +19,39 @@ import (
 )
 
 const (
-	InputDataErrMsg = "db: input data invalid"
-	DataErrMsg      = "db: db data invalid"
-	ReadErrMsg      = "db: read failed"
-	WriteErrMsg     = "db: write failed"
-	TxErrMsg        = "db: transaction error"
+	// ErrInvalidInputData indicates invalid data was tried to input in the DB.
+	ErrInvalidInputData common.ErrMsg = "db: input data invalid"
+	// ErrDataInvalid indicates invalid data is stored in the DB.
+	ErrDataInvalid common.ErrMsg = "db: db data invalid"
+	// ErrReadFailed indicates that reading from the DB failed.
+	ErrReadFailed common.ErrMsg = "db: read failed"
+	// ErrWriteFailed indicates that writing to the DB failed.
+	ErrWriteFailed common.ErrMsg = "db: write failed"
+	// ErrTx indicates a transaction error.
+	ErrTx common.ErrMsg = "db: transaction error"
 )
 
 func NewTxError(msg string, err error, logCtx ...interface{}) error {
-	return common.NewBasicError(TxErrMsg, err,
+	return common.NewBasicError(ErrTx, err,
 		append([]interface{}{"detailMsg", msg}, logCtx...)...)
 }
 
 func NewInputDataError(msg string, err error, logCtx ...interface{}) error {
-	return common.NewBasicError(InputDataErrMsg, err,
+	return common.NewBasicError(ErrInvalidInputData, err,
 		append([]interface{}{"detailMsg", msg}, logCtx...)...)
 }
 
 func NewDataError(msg string, err error, logCtx ...interface{}) error {
-	return common.NewBasicError(DataErrMsg, err,
+	return common.NewBasicError(ErrDataInvalid, err,
 		append([]interface{}{"detailMsg", msg}, logCtx...)...)
 }
 
 func NewReadError(msg string, err error, logCtx ...interface{}) error {
-	return common.NewBasicError(ReadErrMsg, err,
+	return common.NewBasicError(ErrReadFailed, err,
 		append([]interface{}{"detailMsg", msg}, logCtx...)...)
 }
 
 func NewWriteError(msg string, err error, logCtx ...interface{}) error {
-	return common.NewBasicError(WriteErrMsg, err,
+	return common.NewBasicError(ErrWriteFailed, err,
 		append([]interface{}{"detailMsg", msg}, logCtx...)...)
 }

--- a/go/lib/infra/modules/db/errors_test.go
+++ b/go/lib/infra/modules/db/errors_test.go
@@ -26,23 +26,23 @@ func TestErrFmt(t *testing.T) {
 	}{
 		{
 			Err:      NewTxError("test", nil),
-			Expected: fmt.Sprintf("%s detailMsg=\"test\"", TxErrMsg),
+			Expected: fmt.Sprintf("%s detailMsg=\"test\"", ErrTx),
 		},
 		{
 			Err:      NewInputDataError("test", nil),
-			Expected: fmt.Sprintf("%s detailMsg=\"test\"", InputDataErrMsg),
+			Expected: fmt.Sprintf("%s detailMsg=\"test\"", ErrInvalidInputData),
 		},
 		{
 			Err:      NewDataError("test", nil),
-			Expected: fmt.Sprintf("%s detailMsg=\"test\"", DataErrMsg),
+			Expected: fmt.Sprintf("%s detailMsg=\"test\"", ErrDataInvalid),
 		},
 		{
 			Err:      NewReadError("test", nil),
-			Expected: fmt.Sprintf("%s detailMsg=\"test\"", ReadErrMsg),
+			Expected: fmt.Sprintf("%s detailMsg=\"test\"", ErrReadFailed),
 		},
 		{
 			Err:      NewWriteError("test", nil),
-			Expected: fmt.Sprintf("%s detailMsg=\"test\"", WriteErrMsg),
+			Expected: fmt.Sprintf("%s detailMsg=\"test\"", ErrWriteFailed),
 		},
 	}
 	for _, test := range tests {

--- a/go/lib/infra/modules/db/metrics.go
+++ b/go/lib/infra/modules/db/metrics.go
@@ -15,6 +15,8 @@
 package db
 
 import (
+	"golang.org/x/xerrors"
+
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/prom"
 )
@@ -26,23 +28,17 @@ func ErrToMetricLabel(err error) string {
 		return prom.Success
 	case common.IsTimeoutErr(err):
 		return prom.ErrTimeout
+	case xerrors.Is(err, ErrInvalidInputData):
+		return "input_data_invalid"
+	case xerrors.Is(err, ErrDataInvalid):
+		return "db_data_invalid"
+	case xerrors.Is(err, ErrReadFailed):
+		return "db_read"
+	case xerrors.Is(err, ErrWriteFailed):
+		return "db_write"
+	case xerrors.Is(err, ErrTx):
+		return "db_transaction"
 	default:
-		if msg := common.GetErrorMsg(err); msg != "" {
-			switch msg {
-			case InputDataErrMsg:
-				return "input_data_invalid"
-			case DataErrMsg:
-				return "db_data_invalid"
-			case ReadErrMsg:
-				return "db_read"
-			case WriteErrMsg:
-				return "db_write"
-			case TxErrMsg:
-				return "db_transaction"
-			default:
-				return msg
-			}
-		}
-		return prom.ErrNotClassified
+		return err.Error()
 	}
 }

--- a/go/lib/infra/modules/trust/BUILD.bazel
+++ b/go/lib/infra/modules/trust/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//go/lib/util:go_default_library",
         "//go/proto:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/go/lib/infra/modules/trust/BUILD.bazel
+++ b/go/lib/infra/modules/trust/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//go/lib/scrypto:go_default_library",
         "//go/lib/scrypto/cert:go_default_library",
         "//go/lib/scrypto/trc:go_default_library",
+        "//go/lib/serrors:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/topology:go_default_library",
         "//go/lib/util:go_default_library",

--- a/go/lib/infra/modules/trust/helpers.go
+++ b/go/lib/infra/modules/trust/helpers.go
@@ -84,7 +84,7 @@ func VerifyChain(ctx context.Context, subject addr.IA, chain *cert.Chain,
 			return common.NewBasicError("Unable to verify chain", err)
 		}
 		if chain.Issuer.TRCVersion <= graceTrc.Version &&
-			xerrors.Is(err, cert.IssCertInvalid) {
+			xerrors.Is(err, cert.ErrIssCertInvalid) {
 
 			if errG := chain.Verify(subject, graceTrc); errG != nil {
 				return common.NewBasicError("Unable to verify chain", err, "errGraceTRC", errG)

--- a/go/lib/infra/modules/trust/helpers.go
+++ b/go/lib/infra/modules/trust/helpers.go
@@ -18,6 +18,8 @@ package trust
 import (
 	"context"
 
+	"golang.org/x/xerrors"
+
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl"
@@ -82,7 +84,7 @@ func VerifyChain(ctx context.Context, subject addr.IA, chain *cert.Chain,
 			return common.NewBasicError("Unable to verify chain", err)
 		}
 		if chain.Issuer.TRCVersion <= graceTrc.Version &&
-			common.GetErrorMsg(err) == cert.IssCertInvalid {
+			xerrors.Is(err, cert.IssCertInvalid) {
 
 			if errG := chain.Verify(subject, graceTrc); errG != nil {
 				return common.NewBasicError("Unable to verify chain", err, "errGraceTRC", errG)

--- a/go/lib/infra/modules/trust/trust.go
+++ b/go/lib/infra/modules/trust/trust.go
@@ -438,9 +438,9 @@ func (store *Store) LoadAuthoritativeTRC(dir string) error {
 	opts := infra.TRCOpts{TrustStoreOpts: infra.TrustStoreOpts{LocalOnly: true}}
 	dbTRC, err := store.getTRC(ctx, store.ia.I, scrypto.Version(scrypto.LatestVer), opts, nil)
 	switch {
-	case err != nil && xerrors.Is(err, ErrNotFoundLocally):
+	case err != nil && !xerrors.Is(err, ErrNotFoundLocally):
 		// Unexpected error in trust store
-		return common.NewBasicError("Failed to TRC from store", err)
+		return common.NewBasicError("Failed to load TRC from store", err)
 	case xerrors.Is(err, ErrNotFoundLocally) && fileTRC == nil:
 		return common.NewBasicError("No TRC found on disk or in trustdb", nil)
 	case xerrors.Is(err, ErrNotFoundLocally) && fileTRC != nil:
@@ -493,7 +493,7 @@ func (store *Store) LoadAuthoritativeChain(dir string) error {
 	opts := infra.ChainOpts{TrustStoreOpts: infra.TrustStoreOpts{LocalOnly: true}}
 	chain, err := store.getChain(ctx, store.ia, scrypto.Version(scrypto.LatestVer), opts, nil)
 	switch {
-	case err != nil && xerrors.Is(err, ErrMissingAuthoritative):
+	case err != nil && !xerrors.Is(err, ErrMissingAuthoritative):
 		// Unexpected error in trust store
 		return err
 	case xerrors.Is(err, ErrMissingAuthoritative) && fileChain == nil:

--- a/go/lib/scrypto/cert/BUILD.bazel
+++ b/go/lib/scrypto/cert/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//go/lib/common:go_default_library",
         "//go/lib/scrypto:go_default_library",
         "//go/lib/scrypto/trc:go_default_library",
+        "//go/lib/serrors:go_default_library",
         "//go/lib/util:go_default_library",
         "@com_github_pierrec_lz4//:go_default_library",
     ],

--- a/go/lib/scrypto/cert/chain.go
+++ b/go/lib/scrypto/cert/chain.go
@@ -42,12 +42,12 @@ const (
 	DefaultIssuerCertValidity = 7 * 24 * 60 * 60
 
 	// Error strings
-	IssCertInvalid   = "Issuer certificate invalid"
-	IssExpiresAfter  = "Issuer certificate expires after TRC"
-	IssASNotFound    = "Issuing AS not found"
-	LeafCertInvalid  = "Leaf certificate invalid"
-	LeafExpiresAfter = "Leaf certificate expires after issuer certificate"
-	LeafIssuedBefore = "Leaf certificate issued before issuer certificate"
+	IssCertInvalid   common.ErrMsg = "Issuer certificate invalid"
+	IssExpiresAfter                = "Issuer certificate expires after TRC"
+	IssASNotFound                  = "Issuing AS not found"
+	LeafCertInvalid                = "Leaf certificate invalid"
+	LeafExpiresAfter               = "Leaf certificate expires after issuer certificate"
+	LeafIssuedBefore               = "Leaf certificate issued before issuer certificate"
 )
 
 type Key struct {

--- a/go/lib/serrors/errors.go
+++ b/go/lib/serrors/errors.go
@@ -136,8 +136,7 @@ func WrapStr(msg string, cause error, logCtx ...interface{}) error {
 	}
 }
 
-// New creates a new error with the given message and context. If no context is
-// used prefer using the standard libs New function.
+// New creates a new error with the given message and context.
 func New(msg string, logCtx ...interface{}) error {
 	if len(logCtx) == 0 {
 		return errors.New(msg)

--- a/go/lib/spath/BUILD.bazel
+++ b/go/lib/spath/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
+        "//go/lib/serrors:go_default_library",
         "//go/lib/util:go_default_library",
     ],
 )

--- a/go/lib/spath/hop.go
+++ b/go/lib/spath/hop.go
@@ -27,11 +27,12 @@ import (
 )
 
 const (
+	ErrorHopFTooShort common.ErrMsg = "HopF too short"
+	ErrorHopFBadMac   common.ErrMsg = "Bad HopF MAC"
+
 	HopFieldLength    = common.LineLen
 	DefaultHopFExpiry = ExpTimeType(63)
 	MacLen            = 3
-	ErrorHopFTooShort = "HopF too short"
-	ErrorHopFBadMac   = "Bad HopF MAC"
 	XoverMask         = 0x01
 	VerifyOnlyMask    = 0x02
 	MaxTTL            = 24 * 60 * 60 // One day in seconds


### PR DESCRIPTION
Those checks are dangerous since a refactor could easily break them.
Using xerrors.Is instead is safer against refactors.

Contributes #3042

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3172)
<!-- Reviewable:end -->
