### PR TITLE
SPKI: Generate issuer and AS config for topo

### DIFF
--- a/go/tools/scion-pki/internal/v2/tmpl/BUILD.bazel
+++ b/go/tools/scion-pki/internal/v2/tmpl/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/scrypto:go_default_library",
+        "//go/lib/scrypto/cert/v2:go_default_library",
         "//go/lib/scrypto/trc/v2:go_default_library",
         "//go/lib/util:go_default_library",
         "//go/lib/xtest:go_default_library",

--- a/go/tools/scion-pki/internal/v2/tmpl/topo.go
+++ b/go/tools/scion-pki/internal/v2/tmpl/topo.go
@@ -50,7 +50,7 @@ func (g topoGen) Run(topo topoFile) error {
 	if err := g.genKeys(topo, trcs); err != nil {
 		return serrors.WrapStr("unable to generate key configs", err)
 	}
-	if err := g.genCerts(topo, trcs); err != nil {
+	if err := g.genCerts(topo); err != nil {
 		return serrors.WrapStr("unable to generate certificate configs", err)
 	}
 	pkicmn.QuietPrint("Generated all configuration files\n")
@@ -163,17 +163,17 @@ func (g topoGen) genASKeys(as addr.AS, cfg conf.TRC2) conf.Keys {
 	return keys
 }
 
-func (g topoGen) genCerts(topo topoFile, cfg map[addr.ISD]conf.TRC2) error {
-	if err := g.genIssuerCerts(topo, cfg); err != nil {
+func (g topoGen) genCerts(topo topoFile) error {
+	if err := g.genIssuerCerts(topo); err != nil {
 		return serrors.WrapStr("unable to generate issuer certificates", err)
 	}
-	if err := g.genASCerts(topo, cfg); err != nil {
+	if err := g.genASCerts(topo); err != nil {
 		return serrors.WrapStr("unable to generate AS certificates", err)
 	}
 	return nil
 }
 
-func (g topoGen) genIssuerCerts(topo topoFile, cfg map[addr.ISD]conf.TRC2) error {
+func (g topoGen) genIssuerCerts(topo topoFile) error {
 	for ia, entry := range topo.ASes {
 		if !entry.Core {
 			continue
@@ -205,7 +205,7 @@ func (g topoGen) genIssuerCert(ia addr.IA) conf.Issuer {
 	return cfg
 }
 
-func (g topoGen) genASCerts(topo topoFile, cfg map[addr.ISD]conf.TRC2) error {
+func (g topoGen) genASCerts(topo topoFile) error {
 	for ia, entry := range topo.ASes {
 		issuer := entry.Issuer
 		if entry.Core {

--- a/go/tools/scion-pki/internal/v2/tmpl/topo_test.go
+++ b/go/tools/scion-pki/internal/v2/tmpl/topo_test.go
@@ -96,8 +96,8 @@ func TestTopoGen(t *testing.T) {
 				t.Helper()
 				assert.Equal(t, algo, meta.Algorithm)
 				assert.Equal(t, g.Validity, meta.Validity)
-
 			}
+
 			checkMeta(t, cfg.AS[cert.SigningKey][1], scrypto.Ed25519)
 			checkMeta(t, cfg.AS[cert.RevocationKey][1], scrypto.Ed25519)
 			checkMeta(t, cfg.AS[cert.EncryptionKey][1], scrypto.Curve25519xSalsa20Poly1305)

--- a/go/tools/scion-pki/internal/v2/tmpl/topo_test.go
+++ b/go/tools/scion-pki/internal/v2/tmpl/topo_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/scrypto/cert/v2"
 	"github.com/scionproto/scion/go/lib/scrypto/trc/v2"
 	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/lib/xtest"
@@ -86,4 +87,66 @@ func TestTopoGen(t *testing.T) {
 		assert.Equal(t, exp, cfg.PrimaryASes)
 	})
 
+	for ia, entry := range topo.ASes {
+		t.Run("Keys config "+ia.String(), func(t *testing.T) {
+			cfg, err := conf.LoadKeys(conf.KeysFile(tmpDir, ia))
+			require.NoError(t, err)
+
+			checkMeta := func(t *testing.T, meta conf.KeyMeta, algo string) {
+				t.Helper()
+				assert.Equal(t, algo, meta.Algorithm)
+				assert.Equal(t, g.Validity, meta.Validity)
+
+			}
+			checkMeta(t, cfg.AS[cert.SigningKey][1], scrypto.Ed25519)
+			checkMeta(t, cfg.AS[cert.RevocationKey][1], scrypto.Ed25519)
+			checkMeta(t, cfg.AS[cert.EncryptionKey][1], scrypto.Curve25519xSalsa20Poly1305)
+			if !entry.Core {
+				return
+			}
+			checkMeta(t, cfg.Issuer[cert.IssuingKey][1], scrypto.Ed25519)
+			checkMeta(t, cfg.Primary[trc.IssuingKey][1], scrypto.Ed25519)
+			checkMeta(t, cfg.Primary[trc.OnlineKey][1], scrypto.Ed25519)
+			checkMeta(t, cfg.Primary[trc.OfflineKey][1], scrypto.Ed25519)
+		})
+	}
+
+	for ia, entry := range topo.ASes {
+		if !entry.Core {
+			continue
+		}
+		t.Run("Issuer config "+ia.String(), func(t *testing.T) {
+			cfg, err := conf.LoadIssuer(conf.IssuerFile(tmpDir, ia, 1))
+			require.NoError(t, err)
+
+			assert.Contains(t, cfg.Description, "Issuer certificate")
+			assert.Equal(t, scrypto.Version(1), cfg.Version)
+			assert.Equal(t, scrypto.KeyVersion(1), *cfg.IssuingKeyVersion)
+			assert.Nil(t, cfg.RevocationKeyVersion)
+			assert.Equal(t, scrypto.Version(1), cfg.TRCVersion)
+			assert.Empty(t, cfg.OptDistPoints)
+			assert.Equal(t, g.Validity, cfg.Validity)
+		})
+	}
+
+	for ia, entry := range topo.ASes {
+		issuer := entry.Issuer
+		if entry.Core {
+			issuer = ia
+		}
+		t.Run("AS config "+ia.String(), func(t *testing.T) {
+			cfg, err := conf.LoadAS(conf.ASFile(tmpDir, ia, 1))
+			require.NoError(t, err)
+
+			assert.Contains(t, cfg.Description, "Issuer certificate")
+			assert.Equal(t, scrypto.Version(1), cfg.Version)
+			assert.Equal(t, scrypto.KeyVersion(1), *cfg.SigningKeyVersion)
+			assert.Equal(t, scrypto.KeyVersion(1), *cfg.EncryptionKeyVersion)
+			assert.Equal(t, scrypto.KeyVersion(1), *cfg.RevocationKeyVersion)
+			assert.Equal(t, issuer, cfg.IssuerIA)
+			assert.Equal(t, scrypto.Version(1), cfg.IssuerCertVersion)
+			assert.Empty(t, cfg.OptDistPoints)
+			assert.Equal(t, g.Validity, cfg.Validity)
+		})
+	}
 }


### PR DESCRIPTION
This PR adds the capability to generate issuer and AS certificate
config files for a given topology description.

Additionally, adds missing tests for generated keys.toml.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3363)
<!-- Reviewable:end -->
