### PR TITLE
Ignore ENETUNREACH, EHOSTUNREACH in border io

### DIFF
--- a/go/border/io.go
+++ b/go/border/io.go
@@ -343,8 +343,7 @@ func isHostUnreachable(err error) bool {
 	return isSyscallErrno(err, syscall.EHOSTUNREACH)
 }
 
-func isSyscallErrno(err error, errno syscall.Errno) bool
-{
+func isSyscallErrno(err error, errno syscall.Errno) bool {
 	netErr, ok := err.(*net.OpError)
 	if !ok {
 		return false

--- a/go/border/io.go
+++ b/go/border/io.go
@@ -328,10 +328,23 @@ func shiftUnwrittenPkts(epkts ringbuf.EntryList, pktsWritten int) ringbuf.EntryL
 
 // isRecoverableErr checks whether an non-temporary error is recoverable.
 func isRecoverableErr(err error) bool {
-	return isConnRefused(err)
+	return isConnRefused(err) || isNetUnreachable(err) || isHostUnreachable(err)
 }
 
 func isConnRefused(err error) bool {
+	return isSyscallErrno(err, syscall.ECONNREFUSED)
+}
+
+func isNetUnreachable(err error) bool {
+	return isSyscallErrno(err, syscall.ENETUNREACH)
+}
+
+func isHostUnreachable(err error) bool {
+	return isSyscallErrno(err, syscall.EHOSTUNREACH)
+}
+
+func isSyscallErrno(err error, errno syscall.Errno) bool
+{
 	netErr, ok := err.(*net.OpError)
 	if !ok {
 		return false
@@ -340,7 +353,7 @@ func isConnRefused(err error) bool {
 	if !ok {
 		return false
 	}
-	return osErr.Err == syscall.ECONNREFUSED
+	return osErr.Err == errno
 }
 
 func min(a, b int) int {


### PR DESCRIPTION
When forwarding an incoming packet, ENETUNREACH can be caused by trying
to send the packet to a different address family than what the socket is
listening on (e.g. IPv6 destination address, but border routers internal
address is configured to use IPv4).
As the destination address is controlled by an end host outside the AS,
the router should not abort in this case.

Similiarly, EHOSTUNREACH can be caused by a bad destination address;
from the manual:

> No valid routing table entry matches the destination address.  This error can be caused by an ICMP message from a remote router or for the local routing table.

So this error can be caused by any of:
- a misconfiguration of IP routes on the border router
- specific configuration on the border router to ensure packets are only
  forwarded to the local AS, and a destination address that does not match
- a (temporary) network failure in the local AS

As there is no clear way to destinguish misconfigurations from bad
destination addresses or transient errors, it seems best to just treat
always this as recoverable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3448)
<!-- Reviewable:end -->
