### PR TITLE
Bazel: Use --stamp command line flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,1 @@
-build --workspace_status_command=./tools/bazel-build-env --disk_cache=./.bazel-cache
+build --workspace_status_command=./tools/bazel-build-env --disk_cache=./.bazel-cache --stamp


### PR DESCRIPTION
This fixes the problem introduced by new version of go_rules,
the symptom being that StartupVersion was not set properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3380)
<!-- Reviewable:end -->
