### PR TITLE
TrustStore: Fix flaky unit test

### DIFF
--- a/go/lib/infra/modules/trust/v2/provider_test.go
+++ b/go/lib/infra/modules/trust/v2/provider_test.go
@@ -133,7 +133,9 @@ func TestCryptoProviderGetTRC(t *testing.T) {
 				info := trust.TRCInfo{
 					Version:     dec.TRC.Version + 1,
 					GracePeriod: time.Second,
-					Validity:    scrypto.Validity{NotBefore: dec.TRC.Validity.NotBefore},
+					Validity: scrypto.Validity{
+						NotBefore: util.UnixTime{Time: time.Now().Add(-2 * time.Second)},
+					},
 				}
 				m.DB.EXPECT().GetRawTRC(gomock.Any(), dec.TRC.ISD, dec.TRC.Version).Return(
 					dec.Raw, nil,


### PR DESCRIPTION
The "TRC in database, outside graceperiod" test could fail when the
crypto material was generated less than a second before the test is run.

This change makes sure the test is no longer time dependent.

fixes #3214

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3216)
<!-- Reviewable:end -->
