### PR TITLE
SD: Add request metrics

### DIFF
--- a/go/sciond/internal/metrics/BUILD.bazel
+++ b/go/sciond/internal/metrics/BUILD.bazel
@@ -1,8 +1,20 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = ["metrics.go"],
     importpath = "github.com/scionproto/scion/go/sciond/internal/metrics",
     visibility = ["//go/sciond:__subpackages__"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/prom:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["metrics_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//go/lib/prom/promtest:go_default_library"],
 )

--- a/go/sciond/internal/metrics/metrics.go
+++ b/go/sciond/internal/metrics/metrics.go
@@ -48,9 +48,10 @@ const (
 	ErrNetwork  = prom.ErrReply
 )
 
-var (
-	resultLabel = []string{"result"}
+var resultLabel = []string{prom.LabelResult}
 
+// Metric accessors.
+var (
 	// PathRequests contains metrics for path requests.
 	PathRequests = newPathRequest()
 	// Revocations contains metrics for revocations.
@@ -116,9 +117,9 @@ type PathRequest struct {
 func newPathRequest() PathRequest {
 	return PathRequest{
 		count: prom.NewCounterVec(Namespace, subsystemPath, "requests_total",
-			"The amount of path requests sciond received.", PathRequestLabels{}.Labels()),
+			"The amount of path requests received.", PathRequestLabels{}.Labels()),
 		latency: prom.NewHistogramVec(Namespace, subsystemPath, "request_duration_seconds",
-			"The duration of path requests in sciond.", resultLabel, prom.DefaultLatencyBuckets),
+			"Time to handle path requests.", resultLabel, prom.DefaultLatencyBuckets),
 	}
 }
 
@@ -140,11 +141,10 @@ type Revocation struct {
 
 func newRevocation() Revocation {
 	return Revocation{
-		count: prom.NewCounterVec(Namespace, subsystemRevocation+"s", "total",
-			"The amount of revocations sciond received.", RevocationLabels{}.Labels()),
+		count: prom.NewCounterVec(Namespace, subsystemRevocation, "total",
+			"The amount of revocations received.", RevocationLabels{}.Labels()),
 		latency: prom.NewHistogramVec(Namespace, subsystemRevocation,
-			"notification_duration_seconds",
-			"The duration of processing revocation notifications in sciond.",
+			"notification_duration_seconds", "Time to process revocation notifications.",
 			resultLabel, prom.DefaultLatencyBuckets),
 	}
 }
@@ -186,7 +186,7 @@ func newASInfoRequest() Request {
 		count: prom.NewCounterVec(Namespace, subsystemASInfo, "requests_total",
 			"The amount of AS info requests received.", resultLabel),
 		latency: prom.NewHistogramVec(Namespace, subsystemASInfo, "request_duration_seconds",
-			"The duration of AS info requests in sciond.", resultLabel, prom.DefaultLatencyBuckets),
+			"Time to handle AS info requests.", resultLabel, prom.DefaultLatencyBuckets),
 	}
 }
 
@@ -195,7 +195,7 @@ func newSVCInfo() Request {
 		count: prom.NewCounterVec(Namespace, subsystemSVCInfo, "requests_total",
 			"The amount of SVC info requests received.", resultLabel),
 		latency: prom.NewHistogramVec(Namespace, subsystemSVCInfo, "request_duration_seconds",
-			"The duration of SVC info requests in sciond.",
+			"Time to handle SVC info requests.",
 			resultLabel, prom.DefaultLatencyBuckets),
 	}
 }
@@ -205,6 +205,6 @@ func newIFInfo() Request {
 		count: prom.NewCounterVec(Namespace, subsystemIFInfo, "requests_total",
 			"The amount of IF info requests received.", resultLabel),
 		latency: prom.NewHistogramVec(Namespace, subsystemIFInfo, "request_duration_seconds",
-			"The duration of IF info requests in sciond.", resultLabel, prom.DefaultLatencyBuckets),
+			"Time to handle IF info requests.", resultLabel, prom.DefaultLatencyBuckets),
 	}
 }

--- a/go/sciond/internal/metrics/metrics.go
+++ b/go/sciond/internal/metrics/metrics.go
@@ -184,7 +184,7 @@ func (r Request) Start() func(string) {
 func newASInfoRequest() Request {
 	return Request{
 		count: prom.NewCounterVec(Namespace, subsystemASInfo, "requests_total",
-			"The amount of AS info requests received.", RevocationLabels{}.Labels()),
+			"The amount of AS info requests received.", resultLabel),
 		latency: prom.NewHistogramVec(Namespace, subsystemASInfo, "request_duration_seconds",
 			"The duration of AS info requests in sciond.", resultLabel, prom.DefaultLatencyBuckets),
 	}
@@ -193,7 +193,7 @@ func newASInfoRequest() Request {
 func newSVCInfo() Request {
 	return Request{
 		count: prom.NewCounterVec(Namespace, subsystemSVCInfo, "requests_total",
-			"The amount of SVC info requests received.", RevocationLabels{}.Labels()),
+			"The amount of SVC info requests received.", resultLabel),
 		latency: prom.NewHistogramVec(Namespace, subsystemSVCInfo, "request_duration_seconds",
 			"The duration of SVC info requests in sciond.",
 			resultLabel, prom.DefaultLatencyBuckets),
@@ -203,7 +203,7 @@ func newSVCInfo() Request {
 func newIFInfo() Request {
 	return Request{
 		count: prom.NewCounterVec(Namespace, subsystemIFInfo, "requests_total",
-			"The amount of IF info requests received.", RevocationLabels{}.Labels()),
+			"The amount of IF info requests received.", resultLabel),
 		latency: prom.NewHistogramVec(Namespace, subsystemIFInfo, "request_duration_seconds",
 			"The duration of IF info requests in sciond.", resultLabel, prom.DefaultLatencyBuckets),
 	}

--- a/go/sciond/internal/metrics/metrics.go
+++ b/go/sciond/internal/metrics/metrics.go
@@ -14,5 +14,197 @@
 
 package metrics
 
-// Namespace is the metrics namespace for sciond.
-const Namespace = "sd"
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/prom"
+)
+
+const (
+	// Namespace is the metrics namespace for sciond.
+	Namespace = "sd"
+
+	subsystemPath       = "path"
+	subsystemASInfo     = "as_info"
+	subsystemIFInfo     = "if_info"
+	subsystemSVCInfo    = "service_info"
+	subsystemRevocation = "revocation"
+)
+
+// Revocation sources
+const (
+	RevSrcNotification = "notification"
+	RevSrcSCMP         = "scmp"
+	RevSrcPathReply    = "path_reply"
+)
+
+// Result values
+const (
+	OkSuccess   = prom.Success
+	ErrInternal = prom.ErrInternal
+	ErrNetwork  = prom.ErrReply
+)
+
+var (
+	resultLabel = []string{"result"}
+
+	// PathRequests contains metrics for path requests.
+	PathRequests = newPathRequest()
+	// Revocations contains metrics for revocations.
+	Revocations = newRevocation()
+	// ASInfos contains metrics for AS info requests.
+	ASInfos = newASInfoRequest()
+	// IFInfos contains metrics for IF info requests.
+	IFInfos = newIFInfo()
+	// SVCInfos contains metrics for SVC info requests.
+	SVCInfos = newSVCInfo()
+)
+
+// PathRequestLabels are the labels for path requests metrics.
+type PathRequestLabels struct {
+	Result string
+	Dst    addr.ISD
+}
+
+// Labels returns the labels.
+func (l PathRequestLabels) Labels() []string {
+	return []string{"result", "dst"}
+}
+
+// Values returns the values for the labels.
+func (l PathRequestLabels) Values() []string {
+	return []string{l.Result, l.Dst.String()}
+}
+
+// WithResult returns the labels with the result set.
+func (l PathRequestLabels) WithResult(result string) PathRequestLabels {
+	l.Result = result
+	return l
+}
+
+// RevocationLabels are the labels for revocation metrics.
+type RevocationLabels struct {
+	Result string
+	Src    string
+}
+
+// Labels returns the labels.
+func (l RevocationLabels) Labels() []string {
+	return []string{"result", "src"}
+}
+
+// Values returns the values for the labels.
+func (l RevocationLabels) Values() []string {
+	return []string{l.Result, l.Src}
+}
+
+// WithResult returns the labels with the result set.
+func (l RevocationLabels) WithResult(result string) RevocationLabels {
+	l.Result = result
+	return l
+}
+
+// PathRequest contains the metrics for path requests.
+type PathRequest struct {
+	count   *prometheus.CounterVec
+	latency *prometheus.HistogramVec
+}
+
+func newPathRequest() PathRequest {
+	return PathRequest{
+		count: prom.NewCounterVec(Namespace, subsystemPath, "requests_total",
+			"The amount of path requests sciond received.", PathRequestLabels{}.Labels()),
+		latency: prom.NewHistogramVec(Namespace, subsystemPath, "request_duration_seconds",
+			"The duration of path requests in sciond.", resultLabel, prom.DefaultLatencyBuckets),
+	}
+}
+
+// Start registers the start time of a path request and returns a callback that
+// should be called at the end of processing the request.
+func (r PathRequest) Start() func(PathRequestLabels) {
+	start := time.Now()
+	return func(l PathRequestLabels) {
+		r.count.WithLabelValues(l.Values()...).Inc()
+		r.latency.WithLabelValues(l.Result).Observe(time.Since(start).Seconds())
+	}
+}
+
+// Revocation contains the metrics for revocation processing.
+type Revocation struct {
+	count   *prometheus.CounterVec
+	latency *prometheus.HistogramVec
+}
+
+func newRevocation() Revocation {
+	return Revocation{
+		count: prom.NewCounterVec(Namespace, subsystemRevocation+"s", "total",
+			"The amount of revocations sciond received.", RevocationLabels{}.Labels()),
+		latency: prom.NewHistogramVec(Namespace, subsystemRevocation,
+			"notification_duration_seconds",
+			"The duration of processing revocation notifications in sciond.",
+			resultLabel, prom.DefaultLatencyBuckets),
+	}
+}
+
+// Count returns the counter for revocations, this should only be incremented if
+// Start is not used.
+func (r Revocation) Count(l RevocationLabels) prometheus.Counter {
+	return r.count.WithLabelValues(l.Values()...)
+}
+
+// Start registers the start time of a revocation notification and returns a
+// callback that should be called at the end of processing the notification.
+func (r Revocation) Start() func(RevocationLabels) {
+	start := time.Now()
+	return func(l RevocationLabels) {
+		r.count.WithLabelValues(l.Values()...).Inc()
+		r.latency.WithLabelValues(l.Result).Observe(time.Since(start).Seconds())
+	}
+}
+
+// Request is the generic metric for requests.
+type Request struct {
+	count   *prometheus.CounterVec
+	latency *prometheus.HistogramVec
+}
+
+// Start registers the start time of a request and returns a callback that
+// should be called at the end of processing the request.
+func (r Request) Start() func(string) {
+	start := time.Now()
+	return func(result string) {
+		r.count.WithLabelValues(result).Inc()
+		r.latency.WithLabelValues(result).Observe(time.Since(start).Seconds())
+	}
+}
+
+func newASInfoRequest() Request {
+	return Request{
+		count: prom.NewCounterVec(Namespace, subsystemASInfo, "requests_total",
+			"The amount of AS info requests received.", RevocationLabels{}.Labels()),
+		latency: prom.NewHistogramVec(Namespace, subsystemASInfo, "request_duration_seconds",
+			"The duration of AS info requests in sciond.", resultLabel, prom.DefaultLatencyBuckets),
+	}
+}
+
+func newSVCInfo() Request {
+	return Request{
+		count: prom.NewCounterVec(Namespace, subsystemSVCInfo, "requests_total",
+			"The amount of SVC info requests received.", RevocationLabels{}.Labels()),
+		latency: prom.NewHistogramVec(Namespace, subsystemSVCInfo, "request_duration_seconds",
+			"The duration of SVC info requests in sciond.",
+			resultLabel, prom.DefaultLatencyBuckets),
+	}
+}
+
+func newIFInfo() Request {
+	return Request{
+		count: prom.NewCounterVec(Namespace, subsystemIFInfo, "requests_total",
+			"The amount of IF info requests received.", RevocationLabels{}.Labels()),
+		latency: prom.NewHistogramVec(Namespace, subsystemIFInfo, "request_duration_seconds",
+			"The duration of IF info requests in sciond.", resultLabel, prom.DefaultLatencyBuckets),
+	}
+}

--- a/go/sciond/internal/metrics/metrics_test.go
+++ b/go/sciond/internal/metrics/metrics_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/scionproto/scion/go/lib/prom/promtest"
+	"github.com/scionproto/scion/go/sciond/internal/metrics"
+)
+
+func TestLabels(t *testing.T) {
+	promtest.CheckLabelsStruct(t, metrics.PathRequestLabels{})
+	promtest.CheckLabelsStruct(t, metrics.RevocationLabels{})
+}

--- a/go/sciond/internal/servers/BUILD.bazel
+++ b/go/sciond/internal/servers/BUILD.bazel
@@ -26,5 +26,6 @@ go_library(
         "//go/lib/tracing:go_default_library",
         "//go/proto:go_default_library",
         "//go/sciond/internal/fetcher:go_default_library",
+        "//go/sciond/internal/metrics:go_default_library",
     ],
 )


### PR DESCRIPTION
Adds metrics:
```
# HELP sd_path_request_duration_seconds The duration of path requests in sciond.
# TYPE sd_path_request_duration_seconds histogram
sd_path_request_duration_seconds_bucket{result="ok_success",le="0.01"} 1
sd_path_request_duration_seconds_bucket{result="ok_success",le="0.02"} 6
sd_path_request_duration_seconds_bucket{result="ok_success",le="0.04"} 11
sd_path_request_duration_seconds_bucket{result="ok_success",le="0.08"} 15
sd_path_request_duration_seconds_bucket{result="ok_success",le="0.16"} 16
sd_path_request_duration_seconds_bucket{result="ok_success",le="0.32"} 17
sd_path_request_duration_seconds_bucket{result="ok_success",le="0.64"} 17
sd_path_request_duration_seconds_bucket{result="ok_success",le="1.28"} 18
sd_path_request_duration_seconds_bucket{result="ok_success",le="2.56"} 20
sd_path_request_duration_seconds_bucket{result="ok_success",le="5.12"} 21
sd_path_request_duration_seconds_bucket{result="ok_success",le="10.24"} 21
sd_path_request_duration_seconds_bucket{result="ok_success",le="+Inf"} 21
sd_path_request_duration_seconds_sum{result="ok_success"} 9.515635177999998
sd_path_request_duration_seconds_count{result="ok_success"} 21
# HELP sd_path_requests_total The amount of path requests sciond received.
# TYPE sd_path_requests_total counter
sd_path_requests_total{dst="1",result="ok_success"} 15
sd_path_requests_total{dst="2",result="ok_success"} 6
```

Also adds similar metrics for all other SD requests: `as_info`, `if_info`, `service_info`, and `revocation`.

Contributes #2156

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3247)
<!-- Reviewable:end -->
