### PR TITLE
Fix removing IPv6 registrations in godispatcher

### DIFF
--- a/go/godispatcher/internal/registration/udptable.go
+++ b/go/godispatcher/internal/registration/udptable.go
@@ -121,11 +121,12 @@ func copyIPAddr(ip net.IP) net.IP {
 }
 
 func (t *UDPPortTable) Remove(address *net.UDPAddr) {
-	ipTable, ok := t.v4PortTable[address.Port]
+	portTable := t.getPortTableByIP(address.IP)
+	ipTable, ok := portTable[address.Port]
 	if ok {
 		delete(ipTable, address.IP.String())
 		if len(ipTable) == 0 {
-			delete(t.v4PortTable, address.Port)
+			delete(portTable, address.Port)
 		}
 	}
 }


### PR DESCRIPTION
Analogous to #3451, but now for removing registrations.

This time, I double checked: there should be no further instances of this particular bug. :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3531)
<!-- Reviewable:end -->
