### PR TITLE
segfetcher: Add segreq & revocation metrics

### DIFF
--- a/go/lib/infra/modules/segfetcher/BUILD.bazel
+++ b/go/lib/infra/modules/segfetcher/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//go/lib/ctrl/seg:go_default_library",
         "//go/lib/infra:go_default_library",
         "//go/lib/infra/messenger:go_default_library",
+        "//go/lib/infra/modules/segfetcher/internal/metrics:go_default_library",
         "//go/lib/infra/modules/seghandler:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/pathdb:go_default_library",

--- a/go/lib/infra/modules/segfetcher/fetcher.go
+++ b/go/lib/infra/modules/segfetcher/fetcher.go
@@ -19,10 +19,13 @@ import (
 	"net"
 	"time"
 
+	"golang.org/x/xerrors"
+
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/modules/segfetcher/internal/metrics"
 	"github.com/scionproto/scion/go/lib/infra/modules/seghandler"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/pathdb"
@@ -74,6 +77,8 @@ type FetcherConfig struct {
 	// SciondMode enables sciond mode, this means it uses the local CS to fetch
 	// crypto material and considers revocations in the path lookup.
 	SciondMode bool
+	// The namespace used for metrics.
+	MetricsNamespace string
 }
 
 // New creates a new fetcher from the configuration.
@@ -91,6 +96,7 @@ func (cfg FetcherConfig) New() *Fetcher {
 		QueryInterval:         cfg.QueryInterval,
 		NextQueryCleaner:      NextQueryCleaner{PathDB: cfg.PathDB},
 		CryptoLookupAtLocalCS: cfg.SciondMode,
+		metrics:               metrics.NewFetcher(cfg.MetricsNamespace),
 	}
 }
 
@@ -105,6 +111,7 @@ type Fetcher struct {
 	QueryInterval         time.Duration
 	NextQueryCleaner      NextQueryCleaner
 	CryptoLookupAtLocalCS bool
+	metrics               metrics.Fetcher
 }
 
 // FetchSegs fetches the required segments to build a path between src and dst
@@ -162,16 +169,33 @@ func (f *Fetcher) waitOnProcessed(ctx context.Context, replies <-chan ReplyOrErr
 	for reply := range replies {
 		// TODO(lukedirtwalker): Should we do this in go routines?
 		if reply.Err != nil {
-			return reqSet, serrors.Wrap(errFetch, reply.Err)
+			f.metrics.SegRequests(metrics.ErrNotClassified).Inc()
 		}
 		if reply.Reply == nil || reply.Reply.Recs == nil {
+			f.metrics.SegRequests(metrics.OkSuccess).Inc()
 			continue
 		}
 		r := f.ReplyHandler.Handle(ctx, replyToRecs(reply.Reply), f.verifyServer(reply), nil)
 		select {
 		case <-r.FullReplyProcessed():
+			// sets revocation metrics
+			defer func() {
+				f.metrics.RevocationsReceived(metrics.OkSuccess).Add(
+					float64(len(r.Stats().StoredRevs)))
+				f.metrics.RevocationsReceived(metrics.ErrDB).Add(
+					float64(len(r.Stats().StoredRevs) - len(r.Stats().VerifiedRevs)))
+				revErrors := 0
+				for _, err := range r.VerificationErrors() {
+					if xerrors.Is(err, seghandler.ErrRevVerification) {
+						revErrors++
+					}
+				}
+				f.metrics.RevocationsReceived(metrics.ErrVerify).Add(float64(revErrors))
+			}()
 			if err := r.Err(); err != nil {
+				f.metrics.SegRequests(metrics.ErrProcess).Inc()
 				return reqSet, serrors.Wrap(errDB, err)
+
 			}
 			// TODO(lukedirtwalker): should we return an error if verification
 			// of all segments failed?
@@ -192,7 +216,9 @@ func (f *Fetcher) waitOnProcessed(ctx context.Context, replies <-chan ReplyOrErr
 			if err != nil {
 				logger.Warn("Failed to insert next query", "err", err)
 			}
+			f.metrics.SegRequests(metrics.OkSuccess).Inc()
 		case <-ctx.Done():
+			f.metrics.SegRequests(metrics.ErrTimeout).Inc()
 			return reqSet, ctx.Err()
 		}
 	}

--- a/go/lib/infra/modules/segfetcher/internal/metrics/BUILD.bazel
+++ b/go/lib/infra/modules/segfetcher/internal/metrics/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -12,4 +12,11 @@ go_library(
         "//go/lib/prom:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["fetcher_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//go/lib/prom/promtest:go_default_library"],
 )

--- a/go/lib/infra/modules/segfetcher/internal/metrics/BUILD.bazel
+++ b/go/lib/infra/modules/segfetcher/internal/metrics/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "fetcher.go",
+        "metrics.go",
+    ],
+    importpath = "github.com/scionproto/scion/go/lib/infra/modules/segfetcher/internal/metrics",
+    visibility = ["//go/lib/infra/modules/segfetcher:__subpackages__"],
+    deps = [
+        "//go/lib/prom:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+    ],
+)

--- a/go/lib/infra/modules/segfetcher/internal/metrics/fetcher.go
+++ b/go/lib/infra/modules/segfetcher/internal/metrics/fetcher.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/scionproto/scion/go/lib/prom"
+)
+
+const RevSrcPathReply = "path_reply"
+
+// Fetcher exposes all metrics for the fetcher.
+type Fetcher interface {
+	SegRequests(result string) prometheus.Counter
+	RevocationsReceived(result string) prometheus.Counter
+}
+
+type fetcher struct {
+	segRequest  *prometheus.CounterVec
+	revocations *prometheus.CounterVec
+}
+
+// NewFetcher creates fetcher metrics struct.
+func NewFetcher(namespace string) Fetcher {
+	subst := "fetcher"
+	requests := prom.SafeRegister(prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subst,
+		Name:      "seg_requests_total",
+		Help:      "The number of segment request sent, grouped by result",
+	}, []string{prom.LabelResult})).(*prometheus.CounterVec)
+	revocations := prom.SafeRegister(prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "recv_revocations_total",
+		Help:      "The amount of revocations received by src type and result",
+	}, []string{prom.LabelResult, prom.LabelSrc})).(*prometheus.CounterVec)
+	return fetcher{
+		segRequest:  requests,
+		revocations: revocations,
+	}
+}
+
+func (f fetcher) SegRequests(result string) prometheus.Counter {
+	return f.segRequest.WithLabelValues(result)
+}
+
+func (f fetcher) RevocationsReceived(result string) prometheus.Counter {
+	return f.revocations.WithLabelValues(result, RevSrcPathReply)
+}

--- a/go/lib/infra/modules/segfetcher/internal/metrics/fetcher.go
+++ b/go/lib/infra/modules/segfetcher/internal/metrics/fetcher.go
@@ -84,7 +84,8 @@ func NewFetcher(namespace string) Fetcher {
 		segRequest: prom.NewCounterVecWithLabels(namespace, sub, "seg_requests_total",
 			"The number of segment request sent.", RequestLabels{Result: OkSuccess}),
 		revocations: prom.NewCounterVecWithLabels(namespace, "", "received_revocations_total",
-			"The amount of revocations received.", RevocationLabels{Result: OkSuccess, Src: revSrcPathReply}),
+			"The amount of revocations received.",
+			RevocationLabels{Result: OkSuccess, Src: revSrcPathReply}),
 	}
 }
 

--- a/go/lib/infra/modules/segfetcher/internal/metrics/fetcher_test.go
+++ b/go/lib/infra/modules/segfetcher/internal/metrics/fetcher_test.go
@@ -12,24 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metrics
+package metrics_test
 
 import (
-	"github.com/scionproto/scion/go/lib/prom"
+	"testing"
+
+	"github.com/scionproto/scion/go/lib/infra/modules/segfetcher/internal/metrics"
+	"github.com/scionproto/scion/go/lib/prom/promtest"
 )
 
-// Result values
-const (
-	// ErrDB is used for db related errors.
-	ErrDB = prom.ErrDB
-	// ErrNotClassified is an error that is not further classified.
-	ErrNotClassified = prom.ErrNotClassified
-	// ErrTimeout is a timeout error.
-	ErrProcess = prom.ErrProcess
-	// ErrVerify is used for validation related errors.
-	ErrTimeout = prom.ErrTimeout
-	// ErrProcess is an error during processing e.g. parsing failed.
-	ErrVerify = prom.ErrVerify
-	// OkSuccess is no error.
-	OkSuccess = prom.Success
-)
+func TestLabels(t *testing.T) {
+	promtest.CheckLabelsStruct(t, metrics.RequestLabels{})
+	promtest.CheckLabelsStruct(t, metrics.RevocationLabels{})
+}

--- a/go/lib/infra/modules/segfetcher/internal/metrics/metrics.go
+++ b/go/lib/infra/modules/segfetcher/internal/metrics/metrics.go
@@ -1,0 +1,35 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"github.com/scionproto/scion/go/lib/prom"
+)
+
+// Result values
+const (
+	// OkSuccess is no error.
+	OkSuccess = prom.Success
+	// ErrNotClassified is an error that is not further classified.
+	ErrNotClassified = prom.ErrNotClassified
+	// ErrTimeout is a timeout error.
+	ErrTimeout = prom.ErrTimeout
+	// ErrProcess is an error during processing e.g. parsing failed.
+	ErrProcess = prom.ErrProcess
+	// ErrDB is used for db related errors.
+	ErrDB = prom.ErrDB
+	// ErrVerify is used for validation related errors.
+	ErrVerify = prom.ErrVerify
+)

--- a/go/lib/infra/modules/seghandler/BUILD.bazel
+++ b/go/lib/infra/modules/seghandler/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/ctrl/seg:go_default_library",
         "//go/lib/hiddenpath:go_default_library",
@@ -22,6 +21,7 @@ go_library(
         "//go/lib/pathdb:go_default_library",
         "//go/lib/pathdb/query:go_default_library",
         "//go/lib/revcache:go_default_library",
+        "//go/lib/serrors:go_default_library",
     ],
 )
 

--- a/go/lib/infra/modules/seghandler/BUILD.bazel
+++ b/go/lib/infra/modules/seghandler/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//go/lib/pathdb/query:go_default_library",
         "//go/lib/revcache:go_default_library",
         "//go/lib/serrors:go_default_library",
+        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/go/lib/infra/modules/seghandler/seghandler.go
+++ b/go/lib/infra/modules/seghandler/seghandler.go
@@ -28,11 +28,10 @@ import (
 	"github.com/scionproto/scion/go/lib/serrors"
 )
 
+// errors for metrics classification.
 var (
-	// ErrRevVerification indicates an error while verifying a revocation.
-	ErrRevVerification = serrors.New("error verifying revocation")
-	// ErrSegVerification indicates an error while verifying a segment.
-	ErrSegVerification = serrors.New("error verifying segment")
+	errRevVerification = serrors.New("error verifying revocation")
+	errSegVerification = serrors.New("error verifying segment")
 )
 
 // Segments is a list of segments and revocations belonging to them.
@@ -112,6 +111,7 @@ func (h *Handler) verifyAndStore(ctx context.Context,
 	}
 	verifyErrs, err := h.storeResults(ctx, verifiedUnits, hpGroupID, &result.stats)
 	result.verifyErrs = append(allVerifyErrs, verifyErrs...)
+	result.stats.verificationErrs(result.verifyErrs)
 	result.err = err
 }
 
@@ -123,7 +123,7 @@ func (h *Handler) storeResults(ctx context.Context, verifiedUnits []segverifier.
 	var revs []*path_mgmt.SignedRevInfo
 	for _, unit := range verifiedUnits {
 		if err := unit.SegError(); err != nil {
-			verifyErrs = append(verifyErrs, serrors.Wrap(ErrSegVerification, err,
+			verifyErrs = append(verifyErrs, serrors.Wrap(errSegVerification, err,
 				"seg", unit.Unit.SegMeta.Segment))
 		} else {
 			segs = append(segs, &SegWithHP{
@@ -137,7 +137,7 @@ func (h *Handler) storeResults(ctx context.Context, verifiedUnits []segverifier.
 		}
 		for idx, rev := range unit.Unit.SRevInfos {
 			if err, ok := unit.Errors[idx]; ok {
-				verifyErrs = append(verifyErrs, serrors.Wrap(ErrRevVerification, err, "rev", rev))
+				verifyErrs = append(verifyErrs, serrors.Wrap(errRevVerification, err, "rev", rev))
 			} else {
 				revs = append(revs, rev)
 				stats.VerifiedRevs = append(stats.VerifiedRevs, rev)

--- a/go/path_srv/internal/metrics/revocation.go
+++ b/go/path_srv/internal/metrics/revocation.go
@@ -48,7 +48,7 @@ type revocation struct {
 
 func newRevocation() revocation {
 	return revocation{
-		count: prom.NewCounterVecWithLabels(Namespace, "revocations", "received_total",
+		count: prom.NewCounterVecWithLabels(Namespace, "", "recv_revocations_total",
 			"The amount of revocations received by src type and result",
 			RevocationLabels{}),
 	}

--- a/go/path_srv/internal/metrics/revocation.go
+++ b/go/path_srv/internal/metrics/revocation.go
@@ -48,9 +48,9 @@ type revocation struct {
 
 func newRevocation() revocation {
 	return revocation{
-		count: prom.NewCounterVecWithLabels(Namespace, "", "recv_revocations_total",
-			"The amount of revocations received by src type and result",
-			RevocationLabels{}),
+		count: prom.NewCounterVecWithLabels(Namespace, "", "received_revocations_total",
+			"The amount of revocations received.",
+			RevocationLabels{Result: OkSuccess, Src: RevSrcNotification}),
 	}
 }
 

--- a/go/path_srv/internal/segreq/handler.go
+++ b/go/path_srv/internal/segreq/handler.go
@@ -49,6 +49,7 @@ func NewHandler(args handlers.HandlerArgs) infra.Handler {
 			RequestAPI:          args.SegRequestAPI,
 			DstProvider:         createDstProvider(args, core),
 			Splitter:            &Splitter{ASInspector: args.ASInspector},
+			MetricsNamespace:    metrics.Namespace,
 		}.New(),
 		revCache: args.RevCache,
 	}

--- a/go/proto/structs.gen.go
+++ b/go/proto/structs.gen.go
@@ -3,8 +3,9 @@
 package proto
 
 import (
+	"zombiezen.com/go/capnproto2"
+
 	"github.com/scionproto/scion/go/lib/common"
-	capnp "zombiezen.com/go/capnproto2"
 )
 
 // NewRootStruct calls the appropriate NewRoot<x> function corresponding to the capnp proto type ID,

--- a/go/sciond/internal/fetcher/BUILD.bazel
+++ b/go/sciond/internal/fetcher/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//go/lib/topology:go_default_library",
         "//go/lib/util:go_default_library",
         "//go/sciond/internal/config:go_default_library",
+        "//go/sciond/internal/metrics:go_default_library",
     ],
 )
 

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -40,6 +40,7 @@ import (
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/sciond/internal/config"
+	"github.com/scionproto/scion/go/sciond/internal/metrics"
 )
 
 const (
@@ -80,6 +81,7 @@ func NewFetcher(messenger infra.Messenger, pathDB pathdb.PathDB, trustStore Trus
 			DstProvider:         &dstProvider{IA: localIA},
 			Splitter:            NewRequestSplitter(localIA, trustStore),
 			SciondMode:          true,
+			MetricsNamespace:    metrics.Namespace,
 		}.New(),
 	}
 }

--- a/go/sciond/internal/metrics/metrics.go
+++ b/go/sciond/internal/metrics/metrics.go
@@ -157,8 +157,9 @@ type Revocation struct {
 
 func newRevocation() Revocation {
 	return Revocation{
-		count: prom.NewCounterVecWithLabels(Namespace, "", "recv_revocations_total",
-			"The amount of revocations received by src type and result", RevocationLabels{}),
+		count: prom.NewCounterVecWithLabels(Namespace, "", "received_revocations_total",
+			"The amount of revocations received.",
+			RevocationLabels{Result: OkSuccess, Src: RevSrcNotification}),
 		latency: prom.NewHistogramVec(Namespace, subsystemRevocation,
 			"notification_duration_seconds", "Time to process revocation notifications.",
 			resultLabel{}.Labels(), prom.DefaultLatencyBuckets),

--- a/go/sciond/internal/metrics/metrics.go
+++ b/go/sciond/internal/metrics/metrics.go
@@ -157,8 +157,8 @@ type Revocation struct {
 
 func newRevocation() Revocation {
 	return Revocation{
-		count: prom.NewCounterVecWithLabels(Namespace, subsystemRevocation, "total",
-			"The amount of revocations received.", RevocationLabels{}),
+		count: prom.NewCounterVecWithLabels(Namespace, "", "recv_revocations_total",
+			"The amount of revocations received by src type and result", RevocationLabels{}),
 		latency: prom.NewHistogramVec(Namespace, subsystemRevocation,
 			"notification_duration_seconds", "Time to process revocation notifications.",
 			resultLabel{}.Labels(), prom.DefaultLatencyBuckets),


### PR DESCRIPTION
Add metrics for received revocations and sent segment requests.
Also changes the naming of SD and PS revocation metrics to match.
```
# HELP ps_fetcher_seg_requests_total The number of segment request sent.
# TYPE ps_fetcher_seg_requests_total counter
ps_fetcher_seg_requests_total{result="ok_success"} 1
# HELP ps_received_revocations_total The amount of revocations received.
# TYPE ps_received_revocations_total counter
ps_received_revocations_total{result="err_db",src="path_reply"} 0
ps_received_revocations_total{result="err_verify",src="path_reply"} 0
ps_received_revocations_total{result="ok_success",src="notification"} 1
ps_received_revocations_total{result="ok_success",src="path_reply"} 0
```

Contributes #3106
Fixes #3255

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3264)
<!-- Reviewable:end -->
