### PR TITLE
dispatcher: Fix registration with length 16 IPv4 addresses 

### DIFF
--- a/go/lib/sock/reliable/registration.go
+++ b/go/lib/sock/reliable/registration.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -188,7 +189,7 @@ func (l *registrationAddressField) DecodeFromBytes(b []byte) error {
 func (l *registrationAddressField) SetFromUDPAddr(u *net.UDPAddr) {
 	l.Port = uint16(u.Port)
 	l.AddressType = byte(getIPAddressType(u.IP))
-	l.Address = []byte(u.IP)
+	l.Address = normalizeIP(u.IP)
 }
 
 func (l *registrationAddressField) length() int {


### PR DESCRIPTION
Make sure that an IPv4 is always 4 bytes long otherwise the parsing will fail.
Creating an IP from string via net.ParseIP/net.ResolveUDPAddr creates an IPv4 with a byte slice of length 16.
This was a problem for example for sciond.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3512)
<!-- Reviewable:end -->
