### PR TITLE
Fix nil-pointer dereference in sciond.Path.String

### DIFF
--- a/go/lib/sciond/apitypes.go
+++ b/go/lib/sciond/apitypes.go
@@ -213,8 +213,8 @@ func (p Path) Copy() snet.Path {
 
 func (p Path) String() string {
 	hops := p.fmtInterfaces()
-	return fmt.Sprintf("Hops: [%s] MTU: %d, NextHop: %s:%d",
-		strings.Join(hops, ">"), p.mtu, p.overlay.IP, p.overlay.Port)
+	return fmt.Sprintf("Hops: [%s] MTU: %d, NextHop: %s",
+		strings.Join(hops, ">"), p.mtu, p.overlay)
 }
 
 func (p Path) fmtInterfaces() []string {


### PR DESCRIPTION
A sciond.Path with a nil-overlay could not be printed.
Fixed by using UDPAddr.String instead of manually formatting IP:port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3519)
<!-- Reviewable:end -->
