### PR TITLE
SIG: Allow using message ID for control message dispatching

### DIFF
--- a/go/sig/egress/session/sessmon.go
+++ b/go/sig/egress/session/sessmon.go
@@ -83,7 +83,8 @@ func (sm *sessMonitor) run() {
 	defer pathExpiryTick.Stop()
 	// Register with SIG ctrl dispatcher
 	regc := make(disp.RegPldChan, 1)
-	disp.Dispatcher.Register(disp.RegPollRep, disp.MkRegPollKey(sm.sess.IA(), sm.sess.SessId), regc)
+	disp.Dispatcher.Register(disp.RegPollRep,
+		disp.MkRegPollKey(sm.sess.IA(), sm.sess.SessId, 0), regc)
 	sm.lastReply = time.Now()
 	// Start by querying for the remote SIG instance.
 	sm.smRemote = &iface.RemoteInfo{
@@ -109,7 +110,7 @@ Top:
 		}
 	}
 	err := disp.Dispatcher.Unregister(disp.RegPollRep, disp.MkRegPollKey(sm.sess.IA(),
-		sm.sess.SessId))
+		sm.sess.SessId, 0))
 	if err != nil {
 		log.Error("sessMonitor: unable to unregister from ctrl dispatcher", "err", err)
 	}

--- a/go/sig/main.go
+++ b/go/sig/main.go
@@ -91,7 +91,7 @@ func realMain() int {
 			log.Info("reloadOnSIGHUP: reload done", "success", success)
 		},
 	)
-	disp.Init(sigcmn.CtrlConn)
+	disp.Init(sigcmn.CtrlConn, false)
 	// Parse sig config
 	if loadConfig(cfg.Sig.SIGConfig) != true {
 		log.Crit("Unable to load sig config on startup")


### PR DESCRIPTION
Control message dispatcher can now be run in two different
modes: Either is dispatches the packets based on IA+session,
or based on IA+session+msgID.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3403)
<!-- Reviewable:end -->
