### PR TITLE
snet: Include local IA in debug log when registering to dispatcher

### DIFF
--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -163,6 +163,6 @@ func (n *SCIONNetwork) Listen(ctx context.Context, network string, listen *net.U
 		// Update port
 		conn.listen.Port = int(port)
 	}
-	log.Debug("Registered with dispatcher", "addr", conn.listen)
+	log.Debug("Registered with dispatcher", "addr", &UDPAddr{IA: n.localIA, Host: conn.listen})
 	return newSCIONConn(conn, n.querier, packetConn), nil
 }


### PR DESCRIPTION
Include the local `IA` in the debug log after registering to the dispatcher. This allows to verify that the application is running in the correct networking context.
As a bonus, this allows to copy-paste the logged address from the debug log to connect to a server application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3669)
<!-- Reviewable:end -->
