### PR TITLE
SH: Only build necessary binaries

### DIFF
--- a/.buildkite/pipeline_buildlint.yml
+++ b/.buildkite/pipeline_buildlint.yml
@@ -77,7 +77,7 @@ steps:
     - bazel --bazelrc=.bazelrc_ci build //:scion //:scion-ci >/dev/null 2>&1
     - tar -kxf bazel-bin/scion.tar -C bin --overwrite
     - tar -kxf bazel-bin/scion-ci.tar -C bin --overwrite
-    - ./scion.sh topology nobuild
+    - ./scion.sh topology
     - ./scion.sh run nobuild && sleep 10
     - ./bin/cert_req_integration -log.console warn
     - ./bin/pp_integration  -log.console warn

--- a/.buildkite/pipeline_buildlint.yml
+++ b/.buildkite/pipeline_buildlint.yml
@@ -61,7 +61,7 @@ steps:
       - bazel --bazelrc=.bazelrc_ci build //:scion //:scion-ci >/dev/null 2>&1
       - tar -kxf bazel-bin/scion.tar -C bin --overwrite
       - tar -kxf bazel-bin/scion-ci.tar -C bin --overwrite
-      - ./scion.sh topology nobuild
+      - ./scion.sh topology
       - ./scion.sh run nobuild && sleep 10
       - ./bin/end2end_integration -log.console warn
       - ./integration/revocation_test.sh

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -50,6 +50,16 @@ pkg_tar(
     mode = "0755",
 )
 
+# This contains all of the binaries needed to run the topology generator.
+pkg_tar(
+    name = "scion-topo",
+    package_dir = "",
+    srcs = [
+        "//go/tools/scion-custpk-load:scion-custpk-load",
+        "//go/tools/scion-pki:scion-pki",
+    ],
+    mode = "0755",
+)
 
 # This is a package of tools used for linting the source code.
 pkg_tar(

--- a/acceptance/cert_renewal_acceptance_disabled/test
+++ b/acceptance/cert_renewal_acceptance_disabled/test
@@ -23,7 +23,7 @@ CORE_IA_FILE="$(ia_file $CORE_IA)"
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -t
+    ./scion.sh topology -c $TEST_TOPOLOGY -d -t
     sed -i -e 's/Level = .*$/Level = "trace"/g' \
         -e '/\[logging\.file\]/a FlushInterval = 1' \
         -e '/\[cs\]/a AutomaticRenewal = true' \

--- a/acceptance/common/scion.py
+++ b/acceptance/common/scion.py
@@ -111,8 +111,7 @@ class ScionDocker(Scion):
     @LogExec(logger, "creating dockerized topology")
     def topology(self, topo_file: str, *args: str):
         """ Create the dockerized topology files. """
-        self.scion_sh('topology', 'nobuild', '-c', topo_file, '-t',
-                      '-d', *args)
+        self.scion_sh('topology', '-c', topo_file, '-t', '-d', *args)
 
     def _send_signals(self, svc_names: List[str], sig: str):
         for svc_name in svc_names:
@@ -131,7 +130,7 @@ class ScionSupervisor(Scion):
     @LogExec(logger, "creating supervisor topology")
     def topology(self, topo_file: str, *args: str):
         """ Create the topology files. """
-        self.scion_sh('topology', 'nobuild', '-c', topo_file, *args)
+        self.scion_sh('topology', '-c', topo_file, *args)
 
     def _send_signals(self, svc_names: List[str], sig: str):
         for svc_name in svc_names:

--- a/acceptance/discovery_util/util.sh
+++ b/acceptance/discovery_util/util.sh
@@ -22,7 +22,7 @@ DYNAMIC_DEFAULT="$DYNAMIC_DIR/default.json"
 base_setup() {
     set -e
     # Create topology setup all necessary config files.
-    ./scion.sh topology nobuild -c "$TEST_TOPOLOGY" -d -t -ds
+    ./scion.sh topology -c "$TEST_TOPOLOGY" -d -t -ds
     # Create the topology directories for serving.
     mkdir -p "$STATIC_DIR"
     mkdir -p "$DYNAMIC_DIR"

--- a/acceptance/reconnecting_acceptance/test
+++ b/acceptance/reconnecting_acceptance/test
@@ -11,7 +11,7 @@ TEST_TOPOLOGY="topology/Tiny.topo"
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -t
+    ./scion.sh topology -c $TEST_TOPOLOGY -d -t
     ./scion.sh run nobuild
     ./tools/dc start tester_1-ff00_0_112 tester_1-ff00_0_110
     docker_status

--- a/acceptance/sigutil/common.sh
+++ b/acceptance/sigutil/common.sh
@@ -8,7 +8,7 @@ DST_IA=${DST_IA:-1-ff00:0:112}
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -t --sig -n 242.254.0.0/16
+    ./scion.sh topology -c $TEST_TOPOLOGY -d -t --sig -n 242.254.0.0/16
     for sig in gen/ISD1/*/sig*/sig.toml; do
         sed -i '/\[logging\.file\]/a FlushInterval = 1' "$sig"
     done

--- a/acceptance/topo_br_reload_util/util.sh
+++ b/acceptance/topo_br_reload_util/util.sh
@@ -31,7 +31,7 @@ base_setup() {
 }
 
 base_gen_topo() {
-    ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -t
+    ./scion.sh topology -c $TEST_TOPOLOGY -d -t
     sed -i '/\[logging\.file\]/a FlushInterval = 1' gen/ISD1/*/br*/br.toml
 }
 

--- a/acceptance/topo_invalid_reloads_acceptance/test
+++ b/acceptance/topo_invalid_reloads_acceptance/test
@@ -16,7 +16,7 @@ TOPO="gen/ISD1/AS$AS_FILE/topology.json"
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -t
+    ./scion.sh topology -c $TEST_TOPOLOGY -d -t
     sed -i '/\[logging\.file\]/a FlushInterval = 1' gen/ISD1/*/*/*.toml
     ./tools/dc start scion_ps$IA_FILE-1 scion_sd$IA_FILE
     docker_status

--- a/acceptance/topo_ps_reloads_br_acceptance/test
+++ b/acceptance/topo_ps_reloads_br_acceptance/test
@@ -17,7 +17,7 @@ DST_IA=${DST_IA:-1-ff00:0:111}
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -t
+    ./scion.sh topology -c $TEST_TOPOLOGY -d -t
     sed -i '/\[logging\.file\]/a FlushInterval = 1' gen/ISD1/*/ps*/ps.toml
     ./scion.sh run nobuild
     ./tools/dc start tester_$SRC_IA_FILE

--- a/acceptance/topo_ps_reloads_cs_acceptance_disabled/test
+++ b/acceptance/topo_ps_reloads_cs_acceptance_disabled/test
@@ -15,7 +15,7 @@ AS_FILE="$(as_file $IA)"
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -t
+    ./scion.sh topology -c $TEST_TOPOLOGY -d -t
     sed -i -e '/\[logging\.file\]/a FlushInterval = 1'\
             -e '/\[ps\]/a\CryptoSyncInterval="1s"' gen/ISD1/*/ps*/ps.toml
     ./scion.sh run nobuild

--- a/acceptance/topo_sd_reloads_br_acceptance/test
+++ b/acceptance/topo_sd_reloads_br_acceptance/test
@@ -17,7 +17,7 @@ DST_IA=${DST_IA:-1-ff00:0:110}
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -t
+    ./scion.sh topology -c $TEST_TOPOLOGY -d -t
     sed -i '/\[logging\.file\]/a FlushInterval = 1' gen/ISD1/*/endhost/sd.toml
     ./scion.sh run nobuild
     ./tools/dc start tester_$SRC_IA_FILE

--- a/acceptance/topo_sd_reloads_cs_acceptance_disabled/test
+++ b/acceptance/topo_sd_reloads_cs_acceptance_disabled/test
@@ -16,7 +16,7 @@ DST_IA=${DST_IA:-1-ff00:0:110}
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -t
+    ./scion.sh topology -c $TEST_TOPOLOGY -d -t
     sed -i '/\[logging\.file\]/a FlushInterval = 1' gen/ISD1/*/endhost/sd.toml
     ./scion.sh run nobuild
     ./tools/dc start tester_$SRC_IA_FILE

--- a/acceptance/topo_sd_reloads_ps_acceptance/test
+++ b/acceptance/topo_sd_reloads_ps_acceptance/test
@@ -16,7 +16,7 @@ DST_IA=${DST_IA:-1-ff00:0:110}
 
 test_setup() {
     set -e
-    ./scion.sh topology nobuild -c $TEST_TOPOLOGY -d -t
+    ./scion.sh topology -c $TEST_TOPOLOGY -d -t
     sed -i '/\[logging\.file\]/a FlushInterval = 1' gen/ISD1/*/endhost/sd.toml
     ./scion.sh run nobuild
     ./tools/dc start tester_$SRC_IA_FILE

--- a/scion.sh
+++ b/scion.sh
@@ -25,8 +25,8 @@ cmd_topology() {
     cmd_topo_clean
 
     # Build the necessary binaries.
-    bazel build //:scion-topo || return 1
-	tar --overwrite -xf bazel-bin/scion-topo.tar -C bin
+    bazel build //:scion-topo
+    tar --overwrite -xf bazel-bin/scion-topo.tar -C bin
 
     echo "Create topology, configuration, and execution files."
     is_running_in_docker && set -- "$@" --in-docker
@@ -348,6 +348,10 @@ cmd_version() {
 	_EOF
 }
 
+cmd_build() {
+    make -s
+}
+
 cmd_clean() {
     make -s clean
 }
@@ -407,7 +411,7 @@ cmd_help() {
 	Usage:
 	    $PROGRAM topology
 	        Create topology, configuration, and execution files.
-            All arguments or options are passed to topology/generator.py
+	        All arguments or options are passed to topology/generator.py
 	    $PROGRAM run [nobuild]
 	        Run network.
 	    $PROGRAM sciond ISD-AS [ADDR]
@@ -432,10 +436,10 @@ cmd_help() {
 	        Show this text.
 	    $PROGRAM version
 	        Show version information.
-        $PROGRAM traces [folder]
-            Serve jaeger traces from the specified folder (default: traces/)
-        $PROGRAM stop_traces
-            Stop the jaeger container started during the traces command
+	    $PROGRAM traces [folder]
+	        Serve jaeger traces from the specified folder (default: traces/)
+	    $PROGRAM stop_traces
+	        Stop the jaeger container started during the traces command
 	_EOF
 }
 # END subcommand functions
@@ -445,7 +449,7 @@ COMMAND="$1"
 shift
 
 case "$COMMAND" in
-    coverage|help|lint|run|mstart|mstatus|mstop|stop|status|test|topology|version|clean|sciond|traces|stop_traces|topo_clean)
+    coverage|help|lint|run|mstart|mstatus|mstop|stop|status|test|topology|version|build|clean|sciond|traces|stop_traces|topo_clean)
         "cmd_$COMMAND" "$@" ;;
     start) cmd_run "$@" ;;
     *)  cmd_help; exit 1 ;;

--- a/tools/ci/integration
+++ b/tools/ci/integration
@@ -44,7 +44,7 @@ stop_containers() {
     fi
 }
 
-./docker.sh exec "set -x; ./scion.sh topology nobuild -t ${DOCKER_BE:+ -d -n 172.21.0.0/16 -c topology/Tiny.topo}" ||\
+./docker.sh exec "set -x; ./scion.sh topology -t ${DOCKER_BE:+ -d -n 172.21.0.0/16 -c topology/Tiny.topo}" ||\
     { echo "Failed to create topology"; stop_containers; exit 1; }
 ./docker.sh exec "set -eo pipefail; ./scion.sh run nobuild | grep -v "started" |& tee logs/integration.run"
 ./docker.sh exec "set -eo pipefail; ./scion.sh status |& tee logs/integration.run"


### PR DESCRIPTION
The topology generator only uses two binaries when running.
With this change, scion.sh only builds the necessary binaries instead
of all binaries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3566)
<!-- Reviewable:end -->
