### PR TITLE
cs: allow ISD loops in propagation

### DIFF
--- a/go/cs/main.go
+++ b/go/cs/main.go
@@ -330,6 +330,11 @@ func realMain() int {
 		log.Crit("Unable to create SCION packet conn", "err", err)
 		return 1
 	}
+	propPolicy, err := loadPolicy(cfg.BS.Policies.Propagation, beacon.PropPolicy)
+	if err != nil {
+		log.Crit("Unable to load propagation policy", "err", err)
+		return 1
+	}
 	tasks = &periodicTasks{
 		args:         args,
 		intfs:        intfs,
@@ -337,6 +342,7 @@ func realMain() int {
 		trustStore:   trustStore,
 		trustDB:      trustDB,
 		store:        beaconStore,
+		allowIsdLoop: *propPolicy.Filter.AllowIsdLoop,
 		pathDB:       pathDB,
 		msgr:         msgr,
 		topoProvider: itopo.Provider(),


### PR DESCRIPTION
The AllowISDLoop on the beacon propagator is never set.
Thus, ISD loops are always filtered, even though the default is to allow
loops.

This PR sets the AllowISDLoop to the value specified in the propagation
policy, or to the default value, if the policy does not exist.

fixes #3698

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3699)
<!-- Reviewable:end -->
