### PR TITLE
acceptance: Increase reconnect wait time

### DIFF
--- a/acceptance/reconnecting_acceptance/test
+++ b/acceptance/reconnecting_acceptance/test
@@ -23,7 +23,7 @@ test_run() {
     ./tools/dc stop scion_disp_1-ff00_0_112 scion_disp_1-ff00_0_110
     ./tools/dc start scion_disp_1-ff00_0_112 scion_disp_1-ff00_0_110
     sqlite3 gen-cache/sd1-ff00_0_112.path.db "delete from NextQuery;"
-    sleep 5
+    sleep 15
     bin/end2end_integration -src 1-ff00:0:112 -dst 1-ff00:0:110 -attempts 5 -d
 }
 


### PR DESCRIPTION
The test implicitly checks that the link between as 1-ff00:0:112 and
1-ff00:0:110 is not broken.
It BS does not reconnect withing 3 seconds, the link is revoked.

Increase the sleep to 15 seconds to ensure the revocation has passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3212)
<!-- Reviewable:end -->
