### PR TITLE
Fix address string for IPv6 for QUIC Infra RPC

### DIFF
--- a/go/lib/infra/rpc/rpc.go
+++ b/go/lib/infra/rpc/rpc.go
@@ -189,7 +189,7 @@ func (c *Client) sendRequest() error {
 // with QUIC SNI.
 func computeAddressStr(address net.Addr) string {
 	if v, ok := address.(*snet.UDPAddr); ok {
-		return fmt.Sprintf("%s:%d", v.Host.IP, v.Host.Port)
+		return fmt.Sprintf("[%s]:%d", v.Host.IP, v.Host.Port)
 	}
 	return address.String()
 }


### PR DESCRIPTION
When dialing a QUIC connection, a UDP address is turned into a string which is then again parsed by the QUIC library.
When passing an IPv6 address, the host part of address must be enclosed in brackets, otherwise the parsing  will fail with 'too many colons in address'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3452)
<!-- Reviewable:end -->
