### PR TITLE
CI: add revocation tests to pipeline 2

### DIFF
--- a/.buildkite/hooks/pre-artifact
+++ b/.buildkite/hooks/pre-artifact
@@ -45,6 +45,6 @@ save "logs"
 save "traces"
 save "gen"
 save "gen-cache"
-save "accept_artifacts"
+save "$TEST_ARTIFACTS"
 
 tar chaf "artifacts.out/$ARTIFACTS.tar.gz" -C "$ARTIFACTS_DIR" "$ARTIFACTS"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -8,6 +8,7 @@ echo "Clean existing environment"
 
 if [ "$BUILDKITE_PIPELINE_SLUG" == "scionproto2" ]; then
     export ACCEPTANCE_ARTIFACTS="$PWD/accept_artifacts"
+    mkdir -p "$ACCEPTANCE_ARTIFACTS"
 fi
 
 echo "Starting bazel remote cache proxy"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -4,11 +4,24 @@ set -euo pipefail
 
 echo "Clean existing environment"
 
+# TEST_ARTIFACTS is a generic folder for artifacts that need to be used during
+# testing. It will be collected in the artifacts in the end.
+# Note that this has to be defined in a hook, because in the pipeline the $PWD
+# would be evaluated to early (at pipeline expansion) and thus it would possibly
+# be the wrong value on the agent a step is actually executed.
+export TEST_ARTIFACTS="$PWD/test_artifacts"
+
 . .buildkite/hooks/pre-exit
 
+# Make sure the test artifacts folder exitsts.
+echo "Create test artifacts: mkdir -p $TEST_ARTIFACTS"
+mkdir -p "$TEST_ARTIFACTS"
+
+# Conditionally export ACCEPTANCE_ARTIFACTS it is needed for acceptance tests.
+# We only export it for the new pipeline because the old pipeline has its own
+# definition.
 if [ "$BUILDKITE_PIPELINE_SLUG" == "scionproto2" ]; then
-    export ACCEPTANCE_ARTIFACTS="$PWD/accept_artifacts"
-    mkdir -p "$ACCEPTANCE_ARTIFACTS"
+    export ACCEPTANCE_ARTIFACTS="$TEST_ARTIFACTS"
 fi
 
 echo "Starting bazel remote cache proxy"

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -10,4 +10,4 @@ docker network prune -f
 echo "Remove leftover volumes"
 docker volume prune -f
 
-rm -rf bazel-testlogs logs/* traces gen gen-cache accept_artifacts
+rm -rf bazel-testlogs logs/* traces gen gen-cache "$TEST_ARTIFACTS"

--- a/.buildkite/pipeline2.sh
+++ b/.buildkite/pipeline2.sh
@@ -8,7 +8,6 @@ gen_acceptance() {
         name="$(basename ${test%_acceptance})"
         echo "  - label: \"Acceptance: $name\""
         echo "    command:"
-        echo "      - \"mkdir -p \$\$ACCEPTANCE_ARTIFACTS\""
         echo "      - ./acceptance/ctl gsetup"
         echo "      - ./acceptance/ctl grun $name"
         echo "    key: ${name}_acceptance"
@@ -31,7 +30,6 @@ gen_acceptance2() {
         name=${name#'//acceptance/'}
         echo "  - label: \"Acceptance: $name\""
         echo "    command:"
-        echo "      - mkdir -p \$\$ACCEPTANCE_ARTIFACTS"
         echo "      - bazel test --action_env=ACCEPTANCE_ARTIFACTS $test"
         echo "    key: ${name}_acceptance"
         echo "    artifact_paths:"

--- a/.buildkite/pipeline2.sh
+++ b/.buildkite/pipeline2.sh
@@ -23,5 +23,26 @@ gen_acceptance() {
     done
 }
 
+# gen_acceptance2 generates steps for bazel tests in acceptance folder.
+gen_acceptance2() {
+    for test in $(bazel query 'kind(sh_test, //acceptance/...)' 2>/dev/null); do
+        # test has the format //acceptance/<name>:<name>_test
+        name=$(echo $test | cut -d ':' -f 1)
+        name=${name#'//acceptance/'}
+        echo "  - label: \"Acceptance: $name\""
+        echo "    command:"
+        echo "      - mkdir -p \$\$ACCEPTANCE_ARTIFACTS"
+        echo "      - bazel test --action_env=ACCEPTANCE_ARTIFACTS $test"
+        echo "    key: ${name}_acceptance"
+        echo "    artifact_paths:"
+        echo "      - \"artifacts.out/**/*\""
+        echo "    retry:"
+        echo "      automatic:"
+        echo "        - exit_status: -1 # Agent was lost"
+        echo "        - exit_status: 255 # Forced agent shutdown"
+    done
+}
+
 cat .buildkite/pipeline_buildlint.yml
+gen_acceptance2
 gen_acceptance

--- a/.buildkite/pipeline2.sh
+++ b/.buildkite/pipeline2.sh
@@ -22,15 +22,15 @@ gen_acceptance() {
     done
 }
 
-# gen_acceptance2 generates steps for bazel tests in acceptance folder.
-gen_acceptance2() {
+# gen_bazel_acceptance generates steps for bazel tests in acceptance folder.
+gen_bazel_acceptance() {
     for test in $(bazel query 'kind(sh_test, //acceptance/...)' 2>/dev/null); do
         # test has the format //acceptance/<name>:<name>_test
         name=$(echo $test | cut -d ':' -f 1)
         name=${name#'//acceptance/'}
         echo "  - label: \"Acceptance: $name\""
         echo "    command:"
-        echo "      - bazel test --action_env=ACCEPTANCE_ARTIFACTS $test"
+        echo "      - bazel test $test"
         echo "    key: ${name}_acceptance"
         echo "    artifact_paths:"
         echo "      - \"artifacts.out/**/*\""
@@ -42,5 +42,5 @@ gen_acceptance2() {
 }
 
 cat .buildkite/pipeline_buildlint.yml
-gen_acceptance2
+gen_bazel_acceptance
 gen_acceptance

--- a/.buildkite/pipeline_buildlint.yml
+++ b/.buildkite/pipeline_buildlint.yml
@@ -21,14 +21,12 @@ steps:
     timeout_in_minutes: 10
   - label: "Check generated go_deps.bzl file is up to date with go.mod"
     command:
-      - "rm -rf /tmp/$BUILDKITE_STEP_ID/"
-      - "mkdir -p /tmp/$BUILDKITE_STEP_ID/"
-      - "cp go.mod go.sum go_deps.bzl /tmp/$BUILDKITE_STEP_ID/"
-      - "make godeps -B"
-      - "bazel-${BUILDKITE_PIPELINE_SLUG}/external/go_sdk/bin/go mod tidy"
-      - "diff -u /tmp/$BUILDKITE_STEP_ID/go.mod go.mod"
-      - "diff -u /tmp/$BUILDKITE_STEP_ID/go.sum go.sum"
-      - "diff -u /tmp/$BUILDKITE_STEP_ID/go_deps.bzl go_deps.bzl"
+      - "cp go.mod go.sum go_deps.bzl $$ACCEPTANCE_ARTIFACTS/"
+      - make godeps -B
+      - "bazel-${USER}/external/go_sdk/bin/go mod tidy"
+      - "diff -u $$ACCEPTANCE_ARTIFACTS/go.mod go.mod"
+      - "diff -u $$ACCEPTANCE_ARTIFACTS/go.sum go.sum"
+      - "diff -u $$ACCEPTANCE_ARTIFACTS/go_deps.bzl go_deps.bzl"
     key: go_deps_lint
     retry:
       automatic:
@@ -36,11 +34,9 @@ steps:
         - exit_status: 255 # Forced agent shutdown
   - label: "Check generated go/proto files in git"
     command:
-      - "rm -rf /tmp/$BUILDKITE_STEP_ID/"
-      - "mkdir -p /tmp/$BUILDKITE_STEP_ID/"
-      - "cp -R go/proto/ /tmp/$BUILDKITE_STEP_ID/"
-      - "make gogen"
-      - "diff -ur /tmp/$BUILDKITE_STEP_ID/proto/ go/proto/"
+      - "cp -R go/proto/ $$ACCEPTANCE_ARTIFACTS"
+      - make gogen
+      - "diff -ur $$ACCEPTANCE_ARTIFACTS/proto/ go/proto/"
     key: go_gen_lint
     retry:
       automatic:
@@ -53,26 +49,17 @@ steps:
       automatic:
         - exit_status: -1  # Agent was lost
         - exit_status: 255 # Forced agent shutdown
-  - label: "Acceptance: sig_failover"
+  - label: "Revocation tests"
     command:
-      - mkdir -p $$ACCEPTANCE_ARTIFACTS
-      - bazel test --action_env=ACCEPTANCE_ARTIFACTS //acceptance/sig_failover:sig_failover_test
-    key: sig_failover
+      - bazel --bazelrc=.bazelrc_ci build //:scion //:scion-ci >/dev/null 2>&1
+      - tar -kxf bazel-bin/scion.tar -C bin --overwrite
+      - tar -kxf bazel-bin/scion-ci.tar -C bin --overwrite
+      - ./scion.sh topology nobuild
+      - ./scion.sh run nobuild && sleep 10
+      - ./bin/end2end_integration -log.console warn
+      - ./integration/revocation_test.sh
+    key: revocation_tests
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
         - exit_status: 255 # Forced agent shutdown
-    artifact_paths:
-      - "artifacts.out/**/*"
-  - label: "Acceptance: sig_short_exp_time"
-    command:
-      - mkdir -p $$ACCEPTANCE_ARTIFACTS
-      - bazel test --action_env=ACCEPTANCE_ARTIFACTS //acceptance/sig_short_exp_time:sig_short_exp_time_test
-    key: sig_short_exp_time
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-        - exit_status: 255 # Forced agent shutdown
-    artifact_paths:
-      - "artifacts.out/**/*"
-

--- a/.buildkite/pipeline_buildlint.yml
+++ b/.buildkite/pipeline_buildlint.yml
@@ -23,7 +23,7 @@ steps:
     command:
       - "cp go.mod go.sum go_deps.bzl $$ACCEPTANCE_ARTIFACTS/"
       - make godeps -B
-      - "bazel-${USER}/external/go_sdk/bin/go mod tidy"
+      - "bazel-${BUILDKITE_PIPELINE_SLUG}/external/go_sdk/bin/go mod tidy"
       - "diff -u $$ACCEPTANCE_ARTIFACTS/go.mod go.mod"
       - "diff -u $$ACCEPTANCE_ARTIFACTS/go.sum go.sum"
       - "diff -u $$ACCEPTANCE_ARTIFACTS/go_deps.bzl go_deps.bzl"
@@ -59,6 +59,8 @@ steps:
       - ./bin/end2end_integration -log.console warn
       - ./integration/revocation_test.sh
     key: revocation_tests
+    artifact_paths:
+      - "artifacts.out/**/*"
     retry:
       automatic:
         - exit_status: -1  # Agent was lost

--- a/.buildkite/pipeline_buildlint.yml
+++ b/.buildkite/pipeline_buildlint.yml
@@ -21,12 +21,12 @@ steps:
     timeout_in_minutes: 10
   - label: "Check generated go_deps.bzl file is up to date with go.mod"
     command:
-      - "cp go.mod go.sum go_deps.bzl $$ACCEPTANCE_ARTIFACTS/"
+      - "cp go.mod go.sum go_deps.bzl $$TEST_ARTIFACTS/"
       - make godeps -B
       - "bazel-${BUILDKITE_PIPELINE_SLUG}/external/go_sdk/bin/go mod tidy"
-      - "diff -u $$ACCEPTANCE_ARTIFACTS/go.mod go.mod"
-      - "diff -u $$ACCEPTANCE_ARTIFACTS/go.sum go.sum"
-      - "diff -u $$ACCEPTANCE_ARTIFACTS/go_deps.bzl go_deps.bzl"
+      - "diff -u $$TEST_ARTIFACTS/go.mod go.mod"
+      - "diff -u $$TEST_ARTIFACTS/go.sum go.sum"
+      - "diff -u $$TEST_ARTIFACTS/go_deps.bzl go_deps.bzl"
     key: go_deps_lint
     retry:
       automatic:
@@ -34,9 +34,9 @@ steps:
         - exit_status: 255 # Forced agent shutdown
   - label: "Check generated go/proto files in git"
     command:
-      - "cp -R go/proto/ $$ACCEPTANCE_ARTIFACTS"
+      - "cp -R go/proto/ $$TEST_ARTIFACTS"
       - make gogen
-      - "diff -ur $$ACCEPTANCE_ARTIFACTS/proto/ go/proto/"
+      - "diff -ur $$TEST_ARTIFACTS/proto/ go/proto/"
     key: go_gen_lint
     retry:
       automatic:


### PR DESCRIPTION
Also:
- introduce test artifacts variable as a dir that always exists ready for tests to be used.
- use test artifacts for diff tests in check generated tasks, this dir always exists also on the local CI.
- generate acceptance steps for bazelified acceptance tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3563)
<!-- Reviewable:end -->
