### PR TITLE
TrustStore: Ensure referenced TRC is available

### DIFF
--- a/go/lib/infra/modules/trust/mock_trust/trust.go
+++ b/go/lib/infra/modules/trust/mock_trust/trust.go
@@ -42,6 +42,20 @@ func (m *MockCryptoProvider) EXPECT() *MockCryptoProviderMockRecorder {
 	return m.recorder
 }
 
+// AnnounceTRC mocks base method
+func (m *MockCryptoProvider) AnnounceTRC(arg0 context.Context, arg1 trust.TRCID, arg2 infra.TRCOpts) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AnnounceTRC", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AnnounceTRC indicates an expected call of AnnounceTRC
+func (mr *MockCryptoProviderMockRecorder) AnnounceTRC(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AnnounceTRC", reflect.TypeOf((*MockCryptoProvider)(nil).AnnounceTRC), arg0, arg1, arg2)
+}
+
 // GetASKey mocks base method
 func (m *MockCryptoProvider) GetASKey(arg0 context.Context, arg1 trust.ChainID, arg2 infra.ChainOpts) (scrypto.KeyMeta, error) {
 	m.ctrl.T.Helper()

--- a/go/lib/infra/modules/trust/verifier.go
+++ b/go/lib/infra/modules/trust/verifier.go
@@ -112,13 +112,11 @@ func (v *verifier) Verify(ctx context.Context, msg []byte, sign *proto.SignS) er
 			"expected", v.BoundSrc, "actual", src)
 	}
 
-	// Ensure that the TRC announced in source is available locally. Thus, not
-	// missing TRC updates.
-	tOpts := infra.TRCOpts{
-		TrustStoreOpts: infra.TrustStoreOpts{Server: v.Server},
-		AllowInactive:  true,
-	}
-	if _, err := v.Store.GetTRC(ctx, TRCID{ISD: src.IA.I, Version: src.TRCVer}, tOpts); err != nil {
+	// Announce TRC version to the provider, to ensure the TRC referenced in the
+	// signature source is available locally.
+	id := TRCID{ISD: src.IA.I, Version: src.TRCVer}
+	tOpts := infra.TRCOpts{TrustStoreOpts: infra.TrustStoreOpts{Server: v.Server}}
+	if err := v.Store.AnnounceTRC(ctx, id, tOpts); err != nil {
 		return err
 	}
 

--- a/go/lib/infra/modules/trust/verifier_test.go
+++ b/go/lib/infra/modules/trust/verifier_test.go
@@ -102,9 +102,12 @@ func TestVerify(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		p := mock_trust.NewMockCryptoProvider(ctrl)
-		p.EXPECT().GetTRC(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-		p.EXPECT().GetASKey(gomock.Any(), gomock.Any(),
-			gomock.Any()).Return(scrypto.KeyMeta{Key: public, Algorithm: scrypto.Ed25519}, nil)
+		p.EXPECT().AnnounceTRC(gomock.Any(), trust.TRCID{ISD: 1, Version: 2}, gomock.Any()).Return(
+			nil,
+		)
+		p.EXPECT().GetASKey(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+			scrypto.KeyMeta{Key: public, Algorithm: scrypto.Ed25519}, nil,
+		)
 
 		v := &trust.Verifier{
 			Store: p,
@@ -124,13 +127,12 @@ func TestVerifierWithIA(t *testing.T) {
 	assert.Equal(t, y.BoundIA, ia)
 }
 
-func validSignS(msg, ias string) *proto.SignS {
-	//_, priv, _ := scrypto.GenKeyPair(scrypto.Ed25519)
-	ia, _ := addr.IAFromString(ias)
+func validSignS(msg, rawIA string) *proto.SignS {
+	ia, _ := addr.IAFromString(rawIA)
 	src := ctrl.SignSrcDef{
 		IA:       ia,
 		ChainVer: 1,
-		TRCVer:   1,
+		TRCVer:   2,
 	}
 	sign := proto.NewSignS(proto.SignType_ed25519, src.Pack())
 	sign.SetTimestamp(time.Now())

--- a/go/lib/infra/modules/trust/verifier_test.go
+++ b/go/lib/infra/modules/trust/verifier_test.go
@@ -102,6 +102,7 @@ func TestVerify(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		p := mock_trust.NewMockCryptoProvider(ctrl)
+		p.EXPECT().GetTRC(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 		p.EXPECT().GetASKey(gomock.Any(), gomock.Any(),
 			gomock.Any()).Return(scrypto.KeyMeta{Key: public, Algorithm: scrypto.Ed25519}, nil)
 


### PR DESCRIPTION
When verifying a signature, the verifier now makes sure to have the
referenced TRC available locally.

This is one mechanism how TRC updates are disseminated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3629)
<!-- Reviewable:end -->
