### PR TITLE
Msgr: Fix svc redirect in UDP only mode

### DIFF
--- a/go/lib/infra/messenger/addr.go
+++ b/go/lib/infra/messenger/addr.go
@@ -77,7 +77,7 @@ func (r AddressRewriter) RedirectToQUIC(ctx context.Context,
 	// FIXME(scrye): This is not legitimate use. It's only included for
 	// compatibility with older unit tests. See
 	// https://github.com/scionproto/scion/issues/2611.
-	if address == nil || r.SVCResolutionFraction <= 0.0 {
+	if address == nil {
 		return address, false, nil
 	}
 
@@ -88,6 +88,9 @@ func (r AddressRewriter) RedirectToQUIC(ctx context.Context,
 		fa, err := r.buildFullAddress(ctx, a)
 		if err != nil {
 			return nil, false, err
+		}
+		if r.SVCResolutionFraction <= 0.0 {
+			return fa, false, nil
 		}
 
 		path, err := fa.GetPath()


### PR DESCRIPTION
This fixes a bug where SVC is not resolved in a UDP-only configured host.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3649)
<!-- Reviewable:end -->
