### PR TITLE
Guard against system clock moving backwards.

### DIFF
--- a/go/border/io.go
+++ b/go/border/io.go
@@ -74,7 +74,12 @@ func (r *Router) posixInput(s *rctx.Sock, stop, stopped chan struct{}) {
 
 	// Called when the packet's reference count hits 0.
 	free := func(rp *rpkt.RtrPkt) {
-		procPktTime.Add(time.Since(rp.TimeIn).Seconds())
+		// Protect against system clock moving backwards
+		t := time.Since(rp.TimeIn).Seconds()
+		if t < 0 {
+			t = 0
+		}
+		procPktTime.Add(t)
 		rp.Reset()
 		r.freePkts.Write(ringbuf.EntryList{rp}, true)
 	}


### PR DESCRIPTION
The timestamp returned from the kernel is in system time. This means
it's possible for the kernel received time to appear after the
application receives the packet, which then can cause logic errors to
occur in code that depends on the ordering of these timestamps.

Also guard against this in the BR's packet processing time metric
calculation, as system time could move backwards during the processing
of a packet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3679)
<!-- Reviewable:end -->
