### PR TITLE
Fix circular lookup when AS cert not found.

### DIFF
--- a/go/lib/infra/modules/trust/internal/metrics/metrics.go
+++ b/go/lib/infra/modules/trust/internal/metrics/metrics.go
@@ -41,15 +41,16 @@ const (
 	OkExists    = "ok_exists"
 	OkInserted  = "ok_inserted"
 
-	ErrDB       = prom.ErrDB
-	ErrDenied   = "err_denied"
-	ErrInternal = prom.ErrInternal
-	ErrTransmit = "err_transmit"
-	ErrTimeout  = prom.ErrTimeout
-	ErrValidate = prom.ErrValidate
-	ErrVerify   = prom.ErrVerify
-	ErrTRC      = "err_trc"
-	ErrNotFound = "err_not_found"
+	ErrDB           = prom.ErrDB
+	ErrDenied       = "err_denied"
+	ErrInternal     = prom.ErrInternal
+	ErrTransmit     = "err_transmit"
+	ErrTimeout      = prom.ErrTimeout
+	ErrValidate     = prom.ErrValidate
+	ErrVerify       = prom.ErrVerify
+	ErrTRC          = "err_trc"
+	ErrNotFound     = "err_not_found"
+	ErrNotFoundAuth = "err_not_found_auth"
 )
 
 var (

--- a/go/lib/scrypto/version.go
+++ b/go/lib/scrypto/version.go
@@ -30,6 +30,11 @@ var _ json.Marshaler = (*Version)(nil)
 // marshalled/unmarshalled to/from LatestVer.
 type Version uint64
 
+// IsLatest checks if the value is LatestVer
+func (v Version) IsLatest() bool {
+	return uint64(v) == LatestVer
+}
+
 // UnmarshalJSON checks that the value is not LatestVer.
 func (v *Version) UnmarshalJSON(b []byte) error {
 	parsed, err := strconv.ParseUint(string(b), 10, 64)


### PR DESCRIPTION
Fixes https://github.com/scionproto/scion/issues/3194

This also changes the logic for determining if the trust store is
authoritative or not for a given query. The rules are:
- A CS is authoritative for its own certs for its own AS.
- A core CS is authoritative for all AS certs in the local ISD.
- A core CS is authoritative for TRCs for the local ISD.

Also:
- Make logging/errors a bit more consistent/useful in getChain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3197)
<!-- Reviewable:end -->
