### PR TITLE
Remove common.GetErrorMsg

### DIFF
--- a/go/lib/common/errors.go
+++ b/go/lib/common/errors.go
@@ -33,19 +33,6 @@ type ErrorMsger interface {
 	GetMsg() string
 }
 
-// GetErrorMsg extracts the message from e, if e implements the ErrorMsger
-// interface. As a fall-back, if e implements ErrorNester, GetErrorMsg recurses on
-// the nested error. Otherwise returns an empty string.
-func GetErrorMsg(e error) string {
-	if e, _ := e.(ErrorMsger); e != nil {
-		return e.GetMsg()
-	}
-	if n := GetNestedError(e); n != nil {
-		return GetErrorMsg(n)
-	}
-	return ""
-}
-
 // ErrorNester allows recursing into nested errors.
 type ErrorNester interface {
 	error

--- a/go/lib/sock/reliable/reconnect/BUILD.bazel
+++ b/go/lib/sock/reliable/reconnect/BUILD.bazel
@@ -35,7 +35,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/mocks/net/mock_net:go_default_library",
         "//go/lib/serrors:go_default_library",

--- a/go/lib/sock/reliable/reconnect/conn_io_test.go
+++ b/go/lib/sock/reliable/reconnect/conn_io_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/mocks/net/mock_net"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/sock/reliable/reconnect"
@@ -60,8 +59,7 @@ func TestPacketConnIO(t *testing.T) {
 		Convey("IO must return non-dispatcher errors", func() {
 			mockIO.EXPECT().Do(mockConn).Return(writeNonDispatcherError)
 			err := packetConn.DoIO(mockIO)
-			SoMsg("err", common.GetErrorMsg(err), ShouldEqual,
-				common.GetErrorMsg(writeNonDispatcherError))
+			xtest.AssertErrorsIs(t, err, writeNonDispatcherError)
 		})
 		Convey("IO must return an error if reconnect got an error from the dispatcher", func() {
 			// If reconnection failed while the dispatcher was up (e.g.,

--- a/go/lib/xtest/BUILD.bazel
+++ b/go/lib/xtest/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/common:go_default_library",
         "@com_github_smartystreets_goconvey//convey:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@org_golang_x_xerrors//:go_default_library",

--- a/go/lib/xtest/convey.go
+++ b/go/lib/xtest/convey.go
@@ -41,8 +41,6 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/xerrors"
-
-	"github.com/scionproto/scion/go/lib/common"
 )
 
 type SC struct {
@@ -107,16 +105,6 @@ func SoMsgError(msg string, err error, shouldBeError bool) {
 		SoMsg(msg, err, ShouldNotBeNil)
 	} else {
 		SoMsg(msg, err, ShouldBeNil)
-	}
-}
-
-// SoMsgErrorStr checks whether the top error in err matches string str. If str
-// is empty, then the assertion succeeds if err is nil.
-func SoMsgErrorStr(msg string, err error, str string) {
-	if str == "" {
-		SoMsg(msg, err, ShouldBeNil)
-	} else {
-		SoMsg(msg, common.GetErrorMsg(err), ShouldEqual, str)
 	}
 }
 


### PR DESCRIPTION
We should no longer use it and instead use `errors.Is`

Fixes #3334

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3554)
<!-- Reviewable:end -->
