### PR TITLE
remove global state from Python acceptance

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,6 +36,27 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
 
+# XXX Needs to be before rules_docker
+# Python rules
+git_repository(
+    name = "rules_python",
+    remote = "https://github.com/bazelbuild/rules_python.git",
+    commit = "94677401bc56ed5d756f50b441a6a5c7f735a6d4",
+    shallow_since = "1573842889 -0500",
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()
+
+load("@rules_python//python:pip.bzl", "pip3_import")
+pip3_import(
+   name = "pip3_deps",
+   requirements = "//env/pip3:requirements.txt",
+)
+
+load("@pip3_deps//:requirements.bzl", "pip_install")
+pip_install()
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_pkg",

--- a/acceptance/bs_add_link_acceptance/test
+++ b/acceptance/bs_add_link_acceptance/test
@@ -27,8 +27,9 @@ from plumbum import local
 from plumbum.path.local import LocalPath
 
 from acceptance.common.log import LogExec, init_log
-from acceptance.common.base import CmdBase, set_name, TestBase
-from acceptance.common.scion import svc_names_from_path
+from acceptance.common.base import CmdBase, set_name, TestBase, TestState
+from acceptance.common.scion import svc_names_from_path, SCIONDocker
+from acceptance.common.tools import DC
 
 set_name(__file__)
 logger = logging.getLogger(__name__)
@@ -140,4 +141,5 @@ class TestRun(CmdBase):
 
 if __name__ == '__main__':
     init_log()
+    Test.test_state = TestState(SCIONDocker(), DC(''))
     Test.run()

--- a/acceptance/common/BUILD.bazel
+++ b/acceptance/common/BUILD.bazel
@@ -1,0 +1,43 @@
+load("@rules_python//python:defs.bzl", "py_library")
+load("@pip3_deps//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "base",
+    srcs = ["base.py"],
+    deps = [
+        requirement("plumbum"),
+        "log",
+        "scion",
+        "tools",
+    ],
+)
+
+py_library(
+    name = "go",
+    srcs = ["go.py"],
+)
+
+py_library(
+    name = "log",
+    srcs = ["log.py"],
+)
+
+py_library(
+    name = "scion",
+    srcs = ["scion.py"],
+    deps = [
+        requirement("plumbum"),
+        requirement("toml"),
+        "log",
+    ],
+)
+
+py_library(
+    name = "tools",
+    srcs = ["tools.py"],
+    deps = [
+        requirement("plumbum"),
+    ],
+)

--- a/acceptance/common/base.py
+++ b/acceptance/common/base.py
@@ -16,7 +16,7 @@ import logging
 
 from plumbum import cli
 from plumbum import local
-from plumbum.cmd import docker, mkdir
+from plumbum.cmd import docker, mkdir, mktemp
 from plumbum.path.local import LocalPath
 
 from acceptance.common.log import LogExec
@@ -50,7 +50,7 @@ class TestState:
 
         self.scion = scion
         self.dc = dc
-        self.artifacts = local.path()  # Just init so mypy knows the type.
+        self.artifacts = local.path(mktemp('-d').strip())
         self.no_docker = False
         self.tools_dc = local['./tools/dc']
 
@@ -68,8 +68,7 @@ class TestBase(cli.Application):
         self.test_state.no_docker = True
         self.test_state.scion = SCIONSupervisor()
 
-    @cli.switch('artifacts', str, envname='ACCEPTANCE_ARTIFACTS',
-                mandatory=True)
+    @cli.switch('artifacts', str, envname='ACCEPTANCE_ARTIFACTS')
     def artifacts_dir(self, a_dir: str):
         self.test_state.artifacts = local.path('%s/%s/' % (a_dir, NAME))
 
@@ -103,8 +102,8 @@ class CmdBase(cli.Application):
             self.tools_dc(name, 'down')
 
     @staticmethod
-    def test_dir() -> LocalPath:
-        return local.path('acceptance') / DIR
+    def test_dir(prefix: str = '') -> LocalPath:
+        return local.path(prefix, 'acceptance') / DIR
 
     @staticmethod
     def docker_status():

--- a/acceptance/common/base.py
+++ b/acceptance/common/base.py
@@ -20,7 +20,8 @@ from plumbum.cmd import docker, mkdir
 from plumbum.path.local import LocalPath
 
 from acceptance.common.log import LogExec
-from acceptance.common.scion import ScionDocker, ScionSupervisor
+from acceptance.common.consul import Consul
+from acceptance.common.scion import SCION, SCIONSupervisor
 from acceptance.common.tools import DC
 
 NAME = 'NOT_SET'  # must be set by users of the Base class.
@@ -40,11 +41,19 @@ class TestState:
     TestState is used to share state between the command
     and the sub-command.
     """
-    dc = DC('')  # Just init so mypy knows the type.
-    artifacts = local.path()  # Just init so mypy knows the type.
-    scion = ScionDocker()
-    no_docker = False
-    tools_dc = local['./tools/dc']
+
+    def __init__(self, scion: SCION, dc: DC):
+        """
+        Create new environment state for an execution of the acceptance
+        testing framework. Plumbum subcommands can access this state
+        via the parent to retrieve information about the test environment.
+        """
+
+        self.scion = scion
+        self.dc = dc
+        self.artifacts = local.path()  # Just init so mypy knows the type.
+        self.no_docker = False
+        self.tools_dc = local['./tools/dc']
 
 
 class TestBase(cli.Application):
@@ -52,17 +61,18 @@ class TestBase(cli.Application):
     TestBase is used to implement the test entry point. Tests should
     sub-class it and only define the doc string.
     """
+    test_state = None
 
     @cli.switch('disable-docker', envname='DISABLE_DOCKER',
                 help='Run in supervisor environment.')
     def disable_docker(self):
-        TestState.no_docker = True
-        TestState.scion = ScionSupervisor()
+        self.test_state.no_docker = True
+        self.test_state.scion = SCIONSupervisor()
 
     @cli.switch('artifacts', str, envname='ACCEPTANCE_ARTIFACTS',
                 mandatory=True)
     def artifacts_dir(self, a_dir: str):
-        TestState.artifacts = local.path('%s/%s/' % (a_dir, NAME))
+        self.test_state.artifacts = local.path('%s/%s/' % (a_dir, NAME))
 
 
 class CmdBase(cli.Application):
@@ -96,19 +106,19 @@ class CmdBase(cli.Application):
 
     @property
     def dc(self):
-        return TestState.dc
+        return self.parent.test_state.dc
 
     @property
     def artifacts(self):
-        return TestState.artifacts
+        return self.parent.test_state.artifacts
 
     @property
     def scion(self):
-        return TestState.scion
+        return self.parent.test_state.scion
 
     @property
     def no_docker(self):
-        return TestState.no_docker
+        return self.parent.test_state.no_docker
 
 
 @TestBase.subcommand('name')

--- a/acceptance/common/base.py
+++ b/acceptance/common/base.py
@@ -20,7 +20,6 @@ from plumbum.cmd import docker, mkdir
 from plumbum.path.local import LocalPath
 
 from acceptance.common.log import LogExec
-from acceptance.common.consul import Consul
 from acceptance.common.scion import SCION, SCIONSupervisor
 from acceptance.common.tools import DC
 
@@ -93,6 +92,15 @@ class CmdBase(cli.Application):
         self.scion.stop()
         if not self.no_docker:
             self.dc.collect_logs(self.artifacts / 'logs' / 'docker')
+            self.tools_dc('down')
+
+    def _collect_logs(self, name: str):
+        if LocalPath('gen/%s-dc.yml' % name).exists():
+            self.tools_dc('collect_logs', name, self.artifacts / 'logs' / 'docker')
+
+    def _teardown(self, name: str):
+        if LocalPath('gen/%s-dc.yml' % name).exists():
+            self.tools_dc(name, 'down')
 
     @staticmethod
     def test_dir() -> LocalPath:

--- a/acceptance/common/go.py
+++ b/acceptance/common/go.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Anapaya Systems
+
+from plumbum import local
+from plumbum.machines import LocalMachine
+
+from typing import Tuple
+from pathlib import Path
+
+
+def test(package: str) -> Tuple[int, str, str]:
+    """
+    Runs the Go tests in package. Set argument go_from_bazel to true to retrieve
+    the go binary from the bazel cache.
+
+    The return value is a (retcode, stdout, stderr) plumbum tuple.
+    """
+
+    local.env["ACCEPTANCE"] = 1
+    go = _go_cmd()
+    go = go["test", package]
+    return go.run(retcode=None)
+
+
+def _go_cmd() -> LocalMachine:
+    bazel_info_output = local["bazel"]("info", "output_base")
+    # Remove new line at end of output
+    base_path = bazel_info_output.strip()
+    go_bin_path = Path(base_path) / "external" / "go_sdk" / "bin" / "go"
+    return local[str(go_bin_path)]

--- a/acceptance/common/scion.py
+++ b/acceptance/common/scion.py
@@ -26,8 +26,8 @@ from acceptance.common.log import LogExec
 logger = logging.getLogger(__name__)
 
 
-class Scion(ABC):
-    """ Scion is the base class for interacting with the infrastructure. """
+class SCION(ABC):
+    """ SCION is the base class for interacting with the infrastructure. """
     scion_sh = local['./scion.sh']
     end2end = local['./bin/end2end_integration']
 
@@ -101,9 +101,9 @@ class Scion(ABC):
             toml.dump(t, f)
 
 
-class ScionDocker(Scion):
+class SCIONDocker(SCION):
     """
-    ScionDocker is used for interacting with the dockerized
+    SCIONDocker is used for interacting with the dockerized
     scion infrastructure.
     """
     tools_dc = local['./tools/dc']
@@ -121,10 +121,10 @@ class ScionDocker(Scion):
         self.end2end('-d', retcode=code)
 
 
-class ScionSupervisor(Scion):
+class SCIONSupervisor(SCION):
     """
-    ScionSupervisor is used for interacting with the supervisor
-    scion infrastructure.
+    SCIONSupervisor is used for interacting with the supervisor
+    SCION infrastructure.
     """
 
     @LogExec(logger, "creating supervisor topology")

--- a/acceptance/common/scion.py
+++ b/acceptance/common/scion.py
@@ -72,11 +72,11 @@ class SCION(ABC):
         self._send_signals(svc_names, "SIGHUP")
 
     @LogExec(logger, 'end2end test')
-    def run_end2end(self, expect_fail=False):
-        self._run_end2end(1 if expect_fail else 0)
+    def run_end2end(self, *args, expect_fail=False):
+        self._run_end2end(*args, code=1 if expect_fail else 0)
 
     @abstractmethod
-    def _run_end2end(self, code=0):
+    def _run_end2end(self, *args, code=0):
         """
         Run the end2end integration test.
         :param code: The expected return code.
@@ -117,8 +117,8 @@ class SCIONDocker(SCION):
         for svc_name in svc_names:
             self.tools_dc('scion', 'kill', '-s', sig, 'scion_%s' % svc_name)
 
-    def _run_end2end(self, code=0):
-        self.end2end('-d', retcode=code)
+    def _run_end2end(self, *args, code=0):
+        self.end2end('-d', *args, retcode=code)
 
 
 class SCIONSupervisor(SCION):
@@ -136,8 +136,8 @@ class SCIONSupervisor(SCION):
         for svc_name in svc_names:
             pkill('-f', '--signal', sig, 'bin/.*%s' % svc_name)
 
-    def _run_end2end(self, code=0):
-        self.end2end(retcode=code)
+    def _run_end2end(self, *args, code=0):
+        self.end2end(*args, retcode=code)
 
 
 def svc_names_from_path(files: LocalPath) -> List[str]:

--- a/acceptance/common/tools.py
+++ b/acceptance/common/tools.py
@@ -23,6 +23,7 @@ from plumbum.cmd import (
 from plumbum import local
 
 SCION_DC_FILE = 'gen/scion-dc.yml'
+DC_PROJECT = 'acceptance_scion'
 
 
 def container_ip(container_name: str) -> str:
@@ -33,15 +34,19 @@ def container_ip(container_name: str) -> str:
 
 class DC(object):
 
-    def __init__(self, base_dir: str, compose_file: str = SCION_DC_FILE):
+    def __init__(self,
+                 base_dir: str,
+                 project: str = DC_PROJECT,
+                 compose_file: str = SCION_DC_FILE):
         self.base_dir = base_dir
+        self.project = project
         self.compose_file = compose_file
 
     def __call__(self, *args, **kwargs) -> str:
         """Runs docker compose with the given arguments"""
         with local.env(BASE_DIR=self.base_dir, COMPOSE_FILE=self.compose_file):
             with redirect_stderr(sys.stdout):
-                return docker_compose('-p', 'acceptance_scion', '--no-ansi',
+                return docker_compose('-p', self.project, '--no-ansi',
                                       *args, **kwargs)
 
     def collect_logs(self, out_dir: str = 'logs/docker'):
@@ -52,4 +57,4 @@ class DC(object):
             dst_f = out_p / '%s.log' % svc
             with local.env(BASE_DIR=self.base_dir, COMPOSE_FILE=self.compose_file):
                 with redirect_stderr(sys.stdout):
-                    (docker_compose['-p', 'acceptance_scion', '--no-ansi', 'logs', svc] > dst_f)()
+                    (docker_compose['-p', self.project, '--no-ansi', 'logs', svc] > dst_f)()

--- a/acceptance/showpaths_status_acceptance/test
+++ b/acceptance/showpaths_status_acceptance/test
@@ -22,7 +22,9 @@ from plumbum import local
 
 
 from acceptance.common.log import LogExec, init_log
-from acceptance.common.base import CmdBase, TestBase, set_name
+from acceptance.common.base import CmdBase, TestBase, set_name, TestState
+from acceptance.common.scion import SCIONDocker
+from acceptance.common.tools import DC
 from lib.util import load_yaml_file, load_sciond_file
 
 set_name(__file__)
@@ -84,4 +86,5 @@ class TestRun(Base):
 
 if __name__ == '__main__':
     init_log()
+    Test.test_state = TestState(SCIONDocker(), DC(''))
     Test.run()

--- a/env/pip3/BUILD.bazel
+++ b/env/pip3/BUILD.bazel
@@ -1,0 +1,2 @@
+# Marker file, required to have the local directory be a Bazel package for pip
+# dependencies


### PR DESCRIPTION
Also:
- refactors some names to be compatible with the Python coding style.
- Python acceptance testing common libs are now in Bazel.
- pip dependencies can now be specified in Bazel dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3723)
<!-- Reviewable:end -->
