### PR TITLE
CI: Use bazelrc_ci always on CI

### DIFF
--- a/.bazelrc_ci
+++ b/.bazelrc_ci
@@ -1,1 +1,1 @@
-build --workspace_status_command=./tools/bazel-build-env --show_timestamps --remote_cache=http://localhost:8080 --stamp
+build --remote_cache=http://localhost:8080

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -15,6 +15,9 @@ if [ -z ${BAZEL_REMOTE_S3_ACCESS_KEY_ID+x} ]; then
     exit 0
 fi
 
+# Add bazelrc for CI to home directory, so that remote_cache is picked up.
+mv -f .bazelrc_ci $HOME/.bazelrc
+
 echo "Starting bazel remote cache proxy"
 
 # Start bazel remote cache proxy for S3

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -13,7 +13,7 @@ gen_acceptance() {
         echo "    key: ${name}_acceptance"
         echo "    env:"
         echo "      PYTHONPATH: \"python/:.\""
-        echo "      BAZELRC: .bazelrc_ci"
+        echo "      BAZELRC: \".bazelrc_ci --noworkspace_rc\""
         echo "    artifact_paths:"
         echo "      - \"artifacts.out/**/*\""
         echo "    retry:"
@@ -31,7 +31,7 @@ gen_bazel_acceptance() {
         name=${name#'//acceptance/'}
         echo "  - label: \":bazel: Acceptance: $name\""
         echo "    command:"
-        echo "      - bazel --bazelrc=.bazelrc_ci test $test"
+        echo "      - bazel --bazelrc=.bazelrc_ci --noworkspace_rc test $test"
         echo "    key: ${name}_acceptance"
         echo "    artifact_paths:"
         echo "      - \"artifacts.out/**/*\""

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -13,7 +13,6 @@ gen_acceptance() {
         echo "    key: ${name}_acceptance"
         echo "    env:"
         echo "      PYTHONPATH: \"python/:.\""
-        echo "      BAZELRC: \".bazelrc_ci --noworkspace_rc\""
         echo "    artifact_paths:"
         echo "      - \"artifacts.out/**/*\""
         echo "    retry:"
@@ -31,7 +30,7 @@ gen_bazel_acceptance() {
         name=${name#'//acceptance/'}
         echo "  - label: \":bazel: Acceptance: $name\""
         echo "    command:"
-        echo "      - bazel --bazelrc=.bazelrc_ci --noworkspace_rc test $test"
+        echo "      - bazel test $test"
         echo "    key: ${name}_acceptance"
         echo "    artifact_paths:"
         echo "      - \"artifacts.out/**/*\""

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,6 +36,8 @@ steps:
       - diff -u /tmp/test-artifacts/go.sum go.sum
       - diff -u /tmp/test-artifacts/go_deps.bzl go_deps.bzl
     key: go_deps_lint
+    env:
+      BAZELRC: ".bazelrc_ci --noworkspace_rc"
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
@@ -47,6 +49,8 @@ steps:
       - make gogen
       - diff -ur /tmp/test-artifacts/proto/ go/proto/
     key: go_gen_lint
+    env:
+      BAZELRC: ".bazelrc_ci --noworkspace_rc"
     retry:
       automatic:
         - exit_status: -1  # Agent was lost

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ":bazel: Build scion code"
     command:
-      - bazel --bazelrc=.bazelrc_ci build //:scion //:scion-ci
+      - bazel build //:scion //:scion-ci
     key: build
     retry:
       automatic:
@@ -10,7 +10,7 @@ steps:
     timeout_in_minutes: 10
   - label: ":bazel: Go tests"
     command:
-      - bazel --bazelrc=.bazelrc_ci --noworkspace_rc test //go/... --print_relative_test_log_paths
+      - bazel test //go/... --print_relative_test_log_paths
     key: go_tests
     artifact_paths:
       - "artifacts.out/**/*"
@@ -36,8 +36,6 @@ steps:
       - diff -u /tmp/test-artifacts/go.sum go.sum
       - diff -u /tmp/test-artifacts/go_deps.bzl go_deps.bzl
     key: go_deps_lint
-    env:
-      BAZELRC: ".bazelrc_ci --noworkspace_rc"
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
@@ -49,8 +47,6 @@ steps:
       - make gogen
       - diff -ur /tmp/test-artifacts/proto/ go/proto/
     key: go_gen_lint
-    env:
-      BAZELRC: ".bazelrc_ci --noworkspace_rc"
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
@@ -58,15 +54,13 @@ steps:
   - label: "Lint"
     command: ./scion.sh lint
     key: lint
-    env:
-      BAZELRC: ".bazelrc_ci --noworkspace_rc"
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
         - exit_status: 255 # Forced agent shutdown
   - label: "Revocation tests"
     command:
-      - bazel --bazelrc=.bazelrc_ci --noworkspace_rc build //:scion //:scion-ci >/dev/null 2>&1
+      - bazel build //:scion //:scion-ci >/dev/null 2>&1
       - tar -kxf bazel-bin/scion.tar -C bin --overwrite
       - tar -kxf bazel-bin/scion-ci.tar -C bin --overwrite
       - ./scion.sh topology
@@ -82,7 +76,7 @@ steps:
         - exit_status: 255 # Forced agent shutdown
   - label: "Integration: {cert_req,pp,end2end,scmp}_integration"
     command:
-    - bazel --bazelrc=.bazelrc_ci --noworkspace_rc build //:scion //:scion-ci >/dev/null 2>&1
+    - bazel build //:scion //:scion-ci >/dev/null 2>&1
     - tar -kxf bazel-bin/scion.tar -C bin --overwrite
     - tar -kxf bazel-bin/scion-ci.tar -C bin --overwrite
     - ./scion.sh topology
@@ -101,7 +95,7 @@ steps:
         - exit_status: 255 # Forced agent shutdown
   - label: "Integration: end2end_integration"
     command:
-    - bazel --bazelrc=.bazelrc_ci build //:scion //:scion-ci >/dev/null 2>&1
+    - bazel build //:scion //:scion-ci >/dev/null 2>&1
     - tar -kxf bazel-bin/scion.tar -C bin --overwrite
     - tar -kxf bazel-bin/scion-ci.tar -C bin --overwrite
     - ./scion.sh topology --monolith

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
     timeout_in_minutes: 10
   - label: ":bazel: Go tests"
     command:
-      - bazel --bazelrc=.bazelrc_ci test //go/... --print_relative_test_log_paths
+      - bazel --bazelrc=.bazelrc_ci --noworkspace_rc test //go/... --print_relative_test_log_paths
     key: go_tests
     artifact_paths:
       - "artifacts.out/**/*"
@@ -54,13 +54,15 @@ steps:
   - label: "Lint"
     command: ./scion.sh lint
     key: lint
+    env:
+      BAZELRC: ".bazelrc_ci --noworkspace_rc"
     retry:
       automatic:
         - exit_status: -1  # Agent was lost
         - exit_status: 255 # Forced agent shutdown
   - label: "Revocation tests"
     command:
-      - bazel --bazelrc=.bazelrc_ci build //:scion //:scion-ci >/dev/null 2>&1
+      - bazel --bazelrc=.bazelrc_ci --noworkspace_rc build //:scion //:scion-ci >/dev/null 2>&1
       - tar -kxf bazel-bin/scion.tar -C bin --overwrite
       - tar -kxf bazel-bin/scion-ci.tar -C bin --overwrite
       - ./scion.sh topology
@@ -76,7 +78,7 @@ steps:
         - exit_status: 255 # Forced agent shutdown
   - label: "Integration: {cert_req,pp,end2end,scmp}_integration"
     command:
-    - bazel --bazelrc=.bazelrc_ci build //:scion //:scion-ci >/dev/null 2>&1
+    - bazel --bazelrc=.bazelrc_ci --noworkspace_rc build //:scion //:scion-ci >/dev/null 2>&1
     - tar -kxf bazel-bin/scion.tar -C bin --overwrite
     - tar -kxf bazel-bin/scion-ci.tar -C bin --overwrite
     - ./scion.sh topology

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ mocks:
 	./tools/gomocks
 
 gazelle:
-	bazel run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build ./go
+	bazel --bazelrc=${BAZELRC} run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build ./go
 
 setcap:
 	tools/setcap cap_net_admin,cap_net_raw+ep $(BRACCEPT)

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ BRACCEPT = bin/braccept
 
 GAZELLE_MODE?=fix
 
-BAZELRC?=.bazelrc
-
 all: bazel
 
 clean:
@@ -32,7 +30,7 @@ go_deps.bzl: go.mod
 
 bazel: godeps gogen
 	rm -f bin/*
-	bazel --bazelrc=${BAZELRC} build //:scion //:scion-ci
+	bazel build //:scion //:scion-ci
 	tar -kxf bazel-bin/scion.tar -C bin
 	tar -kxf bazel-bin/scion-ci.tar -C bin
 
@@ -40,7 +38,7 @@ mocks:
 	./tools/gomocks
 
 gazelle:
-	bazel --bazelrc=${BAZELRC} run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build ./go
+	bazel run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build ./go
 
 setcap:
 	tools/setcap cap_net_admin,cap_net_raw+ep $(BRACCEPT)

--- a/docker.sh
+++ b/docker.sh
@@ -34,7 +34,7 @@ cmd_build() {
 
 cmd_tester() {
     set -eo pipefail
-    bazel --bazelrc=${BAZELRC:-.bazelrc} run //docker/testimages:scion_testing_bundle
+    bazel run //docker/testimages:scion_testing_bundle
     docker build -f "docker/testimages/Dockerfile.sig_accept" -t "scion_sig_acceptance" docker/testimages
 }
 

--- a/docker/perapp/build-images.sh
+++ b/docker/perapp/build-images.sh
@@ -11,7 +11,7 @@ STAGE=${1:-prod}
 
 # Build the binaries.
 # This will fetch everything that haven't been fetched yet.
-bazel --bazelrc="$ROOTDIR/${BAZELRC:-.bazelrc}" build //:scion
+bazel --bazelrc=$ROOTDIR/${BAZELRC:-.bazelrc} build //:scion
 
 # Collect the licenses from the bazel cache.
 pushd $ROOTDIR/bazel-scion*/external
@@ -23,7 +23,7 @@ tar cf $ROOTDIR/docker/perapp/licenses.tar -C $TMPDIR --transform 's,^,licenses/
 rm -rf $TMPDIR
 
 # Build the images and push them to local docker repository.
-bazel --bazelrc="$ROOTDIR/${BAZELRC:-.bazelrc}" run //docker/perapp:$STAGE
+bazel --bazelrc=$ROOTDIR/${BAZELRC:-.bazelrc} run //docker/perapp:$STAGE
 
 # Remove licenses
 tar cvf $ROOTDIR/docker/perapp/licenses.tar --files-from /dev/null

--- a/docker/perapp/build-images.sh
+++ b/docker/perapp/build-images.sh
@@ -11,7 +11,7 @@ STAGE=${1:-prod}
 
 # Build the binaries.
 # This will fetch everything that haven't been fetched yet.
-bazel --bazelrc=$ROOTDIR/${BAZELRC:-.bazelrc} build //:scion
+bazel build //:scion
 
 # Collect the licenses from the bazel cache.
 pushd $ROOTDIR/bazel-scion*/external
@@ -23,7 +23,7 @@ tar cf $ROOTDIR/docker/perapp/licenses.tar -C $TMPDIR --transform 's,^,licenses/
 rm -rf $TMPDIR
 
 # Build the images and push them to local docker repository.
-bazel --bazelrc=$ROOTDIR/${BAZELRC:-.bazelrc} run //docker/perapp:$STAGE
+bazel run //docker/perapp:$STAGE
 
 # Remove licenses
 tar cvf $ROOTDIR/docker/perapp/licenses.tar --files-from /dev/null

--- a/scion.sh
+++ b/scion.sh
@@ -298,7 +298,7 @@ go_lint() {
       -a '!' -ipath 'go/lib/pathpol/sequence/*' > $TMPDIR/gofiles.list
 
     lint_step "Building lint tools"
-    bazel build //:lint || return 1
+    bazel --bazelrc=${BAZELRC:-.bazelrc} build //:lint || return 1
     tar -xf bazel-bin/lint.tar -C $TMPDIR || return 1
     local ret=0
     lint_step "impi"

--- a/scion.sh
+++ b/scion.sh
@@ -298,7 +298,7 @@ go_lint() {
       -a '!' -ipath 'go/lib/pathpol/sequence/*' > $TMPDIR/gofiles.list
 
     lint_step "Building lint tools"
-    bazel --bazelrc=${BAZELRC:-.bazelrc} build //:lint || return 1
+    bazel build //:lint || return 1
     tar -xf bazel-bin/lint.tar -C $TMPDIR || return 1
     local ret=0
     lint_step "impi"


### PR DESCRIPTION
By default bazel merges multiple bazelrc as described here:
https://docs.bazel.build/versions/master/guide.html#where-are-the-bazelrc-files
Therefore we just move the CI bazelrc file into the home folder so the remote-cache is applied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3591)
<!-- Reviewable:end -->
