### PR TITLE
Add IPv6 ASes to test topology

### DIFF
--- a/python/lib/defines.py
+++ b/python/lib/defines.py
@@ -37,15 +37,12 @@ GEN_PATH = 'gen'
 TOPO_FILE = "topology.json"
 #: Networks config
 NETWORKS_FILE = "networks.conf"
-PRV_NETWORKS_FILE = "private_networks.conf"
 #: IFIDs list
 IFIDS_FILE = "ifids.yml"
 #: AS list
 AS_LIST_FILE = "as_list.yml"
 #: Prometheus config
 PROM_FILE = "prometheus.yml"
-#: Overlay
-OVERLAY_FILE = "overlay"
 
 #: Buffer size for receiving packets
 SCION_BUFLEN = 65535

--- a/python/topology/common.py
+++ b/python/topology/common.py
@@ -110,11 +110,11 @@ def prom_addr_infra(docker, infra_id, infra_ele, port):
     return "[%s]:%s" % (pub['Public']['Addr'].ip, port)
 
 
-def prom_addr_sciond(docker, topo_id, networks, port):
+def sciond_ip(docker, topo_id, networks):
     for i, net in enumerate(networks):
         for prog, ip_net in networks[net].items():
             if prog == 'sd%s' % topo_id.file_fmt():
-                return '[%s]:%s' % (ip_net.ip, port)
+                return ip_net.ip
     return None
 
 

--- a/python/topology/generator.py
+++ b/python/topology/generator.py
@@ -29,13 +29,10 @@ from topology.config import (
     ConfigGenerator,
     ConfigGenArgs,
     DEFAULT_TOPOLOGY_FILE,
-    GENERATE_BIND_ADDRESS,
 )
 
 
 def add_arguments(parser):
-    parser.add_argument('-6', '--ipv6', action='store_true',
-                        help='Generate IPv6 addresses')
     parser.add_argument('-c', '--topo-config', default=DEFAULT_TOPOLOGY_FILE,
                         help='Path policy file')
     parser.add_argument('-d', '--docker', action='store_true',
@@ -44,8 +41,6 @@ def add_arguments(parser):
                         help='Network to create subnets in (E.g. "127.0.0.0/8"')
     parser.add_argument('-o', '--output-dir', default=GEN_PATH,
                         help='Output directory')
-    parser.add_argument('-b', '--bind-addr', default=GENERATE_BIND_ADDRESS,
-                        help='Generate bind addresses (E.g. "192.168.0.0/16"')
     parser.add_argument('-t', '--trace', action='store_true',
                         help='Enable TRACE level file logging in Go services')
     parser.add_argument('--pseg-ttl', type=int, default=DEFAULT_SEGMENT_TTL,

--- a/python/topology/prometheus.py
+++ b/python/topology/prometheus.py
@@ -30,8 +30,8 @@ from topology.common import (
     ArgsTopoDicts,
     prom_addr_br,
     prom_addr_infra,
-    prom_addr_sciond,
     prom_addr_dispatcher,
+    sciond_ip,
 )
 
 PS_PROM_PORT = 30453
@@ -99,8 +99,8 @@ class PrometheusGenerator(object):
                 br_dispatcher = prom_addr_dispatcher(self.args.docker, topo_id,
                                                      self.args.networks, DISP_PROM_PORT, "br")
                 ele_dict["Dispatcher"] = [host_dispatcher, br_dispatcher]
-            sd_prom_addr = prom_addr_sciond(self.args.docker, topo_id,
-                                            self.args.networks, SCIOND_PROM_PORT)
+            sd_prom_addr = '[%s]:%d' % (sciond_ip(self.args.docker, topo_id, self.args.networks),
+                                        SCIOND_PROM_PORT)
             ele_dict["Sciond"].append(sd_prom_addr)
             config_dict[topo_id] = ele_dict
         self._write_config_files(config_dict)

--- a/python/topology/topo.py
+++ b/python/topology/topo.py
@@ -198,7 +198,7 @@ class TopoGenerator(object):
         self._gen_br_entries(topo_id, as_conf)
         if self.args.sig:
             self.topo_dicts[topo_id]['SIG'] = {}
-            self._gen_sig_entries(topo_id)
+            self._gen_sig_entries(topo_id, as_conf)
 
     def _gen_srv_entries(self, topo_id, as_conf):
         srvs = [

--- a/topology/Default.topo
+++ b/topology/Default.topo
@@ -5,6 +5,7 @@ ASes:
     voting: true
     authoritative: true
     issuing: true
+    underlay: UDP/IPv6
     path_servers: 3
   "1-ff00:0:120": # old 1-12
     core: true
@@ -17,8 +18,10 @@ ASes:
     authoritative: true
     issuing: true
     beacon_servers: 2
+    underlay: UDP/IPv6
   "1-ff00:0:111": # old 1-14
     cert_issuer: 1-ff00:0:110
+    underlay: UDP/IPv6
   "1-ff00:0:112": # old 1-17
     cert_issuer: 1-ff00:0:110
     mtu: 1450
@@ -26,12 +29,14 @@ ASes:
     cert_issuer: 1-ff00:0:120
   "1-ff00:0:122": # old 1-18
     cert_issuer: 1-ff00:0:120
+    underlay: UDP/IPv6
   "1-ff00:0:131": # old 1-16
     cert_issuer: 1-ff00:0:130
     beacon_servers: 3
   "1-ff00:0:132": # old 1-19
     cert_issuer: 1-ff00:0:130
     path_servers: 2
+    underlay: UDP/IPv6
   "1-ff00:0:133": # old 1-10
     cert_issuer: 1-ff00:0:130
   "2-ff00:0:210": # old 2-21
@@ -45,17 +50,20 @@ ASes:
     voting: true
     authoritative: true
     issuing: true
+    underlay: UDP/IPv6
   "2-ff00:0:211": # old 2-23
     cert_issuer: 2-ff00:0:210
+    underlay: UDP/IPv6
   "2-ff00:0:212": # old 2-25
     cert_issuer: 2-ff00:0:210
   "2-ff00:0:221": # old 2-24
     cert_issuer: 2-ff00:0:220
   "2-ff00:0:222": # old 2-26
     cert_issuer: 2-ff00:0:220
+    underlay: UDP/IPv6
 links:
   - {a: "1-ff00:0:110#1",      b: "1-ff00:0:120-A#6",    linkAtoB: CORE}
-  - {a: "1-ff00:0:110#2",      b: "1-ff00:0:130-A#1004", linkAtoB: CORE}
+  - {a: "1-ff00:0:110#2",      b: "1-ff00:0:130-A#1004", linkAtoB: CORE, underlay: UDP/IPv6}
   - {a: "1-ff00:0:110#3",      b: "2-ff00:0:210#453",    linkAtoB: CORE}
   - {a: "1-ff00:0:120-A#1",    b: "1-ff00:0:130-B#1005", linkAtoB: CORE}
   - {a: "1-ff00:0:120-B#2",    b: "2-ff00:0:220#501",    linkAtoB: CORE, mtu: 1350}
@@ -63,22 +71,22 @@ links:
   - {a: "1-ff00:0:120-B#4",    b: "1-ff00:0:121#3",      linkAtoB: CHILD}
   - {a: "1-ff00:0:120#5",      b: "1-ff00:0:111-B#104",  linkAtoB: CHILD}
   - {a: "1-ff00:0:130-A#1001", b: "1-ff00:0:131#4079",   linkAtoB: CHILD}
-  - {a: "1-ff00:0:130-B#1002", b: "1-ff00:0:111-A#105",  linkAtoB: CHILD}
+  - {a: "1-ff00:0:130-B#1002", b: "1-ff00:0:111-A#105",  linkAtoB: CHILD, underlay: UDP/IPv6}
   - {a: "1-ff00:0:130-A#1003", b: "1-ff00:0:112#4095",   linkAtoB: CHILD}
   - {a: "1-ff00:0:111-C#100",  b: "1-ff00:0:121#4",      linkAtoB: PEER}
-  - {a: "1-ff00:0:111-B#101",  b: "2-ff00:0:211-A#5",    linkAtoB: PEER}
+  - {a: "1-ff00:0:111-B#101",  b: "2-ff00:0:211-A#5",    linkAtoB: PEER, underlay: UDP/IPv6}
   - {a: "1-ff00:0:111-C#102",  b: "2-ff00:0:211-A#6",    linkAtoB: PEER}
   - {a: "1-ff00:0:111-A#103",  b: "1-ff00:0:112#4094",   linkAtoB: CHILD}
   - {a: "1-ff00:0:121#1",      b: "1-ff00:0:131#4080",   linkAtoB: PEER}
-  - {a: "1-ff00:0:121#2",      b: "1-ff00:0:122#2",      linkAtoB: CHILD}
+  - {a: "1-ff00:0:121#2",      b: "1-ff00:0:122#2",      linkAtoB: CHILD, underlay: UDP/IPv6}
   - {a: "1-ff00:0:122#1",      b: "1-ff00:0:133#1",      linkAtoB: PEER}
   - {a: "1-ff00:0:131#4078",   b: "1-ff00:0:132#2",      linkAtoB: CHILD}
   - {a: "1-ff00:0:132#1",      b: "1-ff00:0:133#2",      linkAtoB: CHILD}
-  - {a: "2-ff00:0:210#450",    b: "2-ff00:0:220#503",    linkAtoB: CORE}
+  - {a: "2-ff00:0:210#450",    b: "2-ff00:0:220#503",    linkAtoB: CORE, underlay: UDP/IPv6}
   - {a: "2-ff00:0:210#451",    b: "2-ff00:0:211-A#7",    linkAtoB: CHILD}
   - {a: "2-ff00:0:210#452",    b: "2-ff00:0:211-A#8",    linkAtoB: CHILD}
   - {a: "2-ff00:0:220#500",    b: "2-ff00:0:221#2",      linkAtoB: CHILD}
-  - {a: "2-ff00:0:211-A#1",    b: "2-ff00:0:221#3",      linkAtoB: PEER}
+  - {a: "2-ff00:0:211-A#1",    b: "2-ff00:0:221#3",      linkAtoB: PEER, underlay: UDP/IPv6}
   - {a: "2-ff00:0:211-A#2",    b: "2-ff00:0:212#201",    linkAtoB: CHILD}
   - {a: "2-ff00:0:211-A#3",    b: "2-ff00:0:212#200",    linkAtoB: CHILD}
   - {a: "2-ff00:0:211-A#4",    b: "2-ff00:0:222#301",    linkAtoB: CHILD}


### PR DESCRIPTION
Add the possibility to specify the underlay in the topo file format.
Change the topology generator to support the new option.

With this we test IPv4 and IPv6 ASes in the CI integration.

Also remove bind support from the generator, it is no longer supported by Go services.

Fixes #2775

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3593)
<!-- Reviewable:end -->
