### PR TITLE
snet: Make local address optional

### DIFF
--- a/go/lib/snet/BUILD.bazel
+++ b/go/lib/snet/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//go/lib/spath:go_default_library",
         "//go/lib/spkt:go_default_library",
         "//go/lib/topology/overlay:go_default_library",
+        "@com_github_vishvananda_netlink//:go_default_library",
     ],
 )
 

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -130,23 +130,14 @@ func (n *SCIONNetwork) Listen(ctx context.Context, network string, listen *net.U
 	if network != "udp" {
 		return nil, common.NewBasicError("Unknown network", nil, "network", network)
 	}
-
-	// FIXME(scrye): If no local address is specified, we want to
-	// bind to the address of the outbound interface on a random
-	// free port. However, the current dispatcher version cannot
-	// expose that address. Additionally, the dispatcher does not follow
-	// normal operating system semantics for binding on 0.0.0.0 (it
-	// considers it to be a fixed address instead of a wildcard). To avoid
-	// misuse, disallow binding to nil or 0.0.0.0 addresses for now.
 	if listen == nil {
-		return nil, serrors.New("nil listen addr not supported")
+		listen = &net.UDPAddr{}
 	}
+	// XXX(matzf): switch IPv4 or IPv6
 	if listen.IP == nil {
-		return nil, serrors.New("nil listen IP no supported")
+		listen.IP = net.IPv4zero
 	}
-	if listen.IP.IsUnspecified() {
-		return nil, serrors.New("unspecified listen IP not supported")
-	}
+
 	conn := &scionConnBase{
 		net:      network,
 		scionNet: n,


### PR DESCRIPTION
* ~~Make `IA` optional in `snet.Init`. 
   If it is unspecified, just ask the chosen sciond (using existing API).~~
* Allow unspecified local address in `snet.Dial/Listen`
  Register unspecified address (i.e. 0.0.0.0) in the dispatcher.
  The godispatcher already handles this correctly.

   When using an unspecified source address for sending a packet, look up the route to the next hop in the kernel routing table and use the corresponding source address as source address in the SCION packet.
   This uses `netlink` and so is specific to Linux.

* ~~Demo: make `-local` optional in `pingpong` and remove `-srcIA` in `showpath`~~


(Update: rebased only the essentials. The `snet.Init` part is gone because the API changed)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3376)
<!-- Reviewable:end -->
