### PR TITLE
README: https clone, not recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,9 @@ Necessary steps in order to run SCION:
    ```bash
    mkdir -p "$GOPATH/src/github.com/scionproto"
    cd "$GOPATH/src/github.com/scionproto"
-   git clone --recursive git@github.com:scionproto/scion
+   git clone https://github.com:scionproto/scion
    cd scion
    ```
-
-   If you don't have a github account, or haven't setup ssh access to it, this
-   command will make git use https instead:
-   `git config --global url.https://github.com/.insteadOf git@github.com:`
 
 1. Install required packages with dependencies:
 


### PR DESCRIPTION
Using `--recursive` and SSH no longer necessary when cloning because there are no more submodules.
Instruct to use https, because it's simpler -- no instructions about `.insteadOf` necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3205)
<!-- Reviewable:end -->
