### PR TITLE
TrustStore: Resolver handles certificate chains

### DIFF
--- a/go/lib/infra/modules/trust/v2/main_test.go
+++ b/go/lib/infra/modules/trust/v2/main_test.go
@@ -88,6 +88,7 @@ var (
 // Chains
 var (
 	chain110v1 = ChainDesc{IA: ia110, Version: 1}
+	chain120v1 = ChainDesc{IA: ia120, Version: 1}
 )
 
 func TestMain(m *testing.M) {

--- a/go/lib/infra/modules/trust/v2/resolver_test.go
+++ b/go/lib/infra/modules/trust/v2/resolver_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/xerrors"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	trust "github.com/scionproto/scion/go/lib/infra/modules/trust/v2"
@@ -111,6 +112,157 @@ func TestResolverTRC(t *testing.T) {
 			decTRC, err := r.TRC(context.Background(), test.TRCReq, nil)
 			xtest.AssertErrorsIs(t, err, test.ExpectedErr)
 			assert.Equal(t, expected, decTRC)
+		})
+	}
+}
+
+func TestResolverChain(t *testing.T) {
+	internal := serrors.New("internal")
+	type mocks struct {
+		DB       *mock_v2.MockDB
+		Inserter *mock_v2.MockInserter
+		RPC      *mock_v2.MockRPC
+	}
+	tests := map[string]struct {
+		Expect      func(t *testing.T, m mocks) decoded.Chain
+		ChainReq    trust.ChainReq
+		ExpectedErr error
+	}{
+		"valid, TRC in DB": {
+			Expect: func(t *testing.T, m mocks) decoded.Chain {
+				req := trust.ChainReq{IA: ia110, Version: scrypto.LatestVer}
+				dec := loadChain(t, chain110v1)
+				m.RPC.EXPECT().GetCertChain(gomock.Any(), req, nil).Return(
+					dec.Raw, nil,
+				)
+				decTRC := loadTRC(t, trc1v1)
+				m.Inserter.EXPECT().InsertChain(gomock.Any(), dec, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, dec decoded.Chain, p trust.TRCProviderFunc) error {
+						trc, err := p(ctx, dec.Issuer.Subject.I, dec.Issuer.Issuer.TRCVersion)
+						require.NoError(t, err)
+						assert.Equal(t, decTRC.TRC, trc)
+						return err
+					},
+				)
+				m.DB.EXPECT().GetTRC(gomock.Any(), addr.ISD(1), scrypto.Version(1)).Return(
+					decTRC.TRC, nil,
+				)
+				return dec
+			},
+			ChainReq: trust.ChainReq{IA: ia110, Version: scrypto.LatestVer},
+		},
+		"RPC fail": {
+			Expect: func(t *testing.T, m mocks) decoded.Chain {
+				req := trust.ChainReq{IA: ia110, Version: scrypto.LatestVer}
+				m.RPC.EXPECT().GetCertChain(gomock.Any(), req, nil).Return(
+					nil, internal,
+				)
+				return loadChain(t, chain110v1)
+			},
+			ChainReq:    trust.ChainReq{IA: ia110, Version: scrypto.LatestVer},
+			ExpectedErr: internal,
+		},
+		"garbage chain": {
+			Expect: func(t *testing.T, m mocks) decoded.Chain {
+				req := trust.ChainReq{IA: ia110, Version: scrypto.LatestVer}
+				m.RPC.EXPECT().GetCertChain(gomock.Any(), req, nil).Return(
+					[]byte("some_garbage"), nil,
+				)
+				return loadChain(t, chain110v1)
+			},
+			ChainReq:    trust.ChainReq{IA: ia110, Version: scrypto.LatestVer},
+			ExpectedErr: decoded.ErrParse,
+		},
+		"wrong subject": {
+			Expect: func(t *testing.T, m mocks) decoded.Chain {
+				req := trust.ChainReq{IA: ia110, Version: scrypto.LatestVer}
+				m.RPC.EXPECT().GetCertChain(gomock.Any(), req, nil).Return(
+					loadChain(t, chain120v1).Raw, nil,
+				)
+				return loadChain(t, chain110v1)
+			},
+			ChainReq:    trust.ChainReq{IA: ia110, Version: scrypto.LatestVer},
+			ExpectedErr: trust.ErrInvalidResponse,
+		},
+		"wrong version": {
+			Expect: func(t *testing.T, m mocks) decoded.Chain {
+				req := trust.ChainReq{IA: ia110, Version: 2}
+				m.RPC.EXPECT().GetCertChain(gomock.Any(), req, nil).Return(
+					loadChain(t, chain110v1).Raw, nil,
+				)
+				return loadChain(t, chain110v1)
+			},
+			ChainReq:    trust.ChainReq{IA: ia110, Version: 2},
+			ExpectedErr: trust.ErrInvalidResponse,
+		},
+		"DB error": {
+			Expect: func(t *testing.T, m mocks) decoded.Chain {
+				req := trust.ChainReq{IA: ia110, Version: scrypto.LatestVer}
+				dec := loadChain(t, chain110v1)
+				m.RPC.EXPECT().GetCertChain(gomock.Any(), req, nil).Return(
+					dec.Raw, nil,
+				)
+				m.Inserter.EXPECT().InsertChain(gomock.Any(), dec, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, dec decoded.Chain, p trust.TRCProviderFunc) error {
+						_, err := p(ctx, dec.Issuer.Subject.I, dec.Issuer.Issuer.TRCVersion)
+						require.Error(t, err)
+						return err
+					},
+				)
+				m.DB.EXPECT().GetTRC(gomock.Any(), addr.ISD(1), scrypto.Version(1)).Return(
+					nil, internal,
+				)
+				return dec
+			},
+			ChainReq:    trust.ChainReq{IA: ia110, Version: scrypto.LatestVer},
+			ExpectedErr: internal,
+		},
+		"TRC RPC error": {
+			Expect: func(t *testing.T, m mocks) decoded.Chain {
+				req := trust.ChainReq{IA: ia110, Version: scrypto.LatestVer}
+				dec := loadChain(t, chain110v1)
+				m.RPC.EXPECT().GetCertChain(gomock.Any(), req, nil).Return(
+					dec.Raw, nil,
+				)
+				m.Inserter.EXPECT().InsertChain(gomock.Any(), dec, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, dec decoded.Chain, p trust.TRCProviderFunc) error {
+						_, err := p(ctx, dec.Issuer.Subject.I, dec.Issuer.Issuer.TRCVersion)
+						xtest.AssertErrorsIs(t, err, internal)
+						return err
+					},
+				)
+				m.DB.EXPECT().GetTRC(gomock.Any(), addr.ISD(1), scrypto.Version(1)).Return(
+					nil, trust.ErrNotFound,
+				)
+				m.DB.EXPECT().GetTRC(gomock.Any(), addr.ISD(1), scrypto.LatestVer).Return(
+					nil, internal,
+				)
+				return dec
+			},
+			ChainReq:    trust.ChainReq{IA: ia110, Version: scrypto.LatestVer},
+			ExpectedErr: internal,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mctrl := gomock.NewController(t)
+			defer mctrl.Finish()
+			m := mocks{
+				DB:       mock_v2.NewMockDB(mctrl),
+				Inserter: mock_v2.NewMockInserter(mctrl),
+				RPC:      mock_v2.NewMockRPC(mctrl),
+			}
+			expected := test.Expect(t, m)
+			r := trust.NewResolver(m.DB, m.Inserter, m.RPC)
+			dec, err := r.Chain(context.Background(), test.ChainReq, nil)
+			if test.ExpectedErr != nil {
+				require.Error(t, err)
+				assert.Truef(t, xerrors.Is(err, test.ExpectedErr),
+					"actual: %s\nexpected: %s", err, test.ExpectedErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, expected, dec)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR adds the capability to resolve certificate chains to the
resolver.

fixes #3469

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3495)
<!-- Reviewable:end -->
