### PR TITLE
cs: fix fast beaconing recovery

### DIFF
--- a/go/cs/beaconing/registrar.go
+++ b/go/cs/beaconing/registrar.go
@@ -169,7 +169,9 @@ func (r *Registrar) registerRemote(ctx context.Context, segments <-chan beacon.B
 	if expected > 0 && s.count <= 0 {
 		return common.NewBasicError("No beacons registered", nil, "candidates", expected)
 	}
-	r.lastSucc = r.tick.now
+	if s.count > 0 {
+		r.lastSucc = r.tick.now
+	}
 	r.logSummary(logger, s)
 	return nil
 }


### PR DESCRIPTION
There was a regression that the beaconing registrar does not fast recover
after a stale period for registering down segments.

This PR fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3718)
<!-- Reviewable:end -->
