### PR TITLE
Fix wrong git checkout path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Necessary steps in order to run SCION:
    ```bash
    mkdir -p "$GOPATH/src/github.com/scionproto"
    cd "$GOPATH/src/github.com/scionproto"
-   git clone https://github.com:scionproto/scion
+   git clone https://github.com/scionproto/scion
    cd scion
    ```
 


### PR DESCRIPTION
Fixes a wrong URL format for checking out scionproto/scion via git.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3266)
<!-- Reviewable:end -->
