### PR TITLE
sciond: do not use snet.Addr in config

### DIFF
--- a/go/sciond/internal/config/BUILD.bazel
+++ b/go/sciond/internal/config/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//go/lib/pathstorage:go_default_library",
         "//go/lib/sciond:go_default_library",
         "//go/lib/serrors:go_default_library",
-        "//go/lib/snet:go_default_library",
         "//go/lib/truststorage:go_default_library",
         "//go/lib/util:go_default_library",
     ],

--- a/go/sciond/internal/config/config.go
+++ b/go/sciond/internal/config/config.go
@@ -26,7 +26,6 @@ import (
 	"github.com/scionproto/scion/go/lib/pathstorage"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/serrors"
-	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/truststorage"
 	"github.com/scionproto/scion/go/lib/util"
 )
@@ -107,10 +106,7 @@ type SDConfig struct {
 	DeleteSocket bool
 	// Public is the local address to listen on for SCION messages (if Bind is
 	// not set), and to send out messages to other nodes.
-	Public *snet.Addr
-	// If set, Bind is the preferred local address to listen on for SCION
-	// messages.
-	Bind *snet.Addr
+	Public string
 	// PathDB contains the configuration for the PathDB connection.
 	PathDB pathstorage.PathDBConf
 	// RevCache contains the configuration for the RevCache connection.

--- a/go/sciond/internal/config/config_test.go
+++ b/go/sciond/internal/config/config_test.go
@@ -66,7 +66,7 @@ func CheckTestSDConfig(t *testing.T, cfg *SDConfig, id string) {
 	assert.Equal(t, sciond.DefaultSCIONDPath, cfg.Reliable)
 	assert.Equal(t, "/run/shm/sciond/default-unix.sock", cfg.Unix)
 	assert.Equal(t, sciond.DefaultSocketFileMode, int(cfg.SocketFileMode))
-	assert.Equal(t, "1-ff00:0:110,[127.0.0.1]:0", cfg.Public.String())
+	assert.Equal(t, "1-ff00:0:110,[127.0.0.1]:0", cfg.Public)
 	assert.Equal(t, DefaultQueryInterval, cfg.QueryInterval.Duration)
 	assert.False(t, cfg.DeleteSocket)
 }

--- a/go/sciond/internal/config/config_test.go
+++ b/go/sciond/internal/config/config_test.go
@@ -66,7 +66,7 @@ func CheckTestSDConfig(t *testing.T, cfg *SDConfig, id string) {
 	assert.Equal(t, sciond.DefaultSCIONDPath, cfg.Reliable)
 	assert.Equal(t, "/run/shm/sciond/default-unix.sock", cfg.Unix)
 	assert.Equal(t, sciond.DefaultSocketFileMode, int(cfg.SocketFileMode))
-	assert.Equal(t, "1-ff00:0:110,[127.0.0.1]:0", cfg.Public)
+	assert.Equal(t, "127.0.0.1:0", cfg.Public)
 	assert.Equal(t, DefaultQueryInterval, cfg.QueryInterval.Duration)
 	assert.False(t, cfg.DeleteSocket)
 }

--- a/go/sciond/internal/config/sample.go
+++ b/go/sciond/internal/config/sample.go
@@ -31,8 +31,8 @@ SocketFileMode = "0770"
 # If set to True, the socket is removed before being created. (default false)
 DeleteSocket = false
 
-# Local address to listen on for SCION messages,
-# and to send out messages to other nodes. (required)
+# Listening address to register with the local dispatcher
+# in order to receive and send SCION messages to other nodes. (required)
 Public = "127.0.0.1:0"
 
 # The time after which segments for a destination are refetched. (default 5m)

--- a/go/sciond/internal/config/sample.go
+++ b/go/sciond/internal/config/sample.go
@@ -33,7 +33,7 @@ DeleteSocket = false
 
 # Local address to listen on for SCION messages,
 # and to send out messages to other nodes. (required)
-Public = "1-ff00:0:110,[127.0.0.1]:0"
+Public = "127.0.0.1:0"
 
 # The time after which segments for a destination are refetched. (default 5m)
 QueryInterval = "5m"

--- a/go/sciond/internal/config/sample.go
+++ b/go/sciond/internal/config/sample.go
@@ -31,13 +31,9 @@ SocketFileMode = "0770"
 # If set to True, the socket is removed before being created. (default false)
 DeleteSocket = false
 
-# Local address to listen on for SCION messages (if Bind is not set),
+# Local address to listen on for SCION messages,
 # and to send out messages to other nodes. (required)
 Public = "1-ff00:0:110,[127.0.0.1]:0"
-
-# If set, Bind is the preferred local address to listen on for SCION
-# messages.
-# Bind = "1-ff00:0:110,[127.0.0.1]:0"
 
 # The time after which segments for a destination are refetched. (default 5m)
 QueryInterval = "5m"

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -118,9 +118,10 @@ func realMain() int {
 	defer trCloser.Close()
 	opentracing.SetGlobalTracer(tracer)
 
-	var publicIP *net.UDPAddr
-	if p := cfg.SD.Public; p != nil {
-		publicIP = p.ToNetUDPAddr()
+	publicIP, err := net.ResolveUDPAddr("udp", cfg.SD.Public)
+	if err != nil {
+		log.Crit("Unable to resolve listening address", "err", err, "addr", publicIP)
+		return 1
 	}
 
 	nc := infraenv.NetworkConfig{

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -275,7 +275,7 @@ class GoGenerator(object):
             'sd': {
                 'Reliable': os.path.join(SCIOND_API_SOCKDIR, "%s.sock" % name),
                 'Unix': os.path.join(SCIOND_API_SOCKDIR, "%s.unix" % name),
-                'Public': '%s,[127.0.0.1]:0' % ia,
+                'Public': '127.0.0.1:0',
                 'pathDB': {
                     'Connection': os.path.join(self.db_dir, '%s.path.db' % name),
                 },


### PR DESCRIPTION
sciond config needs only the listening IP address.
The IA is being taken from topo `itopo.Get().IA()`

This commit introduces a breaking change in the sciond config.
The public now should be of `<ip>:<port>`, not `ia,<ip>:port`


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3444)
<!-- Reviewable:end -->
