### PR TITLE
Fix metric names for consistency

### DIFF
--- a/go/beacon_srv/internal/metrics/keepalive.go
+++ b/go/beacon_srv/internal/metrics/keepalive.go
@@ -47,9 +47,9 @@ func newKeepalive() exporter {
 	labels := KeepaliveLabels{}.Labels()
 
 	return exporter{
-		out: *prom.NewCounterVec(Namespace, sub, "transmit_msgs_total",
-			"Total number of transmitted keepalive msgs.", labels),
-		in: *prom.NewCounterVec(Namespace, sub, "receive_msgs_total",
+		out: *prom.NewCounterVec(Namespace, sub, "sent_msgs_total",
+			"Total number of sent keepalive msgs.", labels),
+		in: *prom.NewCounterVec(Namespace, sub, "received_msgs_total",
 			"Total number of received keepalive msgs.", labels),
 	}
 

--- a/go/beacon_srv/internal/metrics/revocation.go
+++ b/go/beacon_srv/internal/metrics/revocation.go
@@ -43,7 +43,7 @@ func newRevocation() exporterR {
 	labels := RevocationLabels{}.Labels()
 
 	return exporterR{
-		in: *prom.NewCounterVec(Namespace, sub, "received_revocation_total",
+		in: *prom.NewCounterVec(Namespace, sub, "received_revocations_total",
 			"Total number of received revocation msgs.", labels),
 	}
 


### PR DESCRIPTION
We're standardising on sent+received in metric names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3191)
<!-- Reviewable:end -->
