### PR TITLE
Add metrics to reliable socket and reconnecting libs

### DIFF
--- a/go/lib/addr/host.go
+++ b/go/lib/addr/host.go
@@ -264,6 +264,8 @@ func (h HostSVC) String() string {
 	return fmt.Sprintf("%v %c (0x%04x)", name, cast, uint16(h))
 }
 
+// BaseString returns the upper case name of the service. For hosts or unrecognized services, it
+// returns UNKNOWN.
 func (h HostSVC) BaseString() string {
 	switch h.Base() {
 	case SvcBS:

--- a/go/lib/prom/prom.go
+++ b/go/lib/prom/prom.go
@@ -73,6 +73,9 @@ var (
 	// DefaultLatencyBuckets 10ms, 20ms, 40ms, ... 5.12s, 10.24s.
 	DefaultLatencyBuckets = []float64{0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64,
 		1.28, 2.56, 5.12, 10.24}
+	// DefaultSizeBuckets 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384
+	DefaultSizeBuckets = []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192,
+		16384}
 )
 
 // ExportElementID exports the element ID as configured in the config file.

--- a/go/lib/prom/prom.go
+++ b/go/lib/prom/prom.go
@@ -73,9 +73,8 @@ var (
 	// DefaultLatencyBuckets 10ms, 20ms, 40ms, ... 5.12s, 10.24s.
 	DefaultLatencyBuckets = []float64{0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64,
 		1.28, 2.56, 5.12, 10.24}
-	// DefaultSizeBuckets 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384
-	DefaultSizeBuckets = []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192,
-		16384}
+	// DefaultSizeBuckets 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384
+	DefaultSizeBuckets = []float64{32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384}
 )
 
 // ExportElementID exports the element ID as configured in the config file.

--- a/go/lib/sock/reliable/BUILD.bazel
+++ b/go/lib/sock/reliable/BUILD.bazel
@@ -16,7 +16,9 @@ go_library(
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/overlay:go_default_library",
+        "//go/lib/prom:go_default_library",
         "//go/lib/serrors:go_default_library",
+        "//go/lib/sock/reliable/internal/metrics:go_default_library",
     ],
 )
 

--- a/go/lib/sock/reliable/internal/metrics/BUILD.bazel
+++ b/go/lib/sock/reliable/internal/metrics/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -9,4 +9,11 @@ go_library(
         "//go/lib/prom:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["metrics_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//go/lib/prom/promtest:go_default_library"],
 )

--- a/go/lib/sock/reliable/internal/metrics/BUILD.bazel
+++ b/go/lib/sock/reliable/internal/metrics/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "github.com/scionproto/scion/go/lib/sock/reliable/internal/metrics",
+    visibility = ["//go/lib/sock/reliable:__subpackages__"],
+    deps = [
+        "//go/lib/prom:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+    ],
+)

--- a/go/lib/sock/reliable/internal/metrics/metrics.go
+++ b/go/lib/sock/reliable/internal/metrics/metrics.go
@@ -1,0 +1,113 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/scionproto/scion/go/lib/prom"
+)
+
+// Namespace is the metrics namespace for the metrics in this package.
+const Namespace = "lib"
+
+const sub = "reliable"
+
+var (
+	// M exposes all the initialized metrics for this package.
+	M = newMetrics()
+)
+
+// DialLabels contains the labels for Dial calls.
+type DialLabels struct {
+	Result string
+}
+
+// Labels returns the list of labels.
+func (l DialLabels) Labels() []string {
+	return []string{prom.LabelResult}
+}
+
+// Values returns the label values in the order defined by Labels.
+func (l DialLabels) Values() []string {
+	return []string{l.Result}
+}
+
+// RegisterLabels contains the labels for Register calls.
+type RegisterLabels struct {
+	Result string
+	SVC    string
+}
+
+// Labels returns the list of labels.
+func (l RegisterLabels) Labels() []string {
+	return []string{prom.LabelResult, "svc"}
+}
+
+// Values returns the label values in the order defined by Labels.
+func (l RegisterLabels) Values() []string {
+	return []string{l.Result, l.SVC}
+}
+
+// IOLabels contains the labels for Read and Write calls.
+type IOLabels struct {
+	Result string
+}
+
+// Labels returns the list of labels.
+func (l IOLabels) Labels() []string {
+	return []string{prom.LabelResult}
+}
+
+// Values returns the label values in the order defined by Labels.
+func (l IOLabels) Values() []string {
+	return []string{l.Result}
+}
+
+type metrics struct {
+	dials     *prometheus.CounterVec
+	registers *prometheus.CounterVec
+	reads     *prometheus.HistogramVec
+	writes    *prometheus.HistogramVec
+}
+
+func newMetrics() metrics {
+	return metrics{
+		dials: prom.NewCounterVec(Namespace, sub, "dials_total",
+			"Total number of Dial calls.", DialLabels{}.Labels()),
+		registers: prom.NewCounterVec(Namespace, sub, "registers_total",
+			"Total number of Register calls.", RegisterLabels{}.Labels()),
+		reads: prom.NewHistogramVec(Namespace, sub, "reads_total",
+			"Total number of Read calls", IOLabels{}.Labels(), prom.DefaultSizeBuckets),
+		writes: prom.NewHistogramVec(Namespace, sub, "writes_total",
+			"Total number of Write calls", IOLabels{}.Labels(), prom.DefaultSizeBuckets),
+	}
+}
+
+func (m metrics) Dials(l DialLabels) prometheus.Counter {
+	return m.dials.WithLabelValues(l.Values()...)
+}
+
+func (m metrics) Registers(l RegisterLabels) prometheus.Counter {
+	return m.registers.WithLabelValues(l.Values()...)
+}
+
+func (m metrics) Reads(l IOLabels) prometheus.Observer {
+	return m.reads.WithLabelValues(l.Values()...)
+}
+
+func (m metrics) Writes(l IOLabels) prometheus.Observer {
+	return m.writes.WithLabelValues(l.Values()...)
+}

--- a/go/lib/sock/reliable/internal/metrics/metrics_test.go
+++ b/go/lib/sock/reliable/internal/metrics/metrics_test.go
@@ -1,0 +1,28 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/scionproto/scion/go/lib/prom/promtest"
+	"github.com/scionproto/scion/go/lib/sock/reliable/internal/metrics"
+)
+
+func TestLabels(t *testing.T) {
+	promtest.CheckLabelsStruct(t, metrics.DialLabels{})
+	promtest.CheckLabelsStruct(t, metrics.RegisterLabels{})
+	promtest.CheckLabelsStruct(t, metrics.IOLabels{})
+}

--- a/go/lib/sock/reliable/reconnect/BUILD.bazel
+++ b/go/lib/sock/reliable/reconnect/BUILD.bazel
@@ -15,10 +15,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/overlay:go_default_library",
+        "//go/lib/serrors:go_default_library",
         "//go/lib/sock/reliable:go_default_library",
+        "//go/lib/sock/reliable/reconnect/internal/metrics:go_default_library",
+        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/go/lib/sock/reliable/reconnect/conn.go
+++ b/go/lib/sock/reliable/reconnect/conn.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/sock/reliable"
 )
@@ -93,7 +92,7 @@ Loop:
 		deadline := conn.getDeadlineForOpType(op)
 		select {
 		case <-conn.closeCh:
-			return common.NewBasicError(ErrClosed, nil)
+			return ErrClosed
 		case <-conn.dispatcherState.Up():
 			err = op.Do(conn.getConn())
 			if err != nil {
@@ -109,7 +108,7 @@ Loop:
 			return err
 		case <-conn.deadlineChangedEvent:
 		case <-returnOnDeadline(deadline):
-			return common.NewBasicError(ErrDispatcherDead, nil)
+			return ErrDispatcherDead
 		}
 	}
 	return nil

--- a/go/lib/sock/reliable/reconnect/conn_io_test.go
+++ b/go/lib/sock/reliable/reconnect/conn_io_test.go
@@ -88,7 +88,7 @@ func TestPacketConnIO(t *testing.T) {
 			)
 			packetConn.SetWriteDeadline(time.Now().Add(tickerMultiplier(2)))
 			err := packetConn.DoIO(mockIO)
-			SoMsg("err", common.GetErrorMsg(err), ShouldEqual, reconnect.ErrDispatcherDead)
+			SoMsg("err", err, ShouldEqual, reconnect.ErrDispatcherDead)
 		})
 		Convey("SetWriteDeadline in the past unblocks a blocked writer", func() {
 			mockConn.EXPECT().SetWriteDeadline(Any()).Return(nil).AnyTimes()
@@ -111,7 +111,7 @@ func TestPacketConnIO(t *testing.T) {
 				packetConn.SetWriteDeadline(time.Now().Add(tickerMultiplier(-1)))
 			}()
 			err := packetConn.DoIO(mockIO)
-			SoMsg("err", common.GetErrorMsg(err), ShouldEqual, reconnect.ErrDispatcherDead)
+			SoMsg("err", err, ShouldEqual, reconnect.ErrDispatcherDead)
 		})
 		Convey("SetReadDeadline in the past unblocks a blocked reader", func() {
 			mockConn.EXPECT().SetWriteDeadline(Any()).Return(nil).AnyTimes()
@@ -136,7 +136,7 @@ func TestPacketConnIO(t *testing.T) {
 				packetConn.SetReadDeadline(time.Now().Add(tickerMultiplier(-1)))
 			}()
 			err := packetConn.DoIO(mockIO)
-			SoMsg("err", common.GetErrorMsg(err), ShouldEqual, reconnect.ErrDispatcherDead)
+			SoMsg("err", err, ShouldEqual, reconnect.ErrDispatcherDead)
 		})
 		Convey("After reconnect, IO deadline is inherited by the new connection", func() {
 			deadline := time.Now().Add(tickerMultiplier(1))

--- a/go/lib/sock/reliable/reconnect/errors.go
+++ b/go/lib/sock/reliable/reconnect/errors.go
@@ -14,9 +14,11 @@
 
 package reconnect
 
-const (
-	ErrDispatcherDead            = "dispatcher dead"
-	ErrReconnecterTimeoutExpired = "Timeout expired"
-	ErrReconnecterStopped        = "Stop method was called"
-	ErrClosed                    = "closed"
+import "github.com/scionproto/scion/go/lib/serrors"
+
+var (
+	ErrDispatcherDead            = serrors.New("dispatcher dead")
+	ErrReconnecterTimeoutExpired = serrors.New("timeout expired")
+	ErrReconnecterStopped        = serrors.New("stop method was called")
+	ErrClosed                    = serrors.New("closed")
 )

--- a/go/lib/sock/reliable/reconnect/errors.go
+++ b/go/lib/sock/reliable/reconnect/errors.go
@@ -17,7 +17,8 @@ package reconnect
 import "github.com/scionproto/scion/go/lib/serrors"
 
 var (
-	ErrDispatcherDead            = serrors.New("dispatcher dead")
+	ErrDispatcherDead = serrors.New("dispatcher dead")
+	// FIXME(scrye): Change this s.t. it's serrors.IsTimeout compatible.
 	ErrReconnecterTimeoutExpired = serrors.New("timeout expired")
 	ErrReconnecterStopped        = serrors.New("stop method was called")
 	ErrClosed                    = serrors.New("closed")

--- a/go/lib/sock/reliable/reconnect/internal/metrics/BUILD.bazel
+++ b/go/lib/sock/reliable/reconnect/internal/metrics/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "github.com/scionproto/scion/go/lib/sock/reliable/reconnect/internal/metrics",
+    visibility = ["//go/lib/sock/reliable/reconnect:__subpackages__"],
+    deps = [
+        "//go/lib/prom:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+    ],
+)

--- a/go/lib/sock/reliable/reconnect/internal/metrics/metrics.go
+++ b/go/lib/sock/reliable/reconnect/internal/metrics/metrics.go
@@ -1,0 +1,69 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/scionproto/scion/go/lib/prom"
+)
+
+// Namespace is the metrics namespace for the metrics in this package.
+const Namespace = "lib"
+
+const sub = "reconnect"
+
+var (
+	// M exposes all the initialized metrics for this package.
+	M = newMetrics()
+)
+
+// Labels contains the labels for the metrics in this package.
+type Labels struct {
+}
+
+// Labels returns the list of labels.
+func (l Labels) Labels() []string {
+	return []string{}
+}
+
+// Values returns the label values in the order defined by Labels.
+func (l Labels) Values() []string {
+	return []string{}
+}
+
+type metrics struct {
+	timeouts prometheus.Counter
+	retries  prometheus.Counter
+}
+
+func newMetrics() metrics {
+	return metrics{
+		timeouts: prom.NewCounter(Namespace, sub, "timeouts_total",
+			"Total number of reconnection attempt timeouts"),
+		retries: prom.NewCounter(Namespace, sub, "retries_total",
+			"Total number of reconnection attempt retries"),
+	}
+}
+
+// Timeouts returns a counter for timeout errors.
+func (m metrics) Timeouts(_ Labels) prometheus.Counter {
+	return m.timeouts
+}
+
+// Retries returns a counter for individual reconnection attempts.
+func (m metrics) Retries(_ Labels) prometheus.Counter {
+	return m.retries
+}

--- a/go/lib/sock/reliable/reconnect/internal/metrics/metrics.go
+++ b/go/lib/sock/reliable/reconnect/internal/metrics/metrics.go
@@ -30,20 +30,6 @@ var (
 	M = newMetrics()
 )
 
-// Labels contains the labels for the metrics in this package.
-type Labels struct {
-}
-
-// Labels returns the list of labels.
-func (l Labels) Labels() []string {
-	return []string{}
-}
-
-// Values returns the label values in the order defined by Labels.
-func (l Labels) Values() []string {
-	return []string{}
-}
-
 type metrics struct {
 	timeouts prometheus.Counter
 	retries  prometheus.Counter
@@ -59,11 +45,11 @@ func newMetrics() metrics {
 }
 
 // Timeouts returns a counter for timeout errors.
-func (m metrics) Timeouts(_ Labels) prometheus.Counter {
+func (m metrics) Timeouts() prometheus.Counter {
 	return m.timeouts
 }
 
 // Retries returns a counter for individual reconnection attempts.
-func (m metrics) Retries(_ Labels) prometheus.Counter {
+func (m metrics) Retries() prometheus.Counter {
 	return m.retries
 }

--- a/go/lib/sock/reliable/reconnect/network.go
+++ b/go/lib/sock/reliable/reconnect/network.go
@@ -77,10 +77,10 @@ func (pn *DispatcherService) newReconnecterFromListenArgs(ia addr.IA,
 
 	// f represents individual connection attempts
 	f := func(timeout time.Duration) (net.PacketConn, uint16, error) {
-		metrics.M.Retries(metrics.Labels{}).Inc()
+		metrics.M.Retries().Inc()
 		conn, port, err := pn.dispatcher.RegisterTimeout(ia, public, bind, svc, timeout)
 		if xerrors.Is(err, ErrReconnecterTimeoutExpired) {
-			metrics.M.Timeouts(metrics.Labels{}).Inc()
+			metrics.M.Timeouts().Inc()
 		}
 		return conn, port, err
 	}

--- a/go/lib/sock/reliable/reconnect/network.go
+++ b/go/lib/sock/reliable/reconnect/network.go
@@ -18,9 +18,12 @@ import (
 	"net"
 	"time"
 
+	"golang.org/x/xerrors"
+
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/sock/reliable"
+	"github.com/scionproto/scion/go/lib/sock/reliable/reconnect/internal/metrics"
 )
 
 // DispatcherService is a dispatcher wrapper that creates conns
@@ -37,9 +40,7 @@ type DispatcherService struct {
 
 // NewDispatcherService adds transparent reconnection capabilities
 // to dispatcher connections.
-func NewDispatcherService(
-	dispatcher reliable.DispatcherService) *DispatcherService {
-
+func NewDispatcherService(dispatcher reliable.DispatcherService) *DispatcherService {
 	return &DispatcherService{dispatcher: dispatcher}
 }
 
@@ -74,8 +75,14 @@ func (pn *DispatcherService) newReconnecterFromListenArgs(ia addr.IA,
 	public *addr.AppAddr, bind *overlay.OverlayAddr,
 	svc addr.HostSVC, timeout time.Duration) *TickingReconnecter {
 
+	// f represents individual connection attempts
 	f := func(timeout time.Duration) (net.PacketConn, uint16, error) {
-		return pn.dispatcher.RegisterTimeout(ia, public, bind, svc, timeout)
+		metrics.M.Retries(metrics.Labels{}).Inc()
+		conn, port, err := pn.dispatcher.RegisterTimeout(ia, public, bind, svc, timeout)
+		if xerrors.Is(err, ErrReconnecterTimeoutExpired) {
+			metrics.M.Timeouts(metrics.Labels{}).Inc()
+		}
+		return conn, port, err
 	}
 	return NewTickingReconnecter(f)
 }

--- a/go/lib/sock/reliable/reconnect/reconnecter.go
+++ b/go/lib/sock/reliable/reconnect/reconnecter.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/sock/reliable"
 )
@@ -74,7 +73,7 @@ func (r *TickingReconnecter) Reconnect(timeout time.Duration) (net.PacketConn, u
 	for r.stopping.IsFalse() {
 		newTimeout, ok := getNewTimeout(timeout, start)
 		if !ok {
-			return nil, 0, common.NewBasicError(ErrReconnecterTimeoutExpired, nil)
+			return nil, 0, ErrReconnecterTimeoutExpired
 		}
 		conn, port, err := r.reconnectF(newTimeout)
 		switch {
@@ -88,7 +87,7 @@ func (r *TickingReconnecter) Reconnect(timeout time.Duration) (net.PacketConn, u
 			select {
 			case <-t.C:
 			case <-timeoutExpired:
-				return nil, 0, common.NewBasicError(ErrReconnecterTimeoutExpired, nil)
+				return nil, 0, ErrReconnecterTimeoutExpired
 			}
 			continue
 		case err != nil:
@@ -97,7 +96,7 @@ func (r *TickingReconnecter) Reconnect(timeout time.Duration) (net.PacketConn, u
 			return conn, port, nil
 		}
 	}
-	return nil, 0, common.NewBasicError(ErrReconnecterStopped, nil)
+	return nil, 0, ErrReconnecterStopped
 }
 
 // Stop shuts down the reconnection attempt (if any), and waits for the

--- a/go/lib/sock/reliable/reconnect/reconnecter_test.go
+++ b/go/lib/sock/reliable/reconnect/reconnecter_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/sock/reliable/reconnect"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
@@ -65,7 +64,7 @@ func TestTickingReconnectorStop(t *testing.T) {
 			}()
 			go reconnecter.Stop()
 			xtest.AssertReadReturnsBefore(t, barrierCh, tickerMultiplier(4))
-			SoMsg("err", common.GetErrorMsg(err), ShouldEqual, reconnect.ErrReconnecterStopped)
+			SoMsg("err", err, ShouldEqual, reconnect.ErrReconnecterStopped)
 		})
 	})
 	Convey("Given a reconnection function that takes a long time", t, func() {


### PR DESCRIPTION
Metrics:
```
# HELP lib_reliable_dials_total Total number of Dial calls.
# TYPE lib_reliable_dials_total counter
lib_reliable_dials_total{result="err_not_classified"} 1
lib_reliable_dials_total{result="ok_success"} 3
# HELP lib_reliable_registers_total Total number of Register calls.
# TYPE lib_reliable_registers_total counter
lib_reliable_registers_total{result="ok_success",svc="CS"} 1
lib_reliable_registers_total{result="ok_success",svc="UNKNOWN"} 3
# HELP lib_reliable_reads_total Total number of Read calls
# TYPE lib_reliable_reads_total histogram
lib_reliable_reads_total_bucket{result="err_not_classified",le="1"} 2
lib_reliable_reads_total_bucket{result="err_not_classified",le="+Inf"} 2
lib_reliable_reads_total_sum{result="err_not_classified"} 0
lib_reliable_reads_total_count{result="err_not_classified"} 2
lib_reliable_reads_total_bucket{result="ok_success",le="1"} 0
lib_reliable_reads_total_bucket{result="ok_success",le="+Inf"} 422
lib_reliable_reads_total_sum{result="ok_success"} 148709
lib_reliable_reads_total_count{result="ok_success"} 422
# HELP lib_reliable_writes_total Total number of Write calls
# TYPE lib_reliable_writes_total histogram
lib_reliable_writes_total_bucket{result="ok_success",le="1"} 0
lib_reliable_writes_total_bucket{result="ok_success",le="+Inf"} 403
lib_reliable_writes_total_sum{result="ok_success"} 85732
lib_reliable_writes_total_count{result="ok_success"} 403
# HELP lib_reconnect_retries_total Total number of reconnection attempt retries
# TYPE lib_reconnect_retries_total counter
lib_reconnect_retries_total 2
# HELP lib_reconnect_timeouts_total Total number of reconnection attempt timeouts
# TYPE lib_reconnect_timeouts_total counter
lib_reconnect_timeouts_total 0
```

Fixes https://github.com/scionproto/scion/issues/3183.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3242)
<!-- Reviewable:end -->
