### PR TITLE
yang files for proposal

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -276,7 +276,7 @@ cmd_lint() {
 py_lint() {
     lint_header "python"
     local ret=0
-    for i in acceptance python; do
+    for i in acceptance python yang; do
       [ -d "$i" ] || continue
       local cmd="flake8"
       lint_step "$cmd /$i"

--- a/yang/README.md
+++ b/yang/README.md
@@ -1,18 +1,29 @@
 # YANG modules and NETCONF
 
-The python script uses sysrepo+Netopeer2 as persistance and NETCONF Server solutions. For more information about how to install sysrepo+Netopeer2 see: https://github.com/sysrepo/sysrepo and https://github.com/CESNET/Netopeer2/tree/master/server.
+The python script uses sysrepo+Netopeer2 as persistance and NETCONF
+Server solutions. For more information about how to install sysrepo+Netopeer2
+see: <https://github.com/sysrepo/sysrepo>
+and <https://github.com/CESNET/Netopeer2/tree/master/server>.
 
 ## Installation YANG modules
+
 YANG module can be installed using CLI as follows:
+
 ```sh
-$ sysrepoctl --install --yang={MODULE_NAME} --owner={USER}:{GROUP} --permission={OCTAL-REP}
+sysrepoctl --install --yang={MODULE_NAME} --owner={USER}:{GROUP} --permission={OCTAL-REP}
 ```
 
-More information can be found here: http://www.sysrepo.org/.
+More information can be found here: <http://www.sysrepo.org/>.
+
 ## Usage python scripts
 
 The `write_topo.py` script can be used as follows:
+
 ```sh
-$ python write_topo.py [--test]
+python write_topo.py [--test]
 ```
-Note that if flag *test* is used `topology.json` will be send to the standard output upon changes (received by the NETCONF server). Otherwise, `topology.json` will be overwritten on `$HOME/go/src/github.com/scionproto/scion/gen/ISD{}/AS{}/{SERVICE}` for every `{SERVICE}` on the configured `ISD-AS`.
+
+Note that if flag *test* is used `topology.json` will be send to the standard
+output upon changes (received by the NETCONF server). Otherwise,
+`topology.json` will be overwritten on `$HOME/go/src/github.com/scionproto/scion/gen/ISD{}/AS{}/{SERVICE}`
+for every `{SERVICE}` on the configured `ISD-AS`.

--- a/yang/README.md
+++ b/yang/README.md
@@ -1,0 +1,18 @@
+# YANG modules and NETCONF
+
+The python script uses sysrepo+Netopeer2 as persistance and NETCONF Server solutions. For more information about how to install sysrepo+Netopeer2 see: https://github.com/sysrepo/sysrepo and https://github.com/CESNET/Netopeer2/tree/master/server.
+
+## Installation YANG modules
+YANG module can be installed using CLI as follows:
+```sh
+$ sysrepoctl --install --yang={MODULE_NAME} --owner={USER}:{GROUP} --permission={OCTAL-REP}
+```
+
+More information can be found here: http://www.sysrepo.org/.
+## Usage python scripts
+
+The `write_topo.py` script can be used as follows:
+```sh
+$ python write_topo.py [--test]
+```
+Note that if flag *test* is used `topology.json` will be send to the standard output upon changes (received by the NETCONF server). Otherwise, `topology.json` will be overwritten on `$HOME/go/src/github.com/scionproto/scion/gen/ISD{}/AS{}/{SERVICE}` for every `{SERVICE}` on the configured `ISD-AS`.

--- a/yang/python_app/str_helper.py
+++ b/yang/python_app/str_helper.py
@@ -1,0 +1,68 @@
+"""
+:mod:`str_helper` -- YANG string helper functions
+=================================================
+"""
+##################################################
+# Copyright 2019 ETH Zurich
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##################################################
+##################################################
+# This script uses sysrepo swig module in order to take the configuration for
+# one ISD-AS.
+# It suscribes for changes on the topology data-store and writes the
+# topology.json file
+# into every service directory (i.e. Border routers, beacon servers, ...).
+##################################################
+##################################################
+# Author: Jordi Subira
+# Email: jonieto@student.ethz.ch
+##################################################
+import string
+
+
+def conversion_helper(yang_str: str) -> str:
+    """Convert from yang module syntax to topology.json syntax."""
+
+    # E.g converting isd-as -> to Isd_as ;
+    if yang_str in ("isd-as", "mtu"):
+        return yang_str.replace('-', '_').upper()
+    # from border-routers to BorderRouters
+    yang_str = string.capwords(yang_str, '-')
+    return yang_str.replace('-', '')
+
+
+def get_key_list_path(x_path: str) -> str:
+    """Get the key from the path, which defines the entry in the list."""
+
+    # Asuming one key at the moment
+    return x_path.split("'")[-2]
+
+
+def erase_prefix(yang_str: str) -> str:
+    """Erase YANG module prefix."""
+
+    return yang_str.split(":")[1]
+
+
+def get_last_node_name(x_path: str) -> str:
+    """Get the last node name on the x_path provided."""
+
+    last_node = x_path.split(":")[-1].split("/")[-1]  # type: str
+    last_node = conversion_helper(last_node)
+    return last_node
+
+
+def get_value_identityref(id_ref_val: str) -> str:
+    """Strip off module prefix of identity-ref."""
+
+    return id_ref_val.split("-")[-1]

--- a/yang/python_app/sysrepo_type.py
+++ b/yang/python_app/sysrepo_type.py
@@ -1,0 +1,35 @@
+"""
+:mod:`sysrepo_type` -- SYSREPO Constants
+=================================================
+
+This constants can be found either on the sysrepo
+site: http://www.sysrepo.org/static/doc/html/
+or on https://github.com/sysrepo/sysrepo/blob/master/src/sysrepo.h
+
+"""
+
+SR_UNKNOWN_T = 0
+SR_TREE_ITERATOR_T = 1
+SR_LIST_T = 2
+SR_CONTAINER_T = 3
+SR_CONTAINER_PRESENCE_T = 4
+SR_LEAF_EMPTY_T = 5
+SR_NOTIFICATION_T = 6
+SR_BINARY_T = 7
+SR_BITS_T = 8
+SR_BOOL_T = 9
+SR_DECIMAL64_T = 10
+SR_ENUM_T = 11
+SR_IDENTITYREF_T = 12
+SR_INSTANCEID_T = 13
+SR_INT8_T = 14
+SR_INT16_T = 15
+SR_INT32_T = 16
+SR_INT64_T = 17
+SR_STRING_T = 18
+SR_UINT8_T = 19
+SR_UINT16_T = 20
+SR_UINT32_T = 21
+SR_UINT64_T = 22
+SR_ANYXML_T = 23
+SR_ANYDATA_T = 24

--- a/yang/python_app/write_topo.py
+++ b/yang/python_app/write_topo.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python
+"""
+:mod:`write_topo` -- YANG topology.json generator
+=================================================
+
+This module suscribes for changes to the scion-topology data store and
+changes the topology.json files
+"""
+##################################################
+# Copyright 2019 ETH Zurich
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##################################################
+##################################################
+# This script uses sysrepo swig module in order to take the configuration for
+# one ISD-AS.
+# It suscribes for changes on the topology data-store and writes the
+# topology.json file
+# into every service directory (i.e. Border routers, beacon servers, ...).
+##################################################
+##################################################
+# Author: Jordi Subira
+# Email: jonieto@student.ethz.ch
+##################################################
+
+import json
+import os
+import argparse
+import re
+import traceback
+from typing import Dict, List, Any, Union, Optional  # noqa
+
+
+import sysrepo as sr  # type: ignore
+import sysrepo_type as sr_types
+
+import str_helper as helper
+
+R_NUMBER = re.compile(r'[0-9]+')
+R_BR = re.compile(r'br\S*')
+R_IPv4 = re.compile('(' +
+                    r'([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.)' +
+                    '{3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])')
+
+R_IPv6 = re.compile(r'((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}' +
+                    '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|' +
+                    r'(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}' +
+                    '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))')
+
+DIR_APP = os.getcwd()  # type: str
+
+DIR_HOME = os.getenv("HOME")  # type: Optional[str]
+if DIR_HOME is None:
+    raise Exception("No defined HOME env.")
+
+DIR_ISD_AS_FORMAT = "gen/ISD{}/AS{}/"
+DIR_SCION = os.path.join(DIR_HOME,
+                         "go/src/github.com/scionproto/scion/")  # type: str
+
+LIST_SERVICES = ["BorderRouters", "ControlService"]
+TUPLE_UNDERLAY_CONT = ("RemoteUnderlay", "PublicUnderlay", "BindUnderlay")
+TUPLE_BR_ADDRESS_CONT = ("ControlAddress", "InternalAddress")
+
+_PARSING = dict()
+
+AddrPortType = Dict[str, Union[int, str]]
+TopologyDictType = Dict[str, Union[Dict[str, Any], str, int, bool]]
+
+
+def _create_addr_dict(session, xpath: str,
+                      port_name: str = "L4Port") -> AddrPortType:
+    """Helper function to create the inner-part of the addr-port structure."""
+
+    my_aux_dict = dict()  # type: AddrPortType
+
+    values = session.get_items(xpath)
+
+    # In case empty BindUnderlay
+    if values is None:
+        return my_aux_dict
+
+    for i in range(values.val_cnt()):
+        val_type = values.val(i).type()  # type: str
+        val_xpath = values.val(i).xpath()  # type: str
+        if val_type in (sr_types.SR_UINT16_T, sr_types.SR_UINT32_T):
+            my_port = int(values.val(i).val_to_string())
+        elif val_type == sr_types.SR_STRING_T:
+            # must be string for name or address
+            name = helper.get_last_node_name(val_xpath)  # type: str
+            if name != "Name":
+                my_ip = values.val(i).val_to_string()  # type: str
+        else:
+            raise TypeError("Not type list/container on address structure" +
+                            " for " + val_xpath + ", type: " + val_type)
+
+    my_aux_dict = {"Addr": my_ip, port_name: my_port}
+
+    return my_aux_dict
+
+
+def _wrapper_addr_port_dict(session, xpath: str,
+                            port_name: str = "L4Port",
+                            add_type: str = "Public"
+                            ) -> Dict[str, Dict[str, AddrPortType]]:
+    """Helper to create JSON addr-port usual structure."""
+
+    return_dict = dict()
+    aux_dict = _create_addr_dict(session, xpath,
+                                 port_name)  # type: Dict[str, Union[int, str]]
+    if R_IPv4.match(str(aux_dict["Addr"])):
+        return_dict["IPv4"] = {add_type:  aux_dict}
+    elif R_IPv6.match(str(aux_dict["Addr"])):
+        return_dict["IPv6"] = {add_type:  aux_dict}
+    else:
+        raise TypeError("Address does not fulfill neither IPv4 or IPv6 format")
+
+    return return_dict
+
+
+def _aux_create_br_dict(session, x_path: str,
+                        json_obj: TopologyDictType) -> None:
+    """Helper function to parse from YANG node names to JSON node names
+    for border router.
+    """
+
+    values_add = session.get_items(x_path)
+
+    for j in range(values_add.val_cnt()):
+        val_type_add = values_add.val(j).type()  # type: str
+        val_xpath_add = values_add.val(j).xpath()  # type: str
+        if val_type_add != sr_types.SR_CONTAINER_T:
+            raise TypeError("Only expected container values for" +
+                            val_xpath_add)
+
+        name = helper.get_last_node_name(val_xpath_add)  # type: str
+        val_xpath_add += "/*"
+        if name == "ControlAddress":
+            json_obj["CtrlAddr"] = _wrapper_addr_port_dict(session,
+                                                           val_xpath_add
+                                                           )
+        elif name == "InternalAddress":
+            json_obj["InternalAddrs"] = _wrapper_addr_port_dict(session,
+                                                                val_xpath_add,
+                                                                "OverlayPort",
+                                                                "PublicOverlay"
+                                                                )
+        elif name == "RemoteUnderlay":
+            json_obj["RemoteOverlay"] = _create_addr_dict(session,
+                                                          val_xpath_add,
+                                                          "OverlayPort")
+        elif name == "PublicUnderlay":
+            json_obj["PublicOverlay"] = _create_addr_dict(session,
+                                                          val_xpath_add,
+                                                          "OverlayPort")
+        elif name == "BindUnderlay":
+            aux_dict = _create_addr_dict(session,
+                                         val_xpath_add,
+                                         "OverlayPort")  # tpye: AddrPortType
+
+            # Checking not to write empty bind-underlay
+            if aux_dict:
+                json_obj["BindOverlay"] = aux_dict
+        else:
+            raise TypeError("Not expected value type" + name)
+
+
+def _aux_attr_list(session, xpath: str) -> List[str]:
+    ret_list = list()
+
+    values = session.get_items(xpath)
+
+    # In case empty BindUnderlay
+    if values is None:
+        return ret_list
+
+    for i in range(values.val_cnt()):
+        val_type = values.val(i).type()  # type: str
+        val_xpath = values.val(i).xpath()  # type: str
+        if val_type != sr_types.SR_IDENTITYREF_T:
+            raise TypeError("Not type identityref on Attributes list" +
+                            " for " + val_xpath + ", type: " + val_type)
+        id_ref_value = values.val(i).val_to_string()  # type: str
+        ret_list.append(helper.get_value_identityref(id_ref_value))
+
+    return ret_list
+
+
+def _create_dict(session, x_path: str) -> TopologyDictType:
+    """Recursive function to create a dict out of the data
+    store configuration.
+    """
+
+    json_obj = dict()  # type: TopologyDictType
+
+    values = session.get_items(x_path)
+    if values is None:
+        return json_obj
+
+    for i in range(values.val_cnt()):
+        val_type = values.val(i).type()  # type: str
+        val_xpath = values.val(i).xpath()  # type: str
+        if val_type == sr_types.SR_CONTAINER_T:
+            name = helper.get_last_node_name(val_xpath)  # type: str
+            if name in TUPLE_UNDERLAY_CONT or name in TUPLE_BR_ADDRESS_CONT:
+                _aux_create_br_dict(session, val_xpath, json_obj)
+            elif name == "Attributes":
+                val_xpath += "/*"
+                aux_list = _aux_attr_list(session,
+                                          val_xpath)  # type: List[str]
+                json_obj[name] = aux_list
+            else:
+                aux_dict = _create_dict(session,
+                                        val_xpath +
+                                        "/*")  # type: TopologyDictType
+                # Checking not to write empty
+                if aux_dict:
+                    json_obj[name] = aux_dict
+
+        elif val_type == sr_types.SR_LIST_T:
+            key = helper.get_key_list_path(val_xpath)  # type: str
+            # Interfaces, implement special treatment
+            if R_NUMBER.match(key):
+                json_obj[key] = _create_dict(session, val_xpath + "/*")
+
+            # BR list, implement special treatment
+            elif R_BR.match(key):
+                json_obj[key] = _create_dict(session, val_xpath + "/*")
+
+            # Else consider other services
+            else:
+                aux_dict = dict()
+                aux_dict["Addrs"] = _wrapper_addr_port_dict(session,
+                                                            val_xpath + "/*")
+                json_obj[key] = aux_dict
+
+        elif val_type in (sr_types.SR_UINT16_T, sr_types.SR_UINT32_T):
+            name = helper.get_last_node_name(val_xpath)
+            if name != "Number":
+                json_obj[name] = int(values.val(i).val_to_string())
+        elif val_type == sr_types.SR_BOOL_T:
+            name = helper.get_last_node_name(val_xpath)
+            if values.val(i).val_to_string() == "true":
+                json_obj[name] = True
+            else:
+                json_obj[name] = False
+        elif val_type in (sr_types.SR_STRING_T, sr_types.SR_IDENTITYREF_T,
+                          sr_types.SR_ENUM_T):
+            name = helper.get_last_node_name(val_xpath)
+            if name == "Name":
+                continue
+            if name == "UnderlayProto":
+                ul_proto = helper.erase_prefix(values.val(i).val_to_string())
+                if ul_proto == "underlay-udp-ipv4":
+                    json_obj["Overlay"] = "UDP/IPv4"
+                elif ul_proto == "underlay-tcp-ipv4":
+                    json_obj["Overlay"] = "TCP/IPv4"
+                elif ul_proto == "underlay-udp-ipv6":
+                    json_obj["Overlay"] = "UDP/IPv6"
+                elif ul_proto == "underlay-tcp-ipv6":
+                    json_obj["Overlay"] = "TCP/IPv6"
+                else:
+                    raise ValueError("Not expected underlay protocol: " +
+                                     values.val(i).val_to_string())
+            elif name == "Link":
+                json_obj["LinkTo"] = values.val(i).val_to_string().upper()
+            elif name == "Address":
+                json_obj["Addr"] = values.val(i).val_to_string()
+            else:
+                json_obj[name] = values.val(i).val_to_string()
+        else:
+            raise TypeError("Not expected YANG type for " + val_xpath +
+                            "is type " + str(val_type))
+
+    return json_obj
+
+
+def _write_isd_as(json_topo: Dict[str, Any]) -> None:
+    """ This function writes the json file within every service directory."""
+
+    dirs_to_write = list()
+    dirs_to_write.append("endhost")
+
+    if "ISD_AS" not in json_topo:
+        raise ValueError("Expected ISD-AS in the topology configuration.")
+    number_isd = json_topo["ISD_AS"].split("-")[0]
+    as_name = json_topo["ISD_AS"].split("-")[1].replace(":", "_")
+    for service in LIST_SERVICES:
+        if service in json_topo.keys():
+            for key in json_topo[service].keys():
+                dirs_to_write.append(key)
+
+    dir_isd_as = DIR_ISD_AS_FORMAT.format(number_isd, as_name)
+    dir_isd_as = os.path.join(DIR_SCION, dir_isd_as)
+    if not os.path.exists(dir_isd_as):
+        raise FileNotFoundError(dir_isd_as + "doesn't exist.")
+    for service_dir in dirs_to_write:
+        os.chdir(dir_isd_as)
+        topo_file = open(os.path.join(service_dir, 'topology.json'), 'w+')
+        topo_file.truncate(0)
+        json_st = json.dumps(json_topo, indent=4)  # type:str
+        topo_file.write(json_st)
+        topo_file.close()
+        print("------ TOPOLOGY created in " +
+              os.path.join(dir_isd_as, service_dir) + " ------")
+
+
+def _change_current_config(session, module_name: str) -> None:
+    """Function to write topology file or upon NETCONF changes."""
+
+    select_xpath = "/" + module_name + ":topology/*"
+
+    try:
+        json_obj = _create_dict(session,
+                                select_xpath)  # type: TopologyDictType
+    except Exception:
+        traceback.print_exc()
+        raise
+
+    if not json_obj:
+        print("No changes applied.")
+        return
+
+    if 'test' in _PARSING and not _PARSING['test']:
+        try:
+            _write_isd_as(json_obj)
+        except Exception:
+            traceback.print_exc()
+            raise
+    else:
+        print(json.dumps(json_obj, indent=4))
+    print("END Write.")
+
+
+def _print_current_config(session, module_name) -> None:
+    """Print XPath configuration for the module."""
+
+    select_xpath = "/" + module_name + ":*//*"
+
+    values = session.get_items(select_xpath)
+    if values is None:
+        print("Empty Data Store")
+        return
+
+    for i in range(values.val_cnt()):
+        print(values.val(i).to_string(), end='')
+
+
+def module_change_cb(sess, module_name, event, private_ctx):
+    """Callback for subscribed client of given session whenever configuration
+    changes.
+    """
+
+    print("\n\n ========== CONFIG HAS CHANGED, "
+          "CURRENT RUNNING CONFIG: ==========\n")
+
+    _change_current_config(sess, module_name)
+
+    return sr.SR_ERR_OK
+
+
+def main():
+    """Main function."""
+
+    module_name = "scion-topology"
+
+    parser = argparse.ArgumentParser(prog='write_topo.py')
+    parser.add_argument('--test', help="print stdout json file",
+                        action="store_true")
+
+    for k, v in vars(parser.parse_args()).items():
+        _PARSING[k] = v
+
+    # connect to sysrepo
+    conn = sr.Connection(module_name)
+    # start session
+    sess = sr.Session(conn)
+    # subscribe for changes in running config */
+    subscribe = sr.Subscribe(sess)
+    # setting callback
+    subscribe.module_change_subscribe(module_name,
+                                      module_change_cb, None, 0,
+                                      sr.SR_SUBSCR_DEFAULT |
+                                      sr.SR_SUBSCR_APPLY_ONLY)
+
+    print("\n\n ========== READING STARTUP CONFIG: ==========\n")
+    _print_current_config(sess, module_name)
+
+    _change_current_config(sess, module_name)
+    print("\n\n ========== STARTUP CONFIG APPLIED AS RUNNING ==========\n")
+
+    sr.global_loop()
+
+    print("Application exit requested, exiting.\n")
+
+
+if __name__ == '__main__':
+    main()

--- a/yang/yang_modules/ietf-inet-types.yang
+++ b/yang/yang_modules/ietf-inet-types.yang
@@ -1,0 +1,457 @@
+module ietf-inet-types {
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
+  prefix "inet";
+
+  organization
+   "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+
+  contact
+   "WG Web:   <http://tools.ietf.org/wg/netmod/>
+    WG List:  <mailto:netmod@ietf.org>
+
+    WG Chair: David Kessens
+              <mailto:david.kessens@nsn.com>
+
+    WG Chair: Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>
+
+    Editor:   Juergen Schoenwaelder
+              <mailto:j.schoenwaelder@jacobs-university.de>";
+
+  description
+   "This module contains a collection of generally useful derived
+    YANG data types for Internet addresses and related things.
+
+    Copyright (c) 2013 IETF Trust and the persons identified as
+    authors of the code.  All rights reserved.
+
+    Redistribution and use in source and binary forms, with or
+    without modification, is permitted pursuant to, and subject
+    to the license terms contained in, the Simplified BSD License
+    set forth in Section 4.c of the IETF Trust's Legal Provisions
+    Relating to IETF Documents
+    (http://trustee.ietf.org/license-info).
+
+    This version of this YANG module is part of RFC 6991; see
+    the RFC itself for full legal notices.";
+
+  revision 2013-07-15 {
+    description
+     "This revision adds the following new data types:
+      - ip-address-no-zone
+      - ipv4-address-no-zone
+      - ipv6-address-no-zone";
+    reference
+     "RFC 6991: Common YANG Data Types";
+  }
+
+  revision 2010-09-24 {
+    description
+     "Initial revision.";
+    reference
+     "RFC 6021: Common YANG Data Types";
+  }
+
+  /*** collection of types related to protocol fields ***/
+
+  typedef ip-version {
+    type enumeration {
+      enum unknown {
+        value "0";
+        description
+         "An unknown or unspecified version of the Internet
+          protocol.";
+      }
+      enum ipv4 {
+        value "1";
+        description
+         "The IPv4 protocol as defined in RFC 791.";
+      }
+      enum ipv6 {
+        value "2";
+        description
+         "The IPv6 protocol as defined in RFC 2460.";
+      }
+    }
+    description
+     "This value represents the version of the IP protocol.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetVersion textual convention of the SMIv2.";
+    reference
+     "RFC  791: Internet Protocol
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  typedef dscp {
+    type uint8 {
+      range "0..63";
+    }
+    description
+     "The dscp type represents a Differentiated Services Code Point
+      that may be used for marking packets in a traffic stream.
+      In the value set and its semantics, this type is equivalent
+      to the Dscp textual convention of the SMIv2.";
+    reference
+     "RFC 3289: Management Information Base for the Differentiated
+                Services Architecture
+      RFC 2474: Definition of the Differentiated Services Field
+                (DS Field) in the IPv4 and IPv6 Headers
+      RFC 2780: IANA Allocation Guidelines For Values In
+                the Internet Protocol and Related Headers";
+  }
+
+  typedef ipv6-flow-label {
+    type uint32 {
+      range "0..1048575";
+    }
+    description
+     "The ipv6-flow-label type represents the flow identifier or Flow
+      Label in an IPv6 packet header that may be used to
+      discriminate traffic flows.
+
+      In the value set and its semantics, this type is equivalent
+      to the IPv6FlowLabel textual convention of the SMIv2.";
+    reference
+     "RFC 3595: Textual Conventions for IPv6 Flow Label
+      RFC 2460: Internet Protocol, Version 6 (IPv6) Specification";
+  }
+
+  typedef port-number {
+    type uint16 {
+      range "0..65535";
+    }
+    description
+     "The port-number type represents a 16-bit port number of an
+      Internet transport-layer protocol such as UDP, TCP, DCCP, or
+      SCTP.  Port numbers are assigned by IANA.  A current list of
+      all assignments is available from <http://www.iana.org/>.
+
+      Note that the port number value zero is reserved by IANA.  In
+      situations where the value zero does not make sense, it can
+      be excluded by subtyping the port-number type.
+      In the value set and its semantics, this type is equivalent
+      to the InetPortNumber textual convention of the SMIv2.";
+    reference
+     "RFC  768: User Datagram Protocol
+      RFC  793: Transmission Control Protocol
+      RFC 4960: Stream Control Transmission Protocol
+      RFC 4340: Datagram Congestion Control Protocol (DCCP)
+      RFC 4001: Textual Conventions for Internet Network Addresses";
+  }
+
+  /*** collection of types related to autonomous systems ***/
+
+  typedef as-number {
+    type uint32;
+    description
+     "The as-number type represents autonomous system numbers
+      which identify an Autonomous System (AS).  An AS is a set
+      of routers under a single technical administration, using
+      an interior gateway protocol and common metrics to route
+      packets within the AS, and using an exterior gateway
+      protocol to route packets to other ASes.  IANA maintains
+      the AS number space and has delegated large parts to the
+      regional registries.
+
+      Autonomous system numbers were originally limited to 16
+      bits.  BGP extensions have enlarged the autonomous system
+      number space to 32 bits.  This type therefore uses an uint32
+      base type without a range restriction in order to support
+      a larger autonomous system number space.
+
+      In the value set and its semantics, this type is equivalent
+      to the InetAutonomousSystemNumber textual convention of
+      the SMIv2.";
+    reference
+     "RFC 1930: Guidelines for creation, selection, and registration
+                of an Autonomous System (AS)
+      RFC 4271: A Border Gateway Protocol 4 (BGP-4)
+      RFC 4001: Textual Conventions for Internet Network Addresses
+      RFC 6793: BGP Support for Four-Octet Autonomous System (AS)
+                Number Space";
+  }
+
+  /*** collection of types related to IP addresses and hostnames ***/
+
+  typedef ip-address {
+    type union {
+      type inet:ipv4-address;
+      type inet:ipv6-address;
+    }
+    description
+     "The ip-address type represents an IP address and is IP
+      version neutral.  The format of the textual representation
+      implies the IP version.  This type supports scoped addresses
+      by allowing zone identifiers in the address format.";
+    reference
+     "RFC 4007: IPv6 Scoped Address Architecture";
+  }
+
+  typedef ipv4-address {
+    type string {
+      pattern
+        '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+      +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+      + '(%[\p{N}\p{L}]+)?';
+    }
+    description
+      "The ipv4-address type represents an IPv4 address in
+       dotted-quad notation.  The IPv4 address may include a zone
+       index, separated by a % sign.
+
+       The zone index is used to disambiguate identical address
+       values.  For link-local addresses, the zone index will
+       typically be the interface index number or the name of an
+       interface.  If the zone index is not present, the default
+       zone of the device will be used.
+
+       The canonical format for the zone index is the numerical
+       format";
+  }
+
+  typedef ipv6-address {
+    type string {
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+            + '(%[\p{N}\p{L}]+)?';
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+            + '(%.+)?';
+    }
+    description
+     "The ipv6-address type represents an IPv6 address in full,
+      mixed, shortened, and shortened-mixed notation.  The IPv6
+      address may include a zone index, separated by a % sign.
+
+      The zone index is used to disambiguate identical address
+      values.  For link-local addresses, the zone index will
+      typically be the interface index number or the name of an
+      interface.  If the zone index is not present, the default
+      zone of the device will be used.
+
+      The canonical format of IPv6 addresses uses the textual
+      representation defined in Section 4 of RFC 5952.  The
+      canonical format for the zone index is the numerical
+      format as described in Section 11.2 of RFC 4007.";
+    reference
+     "RFC 4291: IP Version 6 Addressing Architecture
+      RFC 4007: IPv6 Scoped Address Architecture
+      RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  typedef ip-address-no-zone {
+    type union {
+      type inet:ipv4-address-no-zone;
+      type inet:ipv6-address-no-zone;
+    }
+    description
+     "The ip-address-no-zone type represents an IP address and is
+      IP version neutral.  The format of the textual representation
+      implies the IP version.  This type does not support scoped
+      addresses since it does not allow zone identifiers in the
+      address format.";
+    reference
+     "RFC 4007: IPv6 Scoped Address Architecture";
+  }
+
+  typedef ipv4-address-no-zone {
+    type inet:ipv4-address {
+      pattern '[0-9\.]*';
+    }
+    description
+      "An IPv4 address without a zone index.  This type, derived from
+       ipv4-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+  }
+
+  typedef ipv6-address-no-zone {
+    type inet:ipv6-address {
+      pattern '[0-9a-fA-F:\.]*';
+    }
+    description
+      "An IPv6 address without a zone index.  This type, derived from
+       ipv6-address, may be used in situations where the zone is
+       known from the context and hence no zone index is needed.";
+    reference
+     "RFC 4291: IP Version 6 Addressing Architecture
+      RFC 4007: IPv6 Scoped Address Architecture
+      RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  typedef ip-prefix {
+    type union {
+      type inet:ipv4-prefix;
+      type inet:ipv6-prefix;
+    }
+    description
+     "The ip-prefix type represents an IP prefix and is IP
+      version neutral.  The format of the textual representations
+      implies the IP version.";
+  }
+
+  typedef ipv4-prefix {
+    type string {
+      pattern
+         '(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}'
+       +  '([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])'
+       + '/(([0-9])|([1-2][0-9])|(3[0-2]))';
+    }
+    description
+     "The ipv4-prefix type represents an IPv4 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 32.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The canonical format of an IPv4 prefix has all bits of
+      the IPv4 address set to zero that are not part of the
+      IPv4 prefix.";
+  }
+
+  typedef ipv6-prefix {
+    type string {
+      pattern '((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}'
+            + '((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|'
+            + '(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}'
+            + '(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))'
+            + '(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))';
+      pattern '(([^:]+:){6}(([^:]+:[^:]+)|(.*\..*)))|'
+            + '((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)'
+            + '(/.+)';
+    }
+    description
+     "The ipv6-prefix type represents an IPv6 address prefix.
+      The prefix length is given by the number following the
+      slash character and must be less than or equal to 128.
+
+      A prefix length value of n corresponds to an IP address
+      mask that has n contiguous 1-bits from the most
+      significant bit (MSB) and all other bits set to 0.
+
+      The IPv6 address should have all bits that do not belong
+      to the prefix set to zero.
+
+      The canonical format of an IPv6 prefix has all bits of
+      the IPv6 address set to zero that are not part of the
+      IPv6 prefix.  Furthermore, the IPv6 address is represented
+      as defined in Section 4 of RFC 5952.";
+    reference
+     "RFC 5952: A Recommendation for IPv6 Address Text
+                Representation";
+  }
+
+  /*** collection of domain name and URI types ***/
+
+  typedef domain-name {
+    type string {
+      length "1..253";
+      pattern
+        '((([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.)*'
+      + '([a-zA-Z0-9_]([a-zA-Z0-9\-_]){0,61})?[a-zA-Z0-9]\.?)'
+      + '|\.';
+    }
+    description
+     "The domain-name type represents a DNS domain name.  The
+      name SHOULD be fully qualified whenever possible.
+
+      Internet domain names are only loosely specified.  Section
+      3.5 of RFC 1034 recommends a syntax (modified in Section
+      2.1 of RFC 1123).  The pattern above is intended to allow
+      for current practice in domain name use, and some possible
+      future expansion.  It is designed to hold various types of
+      domain names, including names used for A or AAAA records
+      (host names) and other records, such as SRV records.  Note
+      that Internet host names have a stricter syntax (described
+      in RFC 952) than the DNS recommendations in RFCs 1034 and
+      1123, and that systems that want to store host names in
+      schema nodes using the domain-name type are recommended to
+      adhere to this stricter standard to ensure interoperability.
+
+      The encoding of DNS names in the DNS protocol is limited
+      to 255 characters.  Since the encoding consists of labels
+      prefixed by a length bytes and there is a trailing NULL
+      byte, only 253 characters can appear in the textual dotted
+      notation.
+
+      The description clause of schema nodes using the domain-name
+      type MUST describe when and how these names are resolved to
+      IP addresses.  Note that the resolution of a domain-name value
+      may require to query multiple DNS records (e.g., A for IPv4
+      and AAAA for IPv6).  The order of the resolution process and
+      which DNS record takes precedence can either be defined
+      explicitly or may depend on the configuration of the
+      resolver.
+
+      Domain-name values use the US-ASCII encoding.  Their canonical
+      format uses lowercase US-ASCII characters.  Internationalized
+      domain names MUST be A-labels as per RFC 5890.";
+    reference
+     "RFC  952: DoD Internet Host Table Specification
+      RFC 1034: Domain Names - Concepts and Facilities
+      RFC 1123: Requirements for Internet Hosts -- Application
+                and Support
+      RFC 2782: A DNS RR for specifying the location of services
+                (DNS SRV)
+      RFC 5890: Internationalized Domain Names in Applications
+                (IDNA): Definitions and Document Framework";
+  }
+
+  typedef host {
+    type union {
+      type inet:ip-address;
+      type inet:domain-name;
+    }
+    description
+     "The host type represents either an IP address or a DNS
+      domain name.";
+  }
+
+  typedef uri {
+    type string;
+    description
+     "The uri type represents a Uniform Resource Identifier
+      (URI) as defined by STD 66.
+
+      Objects using the uri type MUST be in US-ASCII encoding,
+      and MUST be normalized as described by RFC 3986 Sections
+      6.2.1, 6.2.2.1, and 6.2.2.2.  All unnecessary
+      percent-encoding is removed, and all case-insensitive
+      characters are set to lowercase except for hexadecimal
+      digits, which are normalized to uppercase as described in
+      Section 6.2.2.1.
+
+      The purpose of this normalization is to help provide
+      unique URIs.  Note that this normalization is not
+      sufficient to provide uniqueness.  Two URIs that are
+      textually distinct after this normalization may still be
+      equivalent.
+
+      Objects using the uri type may restrict the schemes that
+      they permit.  For example, 'data:' and 'urn:' schemes
+      might not be appropriate.
+
+      A zero-length URI is not a valid URI.  This can be used to
+      express 'URI absent' where required.
+
+      In the value set and its semantics, this type is equivalent
+      to the Uri SMIv2 textual convention defined in RFC 5017.";
+    reference
+     "RFC 3986: Uniform Resource Identifier (URI): Generic Syntax
+      RFC 3305: Report from the Joint W3C/IETF URI Planning Interest
+                Group: Uniform Resource Identifiers (URIs), URLs,
+                and Uniform Resource Names (URNs): Clarifications
+                and Recommendations
+      RFC 5017: MIB Textual Conventions for Uniform Resource
+                Identifiers (URIs)";
+  }
+
+}

--- a/yang/yang_modules/scion-interfaces.yang
+++ b/yang/yang_modules/scion-interfaces.yang
@@ -1,0 +1,156 @@
+module scion-interfaces {
+  yang-version 1.1;
+  namespace "urn:scion:scion-interfaces";
+  prefix "sc-if";
+
+  import scion-types{
+    prefix "sc-ty";
+  }
+
+  organization
+    "SCION group";
+
+  contact
+  "Some contact here";
+
+  description 
+  "This module contains a collection of data defining the common 
+  interface configuration within the Autonomous System (AS) devices.
+  ";
+
+  revision 2019-11-15 {
+        description "First revision for proposal.";
+  }
+
+  grouping interfaces-top{
+    description "Top level grouping for interfaces";
+    container interfaces{
+      list interface{
+        description 
+        "The list of interfaces on the device.
+
+        Every interface is uniquely identified by a number. Every instance 
+        must define a public underlay and a remote underlay.
+        ";
+        key number;
+
+        leaf number{
+          type uint16;
+          mandatory true;
+        }
+
+        leaf isd-as{
+          description 
+          "
+          The ISD-AS name identifier of the next hop.
+          ";
+          type sc-ty:isd-as-type;
+          mandatory true;
+        }
+
+        leaf bandwidth{
+          description 
+          "
+          The bandwith defined on the interface level
+          ";
+          type uint16;
+        }
+
+        leaf mtu{
+          description "Maximum transmission unit for the interface";
+          type uint16;
+          mandatory true;
+        }
+
+        leaf link{
+          description 
+          "
+          The type of link definition.
+          ";
+          reference 
+            "urn:scion:scion-types";
+          type sc-ty:link-type;
+          mandatory true;
+        }
+
+        leaf underlay-proto {
+            description 
+            "
+            The underlay protocol used between the two border routers on each side of the link.
+            ";
+            type identityref {
+                base "sc-ty:underlay-proto";
+            }
+            mandatory true;
+        }
+
+        container public-underlay{
+          description 
+          "
+          The public underlay defines the address and port for the given interface.
+          ";
+          uses sc-ty:address-port;
+
+          must ' not(derived-from(../underlay-proto, "sc-ty:underlay-proto-ipv4")) or
+                 re-match(current()/address,"(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])")'
+          {
+                  error-message "No match between underlay-proto and address format";
+          }
+
+          must ' not(derived-from(../underlay-proto, "sc-ty:underlay-proto-ipv6")) or
+                 re-match(current()/address,"((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))")'
+          {
+                  error-message "No match between underlay-proto and public-underlay address format";
+          }
+
+        }
+
+        container remote-underlay{
+          description
+          "
+          The remote underlay defines the address and port on the other side
+          of the link.
+          ";
+          uses sc-ty:address-port;
+
+          must ' not(derived-from(../underlay-proto, "sc-ty:underlay-proto-ipv4")) or
+                 re-match(current()/address,"(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])")'
+          {
+                  error-message "No match between underlay-proto and remote-underlay address format";
+          }
+
+          must ' not(derived-from(../underlay-proto, "sc-ty:underlay-proto-ipv6")) or
+                 re-match(current()/address,"((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))")'
+          {
+                  error-message "No match between underlay-proto and public-underlay address format";
+          }
+        }
+
+        container bind-underlay{
+          uses sc-ty:address-port{
+            refine address{
+              mandatory false;
+            }
+            refine l4-port{
+              mandatory false;
+            }
+          }
+
+          must ' not(derived-from(../underlay-proto, "sc-ty:underlay-proto-ipv4")) or
+                 not(current()/address) or
+                 re-match(current()/address,"(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])")'
+          {
+                  error-message "No match between underlay-proto and bind-underlay address format";
+          }
+
+          must ' not(derived-from(../underlay-proto, "sc-ty:underlay-proto-ipv6")) or
+                 not(current()/address) or
+                 re-match(current()/address,"((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))")'
+          {
+                  error-message "No match between underlay-proto and public-underlay address format";
+          }
+        }
+      }//end list interfaces
+    }//end container interfaces
+  } 
+}

--- a/yang/yang_modules/scion-topology.yang
+++ b/yang/yang_modules/scion-topology.yang
@@ -1,0 +1,186 @@
+module scion-topology {
+    yang-version 1.1;
+    namespace "urn:scion:scion-topology";
+    prefix "sc-topo";
+
+    import scion-types{
+      prefix "sc-ty";
+    }
+
+    import scion-interfaces{
+      prefix "sc-if";
+    }
+
+    organization
+    "SCION group";
+
+    contact
+    "Some contact here";
+
+    description 
+    "This module contains a collection of data defining the topology
+    configuration within the Autonomous System (AS) identified by its
+    ISD-AS number.
+    ";
+
+    revision 2020-03-15 {
+        description "Second revision for proposal.";
+    }
+
+    container topology{
+      leaf core{
+        description "This boolean expresses whether or not this module belongs to the ISD core.";
+        type boolean;
+        mandatory true;
+      }
+
+      leaf isd-as{
+        description "The ISD-AS number identifies the AS within the ISD.";
+        type sc-ty:isd-as-type;
+        mandatory true;
+      }
+
+      leaf underlay-proto {
+          description "Definition of the underlay protocol protocol used for communication within the AS.";
+          mandatory true;
+          type identityref {
+              base "sc-ty:underlay-proto";
+          }
+      }
+
+      leaf mtu{
+        description "Maximum Transmission Unit within the AS.";
+        type uint16;
+        mandatory true;
+      }
+
+      container attributes{
+        leaf-list attribute{
+          description "Set of attributes which an AS might have.";
+          reference "https://github.com/scionproto/scion/blob/master/doc/ControlPlanePKI.md#primary-ases";
+
+          type identityref{
+            base "sc-ty:topology-attribute-base";
+          }
+        }
+      }
+
+      container control-service{
+        list control-server{
+          key name;
+          description 
+          "Control server list for the AS.
+
+          Every Control server is uniquely identified within the AS by its 
+          name and can be reached at the provided address and port.
+
+          Control server encompasses Beacon, Certifcate and Path services.
+          ";
+            
+          leaf name{
+            type string;
+          }
+          uses sc-ty:address-port;
+
+          must ' not(derived-from(/topology/underlay-proto, "sc-ty:underlay-proto-ipv4")) or
+                 re-match(current()/address,"(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])")'
+          {
+                  error-message "No match between underlay-proto and address format";
+          }
+
+          must ' not(derived-from(/topology/underlay-proto, "sc-ty:underlay-proto-ipv6")) or
+                 re-match(current()/address,"((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))")'
+          {
+                  error-message "No match between underlay-proto and public-underlay address format";
+          }
+        }
+      }
+
+      container sig{
+        list sig-instance{
+          key name;
+          description 
+          "SCION IP Gateway (SIG) instance list for the AS.
+
+          Every SIG instance enables legacy IP applications to communicate over SCION.
+          ";
+            
+          leaf name{
+            type string;
+          }
+          uses sc-ty:address-port;
+
+          must ' not(derived-from(/topology/underlay-proto, "sc-ty:underlay-proto-ipv4")) or
+                 re-match(current()/address,"(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])")'
+          {
+                  error-message "No match between underlay-proto and address format";
+          }
+
+          must ' not(derived-from(/topology/underlay-proto, "sc-ty:underlay-proto-ipv6")) or
+                 re-match(current()/address,"((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))")'
+          {
+                  error-message "No match between underlay-proto and public-underlay address format";
+          }
+        }
+      }
+
+      container border-routers{
+        list border-router{
+          key name;
+          description 
+          "Border router list for the AS. 
+
+          Every Border router is identified by its name. Every instance must
+          define two addresses, one control address and one internal-address.
+          ";
+          leaf name{
+            type string;
+          }
+
+          container control-address{
+            description
+            "
+            The control address is used to send control-plane traffic to 
+            the border router from inside the AS.
+            ";
+            uses sc-ty:address-port;
+
+            must ' not(derived-from(/topology/underlay-proto, "sc-ty:underlay-proto-ipv4")) or
+                   re-match(current()/address,"(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])")'
+            {
+                    error-message "No match between underlay-proto and address format";
+            }
+
+            must ' not(derived-from(/topology/underlay-proto, "sc-ty:underlay-proto-ipv6")) or
+                   re-match(current()/address,"((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))")'
+            {
+                    error-message "No match between underlay-proto and public-underlay address format";
+            }
+          }
+
+          container internal-address{
+            description
+            "
+            The internal address is used to send data-plane traffic.
+            ";
+            uses sc-ty:address-port;
+
+            must ' not(derived-from(/topology/underlay-proto, "sc-ty:underlay-proto-ipv4")) or
+                   re-match(current()/address,"(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])")'
+            {
+                    error-message "No match between underlay-proto and address format";
+            }
+
+            must ' not(derived-from(/topology/underlay-proto, "sc-ty:underlay-proto-ipv6")) or
+                   re-match(current()/address,"((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))")'
+            {
+                    error-message "No match between underlay-proto and public-underlay address format";
+            }
+          }
+
+          uses sc-if:interfaces-top;
+          
+        }//end list br
+      }//end container br
+    }
+}

--- a/yang/yang_modules/scion-types.yang
+++ b/yang/yang_modules/scion-types.yang
@@ -1,0 +1,204 @@
+module scion-types {
+  namespace "urn:scion:scion-types";
+  prefix "sc-ty";
+
+  import ietf-inet-types{
+    prefix "inet";
+  }
+
+  organization
+    "SCION group";
+
+  contact
+  "Some contact here";
+
+  description 
+  "This module contains a useful collection of data defining 
+   common types and enumerations present within the SCION 
+   architecture.
+  ";
+
+  revision 2019-11-15 {
+      description "First revision for proposal.";
+  }
+
+  identity underlay-proto {
+        description "Base identity for all underlay-proto.";
+  }
+
+  identity underlay-proto-ipv4{
+    description "underlay IPv4.";
+    base "sc-ty:underlay-proto";
+  }
+
+  identity underlay-udp-ipv4{
+    description "underlay UDP over IPv4.";
+    base "sc-ty:underlay-proto-ipv4";
+  }
+
+  identity underlay-tcp-ipv4{
+    description "underlay TCP over IPv4.";
+    base "sc-ty:underlay-proto-ipv4";
+  }
+
+  identity underlay-proto-ipv6{
+    description "underlay IPv6.";
+    base "sc-ty:underlay-proto";
+  }
+
+  identity underlay-udp-ipv6{
+    description "underlay UDP over IPv6.";
+    base "sc-ty:underlay-proto-ipv6";
+  }
+
+  identity underlay-tcp-ipv6{
+    description "underlay TCP over IPv6.";
+    base "sc-ty:underlay-proto-ipv6";
+  }
+  identity db-backend-base{
+    description "Base identity for DB backend";
+  }
+
+  identity db-sqlite{
+    description "Sqlite type for DB backend ";
+    base db-backend-base;
+  }
+
+  identity cache-backend-base{
+    description "Base identity for cache backend";
+  }
+
+  identity mem-cache{
+    description "Mem-cache type for cache backend";
+    base cache-backend-base;
+  }
+
+  identity topology-attribute-base{
+    description "Base identity for attributes list on topology";
+    reference 
+    "https://github.com/scionproto/scion/blob/master/doc/ControlPlanePKI.md#primary-ases";
+  }
+
+  identity topology-attribute-core{
+    description "Core attribute on topology";
+    base topology-attribute-base;
+  }
+
+  identity topology-attribute-voting{
+    description "Voting attribute on topology";
+    base topology-attribute-base;
+  }
+
+  identity topology-attribute-authoritative{
+    description "Authoritative attribute on topology";
+    base topology-attribute-base;
+  }
+
+  identity topology-attribute-issuing{
+    description "Issuing attribute on topology";
+    base topology-attribute-base;
+  }
+
+  typedef isd-as-type{
+    description "This is the type definition for the ISD-AS name";
+    type string{
+      pattern "[0-9]+-[0-9a-fA-F]{1,4}:[0-9a-fA-F]{1,4}:[0-9a-fA-F]{1,4}";
+    }  
+  }
+
+  typedef file-mode-string{
+    description "Unix file mode in octal-string representation ";
+    type string{
+      pattern "[0-7]{4}";
+    }
+  }
+
+  typedef time-string{
+    description "It expresses time type configurations";
+    type string{
+      pattern '([0-9]+)(y|w|d|h|m|s|ms|us|µs|ns)';
+    }
+  }
+
+  typedef link-type{
+    description 
+    "The type of link definition between two AS which can take any
+    of the values in the enumeration.
+    ";
+    type enumeration {
+      enum Child{
+        description "Link to CHILD.";
+      }
+      enum Parent{
+        description "Link to PARENT ISD-AS.";
+      }
+      enum Peer{
+        description "Link to PEER ISD-AS.";
+      }
+      enum Core{
+        description "Link to CORE ISD-AS";
+      }
+    }
+  }
+
+  typedef loggin-level{
+    description 
+    "
+    File logging level.
+    ";
+    type enumeration{
+      enum Trace;
+      enum Debug;
+      enum Info;
+      enum Warn;
+      enum Error;
+      enum Crit;
+    }
+  }
+
+  typedef fail-action{
+    description
+    "
+    Enumeration of possible actions to take in case of fail
+    of fetching topology from the discovery service on start.
+    ";
+
+    type enumeration{
+      enum Fatal{
+        description "Exit process.";
+      }
+      enum Continue{
+        description "Log error and continue with execution.";
+      }
+    }
+  }
+
+  grouping address-port{
+    leaf address{
+      type inet:ip-address;
+      mandatory true;
+      reference 
+        "RFC 6991: Common YANG Data Types";
+    }
+    leaf l4-port{
+      type inet:port-number;
+      mandatory true;
+      reference 
+        "RFC 6991: Common YANG Data Types";
+    }
+  }
+
+  grouping host-ip-port{
+    leaf address{
+      type union{
+        type inet:ip-address;
+        type string;
+      }
+    }
+    leaf l4-port{
+      type inet:port-number;
+      reference 
+        "RFC 6991: Common YANG Data Types";
+    }
+  }
+}


### PR DESCRIPTION
Yang modules:
I divided them into 3 modules:
scion-types.yang: Typedefs, types, common grouping, identities and so on for the topology.

scion-interfaces.yang: data structure with grouping for interface structure. I separated, just in case it could be reusable, besides it makes the scion-topology more readable.

scion-topology.yang: Data model exposing, somehow, a mapping for the topology.json file. With this setting, every device would maintain a copy from the topology for its ISD-AS (likewise now with the topology.json file). It'd be interesting considering whether the services should be exposed separately, i.e. creating a module for border-routers, beacon-servers, and so on, in case they don't need to maintain the entire configuration. 

Python script:
So far it parses the scion-topology data store and outputs one topology.json into every service folder for the ISD-AS (it takes the isd-as defined within the same datastore).

Some things to check and provide any remarks :
1. Servers and BR names pattern is correct
2. ISD-AS pattern is correct
3. Link enumeration is correct 
4. Improving descriptions if possible
5. Check solution for underlays and addresses in BR-interfaces
6. Must scion-topology.yang expose any state data.
7. Considering IPv6 within the parser (if the structure is kept in the topology.json the change should be trivial).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3417)
<!-- Reviewable:end -->
