### PR TITLE
config: strict parsing of config files

### DIFF
--- a/go/border/main.go
+++ b/go/border/main.go
@@ -102,8 +102,12 @@ func realMain() int {
 }
 
 func setupBasic() error {
-	if _, err := toml.DecodeFile(env.ConfigFile(), &cfg); err != nil {
+	md, err := toml.DecodeFile(env.ConfigFile(), &cfg)
+	if err != nil {
 		return serrors.New("Failed to load config", "err", err, "file", env.ConfigFile())
+	}
+	if len(md.Undecoded()) > 0 {
+		return serrors.New("Failed to load config: undecoded keys", "undecoded", md.Undecoded())
 	}
 	cfg.InitDefaults()
 	if err := log.Setup(cfg.Logging); err != nil {

--- a/go/border/main.go
+++ b/go/border/main.go
@@ -104,14 +104,14 @@ func realMain() int {
 func setupBasic() error {
 	md, err := toml.DecodeFile(env.ConfigFile(), &cfg)
 	if err != nil {
-		return serrors.New("Failed to load config", "err", err, "file", env.ConfigFile())
+		return serrors.WrapStr("Failed to load config", err, "file", env.ConfigFile())
 	}
 	if len(md.Undecoded()) > 0 {
 		return serrors.New("Failed to load config: undecoded keys", "undecoded", md.Undecoded())
 	}
 	cfg.InitDefaults()
 	if err := log.Setup(cfg.Logging); err != nil {
-		return serrors.New("Failed to initialize logging", "err", err)
+		return serrors.WrapStr("Failed to initialize logging", err)
 	}
 	prom.ExportElementID(cfg.General.ID)
 	return env.LogAppStarted(common.BR, cfg.General.ID)

--- a/go/cs/beacon/hp_policy.go
+++ b/go/cs/beacon/hp_policy.go
@@ -81,7 +81,7 @@ func (hp *HPRegistration) Validate() error {
 // Hidden path groups pointed to by config file paths are loaded.
 func ParseHPRegYaml(b common.RawBytes) (*HPRegistration, error) {
 	r := &HPRegistration{}
-	if err := yaml.Unmarshal(b, r); err != nil {
+	if err := yaml.UnmarshalStrict(b, r); err != nil {
 		return nil, common.NewBasicError("Unable to parse policy", err)
 	}
 	if err := r.init(); err != nil {

--- a/go/cs/beacon/policy.go
+++ b/go/cs/beacon/policy.go
@@ -218,7 +218,7 @@ func (p *Policy) initDefaults(t PolicyType) error {
 // ParsePolicyYaml parses the policy in yaml format and initializes the default values.
 func ParsePolicyYaml(b common.RawBytes, t PolicyType) (*Policy, error) {
 	p := &Policy{}
-	if err := yaml.Unmarshal(b, p); err != nil {
+	if err := yaml.UnmarshalStrict(b, p); err != nil {
 		return nil, common.NewBasicError("Unable to parse policy", err)
 	}
 	if err := p.initDefaults(t); err != nil {

--- a/go/cs/main.go
+++ b/go/cs/main.go
@@ -702,14 +702,14 @@ func maxExpTimeFactory(store beaconstorage.Store, p beacon.PolicyType) func() sp
 func setupBasic() error {
 	md, err := toml.DecodeFile(env.ConfigFile(), &cfg)
 	if err != nil {
-		return serrors.New("Failed to load config", "err", err, "file", env.ConfigFile())
+		return serrors.WrapStr("Failed to load config", err, "file", env.ConfigFile())
 	}
 	if len(md.Undecoded()) > 0 {
 		return serrors.New("Failed to load config: undecoded keys", "undecoded", md.Undecoded())
 	}
 	cfg.InitDefaults()
 	if err := log.Setup(cfg.Logging); err != nil {
-		return serrors.New("Failed to initialize logging", "err", err)
+		return serrors.WrapStr("Failed to initialize logging", err)
 	}
 	prom.ExportElementID(cfg.General.ID)
 	return env.LogAppStarted(common.CS, cfg.General.ID)

--- a/go/cs/main.go
+++ b/go/cs/main.go
@@ -700,8 +700,12 @@ func maxExpTimeFactory(store beaconstorage.Store, p beacon.PolicyType) func() sp
 }
 
 func setupBasic() error {
-	if _, err := toml.DecodeFile(env.ConfigFile(), &cfg); err != nil {
+	md, err := toml.DecodeFile(env.ConfigFile(), &cfg)
+	if err != nil {
 		return serrors.New("Failed to load config", "err", err, "file", env.ConfigFile())
+	}
+	if len(md.Undecoded()) > 0 {
+		return serrors.New("Failed to load config: undecoded keys", "undecoded", md.Undecoded())
 	}
 	cfg.InitDefaults()
 	if err := log.Setup(cfg.Logging); err != nil {

--- a/go/godispatcher/main.go
+++ b/go/godispatcher/main.go
@@ -114,14 +114,14 @@ func realMain() int {
 func setupBasic() error {
 	md, err := toml.DecodeFile(env.ConfigFile(), &cfg)
 	if err != nil {
-		return serrors.New("Failed to load config", "err", err, "file", env.ConfigFile())
+		return serrors.WrapStr("Failed to load config", err, "file", env.ConfigFile())
 	}
 	if len(md.Undecoded()) > 0 {
 		return serrors.New("Failed to load config: undecoded keys", "undecoded", md.Undecoded())
 	}
 	cfg.InitDefaults()
 	if err := log.Setup(cfg.Logging); err != nil {
-		return err
+		return serrors.WrapStr("Failed to initialize logging", err)
 	}
 	prom.ExportElementID(cfg.Dispatcher.ID)
 	return env.LogAppStarted("Dispatcher", cfg.Dispatcher.ID)

--- a/go/godispatcher/main.go
+++ b/go/godispatcher/main.go
@@ -112,8 +112,12 @@ func realMain() int {
 }
 
 func setupBasic() error {
-	if _, err := toml.DecodeFile(env.ConfigFile(), &cfg); err != nil {
-		return err
+	md, err := toml.DecodeFile(env.ConfigFile(), &cfg)
+	if err != nil {
+		return serrors.New("Failed to load config", "err", err, "file", env.ConfigFile())
+	}
+	if len(md.Undecoded()) > 0 {
+		return serrors.New("Failed to load config: undecoded keys", "undecoded", md.Undecoded())
 	}
 	cfg.InitDefaults()
 	if err := log.Setup(cfg.Logging); err != nil {

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -204,8 +204,12 @@ func (v verificationFactory) NewVerifier() infra.Verifier {
 }
 
 func setupBasic() error {
-	if _, err := toml.DecodeFile(env.ConfigFile(), &cfg); err != nil {
+	md, err := toml.DecodeFile(env.ConfigFile(), &cfg)
+	if err != nil {
 		return serrors.New("Failed to load config", "err", err, "file", env.ConfigFile())
+	}
+	if len(md.Undecoded()) > 0 {
+		return serrors.New("Failed to load config: undecoded keys", "undecoded", md.Undecoded())
 	}
 	cfg.InitDefaults()
 	if err := log.Setup(cfg.Logging); err != nil {

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -206,14 +206,14 @@ func (v verificationFactory) NewVerifier() infra.Verifier {
 func setupBasic() error {
 	md, err := toml.DecodeFile(env.ConfigFile(), &cfg)
 	if err != nil {
-		return serrors.New("Failed to load config", "err", err, "file", env.ConfigFile())
+		return serrors.WrapStr("Failed to load config", err, "file", env.ConfigFile())
 	}
 	if len(md.Undecoded()) > 0 {
 		return serrors.New("Failed to load config: undecoded keys", "undecoded", md.Undecoded())
 	}
 	cfg.InitDefaults()
 	if err := log.Setup(cfg.Logging); err != nil {
-		return serrors.New("Failed to initialize logging", "err", err)
+		return serrors.WrapStr("Failed to initialize logging", err)
 	}
 	prom.ExportElementID(cfg.General.ID)
 	return env.LogAppStarted("SD", cfg.General.ID)

--- a/go/sig/main.go
+++ b/go/sig/main.go
@@ -122,14 +122,14 @@ func setupBasic() error {
 	// Load and initialize config.
 	md, err := toml.DecodeFile(env.ConfigFile(), &cfg)
 	if err != nil {
-		return serrors.New("Failed to load config", "err", err, "file", env.ConfigFile())
+		return serrors.WrapStr("Failed to load config", err, "file", env.ConfigFile())
 	}
 	if len(md.Undecoded()) > 0 {
 		return serrors.New("Failed to load config: undecoded keys", "undecoded", md.Undecoded())
 	}
 	cfg.InitDefaults()
 	if err := log.Setup(cfg.Logging); err != nil {
-		return serrors.New("Failed to initialize logging", "err", err)
+		return serrors.WrapStr("Failed to initialize logging", err)
 	}
 	prom.ExportElementID(cfg.Sig.ID)
 	return env.LogAppStarted("SIG", cfg.Sig.ID)

--- a/go/sig/main.go
+++ b/go/sig/main.go
@@ -120,8 +120,12 @@ func realMain() int {
 // setupBasic loads the config from file and initializes logging.
 func setupBasic() error {
 	// Load and initialize config.
-	if _, err := toml.DecodeFile(env.ConfigFile(), &cfg); err != nil {
+	md, err := toml.DecodeFile(env.ConfigFile(), &cfg)
+	if err != nil {
 		return serrors.New("Failed to load config", "err", err, "file", env.ConfigFile())
+	}
+	if len(md.Undecoded()) > 0 {
+		return serrors.New("Failed to load config: undecoded keys", "undecoded", md.Undecoded())
 	}
 	cfg.InitDefaults()
 	if err := log.Setup(cfg.Logging); err != nil {

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -55,7 +55,6 @@ from topology.topo import DEFAULT_LINK_BW
 
 CS_QUIC_PORT = 30352
 CO_QUIC_PORT = 30357
-SD_QUIC_PORT = 0
 
 
 class GoGenArgs(ArgsTopoDicts):
@@ -256,10 +255,8 @@ class GoGenerator(object):
             'tracing': self._tracing_entry(),
             'metrics': {
                 'prometheus': socket_address_str(ip, SCIOND_PROM_PORT)
-            },
-            'quic': self._quic_conf_entry(SD_QUIC_PORT, self.args.svcfrac),
+            }
         }
-        raw_entry['quic']['address'] = socket_address_str(ip, SD_QUIC_PORT)
         return raw_entry
 
     def generate_disp(self):


### PR DESCRIPTION
Error on ignored keys in config files. 

Misspelled keys in the config files, especially whenever the keys are changed, have cost me embarrassingly many hours of debugging followed by a face-palm. This should fix this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3697)
<!-- Reviewable:end -->
