### PR TITLE
Acceptance: Fix sig reload test

### DIFF
--- a/acceptance/sig_reload_acceptance/test
+++ b/acceptance/sig_reload_acceptance/test
@@ -18,7 +18,7 @@ test_run() {
     jq "del(.ASes.\"$DST_IA\")" $SIG_JSON | sponge $SIG_JSON
     reload_sig "$SRC_IA_FILE" 2
     # Must fail
-    ./bin/sig_ping_acceptance -d -src $SRC_IA -dst $DST_IA || [ $? -eq 1 ]
+    ./bin/sig_ping_acceptance -d -fail -src $SRC_IA -dst $DST_IA
     # Add $DST_IA again to sig.json
     jq ".ASes.\"$DST_IA\" = $HOP_JSON" $SIG_JSON | sponge $SIG_JSON
     reload_sig "$SRC_IA_FILE" 3

--- a/acceptance/sigutil/common.sh
+++ b/acceptance/sigutil/common.sh
@@ -9,6 +9,9 @@ DST_IA=${DST_IA:-1-ff00:0:112}
 test_setup() {
     set -e
     ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -t --sig -n 242.254.0.0/16
+    for sig in gen/ISD1/*/sig*/sig.toml; do
+        sed -i '/\[logging\.file\]/a FlushInterval = 1' "$sig"
+    done
     ./scion.sh run nobuild
     ./tools/dc start 'tester*'
     sleep 7
@@ -24,7 +27,7 @@ print_help() {
 	        execute only the setup phase.
 	    $PROGRAM run
 	        execute only the run phase.
-	    $PROGRAM teardown 
+	    $PROGRAM teardown
 	        execute only the teardown phase.
 	_EOF
 }


### PR DESCRIPTION
This change reduces the logging interval to one second.
Before, the interval was 5 seconds with a sleep of 3 seconds when
checking the logs for some lines. This leads to a lot of unnecessary
flakiness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3502)
<!-- Reviewable:end -->
