### PR TITLE
PS: Expose request metrics

### DIFF
--- a/go/lib/addr/isdas.go
+++ b/go/lib/addr/isdas.go
@@ -69,6 +69,10 @@ func ISDFromFileFmt(s string, prefix bool) (ISD, error) {
 	return ISDFromString(s)
 }
 
+func (isd ISD) String() string {
+	return strconv.FormatUint(uint64(isd), 10)
+}
+
 var _ encoding.TextUnmarshaler = (*AS)(nil)
 
 // AS is the Autonomous System idenifier. See formatting and allocations here:

--- a/go/lib/prom/prom.go
+++ b/go/lib/prom/prom.go
@@ -58,6 +58,8 @@ const (
 	ErrValidate = "err_validate"
 	// ErrVerify is used for validation related errors.
 	ErrVerify = "err_verify"
+	// ErrReply is used for errors when sending the reply.
+	ErrReply = "err_reply"
 )
 
 // FIXME(roosd): remove when moving messenger to new metrics style.

--- a/go/lib/prom/promtest/promtest.go
+++ b/go/lib/prom/promtest/promtest.go
@@ -23,26 +23,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type labels interface {
+	Labels() []string
+	Values() []string
+}
+
 // CheckLabelsStruct checks that labels has a Values and Labels method. It also
 // checks that labels.Labels() returns the struct field names.
 func CheckLabelsStruct(t *testing.T, xLabels interface{}) {
-	type label interface {
-		Labels() []string
-		Values() []string
-	}
-
-	v, ok := xLabels.(label)
+	v, ok := xLabels.(labels)
 	if ok != true {
-		assert.Fail(t, "should implement label interface")
+		assert.Fail(t, "should implement labels interface")
 	}
 
 	assert.Equal(t, len(v.Values()), len(v.Labels()), "should match in length")
+	fields := fieldNames(v)
+	assert.ElementsMatch(t, fields, v.Labels(), "Expected %v but was %v", fields, v.Labels())
+}
 
-	fieldNames := []string{}
+func fieldNames(xLabels labels) []string {
+	names := []string{}
 	labelsType := reflect.TypeOf(xLabels)
 	for i := 0; i < labelsType.NumField(); i++ {
-		fieldNames = append(fieldNames, strcase.ToSnake(labelsType.Field(i).Name))
+		field := labelsType.Field(i)
+		// handle nesting of other labels structs:
+		if field.Type.Implements(reflect.TypeOf((*labels)(nil)).Elem()) {
+			names = append(names, fieldNames(reflect.Zero(field.Type).Interface().(labels))...)
+		} else {
+			names = append(names, strcase.ToSnake(field.Name))
+		}
 	}
-	assert.ElementsMatch(t, fieldNames, v.Labels(), "Expected %v but was %v",
-		fieldNames, v.Labels())
+	return names
 }

--- a/go/path_srv/internal/metrics/BUILD.bazel
+++ b/go/path_srv/internal/metrics/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "metrics.go",
         "registration.go",
+        "requests.go",
     ],
     importpath = "github.com/scionproto/scion/go/path_srv/internal/metrics",
     visibility = ["//go/path_srv:__subpackages__"],
@@ -18,7 +19,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["registration_test.go"],
+    srcs = [
+        "registration_test.go",
+        "requests_test.go",
+    ],
     embed = [":go_default_library"],
     deps = ["//go/lib/prom/promtest:go_default_library"],
 )

--- a/go/path_srv/internal/metrics/BUILD.bazel
+++ b/go/path_srv/internal/metrics/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//go/path_srv:__subpackages__"],
     deps = [
         "//go/lib/addr:go_default_library",
+        "//go/lib/infra/modules/segfetcher:go_default_library",
         "//go/lib/prom:go_default_library",
         "//go/proto:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",

--- a/go/path_srv/internal/metrics/metrics.go
+++ b/go/path_srv/internal/metrics/metrics.go
@@ -32,10 +32,10 @@ var (
 // Result values
 const (
 	Success               = prom.Success
-	RegistrationNew       = "new"
-	RegiststrationUpdated = "updated"
-	RequestCached         = "cached"
-	RequestFetched        = "fetched"
+	RegistrationNew       = "ok_new"
+	RegiststrationUpdated = "ok_updated"
+	RequestCached         = "ok_cached"
+	RequestFetched        = "ok_fetched"
 	ErrParse              = prom.ErrParse
 	ErrInternal           = prom.ErrInternal
 	ErrCrypto             = prom.ErrCrypto

--- a/go/path_srv/internal/metrics/metrics.go
+++ b/go/path_srv/internal/metrics/metrics.go
@@ -25,6 +25,8 @@ const Namespace = "ps"
 var (
 	// Registrations contains metrics for segments registrations.
 	Registrations = newRegistration()
+	// Requests contains metrics for segments requests.
+	Requests = newRequests()
 )
 
 // Result values
@@ -32,11 +34,14 @@ const (
 	Success               = prom.Success
 	RegistrationNew       = "new"
 	RegiststrationUpdated = "updated"
+	RequestCached         = "cached"
+	RequestFetched        = "fetched"
 	ErrParse              = prom.ErrParse
 	ErrInternal           = prom.ErrInternal
 	ErrCrypto             = prom.ErrCrypto
 	ErrDB                 = prom.ErrDB
 	ErrTimeout            = prom.ErrTimeout
+	ErrReply              = prom.ErrReply
 )
 
 // Label values

--- a/go/path_srv/internal/metrics/requests.go
+++ b/go/path_srv/internal/metrics/requests.go
@@ -1,0 +1,99 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/scionproto/scion/go/lib/prom"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/proto"
+)
+
+var reqResults = []string{RequestCached, RequestFetched, ErrCrypto, ErrDB, ErrTimeout, ErrReply}
+
+// RequestOkLabels contains the labels for a request that succeeded.
+type RequestOkLabels struct {
+	Type      proto.PathSegType
+	CacheOnly bool
+	DstISD    addr.ISD
+}
+
+// Labels returns the labels.
+func (l RequestOkLabels) Labels() []string {
+	return []string{"type", "cache_only", "dst_isd"}
+}
+
+// Values returns the values.
+func (l RequestOkLabels) Values() []string {
+	return []string{l.Type.String(), strconv.FormatBool(l.CacheOnly),
+		strconv.FormatUint(uint64(l.DstISD), 10)}
+}
+
+// RequestLabels contains the labels for requests.
+type RequestLabels struct {
+	Result string
+	RequestOkLabels
+}
+
+// Labels returns the labels.
+func (l RequestLabels) Labels() []string {
+	return append([]string{"result"}, l.RequestOkLabels.Labels()...)
+}
+
+// Values returns the values.
+func (l RequestLabels) Values() []string {
+	return append([]string{l.Result}, l.RequestOkLabels.Values()...)
+}
+
+// Request is for request metrics.
+type Request struct {
+	total     *prometheus.CounterVec
+	replySegs *prometheus.CounterVec
+	replyRevs *prometheus.CounterVec
+}
+
+func newRequests() Request {
+	return Request{
+		total: prom.NewCounterVec(Namespace, "", "requests_total",
+			fmt.Sprintf("Number of path requests. \"result\" can be one of: [%s]",
+				strings.Join(reqResults, ",")),
+			RequestLabels{}.Labels()),
+		replySegs: prom.NewCounterVec(Namespace, "", "requests_reply_segs_total",
+			"Number of segments in reply to path request.", RequestOkLabels{}.Labels()),
+		replyRevs: prom.NewCounterVec(Namespace, "", "requests_reply_revs_total",
+			"Number of revocations returned in reply to path request.", RequestOkLabels{}.Labels()),
+	}
+}
+
+// Total returns the counter for requests total.
+func (r Request) Total(l RequestLabels) prometheus.Counter {
+	return r.total.WithLabelValues(l.Values()...)
+}
+
+// ReplySegsTotal returns the counter for the number of segments in a seg reply.
+func (r Request) ReplySegsTotal(l RequestOkLabels) prometheus.Counter {
+	return r.replySegs.WithLabelValues(l.Values()...)
+}
+
+// ReplyRevsTotal returns the counter for the number of revocations in a seg
+// reply.
+func (r Request) ReplyRevsTotal(l RequestOkLabels) prometheus.Counter {
+	return r.replyRevs.WithLabelValues(l.Values()...)
+}

--- a/go/path_srv/internal/metrics/requests.go
+++ b/go/path_srv/internal/metrics/requests.go
@@ -19,10 +19,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/scionproto/scion/go/lib/prom"
-
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/prom"
 	"github.com/scionproto/scion/go/proto"
 )
 

--- a/go/path_srv/internal/metrics/requests.go
+++ b/go/path_srv/internal/metrics/requests.go
@@ -66,41 +66,42 @@ func (l RequestLabels) WithResult(result string) RequestLabels {
 
 // Request is for request metrics.
 type Request struct {
-	total     *prometheus.CounterVec
-	replySegs *prometheus.CounterVec
-	replyRevs *prometheus.CounterVec
+	count       *prometheus.CounterVec
+	repliedSegs *prometheus.CounterVec
+	repliedRevs *prometheus.CounterVec
 }
 
 func newRequests() Request {
 	subsystem := "requests"
 	return Request{
-		total: prom.NewCounterVec(Namespace, subsystem, "total",
+		count: prom.NewCounterVec(Namespace, subsystem, "total",
 			"Number of segment requests total. \"result\" indicates the outcome.",
 			RequestLabels{}.Labels()),
-		replySegs: prom.NewCounterVec(Namespace, subsystem, "reply_segs_total",
+		repliedSegs: prom.NewCounterVec(Namespace, subsystem, "replied_segments_total",
 			"Number of segments in reply to segment requests.", RequestOkLabels{}.Labels()),
-		replyRevs: prom.NewCounterVec(Namespace, subsystem, "reply_revs_total",
-			"Number of revocations returned in reply to segments requests.",
-			RequestOkLabels{}.Labels()),
+		repliedRevs: prom.NewCounterVec(Namespace, subsystem, "replied_revocations_total",
+			"Number of revocations in reply to segments requests.", RequestOkLabels{}.Labels()),
 	}
 }
 
 // Count returns the counter for requests total.
 func (r Request) Count(l RequestLabels) prometheus.Counter {
-	return r.total.WithLabelValues(l.Values()...)
+	return r.count.WithLabelValues(l.Values()...)
 }
 
-// ReplySegsTotal returns the counter for the number of segments in a seg reply.
-func (r Request) ReplySegsTotal(l RequestOkLabels) prometheus.Counter {
-	return r.replySegs.WithLabelValues(l.Values()...)
+// RepliedSegs returns the counter for the number of segments in a seg reply.
+func (r Request) RepliedSegs(l RequestOkLabels) prometheus.Counter {
+	return r.repliedSegs.WithLabelValues(l.Values()...)
 }
 
-// ReplyRevsTotal returns the counter for the number of revocations in a seg
+// RepliedRevs returns the counter for the number of revocations in a seg
 // reply.
-func (r Request) ReplyRevsTotal(l RequestOkLabels) prometheus.Counter {
-	return r.replyRevs.WithLabelValues(l.Values()...)
+func (r Request) RepliedRevs(l RequestOkLabels) prometheus.Counter {
+	return r.repliedRevs.WithLabelValues(l.Values()...)
 }
 
+// DetermineReplyType determines which type of segments is in the reply. The
+// method assumes that segs only contains one type of segments.
 func DetermineReplyType(segs segfetcher.Segments) proto.PathSegType {
 	switch {
 	case len(segs.Up) > 0:

--- a/go/path_srv/internal/metrics/requests_test.go
+++ b/go/path_srv/internal/metrics/requests_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/scionproto/scion/go/lib/prom/promtest"
+	"github.com/scionproto/scion/go/path_srv/internal/metrics"
+)
+
+func TestRequestLabels(t *testing.T) {
+	promtest.CheckLabelsStruct(t, metrics.RequestOkLabels{})
+	promtest.CheckLabelsStruct(t, metrics.RequestLabels{})
+}

--- a/go/path_srv/internal/segreq/BUILD.bazel
+++ b/go/path_srv/internal/segreq/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//go/lib/snet/addrutil:go_default_library",
         "//go/lib/topology:go_default_library",
         "//go/path_srv/internal/handlers:go_default_library",
+        "//go/path_srv/internal/metrics:go_default_library",
         "//go/proto:go_default_library",
     ],
 )

--- a/go/path_srv/internal/segreq/handler.go
+++ b/go/path_srv/internal/segreq/handler.go
@@ -17,8 +17,6 @@ package segreq
 import (
 	"time"
 
-	"github.com/scionproto/scion/go/path_srv/internal/metrics"
-
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
@@ -28,6 +26,7 @@ import (
 	"github.com/scionproto/scion/go/lib/pathdb"
 	"github.com/scionproto/scion/go/lib/revcache"
 	"github.com/scionproto/scion/go/path_srv/internal/handlers"
+	"github.com/scionproto/scion/go/path_srv/internal/metrics"
 	"github.com/scionproto/scion/go/proto"
 )
 

--- a/go/path_srv/internal/segreq/handler.go
+++ b/go/path_srv/internal/segreq/handler.go
@@ -85,7 +85,8 @@ func (h *handler) Handle(request *infra.Request) *infra.HandlerResult {
 		// occur and depending on them reply / return different error codes.
 		logger.Error("Failed to handler request", "err", err)
 		sendAck(proto.Ack_ErrCode_reject, err.Error())
-		// TODO(lukedirtwalker): set result label if we have error categorization.
+		// TODO(lukedirtwalker): set result label if we have error
+		// categorization. (see https://github.com/scionproto/scion/issues/3240)
 		metrics.Requests.Count(labels).Inc()
 		return infra.MetricsErrInternal
 	}
@@ -110,8 +111,8 @@ func (h *handler) Handle(request *infra.Request) *infra.HandlerResult {
 	logger.Debug("[segReqHandler] Replied with segments", "segs", len(reply.Recs.Recs))
 	labels = labels.WithResult(metrics.Success)
 	metrics.Requests.Count(labels).Inc()
-	metrics.Requests.ReplySegsTotal(labels.RequestOkLabels).Add(float64(len(reply.Recs.Recs)))
-	metrics.Requests.ReplyRevsTotal(labels.RequestOkLabels).Add(float64(len(reply.Recs.SRevInfos)))
+	metrics.Requests.RepliedSegs(labels.RequestOkLabels).Add(float64(len(reply.Recs.Recs)))
+	metrics.Requests.RepliedRevs(labels.RequestOkLabels).Add(float64(len(reply.Recs.SRevInfos)))
 	return infra.MetricsResultOk
 }
 


### PR DESCRIPTION
Adds metrics:
```
# HELP ps_requests_replied_revocations_total Number of revocations in reply to segments requests.
# TYPE ps_requests_replied_revocations_total counter
ps_requests_replied_revocations_total{cache_only="false",dst_isd="1",seg_type="down"} 0
# HELP ps_requests_replied_segments_total Number of segments in reply to segment requests.
# TYPE ps_requests_replied_segments_total counter
ps_requests_replied_segments_total{cache_only="false",dst_isd="1",seg_type="down"} 4
# HELP ps_requests_total Number of segment requests total. "result" indicates the outcome.
# TYPE ps_requests_total counter
ps_requests_total{cache_only="false",dst_isd="1",result="ok_success",seg_type="down"} 4
```

Contributes #3106

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3232)
<!-- Reviewable:end -->
