### PR TITLE
topology: replace SCIONAddress to net.UDPAddr os

### DIFF
--- a/go/beacon_srv/internal/ifstate/pusher_test.go
+++ b/go/beacon_srv/internal/ifstate/pusher_test.go
@@ -59,7 +59,7 @@ func TestPusherPush(t *testing.T) {
 				for _, br := range topoProvider.Get().BRNames() {
 					a := topoProvider.Get().SBRAddress(br)
 					msgr.EXPECT().SendIfStateInfos(gomock.Any(), gomock.Eq(expectedMsg),
-						gomock.Eq(a.ToXAddr()), gomock.Any())
+						gomock.Eq(a), gomock.Any())
 				}
 			}
 			p.Push(context.Background(), 101)

--- a/go/beacon_srv/internal/ifstate/revoker.go
+++ b/go/beacon_srv/internal/ifstate/revoker.go
@@ -191,7 +191,7 @@ func (p *brPusher) sendIfStateToAllBRs(ctx context.Context, msg *path_mgmt.IFSta
 
 	for _, br := range topo.BRNames() {
 		t := topo.SBRAddress(br)
-		p.sendIfStateToBr(ctx, msg, br, t.ToXAddr(), wg)
+		p.sendIfStateToBr(ctx, msg, br, t, wg)
 	}
 }
 

--- a/go/beacon_srv/internal/ifstate/revoker_test.go
+++ b/go/beacon_srv/internal/ifstate/revoker_test.go
@@ -322,8 +322,8 @@ func checkInterfaces(intfs *Interfaces, nonActive map[common.IFIDType]State) {
 func brId(t *testing.T, topoProvider topology.Provider, saddr *snet.UDPAddr) string {
 	topo := topoProvider.Get()
 	for _, brID := range topo.BRNames() {
-		leg := topo.SBRAddress(brID)
-		if leg.Host.L3.String() == saddr.Host.IP.String() && leg.IA == saddr.IA {
+		a := topo.SBRAddress(brID)
+		if a.Host.IP.Equal(saddr.Host.IP) && a.IA == saddr.IA {
 			return brID
 		}
 	}

--- a/go/beacon_srv/main.go
+++ b/go/beacon_srv/main.go
@@ -192,8 +192,10 @@ func realMain() int {
 	}
 	// We do not need to drain the connection, since the src address is spoofed
 	// to contain the topo address.
-	ohpAddress := topo.PublicAddress(addr.SvcBS, cfg.General.ID)
-	ohpAddress.Port = 0
+	a := topo.PublicAddress(addr.SvcBS, cfg.General.ID)
+	ohpAddress := &net.UDPAddr{
+		IP: append(a.IP[:0:0], a.IP...), Port: 0,
+	}
 	conn, _, err := pktDisp.RegisterTimeout(topo.IA(), ohpAddress, nil,
 		addr.SvcNone, time.Second)
 	if err != nil {

--- a/go/border/rctrl/ctrl.go
+++ b/go/border/rctrl/ctrl.go
@@ -57,8 +57,8 @@ func Control(sRevInfoQ chan rpkt.RawSRevCallbackArgs, dispatcherReconnect bool) 
 		},
 	)
 	ctrlAddr := ctx.Conf.BR.CtrlAddrs
-	pub := &snet.Addr{IA: ia, Host: ctrlAddr.SCIONAddress}
-	snetConn, err = scionNetwork.ListenSCIONWithBindSVC("udp4", pub, nil, addr.SvcNone, 0)
+	pub := snet.NewUDPAddr(ia, nil, nil, ctrlAddr.SCIONAddress)
+	snetConn, err = scionNetwork.ListenSCIONWithBindSVC("udp4", pub.ToAddr(), nil, addr.SvcNone, 0)
 	if err != nil {
 		fatal.Fatal(common.NewBasicError("Listening on address", err, "addr", ctrlAddr))
 	}

--- a/go/lib/discovery/discoverypool/BUILD.bazel
+++ b/go/lib/discovery/discoverypool/BUILD.bazel
@@ -20,7 +20,6 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
-        "//go/lib/addr:go_default_library",
         "//go/lib/topology:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",

--- a/go/lib/discovery/discoverypool/pool.go
+++ b/go/lib/discovery/discoverypool/pool.go
@@ -16,7 +16,6 @@ package discoverypool
 
 import (
 	"math"
-	"net"
 	"sync"
 
 	"github.com/scionproto/scion/go/lib/common"
@@ -54,14 +53,10 @@ func (p *Pool) Update(svcInfo topology.IDAddrMap) error {
 	defer p.mu.Unlock()
 	// Add missing DS servers.
 	for k, v := range svcInfo {
-		y := &net.UDPAddr{
-			IP:   v.SCIONAddress.L3.IP(),
-			Port: int(v.SCIONAddress.L4),
-		}
 		if info, ok := p.m[k]; !ok {
-			p.m[k] = discoveryinfo.New(k, y)
+			p.m[k] = discoveryinfo.New(k, v.SCIONAddress)
 		} else {
-			info.Update(y)
+			info.Update(v.SCIONAddress)
 		}
 	}
 	// Get list of outdated DS servers.

--- a/go/lib/discovery/discoverypool/pool_test.go
+++ b/go/lib/discovery/discoverypool/pool_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
@@ -80,15 +79,14 @@ func TestPoolUpdate(t *testing.T) {
 		pool := mustLoadPool(t)
 		svcInfo := mustLoadSvcInfo(t)
 		Convey("And a topology containing an updated discovery service entry", func() {
-			svcInfo[ds[0].key].SCIONAddress.L3 = addr.HostFromIP(
-				net.IPv4(127, 0, 0, 21))
+			svcInfo[ds[0].key].SCIONAddress.IP = net.IPv4(127, 0, 0, 21)
 			pool.Update(svcInfo)
 			Convey("The pool should contain the updated info", func() {
 				contains(pool, testInfo{
 					key: ds[0].key,
 					addr: &net.UDPAddr{
 						IP:   net.IPv4(127, 0, 0, 21),
-						Port: int(svcInfo[ds[0].key].SCIONAddress.L4),
+						Port: svcInfo[ds[0].key].SCIONAddress.Port,
 					},
 				})
 			})

--- a/go/lib/healthpool/svcinstance/BUILD.bazel
+++ b/go/lib/healthpool/svcinstance/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "github.com/scionproto/scion/go/lib/healthpool/svcinstance",
     visibility = ["//visibility:public"],
     deps = [
-        "//go/lib/addr:go_default_library",
         "//go/lib/healthpool:go_default_library",
         "//go/lib/topology:go_default_library",
     ],
@@ -21,7 +20,6 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
-        "//go/lib/addr:go_default_library",
         "//go/lib/healthpool:go_default_library",
         "//go/lib/topology:go_default_library",
         "//go/lib/xtest:go_default_library",

--- a/go/lib/healthpool/svcinstance/pool_test.go
+++ b/go/lib/healthpool/svcinstance/pool_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/healthpool"
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/lib/xtest"
@@ -33,22 +32,22 @@ const (
 	ds3new     = "ds1-ff00_0_111-3-new"
 )
 
-var dsInfos = map[string]*addr.AppAddr{
+var dsInfos = map[string]*net.UDPAddr{
 	ds1: {
-		L3: addr.HostFromIP(net.IPv4(127, 0, 0, 22)),
-		L4: 30084,
+		IP:   net.IPv4(127, 0, 0, 22),
+		Port: 30084,
 	},
 	ds2: {
-		L3: addr.HostFromIP(net.IPv4(127, 0, 0, 80)),
-		L4: 30085,
+		IP:   net.IPv4(127, 0, 0, 80),
+		Port: 30085,
 	},
 	ds3new: {
-		L3: addr.HostFromIP(net.IPv4(127, 0, 0, 22)),
-		L4: 30084,
+		IP:   net.IPv4(127, 0, 0, 22),
+		Port: 30084,
 	},
 	ds1updated: {
-		L3: addr.HostFromIP(net.IPv4(127, 0, 0, 21)),
-		L4: 30084,
+		IP:   net.IPv4(127, 0, 0, 21),
+		Port: 30084,
 	},
 }
 
@@ -73,7 +72,7 @@ func TestPoolUpdate(t *testing.T) {
 		pool := mustLoadPool(t)
 		svcInfo := mustLoadSvcInfo(t)
 		Convey("And an instance map containing an updated discovery service entry", func() {
-			svcInfo[ds1].SCIONAddress.L3 = dsInfos[ds1updated].L3
+			svcInfo[ds1].SCIONAddress.IP = dsInfos[ds1updated].IP
 			pool.infos[ds1].Fail()
 			err := pool.Update(svcInfo)
 			SoMsg("err", err, ShouldBeNil)
@@ -118,13 +117,13 @@ func TestPoolChoose(t *testing.T) {
 		p.infos[ds1].Fail()
 		i, err := p.Choose()
 		SoMsg("err first", err, ShouldBeNil)
-		SoMsg("Choose first", i.Addr().Equal(p.infos[ds2].addr), ShouldBeTrue)
+		SoMsg("Choose first", i.Addr().IP.Equal(p.infos[ds2].addr.IP), ShouldBeTrue)
 		SoMsg("Name first", i.Name(), ShouldEqual, ds2)
 		i.Fail()
 		i.Fail()
 		i, err = p.Choose()
 		SoMsg("err second", err, ShouldBeNil)
-		SoMsg("Choose second", i.Addr().Equal(p.infos[ds1].addr), ShouldBeTrue)
+		SoMsg("Choose second", i.Addr().IP.Equal(p.infos[ds1].addr.IP), ShouldBeTrue)
 		SoMsg("Name second", i.Name(), ShouldEqual, ds1)
 	})
 }
@@ -146,12 +145,12 @@ func containsAll(p *Pool, names ...string) {
 	}
 }
 
-func contains(p *Pool, name string, a *addr.AppAddr) {
+func contains(p *Pool, name string, a *net.UDPAddr) {
 	Convey("The pool contains "+name, func() {
 		info, ok := p.infos[name]
 		SoMsg("Not found", ok, ShouldBeTrue)
-		SoMsg("Ip", info.addr.L3.IP(), ShouldResemble, a.L3.IP())
-		SoMsg("Port", info.addr.L4, ShouldEqual, a.L4)
+		SoMsg("Ip", info.addr.IP.String(), ShouldResemble, a.IP.String())
+		SoMsg("Port", info.addr.Port, ShouldEqual, a.Port)
 	})
 }
 

--- a/go/lib/integration/integration.go
+++ b/go/lib/integration/integration.go
@@ -194,7 +194,7 @@ var DispAddr HostAddr = func(ia addr.IA) snet.Addr {
 		os.Exit(1)
 	}
 	bs := topo.BS["bs"+ia.FileFmt(false)+"-1"]
-	return snet.Addr{Host: bs.SCIONAddress, IA: ia}
+	return snet.Addr{Host: addr.AppAddrFromUDP(bs.SCIONAddress), IA: ia}
 }
 
 // interface kept similar to go 1.10

--- a/go/lib/topology/mock_topology/topology.go
+++ b/go/lib/topology/mock_topology/topology.go
@@ -269,10 +269,10 @@ func (mr *MockTopologyMockRecorder) PublicAddress(arg0, arg1 interface{}) *gomoc
 }
 
 // SBRAddress mocks base method
-func (m *MockTopology) SBRAddress(arg0 string) *snet.Addr {
+func (m *MockTopology) SBRAddress(arg0 string) *snet.UDPAddr {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SBRAddress", arg0)
-	ret0, _ := ret[0].(*snet.Addr)
+	ret0, _ := ret[0].(*snet.UDPAddr)
 	return ret0
 }
 

--- a/go/lib/topology/raw.go
+++ b/go/lib/topology/raw.go
@@ -57,9 +57,9 @@ func rawAddrMapToTopoAddr(ram jsontopo.NATSCIONAddressMap) (*TopoAddr, error) {
 	}
 
 	return &TopoAddr{
-		SCIONAddress: &addr.AppAddr{
-			L3: addr.HostFromIP(ip),
-			L4: uint16(addressInfo.Public.Address.L4Port),
+		SCIONAddress: &net.UDPAddr{
+			IP:   ip,
+			Port: addressInfo.Public.Address.L4Port,
 		},
 		UnderlayAddress: &net.UDPAddr{
 			IP:   append(ip[:0:0], ip...),

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -117,7 +117,7 @@ type (
 	// TopoAddr wraps the possible addresses of a SCION service and describes
 	// the underlay to be used for contacting said service.
 	TopoAddr struct {
-		SCIONAddress    *addr.AppAddr
+		SCIONAddress    *net.UDPAddr
 		UnderlayAddress net.Addr
 	}
 )
@@ -427,6 +427,20 @@ func (a *TopoAddr) UnderlayAddr() *net.UDPAddr {
 
 func (a *TopoAddr) String() string {
 	return fmt.Sprintf("TopoAddr{SCION: %v, Underlay: %v}", a.SCIONAddress, a.UnderlayAddress)
+}
+
+func (a *TopoAddr) copy() *TopoAddr {
+	// TODO(scrye): Investigate how this can be removed.
+	if a == nil {
+		return nil
+	}
+	return &TopoAddr{
+		SCIONAddress: &net.UDPAddr{
+			IP:   append(a.SCIONAddress.IP[:0:0], a.SCIONAddress.IP...),
+			Port: a.SCIONAddress.Port,
+		},
+		UnderlayAddress: toUDPAddr(a.UnderlayAddress.(*net.UDPAddr)),
+	}
 }
 
 func toUDPAddr(a net.Addr) *net.UDPAddr {

--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -89,9 +89,9 @@ func TestServiceDetails(t *testing.T) {
 	c := MustLoadTopo(t, "testdata/basic.json")
 	cses := IDAddrMap{
 		"cs1-ff00:0:311-2": TopoAddr{
-			SCIONAddress: &addr.AppAddr{
-				L3: addr.HostFromIP(net.IP{127, 0, 0, 67}),
-				L4: 30073,
+			SCIONAddress: &net.UDPAddr{
+				IP:   net.IP{127, 0, 0, 67},
+				Port: 30073,
 			},
 			UnderlayAddress: &net.UDPAddr{
 				IP:   net.IP{127, 0, 0, 67},
@@ -99,9 +99,9 @@ func TestServiceDetails(t *testing.T) {
 			},
 		},
 		"cs1-ff00:0:311-3": TopoAddr{
-			SCIONAddress: &addr.AppAddr{
-				L3: addr.HostFromIP(net.ParseIP("2001:db8:f00:b43::1")),
-				L4: 23421,
+			SCIONAddress: &net.UDPAddr{
+				IP:   net.ParseIP("2001:db8:f00:b43::1"),
+				Port: 23421,
 			},
 			UnderlayAddress: &net.UDPAddr{
 				IP:   net.ParseIP("2001:db8:f00:b43::1"),
@@ -134,9 +134,9 @@ func TestIFInfoMap(t *testing.T) {
 				Port: 0,
 			},
 			CtrlAddrs: &TopoAddr{
-				SCIONAddress: &addr.AppAddr{
-					L3: addr.HostFromIP(net.ParseIP("2001:db8:a0b:12f0::1")),
-					L4: 30098,
+				SCIONAddress: &net.UDPAddr{
+					IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+					Port: 30098,
 				},
 				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("2001:db8:a0b:12f0::1"), Port: 30041},
 			},
@@ -162,9 +162,9 @@ func TestIFInfoMap(t *testing.T) {
 				Port: 0,
 			},
 			CtrlAddrs: &TopoAddr{
-				SCIONAddress: &addr.AppAddr{
-					L3: addr.HostFromIP(net.ParseIP("2001:db8:a0b:12f0::1")),
-					L4: 30098,
+				SCIONAddress: &net.UDPAddr{
+					IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+					Port: 30098,
 				},
 				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("2001:db8:a0b:12f0::1"), Port: 30041},
 			},
@@ -190,9 +190,9 @@ func TestIFInfoMap(t *testing.T) {
 				Port: 0,
 			},
 			CtrlAddrs: &TopoAddr{
-				SCIONAddress: &addr.AppAddr{
-					L3: addr.HostFromIP(net.ParseIP("2001:db8:a0b:12f0::1")),
-					L4: 30098,
+				SCIONAddress: &net.UDPAddr{
+					IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+					Port: 30098,
 				},
 				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("2001:db8:a0b:12f0::1"), Port: 30041},
 			},
@@ -225,9 +225,9 @@ func TestIFInfoMapCoreAS(t *testing.T) {
 				Port: 0,
 			},
 			CtrlAddrs: &TopoAddr{
-				SCIONAddress: &addr.AppAddr{
-					L3: addr.HostFromIP(net.ParseIP("2001:db8:a0b:12f0::1")),
-					L4: 30098,
+				SCIONAddress: &net.UDPAddr{
+					IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+					Port: 30098,
 				},
 				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("2001:db8:a0b:12f0::1"), Port: 30041},
 			},
@@ -253,9 +253,9 @@ func TestIFInfoMapCoreAS(t *testing.T) {
 				Port: 0,
 			},
 			CtrlAddrs: &TopoAddr{
-				SCIONAddress: &addr.AppAddr{
-					L3: addr.HostFromIP(net.ParseIP("2001:db8:a0b:12f0::2")),
-					L4: 30098,
+				SCIONAddress: &net.UDPAddr{
+					IP:   net.ParseIP("2001:db8:a0b:12f0::2"),
+					Port: 30098,
 				},
 				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("2001:db8:a0b:12f0::2"), Port: 30041},
 			},
@@ -768,9 +768,9 @@ func TestRawAddrMap_ToTopoAddr(t *testing.T) {
 				},
 			},
 			addr: &TopoAddr{
-				SCIONAddress: &addr.AppAddr{
-					L3: addr.HostFromIP(net.IP{192, 168, 1, 1}),
-					L4: 42,
+				SCIONAddress: &net.UDPAddr{
+					IP:   net.IP{192, 168, 1, 1},
+					Port: 42,
 				},
 				UnderlayAddress: &net.UDPAddr{
 					IP:   net.IP{192, 168, 1, 1},
@@ -791,9 +791,9 @@ func TestRawAddrMap_ToTopoAddr(t *testing.T) {
 				},
 			},
 			addr: &TopoAddr{
-				SCIONAddress: &addr.AppAddr{
-					L3: addr.HostFromIP(net.ParseIP("2001:db8:f00:b43::1")),
-					L4: 42,
+				SCIONAddress: &net.UDPAddr{
+					IP:   net.ParseIP("2001:db8:f00:b43::1"),
+					Port: 42,
 				},
 				UnderlayAddress: &net.UDPAddr{
 					IP:   net.ParseIP("2001:db8:f00:b43::1"),
@@ -886,9 +886,9 @@ func TestRawAddrMap_ToTopoAddr(t *testing.T) {
 				},
 			},
 			addr: &TopoAddr{
-				SCIONAddress: &addr.AppAddr{
-					L3: addr.HostFromIP(net.ParseIP("2001:db8:f00:b43::1")),
-					L4: 42,
+				SCIONAddress: &net.UDPAddr{
+					IP:   net.ParseIP("2001:db8:f00:b43::1"),
+					Port: 42,
 				},
 				UnderlayAddress: &net.UDPAddr{
 					IP:   net.ParseIP("2001:db8:f00:b43::1"),


### PR DESCRIPTION
Inside topology, the TopoAddr struct changed
```
	TopoAddr struct {
		SCIONAddress    *addr.AppAddr	-->  *net.UDPAddr
		UnderlayAddress net.Addr		
	}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3507)
<!-- Reviewable:end -->
