### PR TITLE
topo-gen: Create BR dispatcher per BR

### DIFF
--- a/python/topology/common.py
+++ b/python/topology/common.py
@@ -116,13 +116,13 @@ def prom_addr_sciond(docker, topo_id, networks, port):
     return None
 
 
-def prom_addr_dispatcher(docker, topo_id, networks, port, disp_type):
+def prom_addr_dispatcher(docker, topo_id, networks, port, name):
     if not docker:
         return "[127.0.0.1]:%s" % port
     target_name = ''
-    if disp_type == 'br':
-        target_name = 'br%s-1_ctrl' % topo_id.file_fmt()
-    elif disp_type == 'sig':
+    if name.startswith('disp_br'):
+        target_name = 'br%s%s_ctrl' % (topo_id.file_fmt(), name[-2:])
+    elif name.startswith('disp_sig'):
         target_name = 'sig%s' % topo_id.file_fmt()
     else:
         target_name = 'disp%s' % topo_id.file_fmt()

--- a/python/topology/docker.py
+++ b/python/topology/docker.py
@@ -268,7 +268,7 @@ class DockerGenerator(object):
             entry = copy.deepcopy(prep_entry)
             ctrl_net = self.elem_networks[k + "_ctrl"][0]
             ctrl_ip = str(ctrl_net['ipv4'])
-            disp_id = '%s%s' % (topo_id.file_fmt(), k[-2:])    
+            disp_id = '%s%s' % (topo_id.file_fmt(), k[-2:])
             entry['networks'][self.bridges[ctrl_net['net']]] = {'ipv4_address': ctrl_ip}
             entry['container_name'] = '%sdisp_br_%s' % (self.prefix, disp_id)
             entry['volumes'].append(self._disp_br_vol(disp_id))

--- a/python/topology/docker.py
+++ b/python/topology/docker.py
@@ -150,7 +150,7 @@ class DockerGenerator(object):
                 ],
                 'command': []
             }
-            
+
             # Set BR IPs
             in_net = self.elem_networks[k + "_internal"][0]
             entry['networks'][self.bridges[in_net['net']]] = {'ipv4_address': str(in_net['ipv4'])}
@@ -268,7 +268,7 @@ class DockerGenerator(object):
             entry = copy.deepcopy(prep_entry)
             ctrl_net = self.elem_networks[k + "_ctrl"][0]
             ctrl_ip = str(ctrl_net['ipv4'])
-            disp_id = '%s%s' % (topo_id.file_fmt(), k[-2:])            
+            disp_id = '%s%s' % (topo_id.file_fmt(), k[-2:])    
             entry['networks'][self.bridges[ctrl_net['net']]] = {'ipv4_address': ctrl_ip}
             entry['container_name'] = '%sdisp_br_%s' % (self.prefix, disp_id)
             entry['volumes'].append(self._disp_br_vol(disp_id))

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -239,21 +239,21 @@ class GoGenerator(object):
             write_file(config_file_path, toml.dumps(self._build_disp_conf("dispatcher")))
 
     def _gen_disp_docker(self):
-        for topo_id, _ in self.args.topo_dicts.items():
-            for elem in ["disp", "disp_br", "disp_sig"]:
+        for topo_id, topo in self.args.topo_dicts.items():
+            for elem in ["disp", "disp_sig"]:
                 elem = "%s_%s" % (elem, topo_id.file_fmt())
                 elem_dir = os.path.join(topo_id.base_dir(self.args.output_dir), elem)
                 disp_conf = self._build_disp_conf(elem, topo_id)
                 write_file(os.path.join(elem_dir, DISP_CONFIG_NAME), toml.dumps(disp_conf))
+            for k, _ in topo.get("BorderRouters", {}).items():
+                disp_id = '%s_%s%s' % ('disp_br', topo_id.file_fmt(), k[-2:])
+                elem_dir = os.path.join(topo_id.base_dir(self.args.output_dir), disp_id)
+                disp_conf = self._build_disp_conf(disp_id, topo_id)
+                write_file(os.path.join(elem_dir, DISP_CONFIG_NAME), toml.dumps(disp_conf))
 
     def _build_disp_conf(self, name, topo_id=None):
-        disp_type = ''
-        if name.startswith('disp_br'):
-            disp_type = 'br'
-        elif name.startswith('disp_sig'):
-            disp_type = 'sig'
         prometheus_addr = prom_addr_dispatcher(self.args.docker, topo_id,
-                                               self.args.networks, DISP_PROM_PORT, disp_type)
+                                               self.args.networks, DISP_PROM_PORT, name)
         return {
             'dispatcher': {
                 'ID': name,


### PR DESCRIPTION
This commit changes the topology generator to create a BR dispatcher per BR.
This is required since otherwise non -1 BR will not receive control plane traffic.

Fixes #3318

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3321)
<!-- Reviewable:end -->
