### PR TITLE
Avoid vendored deps to simplify go.mod compatibility

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -500,7 +500,7 @@ go_repository(
 
 go_repository(
     name = "com_github_uber_jaeger_client_go",
-    commit = "2f47546e3facd43297739439600bcf43f44cce5d",
+    commit = "5b163d27fabddbb0e7fae4548c8933c379210610",
     importpath = "github.com/uber/jaeger-client-go",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -499,6 +499,12 @@ go_repository(
 )
 
 go_repository(
+    name = "org_uber_go_atomic",
+    commit = "9dc4df04d0d1c39369750a9f6c32c39560672089",
+    importpath = "go.uber.org/atomic",
+)
+
+go_repository(
     name = "com_github_uber_jaeger_client_go",
     commit = "5b163d27fabddbb0e7fae4548c8933c379210610",
     importpath = "github.com/uber/jaeger-client-go",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -276,7 +276,7 @@ go_repository(
 go_repository(
     name = "com_github_cloudflare_sidh",
     commit = "fc8e6378752b38efe6d5814630911b5fc654c223", # vendored in quic-go, fd7246
-    importpath = "github.com/cloudflare/sidh"
+    importpath = "github.com/cloudflare/sidh" # sidh
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -264,6 +264,25 @@ go_repository(
     name = "com_github_lucas_clemente_quic_go",
     commit = "fd7246d7ed6eeb79eb4dc8b7b1bfa8a13047105a",
     importpath = "github.com/lucas-clemente/quic-go",
+    build_extra_args = ["-exclude=vendor"]
+)
+
+go_repository(
+    name = "com_github_marten_seemann_qtls",
+    commit = "591c71538704125b0b189f4cd3c0e61485dd6ef7", # vendored in quic-go, fd7246
+    importpath = "github.com/marten-seemann/qtls"
+)
+
+go_repository(
+    name = "com_github_cloudflare_sidh",
+    commit = "fc8e6378752b38efe6d5814630911b5fc654c223", # vendored in quic-go, fd7246
+    importpath = "github.com/cloudflare/sidh"
+)
+
+go_repository(
+    name = "com_github_cheekybits_genny",
+    commit = "9127e812e1e9e501ce899a18121d316ecb52e4ba", # vendored in quic-go, fd7246
+    importpath = "github.com/cheekybits/genny",
 )
 
 go_repository(

--- a/nogo.json
+++ b/nogo.json
@@ -17,14 +17,15 @@
       "gazelle/cmd/gazelle/diff.go": "",
       "/in_gopkg_yaml_v2/decode.go": "https://github.com/go-yaml/yaml/pull/492",
       "/com_github_mattn_go_sqlite3": "",
-      "/com_github_lucas_clemente_quic_go": "many vendored dependencies have issues",
+      "/com_github_lucas_clemente_quic_go": "",
+      "/com_github_cloudflare_sidh": "",
       "/com_github_vishvananda_netlink": ""
     }
   },
   "printf": {
     "exclude_files": {
       "/com_github_antlr_antlr4/runtime/Go/antlr/": "",
-      "/com_github_lucas_clemente_quic_go/": ""
+      "/com_github_cloudflare_sidh/": ""
     }
   },
   "unreachable": {
@@ -45,7 +46,7 @@
   },
   "shift": {
     "exclude_files": {
-      "/com_github_lucas_clemente_quic_go/": ""
+      "/com_github_marten_seemann_qtls/": ""
     }
   },
   "stdmethods": {


### PR DESCRIPTION
Vendored dependencies are automatically used during builds with bazel. These dependencies are not visible when generating a go.mod file from WORKSPACE.
As go with modules will ignore the vendored dependencies, the result will be that the latest versions of these inderect dependencies will be fetched. This is bad and will typically not work.

---

The purpose of this PR is to prepare for adding a `go.mod` file, generated from the `WORKSPACE` file using the `bzlcompat` tool (see https://github.com/kormat/bzlcompat/pull/2).

With these changes, running `bzlcompat -mod github.com/scionproto/scion` generates the following `go.mod` file:

```
module github.com/scionproto/scion

require (
        github.com/uber/jaeger-client-go 2f47546e3facd43297739439600bcf43f44cce5d
        github.com/protocolbuffers/protobuf 582743bf40c5d3639a70f98f183914a2c0cd0680
...
        golang.org/x/sys d455e41777fca6e8a5a79e34a14b8368bc11d9ba
        github.com/jmhodges/bazel_gomock ff6c20a9b6978c52b88b7a1e2e55b3b86e26685b
)
replace github.com/smartystreets/goconvey => github.com/kormat/goconvey a9793712606dd72b256bcbb0fad0858aa0e72d67
```

Running e.g. `go mod verify` will fixup all the versions into the format preferred by the go modules system:

```
module github.com/scionproto/scion

require (
        github.com/BurntSushi/toml v0.3.1
        github.com/JeanMertz/lll v0.0.0-20180622110546-c7683829ec0c
...
        gopkg.in/yaml.v2 v2.2.2
        zombiezen.com/go/capnproto2 v0.0.0-20190813022230-ddfb9bb855fa
)

replace github.com/smartystreets/goconvey => github.com/kormat/goconvey v0.0.0-20161013142909-a9793712606d
```

The plan is to check these files into git and add a CI step to validate `go.mod` corresponds to the generated file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3355)
<!-- Reviewable:end -->
