### PR TITLE
TrustStore: Implement recurser

### DIFF
--- a/go/lib/infra/modules/trust/v2/BUILD.bazel
+++ b/go/lib/infra/modules/trust/v2/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//go/lib/scrypto:go_default_library",
         "//go/lib/scrypto/trc/v2:go_default_library",
         "//go/lib/serrors:go_default_library",
+        "//go/lib/snet:go_default_library",
         "@org_golang_x_xerrors//:go_default_library",
     ],
 )
@@ -33,6 +34,7 @@ go_test(
         "export_test.go",
         "main_test.go",
         "provider_test.go",
+        "recurser_test.go",
         "resolver_test.go",
     ],
     data = [
@@ -48,6 +50,7 @@ go_test(
         "//go/lib/scrypto:go_default_library",
         "//go/lib/scrypto/trc/v2:go_default_library",
         "//go/lib/serrors:go_default_library",
+        "//go/lib/snet:go_default_library",
         "//go/lib/util:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",

--- a/go/lib/infra/modules/trust/v2/recurser_test.go
+++ b/go/lib/infra/modules/trust/v2/recurser_test.go
@@ -1,0 +1,85 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trust_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/v2"
+	"github.com/scionproto/scion/go/lib/snet"
+)
+
+func TestASLocalRecurserAllowRecursion(t *testing.T) {
+	tests := map[string]struct {
+		Addr      net.Addr
+		Assertion assert.ErrorAssertionFunc
+	}{
+		"host local": {
+			Assertion: assert.NoError,
+		},
+		"AS local": {
+			Addr:      &snet.Addr{IA: ia110},
+			Assertion: assert.NoError,
+		},
+		"remote AS": {
+			Addr:      &snet.Addr{IA: ia120},
+			Assertion: assert.Error,
+		},
+		"invalid Address": {
+			Addr:      &net.IPAddr{IP: net.IP{127, 0, 0, 1}},
+			Assertion: assert.Error,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := trust.ASLocalRecurser{IA: ia110}
+			err := r.AllowRecursion(test.Addr)
+			test.Assertion(t, err)
+		})
+	}
+}
+
+func TestLocalOnlyRecurserAllowRecursion(t *testing.T) {
+	tests := map[string]struct {
+		Addr      net.Addr
+		Assertion assert.ErrorAssertionFunc
+	}{
+		"host local": {
+			Assertion: assert.NoError,
+		},
+		"AS local": {
+			Addr:      &snet.Addr{IA: ia110},
+			Assertion: assert.Error,
+		},
+		"remote AS": {
+			Addr:      &snet.Addr{IA: ia120},
+			Assertion: assert.Error,
+		},
+		"invalid Address": {
+			Addr:      &net.IPAddr{IP: net.IP{127, 0, 0, 1}},
+			Assertion: assert.Error,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := trust.LocalOnlyRecurser{}
+			err := r.AllowRecursion(test.Addr)
+			test.Assertion(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Adds:
- Recurser that decides whether recursion is allowed for a given client.
  - ASLocalRecurser allows all clients in the local AS.
  - LocalOnlyRecurser allows only the local application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3222)
<!-- Reviewable:end -->
