### PR TITLE
TrustStore: Provider handles certificate chains

### DIFF
--- a/go/lib/infra/common.go
+++ b/go/lib/infra/common.go
@@ -523,9 +523,9 @@ type ASInspectorOpts struct {
 // ChainOpts contains the options when fetching certificate chains.
 type ChainOpts struct {
 	TrustStoreOpts
-	// AllowInactiveTRC allows retrieving chains authenticated by no longer
+	// AllowInactive allows retrieving chains authenticated by no longer
 	// active TRCs.
-	AllowInactiveTRC bool
+	AllowInactive bool
 }
 
 // TRCOpts contains the options when fetching TRCs.

--- a/go/lib/infra/modules/trust/handlers.go
+++ b/go/lib/infra/modules/trust/handlers.go
@@ -195,8 +195,8 @@ func (h *chainReqHandler) Handle() *infra.HandlerResult {
 		}
 	} else {
 		opts := infra.ChainOpts{
-			TrustStoreOpts:   infra.TrustStoreOpts{LocalOnly: !h.recurse},
-			AllowInactiveTRC: true,
+			TrustStoreOpts: infra.TrustStoreOpts{LocalOnly: !h.recurse},
+			AllowInactive:  true,
 		}
 
 		chain, err = h.store.getChain(subCtx, chainReq.IA(), scrypto.Version(chainReq.Version),

--- a/go/lib/infra/modules/trust/v2/handlers.go
+++ b/go/lib/infra/modules/trust/v2/handlers.go
@@ -67,7 +67,7 @@ func (h *chainReqHandler) Handle() *infra.HandlerResult {
 	}
 	sendAck := messenger.SendAckHelper(ctx, rw)
 	raw, err := h.provider.GetRawChain(ctx, chainReq.IA(), chainReq.Version,
-		infra.ChainOpts{AllowInactiveTRC: true}, h.request.Peer)
+		infra.ChainOpts{AllowInactive: true}, h.request.Peer)
 	if err != nil {
 		logger.Error("[TrustStore:chainReqHandler] Unable to retrieve chain", "err", err)
 		sendAck(proto.Ack_ErrCode_reject, AckNotFound)

--- a/go/lib/infra/modules/trust/v2/handlers_test.go
+++ b/go/lib/infra/modules/trust/v2/handlers_test.go
@@ -81,7 +81,7 @@ func TestChainReqHandler(t *testing.T) {
 					TrustStoreOpts: infra.TrustStoreOpts{
 						LocalOnly: false,
 					},
-					AllowInactiveTRC: true,
+					AllowInactive: true,
 				}
 				p := mock_v2.NewMockCryptoProvider(ctrl)
 				p.EXPECT().GetRawChain(gomock.Any(), ia110, scrypto.LatestVer,
@@ -106,7 +106,7 @@ func TestChainReqHandler(t *testing.T) {
 					TrustStoreOpts: infra.TrustStoreOpts{
 						LocalOnly: false,
 					},
-					AllowInactiveTRC: true,
+					AllowInactive: true,
 				}
 				p := mock_v2.NewMockCryptoProvider(ctrl)
 				p.EXPECT().GetRawChain(gomock.Any(), ia110, scrypto.LatestVer,
@@ -131,7 +131,7 @@ func TestChainReqHandler(t *testing.T) {
 					TrustStoreOpts: infra.TrustStoreOpts{
 						LocalOnly: false,
 					},
-					AllowInactiveTRC: true,
+					AllowInactive: true,
 				}
 				p := mock_v2.NewMockCryptoProvider(ctrl)
 				p.EXPECT().GetRawChain(gomock.Any(), ia110, scrypto.LatestVer,

--- a/go/lib/infra/modules/trust/v2/provider_test.go
+++ b/go/lib/infra/modules/trust/v2/provider_test.go
@@ -1171,8 +1171,7 @@ func TestCryptoProviderGetRawChain(t *testing.T) {
 				test.DB(t, mctrl),
 				test.Recurser(t, mctrl),
 				test.Resolver(t, mctrl),
-				test.Router(t, mctrl),
-				false)
+				test.Router(t, mctrl))
 			raw, err := p.GetRawChain(nil, test.ChainDesc.IA, test.ChainDesc.Version,
 				test.Opts, nil)
 			xtest.AssertErrorsIs(t, err, test.ExpectedErr)

--- a/go/lib/infra/modules/trust/v2/provider_test.go
+++ b/go/lib/infra/modules/trust/v2/provider_test.go
@@ -678,8 +678,8 @@ func TestCryptoProviderGetRawChain(t *testing.T) {
 					trust.KeyInfo{
 						TRC: trust.TRCInfo{
 							Validity:    info.Validity,
-							GracePeriod: time.Hour,
-							Version:     dec.TRC.Version,
+							GracePeriod: 0,
+							Version:     1,
 						},
 						Version: 1,
 					}, nil,
@@ -730,8 +730,8 @@ func TestCryptoProviderGetRawChain(t *testing.T) {
 					trust.KeyInfo{
 						TRC: trust.TRCInfo{
 							Validity:    info.Validity,
-							GracePeriod: time.Hour,
-							Version:     dec.TRC.Version,
+							GracePeriod: 0,
+							Version:     1,
 						},
 						Version: 1,
 					}, nil,
@@ -958,8 +958,8 @@ func TestCryptoProviderGetRawChain(t *testing.T) {
 					trust.KeyInfo{
 						TRC: trust.TRCInfo{
 							Validity:    info.Validity,
-							GracePeriod: time.Hour,
-							Version:     dec.TRC.Version,
+							GracePeriod: 0,
+							Version:     1,
 						},
 						Version: 1,
 					}, nil,


### PR DESCRIPTION
This PR adds support for certificate chains to the CryptoProvider in the
trust store.

fixes #3470

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3496)
<!-- Reviewable:end -->
