### PR TITLE
Do not use snet global state

### DIFF
--- a/go/integration/cert_req/main.go
+++ b/go/integration/cert_req/main.go
@@ -63,8 +63,9 @@ type client struct {
 }
 
 func (c client) run() int {
+	network := integration.InitNetwork()
 	var err error
-	c.conn, err = snet.ListenSCION("udp4", &integration.Local)
+	c.conn, err = network.ListenSCION("udp4", &integration.Local, 0)
 	if err != nil {
 		integration.LogFatal("Unable to listen", "err", err)
 	}
@@ -179,7 +180,8 @@ func getRemote() error {
 }
 
 func getSVCAddress() (*hostinfo.Host, error) {
-	connector := snet.DefNetwork.Sciond()
+	network := integration.InitNetwork()
+	connector := network.Sciond()
 	ctx, cancelF := context.WithTimeout(context.Background(), integration.DefaultIOTimeout)
 	defer cancelF()
 	reply, err := connector.SVCInfo(ctx, []proto.ServiceType{proto.ServiceType_cs})

--- a/go/integration/common.go
+++ b/go/integration/common.go
@@ -43,7 +43,6 @@ var (
 func Setup() {
 	addFlags()
 	validateFlags()
-	initNetwork()
 }
 
 func addFlags() {
@@ -72,12 +71,14 @@ func validateFlags() {
 	}
 }
 
-func initNetwork() {
-	// Initialize default SCION networking context
-	if err := snet.Init(Local.IA, Sciond, reliable.NewDispatcherService("")); err != nil {
+func InitNetwork() *snet.SCIONNetwork {
+	ds := reliable.NewDispatcherService("")
+	n, err := snet.NewNetwork(Local.IA, Sciond, ds)
+	if err != nil {
 		LogFatal("Unable to initialize SCION network", "err", err)
 	}
 	log.Debug("SCION network successfully initialized")
+	return n
 }
 
 // AttemptFunc attempts a request repeatedly, receives the attempt number

--- a/go/integration/end2end/main.go
+++ b/go/integration/end2end/main.go
@@ -90,10 +90,11 @@ type server struct {
 }
 
 func (s server) run() {
+	network := integration.InitNetwork()
 	connFactory := &snet.DefaultPacketDispatcherService{
 		Dispatcher: reliable.NewDispatcherService(""),
 		SCMPHandler: snet.NewSCMPHandler(
-			pathmgr.New(snet.DefNetwork.Sciond(), pathmgr.Timers{}),
+			pathmgr.New(network.Sciond(), pathmgr.Timers{}),
 		),
 	}
 	conn, port, err := connFactory.RegisterTimeout(integration.Local.IA, integration.Local.Host,
@@ -145,10 +146,11 @@ type client struct {
 }
 
 func (c client) run() int {
+	network := integration.InitNetwork()
 	connFactory := &snet.DefaultPacketDispatcherService{
 		Dispatcher: reliable.NewDispatcherService(""),
 		SCMPHandler: snet.NewSCMPHandler(
-			pathmgr.New(snet.DefNetwork.Sciond(), pathmgr.Timers{}),
+			pathmgr.New(network.Sciond(), pathmgr.Timers{}),
 		),
 	}
 
@@ -160,7 +162,7 @@ func (c client) run() int {
 	}
 	log.Debug("Send on", "local",
 		fmt.Sprintf("%v,[%v]:%d", integration.Local.IA, integration.Local.Host.L3, c.port))
-	c.sdConn = snet.DefNetwork.Sciond()
+	c.sdConn = network.Sciond()
 	return integration.AttemptRepeatedly("End2End", c.attemptRequest)
 }
 

--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -18,11 +18,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/pathmgr"
 	"github.com/scionproto/scion/go/lib/scmp"
-	"github.com/scionproto/scion/go/lib/serrors"
 )
 
 const (
@@ -73,43 +71,6 @@ func newSCIONConn(base *scionConnBase, pr pathmgr.Resolver, conn PacketConn) *SC
 	c.scionConnWriter = *newScionConnWriter(&c.scionConnBase, pr, conn)
 	c.scionConnReader = *newScionConnReader(&c.scionConnBase, conn)
 	return c
-}
-
-// DialSCION calls DialSCION with infinite timeout on the default networking
-// context.
-func DialSCION(network string, laddr, raddr *Addr) (Conn, error) {
-	if DefNetwork == nil {
-		return nil, serrors.New("SCION network not initialized")
-	}
-	return DefNetwork.DialSCION(network, laddr, raddr, 0)
-}
-
-// DialSCIONWithBindSVC calls DialSCIONWithBindSVC with infinite timeout on the
-// default networking context.
-func DialSCIONWithBindSVC(network string, laddr, raddr, baddr *Addr,
-	svc addr.HostSVC) (Conn, error) {
-	if DefNetwork == nil {
-		return nil, serrors.New("SCION network not initialized")
-	}
-	return DefNetwork.DialSCIONWithBindSVC(network, laddr, raddr, baddr, svc, 0)
-}
-
-// ListenSCION calls ListenSCION with infinite timeout on the default
-// networking context.
-func ListenSCION(network string, laddr *Addr) (Conn, error) {
-	if DefNetwork == nil {
-		return nil, serrors.New("SCION network not initialized")
-	}
-	return DefNetwork.ListenSCION(network, laddr, 0)
-}
-
-// ListenSCIONWithBindSVC calls ListenSCIONWithBindSVC with infinite timeout on
-// the default networking context.
-func ListenSCIONWithBindSVC(network string, laddr, baddr *Addr, svc addr.HostSVC) (Conn, error) {
-	if DefNetwork == nil {
-		return nil, serrors.New("SCION network not initialized")
-	}
-	return DefNetwork.ListenSCIONWithBindSVC(network, laddr, baddr, svc, 0)
 }
 
 func (c *SCIONConn) SetDeadline(t time.Time) error {

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -92,7 +92,7 @@ func sListen(network *snet.SCIONNetwork, laddr, baddr *snet.Addr,
 	svc addr.HostSVC) (snet.Conn, error) {
 
 	if network == nil {
-		network = snet.DefNetwork
+		return nil, serrors.New("squic:  SCION network must not be nil")
 	}
 	return network.ListenSCIONWithBindSVC("udp4", laddr, baddr, svc, 0)
 }

--- a/go/sig/egress/session/session.go
+++ b/go/sig/egress/session/session.go
@@ -75,8 +75,8 @@ func NewSession(dstIA addr.IA, sessId mgmt.SessionType, logger log.Logger,
 	s.healthy.Store(false)
 	s.ring = ringbuf.New(64, nil, fmt.Sprintf("egress_%s_%s", dstIA, sessId))
 	// Not using a fixed local port, as this is for outgoing data only.
-	s.conn, err = snet.ListenSCION("udp4",
-		&snet.Addr{IA: sigcmn.IA, Host: &addr.AppAddr{L3: sigcmn.Host}})
+	s.conn, err = sigcmn.Network.ListenSCION("udp4",
+		&snet.Addr{IA: sigcmn.IA, Host: &addr.AppAddr{L3: sigcmn.Host}}, 0)
 	s.sessMonStop = make(chan struct{})
 	s.sessMonStopped = make(chan struct{})
 	s.pktDispStop = make(chan struct{})

--- a/go/sig/ingress/dispatcher.go
+++ b/go/sig/ingress/dispatcher.go
@@ -60,7 +60,7 @@ func NewDispatcher(tio io.ReadWriteCloser) *Dispatcher {
 
 func (d *Dispatcher) Run() error {
 	var err error
-	d.extConn, err = snet.ListenSCION("udp4", d.laddr)
+	d.extConn, err = sigcmn.Network.ListenSCION("udp4", d.laddr, 0)
 	if err != nil {
 		return common.NewBasicError("Unable to initialize extConn", err)
 	}


### PR DESCRIPTION
Do not use snet global state

* Changes the code of {pingpong, integration, sig} to not use the
global state of snet pkg

*Remove code around global state in snet pkg

Fixes #3135

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3366)
<!-- Reviewable:end -->
