### PR TITLE
TrustStore: Implement inserter

### DIFF
--- a/go/lib/infra/modules/trust/v2/BUILD.bazel
+++ b/go/lib/infra/modules/trust/v2/BUILD.bazel
@@ -32,11 +32,13 @@ go_test(
     name = "go_default_test",
     srcs = [
         "export_test.go",
+        "inserter_test.go",
         "inspector_test.go",
         "main_test.go",
         "provider_test.go",
         "recurser_test.go",
         "resolver_test.go",
+        "router_test.go",
     ],
     data = [
         "//go/lib/infra/modules/trust/v2/testdata:crypto_tar",
@@ -44,6 +46,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
         "//go/lib/infra:go_default_library",
         "//go/lib/infra/modules/trust/v2/internal/decoded:go_default_library",
         "//go/lib/infra/modules/trust/v2/mock_v2:go_default_library",
@@ -52,6 +55,8 @@ go_test(
         "//go/lib/scrypto/trc/v2:go_default_library",
         "//go/lib/serrors:go_default_library",
         "//go/lib/snet:go_default_library",
+        "//go/lib/snet/mock_snet:go_default_library",
+        "//go/lib/spath:go_default_library",
         "//go/lib/util:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",

--- a/go/lib/infra/modules/trust/v2/export_test.go
+++ b/go/lib/infra/modules/trust/v2/export_test.go
@@ -14,13 +14,30 @@
 
 package trust
 
+import (
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/snet"
+)
+
 var (
 	// NewCryptoProvider allows instantiating the private cryptoProvider for
 	// black-box testing.
 	NewCryptoProvider = newTestCryptoProvider
-	// newTestInspector allows instantiating the private inspector for
-	// black-box testing.
+	// NewCSRouter allows instantiating the private CS router for black-box
+	// testing.
+	NewCSRouter = newTestCSRouter
+	// NewFwdInserter allows instantiating the private forwarding
+	// inserter for black-box testing.
+	NewFwdInserter = newTestFwdInserter
+	// NewInserter allows instantiating the private inserter for black-box
+	// testing.
+	NewInserter = newTestInserter
+	// NewTestInspector allows instantiating the private inspector for black-box
+	// testing.
 	NewTestInspector = newTestInspector
+	// NewLocalRouter allows instantiating the private resolver for black-box
+	// testing.
+	NewLocalRouter = newTestLocalRouter
 	// NewResolver allows instantiating the private resolver for black-box
 	// testing.
 	NewResolver = newTestResolver
@@ -39,11 +56,45 @@ func newTestCryptoProvider(db DBRead, recurser Recurser, resolver Resolver, rout
 	}
 }
 
+// newTestCSRouter returns a new router for testing.
+func newTestCSRouter(isd addr.ISD, router snet.Router, db TRCRead) Router {
+	return &csRouter{
+		isd:    isd,
+		router: router,
+		db:     db,
+	}
+}
+
+// newTestFwdInserter returns a new forwarding inserter for testing.
+func newTestFwdInserter(db ReadWrite, rpc RPC) Inserter {
+	return &fwdInserter{
+		baseInserter: baseInserter{
+			db: db,
+		},
+		rpc: rpc,
+	}
+}
+
+// newTestInserter returns a new inserter for testing.
+func newTestInserter(db ReadWrite, unsafe bool) Inserter {
+	return &inserter{
+		baseInserter: baseInserter{
+			db:     db,
+			unsafe: unsafe,
+		},
+	}
+}
+
 // newTestInspector returns a new inspector for testing.
 func newTestInspector(provider CryptoProvider) Inspector {
 	return &inspector{
 		provider: provider,
 	}
+}
+
+// newTestLocalRouter returns a new router for testing.
+func newTestLocalRouter(ia addr.IA) Router {
+	return &localRouter{ia: ia}
 }
 
 // newTestResolver returns a new resolver for testing.

--- a/go/lib/infra/modules/trust/v2/inserter_test.go
+++ b/go/lib/infra/modules/trust/v2/inserter_test.go
@@ -1,0 +1,100 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trust_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/v2"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/v2/internal/decoded"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/v2/mock_v2"
+)
+
+func TestInserterInsertTRC(t *testing.T) {
+	tests := map[string]struct {
+		Expect      func(*mock_v2.MockDB, decoded.TRC)
+		Unsafe      bool
+		ExpectedErr error
+	}{
+		"Exists with same contents": {
+			Expect: func(db *mock_v2.MockDB, decTRC decoded.TRC) {
+				db.EXPECT().TRCExists(gomock.Any(), decTRC).Return(
+					true, nil,
+				)
+			},
+		},
+		"Exists with different contents": {
+			Expect: func(db *mock_v2.MockDB, decTRC decoded.TRC) {
+				db.EXPECT().TRCExists(gomock.Any(), decTRC).Return(
+					true, trust.ErrContentMismatch,
+				)
+			},
+			ExpectedErr: trust.ErrContentMismatch,
+		},
+		"Base TRC and unsafe set": {
+			Expect: func(db *mock_v2.MockDB, decTRC decoded.TRC) {
+				db.EXPECT().TRCExists(gomock.Any(), decTRC).Return(
+					false, nil,
+				)
+				db.EXPECT().InsertTRC(gomock.Any(), decTRC).Return(true, nil)
+			},
+			Unsafe: true,
+		},
+		"Base TRC and unsafe set, insert fail": {
+			Expect: func(db *mock_v2.MockDB, decTRC decoded.TRC) {
+				db.EXPECT().TRCExists(gomock.Any(), decTRC).Return(
+					false, nil,
+				)
+				db.EXPECT().InsertTRC(gomock.Any(), decTRC).Return(
+					false, trust.ErrContentMismatch,
+				)
+			},
+			ExpectedErr: trust.ErrContentMismatch,
+			Unsafe:      true,
+		},
+		"Base TRC and unsafe not set": {
+			Expect: func(db *mock_v2.MockDB, decTRC decoded.TRC) {
+				db.EXPECT().TRCExists(gomock.Any(), decTRC).Return(
+					false, nil,
+				)
+			},
+			ExpectedErr: trust.ErrBaseNotSupported,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mctrl := gomock.NewController(t)
+			defer mctrl.Finish()
+
+			db := mock_v2.NewMockDB(mctrl)
+			decoded := loadTRC(t, trc1v1)
+			test.Expect(db, decoded)
+			ins := trust.NewInserter(db, test.Unsafe)
+
+			err := ins.InsertTRC(context.Background(), decoded, nil)
+			if test.ExpectedErr != nil {
+				require.Truef(t, xerrors.Is(err, test.ExpectedErr),
+					"Expected: %s Actual: %s", test.ExpectedErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/go/lib/infra/modules/trust/v2/router_test.go
+++ b/go/lib/infra/modules/trust/v2/router_test.go
@@ -1,0 +1,151 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trust_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/v2"
+	"github.com/scionproto/scion/go/lib/infra/modules/trust/v2/mock_v2"
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/snet/mock_snet"
+	"github.com/scionproto/scion/go/lib/spath"
+	"github.com/scionproto/scion/go/lib/util"
+)
+
+func TestLocalRouterChooseServer(t *testing.T) {
+	tests := map[string]addr.ISD{
+		"ISD local":  1,
+		"Remote ISD": 2,
+	}
+	for name, isd := range tests {
+		t.Run(name, func(t *testing.T) {
+			localCS := &snet.Addr{IA: ia122, Host: addr.NewSVCUDPAppAddr(addr.SvcCS)}
+			router := trust.NewLocalRouter(localCS.IA)
+			routed, err := router.ChooseServer(context.Background(), isd)
+			require.NoError(t, err)
+			assert.Equal(t, localCS, routed)
+		})
+	}
+}
+
+func TestCSRouterChooseServer(t *testing.T) {
+	tests := map[string]struct {
+		ISD         addr.ISD
+		Expect      func(*mock_v2.MockDB, *mock_snet.MockRouter, *mock_snet.MockPath)
+		ExpectedErr error
+	}{
+		"ISD local": {
+			ISD: 1,
+			Expect: func(_ *mock_v2.MockDB, r *mock_snet.MockRouter, p *mock_snet.MockPath) {
+				p.EXPECT().Path().AnyTimes().Return(&spath.Path{Raw: []byte("isd local path")})
+				p.EXPECT().Destination().AnyTimes().Return(ia110)
+				p.EXPECT().OverlayNextHop().AnyTimes().Return(nil)
+				r.EXPECT().Route(gomock.Any(), addr.IA{I: 1}).Return(p, nil)
+			},
+		},
+		"ISD local, Route error": {
+			ISD: 1,
+			Expect: func(_ *mock_v2.MockDB, r *mock_snet.MockRouter, p *mock_snet.MockPath) {
+				r.EXPECT().Route(gomock.Any(), addr.IA{I: 1}).Return(
+					nil, common.NewBasicError("unable to route", nil),
+				)
+			},
+			ExpectedErr: common.NewBasicError("unable to route", nil),
+		},
+		"Remote ISD, Valid TRC": {
+			ISD: 2,
+			Expect: func(db *mock_v2.MockDB, r *mock_snet.MockRouter, p *mock_snet.MockPath) {
+				future := util.UnixTime{Time: time.Now().Add(time.Hour)}
+				db.EXPECT().GetTRCInfo(gomock.Any(), addr.ISD(2), scrypto.Version(0)).Return(
+					trust.TRCInfo{Validity: scrypto.Validity{NotAfter: future}}, nil,
+				)
+				p.EXPECT().Path().AnyTimes().Return(&spath.Path{Raw: []byte("remote ISD path")})
+				p.EXPECT().Destination().AnyTimes().Return(ia210)
+				p.EXPECT().OverlayNextHop().AnyTimes().Return(nil)
+				r.EXPECT().Route(gomock.Any(), addr.IA{I: 2}).Return(p, nil)
+			},
+		},
+		"Remote ISD, TRC not found": {
+			ISD: 2,
+			Expect: func(db *mock_v2.MockDB, r *mock_snet.MockRouter, p *mock_snet.MockPath) {
+				db.EXPECT().GetTRCInfo(gomock.Any(), addr.ISD(2), scrypto.Version(0)).Return(
+					trust.TRCInfo{}, trust.ErrNotFound,
+				)
+				p.EXPECT().Path().AnyTimes().Return(&spath.Path{Raw: []byte("isd local path")})
+				p.EXPECT().Destination().AnyTimes().Return(ia110)
+				p.EXPECT().OverlayNextHop().AnyTimes().Return(nil)
+				r.EXPECT().Route(gomock.Any(), addr.IA{I: 1}).Return(p, nil)
+			},
+		},
+		"Remote ISD, Expired TRC": {
+			ISD: 2,
+			Expect: func(db *mock_v2.MockDB, r *mock_snet.MockRouter, p *mock_snet.MockPath) {
+				passed := util.UnixTime{Time: time.Now().Add(-time.Second)}
+				db.EXPECT().GetTRCInfo(gomock.Any(), addr.ISD(2), scrypto.Version(0)).Return(
+					trust.TRCInfo{Validity: scrypto.Validity{NotAfter: passed}}, nil,
+				)
+				p.EXPECT().Path().AnyTimes().Return(&spath.Path{Raw: []byte("isd local path")})
+				p.EXPECT().Destination().AnyTimes().Return(ia110)
+				p.EXPECT().OverlayNextHop().AnyTimes().Return(nil)
+				r.EXPECT().Route(gomock.Any(), addr.IA{I: 1}).Return(p, nil)
+			},
+		},
+		"Remote ISD, DB error": {
+			ISD: 2,
+			Expect: func(db *mock_v2.MockDB, r *mock_snet.MockRouter, p *mock_snet.MockPath) {
+				db.EXPECT().GetTRCInfo(gomock.Any(), addr.ISD(2), scrypto.Version(0)).Return(
+					trust.TRCInfo{}, common.NewBasicError("DB error", nil),
+				)
+			},
+			ExpectedErr: common.NewBasicError("DB error", nil),
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mctrl := gomock.NewController(t)
+			defer mctrl.Finish()
+			db := mock_v2.NewMockDB(mctrl)
+			r, p := mock_snet.NewMockRouter(mctrl), mock_snet.NewMockPath(mctrl)
+			test.Expect(db, r, p)
+			router := trust.NewCSRouter(1, r, db)
+			res, err := router.ChooseServer(context.Background(), test.ISD)
+			if test.ExpectedErr != nil {
+				require.Error(t, err)
+				assert.True(t, xerrors.Is(err, test.ExpectedErr), "Expected: %s Actual: %s",
+					test.ExpectedErr, err)
+			} else {
+				require.NoError(t, err)
+				expected := &snet.Addr{
+					IA:      p.Destination(),
+					Host:    addr.NewSVCUDPAppAddr(addr.SvcCS),
+					Path:    p.Path(),
+					NextHop: p.OverlayNextHop(),
+				}
+				assert.Equal(t, expected, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds:
- Implement TRC verification and insertion logic.
- The forwarding inserter registers the new trust material with the
  local certificate server before inserting into the database.
  It is supposed to be used by the beacon and path server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3225)
<!-- Reviewable:end -->
