### PR TITLE
Topo file: add support for v2 trust attributes

### DIFF
--- a/acceptance/topo_br_reload_util/Tinier.topo
+++ b/acceptance/topo_br_reload_util/Tinier.topo
@@ -2,6 +2,9 @@
 ASes:
   "1-ff00:0:110":
     core: true
+    voting: true
+    authoritative: true
+    issuing: true
     mtu: 1400
   "1-ff00:0:111":
     cert_issuer: 1-ff00:0:110

--- a/go/tools/scion-pki/internal/v2/tmpl/topo_test.go
+++ b/go/tools/scion-pki/internal/v2/tmpl/topo_test.go
@@ -43,7 +43,7 @@ func TestTopoGen(t *testing.T) {
 
 	topo := topoFile{
 		ASes: map[addr.IA]asEntry{
-			ia110: {Core: true},
+			ia110: {Core: true, Authoritative: true, Issuing: true, Voting: true},
 			ia111: {Issuer: ia110},
 			ia112: {Issuer: ia110},
 		},

--- a/python/topology/topo.py
+++ b/python/topology/topo.py
@@ -187,8 +187,13 @@ class TopoGenerator(object):
         mtu = as_conf.get('mtu', self.args.default_mtu)
         assert mtu >= SCION_MIN_MTU, mtu
         self.topo_dicts[topo_id] = {
-            'Core': as_conf.get('core', False), 'ISD_AS': str(topo_id),
-            'MTU': mtu, 'Overlay': self.overlay
+            'Core': as_conf.get('core', False),
+            'Voting': as_conf.get('voting', False),
+            'Authoritative': as_conf.get('authoritative', False),
+            'Issuing': as_conf.get('issuing', False),
+            'ISD_AS': str(topo_id),
+            'MTU': mtu,
+            'Overlay': self.overlay,
         }
         for i in SCION_SERVICE_NAMES:
             self.topo_dicts[topo_id][i] = {}

--- a/topology/Default.topo
+++ b/topology/Default.topo
@@ -2,11 +2,20 @@
 ASes:
   "1-ff00:0:110": # old 1-11
     core: true
+    voting: true
+    authoritative: true
+    issuing: true
     path_servers: 3
   "1-ff00:0:120": # old 1-12
     core: true
+    voting: true
+    authoritative: true
+    issuing: true
   "1-ff00:0:130": # old 1-13
     core: true
+    voting: true
+    authoritative: true
+    issuing: true
     beacon_servers: 2
   "1-ff00:0:111": # old 1-14
     cert_issuer: 1-ff00:0:110
@@ -27,9 +36,15 @@ ASes:
     cert_issuer: 1-ff00:0:130
   "2-ff00:0:210": # old 2-21
     core: true
+    voting: true
+    authoritative: true
+    issuing: true
     mtu: 1280
   "2-ff00:0:220": # old 2-22
     core: true
+    voting: true
+    authoritative: true
+    issuing: true
   "2-ff00:0:211": # old 2-23
     cert_issuer: 2-ff00:0:210
   "2-ff00:0:212": # old 2-25

--- a/topology/Tiny.topo
+++ b/topology/Tiny.topo
@@ -2,6 +2,9 @@
 ASes:
   "1-ff00:0:110": # old 1-11
     core: true
+    voting: true
+    authoritative: true
+    issuing: true
     mtu: 1400
   "1-ff00:0:111": # old 1-12
     cert_issuer: 1-ff00:0:110

--- a/topology/Wide.topo
+++ b/topology/Wide.topo
@@ -1,21 +1,21 @@
 ---
 ASes:
-  "1-ff00:0:110": {core: true}
-  "1-ff00:0:120": {core: true}
+  "1-ff00:0:110": {core: true, voting: true, authoritative: true, issuing: true}
+  "1-ff00:0:120": {core: true, voting: true, authoritative: true, issuing: true}
   "1-ff00:0:111": {cert_issuer: "1-ff00:0:110"}
   "1-ff00:0:121": {cert_issuer: "1-ff00:0:120"}
-  "2-ff00:0:210": {core: true}
-  "2-ff00:0:220": {core: true}
+  "2-ff00:0:210": {core: true, voting: true, authoritative: true, issuing: true}
+  "2-ff00:0:220": {core: true, voting: true, authoritative: true, issuing: true}
   "2-ff00:0:221": {cert_issuer: "2-ff00:0:220"}
   "2-ff00:0:222": {cert_issuer: "2-ff00:0:220"}
-  "3-ff00:0:310": {core: true}
+  "3-ff00:0:310": {core: true, voting: true, authoritative: true, issuing: true}
   "3-ff00:0:311": {cert_issuer: "3-ff00:0:310"}
   "3-ff00:0:312": {cert_issuer: "3-ff00:0:310"}
   "3-ff00:0:313": {cert_issuer: "3-ff00:0:310"}
-  "4-ff00:0:410": {core: true}
-  "5-ff00:0:510": {core: true}
-  "5-ff00:0:520": {core: true}
-  "5-ff00:0:530": {core: true}
+  "4-ff00:0:410": {core: true, voting: true, authoritative: true, issuing: true}
+  "5-ff00:0:510": {core: true, voting: true, authoritative: true, issuing: true}
+  "5-ff00:0:520": {core: true, voting: true, authoritative: true, issuing: true}
+  "5-ff00:0:530": {core: true, voting: true, authoritative: true, issuing: true}
   "5-ff00:0:511": {cert_issuer: "5-ff00:0:510"}
   "5-ff00:0:531": {cert_issuer: "5-ff00:0:530"}
 links:


### PR DESCRIPTION
The source file for topology generation now has support for  primary attributes as listed in
https://github.com/scionproto/scion/blob/master/doc/ControlPlanePKI.md#primary-ases

Also add support to scion-pki for those properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3586)
<!-- Reviewable:end -->
