### PR TITLE
Fix connected Write on snet.Conn

### DIFF
--- a/go/lib/snet/writer.go
+++ b/go/lib/snet/writer.go
@@ -56,6 +56,8 @@ func (c *scionConnWriter) WriteTo(b []byte, raddr net.Addr) (int, error) {
 	)
 
 	switch a := raddr.(type) {
+	case nil:
+		return 0, common.NewBasicError("Missing remote address", nil)
 	case *Addr:
 		return c.WriteTo(b, a.ToXAddr())
 	case *UDPAddr:
@@ -69,12 +71,8 @@ func (c *scionConnWriter) WriteTo(b []byte, raddr net.Addr) (int, error) {
 		dst, port, path = SCIONAddress{IA: a.IA, Host: a.SVC}, 0, a.Path
 		nextHop = a.NextHop
 	default:
-		if a == nil {
-			return 0, common.NewBasicError("Missing remote address", nil)
-		} else {
-			return 0, common.NewBasicError("Unable to write to non-SCION address", nil,
-				"addr", fmt.Sprintf("%v(%T)", a, a))
-		}
+		return 0, common.NewBasicError("Unable to write to non-SCION address", nil,
+			"addr", fmt.Sprintf("%v(%T)", a, a))
 	}
 
 	pkt := &SCIONPacket{

--- a/go/lib/snet/writer.go
+++ b/go/lib/snet/writer.go
@@ -69,8 +69,12 @@ func (c *scionConnWriter) WriteTo(b []byte, raddr net.Addr) (int, error) {
 		dst, port, path = SCIONAddress{IA: a.IA, Host: a.SVC}, 0, a.Path
 		nextHop = a.NextHop
 	default:
-		return 0, common.NewBasicError("Unable to write to non-SCION address", nil,
-			"addr", fmt.Sprintf("%v(%T)", a, a))
+		if a == nil {
+			return 0, common.NewBasicError("Missing remote address", nil)
+		} else {
+			return 0, common.NewBasicError("Unable to write to non-SCION address", nil,
+				"addr", fmt.Sprintf("%v(%T)", a, a))
+		}
 	}
 
 	pkt := &SCIONPacket{
@@ -100,7 +104,7 @@ func (c *scionConnWriter) WriteTo(b []byte, raddr net.Addr) (int, error) {
 // Write sends b through a connection with fixed remote address. If the remote
 // address for the connection is unknown, Write returns an error.
 func (c *scionConnWriter) Write(b []byte) (int, error) {
-	return c.WriteTo(b, nil)
+	return c.WriteTo(b, c.base.remote)
 }
 
 func (c *scionConnWriter) SetWriteDeadline(t time.Time) error {


### PR DESCRIPTION
Minimal fix for `snet.Conn.Write`.
Previously, passing `nil` into `WriteTo` would automatically pick the
connected remote address, if available. With some of the previous
refactoring (amongst other, in #3571), this is no longer the case. Right
now, `Write` is simply broken.
Apply the simplest fix, just specify to use the connected address
(`base.remote`) in `Write`. Note that the behaviour is still subtly
different than it used to be (e.g. no error if WriteTo is invoked on a
connected socket), but this seems to be the accepted behaviour change
within the refactoring in #3571.

Additionally, add a specific error message for the `nil` address case
in `WriteTo`, as "Unable to write to non-SCION address" was misleading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3617)
<!-- Reviewable:end -->
