### PR TITLE
sciond-lib: Add IFInfo function back to connector interface

### DIFF
--- a/go/lib/sciond/apitypes.go
+++ b/go/lib/sciond/apitypes.go
@@ -87,6 +87,16 @@ func svcAddrToProto(svc addr.HostSVC) proto.ServiceType {
 	}
 }
 
+func ifinfoReplyToMap(ifinfoReply *IFInfoReply) map[common.IFIDType]*net.UDPAddr {
+	m := make(map[common.IFIDType]*net.UDPAddr)
+
+	for _, entry := range ifinfoReply.RawEntries {
+		m[entry.IfID] = entry.HostInfo.UDP()
+	}
+
+	return m
+}
+
 type Path struct {
 	interfaces []pathInterface
 	overlay    *net.UDPAddr

--- a/go/lib/sciond/mock_sciond/BUILD.bazel
+++ b/go/lib/sciond/mock_sciond/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/sciond:go_default_library",
         "//go/lib/snet:go_default_library",

--- a/go/lib/sciond/mock_sciond/sciond.go
+++ b/go/lib/sciond/mock_sciond/sciond.go
@@ -8,10 +8,12 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	addr "github.com/scionproto/scion/go/lib/addr"
+	common "github.com/scionproto/scion/go/lib/common"
 	path_mgmt "github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	sciond "github.com/scionproto/scion/go/lib/sciond"
 	snet "github.com/scionproto/scion/go/lib/snet"
 	proto "github.com/scionproto/scion/go/proto"
+	net "net"
 	reflect "reflect"
 )
 
@@ -103,6 +105,21 @@ func (m *MockConnector) Close(arg0 context.Context) error {
 func (mr *MockConnectorMockRecorder) Close(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockConnector)(nil).Close), arg0)
+}
+
+// IFInfo mocks base method
+func (m *MockConnector) IFInfo(arg0 context.Context, arg1 []common.IFIDType) (map[common.IFIDType]*net.UDPAddr, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IFInfo", arg0, arg1)
+	ret0, _ := ret[0].(map[common.IFIDType]*net.UDPAddr)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IFInfo indicates an expected call of IFInfo
+func (mr *MockConnectorMockRecorder) IFInfo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IFInfo", reflect.TypeOf((*MockConnector)(nil).IFInfo), arg0, arg1)
 }
 
 // Paths mocks base method

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -340,17 +340,6 @@ type IFInfoReply struct {
 	RawEntries []IFInfoReplyEntry `capnp:"entries"`
 }
 
-// Entries maps IFIDs to their addresses and ports; the map is rebuilt each time.
-func (reply *IFInfoReply) Entries() map[common.IFIDType]hostinfo.Host {
-	m := make(map[common.IFIDType]hostinfo.Host)
-
-	for _, entry := range reply.RawEntries {
-		m[entry.IfID] = entry.HostInfo
-	}
-
-	return m
-}
-
 type IFInfoReplyEntry struct {
 	IfID     common.IFIDType
 	HostInfo hostinfo.Host


### PR DESCRIPTION
Add `IFInfo` function back to sciond connector interface, with updated type, so that a map containing the addresses is returned instead of the raw IFInfoReply type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3514)
<!-- Reviewable:end -->
