### PR TITLE
topogen: Don't generate unused config files for Go

### DIFF
--- a/python/topology/config.py
+++ b/python/topology/config.py
@@ -136,7 +136,10 @@ class ConfigGenerator(object):
         self._generate_with_topo(topo_dicts)
         self._write_ca_files(topo_dicts, ca_private_key_files)
         self._write_ca_files(topo_dicts, ca_cert_files)
-        self._write_conf_policies(topo_dicts)
+        all_go = all(t == "go" for t in [self.args.beacon_server, self.args.cert_server,
+                                         self.args.sciond, self.args.path_server])
+        if not all_go:
+            self._write_conf_policies(topo_dicts)
         self._write_networks_conf(self.networks, NETWORKS_FILE)
         if self.args.bind_addr:
             self._write_networks_conf(prv_networks, PRV_NETWORKS_FILE)


### PR DESCRIPTION
path_policy.yml and as.yml are not used by Go services so don't generate them when we use Go only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3280)
<!-- Reviewable:end -->
