### PR TITLE
log: rename LogPanicAndExit to HandlePanic

### DIFF
--- a/go/acceptance/sig_ping_acceptance/main.go
+++ b/go/acceptance/sig_ping_acceptance/main.go
@@ -45,7 +45,7 @@ func realMain() int {
 		fmt.Fprintf(os.Stderr, "Failed to init: %s\n", err)
 		return 1
 	}
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	defer log.Flush()
 	if !*integration.Docker {
 		log.Crit(fmt.Sprintf("Can only run %s test with docker!", name))

--- a/go/border/braccept/main.go
+++ b/go/border/braccept/main.go
@@ -72,7 +72,7 @@ func realMain() int {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		return 1
 	}
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	if err := shared.Init(keysDirPath); err != nil {
 		log.Crit("Initialization failed", "err", err)
 		return 1

--- a/go/border/io.go
+++ b/go/border/io.go
@@ -51,7 +51,7 @@ const (
 )
 
 func (r *Router) posixInput(s *rctx.Sock, stop, stopped chan struct{}) {
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	defer close(stopped)
 	dst := s.Conn.LocalAddr()
 	log.Info("posixInput starting", "addr", dst)
@@ -193,7 +193,7 @@ func (r *Router) posixInputRead(msgs []ipv4.Message, metas []conn.ReadMeta,
 }
 
 func (r *Router) posixOutput(s *rctx.Sock, _, stopped chan struct{}) {
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	defer close(stopped)
 	src := s.Conn.LocalAddr()
 	dst := s.Conn.RemoteAddr()

--- a/go/border/main.go
+++ b/go/border/main.go
@@ -68,7 +68,7 @@ func realMain() int {
 	}
 	defer log.Flush()
 	defer env.LogAppStopped(common.BR, cfg.General.ID)
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	http.HandleFunc("/config", configHandler)
 	http.HandleFunc("/info", env.InfoHandler)
 	http.HandleFunc("/topology", itopo.TopologyHandler)

--- a/go/border/rctrl/ctrl.go
+++ b/go/border/rctrl/ctrl.go
@@ -65,11 +65,11 @@ func Control(sRevInfoQ chan rpkt.RawSRevCallbackArgs, dispatcherReconnect bool) 
 		fatal.Fatal(common.NewBasicError("Listening on address", err, "addr", ctrlAddr))
 	}
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		ifStateUpdate()
 	}()
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		revInfoFwd(sRevInfoQ)
 	}()
 	processCtrl()

--- a/go/border/rctx/io.go
+++ b/go/border/rctx/io.go
@@ -98,13 +98,13 @@ func (s *Sock) Start() {
 		}
 		if s.Reader != nil {
 			go func() {
-				defer log.LogPanicAndExit()
+				defer log.HandlePanic()
 				s.Reader(s, s.stop, s.readerStopped)
 			}()
 		}
 		if s.Writer != nil {
 			go func() {
-				defer log.LogPanicAndExit()
+				defer log.HandlePanic()
 				s.Writer(s, s.stop, s.writerStopped)
 			}()
 		}

--- a/go/border/router.go
+++ b/go/border/router.go
@@ -63,11 +63,11 @@ func NewRouter(id, confDir string) (*Router, error) {
 // processing as well as various other router functions.
 func (r *Router) Start() {
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		r.PacketError()
 	}()
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		rctrl.Control(r.sRevInfoQ, cfg.General.ReconnectToDispatcher)
 	}()
 }
@@ -86,7 +86,7 @@ func (r *Router) ReloadConfig() error {
 }
 
 func (r *Router) handleSock(s *rctx.Sock, stop, stopped chan struct{}) {
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	defer close(stopped)
 	pkts := make(ringbuf.EntryList, processBufCnt)
 	dst := s.Conn.LocalAddr()

--- a/go/cs/beacon/beacondbsqlite/db.go
+++ b/go/cs/beacon/beacondbsqlite/db.go
@@ -134,7 +134,7 @@ func (e *executor) AllRevocations(ctx context.Context) (<-chan beacon.Revocation
 	}
 	res := make(chan beacon.RevocationOrErr)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer close(res)
 		defer rows.Close()
 		for rows.Next() {
@@ -232,7 +232,7 @@ func (e *executor) CandidateBeacons(ctx context.Context, setSize int, usage beac
 	}
 	results := make(chan beacon.BeaconOrErr)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer close(results)
 		for _, b := range beacons {
 			results <- beacon.BeaconOrErr{Beacon: b}

--- a/go/cs/beacon/store.go
+++ b/go/cs/beacon/store.go
@@ -94,7 +94,7 @@ func (s *Store) getBeacons(ctx context.Context, policy *Policy) (<-chan BeaconOr
 	}
 	results := make(chan BeaconOrErr, min(maxResultChanSize, policy.BestSetSize))
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer close(results)
 		s.algo.SelectAndServe(beacons, results, policy.BestSetSize)
 	}()
@@ -181,13 +181,13 @@ func (s *CoreStore) getBeacons(ctx context.Context, policy *Policy) (<-chan Beac
 		}
 		wg.Add(1)
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			defer wg.Done()
 			s.algo.SelectAndServe(beacons, results, policy.BestSetSize)
 		}()
 	}
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer close(results)
 		wg.Wait()
 		if len(errs) > 0 {

--- a/go/cs/beaconing/propagator.go
+++ b/go/cs/beaconing/propagator.go
@@ -198,7 +198,7 @@ type beaconPropagator struct {
 func (p *beaconPropagator) start(ctx context.Context, wg *sync.WaitGroup) {
 	wg.Add(1)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer wg.Done()
 		if err := p.propagate(ctx); err != nil {
 			p.logger.Error("[beaconing.Propagator] Unable to propagate",
@@ -248,7 +248,7 @@ func (p *beaconPropagator) extendAndSend(ctx context.Context, bseg beacon.Beacon
 
 	p.wg.Add(1)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer p.wg.Done()
 
 		labels := metrics.PropagatorLabels{

--- a/go/cs/beaconing/registrar.go
+++ b/go/cs/beaconing/registrar.go
@@ -264,7 +264,7 @@ func (r *remoteRegistrar) startSendSegReg(ctx context.Context, bseg beacon.Beaco
 
 	r.wg.Add(1)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer r.wg.Done()
 		logger := log.FromCtx(ctx)
 		if err := r.msgr.SendSegReg(ctx, reg, addr, messenger.NextId()); err != nil {

--- a/go/cs/ifstate/revoker.go
+++ b/go/cs/ifstate/revoker.go
@@ -200,7 +200,7 @@ func (p *brPusher) sendIfStateToBr(ctx context.Context, msg *path_mgmt.IFStateIn
 
 	wg.Add(1)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer wg.Done()
 		if err := p.msgr.SendIfStateInfos(ctx, msg, a, messenger.NextId()); err != nil {
 			log.FromCtx(ctx).Error("Failed to send interface state to BR",

--- a/go/cs/keepalive/handler.go
+++ b/go/cs/keepalive/handler.go
@@ -144,7 +144,7 @@ func (h *handler) getIntfInfo() (common.IFIDType, *ifstate.Interface, error) {
 
 func (h *handler) startPush(ifid common.IFIDType) {
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		ctx, cancelF := context.WithTimeout(context.Background(), IfStatePushTimeout)
 		defer cancelF()
 		h.tasks.IfStatePusher.Push(ctx, ifid)

--- a/go/cs/main.go
+++ b/go/cs/main.go
@@ -107,7 +107,7 @@ func realMain() int {
 	}
 	defer log.Flush()
 	defer env.LogAppStopped(common.CPService, cfg.General.ID)
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	if err := setup(); err != nil {
 		log.Crit("Setup failed", "err", err)
 		return 1
@@ -304,11 +304,11 @@ func realMain() int {
 	http.HandleFunc("/topology", itopo.TopologyHandler)
 	cfg.Metrics.StartPrometheus()
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		msgr.ListenAndServe()
 	}()
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		tcpMsgr.ListenAndServe()
 	}()
 

--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -88,7 +88,7 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	initNetwork()
 	switch *mode {
 	case ModeClient:
@@ -241,7 +241,7 @@ func (c *client) run() {
 	c.quicStream = newQuicStream(qstream)
 	log.Debug("Quic stream opened", "local", &local, "remote", &remote)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		c.send()
 	}()
 	c.read()
@@ -368,7 +368,7 @@ func (s server) run() {
 		}
 		log.Info("Quic session accepted", "src", qsess.RemoteAddr())
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			s.handleClient(qsess)
 		}()
 	}
@@ -440,7 +440,7 @@ func setSignalHandler(closer io.Closer) {
 	c := make(chan os.Signal)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		<-c
 		closer.Close()
 		os.Exit(1)

--- a/go/examples/pingpong/pp_integration/main.go
+++ b/go/examples/pingpong/pp_integration/main.go
@@ -37,7 +37,7 @@ func realMain() int {
 		fmt.Fprintf(os.Stderr, "Failed to init: %s\n", err)
 		return 1
 	}
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	defer log.Flush()
 	cmnArgs := []string{"-log.console", "debug", "-sciond", integration.SCIOND}
 	clientArgs := []string{"-mode", "client", "-count", "1",

--- a/go/godispatcher/dispatcher/dispatcher.go
+++ b/go/godispatcher/dispatcher/dispatcher.go
@@ -64,7 +64,7 @@ func NewServer(address string) (*Server, error) {
 func (as *Server) Serve() error {
 	errChan := make(chan error)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		netToRingDataplane := &NetToRingDataplane{
 			OverlayConn:  as.ipv4Conn,
 			RoutingTable: as.routingTable,
@@ -72,7 +72,7 @@ func (as *Server) Serve() error {
 		errChan <- netToRingDataplane.Run()
 	}()
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		netToRingDataplane := &NetToRingDataplane{
 			OverlayConn:  as.ipv6Conn,
 			RoutingTable: as.routingTable,

--- a/go/godispatcher/main.go
+++ b/go/godispatcher/main.go
@@ -58,7 +58,7 @@ func realMain() int {
 	}
 	defer log.Flush()
 	defer env.LogAppStopped("Dispatcher", cfg.Dispatcher.ID)
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	if err := cfg.Validate(); err != nil {
 		log.Crit("Unable to validate config", "err", err)
 		return 1
@@ -75,7 +75,7 @@ func realMain() int {
 	}
 
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		err := RunDispatcher(
 			cfg.Dispatcher.DeleteSocket,
 			cfg.Dispatcher.ApplicationSocket,
@@ -88,7 +88,7 @@ func realMain() int {
 	}()
 	if cfg.Dispatcher.PerfData != "" {
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			err := http.ListenAndServe(cfg.Dispatcher.PerfData, nil)
 			if err != nil {
 				fatal.Fatal(err)

--- a/go/godispatcher/network/app_socket.go
+++ b/go/godispatcher/network/app_socket.go
@@ -53,7 +53,7 @@ func (h *AppSocketServer) Handle(conn net.PacketConn) {
 		Logger: log.Root().New("clientID", fmt.Sprintf("%p", conn)),
 	}
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		ch.Handle(h.DispServer)
 	}()
 }
@@ -84,7 +84,7 @@ func (h *AppConnHandler) Handle(appServer *dispatcher.Server) {
 	defer metrics.M.OpenSockets(metrics.SVC{Type: svc}).Dec()
 
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		h.RunRingToAppDataplane()
 	}()
 

--- a/go/godispatcher/network/dispatcher.go
+++ b/go/godispatcher/network/dispatcher.go
@@ -47,12 +47,12 @@ func (d *Dispatcher) ListenAndServe() error {
 
 	errChan := make(chan error)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		errChan <- dispServer.Serve()
 	}()
 
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		dispServer := &AppSocketServer{
 			Listener:   dispServerConn,
 			DispServer: dispServer,

--- a/go/hidden_path_srv/internal/hpsegreq/fetcher.go
+++ b/go/hidden_path_srv/internal/hpsegreq/fetcher.go
@@ -84,12 +84,12 @@ func (f *DefaultFetcher) Fetch(ctx context.Context,
 	for hps, ids := range mapping {
 		if hps.Equal(f.groupInfo.LocalIA) {
 			go func(ids []hiddenpath.GroupId) {
-				defer log.LogPanicAndExit()
+				defer log.HandlePanic()
 				f.fetchDB(ctx, ids, endsAt, replyChan)
 			}(ids)
 		} else {
 			go func(ids []hiddenpath.GroupId, hps addr.IA) {
-				defer log.LogPanicAndExit()
+				defer log.HandlePanic()
 				f.fetchRemote(ctx, ids, endsAt, hps, replyChan)
 			}(ids, hps)
 		}

--- a/go/integration/cert_req/main.go
+++ b/go/integration/cert_req/main.go
@@ -47,7 +47,7 @@ func main() {
 }
 
 func realMain() int {
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	defer log.Flush()
 	addFlags()
 	integration.Setup()

--- a/go/integration/cert_req_integration/main.go
+++ b/go/integration/cert_req_integration/main.go
@@ -40,7 +40,7 @@ func realMain() int {
 		fmt.Fprintf(os.Stderr, "Failed to init: %s\n", err)
 		return 1
 	}
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	defer log.Flush()
 	clientArgs := []string{
 		"-log.console", "debug",

--- a/go/integration/end2end/main.go
+++ b/go/integration/end2end/main.go
@@ -55,7 +55,7 @@ func main() {
 }
 
 func realMain() int {
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	defer log.Flush()
 	addFlags()
 	integration.Setup()

--- a/go/integration/end2end_integration/main.go
+++ b/go/integration/end2end_integration/main.go
@@ -51,7 +51,7 @@ func realMain() int {
 		fmt.Fprintf(os.Stderr, "Failed to init: %s\n", err)
 		return 1
 	}
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	defer log.Flush()
 	clientArgs := []string{
 		"-log.console", "debug",

--- a/go/lib/env/env.go
+++ b/go/lib/env/env.go
@@ -179,14 +179,14 @@ func setupSignals(reloadF func()) {
 	signal.Notify(sig, os.Interrupt)
 	signal.Notify(sig, syscall.SIGTERM)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		s := <-sig
 		log.Info("Received signal, exiting...", "signal", s)
 		fatal.Shutdown(ShutdownGraceInterval)
 	}()
 	if reloadF != nil {
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			for range sighupC {
 				log.Info("Received config reload signal")
 				reloadF()
@@ -232,7 +232,7 @@ func (cfg *Metrics) StartPrometheus() {
 		http.Handle("/metrics", promhttp.Handler())
 		log.Info("Exporting prometheus metrics", "addr", cfg.Prometheus)
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			if err := http.ListenAndServe(cfg.Prometheus, nil); err != nil {
 				fatal.Fatal(common.NewBasicError("HTTP ListenAndServe error", err))
 			}

--- a/go/lib/fatal/fatal.go
+++ b/go/lib/fatal/fatal.go
@@ -92,7 +92,7 @@ func Fatal(err error) {
 		// If the main goroutine fatals out correctly, this won't get a chance
 		// to run.
 		time.AfterFunc(FatalGraceInterval, func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			panic("Main goroutine is not responding to the fatal error. " +
 				"It's probably stuck. Shutting down anyway.")
 		})
@@ -120,7 +120,7 @@ func Shutdown(d time.Duration) {
 		// If the main goroutine shuts down everything in time, this won't get
 		// a chance to run.
 		time.AfterFunc(d, func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			panic(fmt.Sprintf("Main goroutine did not shut down in time (waited %v). It's "+
 				"probably stuck. Forcing shutdown.", d))
 		})

--- a/go/lib/infra/dedupe/dedupe.go
+++ b/go/lib/infra/dedupe/dedupe.go
@@ -147,7 +147,7 @@ func (dd *deduper) Request(parentCtx context.Context,
 	ctx, span := dd.notifications.Add(parentCtx, req, ch, dd.dedupeLifetime)
 	if ctx != nil {
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			dd.handler(ctx, req)
 		}()
 	} else {
@@ -174,7 +174,7 @@ func (dd *deduper) Request(parentCtx context.Context,
 func (dd *deduper) handler(ctx context.Context, req Request) {
 	ch := make(chan Response, 1)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		ch <- dd.requestFunc(ctx, req)
 	}()
 

--- a/go/lib/infra/disp/disp.go
+++ b/go/lib/infra/disp/disp.go
@@ -172,7 +172,7 @@ func (d *Dispatcher) RecvFrom(ctx context.Context) (proto.Cerealizable, int, net
 
 func (d *Dispatcher) goBackgroundReceiver() {
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer close(d.stoppedChan)
 	Loop:
 		for {

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -733,7 +733,7 @@ func (m *Messenger) ListenAndServe() {
 	done := make(chan struct{})
 	if m.config.QUIC != nil {
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			m.listenAndServeQUIC()
 			close(done)
 		}()
@@ -871,7 +871,7 @@ func (m *Messenger) serve(parentCtx context.Context, cancelF context.CancelFunc,
 	metrics.Dispatcher.ReadSizes().Observe(float64(size))
 
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer cancelF()
 		defer span.Finish()
 		handler.Handle(infra.NewRequest(ctx, msg, signedPld, address, pld.ReqId))

--- a/go/lib/infra/messenger/quic_response_writer.go
+++ b/go/lib/infra/messenger/quic_response_writer.go
@@ -37,7 +37,7 @@ type QUICResponseWriter struct {
 
 func (rw *QUICResponseWriter) SendAckReply(ctx context.Context, msg *ack.Ack) error {
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		<-ctx.Done()
 		rw.ReplyWriter.Close()
 	}()
@@ -50,7 +50,7 @@ func (rw *QUICResponseWriter) SendAckReply(ctx context.Context, msg *ack.Ack) er
 
 func (rw *QUICResponseWriter) SendTRCReply(ctx context.Context, msg *cert_mgmt.TRC) error {
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		<-ctx.Done()
 		rw.ReplyWriter.Close()
 	}()
@@ -63,7 +63,7 @@ func (rw *QUICResponseWriter) SendTRCReply(ctx context.Context, msg *cert_mgmt.T
 
 func (rw *QUICResponseWriter) SendCertChainReply(ctx context.Context, msg *cert_mgmt.Chain) error {
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		<-ctx.Done()
 		rw.ReplyWriter.Close()
 	}()
@@ -78,7 +78,7 @@ func (rw *QUICResponseWriter) SendChainIssueReply(ctx context.Context,
 	msg *cert_mgmt.ChainIssRep) error {
 
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		<-ctx.Done()
 		rw.ReplyWriter.Close()
 	}()
@@ -91,7 +91,7 @@ func (rw *QUICResponseWriter) SendChainIssueReply(ctx context.Context,
 
 func (rw *QUICResponseWriter) SendSegReply(ctx context.Context, msg *path_mgmt.SegReply) error {
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		<-ctx.Done()
 		rw.ReplyWriter.Close()
 	}()
@@ -111,7 +111,7 @@ func (rw *QUICResponseWriter) SendIfStateInfoReply(ctx context.Context,
 
 func (rw *QUICResponseWriter) SendHPSegReply(ctx context.Context, msg *path_mgmt.HPSegReply) error {
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		<-ctx.Done()
 		rw.ReplyWriter.Close()
 	}()
@@ -124,7 +124,7 @@ func (rw *QUICResponseWriter) SendHPSegReply(ctx context.Context, msg *path_mgmt
 
 func (rw *QUICResponseWriter) SendHPCfgReply(ctx context.Context, msg *path_mgmt.HPCfgReply) error {
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		<-ctx.Done()
 		rw.ReplyWriter.Close()
 	}()

--- a/go/lib/infra/messenger/tcp/messenger.go
+++ b/go/lib/infra/messenger/tcp/messenger.go
@@ -224,7 +224,7 @@ func (m *Messenger) handleConn(conn net.Conn) error {
 		Address: conn.RemoteAddr(),
 	}
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		m.Handler.ServeRPC(rw, request)
 	}()
 	return nil

--- a/go/lib/infra/modules/itopo/itopo.go
+++ b/go/lib/infra/modules/itopo/itopo.go
@@ -249,7 +249,7 @@ func expiresLater(newTopo, oldTopo *topology.RWTopology) bool {
 func call(clbk func()) {
 	if clbk != nil {
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			clbk()
 		}()
 	}

--- a/go/lib/infra/modules/segfetcher/requester.go
+++ b/go/lib/infra/modules/segfetcher/requester.go
@@ -78,14 +78,14 @@ func (r *DefaultRequester) fetchReqs(ctx context.Context, reqs Requests) <-chan 
 		}
 		wg.Add(1)
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			defer wg.Done()
 			reply, err := r.API.GetSegs(ctx, req.ToSegReq(), dst, messenger.NextId())
 			replies <- ReplyOrErr{Req: req, Reply: reply, Peer: dst, Err: err}
 		}()
 	}
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer close(replies)
 		wg.Wait()
 	}()

--- a/go/lib/infra/modules/seghandler/seghandler.go
+++ b/go/lib/infra/modules/seghandler/seghandler.go
@@ -66,7 +66,7 @@ func (h *Handler) Handle(ctx context.Context, recs Segments, server net.Addr,
 	}
 
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		h.verifyAndStore(ctx, earlyTrigger, result, verifiedCh,
 			units, recs.HPGroupID)
 	}()

--- a/go/lib/infra/modules/segverifier/segverifier.go
+++ b/go/lib/infra/modules/segverifier/segverifier.go
@@ -65,7 +65,7 @@ func StartVerification(ctx context.Context, verifier infra.Verifier, server net.
 	for i := range units {
 		unit := units[i]
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			unit.Verify(ctx, verifier, server, unitResultsC)
 		}()
 	}
@@ -111,13 +111,13 @@ func (u *Unit) Verify(ctx context.Context, verifier infra.Verifier,
 
 	responses := make(chan ElemResult, u.Len())
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		verifySegment(ctx, verifier, server, u.SegMeta, responses)
 	}()
 	for i := range u.SRevInfos {
 		index := i
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			verifyRevInfo(ctx, verifier, server, index, u.SRevInfos[index], responses)
 		}()
 	}

--- a/go/lib/infra/modules/trust/resolver.go
+++ b/go/lib/infra/modules/trust/resolver.go
@@ -164,7 +164,7 @@ func (r DefaultResolver) startFetchTRC(parentCtx context.Context, res chan<- res
 		span.SetTag("version", req.Version)
 		logger := log.FromCtx(ctx)
 
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		logger.Debug("[TrustStore:Resolver] Fetch TRC from remote", "isd", req.ISD,
 			"version", req.Version, "server", server)
 		rawTRC, err := r.RPC.GetTRC(ctx, req, server)

--- a/go/lib/infra/rpc/rpc.go
+++ b/go/lib/infra/rpc/rpc.go
@@ -119,7 +119,7 @@ func (s *Server) handleQUICSession(session quic.Session) error {
 		Address: session.RemoteAddr(),
 	}
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		s.Handler.ServeRPC(rw, request)
 	}()
 	return nil
@@ -152,7 +152,7 @@ func (c *Client) Request(ctx context.Context, request *Request, address net.Addr
 		return nil, err
 	}
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		<-ctx.Done()
 		stream.CancelRead(CtxTimedOutError)
 		stream.CancelWrite(CtxTimedOutError)

--- a/go/lib/integration/binary.go
+++ b/go/lib/integration/binary.go
@@ -130,7 +130,7 @@ func (bi *binaryIntegration) StartServer(ctx context.Context, dst *snet.UDPAddr)
 	// parse until we have the ready signal.
 	// and then discard the output until the end (required by StdoutPipe).
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer sp.Close()
 		signal := fmt.Sprintf("%s%s", ReadySignal, dst.IA)
 		init := true
@@ -147,7 +147,7 @@ func (bi *binaryIntegration) StartServer(ctx context.Context, dst *snet.UDPAddr)
 		}
 	}()
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		bi.writeLog("server", dst.IA.FileFmt(false), dst.IA.FileFmt(false), ep)
 	}()
 	if err = r.Start(); err != nil {
@@ -186,7 +186,7 @@ func (bi *binaryIntegration) StartClient(ctx context.Context,
 		return nil, err
 	}
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		bi.writeLog("client", clientId(src, dst), fmt.Sprintf("%s -> %s", src.IA, dst.IA), ep)
 	}()
 	return r, r.Start()

--- a/go/lib/integration/integration.go
+++ b/go/lib/integration/integration.go
@@ -354,7 +354,7 @@ func workInParallel(workChan chan workFunc, errors chan error, maxGoRoutines int
 	for i := 1; i <= maxGoRoutines; i++ {
 		wg.Add(1)
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			defer wg.Done()
 			for work := range workChan {
 				err := work()

--- a/go/lib/log/log.go
+++ b/go/lib/log/log.go
@@ -94,7 +94,7 @@ func SetupLogFile(name string, logDir string, logLevel string, logSize int, logA
 
 	if logFlush > 0 {
 		go func() {
-			defer LogPanicAndExit()
+			defer HandlePanic()
 			for range time.Tick(time.Duration(logFlush) * time.Second) {
 				Flush()
 			}
@@ -145,8 +145,8 @@ func setHandlers() {
 	log15.Root().SetHandler(handler)
 }
 
-// LogPanicAndExit catches panics and logs them.
-func LogPanicAndExit() {
+// HandlePanic catches panics and logs them.
+func HandlePanic() {
 	if msg := recover(); msg != nil {
 		log15.Crit("Panic", "msg", msg, "stack", string(debug.Stack()))
 		log15.Crit("=====================> Service panicked!")

--- a/go/lib/pathdb/sqlite/sqlite.go
+++ b/go/lib/pathdb/sqlite/sqlite.go
@@ -547,7 +547,7 @@ func (e *executor) GetAll(ctx context.Context) (<-chan query.ResultOrErr, error)
 	}
 	resCh := make(chan query.ResultOrErr)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer close(resCh)
 		defer rows.Close()
 		prevID := -1

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -194,7 +194,7 @@ func (r *resolver) WatchFilter(ctx context.Context, src, dst addr.IA,
 	sp.setDestructor(w.Destroy)
 
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		w.Run()
 	}()
 	return sp, nil

--- a/go/lib/periodic/periodic.go
+++ b/go/lib/periodic/periodic.go
@@ -68,7 +68,7 @@ func Start(task Task, period, timeout time.Duration) *Runner {
 	r.metric.Period(period)
 	r.metric.StartTimestamp(time.Now())
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		r.runLoop()
 	}()
 	return r

--- a/go/lib/sigdisp/disp.go
+++ b/go/lib/sigdisp/disp.go
@@ -31,7 +31,7 @@ import (
 func Init(conn snet.Conn, useid bool) {
 	useID = useid
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		pktdisp.PktDispatcher(conn, dispFunc, nil)
 	}()
 }

--- a/go/lib/sock/reliable/reconnect/conn.go
+++ b/go/lib/sock/reliable/reconnect/conn.go
@@ -137,7 +137,7 @@ func (conn *PacketConn) spawnAsyncReconnecterOnce() {
 	case <-conn.dispatcherState.Up():
 		conn.dispatcherState.SetDown()
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			conn.asyncReconnectWrapper()
 		}()
 	default:

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -187,7 +187,7 @@ func register(ctx context.Context, dispatcher string, ia addr.IA, public *net.UD
 	}
 	resultChannel := make(chan RegistrationReturn)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 
 		// If a timeout was specified, make reads and writes return if deadline exceeded.
 		if deadline, ok := ctx.Deadline(); ok {

--- a/go/lib/svc/internal/ctxconn/ctxconn.go
+++ b/go/lib/svc/internal/ctxconn/ctxconn.go
@@ -46,7 +46,7 @@ func CloseConnOnDone(ctx context.Context, conn DeadlineCloser) CancelFunc {
 
 	cancelSignal := make(chan struct{})
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		select {
 		case <-ctx.Done():
 			if err := conn.Close(); err != nil {

--- a/go/lint/log.go
+++ b/go/lint/log.go
@@ -23,11 +23,11 @@ import (
 )
 
 // Analyzer contains an analyzer that makes sure that go target is always a
-// func literal that calls defer log.LogPanicAndExit as first statement.
+// func literal that calls defer log.HandlePanic as first statement.
 var Analyzer = &analysis.Analyzer{
 	Name: "gocall",
 	Doc: "go target is a func that calls" +
-		" defer log.LogPanicAndExit as first statement",
+		" defer log.HandlePanic as first statement",
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
 	Run:      run,
 }
@@ -44,7 +44,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		switch f := call.Fun.(type) {
 		case *ast.FuncLit:
 			if !checkFuncLit(pass, f) {
-				pass.Reportf(f.Pos(), "First statement should be 'defer LogPanicAndExit()")
+				pass.Reportf(f.Pos(), "First statement should be 'defer HandlePanic()")
 			}
 		default:
 			pass.Reportf(f.Pos(), "go statement should always call a func lit.")
@@ -64,12 +64,12 @@ func checkFuncLit(pass *analysis.Pass, fl *ast.FuncLit) bool {
 	}
 	if pkgNameSave(pass) == "log" {
 		ident, ok := deferStmt.Call.Fun.(*ast.Ident)
-		if !ok || ident.Name != "LogPanicAndExit" {
+		if !ok || ident.Name != "HandlePanic" {
 			return false
 		}
 	} else {
 		callSel, ok := deferStmt.Call.Fun.(*ast.SelectorExpr)
-		if !ok || callSel.Sel.Name != "LogPanicAndExit" {
+		if !ok || callSel.Sel.Name != "HandlePanic" {
 			return false
 		}
 	}

--- a/go/sciond/internal/servers/server.go
+++ b/go/sciond/internal/servers/server.go
@@ -85,7 +85,7 @@ func (srv *Server) ListenAndServe() error {
 		}
 
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			hdl := &ConnHandler{
 				Conn:     conn,
 				Handlers: srv.handlers,

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -82,7 +82,7 @@ func realMain() int {
 	}
 	defer log.Flush()
 	defer env.LogAppStopped("SD", cfg.General.ID)
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	if err := setup(); err != nil {
 		log.Crit("Setup failed", "err", err)
 		return 1
@@ -245,7 +245,7 @@ func NewServer(network string, rsockPath string,
 
 func StartServer(address string, server *servers.Server) {
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		if err := server.ListenAndServe(); err != nil {
 			fatal.Fatal(common.NewBasicError("ListenAndServe error", err, "address", address))
 		}

--- a/go/sig/egress/api.go
+++ b/go/sig/egress/api.go
@@ -31,7 +31,7 @@ func Init(tunIO io.ReadWriteCloser) {
 	iface.Init()
 	// Spawn egress reader
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		reader.NewReader(tunIO).Run()
 	}()
 }

--- a/go/sig/egress/asmap/as.go
+++ b/go/sig/egress/asmap/as.go
@@ -233,12 +233,12 @@ func (ae *ASEntry) cleanSessions() {
 func (ae *ASEntry) setupNet() {
 	ae.egressRing = ringbuf.New(iface.EgressRemotePkts, nil, fmt.Sprintf("egress_%s", ae.IAString))
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		dispatcher.NewDispatcher(ae.IA, ae.egressRing,
 			&selector.SingleSession{Session: ae.Session}).Run()
 	}()
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		ae.monitorHealth()
 	}()
 	ae.Session.Start()

--- a/go/sig/egress/session/session.go
+++ b/go/sig/egress/session/session.go
@@ -85,7 +85,7 @@ func NewSession(dstIA addr.IA, sessId sig_mgmt.SessionType, logger log.Logger,
 	s.workerStopped = make(chan struct{})
 	// spawn a PktDispatcher to log any unexpected messages received on a write-only connection.
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		defer close(s.pktDispStopped)
 		pktdisp.PktDispatcher(s.conn, pktdisp.DispLogger, s.pktDispStop)
 	}()
@@ -94,11 +94,11 @@ func NewSession(dstIA addr.IA, sessId sig_mgmt.SessionType, logger log.Logger,
 
 func (s *Session) Start() {
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		newSessMonitor(s).run()
 	}()
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		worker.NewWorker(s, s.conn, false, s.Logger).Run()
 	}()
 }

--- a/go/sig/egress/worker/worker.go
+++ b/go/sig/egress/worker/worker.go
@@ -98,7 +98,7 @@ func NewWorker(sess iface.Session, writer SCIONWriter, ignoreAddress bool,
 }
 
 func (w *worker) Run() {
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	w.Info("EgressWorker: starting")
 	f := newFrame()
 

--- a/go/sig/internal/ingress/api.go
+++ b/go/sig/internal/ingress/api.go
@@ -35,7 +35,7 @@ func Init(tunIO io.ReadWriteCloser) {
 	}
 	d := NewDispatcher(tunIO, conn)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		if err := d.Run(); err != nil {
 			log.Crit("Ingress dispatcher error", "err", err)
 			fatal.Fatal(err)

--- a/go/sig/internal/ingress/dispatcher.go
+++ b/go/sig/internal/ingress/dispatcher.go
@@ -105,7 +105,7 @@ func (d *Dispatcher) dispatch(frame *FrameBuf, src *snet.UDPAddr) {
 		worker = NewWorker(src, frame.sessId, d.tunIO)
 		d.workers[dispatchStr] = worker
 		go func() {
-			defer log.LogPanicAndExit()
+			defer log.HandlePanic()
 			worker.Run()
 		}()
 	}
@@ -120,7 +120,7 @@ func (d *Dispatcher) cleanup() {
 		if worker.markedForCleanup {
 			delete(d.workers, key)
 			go func() {
-				defer log.LogPanicAndExit()
+				defer log.HandlePanic()
 				worker.Stop()
 			}()
 		} else {

--- a/go/sig/internal/ingress/worker.go
+++ b/go/sig/internal/ingress/worker.go
@@ -142,7 +142,7 @@ func (w *Worker) cleanup() {
 			// back to the bufpool.
 			delete(w.rlists, epoch)
 			go func() {
-				defer log.LogPanicAndExit()
+				defer log.HandlePanic()
 				rlist.removeAll()
 			}()
 		} else {

--- a/go/sig/internal/sigcmn/common.go
+++ b/go/sig/internal/sigcmn/common.go
@@ -142,7 +142,7 @@ func newDispatcher(cfg sigconfig.SigConf) (reliable.Dispatcher, error) {
 		return nil, serrors.WrapStr("unable to initialize bypass dispatcher", err)
 	}
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		err := dispServer.Serve()
 		if err != nil {
 			log.Error("Bypass dispatcher failed", "err", err)

--- a/go/sig/main.go
+++ b/go/sig/main.go
@@ -71,7 +71,7 @@ func realMain() int {
 	}
 	defer log.Flush()
 	defer env.LogAppStopped("SIG", cfg.Sig.ID)
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	if err := validateConfig(); err != nil {
 		log.Crit("Validation of config failed", "err", err)
 		return 1
@@ -101,7 +101,7 @@ func realMain() int {
 	}
 	// Reply to probes from other SIGs.
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		base.PollReqHdlr()
 	}()
 	egress.Init(tunIO)

--- a/go/tools/scmp/cmn/common.go
+++ b/go/tools/scmp/cmn/common.go
@@ -227,7 +227,7 @@ func SetupSignals(f func()) {
 	signal.Notify(sig, os.Interrupt)
 	signal.Notify(sig, syscall.SIGTERM)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		<-sig
 		if f != nil {
 			f()

--- a/go/tools/scmp/echo/echo.go
+++ b/go/tools/scmp/echo/echo.go
@@ -38,7 +38,7 @@ func Run() {
 	cmn.SetupSignals(summary)
 	wg.Add(1)
 	go func() {
-		defer log.LogPanicAndExit()
+		defer log.HandlePanic()
 		sendPkts()
 	}()
 	recvPkts()

--- a/go/tools/scmp/scmp_integration/main.go
+++ b/go/tools/scmp/scmp_integration/main.go
@@ -31,7 +31,7 @@ func realMain() int {
 		fmt.Fprintf(os.Stderr, "Failed to init: %s\n", err)
 		return 1
 	}
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 	defer log.Flush()
 
 	cmnArgs := []string{"-timeout", "4s", "-local", integration.SrcAddrPattern,

--- a/go/tools/showpaths/paths.go
+++ b/go/tools/showpaths/paths.go
@@ -62,7 +62,7 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
-	defer log.LogPanicAndExit()
+	defer log.HandlePanic()
 
 	ctx, cancelF := context.WithTimeout(context.Background(), *timeout)
 	defer cancelF()


### PR DESCRIPTION
According to the linter
```
func name will be used as log.LogPanicAndExit by other packages, and that stutters; consider calling this PanicAndExit

```

Contributes #3592

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3642)
<!-- Reviewable:end -->
