### PR TITLE
Fix sig/mgmt/Addr

### DIFF
--- a/go/sig/egress/session/sessmon.go
+++ b/go/sig/egress/session/sessmon.go
@@ -324,7 +324,7 @@ func (sm *sessMonitor) handleRep(rpld *disp.RegPld) {
 		// Update sessmon's remote.
 		sm.smRemote.Sig = &siginfo.Sig{
 			IA:          sm.smRemote.Sig.IA,
-			Host:        addr.HostFromIP(pollRep.Addr.Ctrl.IP),
+			Host:        pollRep.Addr.Ctrl.Host(),
 			CtrlL4Port:  int(pollRep.Addr.Ctrl.Port),
 			EncapL4Port: int(pollRep.Addr.EncapPort),
 		}

--- a/go/sig/internal/base/pollhdlr.go
+++ b/go/sig/internal/base/pollhdlr.go
@@ -60,7 +60,7 @@ func PollReqHdlr() {
 		}
 		sigCtrlAddr := &snet.Addr{
 			IA:      rpld.Addr.IA,
-			Host:    addr.AppAddrFromUDP(req.Addr.Ctrl),
+			Host:    addr.AppAddrFromUDP(req.Addr.Ctrl.UDP()),
 			Path:    rpld.Addr.Path,
 			NextHop: rpld.Addr.NextHop.Copy(),
 		}

--- a/go/sig/mgmt/BUILD.bazel
+++ b/go/sig/mgmt/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
+        "//go/lib/hostinfo:go_default_library",
         "//go/proto:go_default_library",
     ],
 )

--- a/go/sig/mgmt/addr.go
+++ b/go/sig/mgmt/addr.go
@@ -17,23 +17,23 @@ package mgmt
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/hostinfo"
 	"github.com/scionproto/scion/go/proto"
 )
 
 var _ proto.Cerealizable = (*Addr)(nil)
 
 type Addr struct {
-	Ctrl      *net.UDPAddr
+	Ctrl      *hostinfo.Host
 	EncapPort uint16
 }
 
 func NewAddr(host addr.HostAddr, ctrlPort, encapPort uint16) *Addr {
 	return &Addr{
-		Ctrl:      &net.UDPAddr{IP: host.IP(), Port: int(ctrlPort)},
+		Ctrl:      hostinfo.FromHostAddr(host, ctrlPort),
 		EncapPort: encapPort,
 	}
 }
@@ -53,5 +53,5 @@ func (a *Addr) Write(b common.RawBytes) (int, error) {
 
 func (a *Addr) String() string {
 	return fmt.Sprintf("Host: %s CtrlPort: %d EncapPort: %d",
-		a.Ctrl.IP, a.Ctrl.Port, a.EncapPort)
+		a.Ctrl.Host(), a.Ctrl.Port, a.EncapPort)
 }


### PR DESCRIPTION
We can't use UDPAddr on the wire format, instead use hostinfo again.

Fixes tests broken by  #3370

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3386)
<!-- Reviewable:end -->
