### PR TITLE
update gazelle and rules_go

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,7 +6,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 git_repository(
     name = "io_bazel_rules_go",
     remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.18.7",
+    tag = "v0.20.2",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_rules_dependencies", "go_register_toolchains")
@@ -25,8 +25,11 @@ go_register_toolchains(nogo = "@//:nogo")
 # Gazelle
 http_archive(
     name = "bazel_gazelle",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
-    sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
+    urls = [
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.0/bazel-gazelle-v0.19.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.0/bazel-gazelle-v0.19.0.tar.gz",
+    ],
+    sha256 = "41bff2a0b32b02f20c227d234aa25ef3783998e5453f7eade929704dcff7cd4b",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
@@ -325,7 +328,7 @@ go_repository(
 
 go_repository(
     name = "com_github_prometheus_client_golang",
-    commit = "170205fb58decfd011f1550d4cfb737230d7ae4f", #v1.1.0
+    commit = "170205fb58decfd011f1550d4cfb737230d7ae4f",  #v1.1.0
     importpath = "github.com/prometheus/client_golang",  # prometheus
 )
 
@@ -337,13 +340,13 @@ go_repository(
 
 go_repository(
     name = "com_github_prometheus_common",
-    commit = "31bed53e4047fd6c510e43a941f90cb31be0972a", #v0.6.0
+    commit = "31bed53e4047fd6c510e43a941f90cb31be0972a",  #v0.6.0
     importpath = "github.com/prometheus/common",  # model
 )
 
 go_repository(
     name = "com_github_prometheus_procfs",
-    commit = "3f98efb27840a48a7a2898ec80be07674d19f9c8", #v0.0.3
+    commit = "3f98efb27840a48a7a2898ec80be07674d19f9c8",  #v0.0.3
     importpath = "github.com/prometheus/procfs",
 )
 
@@ -491,4 +494,18 @@ go_repository(
     name = "com_github_iancoleman_strcase",
     commit = "e506e3ef73653e84c592ba44aab577a46678f68c",
     importpath = "github.com/iancoleman/strcase",
+)
+
+go_repository(
+    name = "org_golang_x_net",
+    importpath = "golang.org/x/net",
+    sum = "h1:QPlSTtPE2k6PZPasQUbzuK3p9JbS+vMXYVto8g/yrsg=",
+    version = "v0.0.0-20191105084925-a882066a44e0",
+)
+
+go_repository(
+    name = "org_golang_x_ctx",
+    importpath = "golang.org/x/ctx",
+    sum = "",
+    version = "latest",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -503,9 +503,3 @@ go_repository(
     version = "v0.0.0-20191105084925-a882066a44e0",
 )
 
-go_repository(
-    name = "org_golang_x_ctx",
-    importpath = "golang.org/x/ctx",
-    sum = "",
-    version = "latest",
-)

--- a/go/lib/overlay/conn/BUILD.bazel
+++ b/go/lib/overlay/conn/BUILD.bazel
@@ -6,6 +6,17 @@ go_library(
     importpath = "github.com/scionproto/scion/go/lib/overlay/conn",
     visibility = ["//visibility:public"],
     deps = select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//go/lib/addr:go_default_library",
+            "//go/lib/assert:go_default_library",
+            "//go/lib/common:go_default_library",
+            "//go/lib/log:go_default_library",
+            "//go/lib/overlay:go_default_library",
+            "//go/lib/serrors:go_default_library",
+            "//go/lib/sockctrl:go_default_library",
+            "@org_golang_x_net//ipv4:go_default_library",
+            "@org_golang_x_net//ipv6:go_default_library",
+        ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//go/lib/addr:go_default_library",
             "//go/lib/assert:go_default_library",

--- a/nogo.json
+++ b/nogo.json
@@ -10,6 +10,9 @@
     }
   },
   "nilness": {
+    "only_files": {
+      "//go/": "https://github.com/bazelbuild/rules_go/issues/2172"
+    },
     "exclude_files": {
       "gazelle/cmd/gazelle/diff.go": "",
       "/in_gopkg_yaml_v2/decode.go": "https://github.com/go-yaml/yaml/pull/492",
@@ -26,11 +29,15 @@
   },
   "unreachable": {
     "exclude_files": {
+      "gazelle/pathtools/path.go": "",
       "/com_github_antlr_antlr4/runtime/Go/antlr/": "",
       "/com_github_uber_jaeger_client_go": ""
     }
   },
   "unsafeptr": {
+    "only_files": {
+      "//go/": "https://github.com/bazelbuild/rules_go/issues/2172"
+    },
     "exclude_files": {
       "/com_github_mattn_go_sqlite3/": "",
       "/com_github_google_gopacket/afpacket/": ""
@@ -52,6 +59,9 @@
     }
   },
   "gocall": {
+    "only_files": {
+      "//go/": "https://github.com/bazelbuild/rules_go/issues/2172"
+    },
     "exclude_files": {
       "(vendor|external)/*": "Only applies to internal files",
       "xtest/*": "",


### PR DESCRIPTION
This patch works around some issues in rules_go/nogo from v0.19.0+
where it fails to exclude paths appropiately for packages that use cgo.

See issue below:
https://github.com/bazelbuild/rules_go/issues/2172

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3325)
<!-- Reviewable:end -->
