### PR TITLE
Segfetcher: Make NextQuery dependent on segments 

### DIFF
--- a/.buildkite/acceptance-pipeline.sh
+++ b/.buildkite/acceptance-pipeline.sh
@@ -43,7 +43,7 @@ for test in ./acceptance/sig_short_*_acceptance; do
         echo "  - $BASE/run_step run_acceptance $name"
     fi
     echo "  timeout_in_minutes: 10"
-    echo "  parallelism: 20"
+    echo "  parallelism: 10"
     echo "  retry:"
     echo "    automatic:"
     echo "      - exit_status: 5"   # Pull failed

--- a/.buildkite/acceptance-pipeline.sh
+++ b/.buildkite/acceptance-pipeline.sh
@@ -43,7 +43,7 @@ for test in ./acceptance/sig_short_*_acceptance; do
         echo "  - $BASE/run_step run_acceptance $name"
     fi
     echo "  timeout_in_minutes: 10"
-    echo "  parallelism: 10"
+    echo "  parallelism: 20"
     echo "  retry:"
     echo "    automatic:"
     echo "      - exit_status: 5"   # Pull failed

--- a/.buildkite/acceptance-pipeline.sh
+++ b/.buildkite/acceptance-pipeline.sh
@@ -16,7 +16,7 @@ fi
 
 host_acceptance="br_multi br_child br_parent br_peer br_core_multi br_core_childIf br_core_coreIf"
 
-for test in ./acceptance/*_acceptance; do
+for test in ./acceptance/sig_short_*_acceptance; do
     name="$(basename ${test%_acceptance})"
     if [[ ! "$name" =~ "$ACCEPTANCE_TEST" ]]; then
         continue
@@ -43,6 +43,7 @@ for test in ./acceptance/*_acceptance; do
         echo "  - $BASE/run_step run_acceptance $name"
     fi
     echo "  timeout_in_minutes: 10"
+    echo "  parallelism: 10"
     echo "  retry:"
     echo "    automatic:"
     echo "      - exit_status: 5"   # Pull failed

--- a/.buildkite/acceptance-pipeline.sh
+++ b/.buildkite/acceptance-pipeline.sh
@@ -16,7 +16,7 @@ fi
 
 host_acceptance="br_multi br_child br_parent br_peer br_core_multi br_core_childIf br_core_coreIf"
 
-for test in ./acceptance/sig_short_*_acceptance; do
+for test in ./acceptance/*_acceptance; do
     name="$(basename ${test%_acceptance})"
     if [[ ! "$name" =~ "$ACCEPTANCE_TEST" ]]; then
         continue
@@ -43,7 +43,6 @@ for test in ./acceptance/sig_short_*_acceptance; do
         echo "  - $BASE/run_step run_acceptance $name"
     fi
     echo "  timeout_in_minutes: 10"
-    echo "  parallelism: 10"
     echo "  retry:"
     echo "    automatic:"
     echo "      - exit_status: 5"   # Pull failed

--- a/acceptance/sig_short_exp_time_acceptance/test
+++ b/acceptance/sig_short_exp_time_acceptance/test
@@ -67,7 +67,6 @@ class TestSetup(Base):
 
         self.scion.topology('topology/Tiny.topo', '--sig', '-t', '-n', '242.254.0.0/16')
         self.set_bs_policies()
-        self.set_sd_policies()
         self.scion.run()
         if not self.no_docker:
             self.tools_dc('start', 'tester*')
@@ -85,12 +84,6 @@ class TestSetup(Base):
             }, [path])
             with open(os.path.join(path.dirname, 'policy.yml'), 'w') as outfile:
                 yaml.dump({'MaxExpTime': 0}, outfile, default_flow_style=False)
-
-    def set_sd_policies(self):
-        for path in local.path('gen') // 'ISD*/AS*/endhost/sd.toml':
-            self.scion.set_configs({
-                'sd.QueryInterval': "1m",
-            }, [path])
 
 
 @Test.subcommand("run")

--- a/go/lib/infra/modules/seghandler/result.go
+++ b/go/lib/infra/modules/seghandler/result.go
@@ -20,8 +20,8 @@ import "github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 type Stats struct {
 	// SegDB contains stats about segment insertions/updates.
 	SegDB SegStats
-	// VerifiedSegs indicates the amount of successfully verified segments.
-	VerifiedSegs int
+	// VerifiedSegs contains all segments that were successfully verified.
+	VerifiedSegs []*SegWithHP
 	// StoredRevs contains all revocations that were verified and stored.
 	StoredRevs []*path_mgmt.SignedRevInfo
 	// VerifiedRevs contains all revocations that were verified.

--- a/go/lib/infra/modules/seghandler/seghandler.go
+++ b/go/lib/infra/modules/seghandler/seghandler.go
@@ -123,7 +123,10 @@ func (h *Handler) storeResults(ctx context.Context, verifiedUnits []segverifier.
 				Seg:     unit.Unit.SegMeta,
 				HPGroup: hpGroupID,
 			})
-			stats.VerifiedSegs++
+			stats.VerifiedSegs = append(stats.VerifiedSegs, &SegWithHP{
+				Seg:     unit.Unit.SegMeta,
+				HPGroup: hpGroupID,
+			})
 		}
 		for idx, rev := range unit.Unit.SRevInfos {
 			if err, ok := unit.Errors[idx]; ok {

--- a/go/lib/infra/modules/seghandler/seghandler_test.go
+++ b/go/lib/infra/modules/seghandler/seghandler_test.go
@@ -63,7 +63,7 @@ func TestReplyHandlerEmptyReply(t *testing.T) {
 	assert.NoError(t, r.Err())
 	assert.Nil(t, r.VerificationErrors())
 	stats := r.Stats()
-	assert.Zero(t, stats.VerifiedSegs)
+	assert.Zero(t, len(stats.VerifiedSegs))
 	assert.Zero(t, stats.SegDB.Total())
 	assert.Empty(t, stats.VerifiedRevs)
 	assert.Empty(t, stats.StoredRevs)
@@ -124,7 +124,7 @@ func TestReplyHandlerErrors(t *testing.T) {
 	assert.NoError(t, r.Err())
 	assert.Len(t, r.VerificationErrors(), len(verifyErrs))
 	stats := r.Stats()
-	assert.Zero(t, stats.VerifiedSegs)
+	assert.Zero(t, len(stats.VerifiedSegs))
 	assert.Zero(t, stats.SegDB.Total())
 	assert.Empty(t, stats.VerifiedRevs)
 	assert.Empty(t, stats.StoredRevs)
@@ -193,7 +193,7 @@ func TestReplyHandlerNoErrors(t *testing.T) {
 	assert.NoError(t, r.Err())
 	assert.Nil(t, r.VerificationErrors())
 	stats := r.Stats()
-	assert.Equal(t, 3, stats.VerifiedSegs)
+	assert.Equal(t, 3, len(stats.VerifiedSegs))
 	assert.Equal(t, 3, stats.SegDB.Total())
 	expectedRevs := []*path_mgmt.SignedRevInfo{rev1}
 	assert.ElementsMatch(t, expectedRevs, stats.VerifiedRevs)
@@ -248,7 +248,7 @@ func TestReplyHandlerAllVerifiedInEarlyInterval(t *testing.T) {
 	assert.NoError(t, r.Err())
 	assert.Nil(t, r.VerificationErrors())
 	stats := r.Stats()
-	assert.Equal(t, 2, stats.VerifiedSegs)
+	assert.Equal(t, 2, len(stats.VerifiedSegs))
 	assert.Equal(t, 2, stats.SegDB.Total())
 	expectedRevs := []*path_mgmt.SignedRevInfo{rev1}
 	assert.ElementsMatch(t, expectedRevs, stats.VerifiedRevs)
@@ -309,7 +309,7 @@ func TestReplyHandlerEarlyTriggerStorageError(t *testing.T) {
 	assert.Nil(t, r.VerificationErrors())
 
 	stats := r.Stats()
-	assert.Equal(t, 2, stats.VerifiedSegs)
+	assert.Equal(t, 2, len(stats.VerifiedSegs))
 	assert.Equal(t, 2, stats.SegDB.Total())
 	expectedRevs := []*path_mgmt.SignedRevInfo{rev1}
 	assert.ElementsMatch(t, expectedRevs, stats.VerifiedRevs)
@@ -361,7 +361,7 @@ func TestReplyHandlerStorageError(t *testing.T) {
 	assert.Error(t, r.Err())
 	assert.Nil(t, r.VerificationErrors())
 	stats := r.Stats()
-	assert.Equal(t, 2, stats.VerifiedSegs)
+	assert.Equal(t, 2, len(stats.VerifiedSegs))
 	assert.Zero(t, stats.SegDB.Total())
 	assert.Empty(t, stats.VerifiedRevs)
 	assert.Empty(t, stats.StoredRevs)


### PR DESCRIPTION
With this PR, the next query is dependent on the verified segments.
The next query interval is at least minQueryInterval and at most
the configured query interval.

However, if only segments are found where the time until segment
expiration minus the `expirationLeadTime` (2 minutes) are found that are
less than the configured query interval, then that is chosen.

I.e. the query interval is:
````
maxExpirationDiff = max(seg.Exp().Add(-expirationLeadTime).Sub(now))
min(max(minQueryInterval, maxExpirationDiff), QueryInterval)
````

fixes #2979

Also, revert band-aid fix introduced by #3089


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3208)
<!-- Reviewable:end -->
