### PR TITLE
lint: add buildifier

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,83 +9,84 @@ gazelle(name = "gazelle")
 # and the required tools.
 pkg_tar(
     name = "scion",
-    package_dir = "",
     srcs = [
-        "//go/border:border",
-        "//go/cs:cs",
-        "//go/dispatcher:dispatcher",
-        "//go/tools/logdog:logdog",
-        "//go/sciond:sciond",
-        "//go/scion:scion",
-        "//go/tools/scion-pki:scion-pki",
-        "//go/tools/scmp:scmp",
-        "//go/tools/showpaths:showpaths",
-        "//go/tools/pathdb_dump:pathdb_dump",
-        "//go/sig:sig",
+        "//go/border",
+        "//go/cs",
+        "//go/dispatcher",
+        "//go/scion",
+        "//go/sciond",
+        "//go/sig",
+        "//go/tools/logdog",
+        "//go/tools/pathdb_dump",
+        "//go/tools/scion-pki",
+        "//go/tools/scmp",
+        "//go/tools/showpaths",
     ],
     mode = "0755",
+    package_dir = "",
 )
 
 # This contains all of the binaries needed to run CI (integration & acceptance
 # tests)
 pkg_tar(
     name = "scion-ci",
-    package_dir = "",
     srcs = [
-        "//go/border/braccept:braccept",
-        "//go/integration/cert_req:cert_req",
-        "//go/integration/cert_req_integration:cert_req_integration",
-        "//go/integration/end2end:end2end",
-        "//go/integration/end2end_integration:end2end_integration",
-        "//go/lib/xtest/graphupdater:graphupdater",
-        "//go/examples/pingpong:pingpong",
-        "//go/examples/pingpong/pp_integration:pp_integration",
-        "//go/tools/buildkite_log_downloader:buildkite_log_downloader",
-        "//go/tools/scmp/scmp_integration:scmp_integration",
-        "//go/tools/udpproxy:udpproxy",
-        "//go/acceptance/sig_ping_acceptance:sig_ping_acceptance",
+        "//go/acceptance/sig_ping_acceptance",
+        "//go/border/braccept",
+        "//go/examples/pingpong",
+        "//go/examples/pingpong/pp_integration",
+        "//go/integration/cert_req",
+        "//go/integration/cert_req_integration",
+        "//go/integration/end2end",
+        "//go/integration/end2end_integration",
+        "//go/lib/xtest/graphupdater",
+        "//go/tools/buildkite_log_downloader",
+        "//go/tools/scmp/scmp_integration",
+        "//go/tools/udpproxy",
     ],
     mode = "0755",
+    package_dir = "",
 )
 
 # This contains all of the binaries needed to run the topology generator.
 pkg_tar(
     name = "scion-topo",
-    package_dir = "",
     srcs = [
-        "//go/tools/scion-pki:scion-pki",
+        "//go/tools/scion-pki",
     ],
     mode = "0755",
+    package_dir = "",
 )
 
 # This is a package of tools used for linting the source code.
 pkg_tar(
     name = "lint",
-    package_dir = "",
     srcs = [
-        "@com_github_client9_misspell//cmd/misspell:misspell",
-        "@com_github_jeanmertz_lll//cmd/lll:lll",
-        "@com_github_pavius_impi//cmd/impi:impi",
+        "@com_github_client9_misspell//cmd/misspell",
+        "@com_github_jeanmertz_lll//cmd/lll",
         "@com_github_oncilla_ineffassign//:ineffassign",
+        "@com_github_pavius_impi//cmd/impi",
     ],
     mode = "0755",
+    package_dir = "",
 )
 
 # This is a package of tools used for generating code that is checked in
 # to git (i.e. outside of bazels reach).
 pkg_tar(
     name = "build-tools",
-    package_dir = "",
     srcs = [
-        "@com_zombiezen_go_capnproto2//capnpc-go:capnpc-go",
+        "@com_zombiezen_go_capnproto2//capnpc-go",
     ],
     mode = "0755",
+    package_dir = "",
 )
 
 # Nogo - Go code analysis tool
 nogo(
     name = "nogo",
     config = "nogo.json",
+    visibility = ["//visibility:public"],
     deps = [
         "//go/lint:log",
         "@com_github_oncilla_gochecks//logcheck:go_tool_library",
@@ -114,5 +115,15 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/unusedresult:go_tool_library",
     ],
-    visibility = ["//visibility:public"],
+)
+
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier",
+)
+
+buildifier(
+    name = "buildifier_check",
+    mode = "check",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,7 +25,7 @@ go_register_toolchains(nogo = "@//:nogo")
 # Gazelle
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "41bff2a0b32b02f20c227d234aa25ef3783998e5453f7eade929704dcff7cd4b",
+    sha256 = "86c6d481b3f7aedc1d60c1c211c6f76da282ae197c3b3160f54bd3a8f847896f",
     urls = [
         "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
         "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,7 +9,7 @@ git_repository(
     tag = "v0.20.2",
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
 
 go_rules_dependencies()
 
@@ -25,11 +25,11 @@ go_register_toolchains(nogo = "@//:nogo")
 # Gazelle
 http_archive(
     name = "bazel_gazelle",
+    sha256 = "41bff2a0b32b02f20c227d234aa25ef3783998e5453f7eade929704dcff7cd4b",
     urls = [
         "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
         "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
     ],
-    sha256 = "86c6d481b3f7aedc1d60c1c211c6f76da282ae197c3b3160f54bd3a8f847896f",
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
@@ -40,33 +40,39 @@ gazelle_dependencies()
 # Python rules
 git_repository(
     name = "rules_python",
-    remote = "https://github.com/bazelbuild/rules_python.git",
     commit = "94677401bc56ed5d756f50b441a6a5c7f735a6d4",
+    remote = "https://github.com/bazelbuild/rules_python.git",
     shallow_since = "1573842889 -0500",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
+
 py_repositories()
 
 load("@rules_python//python:pip.bzl", "pip3_import")
+
 pip3_import(
-   name = "pip3_deps",
-   requirements = "//env/pip3:requirements.txt",
+    name = "pip3_deps",
+    requirements = "//env/pip3:requirements.txt",
 )
 
 load("@pip3_deps//:requirements.bzl", "pip_install")
+
 pip_install()
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "rules_pkg",
+    sha256 = "352c090cc3d3f9a6b4e676cf42a6047c16824959b438895a76c2989c6d7c246a",
     urls = [
         "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.5/rules_pkg-0.2.5.tar.gz",
         "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.2.5/rules_pkg-0.2.5.tar.gz",
     ],
-    sha256 = "352c090cc3d3f9a6b4e676cf42a6047c16824959b438895a76c2989c6d7c246a",
 )
+
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
 rules_pkg_dependencies()
 
 # Docker rules
@@ -99,7 +105,7 @@ git_repository(
 
 # Debian packages to install in containers
 load("@distroless//package_manager:package_manager.bzl", "package_manager_repositories")
-load("@distroless//package_manager:dpkg.bzl", "dpkg_src", "dpkg_list")
+load("@distroless//package_manager:dpkg.bzl", "dpkg_list", "dpkg_src")
 
 package_manager_repositories()
 
@@ -202,9 +208,9 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 container_pull(
     name = "ubuntu16",
+    digest = "sha256:a98d9dcf3a34b2b78e78c61d003eb4d7a90d30fd54451686e2f0bd2ef5f602ac",
     registry = "index.docker.io",
     repository = "library/ubuntu",
-    digest = "sha256:a98d9dcf3a34b2b78e78c61d003eb4d7a90d30fd54451686e2f0bd2ef5f602ac",
     tag = "16.04",
 )
 
@@ -234,6 +240,12 @@ git_repository(
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    strip_prefix = "buildtools-master",
+    url = "https://github.com/bazelbuild/buildtools/archive/2.2.1.zip",
+)
 
 load("//:tool_deps.bzl", "tool_deps")
 

--- a/acceptance/sig_failover/BUILD.bazel
+++ b/acceptance/sig_failover/BUILD.bazel
@@ -5,51 +5,51 @@ sh_test(
     size = "small",
     srcs = ["test"],
     data = [
-        "//go/tools/udpproxy:udpproxy",
+        "docker-compose.yml",
         ":dispatcher1",
         ":dispatcher2",
         ":sig1",
         ":sig2",
-        "docker-compose.yml",
+        "//go/tools/udpproxy",
     ],
 )
 
 container_image(
     name = "dispatcher1",
     base = "//docker:dispatcher_debug",
-    files = ["testdata/1-ff00_0_110/dispatcher/disp.toml"],
     entrypoint = [
         "/app/dispatcher",
         "-config",
         "/disp.toml",
     ],
+    files = ["testdata/1-ff00_0_110/dispatcher/disp.toml"],
     stamp = True,
 )
 
 container_image(
     name = "dispatcher2",
     base = "//docker:dispatcher_debug",
-    files = ["testdata/1-ff00_0_111/dispatcher/disp.toml"],
     entrypoint = [
         "/app/dispatcher",
         "-config",
         "/disp.toml",
     ],
+    files = ["testdata/1-ff00_0_111/dispatcher/disp.toml"],
     stamp = True,
 )
 
 container_image(
     name = "sig1",
     base = "//docker:sig_debug",
-    files = [
-        "testdata/1-ff00_0_110/sig/cfg.json",
-        "testdata/1-ff00_0_110/sig/sig.toml",
-        "testdata/1-ff00_0_110/sig/fake_sciond.json",
-    ],
     entrypoint = [
         "/app/sig",
         "-config",
         "/sig.toml",
+    ],
+    files = [
+        "testdata/1-ff00_0_110/sig/cfg.json",
+        "testdata/1-ff00_0_110/sig/fake_sciond.json",
+        "testdata/1-ff00_0_110/sig/sig.toml",
     ],
     stamp = True,
 )
@@ -57,15 +57,15 @@ container_image(
 container_image(
     name = "sig2",
     base = "//docker:sig_debug",
-    files = [
-        "testdata/1-ff00_0_111/sig/cfg.json",
-        "testdata/1-ff00_0_111/sig/sig.toml",
-        "testdata/1-ff00_0_111/sig/fake_sciond.json",
-    ],
     entrypoint = [
         "/app/sig",
         "-config",
         "/sig.toml",
+    ],
+    files = [
+        "testdata/1-ff00_0_111/sig/cfg.json",
+        "testdata/1-ff00_0_111/sig/fake_sciond.json",
+        "testdata/1-ff00_0_111/sig/sig.toml",
     ],
     stamp = True,
 )

--- a/acceptance/sig_short_exp_time/BUILD.bazel
+++ b/acceptance/sig_short_exp_time/BUILD.bazel
@@ -5,51 +5,51 @@ sh_test(
     size = "small",
     srcs = ["test"],
     data = [
-        "//go/tools/udpproxy:udpproxy",
+        "docker-compose.yml",
         ":dispatcher1",
         ":dispatcher2",
         ":sig1",
         ":sig2",
-        "docker-compose.yml",
+        "//go/tools/udpproxy",
     ],
 )
 
 container_image(
     name = "dispatcher1",
     base = "//docker:dispatcher_debug",
-    files = ["testdata/1-ff00_0_110/dispatcher/disp.toml"],
     entrypoint = [
         "/app/dispatcher",
         "-config",
         "/disp.toml",
     ],
+    files = ["testdata/1-ff00_0_110/dispatcher/disp.toml"],
     stamp = True,
 )
 
 container_image(
     name = "dispatcher2",
     base = "//docker:dispatcher_debug",
-    files = ["testdata/1-ff00_0_111/dispatcher/disp.toml"],
     entrypoint = [
         "/app/dispatcher",
         "-config",
         "/disp.toml",
     ],
+    files = ["testdata/1-ff00_0_111/dispatcher/disp.toml"],
     stamp = True,
 )
 
 container_image(
     name = "sig1",
     base = "//docker:sig_debug",
-    files = [
-        "testdata/1-ff00_0_110/sig/cfg.json",
-        "testdata/1-ff00_0_110/sig/sig.toml",
-        "testdata/1-ff00_0_110/sig/fake_sciond.json",
-    ],
     entrypoint = [
         "/app/sig",
         "-config",
         "/sig.toml",
+    ],
+    files = [
+        "testdata/1-ff00_0_110/sig/cfg.json",
+        "testdata/1-ff00_0_110/sig/fake_sciond.json",
+        "testdata/1-ff00_0_110/sig/sig.toml",
     ],
     stamp = True,
 )
@@ -57,15 +57,15 @@ container_image(
 container_image(
     name = "sig2",
     base = "//docker:sig_debug",
-    files = [
-        "testdata/1-ff00_0_111/sig/cfg.json",
-        "testdata/1-ff00_0_111/sig/sig.toml",
-        "testdata/1-ff00_0_111/sig/fake_sciond.json",
-    ],
     entrypoint = [
         "/app/sig",
         "-config",
         "/sig.toml",
+    ],
+    files = [
+        "testdata/1-ff00_0_111/sig/cfg.json",
+        "testdata/1-ff00_0_111/sig/fake_sciond.json",
+        "testdata/1-ff00_0_111/sig/sig.toml",
     ],
     stamp = True,
 )

--- a/acceptance/topo_common/BUILD.bazel
+++ b/acceptance/topo_common/BUILD.bazel
@@ -7,8 +7,8 @@ filegroup(
 filegroup(
     name = "invalid_reloads",
     srcs = [
-        ":topology_invalid_ia",
         ":topology_invalid_attributes",
+        ":topology_invalid_ia",
         ":topology_invalid_mtu",
     ],
     visibility = ["//visibility:public"],

--- a/acceptance/topo_cs_reload/BUILD.bazel
+++ b/acceptance/topo_cs_reload/BUILD.bazel
@@ -5,14 +5,14 @@ go_test(
     name = "go_default_test",
     srcs = ["reload_test.go"],
     data = [
-        ":dispatcher",
-        ":cs",
         "docker-compose.yml",
-        "//acceptance/topo_common:topology",
-        "//acceptance/topo_common:invalid_reloads",
         "testdata/topology_reload.json",
+        ":cs",
+        ":dispatcher",
         ":invalid_changed_ip",
         ":invalid_changed_port",
+        "//acceptance/topo_common:invalid_reloads",
+        "//acceptance/topo_common:topology",
     ],
     deps = [
         "//go/lib/topology:go_default_library",
@@ -24,31 +24,31 @@ go_test(
 container_image(
     name = "dispatcher",
     base = "//docker:dispatcher_debug",
-    files = ["testdata/disp.toml"],
     entrypoint = [
         "/app/dispatcher",
         "-config",
         "/disp.toml",
     ],
+    files = ["testdata/disp.toml"],
 )
 
 container_image(
     name = "cs",
     base = "//docker:cs_debug",
-    files = [
-        "testdata/cs.toml",
-        "//acceptance/topo_common:topology",
-        "//acceptance/topo_common:invalid_reloads",
-        "testdata/topology_reload.json",
-        ":invalid_changed_ip",
-        ":invalid_changed_port",
-    ],
-    tars = [":gen_crypto_tar"],
     entrypoint = [
         "/app/cs",
         "-config",
         "/cs.toml",
     ],
+    files = [
+        "testdata/cs.toml",
+        "testdata/topology_reload.json",
+        ":invalid_changed_ip",
+        ":invalid_changed_port",
+        "//acceptance/topo_common:invalid_reloads",
+        "//acceptance/topo_common:topology",
+    ],
+    tars = [":gen_crypto_tar"],
 )
 
 genrule(
@@ -73,7 +73,7 @@ genrule(
     ],
     cmd = "$(location :testdata/gen_crypto.sh) $(location //go/tools/scion-pki:scion-pki) $@ $(location testdata/test.topo)",
     tools = [
-        "//go/tools/scion-pki:scion-pki",
         ":testdata/gen_crypto.sh",
+        "//go/tools/scion-pki",
     ],
 )

--- a/acceptance/topo_sd_reload/BUILD.bazel
+++ b/acceptance/topo_sd_reload/BUILD.bazel
@@ -5,12 +5,12 @@ go_test(
     name = "go_default_test",
     srcs = ["reload_test.go"],
     data = [
-        ":dispatcher",
-        ":sciond",
-        ":docker-compose.yml",
-        "//acceptance/topo_common:topology",
-        "//acceptance/topo_common:invalid_reloads",
         "testdata/topology_reload.json",
+        ":dispatcher",
+        ":docker-compose.yml",
+        ":sciond",
+        "//acceptance/topo_common:invalid_reloads",
+        "//acceptance/topo_common:topology",
     ],
     deps = [
         "//go/lib/topology:go_default_library",
@@ -22,26 +22,26 @@ go_test(
 container_image(
     name = "dispatcher",
     base = "//docker:dispatcher_debug",
-    files = ["testdata/disp.toml"],
     entrypoint = [
         "/app/dispatcher",
         "-config",
         "/disp.toml",
     ],
+    files = ["testdata/disp.toml"],
 )
 
 container_image(
     name = "sciond",
     base = "//docker:sciond_debug",
-    files = [
-        "testdata/sd.toml",
-        "//acceptance/topo_common:topology",
-        "//acceptance/topo_common:invalid_reloads",
-        "testdata/topology_reload.json",
-    ],
     entrypoint = [
         "/app/sciond",
         "-config",
         "/sd.toml",
+    ],
+    files = [
+        "testdata/sd.toml",
+        "testdata/topology_reload.json",
+        "//acceptance/topo_common:invalid_reloads",
+        "//acceptance/topo_common:topology",
     ],
 )

--- a/docker/BUILD.bazel
+++ b/docker/BUILD.bazel
@@ -33,9 +33,10 @@ container_bundle(
     },
 )
 
-
 scion_app_base()
+
 build_tester_image()
+
 build_sigtester_image()
 
 scion_app_images(
@@ -49,7 +50,6 @@ scion_app_images(
     ],
     workdir = "/share",
 )
-
 
 scion_app_images(
     name = "cs",

--- a/docker/scion_app.bzl
+++ b/docker/scion_app.bzl
@@ -4,7 +4,6 @@ load("@package_bundle//file:packages.bzl", "packages")
 
 # Defines a common base image for all app images.
 def scion_app_base():
-
     # Debian packages to install.
     debs = [
         packages["libc6"],
@@ -65,7 +64,7 @@ def scion_app_base():
 #   workdir - working directory
 #   entrypoint - a list of strings that add up to the command line
 #   stamp - whether to stamp the created images (default=True).
-def scion_app_images(name, binary, appdir, workdir, entrypoint, stamp=True):
+def scion_app_images(name, binary, appdir, workdir, entrypoint, stamp = True):
     pkg_tar(
         name = name + "_docker_files",
         srcs = [binary],

--- a/docker/sig_tester.bzl
+++ b/docker/sig_tester.bzl
@@ -1,9 +1,8 @@
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_bundle")
+load("@io_bazel_rules_docker//container:container.bzl", "container_bundle", "container_image")
 load("@package_bundle//file:packages.bzl", "packages")
 
 def build_sigtester_image():
-
     pkg_tar(
         name = "sig_entrypoint",
         srcs = ["files/sig.sh"],
@@ -33,7 +32,6 @@ def build_sigtester_image():
             ":app_base_files",
             ":sig_docker_files",
             ":sig_entrypoint",
-
         ],
         workdir = "/share",
         entrypoint = ["./sig.sh"],

--- a/docker/tester.bzl
+++ b/docker/tester.bzl
@@ -1,9 +1,8 @@
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image", "container_bundle")
+load("@io_bazel_rules_docker//container:container.bzl", "container_bundle", "container_image")
 load("@package_bundle//file:packages.bzl", "packages")
 
 def build_tester_image():
-
     pkg_tar(
         name = "bin",
         srcs = [
@@ -13,7 +12,7 @@ def build_tester_image():
             "//go/tools/scmp:scmp",
             "//go/tools/showpaths:showpaths",
         ],
-        package_dir="bin",
+        package_dir = "bin",
     )
 
     pkg_tar(

--- a/go/lib/infra/modules/trust/testdata/BUILD.bazel
+++ b/go/lib/infra/modules/trust/testdata/BUILD.bazel
@@ -10,8 +10,8 @@ genrule(
     outs = ["crypto.tar"],
     cmd = "$(location :gen_crypto_tar.sh) $(location //go/tools/scion-pki:scion-pki) $@",
     tools = [
-        "//go/tools/scion-pki:scion-pki",
         ":gen_crypto_tar.sh",
+        "//go/tools/scion-pki",
     ],
     visibility = ["//visibility:public"],
 )

--- a/go/lint/BUILD.bazel
+++ b/go/lint/BUILD.bazel
@@ -6,10 +6,10 @@ go_tool_library(
     name = "log",
     srcs = ["log.go"],
     importpath = "lint",
+    visibility = ["//visibility:public"],
     deps = [
         "@org_golang_x_tools//go/analysis:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/inspect:go_tool_library",
         "@org_golang_x_tools//go/ast/inspector:go_tool_library",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/licenses/BUILD.bazel
+++ b/licenses/BUILD.bazel
@@ -2,9 +2,8 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 pkg_tar(
     name = "licenses",
-    strip_prefix = "data",
-    package_dir = "/licenses",
     srcs = ["data"],
+    package_dir = "/licenses",
+    strip_prefix = "data",
     visibility = ["//visibility:public"],
 )
-

--- a/nogo.json
+++ b/nogo.json
@@ -7,7 +7,8 @@
   "composites": {
     "exclude_files": {
       "gazelle/language/go/resolve.go": "",
-      "/io_bazel_rules_docker/": ""
+      "/io_bazel_rules_docker/": "",
+      "/com_github_bazelbuild_buildtools/": ""
     }
   },
   "nilness": {

--- a/scion.bzl
+++ b/scion.bzl
@@ -4,6 +4,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 def scion_go_binary(*args, **kwargs):
     x_defs = kwargs.get("x_defs", {})
     x_defs.update({
-        "github.com/scionproto/scion/go/lib/env.StartupVersion": "{STABLE_GIT_VERSION}"
+        "github.com/scionproto/scion/go/lib/env.StartupVersion": "{STABLE_GIT_VERSION}",
     })
-    go_binary(x_defs=x_defs, *args, **kwargs)
+    go_binary(x_defs = x_defs, *args, **kwargs)

--- a/scion.sh
+++ b/scion.sh
@@ -270,6 +270,7 @@ cmd_lint() {
     local ret=0
     py_lint || ret=1
     go_lint || ret=1
+    bazel_lint || ret=1
     md_lint || ret=1
     return $ret
 }
@@ -324,6 +325,16 @@ go_lint() {
     make gazelle GAZELLE_MODE=diff || ret=1
     # Clean up the binaries
     rm -rf $TMPDIR
+    return $ret
+}
+
+bazel_lint() {
+    lint_header "bazel"
+    local ret=0
+    bazel run //:buildifier_check || ret=1
+    if [ $ret -ne 0 ]; then
+        printf "\nto fix run:\nbazel run //:buildifier\n"
+    fi
     return $ret
 }
 


### PR DESCRIPTION
Adds 2 new bazel targets:
- `bazel run //:buildifier` runs buildifier in the repo.
- `bazel run //:buildifier_check` checks that all files are up to date.

The latter command is invoked in ./scion.sh lint and is thus also a check for CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3733)
<!-- Reviewable:end -->
