### PR TITLE
Remove forgotten configuration types from beacon_srv

### DIFF
--- a/go/beacon_srv/internal/config/BUILD.bazel
+++ b/go/beacon_srv/internal/config/BUILD.bazel
@@ -8,14 +8,11 @@ go_library(
     deps = [
         "//go/cs/beaconstorage:go_default_library",
         "//go/cs/config:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/config:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/env:go_default_library",
         "//go/lib/infra/modules/idiscovery:go_default_library",
-        "//go/lib/serrors:go_default_library",
         "//go/lib/truststorage:go_default_library",
-        "//go/lib/util:go_default_library",
     ],
 )
 
@@ -26,11 +23,9 @@ go_test(
     deps = [
         "//go/cs/beaconstorage/beaconstoragetest:go_default_library",
         "//go/cs/config:go_default_library",
-        "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/env/envtest:go_default_library",
         "//go/lib/infra/modules/idiscovery/idiscoverytest:go_default_library",
         "//go/lib/truststorage/truststoragetest:go_default_library",
-        "//go/lib/util:go_default_library",
         "@com_github_burntsushi_toml//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
     ],

--- a/go/beacon_srv/internal/config/config.go
+++ b/go/beacon_srv/internal/config/config.go
@@ -21,14 +21,11 @@ import (
 
 	"github.com/scionproto/scion/go/cs/beaconstorage"
 	controlconfig "github.com/scionproto/scion/go/cs/config"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/config"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/env"
 	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery"
-	"github.com/scionproto/scion/go/lib/serrors"
 	"github.com/scionproto/scion/go/lib/truststorage"
-	"github.com/scionproto/scion/go/lib/util"
 )
 
 const (
@@ -124,133 +121,4 @@ func (cfg *Config) Sample(dst io.Writer, path config.Path, _ config.CtxMap) {
 // ConfigName is the toml key.
 func (cfg *Config) ConfigName() string {
 	return "bs_config"
-}
-
-var _ config.Config = (*BSConfig)(nil)
-
-// BSConfig holds the configuration specific to the beacon server.
-type BSConfig struct {
-	// KeepaliveInterval is the interval between sending interface keepalives.
-	KeepaliveInterval util.DurWrap
-	// KeepaliveTimeout is the timeout indicating how long an interface can
-	// receive no keepalive until it is considered expired.
-	KeepaliveTimeout util.DurWrap
-	// OriginationInterval is the interval between originating beacons in a core BS.
-	OriginationInterval util.DurWrap
-	// PropagationInterval is the interval between propagating beacons.
-	PropagationInterval util.DurWrap
-	// RegistrationInterval is the interval between registering segments.
-	RegistrationInterval util.DurWrap
-	// ExpiredCheckInterval is the interval between checking whether interfaces
-	// have expired and should be revoked.
-	ExpiredCheckInterval util.DurWrap
-	// RevTTL is the revocation TTL. (default 10s)
-	RevTTL util.DurWrap
-	// RevOverlap specifies for how long before the expiry of an existing revocation the revoker
-	// can reissue a new revocation. (default 5s)
-	RevOverlap util.DurWrap
-	// Policies contains the policy files.
-	Policies Policies
-}
-
-// InitDefaults the default values for the durations that are equal to zero.
-func (cfg *BSConfig) InitDefaults() {
-	initDurWrap(&cfg.KeepaliveInterval, DefaultKeepaliveInterval)
-	initDurWrap(&cfg.KeepaliveTimeout, DefaultKeepaliveTimeout)
-	initDurWrap(&cfg.OriginationInterval, DefaultOriginationInterval)
-	initDurWrap(&cfg.PropagationInterval, DefaultPropagationInterval)
-	initDurWrap(&cfg.RegistrationInterval, DefaultRegistrationInterval)
-	initDurWrap(&cfg.ExpiredCheckInterval, DefaultExpiredCheckInterval)
-	initDurWrap(&cfg.RevTTL, DefaultRevTTL)
-	initDurWrap(&cfg.RevOverlap, DefaultRevOverlap)
-}
-
-// Validate validates that all durations are set.
-func (cfg *BSConfig) Validate() error {
-	if cfg.KeepaliveInterval.Duration == 0 {
-		return serrors.New("KeepaliveInterval not set")
-	}
-	if cfg.KeepaliveTimeout.Duration == 0 {
-		return serrors.New("KeepaliveTimeout not set")
-	}
-	if cfg.OriginationInterval.Duration == 0 {
-		return serrors.New("OriginationInterval not set")
-	}
-	if cfg.PropagationInterval.Duration == 0 {
-		return serrors.New("PropagationInterval not set")
-	}
-	if cfg.RegistrationInterval.Duration == 0 {
-		return serrors.New("RegistrationInterval not set")
-	}
-	if cfg.ExpiredCheckInterval.Duration == 0 {
-		return serrors.New("ExpiredCheckInterval not set")
-	}
-	if cfg.RevTTL.Duration == 0 {
-		return serrors.New("RevTTL is not set")
-	}
-	if cfg.RevTTL.Duration < path_mgmt.MinRevTTL {
-		return common.NewBasicError("RevTTL must be equal or greater than MinRevTTL", nil,
-			"MinRevTTL", path_mgmt.MinRevTTL)
-	}
-	if cfg.RevOverlap.Duration == 0 {
-		return serrors.New("RevOverlap not set")
-	}
-	if cfg.RevOverlap.Duration > cfg.RevTTL.Duration {
-		return serrors.New("RevOverlap cannot be greater than RevTTL")
-	}
-	return nil
-}
-
-// Sample generates a sample for the beacon server specific configuration.
-func (cfg *BSConfig) Sample(dst io.Writer, path config.Path, ctx config.CtxMap) {
-	config.WriteString(dst, controlconfig.BSSample)
-	config.WriteSample(dst, path, ctx, &cfg.Policies)
-}
-
-// ConfigName is the toml key for the beacon server specific configuration.
-func (cfg *BSConfig) ConfigName() string {
-	return "bs"
-}
-
-func initDurWrap(w *util.DurWrap, def time.Duration) {
-	if w.Duration == 0 {
-		w.Duration = def
-	}
-}
-
-var _ config.Config = (*Policies)(nil)
-
-// Policies contains the file paths of the policies.
-type Policies struct {
-	config.NoDefaulter
-	config.NoValidator
-	// Propagation contains the file path for the propagation policy. If this
-	// is the empty string, the default policy is used.
-	Propagation string
-	// CoreRegistration contains the file path for the core registration
-	// policy. If this is the empty string, the default policy is used. In a
-	// non-core beacon server, this field is ignored.
-	CoreRegistration string
-	// UpRegistration contains the file path for the up registration policy. If
-	// this is the empty string, the default policy is used. In a core beacon
-	// server, this field is ignored.
-	UpRegistration string
-	// DownRegistration contains the file path for the down registration policy.
-	// If this is the empty string, the default policy is used. In a core beacon
-	// server, this field is ignored.
-	DownRegistration string
-	// HiddenPathRegistration contains the file path for the hidden path registration policy
-	// and the corresponding hidden path groups.
-	// If this is the empty string, no hidden path functionality is used.
-	HiddenPathRegistration string
-}
-
-// Sample generates a sample for the beacon server specific configuration.
-func (cfg *Policies) Sample(dst io.Writer, _ config.Path, _ config.CtxMap) {
-	config.WriteString(dst, controlconfig.PoliciesSample)
-}
-
-// ConfigName is the toml key for the beacon server specific configuration.
-func (cfg *Policies) ConfigName() string {
-	return "policies"
 }

--- a/go/beacon_srv/internal/config/config_test.go
+++ b/go/beacon_srv/internal/config/config_test.go
@@ -17,18 +17,15 @@ package config
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/scionproto/scion/go/cs/beaconstorage/beaconstoragetest"
 	controlconfig "github.com/scionproto/scion/go/cs/config"
-	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/env/envtest"
 	"github.com/scionproto/scion/go/lib/infra/modules/idiscovery/idiscoverytest"
 	"github.com/scionproto/scion/go/lib/truststorage/truststoragetest"
-	"github.com/scionproto/scion/go/lib/util"
 )
 
 func TestConfigSample(t *testing.T) {
@@ -41,20 +38,6 @@ func TestConfigSample(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, meta.Undecoded())
 	CheckTestConfig(t, &cfg, idSample)
-}
-
-func TestInvalidTTL(t *testing.T) {
-	cfg := BSConfig{}
-	cfg.InitDefaults()
-	err := cfg.Validate()
-	assert.NoError(t, err)
-	cfg.RevOverlap = util.DurWrap{Duration: cfg.RevTTL.Duration + time.Second}
-	err = cfg.Validate()
-	assert.Error(t, err)
-	cfg.InitDefaults()
-	cfg.RevTTL = util.DurWrap{Duration: path_mgmt.MinRevTTL - time.Second}
-	err = cfg.Validate()
-	assert.Error(t, err)
 }
 
 func InitTestConfig(cfg *Config) {


### PR DESCRIPTION
The types `BSConfig` and `Policies` were forgotten inside `beacon_srv/internal/config`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3603)
<!-- Reviewable:end -->
