### PR TITLE
sciond: Change refresh mechanism to be safer

### DIFF
--- a/go/lib/infra/modules/segfetcher/fetcher.go
+++ b/go/lib/infra/modules/segfetcher/fetcher.go
@@ -84,7 +84,7 @@ func (cfg FetcherConfig) New() *Fetcher {
 	return &Fetcher{
 		Validator: cfg.Validator,
 		Splitter:  cfg.Splitter,
-		Resolver:  NewResolver(cfg.PathDB, cfg.RevCache, !cfg.SciondMode),
+		Resolver:  NewResolver(cfg.PathDB, cfg.RevCache),
 		Requester: &DefaultRequester{API: cfg.RequestAPI, DstProvider: cfg.DstProvider},
 		ReplyHandler: &seghandler.Handler{
 			Verifier: &seghandler.DefaultVerifier{Verifier: cfg.VerificationFactory.NewVerifier()},

--- a/go/lib/infra/modules/segfetcher/request.go
+++ b/go/lib/infra/modules/segfetcher/request.go
@@ -66,6 +66,9 @@ type RequestSet struct {
 	Up    Request
 	Cores Requests
 	Down  Request
+	// Fetch indicates the request should always be fetched from remote,
+	// regardless of whether is is cached.
+	Fetch bool
 }
 
 // IsLoaded returns true if all non-zero requests in the set are in state

--- a/go/sciond/internal/fetcher/BUILD.bazel
+++ b/go/sciond/internal/fetcher/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//go/lib/infra/modules/segfetcher:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/pathdb:go_default_library",
-        "//go/lib/pathdb/query:go_default_library",
         "//go/lib/pathpol:go_default_library",
         "//go/lib/revcache:go_default_library",
         "//go/lib/sciond:go_default_library",

--- a/go/sciond/internal/fetcher/splitter.go
+++ b/go/sciond/internal/fetcher/splitter.go
@@ -55,22 +55,31 @@ func (s *sciondRequestSplitter) Split(ctx context.Context,
 			Up:    segfetcher.Request{Src: r.Src, Dst: s.toWildCard(r.Src)},
 			Cores: []segfetcher.Request{{Src: s.toWildCard(r.Src), Dst: s.toWildCard(r.Dst)}},
 			Down:  segfetcher.Request{Src: s.toWildCard(r.Dst), Dst: r.Dst},
+			Fetch: r.State == segfetcher.Fetch,
 		}, nil
 	case !srcCore && dstCore:
 		if s.isISDLocal(r.Dst) && s.isWildCard(r.Dst) {
-			return segfetcher.RequestSet{Up: r}, nil
+			return segfetcher.RequestSet{
+				Up:    r,
+				Fetch: r.State == segfetcher.Fetch,
+			}, nil
 		}
 		return segfetcher.RequestSet{
 			Up:    segfetcher.Request{Src: r.Src, Dst: s.toWildCard(r.Src)},
 			Cores: []segfetcher.Request{{Src: s.toWildCard(r.Src), Dst: r.Dst}},
+			Fetch: r.State == segfetcher.Fetch,
 		}, nil
 	case srcCore && !dstCore:
 		return segfetcher.RequestSet{
 			Cores: []segfetcher.Request{{Src: r.Src, Dst: s.toWildCard(r.Dst)}},
 			Down:  segfetcher.Request{Src: s.toWildCard(r.Dst), Dst: r.Dst},
+			Fetch: r.State == segfetcher.Fetch,
 		}, nil
 	default:
-		return segfetcher.RequestSet{Cores: []segfetcher.Request{r}}, nil
+		return segfetcher.RequestSet{
+			Cores: []segfetcher.Request{r},
+			Fetch: r.State == segfetcher.Fetch,
+		}, nil
 	}
 }
 

--- a/go/sciond/internal/fetcher/splitter_test.go
+++ b/go/sciond/internal/fetcher/splitter_test.go
@@ -156,6 +156,20 @@ func TestRequestSplitter(t *testing.T) {
 				Down:  segfetcher.Request{Src: isd2, Dst: non_core_211},
 			},
 		},
+		"Up down non-local passes state": {
+			LocalIA: non_core_111,
+			Request: segfetcher.Request{
+				State: segfetcher.Fetch,
+				Src:   non_core_111,
+				Dst:   non_core_211,
+			},
+			ExpectedSet: segfetcher.RequestSet{
+				Up:    segfetcher.Request{Src: non_core_111, Dst: isd1},
+				Cores: []segfetcher.Request{{Src: isd1, Dst: isd2}},
+				Down:  segfetcher.Request{Src: isd2, Dst: non_core_211},
+				Fetch: true,
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Instead of deleting next query entries, just always request at the PS.
This can prevent a weird interaction between concurrent requests, which would lead to 0 cached paths.

Marked as breaking because the behavior changes, i.e., sciond no longer deletes anything in the DB on the refresh flag.

Fixes #2871
Fixes #3416

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3434)
<!-- Reviewable:end -->
