### PR TITLE
br: acceptance setcap on test run

### DIFF
--- a/acceptance/brutil/common.sh
+++ b/acceptance/brutil/common.sh
@@ -21,10 +21,6 @@ BR_TOML=$TEST_ARTIFACTS_DIR/conf/$BR_TOML_FN
 test_setup() {
     set -e
 
-    # XXX(kormat): This is conditional on the binary existing, because when
-    # running on CI 'setup' is run on the host, where the binary doesn't exist.
-    [ -e $BRACCEPT ] && make -s setcap
-
     test_config
 
     local disp_dir="/run/shm/dispatcher"
@@ -64,6 +60,11 @@ test_config() {
 
 test_run() {
     set -e
+
+    # XXX(kormat): This is conditional on the binary existing, because when
+    # running on CI 'setup' is run on the host, where the binary doesn't exist.
+    [ -e $BRACCEPT ] && make -s setcap
+
     $BRACCEPT -testName "${TEST_NAME:?}" -keysDirPath "$TEST_ARTIFACTS_DIR/conf/keys" "$@"
 }
 

--- a/acceptance/brutil/common.sh
+++ b/acceptance/brutil/common.sh
@@ -61,9 +61,13 @@ test_config() {
 test_run() {
     set -e
 
-    # XXX(kormat): This is conditional on the binary existing, because when
-    # running on CI 'setup' is run on the host, where the binary doesn't exist.
-    [ -e $BRACCEPT ] && make -s setcap
+    # XXX(sgmonroy): this sets capabilities on the braccept binary.
+    # Initially this was done during setup and effectively a NOOP in CI given that there is no
+    # bracecpt binary when doing setup in the CI host. Instead capabilities are set when generating
+    # the container.
+    # This change allows to rebuild braccept binary without having to teardown/setup a test, at the cost
+    # of setting the capabilities twice on CI.
+    make -s setcap
 
     $BRACCEPT -testName "${TEST_NAME:?}" -keysDirPath "$TEST_ARTIFACTS_DIR/conf/keys" "$@"
 }


### PR DESCRIPTION
Currently, braccept needs capabilities that are set during acceptance
test setup. Thus everytime time we do make, we get a new binary that
needs capabilities.

This change moves setting the capabilities to the acceptance test run,
allowing to rebuild braccept without having to teardown->setup the
acceptance test every time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3284)
<!-- Reviewable:end -->
