### PR TITLE
sciond: avoid EOF errors on every connect

### DIFF
--- a/go/lib/sciond/fake/fake.go
+++ b/go/lib/sciond/fake/fake.go
@@ -97,7 +97,7 @@ func (p Path) Path() *spath.Path {
 // DummyPath creates a path that is reversible.
 func DummyPath() *spath.Path {
 	return &spath.Path{
-		Raw:    make(common.RawBytes, spath.InfoFieldLength+spath.HopFieldLength),
+		Raw:    make(common.RawBytes, spath.InfoFieldLength+2*spath.HopFieldLength),
 		HopOff: spath.InfoFieldLength,
 	}
 }

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -105,7 +105,8 @@ func (h *ASInfoRequestHandler) Handle(ctx context.Context, conn net.Conn, src ne
 	defer conn.Close()
 	metricsDone := metrics.ASInfos.Start()
 	logger := log.FromCtx(ctx)
-	logger.Debug("[ASInfoRequestHandler] Received request", "req", pld.AsInfoReq)
+	// FIXME(roosd): Promote to debug again.
+	logger.Trace("[ASInfoRequestHandler] Received request", "req", pld.AsInfoReq)
 	workCtx, workCancelF := context.WithTimeout(ctx, DefaultWorkTimeout)
 	defer workCancelF()
 	// NOTE(scrye): Only support single-homed SCIONDs for now (returned slice


### PR DESCRIPTION
This is a workaround for all the EOF errors.
Should be solved properly with a sciond health check RPC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3727)
<!-- Reviewable:end -->
