### PR TITLE
Convert more goconvey tests to normal go tests

### DIFF
--- a/go/godispatcher/network/BUILD.bazel
+++ b/go/godispatcher/network/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
         "//go/lib/spkt:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/godispatcher/network/overlay_test.go
+++ b/go/godispatcher/network/overlay_test.go
@@ -19,7 +19,8 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
@@ -41,7 +42,7 @@ func TestComputeDestination(t *testing.T) {
 		Description string
 		Packet      *spkt.ScnPkt
 		ExpectedDst Destination
-		ExpectedErr common.ErrMsg
+		ExpectedErr error
 	}
 	var testCases = []*TestCase{
 		{
@@ -208,19 +209,17 @@ func TestComputeDestination(t *testing.T) {
 			ExpectedErr: ErrMalformedL4Quote,
 		},
 	}
-	Convey("", t, func() {
-		for _, test := range testCases {
-			Convey(test.Description, func() {
-				destination, err := ComputeDestination(test.Packet)
-				xtest.SoMsgErrorStr("err", err, test.ExpectedErr.Error())
-				SoMsg("destination", destination, ShouldResemble, test.ExpectedDst)
-			})
-		}
-	})
+	for _, test := range testCases {
+		t.Run(test.Description, func(t *testing.T) {
+			destination, err := ComputeDestination(test.Packet)
+			xtest.AssertErrorsIs(t, err, test.ExpectedErr)
+			assert.Equal(t, test.ExpectedDst, destination)
+		})
+	}
 }
 
 func MustPackL4Header(t *testing.T, header l4.L4Header) common.RawBytes {
 	b, err := header.Pack(false)
-	xtest.FailOnErr(t, err)
+	require.NoError(t, err)
 	return b
 }

--- a/go/hidden_path_srv/internal/hpsegreq/BUILD.bazel
+++ b/go/hidden_path_srv/internal/hpsegreq/BUILD.bazel
@@ -58,6 +58,5 @@ go_test(
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )

--- a/go/hidden_path_srv/internal/hpsegreq/fetcher_test.go
+++ b/go/hidden_path_srv/internal/hpsegreq/fetcher_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 
 	"github.com/scionproto/scion/go/hidden_path_srv/internal/hiddenpathdb/adapter"
 	"github.com/scionproto/scion/go/hidden_path_srv/internal/hpsegreq"
@@ -344,12 +343,8 @@ func TestFetcher(t *testing.T) {
 			f := hpsegreq.NewDefaultFetcher(groupInfo, mockMsgr, adapter.New(mockDB))
 			test.setup(mockDB, mockMsgr)
 			recs, err := f.Fetch(context.Background(), test.req, test.peer)
-			if test.err == nil {
-				require.NoError(t, err)
-				assert.ElementsMatch(t, test.res, recs)
-			} else {
-				assert.True(t, xerrors.Is(err, test.err))
-			}
+			xtest.AssertErrorsIs(t, err, test.err)
+			assert.ElementsMatch(t, test.res, recs)
 		})
 	}
 }

--- a/go/hidden_path_srv/internal/registration/BUILD.bazel
+++ b/go/hidden_path_srv/internal/registration/BUILD.bazel
@@ -53,6 +53,5 @@ go_test(
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )

--- a/go/hidden_path_srv/internal/registration/validator_test.go
+++ b/go/hidden_path_srv/internal/registration/validator_test.go
@@ -18,9 +18,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 
 	"github.com/scionproto/scion/go/hidden_path_srv/internal/registration"
 	"github.com/scionproto/scion/go/lib/addr"
@@ -181,13 +179,7 @@ func TestValidator(t *testing.T) {
 				},
 			}
 			err := validator.Validate(msg, test.peer)
-			if test.Err == nil {
-				assert.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				assert.True(t, xerrors.Is(err, test.Err))
-			}
-
+			xtest.AssertErrorsIs(t, err, test.Err)
 		})
 	}
 }

--- a/go/lib/infra/BUILD.bazel
+++ b/go/lib/infra/BUILD.bazel
@@ -36,6 +36,5 @@ go_test(
         "//go/lib/infra/mock_infra:go_default_library",
         "//go/proto:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
     ],
 )

--- a/go/lib/infra/common_test.go
+++ b/go/lib/infra/common_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/scionproto/scion/go/lib/ctrl/ack"
 	"github.com/scionproto/scion/go/lib/infra"
@@ -42,22 +41,21 @@ func (r *mockResource) IsHealthy() bool {
 	return r.healthy
 }
 
+// TestResourceHealth tests that an unhealthy resource results in error replied.
 func TestResourceHealth(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	Convey("Unhealthy resource results in error replied", t, func() {
-		handler := infra.HandlerFunc(func(r *infra.Request) *infra.HandlerResult {
-			return nil
-		})
-		rHandler := infra.NewResourceAwareHandler(handler,
-			&mockResource{name: "tstFail", healthy: false})
-		rwMock := mock_infra.NewMockResponseWriter(ctrl)
-		ctx := infra.NewContextWithResponseWriter(context.Background(), rwMock)
-		rwMock.EXPECT().SendAckReply(gomock.Eq(ctx), gomock.Eq(&ack.Ack{
-			Err:     proto.Ack_ErrCode_reject,
-			ErrDesc: "Resource tstFail not healthy",
-		}))
-		req := infra.NewRequest(ctx, nil, nil, nil, 1)
-		rHandler.Handle(req)
+	handler := infra.HandlerFunc(func(r *infra.Request) *infra.HandlerResult {
+		return nil
 	})
+	rHandler := infra.NewResourceAwareHandler(handler,
+		&mockResource{name: "tstFail", healthy: false})
+	rwMock := mock_infra.NewMockResponseWriter(ctrl)
+	ctx := infra.NewContextWithResponseWriter(context.Background(), rwMock)
+	rwMock.EXPECT().SendAckReply(gomock.Eq(ctx), gomock.Eq(&ack.Ack{
+		Err:     proto.Ack_ErrCode_reject,
+		ErrDesc: "Resource tstFail not healthy",
+	}))
+	req := infra.NewRequest(ctx, nil, nil, nil, 1)
+	rHandler.Handle(req)
 }

--- a/go/lib/infra/modules/trust/v2/router_test.go
+++ b/go/lib/infra/modules/trust/v2/router_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
@@ -33,6 +32,7 @@ import (
 	"github.com/scionproto/scion/go/lib/snet/mock_snet"
 	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 func TestLocalRouterChooseServer(t *testing.T) {
@@ -135,9 +135,7 @@ func TestCSRouterChooseServer(t *testing.T) {
 			router := trust.NewCSRouter(1, r, db)
 			res, err := router.ChooseServer(context.Background(), test.ISD)
 			if test.ExpectedErr != nil {
-				require.Error(t, err)
-				assert.True(t, xerrors.Is(err, test.ExpectedErr), "Expected: %s Actual: %s",
-					test.ExpectedErr, err)
+				xtest.AssertErrorsIs(t, err, test.ExpectedErr)
 			} else {
 				require.NoError(t, err)
 				expected := &snet.Addr{

--- a/go/lib/infra/rpc/BUILD.bazel
+++ b/go/lib/infra/rpc/BUILD.bazel
@@ -25,9 +25,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/ctrl:go_default_library",
-        "//go/lib/xtest:go_default_library",
         "//go/proto:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
         "@com_zombiezen_go_capnproto2//:go_default_library",
         "@com_zombiezen_go_capnproto2//pogs:go_default_library",
     ],

--- a/go/lib/l4/BUILD.bazel
+++ b/go/lib/l4/BUILD.bazel
@@ -21,6 +21,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/common:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/go/lib/l4/udp_test.go
+++ b/go/lib/l4/udp_test.go
@@ -30,57 +30,47 @@ func createUDP() UDP {
 }
 
 func TestUDPFromRaw(t *testing.T) {
-	t.Run("Content must match", func(t *testing.T) {
-		raw := common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0}
-		original := createUDP()
+	raw := common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0}
+	original := createUDP()
 
-		fromRaw, err := UDPFromRaw(raw)
-		assert.NoError(t, err)
-		assert.Equal(t, &original, fromRaw)
-	})
+	fromRaw, err := UDPFromRaw(raw)
+	assert.NoError(t, err)
+	assert.Equal(t, &original, fromRaw)
 }
 
 func TestUDPValidate(t *testing.T) {
-	t.Run("It is structure of size 10, must be ok", func(t *testing.T) {
-		u := createUDP()
+	u := createUDP()
 
-		assert.Equal(t, uint16(10), u.TotalLen)
-		err := u.Validate(int(u.TotalLen) - UDPLen)
-		assert.NoError(t, err)
-	})
+	assert.Equal(t, uint16(10), u.TotalLen)
+	err := u.Validate(int(u.TotalLen) - UDPLen)
+	assert.NoError(t, err)
 }
 
 func TestUDPParse(t *testing.T) {
-	t.Run("Must parse into the same representation", func(t *testing.T) {
-		// assuming we have tested UDPPack
-		expected := createUDP()
-		raw, err := expected.Pack(true)
-		actual := UDP{0, 0, 0xA,
-			make(common.RawBytes, 2)}
+	// assuming we have tested UDPPack
+	expected := createUDP()
+	raw, err := expected.Pack(true)
+	actual := UDP{0, 0, 0xA,
+		make(common.RawBytes, 2)}
 
-		actual.Parse(raw)
-		assert.NoError(t, err)
-		assert.Equal(t, expected, actual)
-	})
+	actual.Parse(raw)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
 }
 
 func TestUDPPack(t *testing.T) {
-	t.Run("Binary content must match", func(t *testing.T) {
-		u := createUDP()
-		raw, err := u.Pack(true)
+	u := createUDP()
+	raw, err := u.Pack(true)
 
-		assert.NoError(t, err)
-		assert.Equal(t, common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0}, raw)
-	})
+	assert.NoError(t, err)
+	assert.Equal(t, common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0}, raw)
 }
 
 func TestUDPWrite(t *testing.T) {
-	t.Run("Binary content must match", func(t *testing.T) {
-		u := createUDP()
-		raw := make(common.RawBytes, 8)
-		err := u.Write(raw)
+	u := createUDP()
+	raw := make(common.RawBytes, 8)
+	err := u.Write(raw)
 
-		assert.NoError(t, err)
-		assert.Equal(t, common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0}, raw)
-	})
+	assert.NoError(t, err)
+	assert.Equal(t, common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0}, raw)
 }

--- a/go/lib/l4/udp_test.go
+++ b/go/lib/l4/udp_test.go
@@ -18,7 +18,7 @@ package l4
 import (
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/scionproto/scion/go/lib/common"
 )
@@ -30,59 +30,57 @@ func createUDP() UDP {
 }
 
 func TestUDPFromRaw(t *testing.T) {
-	Convey("Content must match", t, func() {
+	t.Run("Content must match", func(t *testing.T) {
 		raw := common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0}
 		original := createUDP()
 
 		fromRaw, err := UDPFromRaw(raw)
-		SoMsg("Must build from raw without error", err, ShouldBeNil)
-		SoMsg("Wrongly rebuilt from raw", fromRaw, ShouldResemble, &original)
+		assert.NoError(t, err)
+		assert.Equal(t, &original, fromRaw)
 	})
 }
 
 func TestUDPValidate(t *testing.T) {
-	Convey("It is structure of size 10, must be ok", t, func() {
+	t.Run("It is structure of size 10, must be ok", func(t *testing.T) {
 		u := createUDP()
 
-		So(u.TotalLen, ShouldEqual, 10)
+		assert.Equal(t, uint16(10), u.TotalLen)
 		err := u.Validate(int(u.TotalLen) - UDPLen)
-		SoMsg("This structure must be seen as valid", err, ShouldBeNil)
+		assert.NoError(t, err)
 	})
 }
 
 func TestUDPParse(t *testing.T) {
-	Convey("Must parse into the same representation", t, func() {
+	t.Run("Must parse into the same representation", func(t *testing.T) {
 		// assuming we have tested UDPPack
-		u := createUDP()
-		raw, err := u.Pack(true)
-		u2 := UDP{0, 0, 0xA,
+		expected := createUDP()
+		raw, err := expected.Pack(true)
+		actual := UDP{0, 0, 0xA,
 			make(common.RawBytes, 2)}
 
-		u2.Parse(raw)
-		SoMsg("Must parse this valid input", err, ShouldBeNil)
-		SoMsg("Parsed content must match expected", u2, ShouldResemble, u)
+		actual.Parse(raw)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
 	})
 }
 
 func TestUDPPack(t *testing.T) {
-	Convey("Binary content must match", t, func() {
+	t.Run("Binary content must match", func(t *testing.T) {
 		u := createUDP()
 		raw, err := u.Pack(true)
 
-		SoMsg("Must pack without error", err, ShouldBeNil)
-		SoMsg("Packed content must match expected", raw, ShouldResemble,
-			common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0})
+		assert.NoError(t, err)
+		assert.Equal(t, common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0}, raw)
 	})
 }
 
 func TestUDPWrite(t *testing.T) {
-	Convey("Binary content must match", t, func() {
+	t.Run("Binary content must match", func(t *testing.T) {
 		u := createUDP()
 		raw := make(common.RawBytes, 8)
 		err := u.Write(raw)
 
-		SoMsg("Must write without error", err, ShouldBeNil)
-		SoMsg("Wrong content written", raw,
-			ShouldResemble, common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0})
+		assert.NoError(t, err)
+		assert.Equal(t, common.RawBytes{0x12, 0x34, 0x56, 0x78, 0, 0xA, 0, 0}, raw)
 	})
 }

--- a/go/lib/pathpol/BUILD.bazel
+++ b/go/lib/pathpol/BUILD.bazel
@@ -38,6 +38,5 @@ go_test(
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )

--- a/go/lib/pathpol/acl_test.go
+++ b/go/lib/pathpol/acl_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/xerrors"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
@@ -53,7 +52,7 @@ func TestNewACL(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			acl, err := NewACL(test.Entries...)
-			assert.True(t, xerrors.Is(err, test.ExpectedErr))
+			xtest.AssertErrorsIs(t, err, test.ExpectedErr)
 			if test.ExpectedErr == nil {
 				assert.NotNil(t, acl)
 			}

--- a/go/lib/scrypto/cert/v2/BUILD.bazel
+++ b/go/lib/scrypto/cert/v2/BUILD.bazel
@@ -48,6 +48,5 @@ go_test(
         "//go/lib/xtest:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )

--- a/go/lib/scrypto/cert/v2/as_test.go
+++ b/go/lib/scrypto/cert/v2/as_test.go
@@ -18,11 +18,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/xerrors"
-
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/scrypto/cert/v2"
+	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 func TestASValidate(t *testing.T) {
@@ -88,7 +86,7 @@ func TestASValidate(t *testing.T) {
 			c := newASCert(time.Now())
 			test.Modify(&c)
 			err := c.Validate()
-			assert.True(t, xerrors.Is(err, test.ExpectedErrMsg))
+			xtest.AssertErrorsIs(t, err, test.ExpectedErrMsg)
 		})
 	}
 }

--- a/go/lib/scrypto/cert/v2/base_test.go
+++ b/go/lib/scrypto/cert/v2/base_test.go
@@ -18,9 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/xerrors"
-
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/scrypto/cert/v2"
@@ -71,7 +68,7 @@ func TestBaseValidate(t *testing.T) {
 			c := newBaseCert(time.Now())
 			test.Modify(&c)
 			err := c.Validate()
-			assert.True(t, xerrors.Is(err, test.ExpectedErrMsg))
+			xtest.AssertErrorsIs(t, err, test.ExpectedErrMsg)
 		})
 	}
 }

--- a/go/lib/scrypto/cert/v2/issuer_test.go
+++ b/go/lib/scrypto/cert/v2/issuer_test.go
@@ -18,11 +18,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/xerrors"
-
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/scrypto/cert/v2"
+	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 func TestIssuerValidate(t *testing.T) {
@@ -80,7 +78,7 @@ func TestIssuerValidate(t *testing.T) {
 			c := newIssuerCert(time.Now())
 			test.Modify(&c)
 			err := c.Validate()
-			assert.True(t, xerrors.Is(err, test.ExpectedErrMsg))
+			xtest.AssertErrorsIs(t, err, test.ExpectedErrMsg)
 		})
 	}
 }

--- a/go/lib/scrypto/trc/v2/BUILD.bazel
+++ b/go/lib/scrypto/trc/v2/BUILD.bazel
@@ -42,6 +42,5 @@ go_test(
         "//go/lib/xtest:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )

--- a/go/lib/scrypto/trc/v2/primary_test.go
+++ b/go/lib/scrypto/trc/v2/primary_test.go
@@ -18,10 +18,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/xerrors"
 
 	"github.com/scionproto/scion/go/lib/scrypto"
 	trc "github.com/scionproto/scion/go/lib/scrypto/trc/v2"
+	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 func TestPrimaryASesValidateInvariant(t *testing.T) {
@@ -258,7 +258,7 @@ func TestPrimaryASValidateInvariant(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			err := test.Primary.ValidateInvariant()
-			assert.True(t, xerrors.Is(err, test.ExpectedErrMsg))
+			xtest.AssertErrorsIs(t, err, test.ExpectedErrMsg)
 		})
 	}
 }

--- a/go/lib/scrypto/trc/v2/trc_test.go
+++ b/go/lib/scrypto/trc/v2/trc_test.go
@@ -18,9 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/xerrors"
-
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	trc "github.com/scionproto/scion/go/lib/scrypto/trc/v2"
@@ -135,7 +132,7 @@ func TestTRCValidateInvariant(t *testing.T) {
 			base := newBaseTRC(time.Now())
 			test.Modify(base)
 			err := base.ValidateInvariant()
-			assert.True(t, xerrors.Is(err, test.ExpectedErrMsg))
+			xtest.AssertErrorsIs(t, err, test.ExpectedErrMsg)
 		})
 	}
 }

--- a/go/lib/scrypto/trc/v2/update_test.go
+++ b/go/lib/scrypto/trc/v2/update_test.go
@@ -19,12 +19,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/xerrors"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	trc "github.com/scionproto/scion/go/lib/scrypto/trc/v2"
 	"github.com/scionproto/scion/go/lib/util"
+	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 // TestCommonUpdate tests shared error cases between regular and sensitive updates.
@@ -91,7 +91,7 @@ func TestCommonUpdate(t *testing.T) {
 				Next: updated,
 			}
 			info, err := v.Validate()
-			assert.True(t, xerrors.Is(err, test.ExpectedErrMsg))
+			xtest.AssertErrorsIs(t, err, test.ExpectedErrMsg)
 			if test.ExpectedErrMsg == nil {
 				assert.Equal(t, ut, info.Type)
 			}
@@ -530,7 +530,7 @@ func TestSensitiveUpdate(t *testing.T) {
 				Next: updated,
 			}
 			info, err := v.Validate()
-			assert.True(t, xerrors.Is(err, test.ExpectedErrMsg))
+			xtest.AssertErrorsIs(t, err, test.ExpectedErrMsg)
 			if test.ExpectedErrMsg == nil {
 				assert.Equal(t, trc.SensitiveUpdate, info.Type)
 				initKeyChanges(&test.Info)
@@ -715,7 +715,7 @@ func TestRegularUpdate(t *testing.T) {
 				Next: updated,
 			}
 			info, err := v.Validate()
-			assert.True(t, xerrors.Is(err, test.ExpectedErrMsg))
+			xtest.AssertErrorsIs(t, err, test.ExpectedErrMsg)
 			if test.ExpectedErrMsg == nil {
 				assert.Equal(t, trc.RegularUpdate, info.Type)
 				initKeyChanges(&test.Info)

--- a/go/lib/serrors/BUILD.bazel
+++ b/go/lib/serrors/BUILD.bazel
@@ -13,6 +13,7 @@ go_test(
     srcs = ["errors_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//go/lib/xtest:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@org_golang_x_xerrors//:go_default_library",

--- a/go/lib/serrors/errors_test.go
+++ b/go/lib/serrors/errors_test.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/scionproto/scion/go/lib/serrors"
+	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 type testErrType struct {
@@ -89,8 +90,8 @@ func TestWithCtx(t *testing.T) {
 	t.Run("Is", func(t *testing.T) {
 		err := serrors.New("simple err")
 		errWithCtx := serrors.WithCtx(err, "someCtx", "someValue")
-		assert.True(t, xerrors.Is(errWithCtx, err))
-		assert.True(t, xerrors.Is(errWithCtx, errWithCtx))
+		xtest.AssertErrorsIs(t, errWithCtx, err)
+		xtest.AssertErrorsIs(t, errWithCtx, errWithCtx)
 	})
 	t.Run("As", func(t *testing.T) {
 		err := &testErrType{msg: "test err"}
@@ -112,9 +113,9 @@ func TestWrap(t *testing.T) {
 		err := serrors.New("simple err")
 		msg := serrors.New("msg err")
 		wrappedErr := serrors.Wrap(msg, err, "someCtx", "someValue")
-		assert.True(t, xerrors.Is(wrappedErr, err))
-		assert.True(t, xerrors.Is(wrappedErr, msg))
-		assert.True(t, xerrors.Is(wrappedErr, wrappedErr))
+		xtest.AssertErrorsIs(t, wrappedErr, err)
+		xtest.AssertErrorsIs(t, wrappedErr, msg)
+		xtest.AssertErrorsIs(t, wrappedErr, wrappedErr)
 	})
 	t.Run("As", func(t *testing.T) {
 		err := &testErrType{msg: "test err"}
@@ -144,8 +145,8 @@ func TestWrapStr(t *testing.T) {
 		err := serrors.New("simple err")
 		msg := "msg"
 		wrappedErr := serrors.WrapStr(msg, err, "someCtx", "someValue")
-		assert.True(t, xerrors.Is(wrappedErr, err))
-		assert.True(t, xerrors.Is(wrappedErr, wrappedErr))
+		xtest.AssertErrorsIs(t, wrappedErr, err)
+		xtest.AssertErrorsIs(t, wrappedErr, wrappedErr)
 	})
 	t.Run("As", func(t *testing.T) {
 		err := &testErrType{msg: "test err"}
@@ -174,14 +175,14 @@ func TestNew(t *testing.T) {
 	t.Run("Is", func(t *testing.T) {
 		err1 := serrors.New("err msg")
 		err2 := serrors.New("err msg")
-		assert.True(t, xerrors.Is(err1, err1))
-		assert.True(t, xerrors.Is(err2, err2))
+		xtest.AssertErrorsIs(t, err1, err1)
+		xtest.AssertErrorsIs(t, err2, err2)
 		assert.False(t, xerrors.Is(err1, err2))
 		assert.False(t, xerrors.Is(err2, err1))
 		err1 = serrors.New("err msg", "someCtx", "value")
 		err2 = serrors.New("err msg", "someCtx", "value")
-		assert.True(t, xerrors.Is(err1, err1))
-		assert.True(t, xerrors.Is(err2, err2))
+		xtest.AssertErrorsIs(t, err1, err1)
+		xtest.AssertErrorsIs(t, err2, err2)
 		assert.False(t, xerrors.Is(err1, err2))
 		assert.False(t, xerrors.Is(err2, err1))
 	})

--- a/go/lib/sock/reliable/BUILD.bazel
+++ b/go/lib/sock/reliable/BUILD.bazel
@@ -32,12 +32,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/mocks/net/mock_net:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )

--- a/go/lib/sock/reliable/errors.go
+++ b/go/lib/sock/reliable/errors.go
@@ -23,7 +23,8 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 )
 
-const (
+// Possible errors
+var (
 	ErrNoAddress             common.ErrMsg = "no address found"
 	ErrNoPort                common.ErrMsg = "missing port"
 	ErrPayloadTooLong        common.ErrMsg = "payload too long"
@@ -37,6 +38,8 @@ const (
 	ErrBadLength             common.ErrMsg = "bad length"
 	ErrBufferTooSmall        common.ErrMsg = "buffer too small"
 )
+
+// TODO(lukedirtwalker): Refactor methods in here to use `xerrors`.
 
 func IsDispatcherError(err error) bool {
 	err = extractNestedError(err)

--- a/go/lib/sock/reliable/frame_test.go
+++ b/go/lib/sock/reliable/frame_test.go
@@ -18,9 +18,8 @@ import (
 	"net"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
@@ -29,7 +28,7 @@ func TestOverlayPacketSerializeTo(t *testing.T) {
 		Name          string
 		Packet        *OverlayPacket
 		ExpectedData  []byte
-		ExpectedError common.ErrMsg
+		ExpectedError error
 	}
 	testCases := []TestCase{
 		{
@@ -97,13 +96,13 @@ func TestOverlayPacketSerializeTo(t *testing.T) {
 				10, 2, 3, 4, 0, 80, 10, 5, 6, 7},
 		},
 	}
-	Convey("Different packets serialize correctly", t, func() {
+	t.Run("Different packets serialize correctly", func(t *testing.T) {
 		for _, tc := range testCases {
-			Convey(tc.Name, func() {
+			t.Run(tc.Name, func(t *testing.T) {
 				b := make([]byte, 1500)
 				n, err := tc.Packet.SerializeTo(b)
-				xtest.SoMsgErrorStr("err", err, tc.ExpectedError.Error())
-				SoMsg("data", b[:n], ShouldResemble, tc.ExpectedData)
+				xtest.AssertErrorsIs(t, err, tc.ExpectedError)
+				assert.Equal(t, tc.ExpectedData, b[:n])
 			})
 		}
 	})
@@ -114,7 +113,7 @@ func TestOverlayPacketDecodeFromBytes(t *testing.T) {
 		Name           string
 		Buffer         []byte
 		ExpectedPacket OverlayPacket
-		ExpectedError  common.ErrMsg
+		ExpectedError  error
 	}
 	testCases := []TestCase{
 		{
@@ -183,13 +182,13 @@ func TestOverlayPacketDecodeFromBytes(t *testing.T) {
 			},
 		},
 	}
-	Convey("Different packets decode correctly", t, func() {
+	t.Run("Different packets decode correctly", func(t *testing.T) {
 		for _, tc := range testCases {
-			Convey(tc.Name, func() {
+			t.Run(tc.Name, func(t *testing.T) {
 				var p OverlayPacket
 				err := p.DecodeFromBytes(tc.Buffer)
-				xtest.SoMsgErrorStr("err", err, tc.ExpectedError.Error())
-				SoMsg("packet", p, ShouldResemble, tc.ExpectedPacket)
+				xtest.AssertErrorsIs(t, err, tc.ExpectedError)
+				assert.Equal(t, tc.ExpectedPacket, p)
 			})
 		}
 	})

--- a/go/lib/sock/reliable/packetizer_test.go
+++ b/go/lib/sock/reliable/packetizer_test.go
@@ -18,14 +18,14 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/scionproto/scion/go/lib/mocks/net/mock_net"
 )
 
 func TestReadPacketizer(t *testing.T) {
 	// FIXME(scrye): This will get deleted when we move from to SEQPACKET.
-	Convey("Packetizer should extract multiple packets from an input stream", t, func() {
+	t.Run("Packetizer should extract multiple packets from an input stream", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -50,23 +50,18 @@ func TestReadPacketizer(t *testing.T) {
 			}).AnyTimes()
 		packetizer := NewReadPacketizer(conn)
 		b := make([]byte, 128)
-		Convey("first read", func() {
-			n, err := packetizer.Read(b)
-			SoMsg("err", err, ShouldBeNil)
-			SoMsg("n", n, ShouldEqual, 32)
-			Convey("second read", func() {
-				n, err := packetizer.Read(b)
-				SoMsg("err", err, ShouldBeNil)
-				SoMsg("n", n, ShouldEqual, 32)
-			})
-		})
-
+		n, err := packetizer.Read(b)
+		assert.NoError(t, err, "first packet err")
+		assert.Equal(t, 32, n, "first packet size")
+		n, err = packetizer.Read(b)
+		assert.NoError(t, err, "second packet err")
+		assert.Equal(t, 32, n, "second packet err")
 	})
 }
 
 func TestWriteStreamer(t *testing.T) {
 	// FIXME(scrye): This will get deleted when we move from to SEQPACKET.
-	Convey("Streamer should do repeated calls to send a full message", t, func() {
+	t.Run("Streamer should do repeated calls to send a full message", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -79,6 +74,6 @@ func TestWriteStreamer(t *testing.T) {
 		)
 		streamer := NewWriteStreamer(conn)
 		err := streamer.Write(data)
-		So(err, ShouldBeNil)
+		assert.NoError(t, err)
 	})
 }

--- a/go/lib/spath/BUILD.bazel
+++ b/go/lib/spath/BUILD.bazel
@@ -30,5 +30,6 @@ go_test(
         "//go/lib/util:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/go/lib/svc/BUILD.bazel
+++ b/go/lib/svc/BUILD.bazel
@@ -46,5 +46,6 @@ go_test(
         "//go/lib/xtest:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/go/lib/topology/BUILD.bazel
+++ b/go/lib/topology/BUILD.bazel
@@ -34,9 +34,10 @@ go_test(
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/overlay:go_default_library",
+        "//go/lib/xtest:go_default_library",
         "//go/proto:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/lib/topology/addr_test.go
+++ b/go/lib/topology/addr_test.go
@@ -19,10 +19,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/xerrors"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/overlay"
+	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 var (
@@ -101,7 +101,7 @@ func Test_topoAddrFromRaw(t *testing.T) {
 		}
 		t.Run(desc, func(t *testing.T) {
 			ta, err := topoAddrFromRAM(test.ram, test.overlay)
-			assert.True(t, xerrors.Is(err, test.err))
+			xtest.AssertErrorsIs(t, err, test.err)
 			if test.err == nil {
 				assert.Equal(t, exp, ta)
 			}
@@ -148,7 +148,7 @@ func Test_pubBindAddr(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			pbo := &pubBindAddr{}
 			err := pbo.fromRaw(rpbo, test.udpOverlay)
-			assert.True(t, xerrors.Is(err, test.err))
+			xtest.AssertErrorsIs(t, err, test.err)
 			if test.err == nil {
 				assert.Equal(t, exp, pbo)
 			}

--- a/go/lib/xtest/BUILD.bazel
+++ b/go/lib/xtest/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//go/lib/common:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
+        "@org_golang_x_xerrors//:go_default_library",
     ],
 )
 

--- a/go/lib/xtest/convey.go
+++ b/go/lib/xtest/convey.go
@@ -36,8 +36,11 @@ package xtest
 
 import (
 	"sync"
+	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/xerrors"
 
 	"github.com/scionproto/scion/go/lib/common"
 )
@@ -115,4 +118,11 @@ func SoMsgErrorStr(msg string, err error, str string) {
 	} else {
 		SoMsg(msg, common.GetErrorMsg(err), ShouldEqual, str)
 	}
+}
+
+// AssertErrorsIs checks that errors.Is(actualErr, expectedErr) returns true, if
+// expectedErr is not nil.
+func AssertErrorsIs(t *testing.T, actualErr, expectedErr error) {
+	assert.True(t, xerrors.Is(actualErr, expectedErr), "Expect '%v' to be or contain '%v'",
+		actualErr, expectedErr)
 }

--- a/go/lib/xtest/graphupdater/BUILD.bazel
+++ b/go/lib/xtest/graphupdater/BUILD.bazel
@@ -29,8 +29,8 @@ go_test(
     data = ["//topology:default"],
     embed = [":go_default_library"],
     deps = [
-        "//go/lib/xtest:go_default_library",
         "//go/lib/xtest/graph:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/lib/xtest/graphupdater/main_test.go
+++ b/go/lib/xtest/graphupdater/main_test.go
@@ -17,21 +17,19 @@ package main
 import (
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/scionproto/scion/go/lib/xtest"
 	"github.com/scionproto/scion/go/lib/xtest/graph"
 )
 
 func TestGeneratedUpToDate(t *testing.T) {
-	Convey("Generated up to date", t, func() {
-		g, err := LoadGraph("../../../../" + DefaultTopoFile)
-		xtest.FailOnErr(t, err)
-		graphMapping := make(map[string]int)
-		for i, id := range g.IfaceIds {
-			graphMapping[i.Name()] = id
-		}
-		SoMsg("Generated graph is out of date, run graphupdater",
-			graphMapping, ShouldResemble, graph.StaticIfaceIdMapping)
-	})
+	g, err := LoadGraph("../../../../" + DefaultTopoFile)
+	require.NoError(t, err)
+	graphMapping := make(map[string]int)
+	for i, id := range g.IfaceIds {
+		graphMapping[i.Name()] = id
+	}
+	assert.Equal(t, graph.StaticIfaceIdMapping, graphMapping,
+		"Generated graph is out of date, run graphupdater")
 }

--- a/go/sig/config/BUILD.bazel
+++ b/go/sig/config/BUILD.bazel
@@ -22,6 +22,6 @@ go_test(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/xtest:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/go/tools/scion-pki/internal/pkicmn/BUILD.bazel
+++ b/go/tools/scion-pki/internal/pkicmn/BUILD.bazel
@@ -17,7 +17,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",

--- a/go/tools/scion-pki/internal/pkicmn/pkicmn_test.go
+++ b/go/tools/scion-pki/internal/pkicmn/pkicmn_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
@@ -66,7 +65,7 @@ func TestProcessSelector(t *testing.T) {
 	tests := map[string]struct {
 		selector string
 		isdAsMap map[addr.ISD][]addr.IA
-		err      common.ErrMsg
+		err      error
 	}{
 		"Empty selector string": {
 			err: ErrInvalidSelector,
@@ -120,12 +119,7 @@ func TestProcessSelector(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			isdAsMap, err := ProcessSelector(test.selector)
 			assert.Equal(t, test.isdAsMap, isdAsMap)
-			if test.err != "" {
-				be := err.(common.BasicError)
-				assert.Equal(t, common.ErrMsg(test.err), be.Msg)
-			} else {
-				assert.NoError(t, err)
-			}
+			xtest.AssertErrorsIs(t, err, test.err)
 		})
 	}
 }

--- a/go/tools/scion-pki/internal/v2/conf/BUILD.bazel
+++ b/go/tools/scion-pki/internal/v2/conf/BUILD.bazel
@@ -42,6 +42,5 @@ go_test(
         "//go/tools/scion-pki/internal/v2/conf/testdata:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
-        "@org_golang_x_xerrors//:go_default_library",
     ],
 )

--- a/go/tools/scion-pki/internal/v2/conf/as_test.go
+++ b/go/tools/scion-pki/internal/v2/conf/as_test.go
@@ -17,9 +17,6 @@ package conf_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/xerrors"
-
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/xtest"
@@ -189,7 +186,7 @@ func TestAsValidate(t *testing.T) {
 			}
 			test.Modify(&as)
 			err := as.Validate()
-			assert.True(t, xerrors.Is(err, test.ExpectedErrMsg))
+			xtest.AssertErrorsIs(t, err, test.ExpectedErrMsg)
 		})
 	}
 }


### PR DESCRIPTION
Also introduce `xtest.AssertErrorsIs` and use it instead of manual asserts with `xerrors.Is`

Contributes #3016

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3330)
<!-- Reviewable:end -->
