### PR TITLE
Add metrics for SCIOND client API

### DIFF
--- a/go/lib/sciond/BUILD.bazel
+++ b/go/lib/sciond/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//go/lib/hostinfo:go_default_library",
         "//go/lib/infra/disp:go_default_library",
         "//go/lib/log:go_default_library",
+        "//go/lib/sciond/internal/metrics:go_default_library",
         "//go/lib/serrors:go_default_library",
         "//go/lib/sock/reliable:go_default_library",
         "//go/lib/util:go_default_library",

--- a/go/lib/sciond/internal/metrics/BUILD.bazel
+++ b/go/lib/sciond/internal/metrics/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "github.com/scionproto/scion/go/lib/sciond/internal/metrics",
+    visibility = ["//go/lib/sciond:__subpackages__"],
+    deps = [
+        "//go/lib/prom:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+    ],
+)

--- a/go/lib/sciond/internal/metrics/metrics.go
+++ b/go/lib/sciond/internal/metrics/metrics.go
@@ -76,7 +76,7 @@ func newConn() Request {
 
 func newPathRequest() Request {
 	return Request{
-		count: prom.NewCounterVec(Namespace, subsystemPath, "request_total",
+		count: prom.NewCounterVec(Namespace, subsystemPath, "requests_total",
 			"The amount of Path requests sent.", resultLabel),
 	}
 }

--- a/go/lib/sciond/internal/metrics/metrics.go
+++ b/go/lib/sciond/internal/metrics/metrics.go
@@ -83,7 +83,7 @@ func newPathRequest() Request {
 
 func newRevocation() Request {
 	return Request{
-		count: prom.NewCounterVec(Namespace, subsystemRevocation, "request_total",
+		count: prom.NewCounterVec(Namespace, subsystemRevocation, "requests_total",
 			"The amount of Revocation requests sent.", resultLabel),
 	}
 }
@@ -91,20 +91,20 @@ func newRevocation() Request {
 func newASInfoRequest() Request {
 	return Request{
 		count: prom.NewCounterVec(Namespace, subsystemASInfo, "requests_total",
-			"The amount of AS info requests received.", resultLabel),
+			"The amount of AS info requests sent.", resultLabel),
 	}
 }
 
 func newSVCInfo() Request {
 	return Request{
 		count: prom.NewCounterVec(Namespace, subsystemSVCInfo, "requests_total",
-			"The amount of SVC info requests received.", resultLabel),
+			"The amount of SVC info requests sent.", resultLabel),
 	}
 }
 
 func newIFInfo() Request {
 	return Request{
 		count: prom.NewCounterVec(Namespace, subsystemIFInfo, "requests_total",
-			"The amount of IF info requests received.", resultLabel),
+			"The amount of IF info requests sent.", resultLabel),
 	}
 }

--- a/go/lib/sciond/internal/metrics/metrics.go
+++ b/go/lib/sciond/internal/metrics/metrics.go
@@ -1,0 +1,110 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/scionproto/scion/go/lib/prom"
+)
+
+const (
+	// Namespace is the metrics namespace for the SCIOND client API.
+	Namespace = "lib_sciond"
+
+	subsystemConn       = "conn"
+	subsystemPath       = "path"
+	subsystemASInfo     = "as_info"
+	subsystemIFInfo     = "if_info"
+	subsystemSVCInfo    = "service_info"
+	subsystemRevocation = "revocation"
+)
+
+// Result values
+const (
+	OkSuccess        = prom.Success
+	ErrTimeout       = prom.ErrTimeout
+	ErrNotClassified = prom.ErrNotClassified
+)
+
+var resultLabel = []string{prom.LabelResult}
+
+// Metric accessors.
+var (
+	// PathRequests contains metrics for path requests.
+	PathRequests = newPathRequest()
+	// Revocations contains metrics for revocations.
+	Revocations = newRevocation()
+	// ASInfos contains metrics for AS info requests.
+	ASInfos = newASInfoRequest()
+	// IFInfos contains metrics for IF info requests.
+	IFInfos = newIFInfo()
+	// SVCInfos contains metrics for SVC info requests.
+	SVCInfos = newSVCInfo()
+	// Conns contains metrics for connections to SCIOND.
+	Conns = newConn()
+)
+
+// Request is the generic metric for requests.
+type Request struct {
+	count *prometheus.CounterVec
+}
+
+// Inc increases the metric count. The result parameter is used to label the increment.
+func (r Request) Inc(result string) {
+	r.count.WithLabelValues(result).Inc()
+}
+
+func newConn() Request {
+	return Request{
+		count: prom.NewCounterVec(Namespace, subsystemConn, "connections_total",
+			"The amount of SCIOND connection attempts.", resultLabel),
+	}
+}
+
+func newPathRequest() Request {
+	return Request{
+		count: prom.NewCounterVec(Namespace, subsystemPath, "request_total",
+			"The amount of Path requests sent.", resultLabel),
+	}
+}
+
+func newRevocation() Request {
+	return Request{
+		count: prom.NewCounterVec(Namespace, subsystemRevocation, "request_total",
+			"The amount of Revocation requests sent.", resultLabel),
+	}
+}
+
+func newASInfoRequest() Request {
+	return Request{
+		count: prom.NewCounterVec(Namespace, subsystemASInfo, "requests_total",
+			"The amount of AS info requests received.", resultLabel),
+	}
+}
+
+func newSVCInfo() Request {
+	return Request{
+		count: prom.NewCounterVec(Namespace, subsystemSVCInfo, "requests_total",
+			"The amount of SVC info requests received.", resultLabel),
+	}
+}
+
+func newIFInfo() Request {
+	return Request{
+		count: prom.NewCounterVec(Namespace, subsystemIFInfo, "requests_total",
+			"The amount of IF info requests received.", resultLabel),
+	}
+}

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -213,10 +213,11 @@ func (c *conn) Paths(ctx context.Context, dst, src addr.IA, max uint16,
 		},
 		nil,
 	)
-	metrics.PathRequests.Inc(errorToPrometheusLabel(err))
 	if err != nil {
+		metrics.PathRequests.Inc(errorToPrometheusLabel(err))
 		return nil, serrors.WrapStr("[sciond-API] Failed to get Paths", err)
 	}
+	metrics.PathRequests.Inc(metrics.OkSuccess)
 	return reply.(*Pld).PathReply, nil
 }
 
@@ -238,10 +239,11 @@ func (c *conn) ASInfo(ctx context.Context, ia addr.IA) (*ASInfoReply, error) {
 		},
 		nil,
 	)
-	metrics.ASInfos.Inc(errorToPrometheusLabel(err))
 	if err != nil {
+		metrics.ASInfos.Inc(errorToPrometheusLabel(err))
 		return nil, serrors.WrapStr("[sciond-API] Failed to get ASInfo", err)
 	}
+	metrics.ASInfos.Inc(metrics.OkSuccess)
 	return pld.(*Pld).AsInfoReply, nil
 }
 
@@ -263,10 +265,11 @@ func (c *conn) IFInfo(ctx context.Context, ifs []common.IFIDType) (*IFInfoReply,
 		},
 		nil,
 	)
-	metrics.IFInfos.Inc(errorToPrometheusLabel(err))
 	if err != nil {
+		metrics.IFInfos.Inc(errorToPrometheusLabel(err))
 		return nil, serrors.WrapStr("[sciond-API] Failed to get IFInfo", err)
 	}
+	metrics.IFInfos.Inc(metrics.OkSuccess)
 	return pld.(*Pld).IfInfoReply, nil
 }
 
@@ -290,10 +293,11 @@ func (c *conn) SVCInfo(ctx context.Context,
 		},
 		nil,
 	)
-	metrics.SVCInfos.Inc(errorToPrometheusLabel(err))
 	if err != nil {
+		metrics.SVCInfos.Inc(errorToPrometheusLabel(err))
 		return nil, serrors.WrapStr("[sciond-API] Failed to get SVCInfo", err)
 	}
+	metrics.SVCInfos.Inc(metrics.OkSuccess)
 	return pld.(*Pld).ServiceInfoReply, nil
 }
 
@@ -326,10 +330,11 @@ func (c *conn) RevNotification(ctx context.Context,
 		},
 		nil,
 	)
-	metrics.Revocations.Inc(errorToPrometheusLabel(err))
 	if err != nil {
+		metrics.Revocations.Inc(errorToPrometheusLabel(err))
 		return nil, serrors.WrapStr("[sciond-API] Failed to send RevNotification", err)
 	}
+	metrics.Revocations.Inc(metrics.OkSuccess)
 	return reply.(*Pld).RevReply, nil
 }
 


### PR DESCRIPTION
Added metrics:
```
# HELP lib_sciond_conn_connections_total The amount of SCIOND connection
attempts.
# TYPE lib_sciond_conn_connections_total counter
lib_sciond_conn_connections_total{result="ok_success"} 5
# HELP lib_sciond_path_requests_total The amount of Path requests sent.
# TYPE lib_sciond_path_requests_total counter
lib_sciond_path_request_total{result="ok_success"} 4
```

Metrics for the other client API calls are also included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3254)
<!-- Reviewable:end -->
