### PR TITLE
bs: return stats when insert beacon in db

### DIFF
--- a/go/beacon_srv/internal/beacon/db.go
+++ b/go/beacon_srv/internal/beacon/db.go
@@ -56,9 +56,15 @@ type DBRead interface {
 	AllRevocations(ctx context.Context) (<-chan RevocationOrErr, error)
 }
 
+// InsertStats provides statistics about an insertion.
+type InsertStats struct {
+	Inserted int
+	Updated  int
+}
+
 // DBWrite defines all write operations of the beacon DB.
 type DBWrite interface {
-	InsertBeacon(ctx context.Context, beacon Beacon, usage Usage) (int, error)
+	InsertBeacon(ctx context.Context, beacon Beacon, usage Usage) (InsertStats, error)
 	DeleteExpiredBeacons(ctx context.Context, now time.Time) (int, error)
 	DeleteRevokedBeacons(ctx context.Context, now time.Time) (int, error)
 	InsertRevocation(ctx context.Context, revocation *path_mgmt.SignedRevInfo) error

--- a/go/beacon_srv/internal/beacon/metrics.go
+++ b/go/beacon_srv/internal/beacon/metrics.go
@@ -193,8 +193,9 @@ func (e *executor) AllRevocations(ctx context.Context) (<-chan RevocationOrErr, 
 	return ret, err
 }
 
-func (e *executor) InsertBeacon(ctx context.Context, beacon Beacon, usage Usage) (int, error) {
-	var ret int
+func (e *executor) InsertBeacon(ctx context.Context, beacon Beacon,
+	usage Usage) (InsertStats, error) {
+	var ret InsertStats
 	var err error
 	e.metrics.Observe(ctx, "insert_beacon", func(ctx context.Context) error {
 		ret, err = e.db.InsertBeacon(ctx, beacon, usage)

--- a/go/beacon_srv/internal/beacon/mock_beacon/beacon.go
+++ b/go/beacon_srv/internal/beacon/mock_beacon/beacon.go
@@ -173,10 +173,10 @@ func (mr *MockDBMockRecorder) DeleteRevokedBeacons(arg0, arg1 interface{}) *gomo
 }
 
 // InsertBeacon mocks base method
-func (m *MockDB) InsertBeacon(arg0 context.Context, arg1 beacon.Beacon, arg2 beacon.Usage) (int, error) {
+func (m *MockDB) InsertBeacon(arg0 context.Context, arg1 beacon.Beacon, arg2 beacon.Usage) (beacon.InsertStats, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertBeacon", arg0, arg1, arg2)
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].(beacon.InsertStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -367,10 +367,10 @@ func (mr *MockTransactionMockRecorder) DeleteRevokedBeacons(arg0, arg1 interface
 }
 
 // InsertBeacon mocks base method
-func (m *MockTransaction) InsertBeacon(arg0 context.Context, arg1 beacon.Beacon, arg2 beacon.Usage) (int, error) {
+func (m *MockTransaction) InsertBeacon(arg0 context.Context, arg1 beacon.Beacon, arg2 beacon.Usage) (beacon.InsertStats, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InsertBeacon", arg0, arg1, arg2)
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].(beacon.InsertStats)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
In order to expose in metrics the result `ok_new` or `ok_update` when we have received a beacon,
the insert function to the db must return back this information.

Contributes #3104

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3182)
<!-- Reviewable:end -->
