### PR TITLE
No exception when networks.conf is not present

### DIFF
--- a/python/integration/set_ipv6_addr.py
+++ b/python/integration/set_ipv6_addr.py
@@ -47,6 +47,9 @@ def net_clear(net):
 
 def set_interfaces():
     path = os.path.join(GEN_PATH, NETWORKS_FILE)
+    if not os.path.exists(path):
+        # no network configuration file, nothing to do
+        return
     with open(path, 'r') as f:
         for l in f.readlines():
             split = l.split("= ")


### PR DESCRIPTION
Some `gen` folders (e.g. coming from SCIONLab) will not have a `networks.conf` file. Do not throw an exception in this case while configuring IPv6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3696)
<!-- Reviewable:end -->
