### PR TITLE
segfetcher: Keep next query entries when receiving revocations

### DIFF
--- a/go/lib/infra/modules/segfetcher/requester_test.go
+++ b/go/lib/infra/modules/segfetcher/requester_test.go
@@ -45,15 +45,15 @@ var (
 	non_core_211 = xtest.MustParseIA("2-ff00:0:211")
 	non_core_212 = xtest.MustParseIA("2-ff00:0:212")
 
-	req_111_1   = segfetcher.Request{Src: non_core_111, Dst: isd1}
-	req_1_111   = segfetcher.Request{Src: isd1, Dst: non_core_111}
+	req_111_1   = segfetcher.Request{Src: non_core_111, Dst: isd1, State: segfetcher.Fetch}
+	req_1_111   = segfetcher.Request{Src: isd1, Dst: non_core_111, State: segfetcher.Fetch}
 	req_1_2     = segfetcher.Request{Src: isd1, Dst: isd2}
 	req_1_210   = segfetcher.Request{Src: isd1, Dst: core_210}
-	req_2_211   = segfetcher.Request{Src: isd2, Dst: non_core_211}
+	req_2_211   = segfetcher.Request{Src: isd2, Dst: non_core_211, State: segfetcher.Fetch}
 	req_210_1   = segfetcher.Request{Src: core_210, Dst: isd1}
-	req_210_110 = segfetcher.Request{Src: core_210, Dst: core_110}
-	req_210_120 = segfetcher.Request{Src: core_210, Dst: core_120}
-	req_210_130 = segfetcher.Request{Src: core_210, Dst: core_130}
+	req_210_110 = segfetcher.Request{Src: core_210, Dst: core_110, State: segfetcher.Fetch}
+	req_210_120 = segfetcher.Request{Src: core_210, Dst: core_120, State: segfetcher.Fetch}
+	req_210_130 = segfetcher.Request{Src: core_210, Dst: core_130, State: segfetcher.Fetch}
 )
 
 func TestRequester(t *testing.T) {
@@ -85,9 +85,7 @@ func TestRequester(t *testing.T) {
 				}
 				api.EXPECT().GetSegs(gomock.Any(), gomock.Eq(req), gomock.Any(), gomock.Any()).
 					Return(reply, nil)
-				return []segfetcher.ReplyOrErr{
-					{Req: segfetcher.Request{Src: non_core_111, Dst: isd1}, Reply: reply},
-				}
+				return []segfetcher.ReplyOrErr{{Req: req_111_1, Reply: reply}}
 			},
 		},
 		"Down only": {

--- a/go/path_srv/internal/handlers/segrevoc.go
+++ b/go/path_srv/internal/handlers/segrevoc.go
@@ -76,10 +76,6 @@ func (h *revocHandler) Handle() *infra.HandlerResult {
 		sendAck(proto.Ack_ErrCode_reject, messenger.AckRejectFailedToVerify)
 		return infra.MetricsErrInvalid
 	}
-	// if err := h.NextQueryCleaner.ResetQueryCache(ctx, revInfo); err != nil {
-	// 	logger.Warn("Couldn't reset pathdb cache for revocation", "err", err)
-	// }
-
 	_, err = h.revCache.Insert(ctx, revocation)
 	if err != nil {
 		logger.Error("Failed to insert revInfo", "err", err)

--- a/go/path_srv/internal/handlers/segrevoc.go
+++ b/go/path_srv/internal/handlers/segrevoc.go
@@ -76,9 +76,9 @@ func (h *revocHandler) Handle() *infra.HandlerResult {
 		sendAck(proto.Ack_ErrCode_reject, messenger.AckRejectFailedToVerify)
 		return infra.MetricsErrInvalid
 	}
-	if err := h.NextQueryCleaner.ResetQueryCache(ctx, revInfo); err != nil {
-		logger.Warn("Couldn't reset pathdb cache for revocation", "err", err)
-	}
+	// if err := h.NextQueryCleaner.ResetQueryCache(ctx, revInfo); err != nil {
+	// 	logger.Warn("Couldn't reset pathdb cache for revocation", "err", err)
+	// }
 
 	_, err = h.revCache.Insert(ctx, revocation)
 	if err != nil {

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -263,13 +263,13 @@ func (h *RevNotificationHandler) Handle(ctx context.Context, conn net.PacketConn
 	switch {
 	case isValid(err):
 		revReply.Result = sciond.RevValid
-		revInfo, err := revNotification.SRevInfo.RevInfo()
-		if err != nil {
-			logger.Error("Failed to extract error from rev info", "err", err)
-		}
-		if err := h.NextQueryCleaner.ResetQueryCache(ctx, revInfo); err != nil {
-			logger.Error("Failed to delete query cache", "err", err)
-		}
+		// revInfo, err := revNotification.SRevInfo.RevInfo()
+		// if err != nil {
+		// 	logger.Error("Failed to extract error from rev info", "err", err)
+		// }
+		// if err := h.NextQueryCleaner.ResetQueryCache(ctx, revInfo); err != nil {
+		// 	logger.Error("Failed to delete query cache", "err", err)
+		// }
 	case isStale(err):
 		revReply.Result = sciond.RevStale
 	case isInvalid(err):

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -263,13 +263,6 @@ func (h *RevNotificationHandler) Handle(ctx context.Context, conn net.PacketConn
 	switch {
 	case isValid(err):
 		revReply.Result = sciond.RevValid
-		// revInfo, err := revNotification.SRevInfo.RevInfo()
-		// if err != nil {
-		// 	logger.Error("Failed to extract error from rev info", "err", err)
-		// }
-		// if err := h.NextQueryCleaner.ResetQueryCache(ctx, revInfo); err != nil {
-		// 	logger.Error("Failed to delete query cache", "err", err)
-		// }
 	case isStale(err):
 		revReply.Result = sciond.RevStale
 	case isInvalid(err):


### PR DESCRIPTION
Instead of deleting next query entries when receiving revocation, be smarter when querying:
That means if a query returns no result after being filtered with revocations, try to refetch, otherwise return cached result to clients.

Fixes #3234 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3235)
<!-- Reviewable:end -->
