### PR TITLE
Fix distroless build error

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,8 +58,9 @@ _go_image_repos()
 # Distroless
 git_repository(
     name = "distroless",
-    commit = "07399042ca65818d19aa0a2b0325716e237c4d01",
+    commit = "48dba0a4ace4fcb4fdd8d7e1f7dc1a9ed8b38f7c",
     remote = "https://github.com/GoogleContainerTools/distroless.git",
+    shallow_since = "1582150737 -0500",
 )
 
 # Debian packages to install in containers


### PR DESCRIPTION
Apparently someone updated a binary wrongly, see also:
https://github.com/GoogleContainerTools/distroless/pull/473
https://github.com/GoogleContainerTools/distroless/issues/471#issuecomment-588482860

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3673)
<!-- Reviewable:end -->
