### PR TITLE
messenger: use addr.AppAddr less in tests

### DIFF
--- a/go/lib/infra/messenger/BUILD.bazel
+++ b/go/lib/infra/messenger/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "addr_test.go",
+        "export_test.go",
         "messenger_test.go",
     ],
     embed = [":go_default_library"],
@@ -62,6 +63,6 @@ go_test(
         "//go/lib/svc:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )

--- a/go/lib/infra/messenger/export_test.go
+++ b/go/lib/infra/messenger/export_test.go
@@ -1,0 +1,23 @@
+package messenger
+
+import (
+	"context"
+	"net"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/svc"
+)
+
+func (r AddressRewriter) BuildFullAddress(ctx context.Context, a net.Addr) (*snet.Addr, error) {
+	return r.buildFullAddress(ctx, a)
+}
+
+func (r AddressRewriter) ResolveIfSVC(ctx context.Context, p snet.Path,
+	a *addr.AppAddr) (snet.Path, *addr.AppAddr, bool, error) {
+	return r.resolveIfSVC(ctx, p, a)
+}
+
+func ParseReply(reply *svc.Reply) (*addr.AppAddr, error) {
+	return parseReply(reply)
+}


### PR DESCRIPTION
As part of the remote `add.AppAddr` effort.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3420)
<!-- Reviewable:end -->
