### PR TITLE
snet: Add context to Dispatcher and Listen and Dial

### DIFF
--- a/acceptance/common/scion.py
+++ b/acceptance/common/scion.py
@@ -111,7 +111,7 @@ class ScionDocker(Scion):
     @LogExec(logger, "creating dockerized topology")
     def topology(self, topo_file: str, *args: str):
         """ Create the dockerized topology files. """
-        self.scion_sh('topology', 'nobuild', '-c', topo_file,
+        self.scion_sh('topology', 'nobuild', '-c', topo_file, '-t',
                       '-d', *args)
 
     def _send_signals(self, svc_names: List[str], sig: str):

--- a/acceptance/showpaths_status_acceptance/test
+++ b/acceptance/showpaths_status_acceptance/test
@@ -48,6 +48,8 @@ class TestSetup(Base):
         if not self.no_docker:
             self.tools_dc('start', 'tester*')
             self.docker_status()
+        # give some time for initial setup of control plane
+        time.sleep(4)
 
 
 @Test.subcommand("run")

--- a/acceptance/showpaths_status_acceptance/test
+++ b/acceptance/showpaths_status_acceptance/test
@@ -16,6 +16,7 @@
 
 
 import logging
+import time
 
 from plumbum import local
 

--- a/go/beacon_srv/internal/onehop/network.go
+++ b/go/beacon_srv/internal/onehop/network.go
@@ -1,4 +1,4 @@
-// Copyright 2019 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 package onehop
 
 import (
+	"context"
 	"net"
-	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/layers"
@@ -31,11 +31,10 @@ type OHPPacketDispatcherService struct {
 	snet.PacketDispatcherService
 }
 
-func (s *OHPPacketDispatcherService) RegisterTimeout(ia addr.IA, public *net.UDPAddr,
-	bind *net.UDPAddr, svc addr.HostSVC,
-	timeout time.Duration) (snet.PacketConn, uint16, error) {
+func (s *OHPPacketDispatcherService) Register(ctx context.Context, ia addr.IA,
+	registration *net.UDPAddr, svc addr.HostSVC) (snet.PacketConn, uint16, error) {
 
-	conn, port, err := s.PacketDispatcherService.RegisterTimeout(ia, public, bind, svc, timeout)
+	conn, port, err := s.PacketDispatcherService.Register(ctx, ia, registration, svc)
 	if err != nil {
 		return conn, port, err
 	}

--- a/go/beacon_srv/main.go
+++ b/go/beacon_srv/main.go
@@ -211,9 +211,7 @@ func realMain() int {
 	ohpAddress := &net.UDPAddr{
 		IP: append(a.IP[:0:0], a.IP...), Port: 0,
 	}
-	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
-	defer cancelF()
-	conn, _, err := pktDisp.Register(ctx, topo.IA(), ohpAddress, addr.SvcNone)
+	conn, _, err := pktDisp.Register(context.Background(), topo.IA(), ohpAddress, addr.SvcNone)
 	if err != nil {
 		log.Crit("Unable to create SCION packet conn", "err", err)
 		return 1

--- a/go/beacon_srv/main.go
+++ b/go/beacon_srv/main.go
@@ -211,7 +211,9 @@ func realMain() int {
 	ohpAddress := &net.UDPAddr{
 		IP: append(a.IP[:0:0], a.IP...), Port: 0,
 	}
-	conn, _, err := pktDisp.RegisterTimeout(topo.IA(), ohpAddress, nil, addr.SvcNone, 0)
+	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
+	defer cancelF()
+	conn, _, err := pktDisp.Register(ctx, topo.IA(), ohpAddress, addr.SvcNone)
 	if err != nil {
 		log.Crit("Unable to create SCION packet conn", "err", err)
 		return 1

--- a/go/border/rctrl/ctrl.go
+++ b/go/border/rctrl/ctrl.go
@@ -17,6 +17,7 @@
 package rctrl
 
 import (
+	"context"
 	"github.com/scionproto/scion/go/border/ifstate"
 	"github.com/scionproto/scion/go/border/internal/metrics"
 	"github.com/scionproto/scion/go/border/rctx"
@@ -57,7 +58,8 @@ func Control(sRevInfoQ chan rpkt.RawSRevCallbackArgs, dispatcherReconnect bool) 
 		},
 	)
 	ctrlAddr := ctx.Conf.BR.CtrlAddrs
-	snetConn, err = scionNetwork.Listen("udp", ctrlAddr.SCIONAddress, addr.SvcNone, 0)
+	snetConn, err = scionNetwork.Listen(context.Background(), "udp", ctrlAddr.SCIONAddress,
+		addr.SvcNone)
 	if err != nil {
 		fatal.Fatal(common.NewBasicError("Listening on address", err, "addr", ctrlAddr))
 	}

--- a/go/border/rctrl/ctrl.go
+++ b/go/border/rctrl/ctrl.go
@@ -18,6 +18,7 @@ package rctrl
 
 import (
 	"context"
+
 	"github.com/scionproto/scion/go/border/ifstate"
 	"github.com/scionproto/scion/go/border/internal/metrics"
 	"github.com/scionproto/scion/go/border/rctx"

--- a/go/integration/cert_req/main.go
+++ b/go/integration/cert_req/main.go
@@ -73,7 +73,8 @@ type client struct {
 func (c client) run() int {
 	network := integration.InitNetwork()
 	var err error
-	c.conn, err = network.Listen("udp", integration.Local.ToNetUDPAddr(), addr.SvcNone, 0)
+	c.conn, err = network.Listen(context.Background(), "udp",
+		integration.Local.ToNetUDPAddr(), addr.SvcNone)
 	if err != nil {
 		integration.LogFatal("Unable to listen", "err", err)
 	}

--- a/go/integration/end2end/main.go
+++ b/go/integration/end2end/main.go
@@ -103,9 +103,8 @@ func (s server) run() {
 			sciond.RevHandler{Connector: integration.SDConn()},
 		),
 	}
-	conn, port, err := connFactory.RegisterTimeout(integration.Local.IA,
-		integration.Local.ToNetUDPAddr(),
-		nil, addr.SvcNone, 0)
+	conn, port, err := connFactory.Register(context.Background(), integration.Local.IA,
+		integration.Local.ToNetUDPAddr(), addr.SvcNone)
 	if err != nil {
 		integration.LogFatal("Error listening", "err", err)
 	}
@@ -161,8 +160,8 @@ func (c client) run() int {
 	}
 
 	var err error
-	c.conn, c.port, err = connFactory.RegisterTimeout(integration.Local.IA,
-		integration.Local.ToNetUDPAddr(), nil, addr.SvcNone, 0)
+	c.conn, c.port, err = connFactory.Register(context.Background(), integration.Local.IA,
+		integration.Local.ToNetUDPAddr(), addr.SvcNone)
 	if err != nil {
 		integration.LogFatal("Unable to listen", "err", err)
 	}

--- a/go/lib/infra/infraenv/infraenv.go
+++ b/go/lib/infra/infraenv/infraenv.go
@@ -196,7 +196,7 @@ func (nc *NetworkConfig) initUDPSocket(quicAddress string) (net.PacketConn, erro
 		},
 	)
 	network := snet.NewCustomNetworkWithPR(nc.IA, packetDispatcher)
-	conn, err := network.Listen("udp", nc.Public, nc.SVC, 0)
+	conn, err := network.Listen(context.Background(), "udp", nc.Public, nc.SVC)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to listen on SCION", err)
 	}
@@ -219,7 +219,7 @@ func (nc *NetworkConfig) initQUICSocket() (net.PacketConn, error) {
 	if err != nil {
 		return nil, common.NewBasicError("Unable to parse address", err)
 	}
-	conn, err := network.Listen("udp", udpAddr, addr.SvcNone, 0)
+	conn, err := network.Listen(context.Background(), "udp", udpAddr, addr.SvcNone)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to listen on SCION", err)
 	}

--- a/go/lib/sciond/pathprobe/paths.go
+++ b/go/lib/sciond/pathprobe/paths.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
@@ -115,8 +114,7 @@ func (p Prober) GetStatuses(ctx context.Context,
 			SCMPHandler: scmpH,
 		},
 	)
-	snetConn, err := network.Listen("udp", p.Local.ToNetUDPAddr(),
-		addr.SvcNone, deadline.Sub(time.Now()))
+	snetConn, err := network.Listen(ctx, "udp", p.Local.ToNetUDPAddr(), addr.SvcNone)
 	if err != nil {
 		return nil, common.NewBasicError("listening failed", err)
 	}

--- a/go/lib/snet/interface.go
+++ b/go/lib/snet/interface.go
@@ -25,8 +25,8 @@ import (
 
 type Network interface {
 	Listen(ctx context.Context, network string, listen *net.UDPAddr, svc addr.HostSVC) (Conn, error)
-	Dial(network string, listen *net.UDPAddr, remote *UDPAddr, svc addr.HostSVC,
-		timeout time.Duration) (Conn, error)
+	Dial(ctx context.Context, network string, listen *net.UDPAddr, remote *UDPAddr,
+		 svc addr.HostSVC) (Conn, error)
 }
 
 // Conn represents a SCION connection.

--- a/go/lib/snet/interface.go
+++ b/go/lib/snet/interface.go
@@ -16,6 +16,7 @@
 package snet
 
 import (
+	"context"
 	"net"
 	"time"
 
@@ -23,8 +24,7 @@ import (
 )
 
 type Network interface {
-	Listen(network string, listen *net.UDPAddr, svc addr.HostSVC,
-		timeout time.Duration) (Conn, error)
+	Listen(ctx context.Context, network string, listen *net.UDPAddr, svc addr.HostSVC) (Conn, error)
 	Dial(network string, listen *net.UDPAddr, remote *UDPAddr, svc addr.HostSVC,
 		timeout time.Duration) (Conn, error)
 }

--- a/go/lib/snet/interface.go
+++ b/go/lib/snet/interface.go
@@ -26,7 +26,7 @@ import (
 type Network interface {
 	Listen(ctx context.Context, network string, listen *net.UDPAddr, svc addr.HostSVC) (Conn, error)
 	Dial(ctx context.Context, network string, listen *net.UDPAddr, remote *UDPAddr,
-		 svc addr.HostSVC) (Conn, error)
+		svc addr.HostSVC) (Conn, error)
 }
 
 // Conn represents a SCION connection.

--- a/go/lib/snet/mock_snet/snet.go
+++ b/go/lib/snet/mock_snet/snet.go
@@ -251,20 +251,20 @@ func (m *MockPacketDispatcherService) EXPECT() *MockPacketDispatcherServiceMockR
 	return m.recorder
 }
 
-// RegisterTimeout mocks base method
-func (m *MockPacketDispatcherService) RegisterTimeout(arg0 addr.IA, arg1, arg2 *net.UDPAddr, arg3 addr.HostSVC, arg4 time.Duration) (snet.PacketConn, uint16, error) {
+// Register mocks base method
+func (m *MockPacketDispatcherService) Register(arg0 context.Context, arg1 addr.IA, arg2 *net.UDPAddr, arg3 addr.HostSVC) (snet.PacketConn, uint16, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RegisterTimeout", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "Register", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(snet.PacketConn)
 	ret1, _ := ret[1].(uint16)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// RegisterTimeout indicates an expected call of RegisterTimeout
-func (mr *MockPacketDispatcherServiceMockRecorder) RegisterTimeout(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+// Register indicates an expected call of Register
+func (mr *MockPacketDispatcherServiceMockRecorder) Register(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTimeout", reflect.TypeOf((*MockPacketDispatcherService)(nil).RegisterTimeout), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockPacketDispatcherService)(nil).Register), arg0, arg1, arg2, arg3)
 }
 
 // MockNetwork is a mock of Network interface

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -43,6 +43,7 @@
 package snet
 
 import (
+	"context"
 	"net"
 	"time"
 
@@ -157,8 +158,13 @@ func (n *SCIONNetwork) Listen(network string, listen *net.UDPAddr,
 			Zone: listen.Zone,
 		},
 	}
-	packetConn, port, err := conn.scionNet.dispatcher.RegisterTimeout(n.localIA,
-		listen, nil, svc, timeout)
+	ctx := context.Background()
+	if timeout != 0 {
+		var cancelF context.CancelFunc
+		ctx, cancelF = context.WithTimeout(ctx, timeout)
+		defer cancelF()
+	}
+	packetConn, port, err := conn.scionNet.dispatcher.Register(ctx, n.localIA, listen, svc)
 	if err != nil {
 		return nil, err
 	}

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -17,6 +17,7 @@
 package squic
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 
@@ -85,5 +86,5 @@ func sListen(network *snet.SCIONNetwork, listen *net.UDPAddr,
 	if network == nil {
 		return nil, serrors.New("squic:  SCION network must not be nil")
 	}
-	return network.Listen("udp", listen, svc, 0)
+	return network.Listen(context.Background(), "udp", listen, svc)
 }

--- a/go/lib/sock/reliable/reconnect/network.go
+++ b/go/lib/sock/reliable/reconnect/network.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -44,12 +45,6 @@ func NewDispatcherService(dispatcher reliable.Dispatcher) *DispatcherService {
 }
 
 func (pn *DispatcherService) Register(ctx context.Context, ia addr.IA, public *net.UDPAddr,
-	svc addr.HostSVC) (net.PacketConn, uint16, error) {
-
-	return pn.RegisterTimeout(ctx, ia, public, svc)
-}
-
-func (pn *DispatcherService) RegisterTimeout(ctx context.Context, ia addr.IA, public *net.UDPAddr,
 	svc addr.HostSVC) (net.PacketConn, uint16, error) {
 
 	// Perform initial connection to allocate port. We use a reconnecter here

--- a/go/lib/sock/reliable/reconnect/network_test.go
+++ b/go/lib/sock/reliable/reconnect/network_test.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,7 +55,7 @@ func TestReconnect(t *testing.T) {
 					Return(mockConn, uint16(80), nil)
 
 				network := reconnect.NewDispatcherService(mockDispatcher)
-				packetConn, _, _ := network.RegisterTimeout(context.Background(), localAddr.IA,
+				packetConn, _, _ := network.Register(context.Background(), localAddr.IA,
 					localNoPortAddr.ToNetUDPAddr(), svc)
 				packetConn.(*reconnect.PacketConn).Reconnect()
 			})

--- a/go/lib/svc/resolver.go
+++ b/go/lib/svc/resolver.go
@@ -70,7 +70,7 @@ func (r *Resolver) LookupSVC(ctx context.Context, p snet.Path, svc addr.HostSVC)
 		IP: r.LocalIP,
 	}
 
-	conn, port, err := r.ConnFactory.RegisterTimeout(r.LocalIA, u, nil, addr.SvcNone, 0)
+	conn, port, err := r.ConnFactory.Register(ctx, r.LocalIA, u, addr.SvcNone)
 	if err != nil {
 		return nil, common.NewBasicError(errRegistration, err)
 	}

--- a/go/lib/svc/resolver_test.go
+++ b/go/lib/svc/resolver_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/smartystreets/goconvey/convey"
@@ -49,8 +48,8 @@ func TestResolver(t *testing.T) {
 
 		Convey("If opening up port fails, return error and no reply", func() {
 			mockPacketDispatcherService := mock_snet.NewMockPacketDispatcherService(ctrl)
-			mockPacketDispatcherService.EXPECT().RegisterTimeout(gomock.Any(), gomock.Any(),
-				gomock.Any(), gomock.Any(), gomock.Any()).
+			mockPacketDispatcherService.EXPECT().Register(gomock.Any(), gomock.Any(),
+				gomock.Any(), gomock.Any()).
 				Return(nil, uint16(0), errors.New("no conn"))
 			resolver := &svc.Resolver{
 				LocalIA:     srcIA,
@@ -64,11 +63,9 @@ func TestResolver(t *testing.T) {
 		Convey("Local machine information is used to build conns", func() {
 			mockPacketDispatcherService := mock_snet.NewMockPacketDispatcherService(ctrl)
 			mockConn := mock_snet.NewMockPacketConn(ctrl)
-			mockPacketDispatcherService.EXPECT().RegisterTimeout(srcIA,
+			mockPacketDispatcherService.EXPECT().Register(gomock.Any(), srcIA,
 				&net.UDPAddr{IP: net.IP{192, 0, 2, 1}},
-				nil,
-				addr.SvcNone,
-				time.Duration(0)).Return(mockConn, uint16(42), nil)
+				addr.SvcNone).Return(mockConn, uint16(42), nil)
 			mockRoundTripper := mock_svc.NewMockRoundTripper(ctrl)
 			mockRoundTripper.EXPECT().RoundTrip(gomock.Any(), gomock.Any(), gomock.Any(),
 				gomock.Any())

--- a/go/lib/svc/svc.go
+++ b/go/lib/svc/svc.go
@@ -1,4 +1,4 @@
-// Copyright 2019 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 package svc
 
 import (
+	"context"
 	"net"
-	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
@@ -72,11 +72,10 @@ type ResolverPacketDispatcher struct {
 	handler     RequestHandler
 }
 
-func (d *ResolverPacketDispatcher) RegisterTimeout(ia addr.IA, public *net.UDPAddr,
-	bind *net.UDPAddr, svc addr.HostSVC,
-	timeout time.Duration) (snet.PacketConn, uint16, error) {
+func (d *ResolverPacketDispatcher) Register(ctx context.Context, ia addr.IA,
+	registration *net.UDPAddr, svc addr.HostSVC) (snet.PacketConn, uint16, error) {
 
-	c, port, err := d.dispService.RegisterTimeout(ia, public, bind, svc, timeout)
+	c, port, err := d.dispService.Register(ctx, ia, registration, svc)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -84,7 +83,7 @@ func (d *ResolverPacketDispatcher) RegisterTimeout(ia addr.IA, public *net.UDPAd
 		PacketConn: c,
 		source: snet.SCIONAddress{
 			IA:   ia,
-			Host: addr.HostFromIP(public.IP),
+			Host: addr.HostFromIP(registration.IP),
 		},
 		handler: d.handler,
 	}

--- a/go/lib/svc/svc_test.go
+++ b/go/lib/svc/svc_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 ETH Zurich
+// Copyright 2019 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package svc_test
 
 import (
+	"context"
 	"errors"
 	"net"
 	"testing"
@@ -44,26 +45,26 @@ func TestSVCResolutionServer(t *testing.T) {
 		mockReqHandler := mock_svc.NewMockRequestHandler(ctrl)
 
 		Convey("Underlying dispatcher service fails to set up underlying conn", func() {
-			mockPacketDispatcherService.EXPECT().RegisterTimeout(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+			mockPacketDispatcherService.EXPECT().Register(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 			).Return(nil, uint16(0), errors.New("conn error"))
 
 			dispatcherService := svc.NewResolverPacketDispatcher(mockPacketDispatcherService,
 				mockReqHandler)
-			conn, port, err := dispatcherService.RegisterTimeout(addr.IA{}, &net.UDPAddr{},
-				&net.UDPAddr{}, addr.SvcPS, 0)
+			conn, port, err := dispatcherService.Register(context.Background(), addr.IA{},
+				&net.UDPAddr{}, addr.SvcPS)
 			SoMsg("conn", conn, ShouldBeNil)
 			SoMsg("port", port, ShouldEqual, 0)
 			SoMsg("err", err, ShouldNotBeNil)
 		})
 		Convey("Given an established resolver conn", func() {
-			mockPacketDispatcherService.EXPECT().RegisterTimeout(gomock.Any(), gomock.Any(),
-				gomock.Any(), gomock.Any(), gomock.Any()).Return(mockPacketConn, uint16(1337), nil)
+			mockPacketDispatcherService.EXPECT().Register(gomock.Any(), gomock.Any(),
+				gomock.Any(), gomock.Any()).Return(mockPacketConn, uint16(1337), nil)
 
 			dispatcherService := svc.NewResolverPacketDispatcher(mockPacketDispatcherService,
 				mockReqHandler)
-			conn, port, err := dispatcherService.RegisterTimeout(addr.IA{}, &net.UDPAddr{},
-				&net.UDPAddr{}, addr.SvcPS, 0)
+			conn, port, err := dispatcherService.Register(context.Background(), addr.IA{},
+				&net.UDPAddr{}, addr.SvcPS)
 			SoMsg("conn", conn, ShouldNotBeNil)
 			SoMsg("port", port, ShouldEqual, 1337)
 			SoMsg("err", err, ShouldBeNil)

--- a/go/sig/egress/session/session.go
+++ b/go/sig/egress/session/session.go
@@ -76,8 +76,8 @@ func NewSession(dstIA addr.IA, sessId mgmt.SessionType, logger log.Logger,
 	s.healthy.Store(false)
 	s.ring = ringbuf.New(64, nil, fmt.Sprintf("egress_%s_%s", dstIA, sessId))
 	// Not using a fixed local port, as this is for outgoing data only.
-	s.conn, err = sigcmn.Network.Listen("udp",
-		&net.UDPAddr{IP: sigcmn.Host.IP()}, addr.SvcNone, 0)
+	s.conn, err = sigcmn.Network.Listen(context.Background(), "udp",
+		&net.UDPAddr{IP: sigcmn.Host.IP()}, addr.SvcNone)
 	s.sessMonStop = make(chan struct{})
 	s.sessMonStopped = make(chan struct{})
 	s.pktDispStop = make(chan struct{})

--- a/go/sig/internal/ingress/dispatcher.go
+++ b/go/sig/internal/ingress/dispatcher.go
@@ -16,6 +16,7 @@
 package ingress
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
@@ -60,7 +61,8 @@ func NewDispatcher(tio io.ReadWriteCloser) *Dispatcher {
 
 func (d *Dispatcher) Run() error {
 	var err error
-	d.extConn, err = sigcmn.Network.Listen("udp", d.laddr.ToNetUDPAddr(), addr.SvcNone, 0)
+	d.extConn, err = sigcmn.Network.Listen(context.Background(), "udp",
+		d.laddr.ToNetUDPAddr(), addr.SvcNone)
 	if err != nil {
 		return common.NewBasicError("Unable to initialize extConn", err)
 	}

--- a/go/sig/internal/sigcmn/common.go
+++ b/go/sig/internal/sigcmn/common.go
@@ -16,6 +16,7 @@
 package sigcmn
 
 import (
+	"context"
 	"net"
 	"time"
 
@@ -64,8 +65,8 @@ func Init(cfg sigconfig.SigConf, sdCfg env.SciondClient) error {
 	if err != nil {
 		return common.NewBasicError("Error creating local SCION Network context", err)
 	}
-	conn, err := network.Listen("udp",
-		&net.UDPAddr{IP: Host.IP(), Port: int(cfg.CtrlPort)}, addr.SvcSIG, 0)
+	conn, err := network.Listen(context.Background(), "udp",
+		&net.UDPAddr{IP: Host.IP(), Port: int(cfg.CtrlPort)}, addr.SvcSIG)
 	if err != nil {
 		return common.NewBasicError("Error creating ctrl socket", err)
 	}


### PR DESCRIPTION
- snet.PacketDispatcherService now has a context aware Register method.
- snet.Network's Listen and Dial now both take a context.

Contributes #3136

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3562)
<!-- Reviewable:end -->
