### PR TITLE
PS: Add segsyncer metrics

### DIFF
--- a/go/lib/prom/prom.go
+++ b/go/lib/prom/prom.go
@@ -58,8 +58,8 @@ const (
 	ErrValidate = "err_validate"
 	// ErrVerify is used for validation related errors.
 	ErrVerify = "err_verify"
-	// ErrReply is used for errors when sending the reply.
-	ErrReply = "err_reply"
+	// ErrNetwork is used for errors when sending something over the network.
+	ErrNetwork = "err_network"
 )
 
 // FIXME(roosd): remove when moving messenger to new metrics style.

--- a/go/path_srv/internal/handlers/segreg.go
+++ b/go/path_srv/internal/handlers/segreg.go
@@ -118,9 +118,9 @@ func (h *segRegHandler) Handle() *infra.HandlerResult {
 }
 
 func (h *segRegHandler) incMetrics(labels metrics.RegistrationLabels, stats seghandler.Stats) {
-	labels.Result = metrics.RegistrationNew
+	labels.Result = metrics.OkRegistrationNew
 	metrics.Registrations.ResultsTotal(labels).Add(float64(len(stats.SegDB.InsertedSegs)))
-	labels.Result = metrics.RegiststrationUpdated
+	labels.Result = metrics.OkRegiststrationUpdated
 	metrics.Registrations.ResultsTotal(labels).Add(float64(len(stats.SegDB.UpdatedSegs)))
 }
 

--- a/go/path_srv/internal/handlers/segsync.go
+++ b/go/path_srv/internal/handlers/segsync.go
@@ -82,7 +82,6 @@ func (h *syncHandler) Handle() *infra.HandlerResult {
 		return infra.MetricsErrInvalid
 	}
 	logSegRecs(logger, "[syncHandler]", h.request.Peer, segSync.SegRecs)
-
 	peerPath, err := snetPeer.GetPath()
 	if err != nil {
 		logger.Error("[syncHandler] Failed to initialize path", "err", err)
@@ -109,14 +108,7 @@ func (h *syncHandler) Handle() *infra.HandlerResult {
 		sendAck(proto.Ack_ErrCode_reject, err.Error())
 		return infra.MetricsErrInvalid
 	}
-	h.incMetrics(labels, res.Stats())
+	metrics.Syncs.RegistrationSuccess(labels, res.Stats())
 	sendAck(proto.Ack_ErrCode_ok, "")
 	return infra.MetricsResultOk
-}
-
-func (h *syncHandler) incMetrics(labels metrics.SyncRegLabels, stats seghandler.Stats) {
-	metrics.Syncs.Registrations(labels.WithResult(metrics.RegistrationNew)).
-		Add(float64(len(stats.SegDB.InsertedSegs)))
-	metrics.Syncs.Registrations(labels.WithResult(metrics.RegiststrationUpdated)).
-		Add(float64(len(stats.SegDB.UpdatedSegs)))
 }

--- a/go/path_srv/internal/metrics/BUILD.bazel
+++ b/go/path_srv/internal/metrics/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "metrics.go",
         "registration.go",
         "requests.go",
+        "sync.go",
     ],
     importpath = "github.com/scionproto/scion/go/path_srv/internal/metrics",
     visibility = ["//go/path_srv:__subpackages__"],
@@ -23,6 +24,7 @@ go_test(
     srcs = [
         "registration_test.go",
         "requests_test.go",
+        "sync_test.go",
     ],
     embed = [":go_default_library"],
     deps = ["//go/lib/prom/promtest:go_default_library"],

--- a/go/path_srv/internal/metrics/BUILD.bazel
+++ b/go/path_srv/internal/metrics/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/infra/modules/segfetcher:go_default_library",
-        "//go/lib/infra/modules/seghandler:go_default_library",
         "//go/lib/prom:go_default_library",
         "//go/proto:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",

--- a/go/path_srv/internal/metrics/BUILD.bazel
+++ b/go/path_srv/internal/metrics/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/infra/modules/segfetcher:go_default_library",
+        "//go/lib/infra/modules/seghandler:go_default_library",
         "//go/lib/prom:go_default_library",
         "//go/proto:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",

--- a/go/path_srv/internal/metrics/metrics.go
+++ b/go/path_srv/internal/metrics/metrics.go
@@ -27,6 +27,8 @@ var (
 	Registrations = newRegistration()
 	// Requests contains metrics for segments requests.
 	Requests = newRequests()
+	// Syncs contains metrics for segment synchronization.
+	Syncs = newSync()
 )
 
 // Result values
@@ -41,7 +43,10 @@ const (
 	ErrCrypto             = prom.ErrCrypto
 	ErrDB                 = prom.ErrDB
 	ErrTimeout            = prom.ErrTimeout
-	ErrReply              = prom.ErrReply
+	ErrNetwork            = prom.ErrNetwork
+	ErrNotClassified      = prom.ErrNotClassified
+	// ErrNoPath indicates no path is available to send a message.
+	ErrNoPath = "err_no_path"
 )
 
 // Label values

--- a/go/path_srv/internal/metrics/metrics.go
+++ b/go/path_srv/internal/metrics/metrics.go
@@ -33,20 +33,34 @@ var (
 
 // Result values
 const (
-	Success               = prom.Success
-	RegistrationNew       = "ok_new"
-	RegiststrationUpdated = "ok_updated"
-	RequestCached         = "ok_cached"
-	RequestFetched        = "ok_fetched"
-	ErrParse              = prom.ErrParse
-	ErrInternal           = prom.ErrInternal
-	ErrCrypto             = prom.ErrCrypto
-	ErrDB                 = prom.ErrDB
-	ErrTimeout            = prom.ErrTimeout
-	ErrNetwork            = prom.ErrNetwork
-	ErrNotClassified      = prom.ErrNotClassified
+	// OkSuccess is no error.
+	OkSuccess = prom.Success
+	// OkRegistrationNew indicates something new was registered.
+	OkRegistrationNew = "ok_new"
+	// OkRegiststrationUpdated indicates a registration was updated.
+	OkRegiststrationUpdated = "ok_updated"
+	// OkRequestCached indicates the request could be processed and the result
+	// came from cache.
+	OkRequestCached = "ok_cached"
+	// OkRequestFetched indicates the request could be processed but the result
+	// needed to be fetched from a remote server.
+	OkRequestFetched = "ok_fetched"
+	// ErrParse indicates
+	ErrParse = prom.ErrParse
+	// ErrInternal indicates an internal problem (likely a code bug).
+	ErrInternal = prom.ErrInternal
+	// ErrCrypto indicates a problem with crypto.
+	ErrCrypto = prom.ErrCrypto
+	// ErrDB indicates a problem with the DB.
+	ErrDB = prom.ErrDB
+	// ErrTimeout indicates a timeout error.
+	ErrTimeout = prom.ErrTimeout
+	// ErrNetwork indicates a problem with the network.
+	ErrNetwork = prom.ErrNetwork
+	// ErrNotClassified indicates an error that is not further classified.
+	ErrNotClassified = prom.ErrNotClassified
 	// ErrNoPath indicates no path is available to send a message.
-	ErrNoPath = "err_no_path"
+	ErrNoPath = "err_nopath"
 )
 
 // Label values

--- a/go/path_srv/internal/metrics/metrics.go
+++ b/go/path_srv/internal/metrics/metrics.go
@@ -27,8 +27,8 @@ var (
 	Registrations = newRegistration()
 	// Requests contains metrics for segments requests.
 	Requests = newRequests()
-	// Syncs contains metrics for segment synchronization.
-	Syncs = newSync()
+	// Sync contains metrics for segment synchronization.
+	Sync = newSync()
 )
 
 // Result values
@@ -45,7 +45,7 @@ const (
 	// OkRequestFetched indicates the request could be processed but the result
 	// needed to be fetched from a remote server.
 	OkRequestFetched = "ok_fetched"
-	// ErrParse indicates
+	// ErrParse indicates a parse error.
 	ErrParse = prom.ErrParse
 	// ErrInternal indicates an internal problem (likely a code bug).
 	ErrInternal = prom.ErrInternal

--- a/go/path_srv/internal/metrics/registration.go
+++ b/go/path_srv/internal/metrics/registration.go
@@ -26,7 +26,7 @@ import (
 )
 
 // regResults lists all possible results for registrations.
-var regResults = []string{RegistrationNew, RegiststrationUpdated, ErrParse, ErrInternal,
+var regResults = []string{OkRegistrationNew, OkRegiststrationUpdated, ErrParse, ErrInternal,
 	ErrCrypto, ErrDB, ErrInternal, ErrTimeout}
 
 // RegistrationLabels contains the label values for registration metrics.

--- a/go/path_srv/internal/metrics/sync.go
+++ b/go/path_srv/internal/metrics/sync.go
@@ -1,0 +1,94 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/prom"
+)
+
+// SyncRegLabels contains the label values for synchronization registration
+// metrics.
+type SyncRegLabels struct {
+	Result string
+	Src    addr.IA
+}
+
+// Labels returns the labels.
+func (l SyncRegLabels) Labels() []string {
+	return []string{"result", "src"}
+}
+
+// Values returns the values.
+func (l SyncRegLabels) Values() []string {
+	return []string{l.Result, l.Src.String()}
+}
+
+// WithResult return the labels with a changed result.
+func (l SyncRegLabels) WithResult(result string) SyncRegLabels {
+	l.Result = result
+	return l
+}
+
+// SyncPushLabels contains the label values for synchronization pushes.
+type SyncPushLabels struct {
+	Result string
+	Dst    addr.IA
+}
+
+// Labels returns the labels.
+func (l SyncPushLabels) Labels() []string {
+	return []string{"result", "dst"}
+}
+
+// Values returns the values.
+func (l SyncPushLabels) Values() []string {
+	return []string{l.Result, l.Dst.String()}
+}
+
+// WithResult return the labels with a changed result.
+func (l SyncPushLabels) WithResult(result string) SyncPushLabels {
+	l.Result = result
+	return l
+}
+
+// Sync contains metrics for segment synchronization.
+type Sync struct {
+	regsTotal   *prometheus.CounterVec
+	pushesTotal *prometheus.CounterVec
+}
+
+func newSync() Sync {
+	subsystem := "segment_sync"
+	return Sync{
+		regsTotal: prom.NewCounterVec(Namespace, subsystem, "registrations_total",
+			"Number of segments received in down segment synchronizations",
+			SyncRegLabels{}.Labels()),
+		pushesTotal: prom.NewCounterVec(Namespace, subsystem, "pushes_total",
+			"Number of pushes towards a destination", SyncPushLabels{}.Labels()),
+	}
+}
+
+// Registrations returns the counter for synchronization registration messages.
+func (s Sync) Registrations(l SyncRegLabels) prometheus.Counter {
+	return s.regsTotal.WithLabelValues(l.Values()...)
+}
+
+// Pushes returns the counter for synchronization pushes.
+func (s Sync) Pushes(l SyncPushLabels) prometheus.Counter {
+	return s.pushesTotal.WithLabelValues(l.Values()...)
+}

--- a/go/path_srv/internal/metrics/sync.go
+++ b/go/path_srv/internal/metrics/sync.go
@@ -18,12 +18,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/infra/modules/seghandler"
 	"github.com/scionproto/scion/go/lib/prom"
 )
 
-// SyncRegLabels contains the label values for synchronization registration
-// metrics.
+// SyncRegLabels contains the label values for synchronization registration metrics.
 type SyncRegLabels struct {
 	Result string
 	Src    addr.IA
@@ -67,15 +65,15 @@ func (l SyncPushLabels) WithResult(result string) SyncPushLabels {
 	return l
 }
 
-// Sync contains metrics for segment synchronization.
-type Sync struct {
+// sync contains metrics for segment synchronization.
+type sync struct {
 	registrations *prometheus.CounterVec
 	pushes        *prometheus.CounterVec
 }
 
-func newSync() Sync {
+func newSync() sync {
 	subsystem := "segment_sync"
-	return Sync{
+	return sync{
 		registrations: prom.NewCounterVec(Namespace, subsystem, "registrations_total",
 			"Number of segments registered in down segment synchronizations",
 			SyncRegLabels{}.Labels()),
@@ -85,19 +83,17 @@ func newSync() Sync {
 }
 
 // Registrations returns the counter for synchronization registration messages.
-func (s Sync) Registrations(l SyncRegLabels) prometheus.Counter {
+func (s sync) Registrations(l SyncRegLabels) prometheus.Counter {
 	return s.registrations.WithLabelValues(l.Values()...)
 }
 
 // RegistrationSuccess increments registrations with the given stats.
-func (s Sync) RegistrationSuccess(l SyncRegLabels, stats seghandler.Stats) {
-	s.Registrations(l.WithResult(OkRegistrationNew)).
-		Add(float64(len(stats.SegDB.InsertedSegs)))
-	s.Registrations(l.WithResult(OkRegiststrationUpdated)).
-		Add(float64(len(stats.SegDB.UpdatedSegs)))
+func (s sync) RegistrationSuccess(l SyncRegLabels, new, updated int) {
+	s.Registrations(l.WithResult(OkRegistrationNew)).Add(float64(new))
+	s.Registrations(l.WithResult(OkRegiststrationUpdated)).Add(float64(updated))
 }
 
 // Pushes returns the counter for synchronization pushes.
-func (s Sync) Pushes(l SyncPushLabels) prometheus.Counter {
+func (s sync) Pushes(l SyncPushLabels) prometheus.Counter {
 	return s.pushes.WithLabelValues(l.Values()...)
 }

--- a/go/path_srv/internal/metrics/sync.go
+++ b/go/path_srv/internal/metrics/sync.go
@@ -29,7 +29,7 @@ type SyncRegLabels struct {
 
 // Labels returns the labels.
 func (l SyncRegLabels) Labels() []string {
-	return []string{"result", "src"}
+	return []string{prom.LabelResult, prom.LabelSrc}
 }
 
 // Values returns the values.
@@ -51,7 +51,7 @@ type SyncPushLabels struct {
 
 // Labels returns the labels.
 func (l SyncPushLabels) Labels() []string {
-	return []string{"result", "dst"}
+	return []string{prom.LabelResult, "dst"}
 }
 
 // Values returns the values.
@@ -65,7 +65,6 @@ func (l SyncPushLabels) WithResult(result string) SyncPushLabels {
 	return l
 }
 
-// sync contains metrics for segment synchronization.
 type sync struct {
 	registrations *prometheus.CounterVec
 	pushes        *prometheus.CounterVec
@@ -88,8 +87,8 @@ func (s sync) Registrations(l SyncRegLabels) prometheus.Counter {
 }
 
 // RegistrationSuccess increments registrations with the given stats.
-func (s sync) RegistrationSuccess(l SyncRegLabels, new, updated int) {
-	s.Registrations(l.WithResult(OkRegistrationNew)).Add(float64(new))
+func (s sync) RegistrationSuccess(l SyncRegLabels, inserted, updated int) {
+	s.Registrations(l.WithResult(OkRegistrationNew)).Add(float64(inserted))
 	s.Registrations(l.WithResult(OkRegiststrationUpdated)).Add(float64(updated))
 }
 

--- a/go/path_srv/internal/metrics/sync_test.go
+++ b/go/path_srv/internal/metrics/sync_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/scionproto/scion/go/lib/prom/promtest"
+	"github.com/scionproto/scion/go/path_srv/internal/metrics"
+)
+
+func TestSyncLabels(t *testing.T) {
+	promtest.CheckLabelsStruct(t, metrics.SyncRegLabels{})
+	promtest.CheckLabelsStruct(t, metrics.SyncPushLabels{})
+}

--- a/go/path_srv/internal/segreq/handler.go
+++ b/go/path_srv/internal/segreq/handler.go
@@ -109,7 +109,7 @@ func (h *handler) Handle(request *infra.Request) *infra.HandlerResult {
 		return infra.MetricsErrInternal
 	}
 	logger.Debug("[segReqHandler] Replied with segments", "segs", len(reply.Recs.Recs))
-	labels = labels.WithResult(metrics.Success)
+	labels = labels.WithResult(metrics.OkSuccess)
 	metrics.Requests.Count(labels).Inc()
 	metrics.Requests.RepliedSegs(labels.RequestOkLabels).Add(float64(len(reply.Recs.Recs)))
 	metrics.Requests.RepliedRevs(labels.RequestOkLabels).Add(float64(len(reply.Recs.SRevInfos)))

--- a/go/path_srv/internal/segreq/handler.go
+++ b/go/path_srv/internal/segreq/handler.go
@@ -105,7 +105,7 @@ func (h *handler) Handle(request *infra.Request) *infra.HandlerResult {
 	}
 	if err = rw.SendSegReply(ctx, reply); err != nil {
 		logger.Error("[segReqHandler] Failed to send reply", "err", err)
-		metrics.Requests.Count(labels.WithResult(metrics.ErrReply)).Inc()
+		metrics.Requests.Count(labels.WithResult(metrics.ErrNetwork)).Inc()
 		return infra.MetricsErrInternal
 	}
 	logger.Debug("[segReqHandler] Replied with segments", "segs", len(reply.Recs.Recs))

--- a/go/path_srv/internal/segsyncer/BUILD.bazel
+++ b/go/path_srv/internal/segsyncer/BUILD.bazel
@@ -21,6 +21,8 @@ go_library(
         "//go/lib/snet/addrutil:go_default_library",
         "//go/lib/topology:go_default_library",
         "//go/path_srv/internal/handlers:go_default_library",
+        "//go/path_srv/internal/metrics:go_default_library",
         "//go/proto:go_default_library",
+        "@org_golang_x_xerrors//:go_default_library",
     ],
 )

--- a/go/path_srv/internal/segsyncer/segsyncer.go
+++ b/go/path_srv/internal/segsyncer/segsyncer.go
@@ -110,7 +110,7 @@ func (s *SegSyncer) Run(ctx context.Context) {
 		logger.Error("[segsyncer.SegSyncer] Failed to find path to remote",
 			"dstIA", s.dstIA, "err", err)
 		s.repErrCnt++
-		metrics.Syncs.Pushes(labels.WithResult(errToMetricsLabel(ctx, err))).Inc()
+		metrics.Syncs.Pushes(labels.WithResult(errToMetricsLabel(logger, err))).Inc()
 		return
 	}
 	cnt, err := s.runInternal(ctx, cPs)
@@ -118,14 +118,14 @@ func (s *SegSyncer) Run(ctx context.Context) {
 		logger.Error("[segsyncer.SegSyncer] Failed to send segSync",
 			"dstIA", s.dstIA, "err", err)
 		s.repErrCnt++
-		metrics.Syncs.Pushes(labels.WithResult(errToMetricsLabel(ctx, err))).Inc()
+		metrics.Syncs.Pushes(labels.WithResult(errToMetricsLabel(logger, err))).Inc()
 		return
 	}
 	if cnt > 0 {
 		logger.Debug("[segsyncer.SegSyncer] Sent down segments",
 			"dstIA", s.dstIA, "cnt", cnt)
 	}
-	metrics.Syncs.Pushes(labels.WithResult(metrics.Success)).Inc()
+	metrics.Syncs.Pushes(labels.WithResult(metrics.OkSuccess)).Inc()
 	s.repErrCnt = 0
 }
 
@@ -228,7 +228,7 @@ func (s *SegSyncer) createMessages(ctx context.Context,
 	return msgs, nil
 }
 
-func errToMetricsLabel(ctx context.Context, err error) string {
+func errToMetricsLabel(logger log.Logger, err error) string {
 	switch {
 	case serrors.IsTimeout(err):
 		return metrics.ErrTimeout
@@ -241,7 +241,7 @@ func errToMetricsLabel(ctx context.Context, err error) string {
 	case xerrors.Is(err, errNet):
 		return metrics.ErrNetwork
 	default:
-		log.FromCtx(ctx).Debug("[segsyncer.SegSyncer] Unclassified err", "err", err)
+		logger.Debug("[segsyncer.SegSyncer] Unclassified err", "err", err)
 		return metrics.ErrNotClassified
 	}
 }

--- a/go/path_srv/internal/segsyncer/segsyncer.go
+++ b/go/path_srv/internal/segsyncer/segsyncer.go
@@ -110,7 +110,7 @@ func (s *SegSyncer) Run(ctx context.Context) {
 		logger.Error("[segsyncer.SegSyncer] Failed to find path to remote",
 			"dstIA", s.dstIA, "err", err)
 		s.repErrCnt++
-		metrics.Syncs.Pushes(labels.WithResult(errToMetricsLabel(logger, err))).Inc()
+		metrics.Sync.Pushes(labels.WithResult(errToMetricsLabel(err))).Inc()
 		return
 	}
 	cnt, err := s.runInternal(ctx, cPs)
@@ -118,14 +118,14 @@ func (s *SegSyncer) Run(ctx context.Context) {
 		logger.Error("[segsyncer.SegSyncer] Failed to send segSync",
 			"dstIA", s.dstIA, "err", err)
 		s.repErrCnt++
-		metrics.Syncs.Pushes(labels.WithResult(errToMetricsLabel(logger, err))).Inc()
+		metrics.Sync.Pushes(labels.WithResult(errToMetricsLabel(err))).Inc()
 		return
 	}
 	if cnt > 0 {
 		logger.Debug("[segsyncer.SegSyncer] Sent down segments",
 			"dstIA", s.dstIA, "cnt", cnt)
 	}
-	metrics.Syncs.Pushes(labels.WithResult(metrics.OkSuccess)).Inc()
+	metrics.Sync.Pushes(labels.WithResult(metrics.OkSuccess)).Inc()
 	s.repErrCnt = 0
 }
 
@@ -228,7 +228,7 @@ func (s *SegSyncer) createMessages(ctx context.Context,
 	return msgs, nil
 }
 
-func errToMetricsLabel(logger log.Logger, err error) string {
+func errToMetricsLabel(err error) string {
 	switch {
 	case serrors.IsTimeout(err):
 		return metrics.ErrTimeout
@@ -241,7 +241,6 @@ func errToMetricsLabel(logger log.Logger, err error) string {
 	case xerrors.Is(err, errNet):
 		return metrics.ErrNetwork
 	default:
-		logger.Debug("[segsyncer.SegSyncer] Unclassified err", "err", err)
 		return metrics.ErrNotClassified
 	}
 }

--- a/go/sciond/internal/metrics/metrics.go
+++ b/go/sciond/internal/metrics/metrics.go
@@ -45,7 +45,7 @@ const (
 const (
 	OkSuccess   = prom.Success
 	ErrInternal = prom.ErrInternal
-	ErrNetwork  = prom.ErrReply
+	ErrNetwork  = prom.ErrNetwork
 )
 
 var resultLabel = []string{prom.LabelResult}


### PR DESCRIPTION
Adds metrics:
```
# HELP ps_segment_sync_pushes_total Number of pushes towards a destination
# TYPE ps_segment_sync_pushes_total counter
ps_segment_sync_pushes_total{dst="1-ff00:0:120",result="err_nopath"} 5
ps_segment_sync_pushes_total{dst="1-ff00:0:120",result="ok_success"} 139
ps_segment_sync_pushes_total{dst="1-ff00:0:130",result="err_nopath"} 1
ps_segment_sync_pushes_total{dst="1-ff00:0:130",result="ok_success"} 143
# HELP ps_segment_sync_registrations_total Number of segments registered in down segment synchronizations
# TYPE ps_segment_sync_registrations_total counter
ps_segment_sync_registrations_total{result="ok_new",src="1-ff00:0:120"} 4
ps_segment_sync_registrations_total{result="ok_new",src="1-ff00:0:130"} 6
ps_segment_sync_registrations_total{result="ok_updated",src="1-ff00:0:120"} 93
ps_segment_sync_registrations_total{result="ok_updated",src="1-ff00:0:130"} 142
```

Contributes #3106

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3241)
<!-- Reviewable:end -->
