### PR TITLE
Fix BR acceptance tests in old CI pipeline

### DIFF
--- a/.buildkite/hooks/pre-artifact
+++ b/.buildkite/hooks/pre-artifact
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-# Currently this only if for the new pipeline, so if we aren't on the new
+# Currently this is only needed for the new pipeline, so if we aren't on the new
 # pipeline just exit.
 if [ ! "$BUILDKITE_PIPELINE_SLUG" == "scionproto2" ]; then
     exit 0

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -6,7 +6,9 @@ echo "Clean existing environment"
 
 . .buildkite/hooks/pre-exit
 
-export ACCEPTANCE_ARTIFACTS="$PWD/accept_artifacts"
+if [ "$BUILDKITE_PIPELINE_SLUG" == "scionproto2" ]; then
+    export ACCEPTANCE_ARTIFACTS="$PWD/accept_artifacts"
+fi
 
 echo "Starting bazel remote cache proxy"
 


### PR DESCRIPTION
The ACCEPTANCE_ARTIFACTS env var should only be updated in the new
pipeline during CI pre-command hooks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3557)
<!-- Reviewable:end -->
