### PR TITLE
CI: Fix failure in lint steps of new pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,7 +21,8 @@ steps:
     timeout_in_minutes: 10
   - label: "Check generated go_deps.bzl file is up to date with go.mod"
     command:
-      - "mkdir /tmp/$BUILDKITE_STEP_ID/"
+      - "rm -rf mkdir /tmp/$BUILDKITE_STEP_ID/"
+      - "mkdir -p /tmp/$BUILDKITE_STEP_ID/"
       - "cp go.mod go.sum go_deps.bzl /tmp/$BUILDKITE_STEP_ID/"
       - "make godeps -B"
       - "bazel-${BUILDKITE_PIPELINE_SLUG}/external/go_sdk/bin/go mod tidy"
@@ -35,7 +36,8 @@ steps:
         - exit_status: 255 # Forced agent shutdown
   - label: "Check generated go/proto files in git"
     command:
-      - "mkdir /tmp/$BUILDKITE_STEP_ID/"
+      - "rm -rf mkdir /tmp/$BUILDKITE_STEP_ID/"
+      - "mkdir -p /tmp/$BUILDKITE_STEP_ID/"
       - "cp -R go/proto/ /tmp/$BUILDKITE_STEP_ID/"
       - "make gogen"
       - "diff -ur /tmp/$BUILDKITE_STEP_ID/proto/ go/proto/"


### PR DESCRIPTION
If an agent is reused the STEP_ID can be the same, therefore delete the tmp directory first and recreate it cleanly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3533)
<!-- Reviewable:end -->
