### PR TITLE
Minimized interface argument needed to create default SCMP handler

### DIFF
--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -114,7 +114,7 @@ func NewNetworkWithPR(ia addr.IA, dispatcher reliable.DispatcherService,
 		&DefaultPacketDispatcherService{
 			Dispatcher: dispatcher,
 			SCMPHandler: &scmpHandler{
-				pathResolver: pr,
+				revocationHandler: pr,
 			},
 		},
 		pr,


### PR DESCRIPTION
The previous argument type was a path resolver, but most of the
interface was not needed. The new smaller interface simplifies
simplifies mocking and improves clarity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3305)
<!-- Reviewable:end -->
