### PR TITLE
acceptance: make topo_br_reload more reliable

### DIFF
--- a/acceptance/topo_br_reload_if_ip_acceptance/test
+++ b/acceptance/topo_br_reload_if_ip_acceptance/test
@@ -84,7 +84,8 @@ check_change_remote_ip() {
     # Connectivity is broken at this point
     change_remote_ip $SRC_TOPO $SRC_IA_FILE $dummy_dst
     change_remote_ip $DST_TOPO $DST_IA_FILE $dummy_src
-    sleep 3
+    # make sure revocation is expired
+    sleep 10
     check_connectivity "End check_change_remote_ip"
 }
 

--- a/acceptance/topo_br_reload_if_port_acceptance/test
+++ b/acceptance/topo_br_reload_if_port_acceptance/test
@@ -50,7 +50,8 @@ check_change_remote_port() {
     # Connectivity is broken at this point
     jq '.BorderRouters[].Interfaces[].RemoteOverlay.OverlayPort = 42424' $DST_TOPO | sponge $DST_TOPO
     ./tools/dc scion kill -s HUP scion_br"$DST_IA_FILE"-1
-    sleep 5
+    # make sure revocation is expired
+    sleep 10
     check_logs "Remote:$addr_src:42424" $DST_IA_FILE
     check_connectivity "End check_change_remote_port"
 }


### PR DESCRIPTION
Occasionally, the test is so slow that a revocation is issued.
This introduces a sleep of 10 seconds, such that all revocations
have expired and the test can correctly check if there is connectivity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3712)
<!-- Reviewable:end -->
