### PR TITLE
Refactor overlay addresses to always use net.IP

### DIFF
--- a/go/beacon_srv/internal/onehop/sender_test.go
+++ b/go/beacon_srv/internal/onehop/sender_test.go
@@ -110,9 +110,7 @@ func TestSenderSend(t *testing.T) {
 			MAC: createMac(t),
 		}
 		// Read from connection to unblock sender.
-		host := addr.HostFromIP(net.IP{127, 0, 0, 42})
-		ov, err := overlay.NewOverlayAddr(host, 1337)
-		xtest.FailOnErr(t, err)
+		ov := overlay.NewOverlayAddr(net.IP{127, 0, 0, 42}, 1337)
 		var pkt *snet.SCIONPacket
 		conn.EXPECT().WriteTo(gomock.Any(), ov).DoAndReturn(
 			func(ipkt, _ interface{}) error {
@@ -121,7 +119,7 @@ func TestSenderSend(t *testing.T) {
 			},
 		)
 		msg := testPacket()
-		err = s.Send(msg, ov)
+		err := s.Send(msg, ov)
 		SoMsg("err", err, ShouldBeNil)
 		checkTestPkt(t, s, msg, pkt)
 	})

--- a/go/border/BUILD.bazel
+++ b/go/border/BUILD.bazel
@@ -64,7 +64,6 @@ go_test(
         "//go/border/brconf:go_default_library",
         "//go/border/rctx:go_default_library",
         "//go/border/rpkt:go_default_library",
-        "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/infra/modules/itopo:go_default_library",
         "//go/lib/log:go_default_library",

--- a/go/border/io_test.go
+++ b/go/border/io_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/scionproto/scion/go/border/rctx"
 	"github.com/scionproto/scion/go/border/rpkt"
-	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/overlay"
 	"github.com/scionproto/scion/go/lib/overlay/conn"
@@ -149,9 +148,7 @@ func newTestPktList(t *testing.T, length int) (ringbuf.EntryList, func(expected 
 }
 
 func newTestDst(t *testing.T) *overlay.OverlayAddr {
-	dst, err := overlay.NewOverlayAddr(addr.HostFromIP(net.IP{127, 0, 0, 1}), overlay.EndhostPort)
-	require.NoError(t, err)
-	return dst
+	return overlay.NewOverlayAddr(net.IP{127, 0, 0, 1}, overlay.EndhostPort)
 }
 
 func newTestSock(r *Router, ringSize int, mconn conn.Conn) *rctx.Sock {

--- a/go/border/rpkt/route.go
+++ b/go/border/rpkt/route.go
@@ -115,10 +115,7 @@ func (rp *RtrPkt) forwardFromExternal() (HookResult, error) {
 		rp.CmnHdr.HdrLenBytes()
 	if onLastSeg && rp.dstIA.Equal(rp.Ctx.Conf.IA) {
 		// Destination is a host in the local ISD-AS.
-		dst, err := overlay.NewOverlayAddr(rp.dstHost, overlay.EndhostPort)
-		if err != nil {
-			return HookError, err
-		}
+		dst := overlay.NewOverlayAddr(rp.dstHost.IP(), overlay.EndhostPort)
 		rp.Egress = append(rp.Egress, EgressPair{S: rp.Ctx.LocSockOut, Dst: dst})
 		return HookContinue, nil
 	}

--- a/go/border/rpkt/route.go
+++ b/go/border/rpkt/route.go
@@ -115,6 +115,11 @@ func (rp *RtrPkt) forwardFromExternal() (HookResult, error) {
 		rp.CmnHdr.HdrLenBytes()
 	if onLastSeg && rp.dstIA.Equal(rp.Ctx.Conf.IA) {
 		// Destination is a host in the local ISD-AS.
+		if rp.dstHost.IP() == nil {
+			// Not an IP address, cannot build an overlay with this
+			return HookError, common.NewBasicError("invalid overlay L3 address", nil,
+				"addr", rp.dstHost)
+		}
 		dst := overlay.NewOverlayAddr(rp.dstHost.IP(), overlay.EndhostPort)
 		rp.Egress = append(rp.Egress, EgressPair{S: rp.Ctx.LocSockOut, Dst: dst})
 		return HookContinue, nil

--- a/go/godispatcher/main_test.go
+++ b/go/godispatcher/main_test.go
@@ -79,9 +79,9 @@ type ClientAddress struct {
 var (
 	commonIA               = xtest.MustParseIA("1-ff00:0:1")
 	commonPublicL3Address  = addr.HostFromIP(net.IP{127, 0, 0, 1})
-	commonOverlayL3Address = addr.HostFromIP(net.IP{127, 0, 0, 1})
+	commonOverlayL3Address = net.IP{127, 0, 0, 1}
 	commonOverlayL4Address = dispatcherTestPort
-	commonOverlayAddress   = MustNewOverlayAddr(commonOverlayL3Address, commonOverlayL4Address)
+	commonOverlayAddress   = overlay.NewOverlayAddr(commonOverlayL3Address, commonOverlayL4Address)
 	clientXAddress         = &ClientAddress{
 		IA:             commonIA,
 		PublicAddress:  commonPublicL3Address,
@@ -484,14 +484,6 @@ func RunTestCase(t *testing.T, tc *TestCase, settings *TestSettings) {
 			t.Errorf("== payload: have %#v, expect %#v", packet.Pld, tc.ExpectedPacket.Pld)
 		}
 	}
-}
-
-func MustNewOverlayAddr(l3 addr.HostAddr, l4 uint16) *overlay.OverlayAddr {
-	address, err := overlay.NewOverlayAddr(l3, l4)
-	if err != nil {
-		panic(err)
-	}
-	return address
 }
 
 func MustPackL4Header(header l4.L4Header) common.RawBytes {

--- a/go/godispatcher/network/app_socket.go
+++ b/go/godispatcher/network/app_socket.go
@@ -268,14 +268,10 @@ func (h *AppConnHandler) RunRingToAppDataplane(r *ringbuf.Ring) {
 		}
 		if n > 0 {
 			pkt := entries[0].(*respool.Packet)
-			overlayAddr, err := overlay.NewOverlayAddr(
-				addr.HostFromIP(pkt.OverlayRemote.IP),
+			overlayAddr := overlay.NewOverlayAddr(
+				pkt.OverlayRemote.IP,
 				uint16(pkt.OverlayRemote.Port),
 			)
-			if err != nil {
-				h.Logger.Warn("[network->app] Unable to encode overlay address.", "err", err)
-				continue
-			}
 			n, err := pkt.SendOnConn(h.Conn, overlayAddr)
 			if err != nil {
 				metrics.M.AppWriteErrors().Inc()

--- a/go/integration/end2end/main.go
+++ b/go/integration/end2end/main.go
@@ -186,11 +186,7 @@ func (c client) ping(ctx context.Context, n int) error {
 	}
 	c.conn.SetWriteDeadline(getDeadline(ctx))
 	if remote.NextHop == nil {
-		var err error
-		remote.NextHop, err = overlay.NewOverlayAddr(remote.Host.L3, overlay.EndhostPort)
-		if err != nil {
-			return common.NewBasicError("Error building overlay", err)
-		}
+		remote.NextHop = overlay.NewOverlayAddr(remote.Host.L3.IP(), overlay.EndhostPort)
 	}
 	var debugID [common.ExtnFirstLineLen]byte
 	// API guarantees return values are ok

--- a/go/lib/hostinfo/hostinfo.go
+++ b/go/lib/hostinfo/hostinfo.go
@@ -71,7 +71,7 @@ func (h *Host) Host() addr.HostAddr {
 }
 
 func (h *Host) Overlay() (*overlay.OverlayAddr, error) {
-	return overlay.NewOverlayAddr(h.Host(), h.Port)
+	return overlay.NewOverlayAddr(h.Host().IP(), h.Port), nil
 }
 
 func (h *Host) Copy() *Host {

--- a/go/lib/hostinfo/hostinfo.go
+++ b/go/lib/hostinfo/hostinfo.go
@@ -71,6 +71,9 @@ func (h *Host) Host() addr.HostAddr {
 }
 
 func (h *Host) Overlay() (*overlay.OverlayAddr, error) {
+	if h.Host().IP() == nil {
+		return nil, common.NewBasicError("unsupported overlay L3 address", nil, "addr", h.Host())
+	}
 	return overlay.NewOverlayAddr(h.Host().IP(), h.Port), nil
 }
 

--- a/go/lib/infra/messenger/addr_test.go
+++ b/go/lib/infra/messenger/addr_test.go
@@ -149,11 +149,7 @@ func TestBuildFullAddress(t *testing.T) {
 			SoMsg("err", err, ShouldBeNil)
 		})
 		Convey("snet address in local AS, overlay address extraction succeeds", func() {
-			overlayAddr, err := overlay.NewOverlayAddr(
-				addr.HostFromIP(net.IP{192, 168, 0, 1}),
-				10,
-			)
-			xtest.FailOnErr(t, err)
+			overlayAddr := overlay.NewOverlayAddr(net.IP{192, 168, 0, 1}, 10)
 			router.EXPECT().LocalIA().Return(localIA).AnyTimes()
 			svcRouter.EXPECT().GetOverlay(addr.SvcBS).Return(overlayAddr, nil)
 

--- a/go/lib/overlay/BUILD.bazel
+++ b/go/lib/overlay/BUILD.bazel
@@ -11,6 +11,5 @@ go_library(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
-        "//go/lib/serrors:go_default_library",
     ],
 )

--- a/go/lib/overlay/addr.go
+++ b/go/lib/overlay/addr.go
@@ -34,7 +34,7 @@ func NewOverlayAddr(l3 net.IP, l4 uint16) *OverlayAddr {
 }
 
 func (a *OverlayAddr) L3() addr.HostAddr {
-	return addr.HostFromIP(copyIP(a.l3))
+	return addr.HostFromIP(a.l3)
 }
 
 func (a *OverlayAddr) L4() uint16 {

--- a/go/lib/overlay/addr.go
+++ b/go/lib/overlay/addr.go
@@ -27,11 +27,14 @@ type OverlayAddr struct {
 }
 
 func NewOverlayAddr(l3 net.IP, l4 uint16) *OverlayAddr {
-	return &OverlayAddr{l3: l3, l4: l4}
+	if l3.To4() != nil {
+		l3 = l3.To4()
+	}
+	return &OverlayAddr{l3: copyIP(l3), l4: l4}
 }
 
 func (a *OverlayAddr) L3() addr.HostAddr {
-	return addr.HostFromIP(a.l3)
+	return addr.HostFromIP(copyIP(a.l3))
 }
 
 func (a *OverlayAddr) L4() uint16 {
@@ -49,7 +52,7 @@ func (a *OverlayAddr) Copy() *OverlayAddr {
 	if a == nil {
 		return nil
 	}
-	return &OverlayAddr{l3: append(a.l3[0:0], a.l3...), l4: a.l4}
+	return &OverlayAddr{l3: copyIP(a.l3), l4: a.l4}
 }
 
 func (a *OverlayAddr) Equal(o *OverlayAddr) bool {
@@ -80,5 +83,9 @@ func (a *OverlayAddr) String() string {
 }
 
 func (a *OverlayAddr) ToUDPAddr() *net.UDPAddr {
-	return &net.UDPAddr{IP: a.l3, Port: int(a.l4)}
+	return &net.UDPAddr{IP: copyIP(a.l3), Port: int(a.l4)}
+}
+
+func copyIP(ip net.IP) net.IP {
+	return append(ip[:0:0], ip...)
 }

--- a/go/lib/overlay/addr.go
+++ b/go/lib/overlay/addr.go
@@ -19,29 +19,19 @@ import (
 	"net"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/serrors"
 )
 
 type OverlayAddr struct {
-	l3 addr.HostAddr
+	l3 net.IP
 	l4 uint16
 }
 
-func NewOverlayAddr(l3 addr.HostAddr, l4 uint16) (*OverlayAddr, error) {
-	if l3 == nil {
-		return nil, serrors.New("L3 required")
-	}
-	switch l3.Type() {
-	case addr.HostTypeIPv4, addr.HostTypeIPv6:
-	default:
-		return nil, common.NewBasicError("Unsupported L3 protocol", nil, "type", l3.Type())
-	}
-	return &OverlayAddr{l3: l3, l4: l4}, nil
+func NewOverlayAddr(l3 net.IP, l4 uint16) *OverlayAddr {
+	return &OverlayAddr{l3: l3, l4: l4}
 }
 
 func (a *OverlayAddr) L3() addr.HostAddr {
-	return a.l3
+	return addr.HostFromIP(a.l3)
 }
 
 func (a *OverlayAddr) L4() uint16 {
@@ -49,19 +39,17 @@ func (a *OverlayAddr) L4() uint16 {
 }
 
 func (a *OverlayAddr) Type() Type {
-	if a.l3.Type() == addr.HostTypeIPv4 {
+	if a.l3.To4() != nil {
 		return UDPIPv4
-	} else {
-		// must be IPv6
-		return UDPIPv6
 	}
+	return UDPIPv6
 }
 
 func (a *OverlayAddr) Copy() *OverlayAddr {
 	if a == nil {
 		return nil
 	}
-	return &OverlayAddr{l3: a.l3.Copy(), l4: a.l4}
+	return &OverlayAddr{l3: append(a.l3[0:0], a.l3...), l4: a.l4}
 }
 
 func (a *OverlayAddr) Equal(o *OverlayAddr) bool {
@@ -92,8 +80,5 @@ func (a *OverlayAddr) String() string {
 }
 
 func (a *OverlayAddr) ToUDPAddr() *net.UDPAddr {
-	if a.l3 == nil {
-		return nil
-	}
-	return &net.UDPAddr{IP: a.l3.IP(), Port: int(a.l4)}
+	return &net.UDPAddr{IP: a.l3, Port: int(a.l4)}
 }

--- a/go/lib/overlay/conn/BUILD.bazel
+++ b/go/lib/overlay/conn/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
             "@org_golang_x_net//ipv6:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
-            "//go/lib/addr:go_default_library",
             "//go/lib/assert:go_default_library",
             "//go/lib/common:go_default_library",
             "//go/lib/log:go_default_library",

--- a/go/lib/overlay/conn/BUILD.bazel
+++ b/go/lib/overlay/conn/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = select({
         "@io_bazel_rules_go//go/platform:android": [
-            "//go/lib/addr:go_default_library",
             "//go/lib/assert:go_default_library",
             "//go/lib/common:go_default_library",
             "//go/lib/log:go_default_library",

--- a/go/lib/overlay/conn/conn.go
+++ b/go/lib/overlay/conn/conn.go
@@ -27,7 +27,6 @@ import (
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 
-	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/assert"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/log"
@@ -299,8 +298,7 @@ func (c *connUDPBase) Read(b common.RawBytes) (int, *ReadMeta, error) {
 	if c.Remote != nil {
 		c.readMeta.Src = c.Remote
 	} else {
-		l3 := addr.HostFromIP(src.IP)
-		c.readMeta.Src, _ = overlay.NewOverlayAddr(l3, uint16(src.Port))
+		c.readMeta.Src = overlay.NewOverlayAddr(src.IP, uint16(src.Port))
 	}
 	return n, &c.readMeta, err
 }
@@ -399,8 +397,7 @@ func (m *ReadMeta) setSrc(a *overlay.OverlayAddr, raddr *net.UDPAddr, ot overlay
 	if a != nil {
 		m.Src = a
 	} else {
-		l3 := addr.HostFromIP(raddr.IP)
-		m.Src, _ = overlay.NewOverlayAddr(l3, uint16(raddr.Port))
+		m.Src = overlay.NewOverlayAddr(raddr.IP, uint16(raddr.Port))
 	}
 }
 

--- a/go/lib/snet/router.go
+++ b/go/lib/snet/router.go
@@ -322,11 +322,5 @@ func (m *LocalMachine) AppAddress() *addr.AppAddr {
 // BindAddress returns a bind address for the local machine. The port is
 // set to 0.
 func (m *LocalMachine) BindAddress() *overlay.OverlayAddr {
-	ov, err := overlay.NewOverlayAddr(addr.HostFromIP(m.InterfaceIP), 0)
-	if err != nil {
-		// XXX(scrye): due to the hardcoded types in this function, this should
-		// never panic
-		panic(err)
-	}
-	return ov
+	return overlay.NewOverlayAddr(m.InterfaceIP, 0)
 }

--- a/go/lib/snet/router_test.go
+++ b/go/lib/snet/router_test.go
@@ -70,7 +70,7 @@ func TestLocalMachineBuildBindAddress(t *testing.T) {
 			Machine: &LocalMachine{
 				InterfaceIP: net.IP{192, 0, 2, 1},
 			},
-			ExpectedBindAddr: mustNewOverlayAddr(addr.HostFromIP(net.IP{192, 0, 2, 1}), 0),
+			ExpectedBindAddr: overlay.NewOverlayAddr(net.IP{192, 0, 2, 1}, 0),
 		},
 	}
 
@@ -79,12 +79,4 @@ func TestLocalMachineBuildBindAddress(t *testing.T) {
 			assert.Equal(t, test.ExpectedBindAddr, test.Machine.BindAddress())
 		})
 	}
-}
-
-func mustNewOverlayAddr(l3 addr.HostAddr, l4 uint16) *overlay.OverlayAddr {
-	ov, err := overlay.NewOverlayAddr(l3, l4)
-	if err != nil {
-		panic(err)
-	}
-	return ov
 }

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -287,12 +287,8 @@ func (n *SCIONNetwork) ListenSCIONWithBindSVC(network string, laddr, baddr *Addr
 	}
 	var bindAddr *overlay.OverlayAddr
 	if baddr != nil {
-		var err error
 		conn.baddr = baddr.Copy()
-		bindAddr, err = overlay.NewOverlayAddr(baddr.Host.L3, baddr.Host.L4)
-		if err != nil {
-			return nil, common.NewBasicError("Unable to construct overlay bind address", err)
-		}
+		bindAddr = overlay.NewOverlayAddr(baddr.Host.L3.IP(), baddr.Host.L4)
 		if !conn.baddr.IA.Equal(conn.scionNet.localIA) {
 			return nil, common.NewBasicError("Unable to listen on non-local IA", nil,
 				"expected", conn.scionNet.localIA, "actual", conn.baddr.IA, "type", "bind")

--- a/go/lib/snet/writer.go
+++ b/go/lib/snet/writer.go
@@ -176,7 +176,7 @@ func (r *remoteAddressResolver) resolveLocalDestination(address *Addr) (*Addr, e
 		return nil, common.NewBasicError(ErrExtraPath, nil)
 	}
 	if address.NextHop == nil {
-		return addOverlayFromScionAddress(address)
+		return addOverlayFromScionAddress(address), nil
 	}
 	return address, nil
 }
@@ -206,12 +206,8 @@ func (r *remoteAddressResolver) addPath(address *Addr) (*Addr, error) {
 	return address, nil
 }
 
-func addOverlayFromScionAddress(address *Addr) (*Addr, error) {
-	var err error
+func addOverlayFromScionAddress(address *Addr) *Addr {
 	address = address.Copy()
-	address.NextHop, err = overlay.NewOverlayAddr(address.Host.L3, overlay.EndhostPort)
-	if err != nil {
-		return nil, common.NewBasicError(ErrBadOverlay, err)
-	}
-	return address, nil
+	address.NextHop = overlay.NewOverlayAddr(address.Host.L3.IP(), overlay.EndhostPort)
+	return address
 }

--- a/go/lib/sock/reliable/reconnect/main_test.go
+++ b/go/lib/sock/reliable/reconnect/main_test.go
@@ -68,11 +68,7 @@ func MustBuildOverlay(str string) *overlay.OverlayAddr {
 	if err != nil {
 		panic(fmt.Sprintf("bad overlay address %v, err=%v", str, err))
 	}
-	ov, err := overlay.NewOverlayAddr(addr.HostFromIP(udpAddr.IP), uint16(udpAddr.Port))
-	if err != nil {
-		panic(fmt.Sprintf("cannot build overlay, err=%v", err))
-	}
-	return ov
+	return overlay.NewOverlayAddr(udpAddr.IP, uint16(udpAddr.Port))
 }
 
 // tickerMultiplier computes durations relative to the default reconnect

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -282,14 +282,7 @@ func (conn *Conn) readFrom(buf []byte) (int, net.Addr, error) {
 	p.DecodeFromBytes(conn.readBuffer[:n])
 	var overlayAddr *overlay.OverlayAddr
 	if p.Address != nil {
-		var err error
-		overlayAddr, err = overlay.NewOverlayAddr(
-			addr.HostFromIP(p.Address.IP),
-			uint16(p.Address.Port),
-		)
-		if err != nil {
-			return 0, nil, common.NewBasicError("overlay error", err)
-		}
+		overlayAddr = overlay.NewOverlayAddr(p.Address.IP, uint16(p.Address.Port))
 	}
 	if len(buf) < len(p.Payload) {
 		return 0, nil, serrors.New("buffer too small")

--- a/go/lib/svc/svc_test.go
+++ b/go/lib/svc/svc_test.go
@@ -246,8 +246,7 @@ func TestDefaultHandler(t *testing.T) {
 
 		conn := mock_snet.NewMockPacketConn(ctrl)
 		packet := &snet.SCIONPacket{}
-		ov, err := overlay.NewOverlayAddr(addr.HostIPv4(net.IP{192, 168, 0, 1}), 0x29a)
-		xtest.FailOnErr(t, err)
+		ov := overlay.NewOverlayAddr(net.IP{192, 168, 0, 1}, 0x29a)
 		conn.EXPECT().WriteTo(packet, ov).Times(1)
 		sender := &svc.BaseHandler{}
 
@@ -257,7 +256,7 @@ func TestDefaultHandler(t *testing.T) {
 			Packet:  packet,
 			Overlay: ov,
 		}
-		_, err = sender.Handle(request)
+		_, err := sender.Handle(request)
 		So(err, ShouldBeNil)
 	})
 }

--- a/go/lib/topology/addr_test.go
+++ b/go/lib/topology/addr_test.go
@@ -16,6 +16,7 @@ package topology
 
 import (
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -121,7 +122,6 @@ func Test_pubBindAddr(t *testing.T) {
 		// Errors
 		{"Invaild Public IP Address", false, pubBad, nil, nil, ErrInvalidPub},
 		{"Invaild Bind IP Address", false, pubIPv4, nil, bindBad, ErrInvalidBind},
-		{"No UDP Overlay", false, pubUDPIPv4, nil, bindBad, ErrOverlayPort},
 		// IPv4 Overlay
 		{"IPv4 Pub", false, pubIPv4, nil, nil, nil},
 		{"IPv4 PubBind", false, pubIPv4, nil, bindIPv4, nil},
@@ -134,7 +134,7 @@ func Test_pubBindAddr(t *testing.T) {
 		{"IPv6 PubBind", false, pubIPv6, nil, bindIPv6, nil},
 		// IPv6+UDP Overlay
 		{"IPv6+UDP Pub", true, pubUDPIPv6, nil, nil, nil},
-		{"IPv4+UDP Pub Default Port", true, pubIPv6, pubUDPIPv6, nil, nil},
+		{"IPv6+UDP Pub Default Port", true, pubIPv6, pubUDPIPv6, nil, nil},
 		{"IPv6+UDP PubBind", true, pubUDPIPv6, nil, bindIPv6, nil},
 	}
 	for i, test := range basic_tests {
@@ -205,8 +205,11 @@ func newOverlay(rapo *RawAddrPortOverlay) *overlay.OverlayAddr {
 	if rapo == nil {
 		return nil
 	}
-	o, _ := overlay.NewOverlayAddr(addr.HostFromIPStr(rapo.Addr), uint16(rapo.OverlayPort))
-	return o
+	ip := net.ParseIP(rapo.Addr)
+	if ip.To4() != nil {
+		ip = ip.To4()
+	}
+	return overlay.NewOverlayAddr(ip, uint16(rapo.OverlayPort))
 }
 
 func shouldEqPubBindAddr(actual interface{}, expected ...interface{}) string {

--- a/go/lib/topology/braddr.go
+++ b/go/lib/topology/braddr.go
@@ -157,24 +157,17 @@ type OverBindAddr struct {
 }
 
 func (ob *OverBindAddr) fromRaw(rob *RawOverlayBind, udpOverlay bool) error {
-	var err error
 	l3 := addr.HostFromIPStr(rob.PublicOverlay.Addr)
 	if l3 == nil {
 		return common.NewBasicError(ErrInvalidPub, nil, "ip", rob.PublicOverlay.Addr)
 	}
-	ob.PublicOverlay, err = newOverlayAddr(udpOverlay, l3, rob.PublicOverlay.OverlayPort)
-	if err != nil {
-		return err
-	}
+	ob.PublicOverlay = overlay.NewOverlayAddr(l3.IP(), uint16(rob.PublicOverlay.OverlayPort))
 	if rob.BindOverlay != nil {
 		l3 := addr.HostFromIPStr(rob.BindOverlay.Addr)
 		if l3 == nil {
 			return common.NewBasicError(ErrInvalidBind, nil, "ip", rob.BindOverlay.Addr)
 		}
-		ob.BindOverlay, err = newOverlayAddr(udpOverlay, l3, rob.PublicOverlay.OverlayPort)
-		if err != nil {
-			return err
-		}
+		ob.BindOverlay = overlay.NewOverlayAddr(l3.IP(), uint16(rob.PublicOverlay.OverlayPort))
 	}
 	return nil
 }

--- a/go/lib/topology/raw.go
+++ b/go/lib/topology/raw.go
@@ -189,7 +189,7 @@ func (b RawBRIntf) remoteBRAddr(o overlay.Type) (*overlay.OverlayAddr, error) {
 	if !o.IsUDP() && (b.RemoteOverlay.OverlayPort != 0) {
 		return nil, common.NewBasicError(ErrOverlayPort, nil, "addr", b.RemoteOverlay)
 	}
-	return overlay.NewOverlayAddr(l3, uint16(b.RemoteOverlay.OverlayPort))
+	return overlay.NewOverlayAddr(l3.IP(), uint16(b.RemoteOverlay.OverlayPort)), nil
 }
 
 type RawAddrOverlay struct {

--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -33,13 +33,9 @@ import (
 
 var testTopo *Topo
 
-// Helpers
 func mkO(l3 addr.HostAddr, op int) *overlay.OverlayAddr {
 	if l3 == nil {
 		return nil
-	}
-	if op == 0 {
-		return overlay.NewOverlayAddr(l3.IP(), 0)
 	}
 	return overlay.NewOverlayAddr(l3.IP(), uint16(op))
 }

--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -16,18 +16,15 @@
 package topology
 
 import (
-	// Stdlib
 	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
-	// External
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	// Local
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/overlay"
@@ -38,16 +35,13 @@ var testTopo *Topo
 
 // Helpers
 func mkO(l3 addr.HostAddr, op int) *overlay.OverlayAddr {
-	var o *overlay.OverlayAddr
 	if l3 == nil {
 		return nil
 	}
 	if op == 0 {
-		o, _ = overlay.NewOverlayAddr(l3, 0)
-	} else {
-		o, _ = overlay.NewOverlayAddr(l3, uint16(op))
+		return overlay.NewOverlayAddr(l3.IP(), 0)
 	}
-	return o
+	return overlay.NewOverlayAddr(l3.IP(), uint16(op))
 }
 
 func mkPBO(ip string, port int, bindip string, bindport int, op int) *pubBindAddr {

--- a/go/tools/scmp/cmn/common.go
+++ b/go/tools/scmp/cmn/common.go
@@ -168,7 +168,7 @@ func NewSCMPPkt(t scmp.Type, info scmp.Info, ext common.Extension) *spkt.ScnPkt 
 func NextHopAddr() net.Addr {
 	var nhAddr *overlay.OverlayAddr
 	if Remote.NextHop == nil {
-		nhAddr, _ = overlay.NewOverlayAddr(Remote.Host.L3, overlay.EndhostPort)
+		nhAddr = overlay.NewOverlayAddr(Remote.Host.L3.IP(), overlay.EndhostPort)
 	} else {
 		nhAddr = Remote.NextHop
 	}

--- a/go/tools/scmp/main.go
+++ b/go/tools/scmp/main.go
@@ -68,10 +68,7 @@ func main() {
 	// Connect to the dispatcher
 	var overlayBindAddr *overlay.OverlayAddr
 	if cmn.Bind.Host != nil {
-		overlayBindAddr, err = overlay.NewOverlayAddr(cmn.Bind.Host.L3, cmn.Bind.Host.L4)
-		if err != nil {
-			cmn.Fatal("Failed to create bind address: %v\n", err)
-		}
+		overlayBindAddr = overlay.NewOverlayAddr(cmn.Bind.Host.L3.IP(), cmn.Bind.Host.L4)
 	}
 	cmn.Conn, _, err = reliable.Register(*dispatcher, cmn.Local.IA, cmn.Local.Host,
 		overlayBindAddr, addr.SvcNone)


### PR DESCRIPTION
We currently do not support any other overlay L3. Also, the overlay
connection objects always expect IP addresses. This makes the
net.IP address requirement explicit in the overlay address constructor.
Also, the constructor can no longer error out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3332)
<!-- Reviewable:end -->
