### PR TITLE
snet: Add Interfaces() to Path interface

### DIFF
--- a/go/lib/infra/messenger/BUILD.bazel
+++ b/go/lib/infra/messenger/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
         "//go/lib/infra/mock_infra:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/overlay:go_default_library",
+        "//go/lib/sciond:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/snet/mock_snet:go_default_library",
         "//go/lib/spath:go_default_library",

--- a/go/lib/infra/messenger/addr_test.go
+++ b/go/lib/infra/messenger/addr_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/infra/messenger/mock_messenger"
 	"github.com/scionproto/scion/go/lib/overlay"
+	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/snet/mock_snet"
 	"github.com/scionproto/scion/go/lib/spath"
@@ -489,6 +490,10 @@ func (t *testPath) OverlayNextHop() *overlay.OverlayAddr {
 }
 
 func (t *testPath) Path() *spath.Path {
+	panic("not implemented")
+}
+
+func (t *testPath) Interfaces() []sciond.PathInterface {
 	panic("not implemented")
 }
 

--- a/go/lib/snet/mock_snet/BUILD.bazel
+++ b/go/lib/snet/mock_snet/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/overlay:go_default_library",
+        "//go/lib/sciond:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/spath:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",

--- a/go/lib/snet/mock_snet/snet.go
+++ b/go/lib/snet/mock_snet/snet.go
@@ -9,6 +9,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	addr "github.com/scionproto/scion/go/lib/addr"
 	overlay "github.com/scionproto/scion/go/lib/overlay"
+	sciond "github.com/scionproto/scion/go/lib/sciond"
 	snet "github.com/scionproto/scion/go/lib/snet"
 	spath "github.com/scionproto/scion/go/lib/spath"
 	net "net"
@@ -519,6 +520,20 @@ func (m *MockPath) Fingerprint() string {
 func (mr *MockPathMockRecorder) Fingerprint() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fingerprint", reflect.TypeOf((*MockPath)(nil).Fingerprint))
+}
+
+// Interfaces mocks base method
+func (m *MockPath) Interfaces() []sciond.PathInterface {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Interfaces")
+	ret0, _ := ret[0].([]sciond.PathInterface)
+	return ret0
+}
+
+// Interfaces indicates an expected call of Interfaces
+func (mr *MockPathMockRecorder) Interfaces() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Interfaces", reflect.TypeOf((*MockPath)(nil).Interfaces))
 }
 
 // MTU mocks base method

--- a/go/lib/snet/router.go
+++ b/go/lib/snet/router.go
@@ -132,6 +132,9 @@ type Path interface {
 	// The returned path is initialized and ready for use in snet calls that
 	// deal with raw paths.
 	Path() *spath.Path
+	// Interfaces returns a list of interfaces on the path. If the list is not
+	// available the result is nil.
+	Interfaces() []sciond.PathInterface
 	// Destination is the AS the path points to. Empty paths return the local
 	// AS of the router that created them.
 	Destination() addr.IA
@@ -174,6 +177,15 @@ func (p *path) Path() *spath.Path {
 		return nil
 	}
 	return p.spath.Copy()
+}
+
+func (p *path) Interfaces() []sciond.PathInterface {
+	if p.spath == nil {
+		return nil
+	}
+	res := make([]sciond.PathInterface, len(p.sciondPath.Path.Interfaces))
+	copy(res, p.sciondPath.Path.Interfaces)
+	return res
 }
 
 func (p *path) Destination() addr.IA {
@@ -228,6 +240,10 @@ func (p *partialPath) Path() *spath.Path {
 		return nil
 	}
 	return p.spath.Copy()
+}
+
+func (p *partialPath) Interfaces() []sciond.PathInterface {
+	return nil
 }
 
 func (p *partialPath) Destination() addr.IA {

--- a/go/lib/svc/BUILD.bazel
+++ b/go/lib/svc/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//go/lib/common:go_default_library",
         "//go/lib/l4:go_default_library",
         "//go/lib/overlay:go_default_library",
+        "//go/lib/sciond:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/spath:go_default_library",
         "//go/lib/svc/internal/ctxconn:go_default_library",

--- a/go/lib/svc/resolver.go
+++ b/go/lib/svc/resolver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/l4"
 	"github.com/scionproto/scion/go/lib/overlay"
+	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/lib/svc/internal/ctxconn"
@@ -180,6 +181,10 @@ func (p *path) OverlayNextHop() *overlay.OverlayAddr {
 
 func (p *path) Path() *spath.Path {
 	return p.spath
+}
+
+func (p *path) Interfaces() []sciond.PathInterface {
+	return nil
 }
 
 func (p *path) Destination() addr.IA {


### PR DESCRIPTION
This allows to retreive the list of AS/IFID pairs from a path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3252)
<!-- Reviewable:end -->
