### PR TITLE
Make scmp.Error compatible with go 1.13 error funcs

### DIFF
--- a/go/lib/scmp/error.go
+++ b/go/lib/scmp/error.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,10 +19,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/serrors"
 )
-
-var _ common.ErrorNester = (*Error)(nil)
 
 // Error represents an SCMP error, with an optional nested error.
 type Error struct {
@@ -32,8 +31,8 @@ type Error struct {
 
 // NewError creates a new SCMP Error with the specified scmp Class/Type/Info,
 // and optional nested error.
-func NewError(class Class, type_ Type, info Info, e error) error {
-	return &Error{CT: ClassType{class, type_}, Info: info, Err: e}
+func NewError(class Class, t Type, info Info, e error) error {
+	return &Error{CT: ClassType{class, t}, Info: info, Err: e}
 }
 
 func (e *Error) TopError() string {
@@ -49,21 +48,9 @@ func (e *Error) TopError() string {
 }
 
 func (e *Error) Error() string {
-	return common.FmtError(e)
+	return serrors.FmtError(e)
 }
 
-func (e *Error) GetErr() error {
+func (e *Error) Unwrap() error {
 	return e.Err
-}
-
-// ToError converts an e to an Error. If that fails, it recurses on the nested
-// error, if any, and otherwise returns nil.
-func ToError(e error) *Error {
-	if e, ok := e.(*Error); ok {
-		return e
-	}
-	if n := common.GetNestedError(e); n != nil {
-		return ToError(n)
-	}
-	return nil
 }

--- a/go/lib/spkt/BUILD.bazel
+++ b/go/lib/spkt/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//go/lib/common:go_default_library",
         "//go/lib/l4:go_default_library",
         "//go/lib/scmp:go_default_library",
+        "//go/lib/serrors:go_default_library",
         "//go/lib/spath:go_default_library",
         "//go/lib/util:go_default_library",
     ],
@@ -24,6 +25,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/scmp:go_default_library",
-        "@com_github_smartystreets_goconvey//convey:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/lib/spkt/cmnhdr.go
+++ b/go/lib/spkt/cmnhdr.go
@@ -41,7 +41,7 @@ type CmnHdr struct {
 }
 
 // ErrUnsupportedVersion indicates an unsupported SCION version.
-var ErrUnsupportedVersion = serrors.New("unsuppoerted SCION version")
+var ErrUnsupportedVersion = serrors.New("unsupported SCION version")
 
 func CmnHdrFromRaw(b []byte) (*CmnHdr, error) {
 	c := &CmnHdr{}

--- a/go/lib/spkt/cmnhdr.go
+++ b/go/lib/spkt/cmnhdr.go
@@ -1,4 +1,5 @@
 // Copyright 2016 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +21,7 @@ import (
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/scmp"
+	"github.com/scionproto/scion/go/lib/serrors"
 )
 
 const (
@@ -38,11 +40,10 @@ type CmnHdr struct {
 	NextHdr   common.L4ProtocolType
 }
 
-const (
-	ErrUnsuppVersion common.ErrMsg = "Unsupported SCION version"
-)
+// ErrUnsupportedVersion indicates an unsupported SCION version.
+var ErrUnsupportedVersion = serrors.New("unsuppoerted SCION version")
 
-func CmnHdrFromRaw(b common.RawBytes) (*CmnHdr, error) {
+func CmnHdrFromRaw(b []byte) (*CmnHdr, error) {
 	c := &CmnHdr{}
 	if err := c.Parse(b); err != nil {
 		return nil, err
@@ -50,9 +51,9 @@ func CmnHdrFromRaw(b common.RawBytes) (*CmnHdr, error) {
 	return c, nil
 }
 
-func (c *CmnHdr) Parse(b common.RawBytes) error {
+func (c *CmnHdr) Parse(b []byte) error {
 	if len(b) < CmnHdrLen {
-		return common.NewBasicError("Packet is shorter than the common header length", nil,
+		return serrors.New("Packet is shorter than the common header length",
 			"min", CmnHdrLen, "actual", len(b))
 	}
 	offset := 0
@@ -73,8 +74,7 @@ func (c *CmnHdr) Parse(b common.RawBytes) error {
 	if c.Ver != SCIONVersion {
 		// This can only usefully be replied to if the version specified is one
 		// that the current router supports, but has deprecated.
-		return common.NewBasicError(
-			ErrUnsuppVersion,
+		return serrors.Wrap(ErrUnsupportedVersion,
 			scmp.NewError(scmp.C_CmnHdr, scmp.T_C_BadVersion, nil, nil),
 			"expected", SCIONVersion, "actual", c.Ver,
 		)
@@ -82,7 +82,7 @@ func (c *CmnHdr) Parse(b common.RawBytes) error {
 	return nil
 }
 
-func (c *CmnHdr) Write(b common.RawBytes) {
+func (c *CmnHdr) Write(b []byte) {
 	offset := 0
 	var verDstSrc uint16
 	verDstSrc = uint16(c.Ver&0xF)<<12 | uint16(c.DstType&0x3F)<<6 | uint16(c.SrcType&0x3F)
@@ -99,7 +99,7 @@ func (c *CmnHdr) Write(b common.RawBytes) {
 	b[offset] = uint8(c.NextHdr)
 }
 
-func (c *CmnHdr) UpdatePathOffsets(b common.RawBytes, iOff, hOff uint8) {
+func (c *CmnHdr) UpdatePathOffsets(b []byte, iOff, hOff uint8) {
 	c.CurrInfoF = iOff
 	c.CurrHopF = hOff
 	b[5] = c.CurrInfoF

--- a/go/lib/spkt/cmnhdr_test.go
+++ b/go/lib/spkt/cmnhdr_test.go
@@ -1,4 +1,5 @@
 // Copyright 2017 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,61 +16,60 @@
 package spkt
 
 import (
+	"errors"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/go/lib/scmp"
 )
 
 var cmnhInput = [CmnHdrLen]byte{0x01, 0xf8, 0x0c, 0xb6, 0x1f, 0xab, 0xcd, 0xef}
 
-func Test_CmnHdr_Parse(t *testing.T) {
-	Convey("CmnHdr.Parse should parse bytes correctly", t, func() {
+func TestCmnHdrParse(t *testing.T) {
+	t.Run("CmnHdr.Parse should parse bytes correctly", func(t *testing.T) {
 		cmn := &CmnHdr{}
-		So(cmn.Parse(cmnhInput[:]), ShouldEqual, nil)
-		So(cmn.Ver, ShouldEqual, 0x0)
-		So(cmn.DstType, ShouldEqual, 0x07)
-		So(cmn.SrcType, ShouldEqual, 0x38)
-		So(cmn.TotalLen, ShouldEqual, 0x0cb6)
-		So(cmn.HdrLen, ShouldEqual, 0x1f)
-		So(cmn.CurrInfoF, ShouldEqual, 0xab)
-		So(cmn.CurrHopF, ShouldEqual, 0xcd)
-		So(cmn.NextHdr, ShouldEqual, 0xef)
+		assert.NoError(t, cmn.Parse(cmnhInput[:]))
+		assert.EqualValues(t, 0x0, cmn.Ver)
+		assert.EqualValues(t, 0x07, cmn.DstType)
+		assert.EqualValues(t, 0x38, cmn.SrcType)
+		assert.EqualValues(t, 0x0cb6, cmn.TotalLen)
+		assert.EqualValues(t, 0x1f, cmn.HdrLen)
+		assert.EqualValues(t, 0xab, cmn.CurrInfoF)
+		assert.EqualValues(t, 0xcd, cmn.CurrHopF)
+		assert.EqualValues(t, 0xef, cmn.NextHdr)
 	})
-	Convey("CmnHdr.Parse should report unsupported version", t, func() {
+	t.Run("CmnHdr.Parse should report unsupported version", func(t *testing.T) {
 		cmn := &CmnHdr{}
 		input := append([]byte(nil), cmnhInput[:]...)
 		input[0] |= 0x30
 		err := cmn.Parse(input)
-		So(err, ShouldNotBeNil)
-		serr := scmp.ToError(err)
-		So(serr, ShouldNotBeNil)
-		So(serr.CT, ShouldResemble, scmp.ClassType{Class: scmp.C_CmnHdr, Type: scmp.T_C_BadVersion})
-		So(cmn.Ver, ShouldEqual, 0x3)
+		assert.Error(t, err)
+		var serr *scmp.Error
+		require.True(t, errors.As(err, &serr))
+		assert.Error(t, serr)
+		assert.Equal(t, scmp.ClassType{Class: scmp.C_CmnHdr, Type: scmp.T_C_BadVersion}, serr.CT)
+		assert.EqualValues(t, 0x3, cmn.Ver)
 	})
 }
 
-func Test_CmnHdr_Write(t *testing.T) {
-	Convey("CmnHdr.Write should write bytes correctly", t, func() {
-		cmn := &CmnHdr{
-			Ver: 0x0, DstType: 0x07, SrcType: 0x38, TotalLen: 0x0cb6,
-			HdrLen: 0x1f, CurrInfoF: 0xab, CurrHopF: 0xcd, NextHdr: 0xef,
-		}
-		out := make([]byte, CmnHdrLen)
-		cmn.Write(out)
-		So(out, ShouldResemble, cmnhInput[:])
-	})
+func TestCmnHdrWrite(t *testing.T) {
+	cmn := &CmnHdr{
+		Ver: 0x0, DstType: 0x07, SrcType: 0x38, TotalLen: 0x0cb6,
+		HdrLen: 0x1f, CurrInfoF: 0xab, CurrHopF: 0xcd, NextHdr: 0xef,
+	}
+	out := make([]byte, CmnHdrLen)
+	cmn.Write(out)
+	assert.Equal(t, cmnhInput[:], out)
 }
 
-func Test_CmnHdr_UpdatePathOffsets(t *testing.T) {
-	Convey("CmnHdr.UpdatePathOffsets should update values correctly", t, func() {
-		cmn := &CmnHdr{}
-		cmn.Parse(cmnhInput[:])
-		out := make([]byte, CmnHdrLen)
-		cmn.UpdatePathOffsets(out, 0x12, 0x23)
-		So(out, ShouldResemble, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x23, 0x00})
-		So(cmn.CurrInfoF, ShouldEqual, 0x12)
-		So(cmn.CurrHopF, ShouldEqual, 0x23)
-	})
+func TestCmnHdrUpdatePathOffsets(t *testing.T) {
+	cmn := &CmnHdr{}
+	cmn.Parse(cmnhInput[:])
+	out := make([]byte, CmnHdrLen)
+	cmn.UpdatePathOffsets(out, 0x12, 0x23)
+	assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x23, 0x00}, out)
+	assert.EqualValues(t, 0x12, cmn.CurrInfoF)
+	assert.EqualValues(t, 0x23, cmn.CurrHopF)
 }


### PR DESCRIPTION
Remove ToError, instead use errors.As
Add Unwrap method

Also remove Convey from spkt test.

Fixes #3312

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3558)
<!-- Reviewable:end -->
