### PR TITLE
PS: Add metrics for revocation notifications

### DIFF
--- a/go/lib/infra/modules/segfetcher/fetcher.go
+++ b/go/lib/infra/modules/segfetcher/fetcher.go
@@ -40,10 +40,6 @@ type ReplyHandler interface {
 		earlyTrigger <-chan struct{}) *seghandler.ProcessedResult
 }
 
-type Stats struct {
-	Revocations int
-}
-
 // FetcherConfig is the configuration for the fetcher.
 type FetcherConfig struct {
 	// QueryInterval specifies after how much time segments should be

--- a/go/lib/infra/modules/segfetcher/fetcher.go
+++ b/go/lib/infra/modules/segfetcher/fetcher.go
@@ -40,6 +40,10 @@ type ReplyHandler interface {
 		earlyTrigger <-chan struct{}) *seghandler.ProcessedResult
 }
 
+type Stats struct {
+	Revocations int
+}
+
 // FetcherConfig is the configuration for the fetcher.
 type FetcherConfig struct {
 	// QueryInterval specifies after how much time segments should be

--- a/go/lib/prom/prom.go
+++ b/go/lib/prom/prom.go
@@ -30,8 +30,10 @@ const (
 	LabelStatus = "status"
 	// LabelOperation is the label for the name of an executed operation.
 	LabelOperation = "op"
-	// LabelSrc is the label for the src of a request.
+	// LabelSrc is the label for the source.
 	LabelSrc = "src"
+	// LabelDst is the label for the destination.
+	LabelDst = "dst"
 )
 
 // Common result values.

--- a/go/path_srv/internal/metrics/BUILD.bazel
+++ b/go/path_srv/internal/metrics/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "metrics.go",
         "registration.go",
         "requests.go",
+        "revocation.go",
         "sync.go",
     ],
     importpath = "github.com/scionproto/scion/go/path_srv/internal/metrics",
@@ -24,6 +25,7 @@ go_test(
     srcs = [
         "registration_test.go",
         "requests_test.go",
+        "revocation_test.go",
         "sync_test.go",
     ],
     embed = [":go_default_library"],

--- a/go/path_srv/internal/metrics/metrics.go
+++ b/go/path_srv/internal/metrics/metrics.go
@@ -29,6 +29,8 @@ var (
 	Requests = newRequests()
 	// Sync contains metrics for segment synchronization.
 	Sync = newSync()
+	// Revocation contains metrics for revocations.
+	Revocation = newRevocation()
 )
 
 // Result values
@@ -61,6 +63,13 @@ const (
 	ErrNotClassified = prom.ErrNotClassified
 	// ErrNoPath indicates no path is available to send a message.
 	ErrNoPath = "err_nopath"
+)
+
+// Revocation sources
+const (
+	RevSrcNotification = "notification"
+	RevSrcSCMP         = "scmp"
+	RevSrcPathReply    = "path_reply"
 )
 
 // Label values

--- a/go/path_srv/internal/metrics/revocation.go
+++ b/go/path_srv/internal/metrics/revocation.go
@@ -1,0 +1,58 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/scionproto/scion/go/lib/prom"
+)
+
+// RevocationLabels are the labels for revocation metrics.
+type RevocationLabels struct {
+	Result string
+	Src    string
+}
+
+// Labels returns the labels.
+func (l RevocationLabels) Labels() []string {
+	return []string{prom.LabelResult, prom.LabelSrc}
+}
+
+// Values returns the values for the labels.
+func (l RevocationLabels) Values() []string {
+	return []string{l.Result, l.Src}
+}
+
+// WithResult returns the labels with the result set.
+func (l RevocationLabels) WithResult(result string) RevocationLabels {
+	l.Result = result
+	return l
+}
+
+type revocation struct {
+	count *prometheus.CounterVec
+}
+
+func newRevocation() revocation {
+	return revocation{
+		count: prom.NewCounterVec(Namespace, "revocations", "received_total",
+			"The amount of revocations received by src type and result",
+			RevocationLabels{}.Labels()),
+	}
+}
+
+func (r revocation) Count(l RevocationLabels) prometheus.Counter {
+	return r.count.WithLabelValues(l.Values()...)
+}

--- a/go/path_srv/internal/metrics/revocation.go
+++ b/go/path_srv/internal/metrics/revocation.go
@@ -16,6 +16,7 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/scionproto/scion/go/lib/prom"
 )
 

--- a/go/path_srv/internal/metrics/revocation_test.go
+++ b/go/path_srv/internal/metrics/revocation_test.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/scionproto/scion/go/lib/prom/promtest"
+	"github.com/scionproto/scion/go/path_srv/internal/metrics"
+)
+
+func TestRevocationLabels(t *testing.T) {
+	promtest.CheckLabelsStruct(t, metrics.RevocationLabels{})
+}

--- a/go/sciond/internal/metrics/metrics.go
+++ b/go/sciond/internal/metrics/metrics.go
@@ -72,7 +72,7 @@ type PathRequestLabels struct {
 
 // Labels returns the labels.
 func (l PathRequestLabels) Labels() []string {
-	return []string{"result", "dst"}
+	return []string{prom.LabelResult, prom.LabelDst}
 }
 
 // Values returns the values for the labels.
@@ -94,7 +94,7 @@ type RevocationLabels struct {
 
 // Labels returns the labels.
 func (l RevocationLabels) Labels() []string {
-	return []string{"result", "src"}
+	return []string{prom.LabelResult, prom.LabelSrc}
 }
 
 // Values returns the values for the labels.


### PR DESCRIPTION
Adds the following metrics:
```
# HELP ps_revocations_received_total The amount of revocations received by src type and result
# TYPE ps_revocations_received_total counter
ps_revocations_received_total{result="ok_success",src="notification"} 11
```

Contributes #3106

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3262)
<!-- Reviewable:end -->
