### PR TITLE
BS: Register one-hop dispatcher without timeout

### DIFF
--- a/go/beacon_srv/main.go
+++ b/go/beacon_srv/main.go
@@ -211,8 +211,7 @@ func realMain() int {
 	ohpAddress := &net.UDPAddr{
 		IP: append(a.IP[:0:0], a.IP...), Port: 0,
 	}
-	conn, _, err := pktDisp.RegisterTimeout(topo.IA(), ohpAddress, nil,
-		addr.SvcNone, time.Second)
+	conn, _, err := pktDisp.RegisterTimeout(topo.IA(), ohpAddress, nil, addr.SvcNone, 0)
 	if err != nil {
 		log.Crit("Unable to create SCION packet conn", "err", err)
 		return 1


### PR DESCRIPTION
Register one-hop packet dispatcher without timeout similar to all
other registration calls.

It has happened on CI that the dispatcher took slightly longer than the timeout of 1 second.
Resulting in tests failing.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3546)
<!-- Reviewable:end -->
