### PR TITLE
Lint: Update flake8

### DIFF
--- a/env/debian/pkgs.txt
+++ b/env/debian/pkgs.txt
@@ -4,7 +4,6 @@ cgroup-bin
 curl
 dnsutils
 file
-flake8
 g++
 gcc
 git
@@ -17,7 +16,6 @@ netcat-openbsd
 ntp
 patch
 python3-dev
-python3-flake8
 python3-nose
 python3-pip
 python3-wheel

--- a/env/pip3/requirements.txt
+++ b/env/pip3/requirements.txt
@@ -8,3 +8,23 @@ pyyaml==5.1.1 --hash=sha256:b4bb4d3f5e232425e25dda21c070ce05168a786ac9eda43768ab
 supervisor==4.1.0 --hash=sha256:2dc86fe0476e945e61483d614ceb2cf4f93b95282eb243bdf792621994360383 --hash=sha256:a76b2f77a560f2dc411c0254a4eb15f555e99faac48621b0f1fc9ab013944f47 # Direct dependency
 # supervisor-wildcards: licenses/BSD-3-Clause
 supervisor-wildcards==0.1.3 --hash=sha256:02f532bf059e99aa38a3170cf4295f9dd123cfb16f209240575d853fd90710f8 # Direct dependency
+entrypoints==0.3 \
+    --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
+    --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451 \
+    # via flake8
+flake8==3.7.9 \
+    --hash=sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb \
+    --hash=sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca
+mccabe==0.6.1 \
+    --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
+    --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f \
+    # via flake8
+pycodestyle==2.5.0 \
+    --hash=sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56 \
+    --hash=sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c \
+    # via flake8
+pyflakes==2.1.1 \
+    --hash=sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0 \
+    --hash=sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2 \
+    # via flake8
+

--- a/python/lib/packet/host_addr.py
+++ b/python/lib/packet/host_addr.py
@@ -197,7 +197,7 @@ _map = {
 
 
 def haddr_get_type(type_):  # pragma: no cover
-    """
+    r"""
     Look up host address class by type.
 
     :param type\_: host address type. E.g. ``1`` or ``"IPV4"``.
@@ -211,7 +211,7 @@ def haddr_get_type(type_):  # pragma: no cover
 
 
 def haddr_parse(type_, *args, **kwargs):  # pragma: no cover
-    """
+    r"""
     Parse host address and return object.
 
     :param type\_: host address type. E.g. ``1`` or ``"IPV4"``.

--- a/python/test/lib/log_test.py
+++ b/python/test/lib/log_test.py
@@ -50,7 +50,7 @@ class TestHandleError(object):
         # Call
         try:
             raise SCIONTestError
-        except:
+        except SCIONTestError:
             ntools.assert_raises(SCIONTestError, _handleError, handler, "hi")
         # Tests
         ntools.eq_(handler.stream.write.call_count, 3)

--- a/tools/gomocks
+++ b/tools/gomocks
@@ -114,5 +114,6 @@ def is_scion_package(target_package: str) -> bool:
 def strip_scion_package_prefix(target_package: str) -> str:
     return target_package[len(SCION_PACKAGE_PREFIX)+1:]
 
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Updates flake8 to 3.7.9 to have type annotation support.
Install flake8 via pip instead of debian, remove from debian deps.
Also fix issues flagged by the new version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3559)
<!-- Reviewable:end -->
