### PR TITLE
segfetcher: Stop fetch loop on errors

### DIFF
--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -986,8 +986,7 @@ func (pr *pathingRequester) Request(ctx context.Context, pld *ctrl.Pld,
 	logger := log.FromCtx(ctx)
 	if redirect && pr.quicRequester != nil {
 		logger.Trace("Request upgraded to QUIC", "remote", newAddr)
-		pld, err := pr.quicRequester.Request(ctx, pld, newAddr)
-		return pld, err
+		return pr.quicRequester.Request(ctx, pld, newAddr)
 	}
 	logger.Trace("Request could not be upgraded to QUIC, using UDP", "remote", newAddr)
 	if downgradeToNotify {
@@ -1041,6 +1040,7 @@ func (r *QUICRequester) Request(ctx context.Context, pld *ctrl.Pld,
 
 	request := &rpc.Request{Message: msg}
 	reply, err := r.QUICClientConfig.Request(ctx, request, newAddr)
+	log.FromCtx(ctx).Trace("QUICRequester", "err", err)
 	if err != nil {
 		return nil, err
 	}

--- a/go/lib/infra/modules/segfetcher/fetcher.go
+++ b/go/lib/infra/modules/segfetcher/fetcher.go
@@ -140,7 +140,6 @@ func (f *Fetcher) FetchSegs(ctx context.Context, req Request) (Segments, error) 
 		}
 		// in 3 iteration (i==2) everything should be resolved.
 		if i >= 2 {
-			log.FromCtx(ctx).Error("No convergence in lookup", "iteration", i+1)
 			return segs, common.NewBasicError("Segment lookup doesn't converge", nil,
 				"iterations", i+1)
 		}
@@ -149,6 +148,7 @@ func (f *Fetcher) FetchSegs(ctx context.Context, req Request) (Segments, error) 
 		// timeouts. And having 10s timeouts plays really bad together with
 		// revocations. See also: https://github.com/scionproto/scion/issues/3052
 		reqCtx, cancelF := context.WithTimeout(ctx, 3*time.Second)
+		reqCtx = log.CtxWith(reqCtx, log.FromCtx(ctx))
 		replies := f.Requester.Request(reqCtx, reqSet)
 		// TODO(lukedirtwalker): We need to have early trigger for the last request.
 		if reqSet, err = f.waitOnProcessed(ctx, replies, reqSet); err != nil {
@@ -168,10 +168,15 @@ func (f *Fetcher) waitOnProcessed(ctx context.Context, replies <-chan ReplyOrErr
 		// TODO(lukedirtwalker): Should we do this in go routines?
 		labels := metrics.RequestLabels{Result: metrics.ErrNotClassified}
 		if reply.Err != nil {
+			if serrors.IsTimeout(reply.Err) {
+				labels.Result = metrics.ErrTimeout
+			}
 			f.metrics.SegRequests(labels).Inc()
+			return reqSet, reply.Err
 		}
 		if reply.Reply == nil || reply.Reply.Recs == nil {
 			f.metrics.SegRequests(labels.WithResult(metrics.OkSuccess)).Inc()
+			reqSet = updateRequestState(reqSet, reply.Req, Fetched)
 			continue
 		}
 		r := f.ReplyHandler.Handle(ctx, replyToRecs(reply.Reply), f.verifyServer(reply), nil)
@@ -185,18 +190,7 @@ func (f *Fetcher) waitOnProcessed(ctx context.Context, replies <-chan ReplyOrErr
 			}
 			// TODO(lukedirtwalker): should we return an error if verification
 			// of all segments failed?
-			// TODO(lukedirtwalker): move state update to separate func
-			if reqSet.Up.EqualAddr(reply.Req) {
-				reqSet.Up.State = Fetched
-			} else if reqSet.Down.EqualAddr(reply.Req) {
-				reqSet.Down.State = Fetched
-			} else {
-				for i, coreReq := range reqSet.Cores {
-					if coreReq.EqualAddr(reply.Req) {
-						reqSet.Cores[i].State = Fetched
-					}
-				}
-			}
+			reqSet = updateRequestState(reqSet, reply.Req, Fetched)
 			nextQuery := f.nextQuery(r.Stats().VerifiedSegs)
 			_, err := f.PathDB.InsertNextQuery(ctx, reply.Req.Src, reply.Req.Dst, nil, nextQuery)
 			if err != nil {
@@ -254,4 +248,19 @@ func replyToRecs(reply *path_mgmt.SegReply) seghandler.Segments {
 		Segs:      reply.Recs.Recs,
 		SRevInfos: reply.Recs.SRevInfos,
 	}
+}
+
+func updateRequestState(reqSet RequestSet, reqToUpdate Request, newState RequestState) RequestSet {
+	if reqSet.Up.EqualAddr(reqToUpdate) {
+		reqSet.Up.State = newState
+	} else if reqSet.Down.EqualAddr(reqToUpdate) {
+		reqSet.Down.State = newState
+	} else {
+		for i, coreReq := range reqSet.Cores {
+			if coreReq.EqualAddr(reqToUpdate) {
+				reqSet.Cores[i].State = newState
+			}
+		}
+	}
+	return reqSet
 }

--- a/go/lib/infra/modules/segfetcher/fetcher.go
+++ b/go/lib/infra/modules/segfetcher/fetcher.go
@@ -142,7 +142,6 @@ func (f *Fetcher) FetchSegs(ctx context.Context, req Request) (Segments, error) 
 		// 1 iteration: up & down segment fetched.
 		// 2 iteration: up & down resolved, core fetched.
 		// 3 iteration: core resolved -> done.
-		// If we need more than that something breaks assumptions.
 		if i >= 2 {
 			return segs, common.NewBasicError(
 				"Segment lookup not done in expected amount of iterations (implementation bug)",

--- a/go/lib/infra/modules/segfetcher/fetcher.go
+++ b/go/lib/infra/modules/segfetcher/fetcher.go
@@ -138,10 +138,15 @@ func (f *Fetcher) FetchSegs(ctx context.Context, req Request) (Segments, error) 
 		if reqSet.IsLoaded() {
 			break
 		}
-		// in 3 iteration (i==2) everything should be resolved.
+		// in 3 iteration (i==2) everything should be resolved, worst case:
+		// 1 iteration: up & down segment fetched.
+		// 2 iteration: up & down resolved, core fetched.
+		// 3 iteration: core resolved -> done.
+		// If we need more than that something breaks assumptions.
 		if i >= 2 {
-			return segs, common.NewBasicError("Segment lookup doesn't converge", nil,
-				"iterations", i+1)
+			return segs, common.NewBasicError(
+				"Segment lookup not done in expected amount of iterations (implementation bug)",
+				nil, "iterations", i+1)
 		}
 		// XXX(lukedirtwalker): Optimally we wouldn't need a different timeout
 		// here. The problem is that revocations can't be differentiated from

--- a/go/lib/infra/modules/segfetcher/request.go
+++ b/go/lib/infra/modules/segfetcher/request.go
@@ -76,6 +76,19 @@ func (r RequestSet) IsLoaded() bool {
 		r.Cores.AllLoaded()
 }
 
+func (r RequestSet) resolveUp() bool {
+	return !r.Up.IsZero() && (r.Up.State == Unresolved || r.Up.State == Fetched)
+}
+
+func (r RequestSet) resolveDown() bool {
+	return !r.Down.IsZero() && (r.Down.State == Unresolved || r.Down.State == Fetched)
+}
+
+func (r RequestSet) upDownResolved() bool {
+	return (r.Up.IsZero() || r.Up.State == Loaded) &&
+		(r.Down.IsZero() || r.Down.State == Loaded)
+}
+
 // Requests is a list of requests and provides some convenience methods on top
 // of it.
 type Requests []Request

--- a/go/lib/infra/rpc/rpc.go
+++ b/go/lib/infra/rpc/rpc.go
@@ -1,4 +1,4 @@
-// Copyright 2019 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -164,6 +164,11 @@ func (c *Client) Request(ctx context.Context, request *Request, address net.Addr
 	}
 	msg, err := proto.SafeDecode(capnp.NewDecoder(stream))
 	if err != nil {
+		// if we have a timeout make it visible.
+		if strings.Contains(err.Error(),
+			fmt.Sprintf("canceled with error code %d", CtxTimedOutError)) && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		return nil, err
 	}
 

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -82,7 +82,9 @@ func (h *PathRequestHandler) Handle(ctx context.Context, conn net.PacketConn, sr
 		logger.Warn("Unable to reply to client", "client", src, "err", err)
 		metricsDone(labels.WithResult(metrics.ErrNetwork))
 	} else {
-		logger.Debug("Replied with paths", "num_paths", len(getPathsReply.Entries))
+		logger.Debug("Replied with paths",
+			"num_paths", len(getPathsReply.Entries),
+			"err_code", getPathsReply.ErrorCode)
 		logger.Trace("Full reply", "paths", getPathsReply)
 		metricsDone(labels)
 	}


### PR DESCRIPTION
If we have an error we should not simply ignore it and continue processing.
Instead the fetcher now returns the error immediately.

Also
* do not continue resolving&fetching when 0 up/down segments are cached
* log sciond error code in debug
* remove duplicated log about convergence problem
* improve returned error when a timeout occurs in QUIC

Fixes #2721
Fixes #3293
Fixes #3294
Fixes #3094

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3306)
<!-- Reviewable:end -->
