### PR TITLE
 Remove unused sd_client config from control service 

### DIFF
--- a/acceptance/topo_cs_reload/testdata/cs.toml
+++ b/acceptance/topo_cs_reload/testdata/cs.toml
@@ -20,6 +20,3 @@ Connection = "cs1-ff00_0_110-1.beacon.db"
 
 [metrics]
 Prometheus = "242.253.100.2:30453"
-
-[sd_client]
-Address = "242.253.100.3:30255"

--- a/go/cs/config/config.go
+++ b/go/cs/config/config.go
@@ -80,18 +80,17 @@ var _ config.Config = (*Config)(nil)
 
 // Config is the beacon server configuration.
 type Config struct {
-	General        env.General
-	Features       env.Features
-	Logging        env.Logging
-	Metrics        env.Metrics
-	Tracing        env.Tracing
-	QUIC           env.QUIC `toml:"quic"`
-	TrustDB        truststorage.TrustDBConf
-	BeaconDB       beaconstorage.BeaconDBConf
-	BS             BSConfig
-	CS             CSConfig
-	PS             PSConfig
-	EnableQUICTest bool
+	General  env.General
+	Features env.Features
+	Logging  env.Logging
+	Metrics  env.Metrics
+	Tracing  env.Tracing
+	QUIC     env.QUIC `toml:"quic"`
+	TrustDB  truststorage.TrustDBConf
+	BeaconDB beaconstorage.BeaconDBConf
+	BS       BSConfig
+	CS       CSConfig
+	PS       PSConfig
 }
 
 // InitDefaults initializes the default values for all parts of the config.

--- a/go/cs/config/config.go
+++ b/go/cs/config/config.go
@@ -85,8 +85,7 @@ type Config struct {
 	Logging        env.Logging
 	Metrics        env.Metrics
 	Tracing        env.Tracing
-	QUIC           env.QUIC         `toml:"quic"`
-	SCIOND         env.SCIONDClient `toml:"sd_client"`
+	QUIC           env.QUIC `toml:"quic"`
 	TrustDB        truststorage.TrustDBConf
 	BeaconDB       beaconstorage.BeaconDBConf
 	BS             BSConfig
@@ -103,7 +102,6 @@ func (cfg *Config) InitDefaults() {
 		&cfg.Logging,
 		&cfg.Metrics,
 		&cfg.Tracing,
-		&cfg.SCIOND,
 		&cfg.TrustDB,
 		&cfg.BeaconDB,
 		&cfg.BS,
@@ -119,7 +117,6 @@ func (cfg *Config) Validate() error {
 		&cfg.Features,
 		&cfg.Logging,
 		&cfg.Metrics,
-		&cfg.SCIOND,
 		&cfg.TrustDB,
 		&cfg.BeaconDB,
 		&cfg.BS,
@@ -137,7 +134,6 @@ func (cfg *Config) Sample(dst io.Writer, path config.Path, _ config.CtxMap) {
 		&cfg.Metrics,
 		&cfg.Tracing,
 		&cfg.QUIC,
-		&cfg.SCIOND,
 		&cfg.TrustDB,
 		&cfg.BeaconDB,
 		&cfg.BS,

--- a/go/lib/env/testdata/cs.toml
+++ b/go/lib/env/testdata/cs.toml
@@ -14,13 +14,6 @@
   # reconnects.
   ReconnectToDispatcher = true
 
-[sd_client]
-  # Sciond path. It defaults to sciond.DefaultSCIONDPath.
-  Path = "/run/shm/sciond/1-ff00_0_110.sock"
-
-  # Timeout for trying to connect to sciond. (default 20s)
-  Timeout = "20s"
-
 [logging]
   [logging.file]
     # Location of the logging file.

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -111,7 +111,6 @@ class GoGenerator(object):
                                             CS_CONFIG_NAME), toml.dumps(bs_conf))
 
     def _build_control_service_conf(self, topo_id, ia, base, name, infra_elem):
-        sciond = "[%s]:%d" % (sciond_ip(self.args.docker, topo_id, self.args.networks), SD_API_PORT)
         config_dir = '/share/conf' if self.args.docker else os.path.join(
             base, name)
         raw_entry = {
@@ -132,9 +131,6 @@ class GoGenerator(object):
             'tracing': self._tracing_entry(),
             'metrics': self._metrics_entry(name, infra_elem, CS_PROM_PORT),
             'quic': self._quic_conf_entry(CS_QUIC_PORT, self.args.svcfrac, infra_elem),
-            'sd_client': {
-                'address': sciond,
-            },
             'cs': {
                 'LeafReissueLeadTime': "6h",
                 'IssuerReissueLeadTime': "3d",


### PR DESCRIPTION
The control service does not use the `sd_client` option, as it does not use SCIOND (c.f. #3652, "routing is done directly on top of the path database, instead of going through SCIOND").

Also removes the old `EnableQUICTest` flag, that isn't used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3668)
<!-- Reviewable:end -->
