### PR TITLE
Make specifying zookeeper in topo files optional

### DIFF
--- a/acceptance/sig_failover_acceptance/Test.topo
+++ b/acceptance/sig_failover_acceptance/Test.topo
@@ -1,8 +1,4 @@
 --- # Topology for sig_failover_acceptance test.
-defaults:
-  zookeepers:
-    1:
-      addr: 127.0.0.1
 ASes:
   "1-ff00:0:110":
     core: true

--- a/acceptance/topo_br_reload_util/Tinier.topo
+++ b/acceptance/topo_br_reload_util/Tinier.topo
@@ -1,8 +1,4 @@
 --- # Two AS Topology
-defaults:
-  zookeepers:
-    1:
-      addr: 127.0.0.1
 ASes:
   "1-ff00:0:110":
     core: true

--- a/python/topology/config.py
+++ b/python/topology/config.py
@@ -121,9 +121,6 @@ class ConfigGenerator(object):
             priv_net = DEFAULT_PRIV_NETWORK
         self.subnet_gen = SubnetGenerator(def_network, self.args.docker, self.args.in_docker)
         self.prvnet_gen = SubnetGenerator(priv_net, self.args.docker, self.args.in_docker)
-        if "zookeepers" not in defaults:
-            logging.critical("No zookeeper configured in the topology!")
-            sys.exit(1)
         self.default_mtu = defaults.get("mtu", DEFAULT_MTU)
 
     def generate_all(self):

--- a/python/topology/topo.py
+++ b/python/topology/topo.py
@@ -329,10 +329,15 @@ class TopoGenerator(object):
         self.topo_dicts[topo_id]['SIG'][elem_id] = d
 
     def _gen_zk_entries(self, topo_id, as_conf):
+        if ("defaults" not in self.args.topo_config_dict or
+            "zookeepers" not in self.args.topo_config_dict["defaults"]):
+            return
         zk_conf = self.args.topo_config_dict["defaults"]["zookeepers"]
         if len(zk_conf) > 1:
             logging.critical("Only one zk instance is supported!")
             sys.exit(1)
+        if len(zk_conf) < 1:
+            return
         addr = zk_conf[1].get("addr", None)
         port = zk_conf[1].get("port", None)
         zk_entry = self._gen_zk_entry(addr, port, self.args.in_docker, self.args.docker)

--- a/python/topology/topo.py
+++ b/python/topology/topo.py
@@ -330,7 +330,7 @@ class TopoGenerator(object):
 
     def _gen_zk_entries(self, topo_id, as_conf):
         if ("defaults" not in self.args.topo_config_dict or
-            "zookeepers" not in self.args.topo_config_dict["defaults"]):
+                "zookeepers" not in self.args.topo_config_dict["defaults"]):
             return
         zk_conf = self.args.topo_config_dict["defaults"]["zookeepers"]
         if len(zk_conf) > 1:

--- a/topology/Default.topo
+++ b/topology/Default.topo
@@ -1,9 +1,4 @@
 --- # Default topology
-defaults:
-  zookeepers:
-    1:
-      addr: 127.0.0.1
-      port: 2181
 ASes:
   "1-ff00:0:110": # old 1-11
     core: true

--- a/topology/Tiny.topo
+++ b/topology/Tiny.topo
@@ -1,8 +1,4 @@
 --- # Tiny Topology
-defaults:
-  zookeepers:
-    1:
-      addr: 127.0.0.1
 ASes:
   "1-ff00:0:110": # old 1-11
     core: true

--- a/topology/Wide.topo
+++ b/topology/Wide.topo
@@ -1,9 +1,4 @@
 ---
-defaults:
-  zookeepers:
-    1:
-      addr: 127.0.0.1
-
 ASes:
   "1-ff00:0:110": {core: true}
   "1-ff00:0:120": {core: true}


### PR DESCRIPTION
For pure golang topologies we don't require zookeeper anymore,
so we should also not require zookeeper to be specified in the topo file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3278)
<!-- Reviewable:end -->
