### PR TITLE
Avoid net.ResolveUDPAddr in snet.UDPAddrFromString

### DIFF
--- a/go/lib/snet/udpaddr.go
+++ b/go/lib/snet/udpaddr.go
@@ -75,11 +75,11 @@ func UDPAddrFromString(s string) (*UDPAddr, error) {
 	if ip == nil {
 		return nil, serrors.New("invalid address: no IP specified", "host", rawHost)
 	}
-	port, err := strconv.Atoi(rawPort)
-	if err != nil || 0 > port || port > 65535 {
+	port, err := strconv.ParseUint(rawPort, 10, 16)
+	if err != nil {
 		return nil, serrors.New("invalid port", "host", rawHost)
 	}
-	return &UDPAddr{IA: ia, Host: &net.UDPAddr{IP: ip, Port: port}}, nil
+	return &UDPAddr{IA: ia, Host: &net.UDPAddr{IP: ip, Port: int(port)}}, nil
 }
 
 // Network implements net.Addr interface.

--- a/go/lib/snet/udpaddr.go
+++ b/go/lib/snet/udpaddr.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/scionproto/scion/go/lib/addr"
@@ -65,14 +66,20 @@ func UDPAddrFromString(s string) (*UDPAddr, error) {
 	if ip := net.ParseIP(strings.Trim(rawHost, "[]")); ip != nil {
 		return &UDPAddr{IA: ia, Host: &net.UDPAddr{IP: ip, Port: 0}}, nil
 	}
-	udpAddr, err := net.ResolveUDPAddr("udp", rawHost)
+
+	rawIP, rawPort, err := net.SplitHostPort(rawHost)
 	if err != nil {
 		return nil, err
 	}
-	if udpAddr.IP == nil {
+	ip := net.ParseIP(rawIP)
+	if ip == nil {
 		return nil, serrors.New("invalid address: no IP specified", "host", rawHost)
 	}
-	return &UDPAddr{IA: ia, Host: udpAddr}, nil
+	port, err := strconv.Atoi(rawPort)
+	if err != nil || 0 > port || port > 65535 {
+		return nil, serrors.New("invalid port", "host", rawHost)
+	}
+	return &UDPAddr{IA: ia, Host: &net.UDPAddr{IP: ip, Port: port}}, nil
 }
 
 // Network implements net.Addr interface.


### PR DESCRIPTION
Parse the host IP, port directly instead of using net.ResolveUDPAddr, which also resolves hostnames. Hostnames should not be considered inside SCION addresses.

Fixes #3654

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3662)
<!-- Reviewable:end -->
