### PR TITLE
Use debian 9 packages for perapp containers

### DIFF
--- a/docker/perapp/scion_app.bzl
+++ b/docker/perapp/scion_app.bzl
@@ -1,6 +1,6 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@package_bundle_debian10//file:packages.bzl", "packages")
+load("@package_bundle//file:packages.bzl", "packages")
 
 # NOTE: In the git repo licenses.tar is an empty tarball.
 # It is replaced by an actual tarball in the base docker image.


### PR DESCRIPTION
We still need package_bundle_debian10 because distroless base loads this unconditionally.
(see https://github.com/GoogleContainerTools/distroless/blob/b54513ef989c81d68cb27d9c7958697e2fedd2c4/base/base.bzl#L5)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3436)
<!-- Reviewable:end -->
