### PR TITLE
SNET: remove snet.Addr usage in read/write functions

### DIFF
--- a/go/border/rctrl/ctrl.go
+++ b/go/border/rctrl/ctrl.go
@@ -79,7 +79,7 @@ func processCtrl() {
 	b := make(common.RawBytes, maxBufSize)
 	cl := metrics.ControlLabels{}
 	for {
-		pktLen, src, err := snetConn.ReadFromSCION(b)
+		pktLen, src, err := snetConn.ReadFrom(b)
 		if err != nil {
 			cl.Result = metrics.ErrRead
 			metrics.Control.Reads(cl).Inc()

--- a/go/border/rctrl/ifstate.go
+++ b/go/border/rctrl/ifstate.go
@@ -72,10 +72,6 @@ func genIFStateReq() error {
 		metrics.Control.SentIFStateReq(cl).Inc()
 		return common.NewBasicError("Writing IFStateReq signed Ctrl payload", err)
 	}
-	dst := &snet.Addr{
-		IA:   ia,
-		Host: &addr.AppAddr{L3: addr.SvcBS.Multicast()},
-	}
 	bsAddrs, err := rctx.Get().ResolveSVCMulti(addr.SvcBS)
 	if err != nil {
 		cl.Result = metrics.ErrResolveSVC
@@ -84,15 +80,15 @@ func genIFStateReq() error {
 	}
 
 	var errors common.MultiError
-	for _, addr := range bsAddrs {
-		dst.NextHop = addr
-		if _, err := snetConn.WriteToSCION(pld, dst); err != nil {
+	for _, a := range bsAddrs {
+		dst := snet.NewSVCAddr(ia, nil, a, addr.SvcBS.Multicast())
+		if _, err := snetConn.WriteTo(pld, dst); err != nil {
 			cl.Result = metrics.ErrWrite
 			metrics.Control.SentIFStateReq(cl).Inc()
 			errors = append(errors, common.NewBasicError("Writing IFStateReq", err, "dst", dst))
 			continue
 		}
-		logger.Debug("Sent IFStateReq", "dst", dst, "overlayDst", addr)
+		logger.Debug("Sent IFStateReq", "dst", dst, "overlayDst", a)
 		cl.Result = metrics.Success
 		metrics.Control.SentIFStateReq(cl).Inc()
 	}

--- a/go/border/rctrl/revinfo.go
+++ b/go/border/rctrl/revinfo.go
@@ -73,10 +73,7 @@ func fwdRevInfo(sRevInfo *path_mgmt.SignedRevInfo, dstHost addr.HostSVC) {
 		logger.Error("Writing RevInfo signed Ctrl payload", "err", err)
 		return
 	}
-	dst := &snet.Addr{
-		IA:   ia,
-		Host: &addr.AppAddr{L3: dstHost},
-	}
+	dst := snet.NewSVCAddr(ia, nil, nil, dstHost)
 	dst.NextHop, err = ctx.ResolveSVCAny(dstHost)
 	if err != nil {
 		cl.Result = metrics.ErrResolveSVC
@@ -84,7 +81,7 @@ func fwdRevInfo(sRevInfo *path_mgmt.SignedRevInfo, dstHost addr.HostSVC) {
 		logger.Error("Resolving SVC anycast", "err", err, "addr", dst)
 		return
 	}
-	if _, err := snetConn.WriteToSCION(pld, dst); err != nil {
+	if _, err := snetConn.WriteTo(pld, dst); err != nil {
 		metrics.Control.SentRevInfos(cl).Inc()
 		logger.Error("Writing RevInfo", "dst", dst, "err", err)
 		return

--- a/go/lib/pktdisp/disp.go
+++ b/go/lib/pktdisp/disp.go
@@ -16,6 +16,8 @@
 package pktdisp
 
 import (
+	"net"
+
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/fatal"
 	"github.com/scionproto/scion/go/lib/log"
@@ -25,7 +27,7 @@ import (
 
 type DispPkt struct {
 	Raw  common.RawBytes
-	Addr *snet.Addr
+	Addr net.Addr
 }
 
 type DispatchFunc func(*DispPkt)
@@ -44,7 +46,7 @@ func PktDispatcher(c snet.Conn, f DispatchFunc, pktDispStop chan struct{}) {
 			return
 		default:
 			dp.Raw = dp.Raw[:cap(dp.Raw)]
-			n, dp.Addr, err = c.ReadFromSCION(dp.Raw)
+			n, dp.Addr, err = c.ReadFrom(dp.Raw)
 			if err != nil {
 				if reliable.IsDispatcherError(err) {
 					fatal.Fatal(err)

--- a/go/lib/sciond/pathprobe/paths.go
+++ b/go/lib/sciond/pathprobe/paths.go
@@ -143,14 +143,8 @@ func (p Prober) GetStatuses(ctx context.Context,
 }
 
 func (p Prober) send(scionConn snet.Conn, path snet.Path) error {
-	addr := &snet.Addr{
-		IA: p.DstIA,
-		Host: &addr.AppAddr{
-			L3: addr.HostSVCFromString("NONE"),
-		},
-		NextHop: path.OverlayNextHop(),
-		Path:    path.Path(),
-	}
+	addr := snet.NewSVCAddr(p.DstIA, path.Path(), path.OverlayNextHop(),
+		addr.SvcNone)
 	log.Debug("Sending test packet.", "path", fmt.Sprintf("%s", path))
 	_, err := scionConn.WriteTo([]byte{}, addr)
 	if err != nil {
@@ -161,7 +155,7 @@ func (p Prober) send(scionConn snet.Conn, path snet.Path) error {
 
 func (p Prober) receive(scionConn snet.Conn) error {
 	b := make([]byte, 1500, 1500)
-	_, _, err := scionConn.ReadFromSCION(b)
+	_, _, err := scionConn.ReadFrom(b)
 	if err == nil {
 		// We've got an actual reply instead of SCMP error. This should not happen.
 		return nil

--- a/go/lib/snet/interface.go
+++ b/go/lib/snet/interface.go
@@ -33,10 +33,8 @@ type Network interface {
 type Conn interface {
 	Read(b []byte) (int, error)
 	ReadFrom(b []byte) (int, net.Addr, error)
-	ReadFromSCION(b []byte) (int, *Addr, error)
 	Write(b []byte) (int, error)
 	WriteTo(b []byte, address net.Addr) (int, error)
-	WriteToSCION(b []byte, address *Addr) (int, error)
 	Close() error
 	LocalAddr() net.Addr
 	SVC() addr.HostSVC

--- a/go/lib/snet/mock_snet/snet.go
+++ b/go/lib/snet/mock_snet/snet.go
@@ -97,22 +97,6 @@ func (mr *MockConnMockRecorder) ReadFrom(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFrom", reflect.TypeOf((*MockConn)(nil).ReadFrom), arg0)
 }
 
-// ReadFromSCION mocks base method
-func (m *MockConn) ReadFromSCION(arg0 []byte) (int, *snet.Addr, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadFromSCION", arg0)
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(*snet.Addr)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ReadFromSCION indicates an expected call of ReadFromSCION
-func (mr *MockConnMockRecorder) ReadFromSCION(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadFromSCION", reflect.TypeOf((*MockConn)(nil).ReadFromSCION), arg0)
-}
-
 // RemoteAddr mocks base method
 func (m *MockConn) RemoteAddr() net.Addr {
 	m.ctrl.T.Helper()
@@ -211,21 +195,6 @@ func (m *MockConn) WriteTo(arg0 []byte, arg1 net.Addr) (int, error) {
 func (mr *MockConnMockRecorder) WriteTo(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteTo", reflect.TypeOf((*MockConn)(nil).WriteTo), arg0, arg1)
-}
-
-// WriteToSCION mocks base method
-func (m *MockConn) WriteToSCION(arg0 []byte, arg1 *snet.Addr) (int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteToSCION", arg0, arg1)
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WriteToSCION indicates an expected call of WriteToSCION
-func (mr *MockConnMockRecorder) WriteToSCION(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteToSCION", reflect.TypeOf((*MockConn)(nil).WriteToSCION), arg0, arg1)
 }
 
 // MockPacketDispatcherService is a mock of PacketDispatcherService interface

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -21,12 +21,12 @@
 // context.
 //
 // A connection can be created by calling Dial or Listen; both functions
-// register an address-port pair with the local dispatcher. For Dial, the remote
-// address is fixed, meaning only Read and Write can be used. Attempting to
-// ReadFrom or WriteTo a connection created by Dial is an invalid operation. For
-// Listen, the remote address cannot be fixed. ReadFrom, ReadFromSCION can be
-// used to read from the connection and find out the sender's address; WriteTo
-// and WriteToSCION can be used to send a message to a chosen destination.
+// register an address-port pair with the local dispatcher. For Dial, the
+// remote address is fixed, meaning only Read and Write can be used. Attempting
+// to ReadFrom or WriteTo a connection created by Dial is an invalid operation.
+// For Listen, the remote address cannot be fixed. ReadFrom can be used to read
+// from the connection and find out the sender's address; and WriteTo can be
+// used to send a message to a chosen destination.
 //
 // Multiple networking contexts can share the same SCIOND and/or dispatcher.
 //

--- a/go/lib/snet/udpaddr.go
+++ b/go/lib/snet/udpaddr.go
@@ -34,6 +34,9 @@ func (a *UDPAddr) String() string {
 
 // ToAddr returns a legacy snet.Addr.
 func (a *UDPAddr) ToAddr() *Addr {
+	if a == nil {
+		return nil
+	}
 	ret := &Addr{
 		IA:      a.IA,
 		NextHop: CopyUDPAddr(a.NextHop),

--- a/go/sig/internal/disp/disp.go
+++ b/go/sig/internal/disp/disp.go
@@ -131,7 +131,14 @@ func (dm *dispRegistry) sigCtrl(pld *mgmt.Pld, addr *snet.Addr) {
 
 func dispFunc(dp *pktdisp.DispPkt) {
 	scpld, err := ctrl.NewSignedPldFromRaw(dp.Raw)
-	src := dp.Addr.Copy()
+	var src *snet.Addr
+	switch v := dp.Addr.(type) {
+	case *snet.Addr:
+		src = v.Copy()
+	default:
+		log.Error("Not valid snet address")
+		return
+	}
 	if err != nil {
 		log.Error("Unable to parse signed ctrl payload", "src", src, "err", err)
 		return


### PR DESCRIPTION

Remove the {write,read}FromSCION function from the snet interface
in order to simplify it. Client of snet/interface should transfer
the net.Addr interface.

Also, it removes appaddr references

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3583)
<!-- Reviewable:end -->
