### PR TITLE
Add HTTP status pages

### DIFF
--- a/go/border/brconf/BUILD.bazel
+++ b/go/border/brconf/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["params_test.go"],
+    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
         "//go/lib/env/envtest:go_default_library",

--- a/go/godispatcher/main.go
+++ b/go/godispatcher/main.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"net/http"
@@ -96,6 +97,8 @@ func realMain() int {
 	}
 
 	env.SetupEnv(nil)
+	http.HandleFunc("/config", configHandler)
+	http.HandleFunc("/info", env.InfoHandler)
 	cfg.Metrics.StartPrometheus()
 
 	returnCode := waitForTeardown()
@@ -176,4 +179,11 @@ func checkPerms() error {
 		return serrors.New("Running as root is not allowed for security reasons")
 	}
 	return nil
+}
+
+func configHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	var buf bytes.Buffer
+	toml.NewEncoder(&buf).Encode(cfg)
+	fmt.Fprint(w, buf.String())
 }

--- a/go/lib/env/env.go
+++ b/go/lib/env/env.go
@@ -300,3 +300,16 @@ func (cfg *QUIC) Sample(dst io.Writer, path config.Path, _ config.CtxMap) {
 func (cfg *QUIC) ConfigName() string {
 	return "quic"
 }
+
+func InfoHandler(w http.ResponseWriter, r *http.Request) {
+	info := VersionInfo()
+	inDocker, err := util.RunsInDocker()
+	if err == nil {
+		info += fmt.Sprintf("  In docker:     %v\n", inDocker)
+	}
+	info += fmt.Sprintf("  pid:           %d\n", os.Getpid())
+	info += fmt.Sprintf("  euid/egid:     %d %d\n", os.Geteuid(), os.Getegid())
+	info += fmt.Sprintf("  cmd line:      %q\n", os.Args)
+	w.Header().Set("Content-Type", "text/plain")
+	fmt.Fprintf(w, info)
+}

--- a/go/lib/infra/modules/itopo/itopo.go
+++ b/go/lib/infra/modules/itopo/itopo.go
@@ -16,6 +16,9 @@
 package itopo
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"sync"
 	"time"
 
@@ -369,4 +372,14 @@ func call(clbk func()) {
 func incUpdateMetric(l metrics.UpdateLabels) {
 	metrics.Updates.Last(l).SetToCurrentTime()
 	metrics.Updates.Total(l).Inc()
+}
+
+func TopologyHandler(w http.ResponseWriter, r *http.Request) {
+	st.RLock()
+	defer st.RUnlock()
+	w.Header().Set("Content-Type", "application/json")
+	bytes, err := json.MarshalIndent(st.topo.Get(), "", "    ")
+	if err == nil {
+		fmt.Fprint(w, string(bytes)+"\n")
+	}
 }


### PR DESCRIPTION
The HTTP pages are exposed via the existing monitoring port.

1. Add config page to all SCION services (content of the toml config)
2. Add info page to all SCION services (just the build version at the moment)
3. Add topology page to all SCION services (content of loaded topology)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3608)
<!-- Reviewable:end -->
