### PR TITLE
Remove redundant select expression

### DIFF
--- a/go/lib/overlay/conn/BUILD.bazel
+++ b/go/lib/overlay/conn/BUILD.bazel
@@ -5,8 +5,7 @@ go_library(
     srcs = ["conn.go"],
     importpath = "github.com/scionproto/scion/go/lib/overlay/conn",
     visibility = ["//visibility:public"],
-    deps = select({
-        "@io_bazel_rules_go//go/platform:android": [
+    deps = [
             "//go/lib/assert:go_default_library",
             "//go/lib/common:go_default_library",
             "//go/lib/log:go_default_library",
@@ -16,16 +15,4 @@ go_library(
             "@org_golang_x_net//ipv4:go_default_library",
             "@org_golang_x_net//ipv6:go_default_library",
         ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "//go/lib/assert:go_default_library",
-            "//go/lib/common:go_default_library",
-            "//go/lib/log:go_default_library",
-            "//go/lib/serrors:go_default_library",
-            "//go/lib/sockctrl:go_default_library",
-            "//go/lib/topology/overlay:go_default_library",
-            "@org_golang_x_net//ipv4:go_default_library",
-            "@org_golang_x_net//ipv6:go_default_library",
-        ],
-        "//conditions:default": [],
-    }),
 )


### PR DESCRIPTION
This select expression was introduced in #3325, but is no longer necessary and actively harmful when trying to compile SCION for Android (the build fails due to this expression, so we had to [remove it](https://github.com/ekuiter/scion-android-binary/blob/60e97b837e73ec25fd3a3900e09f5488c0f4235d/build.sh#L71) manually). Semantically, it does not even make a difference, as in both selected cases the same dependencies are returned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3706)
<!-- Reviewable:end -->
