### PR TITLE
segfetcher: Add LocalInfo to resolver

### DIFF
--- a/go/lib/infra/modules/segfetcher/fetcher.go
+++ b/go/lib/infra/modules/segfetcher/fetcher.go
@@ -75,8 +75,10 @@ type FetcherConfig struct {
 	// SciondMode enables sciond mode, this means it uses the local CS to fetch
 	// crypto material and considers revocations in the path lookup.
 	SciondMode bool
-	// The namespace used for metrics.
+	// MetricsNamespace is the namespace used for metrics.
 	MetricsNamespace string
+	// LocalInfo provides information about local segments.
+	LocalInfo LocalInfo
 }
 
 // New creates a new fetcher from the configuration.
@@ -84,7 +86,7 @@ func (cfg FetcherConfig) New() *Fetcher {
 	return &Fetcher{
 		Validator: cfg.Validator,
 		Splitter:  cfg.Splitter,
-		Resolver:  NewResolver(cfg.PathDB, cfg.RevCache),
+		Resolver:  NewResolver(cfg.PathDB, cfg.RevCache, cfg.LocalInfo),
 		Requester: &DefaultRequester{API: cfg.RequestAPI, DstProvider: cfg.DstProvider},
 		ReplyHandler: &seghandler.Handler{
 			Verifier: &seghandler.DefaultVerifier{Verifier: cfg.VerificationFactory.NewVerifier()},

--- a/go/lib/infra/modules/segfetcher/resolver_test.go
+++ b/go/lib/infra/modules/segfetcher/resolver_test.go
@@ -94,7 +94,7 @@ func (rt resolverTest) run(t *testing.T) {
 	} else {
 		revCache.EXPECT().Get(gomock.Any(), gomock.Any()).AnyTimes()
 	}
-	resolver := segfetcher.NewResolver(db, revCache, localInfoNever{})
+	resolver := segfetcher.NewResolver(db, revCache, neverLocal{})
 	segs, remainingReqs, err := resolver.Resolve(context.Background(), rt.Segs, rt.Req)
 	assert.Equal(t, rt.ExpectedSegments, segs)
 	assert.Equal(t, rt.ExpectedReqSet, remainingReqs)
@@ -876,9 +876,6 @@ func (m keySetContains) String() string {
 	return fmt.Sprintf("revcache.KeySet containing %v", m.keys)
 }
 
-type localInfoNever struct {
-}
+type neverLocal struct{}
 
-func (localInfoNever) IsSegLocal(_ context.Context, _, _ addr.IA) (bool, error) {
-	return false, nil
-}
+func (neverLocal) IsSegLocal(_ context.Context, _, _ addr.IA) (bool, error) { return false, nil }

--- a/go/lib/infra/modules/segfetcher/resolver_test.go
+++ b/go/lib/infra/modules/segfetcher/resolver_test.go
@@ -94,7 +94,7 @@ func (rt resolverTest) run(t *testing.T) {
 	} else {
 		revCache.EXPECT().Get(gomock.Any(), gomock.Any()).AnyTimes()
 	}
-	resolver := segfetcher.NewResolver(db, revCache)
+	resolver := segfetcher.NewResolver(db, revCache, localInfoNever{})
 	segs, remainingReqs, err := resolver.Resolve(context.Background(), rt.Segs, rt.Req)
 	assert.Equal(t, rt.ExpectedSegments, segs)
 	assert.Equal(t, rt.ExpectedReqSet, remainingReqs)
@@ -874,4 +874,11 @@ func (m keySetContains) Matches(other interface{}) bool {
 
 func (m keySetContains) String() string {
 	return fmt.Sprintf("revcache.KeySet containing %v", m.keys)
+}
+
+type localInfoNever struct {
+}
+
+func (localInfoNever) IsSegLocal(_ context.Context, _, _ addr.IA) (bool, error) {
+	return false, nil
 }

--- a/go/path_srv/internal/segreq/handler.go
+++ b/go/path_srv/internal/segreq/handler.go
@@ -50,6 +50,7 @@ func NewHandler(args handlers.HandlerArgs) infra.Handler {
 			DstProvider:         createDstProvider(args, core),
 			Splitter:            &Splitter{ASInspector: args.ASInspector},
 			MetricsNamespace:    metrics.Namespace,
+			LocalInfo:           args.PathDB.(*PathDB).LocalInfo,
 		}.New(),
 		revCache: args.RevCache,
 	}

--- a/go/sciond/internal/fetcher/fetcher.go
+++ b/go/sciond/internal/fetcher/fetcher.go
@@ -80,6 +80,7 @@ func NewFetcher(messenger infra.Messenger, pathDB pathdb.PathDB, trustStore Trus
 			Splitter:            NewRequestSplitter(localIA, trustStore),
 			SciondMode:          true,
 			MetricsNamespace:    metrics.Namespace,
+			LocalInfo:           neverLocal{},
 		}.New(),
 	}
 }
@@ -323,3 +324,7 @@ type dstProvider struct {
 func (r *dstProvider) Dst(_ context.Context, _ segfetcher.Request) (net.Addr, error) {
 	return &snet.Addr{IA: r.IA, Host: addr.NewSVCUDPAppAddr(addr.SvcPS)}, nil
 }
+
+type neverLocal struct{}
+
+func (neverLocal) IsSegLocal(_ context.Context, _, _ addr.IA) (bool, error) { return false, nil }


### PR DESCRIPTION
This is to make sure that we never try to fetch segments that are locally cached.
This happened some times in the past.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3437)
<!-- Reviewable:end -->
