### PR TITLE
snet: Split paths to own file, add PathInterface

### DIFF
--- a/go/lib/infra/messenger/BUILD.bazel
+++ b/go/lib/infra/messenger/BUILD.bazel
@@ -58,7 +58,6 @@ go_test(
         "//go/lib/infra/messenger/mock_messenger:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/overlay:go_default_library",
-        "//go/lib/sciond:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/snet/mock_snet:go_default_library",
         "//go/lib/spath:go_default_library",

--- a/go/lib/infra/messenger/addr_test.go
+++ b/go/lib/infra/messenger/addr_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/infra/messenger/mock_messenger"
 	"github.com/scionproto/scion/go/lib/overlay"
-	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/snet/mock_snet"
 	"github.com/scionproto/scion/go/lib/spath"
@@ -474,7 +473,7 @@ func (t *testPath) Path() *spath.Path {
 	panic("not implemented")
 }
 
-func (t *testPath) Interfaces() []sciond.PathInterface {
+func (t *testPath) Interfaces() []snet.PathInterface {
 	panic("not implemented")
 }
 

--- a/go/lib/pathmgr/pathmgr_test.go
+++ b/go/lib/pathmgr/pathmgr_test.go
@@ -219,7 +219,7 @@ func TestWatchFilter(t *testing.T) {
 			replySet := make(pathpol.PathSet)
 			for key, v := range ps {
 				for _, intf := range v.Interfaces() {
-					if intf.IA().Equal(src) && intf.IfId() == 105 {
+					if intf.IA().Equal(src) && intf.ID() == 105 {
 						replySet[key] = v
 						break
 					}

--- a/go/lib/pathpol/hop_pred.go
+++ b/go/lib/pathpol/hop_pred.go
@@ -100,7 +100,7 @@ func (hp *HopPredicate) pathIFMatch(pi PathInterface, in bool) bool {
 	if len(hp.IfIDs) == 2 && !in {
 		ifInd = 1
 	}
-	if hp.IfIDs[ifInd] != 0 && hp.IfIDs[ifInd] != pi.IfId() {
+	if hp.IfIDs[ifInd] != 0 && hp.IfIDs[ifInd] != pi.ID() {
 		return false
 	}
 	return true

--- a/go/lib/pathpol/pathset.go
+++ b/go/lib/pathpol/pathset.go
@@ -32,8 +32,8 @@ type Path interface {
 
 // PathInterface is an interface on the path.
 type PathInterface interface {
-	// IfId is the id of the interface.
-	IfId() common.IFIDType
+	// ID is the ID of the interface.
+	ID() common.IFIDType
 	// IA is the ISD AS identifier of the interface.
 	IA() addr.IA
 }

--- a/go/lib/pathpol/policy_test.go
+++ b/go/lib/pathpol/policy_test.go
@@ -657,8 +657,8 @@ type testPathIntf struct {
 	ifid common.IFIDType
 }
 
-func (i testPathIntf) IfId() common.IFIDType { return i.ifid }
-func (i testPathIntf) IA() addr.IA           { return i.ia }
+func (i testPathIntf) ID() common.IFIDType { return i.ifid }
+func (i testPathIntf) IA() addr.IA         { return i.ia }
 
 func mustHopPredicate(t *testing.T, str string) *HopPredicate {
 	hp, err := HopPredicateFromString(str)

--- a/go/lib/pathpol/sequence.go
+++ b/go/lib/pathpol/sequence.go
@@ -91,13 +91,13 @@ func (s *Sequence) Eval(inputSet PathSet) PathSet {
 		// one element in form <IA>#<inbound-interface>,<outbound-interface>,
 		// e.g. 64-ff00:0:112#3,5. For the source AS, the inbound interface will be
 		// zero. For destination AS, outbound interface will be zero.
-		p := fmt.Sprintf("%s#0,%d ", ifaces[0].IA(), ifaces[0].IfId())
+		p := fmt.Sprintf("%s#0,%d ", ifaces[0].IA(), ifaces[0].ID())
 		for i := 1; i < len(ifaces)-1; i += 2 {
 			p += fmt.Sprintf("%s#%d,%d ", ifaces[i].IA(),
-				ifaces[i].IfId(), ifaces[i+1].IfId())
+				ifaces[i].ID(), ifaces[i+1].ID())
 		}
 		p += fmt.Sprintf("%s#%d,0 ", ifaces[len(ifaces)-1].IA(),
-			ifaces[len(ifaces)-1].IfId())
+			ifaces[len(ifaces)-1].ID())
 		// Check whether the string matches the sequence regexp.
 		//fmt.Printf("EVAL: %s\n", p)
 		if s.re.MatchString(p) {

--- a/go/lib/sciond/mock_sciond/sciond.go
+++ b/go/lib/sciond/mock_sciond/sciond.go
@@ -13,7 +13,6 @@ import (
 	sciond "github.com/scionproto/scion/go/lib/sciond"
 	proto "github.com/scionproto/scion/go/proto"
 	reflect "reflect"
-	time "time"
 )
 
 // MockService is a mock of Service interface
@@ -40,33 +39,18 @@ func (m *MockService) EXPECT() *MockServiceMockRecorder {
 }
 
 // Connect mocks base method
-func (m *MockService) Connect() (sciond.Connector, error) {
+func (m *MockService) Connect(arg0 context.Context) (sciond.Connector, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Connect")
+	ret := m.ctrl.Call(m, "Connect", arg0)
 	ret0, _ := ret[0].(sciond.Connector)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Connect indicates an expected call of Connect
-func (mr *MockServiceMockRecorder) Connect() *gomock.Call {
+func (mr *MockServiceMockRecorder) Connect(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockService)(nil).Connect))
-}
-
-// ConnectTimeout mocks base method
-func (m *MockService) ConnectTimeout(arg0 time.Duration) (sciond.Connector, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectTimeout", arg0)
-	ret0, _ := ret[0].(sciond.Connector)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ConnectTimeout indicates an expected call of ConnectTimeout
-func (mr *MockServiceMockRecorder) ConnectTimeout(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectTimeout", reflect.TypeOf((*MockService)(nil).ConnectTimeout), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockService)(nil).Connect), arg0)
 }
 
 // MockConnector is a mock of Connector interface

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -272,7 +272,7 @@ func (iface PathInterface) IA() addr.IA {
 	return iface.RawIsdas.IA()
 }
 
-func (iface PathInterface) IfId() common.IFIDType {
+func (iface PathInterface) ID() common.IFIDType {
 	return iface.IfID
 }
 

--- a/go/lib/snet/BUILD.bazel
+++ b/go/lib/snet/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "dispatcher.go",
         "interface.go",
         "packet_conn.go",
+        "path.go",
         "reader.go",
         "router.go",
         "snet.go",

--- a/go/lib/snet/mock_snet/BUILD.bazel
+++ b/go/lib/snet/mock_snet/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/overlay:go_default_library",
-        "//go/lib/sciond:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/spath:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",

--- a/go/lib/snet/mock_snet/snet.go
+++ b/go/lib/snet/mock_snet/snet.go
@@ -9,7 +9,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	addr "github.com/scionproto/scion/go/lib/addr"
 	overlay "github.com/scionproto/scion/go/lib/overlay"
-	sciond "github.com/scionproto/scion/go/lib/sciond"
 	snet "github.com/scionproto/scion/go/lib/snet"
 	spath "github.com/scionproto/scion/go/lib/spath"
 	net "net"
@@ -523,10 +522,10 @@ func (mr *MockPathMockRecorder) Fingerprint() *gomock.Call {
 }
 
 // Interfaces mocks base method
-func (m *MockPath) Interfaces() []sciond.PathInterface {
+func (m *MockPath) Interfaces() []snet.PathInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Interfaces")
-	ret0, _ := ret[0].([]sciond.PathInterface)
+	ret0, _ := ret[0].([]snet.PathInterface)
 	return ret0
 }
 

--- a/go/lib/snet/path.go
+++ b/go/lib/snet/path.go
@@ -61,6 +61,9 @@ type Path interface {
 	Copy() Path
 }
 
+// PathInterface is an interface of the path. This is currently an interface so
+// that packages which can not depend on snet can still implement the snet.Path
+// interface.
 type PathInterface interface {
 	ID() common.IFIDType
 	IA() addr.IA
@@ -126,7 +129,7 @@ func (p *path) Interfaces() []PathInterface {
 	}
 	res := make([]PathInterface, 0, len(p.sciondPath.Path.Interfaces))
 	for _, intf := range p.sciondPath.Path.Interfaces {
-		res = append(res, pathInterface{ia: intf.IA(), id: intf.IfID})
+		res = append(res, intf)
 	}
 	return res
 }
@@ -215,11 +218,3 @@ func (p *partialPath) Copy() Path {
 		destination: p.destination,
 	}
 }
-
-type pathInterface struct {
-	ia addr.IA
-	id common.IFIDType
-}
-
-func (i pathInterface) IA() addr.IA         { return i.ia }
-func (i pathInterface) ID() common.IFIDType { return i.id }

--- a/go/lib/snet/path.go
+++ b/go/lib/snet/path.go
@@ -1,0 +1,225 @@
+// Copyright 2019 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snet
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/overlay"
+	"github.com/scionproto/scion/go/lib/sciond"
+	"github.com/scionproto/scion/go/lib/serrors"
+	"github.com/scionproto/scion/go/lib/spath"
+)
+
+// Path is an abstract representation of a path. Most applications do not need
+// access to the raw internals.
+//
+// An empty path is a special kind of path that can be used for intra-AS
+// traffic. Empty paths are valid return values for certain route calls (e.g.,
+// if the source and destination ASes match, or if a router was configured
+// without a source of paths).
+type Path interface {
+	// Fingerprint uniquely identifies the path based on the sequence of
+	// ASes and BRs. Other metadata, such as MTU or NextHop have no effect
+	// on the fingerprint. Empty string means unknown fingerprint.
+	Fingerprint() string
+	// OverlayNextHop returns the address:port pair of a local-AS overlay
+	// speaker. Usually, this is a border router that will forward the traffic.
+	OverlayNextHop() *overlay.OverlayAddr
+	// Path returns a raw (data-plane compatible) representation of the path.
+	// The returned path is initialized and ready for use in snet calls that
+	// deal with raw paths.
+	Path() *spath.Path
+	// Interfaces returns a list of interfaces on the path. If the list is not
+	// available the result is nil.
+	Interfaces() []PathInterface
+	// Destination is the AS the path points to. Empty paths return the local
+	// AS of the router that created them.
+	Destination() addr.IA
+	// MTU returns the MTU of the path. If the result is zero, MTU is unknown.
+	MTU() uint16
+	// Expiry returns the expiration time of the path. If the result is a zero
+	// value expiration time is unknown.
+	Expiry() time.Time
+	// Copy create a copy of the path.
+	Copy() Path
+}
+
+type PathInterface interface {
+	ID() common.IFIDType
+	IA() addr.IA
+}
+
+var _ Path = (*path)(nil)
+
+type path struct {
+	// sciondPath contains SCIOND-related path metadata.
+	sciondPath *sciond.PathReplyEntry
+	// spath is the raw SCION forwarding path.
+	spath *spath.Path
+	// overlay is the intra-AS next-hop to use for this path.
+	overlay *overlay.OverlayAddr
+	// source is the AS where the path starts.
+	source addr.IA
+}
+
+func newPathFromSDReply(srcIA addr.IA, replyEntry *sciond.PathReplyEntry) (Path, error) {
+	sp := spath.New(replyEntry.Path.FwdPath)
+	// Preinitialize offsets, we don't want to propagate unusable paths
+	if err := sp.InitOffsets(); err != nil {
+		return nil, serrors.WrapStr("path error", err)
+	}
+	overlayAddr, err := replyEntry.HostInfo.Overlay()
+	if err != nil {
+		return nil, serrors.WrapStr("path error", err)
+	}
+	return &path{
+		sciondPath: replyEntry,
+		spath:      sp,
+		overlay:    overlayAddr,
+		source:     srcIA,
+	}, nil
+}
+
+func (p *path) Fingerprint() string {
+	if p.sciondPath == nil {
+		return ""
+	}
+	h := sha256.New()
+	for _, iface := range p.sciondPath.Path.Interfaces {
+		binary.Write(h, common.Order, iface.RawIsdas)
+		binary.Write(h, common.Order, iface.IfID)
+	}
+	return string(h.Sum(nil))
+}
+
+func (p *path) OverlayNextHop() *overlay.OverlayAddr {
+	return p.overlay.Copy()
+}
+
+func (p *path) Path() *spath.Path {
+	if p.spath == nil {
+		return nil
+	}
+	return p.spath.Copy()
+}
+
+func (p *path) Interfaces() []PathInterface {
+	if p.spath == nil {
+		return nil
+	}
+	res := make([]PathInterface, 0, len(p.sciondPath.Path.Interfaces))
+	for _, intf := range p.sciondPath.Path.Interfaces {
+		res = append(res, pathInterface{ia: intf.IA(), id: intf.IfID})
+	}
+	return res
+}
+
+func (p *path) Destination() addr.IA {
+	if p.sciondPath == nil {
+		return p.source
+	}
+	return p.sciondPath.Path.DstIA()
+}
+
+func (p *path) MTU() uint16 {
+	if p.sciondPath == nil {
+		return 0
+	}
+	return p.sciondPath.Path.Mtu
+}
+
+func (p *path) Expiry() time.Time {
+	if p.sciondPath == nil {
+		return time.Time{}
+	}
+	return p.sciondPath.Path.Expiry()
+}
+
+func (p *path) Copy() Path {
+	return &path{
+		sciondPath: p.sciondPath.Copy(),
+		spath:      p.spath.Copy(),
+		overlay:    p.overlay.Copy(),
+		source:     p.source,
+	}
+}
+
+func (p *path) String() string {
+	if p.sciondPath == nil {
+		return ""
+	}
+	return p.sciondPath.String()
+}
+
+// partialPath is a path object with incomplete metadata. It is used as a
+// temporary solution where a full path cannot be reconstituted from other
+// objects, notably snet.Addr.
+type partialPath struct {
+	spath       *spath.Path
+	overlay     *overlay.OverlayAddr
+	destination addr.IA
+}
+
+func (p *partialPath) Fingerprint() string {
+	return ""
+}
+
+func (p *partialPath) OverlayNextHop() *overlay.OverlayAddr {
+	return p.overlay
+}
+
+func (p *partialPath) Path() *spath.Path {
+	if p.spath == nil {
+		return nil
+	}
+	return p.spath.Copy()
+}
+
+func (p *partialPath) Interfaces() []PathInterface {
+	return nil
+}
+
+func (p *partialPath) Destination() addr.IA {
+	return p.destination
+}
+
+func (p *partialPath) MTU() uint16 {
+	return 0
+}
+
+func (p *partialPath) Expiry() time.Time {
+	return time.Time{}
+}
+
+func (p *partialPath) Copy() Path {
+	return &partialPath{
+		spath:       p.spath.Copy(),
+		overlay:     p.overlay.Copy(),
+		destination: p.destination,
+	}
+}
+
+type pathInterface struct {
+	ia addr.IA
+	id common.IFIDType
+}
+
+func (i pathInterface) IA() addr.IA         { return i.ia }
+func (i pathInterface) ID() common.IFIDType { return i.id }

--- a/go/lib/snet/path.go
+++ b/go/lib/snet/path.go
@@ -33,7 +33,8 @@ import (
 // An empty path is a special kind of path that can be used for intra-AS
 // traffic. Empty paths are valid return values for certain route calls (e.g.,
 // if the source and destination ASes match, or if a router was configured
-// without a source of paths).
+// without a source of paths). An empty path only contains a Destination value,
+// all other values are zero values.
 type Path interface {
 	// Fingerprint uniquely identifies the path based on the sequence of
 	// ASes and BRs. Other metadata, such as MTU or NextHop have no effect

--- a/go/lib/svc/BUILD.bazel
+++ b/go/lib/svc/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//go/lib/common:go_default_library",
         "//go/lib/l4:go_default_library",
         "//go/lib/overlay:go_default_library",
-        "//go/lib/sciond:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/spath:go_default_library",
         "//go/lib/svc/internal/ctxconn:go_default_library",

--- a/go/lib/svc/resolver.go
+++ b/go/lib/svc/resolver.go
@@ -25,7 +25,6 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/l4"
 	"github.com/scionproto/scion/go/lib/overlay"
-	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/lib/svc/internal/ctxconn"
@@ -183,7 +182,7 @@ func (p *path) Path() *spath.Path {
 	return p.spath
 }
 
-func (p *path) Interfaces() []sciond.PathInterface {
+func (p *path) Interfaces() []snet.PathInterface {
 	return nil
 }
 

--- a/go/path_srv/internal/segutil/filter.go
+++ b/go/path_srv/internal/segutil/filter.go
@@ -116,5 +116,5 @@ type pathInterface struct {
 	ifid common.IFIDType
 }
 
-func (i pathInterface) IA() addr.IA           { return i.ia }
-func (i pathInterface) IfId() common.IFIDType { return i.ifid }
+func (i pathInterface) IA() addr.IA         { return i.ia }
+func (i pathInterface) ID() common.IFIDType { return i.ifid }

--- a/go/sciond/internal/fetcher/filter.go
+++ b/go/sciond/internal/fetcher/filter.go
@@ -61,7 +61,7 @@ func newPathWrap(p *combinator.Path) pathWrap {
 	keyParts := make([]string, 0, len(p.Interfaces))
 	for _, intf := range p.Interfaces {
 		intfs = append(intfs, intf)
-		keyParts = append(keyParts, fmt.Sprintf("%s#%d", intf.IA(), intf.IfId()))
+		keyParts = append(keyParts, fmt.Sprintf("%s#%d", intf.IA(), intf.ID()))
 	}
 	return pathWrap{
 		key:      strings.Join(keyParts, " "),


### PR DESCRIPTION
The PathInterface is required to loosen the dependency on sciond.

Contributes #3348

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3384)
<!-- Reviewable:end -->
