### PR TITLE
Add metrics to snet

### DIFF
--- a/go/lib/snet/BUILD.bazel
+++ b/go/lib/snet/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//go/lib/scmp:go_default_library",
         "//go/lib/serrors:go_default_library",
         "//go/lib/snet/internal/ctxmonitor:go_default_library",
+        "//go/lib/snet/internal/metrics:go_default_library",
         "//go/lib/snet/internal/pathsource:go_default_library",
         "//go/lib/sock/reliable:go_default_library",
         "//go/lib/spath:go_default_library",

--- a/go/lib/snet/dispatcher.go
+++ b/go/lib/snet/dispatcher.go
@@ -25,6 +25,7 @@ import (
 	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/pathmgr"
 	"github.com/scionproto/scion/go/lib/scmp"
+	"github.com/scionproto/scion/go/lib/snet/internal/metrics"
 	"github.com/scionproto/scion/go/lib/sock/reliable"
 )
 
@@ -99,6 +100,7 @@ type scmpHandler struct {
 func (h *scmpHandler) Handle(pkt *SCIONPacket) error {
 	hdr, ok := pkt.L4Header.(*scmp.Hdr)
 	if !ok {
+		metrics.M.SCMPErrors().Inc()
 		return common.NewBasicError("scmp handler invoked with non-scmp packet", nil, "pkt", pkt)
 	}
 

--- a/go/lib/snet/dispatcher.go
+++ b/go/lib/snet/dispatcher.go
@@ -100,8 +100,14 @@ type scmpHandler struct {
 func (h *scmpHandler) Handle(pkt *SCIONPacket) error {
 	hdr, ok := pkt.L4Header.(*scmp.Hdr)
 	if !ok {
-		metrics.M.SCMPErrors().Inc()
 		return common.NewBasicError("scmp handler invoked with non-scmp packet", nil, "pkt", pkt)
+	}
+	if hdr.Class != scmp.C_General {
+		metrics.M.SCMPErrors().Inc()
+	}
+	if hdr.Class == scmp.C_General && hdr.Type == scmp.T_G_Unspecified {
+		// SCMP::General::Unspecified is used for errors
+		metrics.M.SCMPErrors().Inc()
 	}
 
 	// Only handle revocations for now

--- a/go/lib/snet/internal/metrics/BUILD.bazel
+++ b/go/lib/snet/internal/metrics/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "github.com/scionproto/scion/go/lib/snet/internal/metrics",
+    visibility = ["//go/lib/snet:__subpackages__"],
+    deps = [
+        "//go/lib/prom:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+    ],
+)

--- a/go/lib/snet/internal/metrics/metrics.go
+++ b/go/lib/snet/internal/metrics/metrics.go
@@ -1,0 +1,128 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/scionproto/scion/go/lib/prom"
+)
+
+const (
+	// Namespace is the metrics namespace for the SCIOND client API.
+	Namespace = "lib_snet"
+
+	subDials           = "dials"
+	subListens         = "listens"
+	subCloses          = "closes"
+	subRead            = "read"
+	subWrite           = "write"
+	subSCMPError       = "scmp_error"
+	subDispatcherError = "dispatcher_error"
+	subParseError      = "parse_error"
+)
+
+var (
+	// M exposes all the initialized metrics for this package.
+	M = newMetrics()
+)
+
+type metrics struct {
+	dials            prometheus.Counter
+	listens          prometheus.Counter
+	closes           prometheus.Counter
+	readBytes        prometheus.Counter
+	readPackets      prometheus.Counter
+	writeBytes       prometheus.Counter
+	writePackets     prometheus.Counter
+	parseErrors      prometheus.Counter
+	scmpErrors       prometheus.Counter
+	dispatcherErrors prometheus.Counter
+}
+
+func newMetrics() metrics {
+	return metrics{
+		dials: prom.NewCounter(Namespace, subDials, "total",
+			"Total number of Dial calls."),
+		listens: prom.NewCounter(Namespace, subListens, "total",
+			"Total number of Listen calls."),
+		closes: prom.NewCounter(Namespace, subCloses, "total",
+			"Total number of Close calls."),
+		readBytes: prom.NewCounter(Namespace, subRead, "total_bytes",
+			"Total number of bytes read"),
+		readPackets: prom.NewCounter(Namespace, subRead, "total_pkts",
+			"Total number of packetes read"),
+		writeBytes: prom.NewCounter(Namespace, subWrite, "total_bytes",
+			"Total number of bytes written"),
+		writePackets: prom.NewCounter(Namespace, subWrite, "total_pkts",
+			"Total number of packets written"),
+		scmpErrors: prom.NewCounter(Namespace, subSCMPError, "total",
+			"Total number of SCMP errors"),
+		dispatcherErrors: prom.NewCounter(Namespace, subDispatcherError, "total",
+			"Total number of dispatcher errors"),
+		parseErrors: prom.NewCounter(Namespace, subParseError, "total",
+			"Total number of parse errors"),
+	}
+}
+
+// Dials returns the dials counter.
+func (m metrics) Dials() prometheus.Counter {
+	return m.dials
+}
+
+// Listens returns the listens counter.
+func (m metrics) Listens() prometheus.Counter {
+	return m.listens
+}
+
+// Closes returns the closes counter.
+func (m metrics) Closes() prometheus.Counter {
+	return m.closes
+}
+
+// ReadBytes returns the bytes read counter.
+func (m metrics) ReadBytes() prometheus.Counter {
+	return m.readBytes
+}
+
+// ReadPackets returns the packets read counter.
+func (m metrics) ReadPackets() prometheus.Counter {
+	return m.readPackets
+}
+
+// WriteBytes returns the bytes written counter.
+func (m metrics) WriteBytes() prometheus.Counter {
+	return m.writeBytes
+}
+
+// WritePackets returns the packets written counter.
+func (m metrics) WritePackets() prometheus.Counter {
+	return m.writePackets
+}
+
+// DispatcherErrors returns the dispather errors counter.
+func (m metrics) DispatcherErrors() prometheus.Counter {
+	return m.dispatcherErrors
+}
+
+// SCMPErrors returns the SCMP errors counter.
+func (m metrics) SCMPErrors() prometheus.Counter {
+	return m.scmpErrors
+}
+
+// ParseErrors returns the parse errors counter.
+func (m metrics) ParseErrors() prometheus.Counter {
+	return m.parseErrors
+}

--- a/go/lib/snet/packet_conn.go
+++ b/go/lib/snet/packet_conn.go
@@ -189,6 +189,7 @@ func (c *SCIONPacketConn) ReadFrom(pkt *SCIONPacket, ov *overlay.OverlayAddr) er
 		}
 		if scmpHdr, ok := pkt.L4Header.(*scmp.Hdr); ok {
 			if c.scmpHandler == nil {
+				metrics.M.SCMPErrors().Inc()
 				return common.NewBasicError("scmp packet received, but no handler found", nil,
 					"scmp.Hdr", scmpHdr, "src", pkt.Source)
 			}

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -57,6 +57,7 @@ import (
 	"github.com/scionproto/scion/go/lib/pathmgr"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/serrors"
+	"github.com/scionproto/scion/go/lib/snet/internal/metrics"
 	"github.com/scionproto/scion/go/lib/sock/reliable"
 )
 
@@ -200,6 +201,7 @@ func (n *SCIONNetwork) DialSCION(network string, laddr, raddr *Addr,
 func (n *SCIONNetwork) DialSCIONWithBindSVC(network string, laddr, raddr, baddr *Addr,
 	svc addr.HostSVC, timeout time.Duration) (Conn, error) {
 
+	metrics.M.Dials().Inc()
 	if raddr == nil {
 		return nil, serrors.New("Unable to dial to nil remote")
 	}
@@ -233,6 +235,7 @@ func (n *SCIONNetwork) ListenSCION(network string, laddr *Addr,
 func (n *SCIONNetwork) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr,
 	svc addr.HostSVC, timeout time.Duration) (Conn, error) {
 
+	metrics.M.Listens().Inc()
 	// FIXME(scrye): If no local address is specified, we want to
 	// bind to the address of the outbound interface on a random
 	// free port. However, the current dispatcher version cannot


### PR DESCRIPTION
Fixes https://github.com/scionproto/scion/issues/3107

Adds the following metrics:
```
# HELP lib_snet_closes_total Total number of Close calls.
# TYPE lib_snet_closes_total counter
lib_snet_closes_total 0
# HELP lib_snet_dials_total Total number of Dial calls.
# TYPE lib_snet_dials_total counter
lib_snet_dials_total 0
# HELP lib_snet_dispatcher_error_total Total number of dispatcher errors
# TYPE lib_snet_dispatcher_error_total counter
lib_snet_dispatcher_error_total 0
# HELP lib_snet_listens_total Total number of Listen calls.
# TYPE lib_snet_listens_total counter
lib_snet_listens_total 2
# HELP lib_snet_parse_error_total Total number of parse errors
# TYPE lib_snet_parse_error_total counter
lib_snet_parse_error_total 0
# HELP lib_snet_read_total_bytes Total number of bytes read
# TYPE lib_snet_read_total_bytes counter
lib_snet_read_total_bytes 1.163921e+06
# HELP lib_snet_read_total_pkts Total number of packetes read
# TYPE lib_snet_read_total_pkts counter
lib_snet_read_total_pkts 3105
# HELP lib_snet_scmp_error_total Total number of SCMP errors
# TYPE lib_snet_scmp_error_total counter
lib_snet_scmp_error_total 0
# HELP lib_snet_write_total_bytes Total number of bytes written
# TYPE lib_snet_write_total_bytes counter
lib_snet_write_total_bytes 579712
# HELP lib_snet_write_total_pkts Total number of packets written
# TYPE lib_snet_write_total_pkts counter
lib_snet_write_total_pkts 3037
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3257)
<!-- Reviewable:end -->
