### PR TITLE
healthpool: fix flaky test

### DIFF
--- a/go/lib/healthpool/BUILD.bazel
+++ b/go/lib/healthpool/BUILD.bazel
@@ -25,7 +25,8 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//go/lib/xtest:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/lib/healthpool/pool.go
+++ b/go/lib/healthpool/pool.go
@@ -31,6 +31,15 @@ const ErrPoolClosed common.ErrMsg = "Pool closed"
 // InfoSet is a set of infos.
 type InfoSet map[Info]struct{}
 
+// List transforms the info set to a list.
+func (s InfoSet) List() []Info {
+	infos := make([]Info, 0, len(s))
+	for info := range s {
+		infos = append(infos, info)
+	}
+	return infos
+}
+
 // Pool holds entries and their health. It allows to choose entries based
 // on their health.
 type Pool struct {
@@ -94,6 +103,17 @@ func (p *Pool) Choose() (Info, error) {
 		return nil, common.NewBasicError(ErrPoolClosed, nil)
 	}
 	return p.choose()
+}
+
+// Infos returns a list of all infos in the pool.
+func (p *Pool) Infos() []Info {
+	p.infosMtx.RLock()
+	defer p.infosMtx.RUnlock()
+	infos := make([]Info, 0, len(p.infos))
+	for info := range p.infos {
+		infos = append(infos, info)
+	}
+	return infos
 }
 
 // Close closes the pool and stops the periodic fail expiration. After

--- a/go/lib/healthpool/pool_test.go
+++ b/go/lib/healthpool/pool_test.go
@@ -52,6 +52,7 @@ func TestNewPool(t *testing.T) {
 	}
 
 	for name, test := range tests {
+		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			p, err := NewPool(test.Infos, test.Options)
@@ -161,7 +162,7 @@ func TestPoolExpiresFails(t *testing.T) {
 	)
 	require.NoError(t, err)
 	p.expirer.TriggerRun()
-	time.Sleep(time.Second)
+	time.Sleep(time.Millisecond)
 	assert.Equal(t, 16, one.FailCount())
 	assert.Equal(t, 32, two.FailCount())
 }


### PR DESCRIPTION
The TestPoolExpiresFails test no longer is flaky.
Additionally, remove goconvey.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3307)
<!-- Reviewable:end -->
