### PR TITLE
CI: add bazel timestamps and enable local run of the pipeline

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,1 @@
-build --workspace_status_command=./tools/bazel-build-env --disk_cache=./.bazel-cache --stamp
+build --workspace_status_command=./tools/bazel-build-env --show_timestamps --disk_cache=./.bazel-cache --stamp

--- a/.bazelrc_ci
+++ b/.bazelrc_ci
@@ -1,1 +1,1 @@
-build --workspace_status_command=./tools/bazel-build-env --remote_cache=http://localhost:8080 --stamp
+build --workspace_status_command=./tools/bazel-build-env --show_timestamps --remote_cache=http://localhost:8080 --stamp

--- a/.buildkite/hooks/pre-artifact
+++ b/.buildkite/hooks/pre-artifact
@@ -33,7 +33,7 @@ save "logs"
 save "traces"
 save "gen"
 save "gen-cache"
-save "$TEST_ARTIFACTS"
+save "test-artifacts"
 
 tar chaf "artifacts.out/$ARTIFACTS.tar.gz" -C artifacts "$ARTIFACTS"
 rm -rf artifacts

--- a/.buildkite/hooks/pre-artifact
+++ b/.buildkite/hooks/pre-artifact
@@ -33,7 +33,7 @@ save "logs"
 save "traces"
 save "gen"
 save "gen-cache"
-save "test-artifacts"
+save "/tmp/test-artifacts"
 
 tar chaf "artifacts.out/$ARTIFACTS.tar.gz" -C artifacts "$ARTIFACTS"
 rm -rf artifacts

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -5,7 +5,7 @@ set -euo pipefail
 
 # ACCEPTANCE_ARTIFACTS is used for acceptance tests built with the "old"
 # acceptance framework
-export ACCEPTANCE_ARTIFACTS=test-artifacts
+export ACCEPTANCE_ARTIFACTS=/tmp/test-artifacts
 
 echo "Clean existing environment"
 . .buildkite/hooks/pre-exit

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -2,23 +2,13 @@
 
 set -euo pipefail
 
-echo "Clean existing environment"
 
-# TEST_ARTIFACTS is a generic folder for artifacts that need to be used during
-# testing. It will be collected in the artifacts in the end.
-# Note that this has to be defined in a hook, because in the pipeline the $PWD
-# would be evaluated to early (at pipeline expansion) and thus it would possibly
-# be the wrong value on the agent a step is actually executed.
-export TEST_ARTIFACTS="$PWD/test_artifacts"
 # ACCEPTANCE_ARTIFACTS is used for acceptance tests built with the "old"
 # acceptance framework
-export ACCEPTANCE_ARTIFACTS="$TEST_ARTIFACTS"
+export ACCEPTANCE_ARTIFACTS=test-artifacts
 
+echo "Clean existing environment"
 . .buildkite/hooks/pre-exit
-
-# Make sure the test artifacts folder exitsts.
-echo "Create test artifacts: mkdir -p $TEST_ARTIFACTS"
-mkdir -p "$TEST_ARTIFACTS"
 
 if [ -z ${BAZEL_REMOTE_S3_ACCESS_KEY_ID+x} ]; then
     echo "S3 env not set, not starting bazel remote proxy"

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -10,4 +10,4 @@ docker network prune -f
 echo "Remove leftover volumes"
 docker volume prune -f
 
-rm -rf bazel-testlogs logs/* traces gen gen-cache test-artifacts
+rm -rf bazel-testlogs logs/* traces gen gen-cache /tmp/test-artifacts

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -10,4 +10,4 @@ docker network prune -f
 echo "Remove leftover volumes"
 docker volume prune -f
 
-rm -rf bazel-testlogs logs/* traces gen gen-cache "$TEST_ARTIFACTS"
+rm -rf bazel-testlogs logs/* traces gen gen-cache test-artifacts

--- a/.buildkite/pipeline_buildlint.yml
+++ b/.buildkite/pipeline_buildlint.yml
@@ -28,13 +28,13 @@ steps:
         - exit_status: 255 # Forced agent shutdown
   - label: "Check generated go_deps.bzl file is up to date with go.mod"
     command:
-      - mkdir -p ./test-artifacts
-      - cp go.mod go.sum go_deps.bzl ./test-artifacts/
+      - mkdir -p /tmp/test-artifacts
+      - cp go.mod go.sum go_deps.bzl /tmp/test-artifacts/
       - make godeps -B
       - bazel-${BUILDKITE_PIPELINE_SLUG}/external/go_sdk/bin/go mod tidy
-      - diff -u ./test-artifacts/go.mod go.mod
-      - diff -u ./test-artifacts/go.sum go.sum
-      - diff -u ./test-artifacts/go_deps.bzl go_deps.bzl
+      - diff -u /tmp/test-artifacts/go.mod go.mod
+      - diff -u /tmp/test-artifacts/go.sum go.sum
+      - diff -u /tmp/test-artifacts/go_deps.bzl go_deps.bzl
     key: go_deps_lint
     retry:
       automatic:
@@ -42,10 +42,10 @@ steps:
         - exit_status: 255 # Forced agent shutdown
   - label: "Check generated go/proto files in git"
     command:
-      - mkdir -p ./test-artifacts
-      - cp -R go/proto/ ./test-artifacts/
+      - mkdir -p /tmp/test-artifacts
+      - cp -R go/proto/ /tmp/test-artifacts/
       - make gogen
-      - diff -ur ./test-artifacts/proto/ go/proto/
+      - diff -ur /tmp/test-artifacts/proto/ go/proto/
     key: go_gen_lint
     retry:
       automatic:

--- a/.buildkite/pipeline_buildlint.yml
+++ b/.buildkite/pipeline_buildlint.yml
@@ -28,12 +28,13 @@ steps:
         - exit_status: 255 # Forced agent shutdown
   - label: "Check generated go_deps.bzl file is up to date with go.mod"
     command:
-      - "cp go.mod go.sum go_deps.bzl $$TEST_ARTIFACTS/"
+      - mkdir -p ./test-artifacts
+      - cp go.mod go.sum go_deps.bzl ./test-artifacts/
       - make godeps -B
-      - "bazel-${BUILDKITE_PIPELINE_SLUG}/external/go_sdk/bin/go mod tidy"
-      - "diff -u $$TEST_ARTIFACTS/go.mod go.mod"
-      - "diff -u $$TEST_ARTIFACTS/go.sum go.sum"
-      - "diff -u $$TEST_ARTIFACTS/go_deps.bzl go_deps.bzl"
+      - bazel-${BUILDKITE_PIPELINE_SLUG}/external/go_sdk/bin/go mod tidy
+      - diff -u ./test-artifacts/go.mod go.mod
+      - diff -u ./test-artifacts/go.sum go.sum
+      - diff -u ./test-artifacts/go_deps.bzl go_deps.bzl
     key: go_deps_lint
     retry:
       automatic:
@@ -41,9 +42,10 @@ steps:
         - exit_status: 255 # Forced agent shutdown
   - label: "Check generated go/proto files in git"
     command:
-      - "cp -R go/proto/ $$TEST_ARTIFACTS"
+      - mkdir -p ./test-artifacts
+      - cp -R go/proto/ ./test-artifacts/
       - make gogen
-      - "diff -ur $$TEST_ARTIFACTS/proto/ go/proto/"
+      - diff -ur ./test-artifacts/proto/ go/proto/
     key: go_gen_lint
     retry:
       automatic:

--- a/acceptance/lib.sh
+++ b/acceptance/lib.sh
@@ -36,6 +36,7 @@ build_docker_perapp() {
 
 artifacts_dir() {
     export ACCEPTANCE_ARTIFACTS="${ACCEPTANCE_ARTIFACTS:-$(mktemp -d /tmp/acceptance-artifacts-$(date +"%Y%m%d-%H%M%S").XXXXXXX)}"
+    mkdir -p "${ACCEPTANCE_ARTIFACTS}"
     echo "Acceptance artifacts saved to $ACCEPTANCE_ARTIFACTS"
 }
 


### PR DESCRIPTION
This PR adds timestamps in bazel and hardcodes the test-artifact folder in order to 
enable local run. Now everything runs locally  apart from acceptance test that require 
some sudo interactive action.

Contributes #3286 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3589)
<!-- Reviewable:end -->
