### PR TITLE
Upgrade water dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -379,7 +379,7 @@ go_repository(
 
 go_repository(
     name = "com_github_songgao_water",
-    commit = "99d07fc117afd4d997bc5ebca77c241644ffe24a",
+    commit = "fd331bda3f4bbc9aad07ccd4bd2abaa1e363a852",
     importpath = "github.com/songgao/water",
 )
 


### PR DESCRIPTION
Recently we saw SIG acceptance tests fail more often that usual.
Since the Go1.13 change (#3362) we saw in some SIGs problems with the TUN device.
Investigating further we came across https://github.com/golang/go/issues/30624.
From there we saw that water library is very old and still uses os.OpenFile,
which was replaced in other similar libs to mitigate afformentioned Go issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3406)
<!-- Reviewable:end -->
