### PR TITLE
snet: Allow dial/listen using IPv6 addresses

### DIFF
--- a/go/border/rctrl/ctrl.go
+++ b/go/border/rctrl/ctrl.go
@@ -57,7 +57,7 @@ func Control(sRevInfoQ chan rpkt.RawSRevCallbackArgs, dispatcherReconnect bool) 
 		},
 	)
 	ctrlAddr := ctx.Conf.BR.CtrlAddrs
-	snetConn, err = scionNetwork.Listen("udp4", ctrlAddr.SCIONAddress, addr.SvcNone, 0)
+	snetConn, err = scionNetwork.Listen("udp", ctrlAddr.SCIONAddress, addr.SvcNone, 0)
 	if err != nil {
 		fatal.Fatal(common.NewBasicError("Listening on address", err, "addr", ctrlAddr))
 	}

--- a/go/integration/cert_req/main.go
+++ b/go/integration/cert_req/main.go
@@ -65,7 +65,7 @@ type client struct {
 func (c client) run() int {
 	network := integration.InitNetwork()
 	var err error
-	c.conn, err = network.Listen("udp4", integration.Local.ToNetUDPAddr(), addr.SvcNone, 0)
+	c.conn, err = network.Listen("udp", integration.Local.ToNetUDPAddr(), addr.SvcNone, 0)
 	if err != nil {
 		integration.LogFatal("Unable to listen", "err", err)
 	}

--- a/go/lib/infra/infraenv/infraenv.go
+++ b/go/lib/infra/infraenv/infraenv.go
@@ -200,7 +200,7 @@ func (nc *NetworkConfig) initUDPSocket(quicAddress string) (net.PacketConn, erro
 		},
 	)
 	network := snet.NewCustomNetworkWithPR(nc.IA, packetDispatcher)
-	conn, err := network.Listen("udp4", nc.Public, nc.SVC, 0)
+	conn, err := network.Listen("udp", nc.Public, nc.SVC, 0)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to listen on SCION", err)
 	}
@@ -223,7 +223,7 @@ func (nc *NetworkConfig) initQUICSocket() (net.PacketConn, error) {
 	if err != nil {
 		return nil, common.NewBasicError("Unable to parse address", err)
 	}
-	conn, err := network.Listen("udp4", udpAddr, addr.SvcNone, 0)
+	conn, err := network.Listen("udp", udpAddr, addr.SvcNone, 0)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to listen on SCION", err)
 	}

--- a/go/lib/sciond/pathprobe/paths.go
+++ b/go/lib/sciond/pathprobe/paths.go
@@ -117,7 +117,7 @@ func (p Prober) GetStatuses(ctx context.Context,
 			SCMPHandler: scmpH,
 		},
 	)
-	snetConn, err := network.Listen("udp4", p.Local.ToNetUDPAddr(),
+	snetConn, err := network.Listen("udp", p.Local.ToNetUDPAddr(),
 		addr.SvcNone, deadline.Sub(time.Now()))
 	if err != nil {
 		return nil, common.NewBasicError("listening failed", err)

--- a/go/lib/snet/base.go
+++ b/go/lib/snet/base.go
@@ -32,7 +32,7 @@ type scionConnBase struct {
 	// Reference to SCION networking context
 	scionNet *SCIONNetwork
 
-	// Describes L3 and L4 protocol; currently only udp4 is implemented
+	// Describes L4 protocol; currently only udp is implemented
 	net string
 }
 

--- a/go/lib/snet/reader.go
+++ b/go/lib/snet/reader.go
@@ -87,7 +87,7 @@ func (c *scionConnReader) read(b []byte) (int, *Addr, error) {
 
 	var remote *Addr
 	// On UDP4 network we can get either UDP traffic or SCMP messages
-	if c.base.net == "udp4" {
+	if c.base.net == "udp" {
 		// Extract remote address
 		remote = &Addr{
 			IA: pkt.Source.IA,

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -94,7 +94,7 @@ func NewCustomNetworkWithPR(ia addr.IA, pktDispatcher PacketDispatcherService) *
 }
 
 // Dial returns a SCION connection to remote. Nil values for listen are not
-// supported yet.  Parameter network must be "udp4". The returned connection's
+// supported yet.  Parameter network must be "udp". The returned connection's
 // Read and Write methods can be used to receive and send SCION packets.
 //
 // The timeout is used for connection setup, it doesn't affect the returned
@@ -118,7 +118,7 @@ func (n *SCIONNetwork) Dial(network string, listen *net.UDPAddr, remote *UDPAddr
 // Listen registers laddr with the dispatcher. Nil values for laddr are
 // not supported yet. The returned connection's ReadFrom and WriteTo methods
 // can be used to receive and send SCION packets with per-packet addressing.
-// Parameter network must be "udp4".
+// Parameter network must be "udp".
 //
 // The timeout is used for connection setup, it doesn't affect the returned
 // connection. A timeout of 0 means infinite timeout.
@@ -126,6 +126,11 @@ func (n *SCIONNetwork) Listen(network string, listen *net.UDPAddr,
 	svc addr.HostSVC, timeout time.Duration) (Conn, error) {
 
 	metrics.M.Listens().Inc()
+
+	if network != "udp" {
+		return nil, common.NewBasicError("Unknown network", nil, "network", network)
+	}
+
 	// FIXME(scrye): If no local address is specified, we want to
 	// bind to the address of the outbound interface on a random
 	// free port. However, the current dispatcher version cannot
@@ -133,11 +138,6 @@ func (n *SCIONNetwork) Listen(network string, listen *net.UDPAddr,
 	// normal operating system semantics for binding on 0.0.0.0 (it
 	// considers it to be a fixed address instead of a wildcard). To avoid
 	// misuse, disallow binding to nil or 0.0.0.0 addresses for now.
-	switch network {
-	case "udp4":
-	default:
-		return nil, common.NewBasicError("Network not implemented", nil, "net", network)
-	}
 	if listen == nil {
 		return nil, serrors.New("nil listen addr not supported")
 	}

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -85,5 +85,5 @@ func sListen(network *snet.SCIONNetwork, listen *net.UDPAddr,
 	if network == nil {
 		return nil, serrors.New("squic:  SCION network must not be nil")
 	}
-	return network.Listen("udp4", listen, svc, 0)
+	return network.Listen("udp", listen, svc, 0)
 }

--- a/go/sig/egress/session/session.go
+++ b/go/sig/egress/session/session.go
@@ -76,7 +76,7 @@ func NewSession(dstIA addr.IA, sessId mgmt.SessionType, logger log.Logger,
 	s.healthy.Store(false)
 	s.ring = ringbuf.New(64, nil, fmt.Sprintf("egress_%s_%s", dstIA, sessId))
 	// Not using a fixed local port, as this is for outgoing data only.
-	s.conn, err = sigcmn.Network.Listen("udp4",
+	s.conn, err = sigcmn.Network.Listen("udp",
 		&net.UDPAddr{IP: sigcmn.Host.IP()}, addr.SvcNone, 0)
 	s.sessMonStop = make(chan struct{})
 	s.sessMonStopped = make(chan struct{})

--- a/go/sig/internal/ingress/dispatcher.go
+++ b/go/sig/internal/ingress/dispatcher.go
@@ -60,7 +60,7 @@ func NewDispatcher(tio io.ReadWriteCloser) *Dispatcher {
 
 func (d *Dispatcher) Run() error {
 	var err error
-	d.extConn, err = sigcmn.Network.Listen("udp4", d.laddr.ToNetUDPAddr(), addr.SvcNone, 0)
+	d.extConn, err = sigcmn.Network.Listen("udp", d.laddr.ToNetUDPAddr(), addr.SvcNone, 0)
 	if err != nil {
 		return common.NewBasicError("Unable to initialize extConn", err)
 	}

--- a/go/sig/sigcmn/common.go
+++ b/go/sig/sigcmn/common.go
@@ -81,7 +81,7 @@ func Init(cfg sigconfig.SigConf, sdCfg env.SciondClient) error {
 	if err != nil {
 		return common.NewBasicError("Error creating local SCION Network context", err)
 	}
-	conn, err := network.Listen("udp4",
+	conn, err := network.Listen("udp",
 		&net.UDPAddr{IP: Host.IP(), Port: int(cfg.CtrlPort)}, addr.SvcSIG, 0)
 	if err != nil {
 		return common.NewBasicError("Error creating ctrl socket", err)


### PR DESCRIPTION
Explicitly allow Dial/Listen using IPv6 addresses, by removing the fixed `"udp4"` network string. The actual address type checks have already been removed very recently in #3521.
Pass "udp" as network in all Dial/Listen calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3522)
<!-- Reviewable:end -->
