### PR TITLE
SPKI: Prototype, sign and combine in one command

### DIFF
--- a/go/lib/infra/modules/trust/v2/inserter_test.go
+++ b/go/lib/infra/modules/trust/v2/inserter_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestInserterInsertTRC(t *testing.T) {
-	t.SkipNow()
 	tests := map[string]struct {
 		Expect      func(*mock_v2.MockDB, decoded.TRC)
 		Unsafe      bool

--- a/go/lib/infra/modules/trust/v2/inspector_test.go
+++ b/go/lib/infra/modules/trust/v2/inspector_test.go
@@ -32,7 +32,6 @@ import (
 )
 
 func TestInspectorByAttributes(t *testing.T) {
-	t.SkipNow()
 	tests := map[string]struct {
 		Attrs       []infra.Attribute
 		Expect      func(*mock_v2.MockCryptoProvider, *trc.TRC)
@@ -95,7 +94,6 @@ func TestInspectorByAttributes(t *testing.T) {
 }
 
 func TestInspectorHasAttributes(t *testing.T) {
-	t.SkipNow()
 	tests := map[string]struct {
 		IA          addr.IA
 		Attrs       []infra.Attribute

--- a/go/lib/infra/modules/trust/v2/provider_test.go
+++ b/go/lib/infra/modules/trust/v2/provider_test.go
@@ -36,7 +36,6 @@ import (
 )
 
 func TestCryptoProviderGetTRC(t *testing.T) {
-	t.SkipNow()
 	internal := serrors.New("internal")
 	type mocks struct {
 		DB       *mock_v2.MockDB
@@ -258,7 +257,6 @@ func TestCryptoProviderGetTRC(t *testing.T) {
 }
 
 func TestCryptoProviderGetTRCLatest(t *testing.T) {
-	t.SkipNow()
 	internal := serrors.New("internal")
 	type mocks struct {
 		DB       *mock_v2.MockDB

--- a/go/lib/infra/modules/trust/v2/recurser_test.go
+++ b/go/lib/infra/modules/trust/v2/recurser_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestASLocalRecurserAllowRecursion(t *testing.T) {
-	t.SkipNow()
 	tests := map[string]struct {
 		Addr      net.Addr
 		Assertion assert.ErrorAssertionFunc

--- a/go/lib/infra/modules/trust/v2/resolver_test.go
+++ b/go/lib/infra/modules/trust/v2/resolver_test.go
@@ -33,7 +33,6 @@ import (
 )
 
 func TestResolverTRC(t *testing.T) {
-	t.SkipNow()
 	internal := serrors.New("internal")
 	type mocks struct {
 		DB       *mock_v2.MockDB

--- a/go/lib/infra/modules/trust/v2/router_test.go
+++ b/go/lib/infra/modules/trust/v2/router_test.go
@@ -36,7 +36,6 @@ import (
 )
 
 func TestLocalRouterChooseServer(t *testing.T) {
-	t.SkipNow()
 	tests := map[string]addr.ISD{
 		"ISD local":  1,
 		"Remote ISD": 2,
@@ -53,7 +52,6 @@ func TestLocalRouterChooseServer(t *testing.T) {
 }
 
 func TestCSRouterChooseServer(t *testing.T) {
-	t.SkipNow()
 	tests := map[string]struct {
 		ISD         addr.ISD
 		Expect      func(*mock_v2.MockDB, *mock_snet.MockRouter, *mock_snet.MockPath)

--- a/go/lib/infra/modules/trust/v2/testdata/gen_crypto_tar.sh
+++ b/go/lib/infra/modules/trust/v2/testdata/gen_crypto_tar.sh
@@ -9,8 +9,8 @@ set -e
 
 TMP=`mktemp -d`
 
-# $1 v2 tmpl topo -d $TMP ./topology/Default.topo > /dev/null
-# $1 v2 keys gen -d $TMP "*-*" > /dev/null
-# $1 v2 trcs gen -d $TMP "*" > /dev/null
+$1 v2 tmpl topo -d $TMP ./topology/Default.topo > /dev/null
+$1 v2 keys private -d $TMP "*-*" > /dev/null
+$1 v2 trcs gen -d $TMP "*" > /dev/null
 
 tar -C $TMP -cf $2 .

--- a/go/tools/scion-pki/internal/v2/trcs/BUILD.bazel
+++ b/go/tools/scion-pki/internal/v2/trcs/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "cmd.go",
         "combine.go",
+        "gen.go",
         "human.go",
         "loader.go",
         "prototype.go",
@@ -33,6 +34,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "combine_test.go",
+        "gen_test.go",
         "prototype_test.go",
         "sign_test.go",
     ],

--- a/go/tools/scion-pki/internal/v2/trcs/BUILD.bazel
+++ b/go/tools/scion-pki/internal/v2/trcs/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     srcs = [
         "combine_test.go",
         "gen_test.go",
+        "loader_test.go",
         "prototype_test.go",
         "sign_test.go",
     ],

--- a/go/tools/scion-pki/internal/v2/trcs/cmd.go
+++ b/go/tools/scion-pki/internal/v2/trcs/cmd.go
@@ -51,6 +51,26 @@ Selector:
 `,
 }
 
+var gen = &cobra.Command{
+	Use:   "gen",
+	Short: "Generate new TRCs",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		g := fullGen{
+			Dirs:    pkicmn.GetDirs(),
+			Version: scrypto.Version(version),
+		}
+		asMap, err := pkicmn.ProcessSelector(args[0])
+		if err != nil {
+			return serrors.WrapStr("unable to select target ISDs", err, "selector", args[0])
+		}
+		if err := g.Run(asMap); err != nil {
+			return serrors.WrapStr("unable to generate prototype TRCs", err)
+		}
+		return nil
+	},
+}
+
 var proto = &cobra.Command{
 	Use:   "proto",
 	Short: "Generate new proto TRCs",
@@ -138,6 +158,7 @@ var human = &cobra.Command{
 
 func init() {
 	Cmd.PersistentFlags().Uint64Var(&version, "version", 0, "TRC version (0 indicates newest)")
+	Cmd.AddCommand(gen)
 	Cmd.AddCommand(proto)
 	Cmd.AddCommand(sign)
 	Cmd.AddCommand(combine)

--- a/go/tools/scion-pki/internal/v2/trcs/gen.go
+++ b/go/tools/scion-pki/internal/v2/trcs/gen.go
@@ -1,0 +1,54 @@
+// Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trcs
+
+import (
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/serrors"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
+)
+
+type fullGen struct {
+	Dirs    pkicmn.Dirs
+	Version scrypto.Version
+}
+
+func (g fullGen) Run(asMap pkicmn.ASMap) error {
+	cfgs, err := loader{Dirs: g.Dirs, Version: g.Version}.LoadConfigs(asMap.ISDs())
+	if err != nil {
+		return serrors.WrapStr("unable to load TRC configs", err)
+	}
+	protos, err := protoGen{Dirs: g.Dirs, Version: g.Version}.Generate(cfgs)
+	if err != nil {
+		return serrors.WrapStr("unable to generate prototype TRCs", err)
+	}
+	parts, err := signatureGen{Dirs: g.Dirs, Version: g.Version}.Generate(asMap, cfgs, protos)
+	if err != nil {
+		return serrors.WrapStr("unable to sign prototype TRCs", err)
+	}
+	c := combiner{Dirs: g.Dirs}
+	combined, err := c.Combine(protos, parts)
+	if err != nil {
+		return serrors.WrapStr("unable to combine parts and prototype TRC", err)
+	}
+	if err := (validator{Dirs: c.Dirs}).Validate(combined); err != nil {
+		return serrors.WrapStr("invalid combined TRCs generated", err)
+	}
+	if err := c.Write(combined); err != nil {
+		return serrors.WrapStr("unable to write combined TRCs", err)
+	}
+	return nil
+}

--- a/go/tools/scion-pki/internal/v2/trcs/gen_test.go
+++ b/go/tools/scion-pki/internal/v2/trcs/gen_test.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trcs
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/xtest"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
+)
+
+func TestFullGen(t *testing.T) {
+	if *update {
+		create := func(v scrypto.Version) error {
+			force := pkicmn.Force
+			pkicmn.Force = true
+			defer func() { pkicmn.Force = force }()
+			g := fullGen{Dirs: pkicmn.Dirs{Root: "./testdata", Out: "./testdata"}, Version: v}
+			return g.Run(testASMap)
+		}
+		require.NoError(t, create(1))
+		require.NoError(t, create(2))
+		require.NoError(t, create(3))
+	}
+	tests := map[string]struct {
+		Version scrypto.Version
+	}{
+		"v1": {Version: 1},
+		"v2": {Version: 2},
+		"v3": {Version: 3},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			tmpDir, cleanF := xtest.MustTempDir("", "test-trcs-gen")
+			defer cleanF()
+
+			// Setup file structure in temporary directory.
+			isdDir := filepath.Join(tmpDir, "ISD1")
+			require.NoError(t, os.MkdirAll(isdDir, 0777))
+			err := exec.Command("cp", "-r",
+				"./testdata/ISD1/ASff00_0_110",
+				"./testdata/ISD1/ASff00_0_120",
+				"./testdata/ISD1/ASff00_0_130",
+				isdDir).Run()
+			require.NoError(t, err)
+			if test.Version > 1 {
+				require.NoError(t, os.MkdirAll(Dir(tmpDir, 1), 0777))
+				err = exec.Command("cp", SignedFile("./testdata", 1, test.Version-1),
+					SignedFile(tmpDir, 1, test.Version-1)).Run()
+				require.NoError(t, err)
+			}
+
+			// Run fullGen generator and compare golden files.
+			g := fullGen{
+				Dirs:    pkicmn.Dirs{Root: "./testdata", Out: tmpDir},
+				Version: test.Version,
+			}
+			err = g.Run(testASMap)
+			require.NoError(t, err)
+
+			golden, err := ioutil.ReadFile(SignedFile("./testdata", 1, test.Version))
+			require.NoError(t, err)
+			result, err := ioutil.ReadFile(SignedFile(tmpDir, 1, test.Version))
+			require.NoError(t, err)
+			assert.Equal(t, golden, result)
+		})
+	}
+}

--- a/go/tools/scion-pki/internal/v2/trcs/loader_test.go
+++ b/go/tools/scion-pki/internal/v2/trcs/loader_test.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trcs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
+)
+
+func TestLoaderLoadConfigs(t *testing.T) {
+	tests := map[string]struct {
+		Version  scrypto.Version
+		Expected scrypto.Version
+	}{
+		"v1":  {Version: 1, Expected: 1},
+		"v2":  {Version: 2, Expected: 2},
+		"v3":  {Version: 3, Expected: 3},
+		"max": {Version: 0, Expected: 3},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			l := loader{
+				Dirs:    pkicmn.Dirs{Root: "./testdata", Out: "./testdata"},
+				Version: test.Version,
+			}
+			cfgs, err := l.LoadConfigs(testASMap.ISDs())
+			require.NoError(t, err)
+			assert.Equal(t, test.Expected, cfgs[1].Version)
+		})
+	}
+}

--- a/go/tools/scion-pki/internal/v2/trcs/prototype_test.go
+++ b/go/tools/scion-pki/internal/v2/trcs/prototype_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/xtest"
 	"github.com/scionproto/scion/go/tools/scion-pki/internal/pkicmn"
@@ -38,7 +37,7 @@ var (
 	ia120 = xtest.MustParseIA("1-ff00:0:120")
 	ia130 = xtest.MustParseIA("1-ff00:0:130")
 
-	testASMap = map[addr.ISD][]addr.IA{1: {ia110, ia120, ia130}}
+	testASMap = pkicmn.ASMap{1: {ia110, ia120, ia130}}
 )
 
 func TestProtoGen(t *testing.T) {


### PR DESCRIPTION
This change adds the ability to prototype, sign and combine a TRC
with a single command. The only the final signed TRC is stored on the
file system.

This PR also re-enables the trust store unit tests.
fixes #3317

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3371)
<!-- Reviewable:end -->
