### PR TITLE
Fixed HBH ext parse panic when start >= end

### DIFF
--- a/go/border/rpkt/extns.go
+++ b/go/border/rpkt/extns.go
@@ -18,6 +18,7 @@
 package rpkt
 
 import (
+	"github.com/scionproto/scion/go/lib/assert"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/scmp"
 	"github.com/scionproto/scion/go/lib/serrors"
@@ -36,11 +37,16 @@ type rExtension interface {
 const (
 	// FIXME(kormat): remove when generic header walker is implemented.
 	ErrExtChainTooLong common.ErrMsg = "Extension header chain longer than packet"
+	ErrExtChainCorrupt common.ErrMsg = "Extension header specifies invalid size"
 )
 
 // extnParseHBH parses a specified hop-by-hop extension in a packet.
 func (rp *RtrPkt) extnParseHBH(extType common.ExtnType,
 	start, end, pos int) (rExtension, error) {
+	if assert.On {
+		assert.Must(end-start+common.ExtnSubHdrLen >= common.LineLen,
+			"Extension must be at least one line length")
+	}
 	switch {
 	case extType == common.ExtnSCMPType:
 		return rSCMPExtFromRaw(rp, start, end)


### PR DESCRIPTION
The router could crash if a packet arrived with data resulting in the function `go/border/rpkt/extn_scmp.go/rSCMPExtFromRaw(...)` receiving a `start >= end`, which would panic on line 38.

The error is caused by `go/border/rpkt/parse.go/rp.parseHopExtns()` calling `rp.extnParseHBH(...)` on line 123, which then calls `rSCMPExtFromRaw(...)` with no checks for `start` or `end`.

I decided to add an error check in `rp.extnParseHBH(...)` instead of where the panic happens (`rSCMPExtFromRaw(...)`), because a header of invalid offset or length should fail, even when `start` or `end` are not read, such as in `rOneHopPathFromRaw`.

The problem might also be fixed earlier, in `rp.parseHopExtns()`, where the erroneous values are actually read in. However, I was unsure if this is better and so left the error catching in `rp.extnParseHBH(...)`

I also chose to use as an error check that the total length of the extension must be greater than `common.LineLen`, since an extension of any less size should not be valid anyway.

For reference: The packet that caused the panic was:

`00c10067070405000001ff00000001110001ff000000011080007f00000b0000857b3362e3400140003f0000014152c1000000000000000000000000000000001101010000000000792c000000271f920000001b10084002110582510801027f10065002020102`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3674)
<!-- Reviewable:end -->
