### PR TITLE
topology: simplify format

### DIFF
--- a/acceptance/br_child_acceptance/conf/topology.json
+++ b/acceptance/br_child_acceptance/conf/topology.json
@@ -1,98 +1,86 @@
 {
-  "ISD_AS": "1-ff00:0:1",
-  "Overlay": "UDP/IPv4",
-  "Attributes": [],
-  "MTU": 1472,
-  "BorderRouters": {
+  "isd_as": "1-ff00:0:1",
+  "mtu": 1472,
+  "attributes": [],
+  "border_routers": {
     "brA": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20001, "Addr": "192.168.0.101" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30001, "Addr": "192.168.0.11" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.11:30001",
+      "ctrl_addr": "192.168.0.101:20001",
+      "interfaces": {
         "141": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.14.2" },
-          "ISD_AS": "1-ff00:0:4",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.14.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.14.2:50000",
+            "remote": "192.168.14.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:4",
+          "link_to": "CHILD",
+          "mtu": 1472
         },
         "151": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.15.2" },
-          "ISD_AS": "1-ff00:0:5",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.15.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.15.2:50000",
+            "remote": "192.168.15.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:5",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     },
     "brB": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20002, "Addr": "192.168.0.102" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30002, "Addr": "192.168.0.12" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.12:30002",
+      "ctrl_addr": "192.168.0.102:20002",
+      "interfaces": {
         "171": {
-          "LinkTo": "PEER",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.17.2" },
-          "ISD_AS": "2-ff00:0:7",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.17.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.17.2:50000",
+            "remote": "192.168.17.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:7",
+          "link_to": "PEER",
+          "mtu": 1472
         }
       }
     },
     "brC": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20003, "Addr": "192.168.0.103" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30003, "Addr": "192.168.0.13" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.13:30003",
+      "ctrl_addr": "192.168.0.103:20003",
+      "interfaces": {
         "181": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.18.2" },
-          "ISD_AS": "1-ff00:0:8",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.18.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.18.2:50000",
+            "remote": "192.168.18.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:8",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     },
     "brD": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20004, "Addr": "192.168.0.104" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30004, "Addr": "192.168.0.14" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.14:30004",
+      "ctrl_addr": "192.168.0.104:20004",
+      "interfaces": {
         "191": {
-          "LinkTo": "PARENT",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.19.2" },
-          "ISD_AS": "1-ff00:0:9",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.19.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.19.2:50000",
+            "remote": "192.168.19.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:9",
+          "link_to": "PARENT",
+          "mtu": 1472
         }
       }
     }
   },
-  "ControlService": {
-    "csA": { "Addrs": {
-        "IPv4": { "Public": { "L4Port": 20007, "Addr": "192.168.0.71" } }
-    } }
+  "control_service": {
+    "csA": {
+      "addr": "192.168.0.71:20007"
+    }
   }
 }

--- a/acceptance/br_core_childIf_acceptance/conf/topology.json
+++ b/acceptance/br_core_childIf_acceptance/conf/topology.json
@@ -1,70 +1,65 @@
 {
-  "ISD_AS": "1-ff00:0:1",
-  "Overlay": "UDP/IPv4",
-  "Attributes": ["authoritative", "core", "issuing", "voting"],
-  "MTU": 1472,
-  "BorderRouters": {
+  "isd_as": "1-ff00:0:1",
+  "mtu": 1472,
+  "attributes": [
+    "authoritative",
+    "core",
+    "issuing",
+    "voting"
+  ],
+  "border_routers": {
     "core-brA": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20001, "Addr": "192.168.0.101" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30001, "Addr": "192.168.0.11" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.11:30001",
+      "ctrl_addr": "192.168.0.101:20001",
+      "interfaces": {
         "141": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.14.2" },
-          "ISD_AS": "1-ff00:0:4",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.14.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.14.2:50000",
+            "remote": "192.168.14.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:4",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     },
     "core-brB": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20002, "Addr": "192.168.0.102" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30002, "Addr": "192.168.0.12" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.12:30002",
+      "ctrl_addr": "192.168.0.102:20002",
+      "interfaces": {
         "171": {
-          "LinkTo": "CORE",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.17.2" },
-          "ISD_AS": "2-ff00:0:7",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.17.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.17.2:50000",
+            "remote": "192.168.17.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:7",
+          "link_to": "CORE",
+          "mtu": 1472
         }
       }
     },
     "core-brC": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20003, "Addr": "192.168.0.103" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30003, "Addr": "192.168.0.13" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.13:30003",
+      "ctrl_addr": "192.168.0.103:20003",
+      "interfaces": {
         "181": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.18.2" },
-          "ISD_AS": "1-ff00:0:8",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.18.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.18.2:50000",
+            "remote": "192.168.18.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:8",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     }
   },
-  "ControlService": {
-    "core-csA": { "Addrs": {
-        "IPv4": { "Public": { "L4Port": 20007, "Addr": "192.168.0.71" } }
-    } }
+  "control_service": {
+    "core-csA": {
+      "addr": "192.168.0.71:20007"
+    }
   }
 }

--- a/acceptance/br_core_coreIf_acceptance/conf/topology.json
+++ b/acceptance/br_core_coreIf_acceptance/conf/topology.json
@@ -1,70 +1,65 @@
 {
-  "ISD_AS": "1-ff00:0:1",
-  "Overlay": "UDP/IPv4",
-  "Attributes": ["authoritative", "core", "issuing", "voting"],
-  "MTU": 1472,
-  "BorderRouters": {
+  "isd_as": "1-ff00:0:1",
+  "mtu": 1472,
+  "attributes": [
+    "authoritative",
+    "core",
+    "issuing",
+    "voting"
+  ],
+  "border_routers": {
     "core-brA": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20001, "Addr": "192.168.0.101" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30001, "Addr": "192.168.0.11" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.11:30001",
+      "ctrl_addr": "192.168.0.101:20001",
+      "interfaces": {
         "121": {
-          "LinkTo": "CORE",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.12.2" },
-          "ISD_AS": "1-ff00:0:2",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.12.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.12.2:50000",
+            "remote": "192.168.12.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:2",
+          "link_to": "CORE",
+          "mtu": 1472
         }
       }
     },
     "core-brB": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20002, "Addr": "192.168.0.102" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30002, "Addr": "192.168.0.12" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.12:30002",
+      "ctrl_addr": "192.168.0.102:20002",
+      "interfaces": {
         "171": {
-          "LinkTo": "CORE",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.17.2" },
-          "ISD_AS": "2-ff00:0:7",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.17.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.17.2:50000",
+            "remote": "192.168.17.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:7",
+          "link_to": "CORE",
+          "mtu": 1472
         }
       }
     },
     "core-brC": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20003, "Addr": "192.168.0.103" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30003, "Addr": "192.168.0.13" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.13:30003",
+      "ctrl_addr": "192.168.0.103:20003",
+      "interfaces": {
         "181": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.18.2" },
-          "ISD_AS": "1-ff00:0:8",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.18.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.18.2:50000",
+            "remote": "192.168.18.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:8",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     }
   },
-  "ControlService": {
-    "core-csA": { "Addrs": {
-        "IPv4": { "Public": { "L4Port": 20007, "Addr": "192.168.0.71" } }
-    } }
+  "control_service": {
+    "core-csA": {
+      "addr": "192.168.0.71:20007"
+    }
   }
 }

--- a/acceptance/br_core_multi_acceptance/conf/topology.json
+++ b/acceptance/br_core_multi_acceptance/conf/topology.json
@@ -1,97 +1,95 @@
 {
-  "ISD_AS": "1-ff00:0:1",
-  "Overlay": "UDP/IPv4",
-  "Attributes": ["authoritative", "core", "issuing", "voting"],
-  "MTU": 1472,
-  "BorderRouters": {
+  "isd_as": "1-ff00:0:1",
+  "mtu": 1472,
+  "attributes": [
+    "authoritative",
+    "core",
+    "issuing",
+    "voting"
+  ],
+  "border_routers": {
     "core-brA": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20001, "Addr": "192.168.0.101" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30001, "Addr": "192.168.0.11" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.11:30001",
+      "ctrl_addr": "192.168.0.101:20001",
+      "interfaces": {
         "121": {
-          "LinkTo": "CORE",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.12.2" },
-          "ISD_AS": "1-ff00:0:2",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.12.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.12.2:50000",
+            "remote": "192.168.12.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:2",
+          "link_to": "CORE",
+          "mtu": 1472
         },
         "131": {
-          "LinkTo": "CORE",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.13.2" },
-          "ISD_AS": "2-ff00:0:3",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.13.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.13.2:50000",
+            "remote": "192.168.13.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:3",
+          "link_to": "CORE",
+          "mtu": 1472
         },
         "141": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.14.2" },
-          "ISD_AS": "1-ff00:0:4",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.14.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.14.2:50000",
+            "remote": "192.168.14.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:4",
+          "link_to": "CHILD",
+          "mtu": 1472
         },
         "151": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.15.2" },
-          "ISD_AS": "1-ff00:0:5",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.15.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.15.2:50000",
+            "remote": "192.168.15.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:5",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     },
     "core-brB": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20002, "Addr": "192.168.0.102" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30002, "Addr": "192.168.0.12" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.12:30002",
+      "ctrl_addr": "192.168.0.102:20002",
+      "interfaces": {
         "171": {
-          "LinkTo": "CORE",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.17.2" },
-          "ISD_AS": "2-ff00:0:7",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.17.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.17.2:50000",
+            "remote": "192.168.17.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:7",
+          "link_to": "CORE",
+          "mtu": 1472
         }
       }
     },
     "core-brC": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20003, "Addr": "192.168.0.103" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30003, "Addr": "192.168.0.13" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.13:30003",
+      "ctrl_addr": "192.168.0.103:20003",
+      "interfaces": {
         "181": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.18.2" },
-          "ISD_AS": "1-ff00:0:8",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.18.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.18.2:50000",
+            "remote": "192.168.18.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:8",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     }
   },
-  "ControlService": {
-    "core-csA": { "Addrs": {
-        "IPv4": { "Public": { "L4Port": 20007, "Addr": "192.168.0.71" } }
-    } }
+  "control_service": {
+    "core-csA": {
+      "addr": "192.168.0.71:20007"
+    }
   }
 }

--- a/acceptance/br_multi_acceptance/conf/topology.json
+++ b/acceptance/br_multi_acceptance/conf/topology.json
@@ -1,124 +1,114 @@
 {
-  "ISD_AS": "1-ff00:0:1",
-  "Overlay": "UDP/IPv4",
-  "Attributes": [],
-  "MTU": 1472,
-  "BorderRouters": {
+  "isd_as": "1-ff00:0:1",
+  "mtu": 1472,
+  "attributes": [],
+  "border_routers": {
     "brA": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20001, "Addr": "192.168.0.101" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30001, "Addr": "192.168.0.11" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.11:30001",
+      "ctrl_addr": "192.168.0.101:20001",
+      "interfaces": {
         "121": {
-          "LinkTo": "PEER",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.12.2" },
-          "ISD_AS": "1-ff00:0:2",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.12.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.12.2:50000",
+            "remote": "192.168.12.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:2",
+          "link_to": "PEER",
+          "mtu": 1472
         },
         "131": {
-          "LinkTo": "PARENT",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.13.2" },
-          "ISD_AS": "2-ff00:0:3",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.13.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.13.2:50000",
+            "remote": "192.168.13.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:3",
+          "link_to": "PARENT",
+          "mtu": 1472
         },
         "141": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.14.2" },
-          "ISD_AS": "1-ff00:0:4",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.14.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.14.2:50000",
+            "remote": "192.168.14.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:4",
+          "link_to": "CHILD",
+          "mtu": 1472
         },
         "151": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.15.2" },
-          "ISD_AS": "1-ff00:0:5",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.15.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.15.2:50000",
+            "remote": "192.168.15.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:5",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     },
     "brB": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20002, "Addr": "192.168.0.102" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30002, "Addr": "192.168.0.12" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.12:30002",
+      "ctrl_addr": "192.168.0.102:20002",
+      "interfaces": {
         "171": {
-          "LinkTo": "PEER",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.17.2" },
-          "ISD_AS": "2-ff00:0:7",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.17.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.17.2:50000",
+            "remote": "192.168.17.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:7",
+          "link_to": "PEER",
+          "mtu": 1472
         }
       }
     },
     "brC": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20003, "Addr": "192.168.0.103" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30003, "Addr": "192.168.0.13" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.13:30003",
+      "ctrl_addr": "192.168.0.103:20003",
+      "interfaces": {
         "181": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.18.2" },
-          "ISD_AS": "1-ff00:0:8",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.18.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.18.2:50000",
+            "remote": "192.168.18.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:8",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     },
     "brD": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20004, "Addr": "192.168.0.104" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30004, "Addr": "192.168.0.14" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.14:30004",
+      "ctrl_addr": "192.168.0.104:20004",
+      "interfaces": {
         "191": {
-          "LinkTo": "PARENT",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.19.2" },
-          "ISD_AS": "1-ff00:0:9",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.19.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.19.2:50000",
+            "remote": "192.168.19.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:9",
+          "link_to": "PARENT",
+          "mtu": 1472
         }
       }
     }
   },
-  "SIG": {
-    "sigA": { "Addrs": {
-      "IPv4": { "Public": { "L4Port": 31014, "Addr": "192.168.0.51" } }
-    } },
-    "sigB": { "Addrs": {
-      "IPv4": { "Public": { "L4Port": 31014, "Addr": "192.168.0.61" } }
-    } }
+  "control_service": {
+    "csA": {
+      "addr": "192.168.0.71:20007"
+    }
   },
-  "ControlService": {
-    "csA": { "Addrs": {
-        "IPv4": { "Public": { "L4Port": 20007, "Addr": "192.168.0.71" } }
-    } }
+  "sigs": {
+    "sigA": {
+      "addr": "192.168.0.51:31014"
+    },
+    "sigB": {
+      "addr": "192.168.0.61:31014"
+    }
   }
 }

--- a/acceptance/br_parent_acceptance/conf/topology.json
+++ b/acceptance/br_parent_acceptance/conf/topology.json
@@ -1,97 +1,84 @@
 {
-  "ISD_AS": "1-ff00:0:1",
-  "Overlay": "UDP/IPv4",
-  "Attributes": [],
-  "MTU": 1472,
-  "BorderRouters": {
+  "isd_as": "1-ff00:0:1",
+  "mtu": 1472,
+  "attributes": [],
+  "border_routers": {
     "brA": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20001, "Addr": "192.168.0.101" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30001, "Addr": "192.168.0.11" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.11:30001",
+      "ctrl_addr": "192.168.0.101:20001",
+      "interfaces": {
         "131": {
-          "LinkTo": "PARENT",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.13.2" },
-          "ISD_AS": "2-ff00:0:3",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.13.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.13.2:50000",
+            "remote": "192.168.13.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:3",
+          "link_to": "PARENT",
+          "mtu": 1472
         }
       }
     },
     "brB": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20002, "Addr": "192.168.0.102" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30002, "Addr": "192.168.0.12" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.12:30002",
+      "ctrl_addr": "192.168.0.102:20002",
+      "interfaces": {
         "171": {
-          "LinkTo": "PEER",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.17.2" },
-          "ISD_AS": "2-ff00:0:7",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.17.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.17.2:50000",
+            "remote": "192.168.17.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:7",
+          "link_to": "PEER",
+          "mtu": 1472
         }
       }
     },
     "brC": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20003, "Addr": "192.168.0.103" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30003, "Addr": "192.168.0.13" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.13:30003",
+      "ctrl_addr": "192.168.0.103:20003",
+      "interfaces": {
         "181": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.18.2" },
-          "ISD_AS": "1-ff00:0:8",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.18.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.18.2:50000",
+            "remote": "192.168.18.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:8",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     },
     "brD": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20004, "Addr": "192.168.0.104" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30004, "Addr": "192.168.0.14" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.14:30004",
+      "ctrl_addr": "192.168.0.104:20004",
+      "interfaces": {
         "191": {
-          "LinkTo": "PARENT",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.19.2" },
-          "ISD_AS": "1-ff00:0:9",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.19.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.19.2:50000",
+            "remote": "192.168.19.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:9",
+          "link_to": "PARENT",
+          "mtu": 1472
         }
       }
     }
   },
-  "SIG": {
-    "sigA": { "Addrs": {
-      "IPv4": { "Public": { "L4Port": 31014, "Addr": "192.168.0.51" } }
-    } },
-    "sigB": { "Addrs": {
-      "IPv4": { "Public": { "L4Port": 31014, "Addr": "192.168.0.61" } }
-    } }
+  "control_service": {
+    "csA": {
+      "addr": "192.168.0.71:20007"
+    }
   },
-  "ControlService": {
-    "csA": { "Addrs": {
-        "IPv4": { "Public": { "L4Port": 20007, "Addr": "192.168.0.71" } }
-    } }
+  "sigs": {
+    "sigA": {
+      "addr": "192.168.0.51:31014"
+    },
+    "sigB": {
+      "addr": "192.168.0.61:31014"
+    }
   }
 }

--- a/acceptance/br_peer_acceptance/conf/topology.json
+++ b/acceptance/br_peer_acceptance/conf/topology.json
@@ -1,89 +1,76 @@
 {
-  "ISD_AS": "1-ff00:0:1",
-  "Overlay": "UDP/IPv4",
-  "Attributes": [],
-  "MTU": 1472,
-  "BorderRouters": {
+  "isd_as": "1-ff00:0:1",
+  "mtu": 1472,
+  "attributes": [],
+  "border_routers": {
     "brA": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20001, "Addr": "192.168.0.101" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30001, "Addr": "192.168.0.11" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.11:30001",
+      "ctrl_addr": "192.168.0.101:20001",
+      "interfaces": {
         "121": {
-          "LinkTo": "PEER",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.12.2" },
-          "ISD_AS": "1-ff00:0:2",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.12.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.12.2:50000",
+            "remote": "192.168.12.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:2",
+          "link_to": "PEER",
+          "mtu": 1472
         }
       }
     },
     "brB": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20002, "Addr": "192.168.0.102" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30002, "Addr": "192.168.0.12" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.12:30002",
+      "ctrl_addr": "192.168.0.102:20002",
+      "interfaces": {
         "171": {
-          "LinkTo": "PEER",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.17.2" },
-          "ISD_AS": "2-ff00:0:7",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.17.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.17.2:50000",
+            "remote": "192.168.17.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:7",
+          "link_to": "PEER",
+          "mtu": 1472
         }
       }
     },
     "brC": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20003, "Addr": "192.168.0.103" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30003, "Addr": "192.168.0.13" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.13:30003",
+      "ctrl_addr": "192.168.0.103:20003",
+      "interfaces": {
         "181": {
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.18.2" },
-          "ISD_AS": "1-ff00:0:8",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.18.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.18.2:50000",
+            "remote": "192.168.18.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:8",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     },
     "brD": {
-      "CtrlAddr": {
-        "IPv4": { "Public": { "L4Port": 20004, "Addr": "192.168.0.104" } }
-      },
-      "InternalAddrs": {
-        "IPv4": { "PublicOverlay": { "OverlayPort": 30004, "Addr": "192.168.0.14" } }
-      },
-      "Interfaces": {
+      "internal_addr": "192.168.0.14:30004",
+      "ctrl_addr": "192.168.0.104:20004",
+      "interfaces": {
         "191": {
-          "LinkTo": "PARENT",
-          "MTU": 1472,
-          "Overlay": "UDP/IPv4",
-          "PublicOverlay": { "OverlayPort": 50000, "Addr": "192.168.19.2" },
-          "ISD_AS": "1-ff00:0:9",
-          "RemoteOverlay": { "OverlayPort": 40000, "Addr": "192.168.19.3" },
-          "Bandwidth": 1000
+          "underlay": {
+            "public": "192.168.19.2:50000",
+            "remote": "192.168.19.3:40000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:9",
+          "link_to": "PARENT",
+          "mtu": 1472
         }
       }
     }
   },
-  "ControlService": {
-    "csA": { "Addrs": {
-        "IPv4": { "Public": { "L4Port": 20007, "Addr": "192.168.0.71" } }
-    } }
+  "control_service": {
+    "csA": {
+      "addr": "192.168.0.71:20007"
+    }
   }
 }

--- a/acceptance/bs_add_link_acceptance/test
+++ b/acceptance/bs_add_link_acceptance/test
@@ -102,11 +102,11 @@ class TestSetup(CmdBase):
         """ Filter all interfaces in all topologies that link to an interface in ia. """
         t = deepcopy(topos)
         for fn, topo in topos.items():
-            for br_name, br_dict in topo['BorderRouters'].items():
-                for intf_id, intf_dict in br_dict['Interfaces'].items():
-                    if intf_dict['ISD_AS'] in ia:
+            for br_name, br_dict in topo['border_routers'].items():
+                for intf_id, intf_dict in br_dict['interfaces'].items():
+                    if intf_dict['isd_as'] in ia:
                         logging.debug('filtering interface %s:%s' % (br_name, intf_id))
-                        del t[fn]['BorderRouters'][br_name]['Interfaces'][intf_id]
+                        del t[fn]['border_routers'][br_name]['interfaces'][intf_id]
         return t
 
     @staticmethod

--- a/acceptance/common.sh
+++ b/acceptance/common.sh
@@ -19,43 +19,6 @@ as_file() {
 }
 
 #######################################
-# Collects metrics from services that can be found in the topology file
-# Metrics are saved in METRICS_DIR/
-# Arguments:
-#   Topology path
-#   METRICS_DIR
-#######################################
-collect_metrics() {
-    TOPOLOGY=${1:?}
-    echo "Reading topology: $TOPOLOGY"
-    METRICS_DIR=${2:?}
-    echo "Saving metrics in $METRICS_DIR"
-    mkdir -p "$METRICS_DIR"
-
-    collect_elem_metrics 'BorderRouters' '30442' 'InternalAddrs.IPv4.PublicOverlay.Addr'
-    collect_elem_metrics 'SIG' '30456'
-    collect_elem_metrics 'ControlService'
-}
-
-#######################################
-# Collect metrics for one element type
-# Arguments:
-#   Service Type
-#   Port
-#   IP Addr Key (optional)
-#######################################
-collect_elem_metrics() {
-    local elems=$(jq -r ".${1:?} | keys | .[]" $TOPOLOGY)
-    local addr_key=${3:-Addrs.IPv4.Public.Addr}
-    for elem in $elems; do
-        local ip="$(jq -r .$1[\"$elem\"].$addr_key $TOPOLOGY)"
-        local topo_port="$(jq -r .$1[\"$elem\"].Addrs.IPv4.Public.L4Port $TOPOLOGY)"
-        echo "Collect $elem metrics from $ip:${2:-$topo_port}"
-        curl "$ip:${2:-$topo_port}/metrics" -o "$METRICS_DIR/$elem" -s -S --connect-timeout 2
-    done
-}
-
-#######################################
 # Print docker container status
 #######################################
 docker_status() {

--- a/acceptance/topo_br_reload_if_ip_acceptance/test
+++ b/acceptance/topo_br_reload_if_ip_acceptance/test
@@ -33,18 +33,18 @@ test_setup() {
     # Remove dummy link from the topology
     cp $SRC_TOPO $FULL_TOPO
     for topo in gen/ISD1/*/*/topology.json; do
-        jq "del(.BorderRouters[].Interfaces[$DUMMY_IFID_SRC]) | del(.BorderRouters[].Interfaces[$DUMMY_IFID_DST])" $topo | sponge $topo
+        jq "del(.border_routers[].interfaces[$DUMMY_IFID_SRC]) | del(.border_routers[].interfaces[$DUMMY_IFID_DST])" $topo | sponge $topo
     done
     base_run_topo
 }
 
 test_run() {
     set -e
-    local orig_src=$(jq ".BorderRouters[].Interfaces[].PublicOverlay" $SRC_TOPO)
-    local dummy_src=$(jq ".BorderRouters[].Interfaces[$DUMMY_IFID_SRC].PublicOverlay.Addr" $FULL_TOPO)
+    local orig_src=$(jq ".border_routers[].interfaces[].underlay.public" $SRC_TOPO)
+    local dummy_src=$(jq ".border_routers[].interfaces[$DUMMY_IFID_SRC].underlay.public" $FULL_TOPO)
 
-    local orig_dst=$(jq ".BorderRouters[].Interfaces[$IFID_DST].PublicOverlay" $DST_TOPO)
-    local dummy_dst=$(jq ".BorderRouters[].Interfaces[$DUMMY_IFID_SRC].RemoteOverlay.Addr" $FULL_TOPO)
+    local orig_dst=$(jq ".border_routers[].interfaces[$IFID_DST].underlay.public" $DST_TOPO)
+    local dummy_dst=$(jq ".border_routers[].interfaces[$DUMMY_IFID_SRC].underlay.remote" $FULL_TOPO)
 
     check_change_invalid_local_ip
     check_change_local_ip
@@ -54,7 +54,7 @@ test_run() {
 
 check_change_invalid_local_ip() {
     check_connectivity "Start check_change_invalid_local_ip"
-    jq '.BorderRouters[].Interfaces[].PublicOverlay.Addr = "172.20.255.0"' $SRC_TOPO | sponge $SRC_TOPO
+    jq '.border_routers[].interfaces[].underlay.public = "172.20.255.0:0"' $SRC_TOPO | sponge $SRC_TOPO
     ./tools/dc scion kill -s HUP scion_br"$SRC_IA_FILE"-1
     sleep 2
     check_logs "Unable to reload config" $SRC_IA_FILE
@@ -73,7 +73,7 @@ check_change_local_ip() {
 }
 
 change_local_ip() {
-    jq ".BorderRouters[].Interfaces[].PublicOverlay.Addr = $3" $1 | sponge $1
+    jq ".border_routers[].interfaces[].underlay.public = $3" $1 | sponge $1
     ./tools/dc scion kill -s HUP scion_br"$2"-1
     sleep 2
     check_logs "posixOutput starting addr=$(unqoute $3)" $2
@@ -91,7 +91,7 @@ check_change_remote_ip() {
 
 change_remote_ip() {
     # Connectivity is broken at this point
-    jq ".BorderRouters[].Interfaces[].RemoteOverlay.Addr = $3" $1 | sponge $1
+    jq ".border_routers[].interfaces[].underlay.remote = $3" $1 | sponge $1
     ./tools/dc scion kill -s HUP scion_br"$2"-1
     sleep 2
     check_logs "Remote:$(unqoute $3)" $2
@@ -99,9 +99,9 @@ change_remote_ip() {
 
 check_change_initial_ip() {
     check_connectivity "Start check_change_initial_ip"
-    local pre=".BorderRouters[].Interfaces[]"
-    jq "$pre.PublicOverlay = $orig_src | $pre.RemoteOverlay = $orig_dst" $SRC_TOPO | sponge $SRC_TOPO
-    jq "$pre.PublicOverlay = $orig_dst | $pre.RemoteOverlay = $orig_src" $DST_TOPO | sponge $DST_TOPO
+    local pre=".border_routers[].interfaces[]"
+    jq "$pre.underlay.public = $orig_src | $pre.underlay.remote = $orig_dst" $SRC_TOPO | sponge $SRC_TOPO
+    jq "$pre.underlay.public = $orig_dst | $pre.underlay.remote = $orig_src" $DST_TOPO | sponge $DST_TOPO
     ./tools/dc scion kill -s HUP scion_br"$SRC_IA_FILE"-1 scion_br"$DST_IA_FILE"-1
     check_connectivity "End check_change_initial_ip"
 }

--- a/acceptance/topo_br_reload_if_port_acceptance/test
+++ b/acceptance/topo_br_reload_if_port_acceptance/test
@@ -21,11 +21,11 @@ test_setup() {
 
 test_run() {
     set -e
-    local orig_src=$(jq '.BorderRouters[].Interfaces[].PublicOverlay' $SRC_TOPO)
-    local addr_src=$(jq -r '.Addr' <(echo $orig_src))
+    local orig_src=$(jq '.border_routers[].interfaces[].underlay.public' $SRC_TOPO)
+    local addr_src=$(jq '.border_routers[].interfaces[].underlay.public | split(":")[0]' -r $SRC_TOPO)
 
-    local orig_dst=$(jq '.BorderRouters[].Interfaces[].PublicOverlay' $DST_TOPO)
-    local addr_dst=$(jq -r '.Addr' <(echo $orig_dst))
+    local orig_dst=$(jq '.border_routers[].interfaces[].underlay.public' $DST_TOPO)
+    local addr_dst=$(jq '.border_routers[].interfaces[].underlay.public | split(":")[0]' -r $DST_TOPO)
 
     check_change_local_port
     check_change_remote_port
@@ -34,7 +34,7 @@ test_run() {
 
 check_change_local_port() {
     check_connectivity "Start check_change_local_port"
-    jq '.BorderRouters[].Interfaces[].PublicOverlay.OverlayPort = 42424' $SRC_TOPO | sponge $SRC_TOPO
+    jq ".border_routers[].interfaces[].underlay.public = \"$addr_src:42424\"" $SRC_TOPO | sponge $SRC_TOPO
     ./tools/dc scion kill -s HUP scion_br"$SRC_IA_FILE"-1
     sleep 2
     check_logs "posixOutput starting addr=$addr_src:42424" $SRC_IA_FILE
@@ -48,7 +48,7 @@ check_change_local_port() {
 
 check_change_remote_port() {
     # Connectivity is broken at this point
-    jq '.BorderRouters[].Interfaces[].RemoteOverlay.OverlayPort = 42424' $DST_TOPO | sponge $DST_TOPO
+    jq ".border_routers[].interfaces[].underlay.remote = \"$addr_src:42424\"" $DST_TOPO | sponge $DST_TOPO
     ./tools/dc scion kill -s HUP scion_br"$DST_IA_FILE"-1
     # make sure revocation is expired
     sleep 10
@@ -58,8 +58,8 @@ check_change_remote_port() {
 
 check_change_initial_port() {
     check_connectivity "Start check_change_initial_port"
-    jq ".BorderRouters[].Interfaces[].PublicOverlay = $orig_src" $SRC_TOPO | sponge $SRC_TOPO
-    jq ".BorderRouters[].Interfaces[].RemoteOverlay = $orig_src" $DST_TOPO | sponge $DST_TOPO
+    jq ".border_routers[].interfaces[].underlay.public = $orig_src" $SRC_TOPO | sponge $SRC_TOPO
+    jq ".border_routers[].interfaces[].underlay.remote = $orig_src" $DST_TOPO | sponge $DST_TOPO
     ./tools/dc scion kill -s HUP scion_br"$SRC_IA_FILE"-1
     ./tools/dc scion kill -s HUP scion_br"$DST_IA_FILE"-1
     check_connectivity "End check_change_initial_port"

--- a/acceptance/topo_br_reload_rollback_acceptance/test
+++ b/acceptance/topo_br_reload_rollback_acceptance/test
@@ -30,15 +30,15 @@ test_run() {
 
 check_internal_fail() {
     check_connectivity "Start check_internal_fail"
-    jq '.BorderRouters[].InternalAddrs.IPv4.PublicOverlay.Addr = "172.220.42.42"' $SRC_TOPO | sponge $SRC_TOPO
+    jq '.border_routers[].internal_addr = "172.220.42.42:42424"' $SRC_TOPO | sponge $SRC_TOPO
     ./tools/dc scion kill -s HUP scion_br"$SRC_IA_FILE"-1
     check_connectivity "End check_internal_fail"
 }
 
 check_if_local_fail() {
     check_connectivity "Start check_if_local_fail"
-    jq '.BorderRouters[].InternalAddrs.IPv4.PublicOverlay.OverlayPort = 42424' $SRC_TOPO | sponge $SRC_TOPO
-    jq '.BorderRouters[].Interfaces[].PublicOverlay.Addr = "172.220.42.42"' $SRC_TOPO | sponge $SRC_TOPO
+    jq '.border_routers[].internal_addr = "172.220.42.42:42424"' $SRC_TOPO | sponge $SRC_TOPO
+    jq '.border_routers[].interfaces[].underlay.public = "172.220.42.42:42424"' $SRC_TOPO | sponge $SRC_TOPO
     ./tools/dc scion kill -s HUP scion_br"$SRC_IA_FILE"-1
     check_connectivity "End check_if_local_fail"
 }

--- a/acceptance/topo_common/BUILD.bazel
+++ b/acceptance/topo_common/BUILD.bazel
@@ -18,19 +18,19 @@ genrule(
     name = "topology_invalid_ia",
     srcs = ["topology.json"],
     outs = ["topology_invalid_ia.json"],
-    cmd = "jq '.ISD_AS = \"1-ff00:0:111\"' $(location :topology.json) > $@",
+    cmd = "jq '.isd_as = \"1-ff00:0:111\"' $(location :topology.json) > $@",
 )
 
 genrule(
     name = "topology_invalid_attributes",
     srcs = ["topology.json"],
     outs = ["topology_invalid_attributes.json"],
-    cmd = "jq '.Attributes = [\"core\"]' $(location :topology.json) > $@",
+    cmd = "jq '.attributes = [\"core\"]' $(location :topology.json) > $@",
 )
 
 genrule(
     name = "topology_invalid_mtu",
     srcs = ["topology.json"],
     outs = ["topology_invalid_mtu.json"],
-    cmd = "jq '.MTU = 42' $(location :topology.json) > $@",
+    cmd = "jq '.mtu = 42' $(location :topology.json) > $@",
 )

--- a/acceptance/topo_common/topology.json
+++ b/acceptance/topo_common/topology.json
@@ -1,97 +1,49 @@
 {
-  "MTU": 1400,
-  "BorderRouters": {
-    "br1-ff00_0_110-1": {
-      "Interfaces": {
-        "1": {
-          "MTU": 1280,
-          "RemoteOverlay": {
-            "Addr": "127.0.0.5",
-            "OverlayPort": 50000
-          },
-          "Bandwidth": 1000,
-          "ISD_AS": "1-ff00:0:111",
-          "PublicOverlay": {
-            "Addr": "127.0.0.4",
-            "OverlayPort": 50000
-          },
-          "LinkTo": "CHILD",
-          "Overlay": "UDP/IPv4"
-        }
-      },
-      "InternalAddrs": {
-        "IPv4": {
-          "PublicOverlay": {
-            "Addr": "127.0.0.9",
-            "OverlayPort": 31008
-          }
-        }
-      },
-      "CtrlAddr": {
-        "IPv4": {
-          "Public": {
-            "Addr": "127.0.0.9",
-            "L4Port": 31006
-          }
-        }
-      }
-    },
-    "br1-ff00_0_110-2": {
-      "Interfaces": {
-        "2": {
-          "MTU": 1472,
-          "RemoteOverlay": {
-            "Addr": "127.0.0.7",
-            "OverlayPort": 50000
-          },
-          "Bandwidth": 500,
-          "ISD_AS": "1-ff00:0:112",
-          "PublicOverlay": {
-            "Addr": "127.0.0.6",
-            "OverlayPort": 50000
-          },
-          "LinkTo": "CHILD",
-          "Overlay": "UDP/IPv4"
-        }
-      },
-      "InternalAddrs": {
-        "IPv4": {
-          "PublicOverlay": {
-            "Addr": "127.0.0.10",
-            "OverlayPort": 31012
-          }
-        }
-      },
-      "CtrlAddr": {
-        "IPv4": {
-          "Public": {
-            "Addr": "127.0.0.10",
-            "L4Port": 31010
-          }
-        }
-      }
-    }
-  },
-  "ColibriService": {},
-  "DiscoveryService": {},
-  "Attributes": [
+  "isd_as": "1-ff00:0:110",
+  "mtu": 1400,
+  "attributes": [
     "authoritative",
     "core",
     "issuing",
     "voting"
   ],
-  "ISD_AS": "1-ff00:0:110",
-  "ControlService": {
-    "cs1-ff00_0_110-1": {
-      "Addrs": {
-        "IPv4": {
-          "Public": {
-            "Addr": "127.0.0.12",
-            "L4Port": 31002
-          }
+  "border_routers": {
+    "br1-ff00_0_110-1": {
+      "internal_addr": "127.0.0.9:31008",
+      "ctrl_addr": "127.0.0.9:31006",
+      "interfaces": {
+        "1": {
+          "underlay": {
+            "public": "127.0.0.4:50000",
+            "remote": "127.0.0.5:50000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:111",
+          "link_to": "CHILD",
+          "mtu": 1280
+        }
+      }
+    },
+    "br1-ff00_0_110-2": {
+      "internal_addr": "127.0.0.10:31012",
+      "ctrl_addr": "127.0.0.10:31010",
+      "interfaces": {
+        "2": {
+          "underlay": {
+            "public": "127.0.0.6:50000",
+            "remote": "127.0.0.7:50000"
+          },
+          "bandwidth": 500,
+          "isd_as": "1-ff00:0:112",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     }
   },
-  "Overlay": "UDP/IPv4"
+  "control_service": {
+    "cs1-ff00_0_110-1": {
+      "addr": "127.0.0.12:31002"
+    }
+  }
 }

--- a/acceptance/topo_cs_reload/BUILD.bazel
+++ b/acceptance/topo_cs_reload/BUILD.bazel
@@ -55,14 +55,14 @@ genrule(
     name = "invalid_changed_ip",
     srcs = ["//acceptance/topo_common:topology"],
     outs = ["topology_invalid_changed_ip.json"],
-    cmd = "jq '.ControlService[].Addrs.IPv4.Public.Addr = \"242.42.42.2\"' $(location //acceptance/topo_common:topology) > $@",
+    cmd = "jq '.control_service[].addr = \"242.42.42.2:31002\"' $(location //acceptance/topo_common:topology) > $@",
 )
 
 genrule(
     name = "invalid_changed_port",
     srcs = ["//acceptance/topo_common:topology"],
     outs = ["topology_invalid_changed_port.json"],
-    cmd = "jq '.ControlService[].Addrs.IPv4.Public.L4Port = 42424' $(location //acceptance/topo_common:topology) > $@",
+    cmd = "jq '.control_service[].addr = \"127.0.0.12:42424\"' $(location //acceptance/topo_common:topology) > $@",
 )
 
 genrule(

--- a/acceptance/topo_cs_reload/testdata/topology_reload.json
+++ b/acceptance/topo_cs_reload/testdata/topology_reload.json
@@ -1,97 +1,49 @@
 {
-  "MTU": 1400,
-  "BorderRouters": {
-    "br1-ff00_0_110-1": {
-      "Interfaces": {
-        "1": {
-          "MTU": 1280,
-          "RemoteOverlay": {
-            "Addr": "127.0.1.5",
-            "OverlayPort": 50000
-          },
-          "Bandwidth": 1000,
-          "ISD_AS": "1-ff00:0:111",
-          "PublicOverlay": {
-            "Addr": "127.0.1.4",
-            "OverlayPort": 50000
-          },
-          "LinkTo": "CHILD",
-          "Overlay": "UDP/IPv4"
-        }
-      },
-      "InternalAddrs": {
-        "IPv4": {
-          "PublicOverlay": {
-            "Addr": "127.0.1.9",
-            "OverlayPort": 31008
-          }
-        }
-      },
-      "CtrlAddr": {
-        "IPv4": {
-          "Public": {
-            "Addr": "127.0.1.9",
-            "L4Port": 31006
-          }
-        }
-      }
-    },
-    "br1-ff00_0_110-2": {
-      "Interfaces": {
-        "2": {
-          "MTU": 1472,
-          "RemoteOverlay": {
-            "Addr": "127.0.1.7",
-            "OverlayPort": 50000
-          },
-          "Bandwidth": 500,
-          "ISD_AS": "1-ff00:0:112",
-          "PublicOverlay": {
-            "Addr": "127.0.1.6",
-            "OverlayPort": 50000
-          },
-          "LinkTo": "CHILD",
-          "Overlay": "UDP/IPv4"
-        }
-      },
-      "InternalAddrs": {
-        "IPv4": {
-          "PublicOverlay": {
-            "Addr": "127.0.1.10",
-            "OverlayPort": 31012
-          }
-        }
-      },
-      "CtrlAddr": {
-        "IPv4": {
-          "Public": {
-            "Addr": "127.0.1.10",
-            "L4Port": 31010
-          }
-        }
-      }
-    }
-  },
-  "ColibriService": {},
-  "DiscoveryService": {},
-  "Attributes": [
+  "isd_as": "1-ff00:0:110",
+  "mtu": 1400,
+  "attributes": [
     "authoritative",
     "core",
     "issuing",
     "voting"
   ],
-  "ISD_AS": "1-ff00:0:110",
-  "ControlService": {
-    "cs1-ff00_0_110-1": {
-      "Addrs": {
-        "IPv4": {
-          "Public": {
-            "Addr": "127.0.0.12",
-            "L4Port": 31002
-          }
+  "border_routers": {
+    "br1-ff00_0_110-1": {
+      "internal_addr": "127.0.1.9:31008",
+      "ctrl_addr": "127.0.1.9:31006",
+      "interfaces": {
+        "1": {
+          "underlay": {
+            "public": "127.0.1.4:50000",
+            "remote": "127.0.1.5:50000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:111",
+          "link_to": "CHILD",
+          "mtu": 1280
+        }
+      }
+    },
+    "br1-ff00_0_110-2": {
+      "internal_addr": "127.0.1.10:31012",
+      "ctrl_addr": "127.0.1.10:31010",
+      "interfaces": {
+        "2": {
+          "underlay": {
+            "public": "127.0.1.6:50000",
+            "remote": "127.0.1.7:50000"
+          },
+          "bandwidth": 500,
+          "isd_as": "1-ff00:0:112",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     }
   },
-  "Overlay": "UDP/IPv4"
+  "control_service": {
+    "cs1-ff00_0_110-1": {
+      "addr": "127.0.0.12:31002"
+    }
+  }
 }

--- a/acceptance/topo_sd_reload/testdata/topology_reload.json
+++ b/acceptance/topo_sd_reload/testdata/topology_reload.json
@@ -1,96 +1,49 @@
 {
-  "MTU": 1400,
-  "BorderRouters": {
-    "br1-ff00_0_110-1": {
-      "Interfaces": {
-        "1": {
-          "MTU": 1280,
-          "RemoteOverlay": {
-            "Addr": "127.0.1.5",
-            "OverlayPort": 50000
-          },
-          "Bandwidth": 1000,
-          "ISD_AS": "1-ff00:0:111",
-          "PublicOverlay": {
-            "Addr": "127.0.1.4",
-            "OverlayPort": 50000
-          },
-          "LinkTo": "CHILD",
-          "Overlay": "UDP/IPv4"
-        }
-      },
-      "InternalAddrs": {
-        "IPv4": {
-          "PublicOverlay": {
-            "Addr": "127.0.1.9",
-            "OverlayPort": 31008
-          }
-        }
-      },
-      "CtrlAddr": {
-        "IPv4": {
-          "Public": {
-            "Addr": "127.0.1.9",
-            "L4Port": 31006
-          }
-        }
-      }
-    },
-    "br1-ff00_0_110-2": {
-      "Interfaces": {
-        "2": {
-          "MTU": 1472,
-          "RemoteOverlay": {
-            "Addr": "127.0.1.7",
-            "OverlayPort": 50000
-          },
-          "Bandwidth": 500,
-          "ISD_AS": "1-ff00:0:112",
-          "PublicOverlay": {
-            "Addr": "127.0.1.6",
-            "OverlayPort": 50000
-          },
-          "LinkTo": "CHILD",
-          "Overlay": "UDP/IPv4"
-        }
-      },
-      "InternalAddrs": {
-        "IPv4": {
-          "PublicOverlay": {
-            "Addr": "127.0.1.10",
-            "OverlayPort": 31012
-          }
-        }
-      },
-      "CtrlAddr": {
-        "IPv4": {
-          "Public": {
-            "Addr": "127.0.1.10",
-            "L4Port": 31010
-          }
-        }
-      }
-    }
-  },
-  "ColibriService": {},
-  "Attributes": [
+  "isd_as": "1-ff00:0:110",
+  "mtu": 1400,
+  "attributes": [
     "authoritative",
     "core",
     "issuing",
     "voting"
   ],
-  "ISD_AS": "1-ff00:0:110",
-  "ControlService": {
-    "cs1-ff00_0_110-1": {
-      "Addrs": {
-        "IPv4": {
-          "Public": {
-            "Addr": "127.0.1.12",
-            "L4Port": 31002
-          }
+  "border_routers": {
+    "br1-ff00_0_110-1": {
+      "internal_addr": "127.0.1.9:31008",
+      "ctrl_addr": "127.0.1.9:31006",
+      "interfaces": {
+        "1": {
+          "underlay": {
+            "public": "127.0.1.4:50000",
+            "remote": "127.0.1.5:50000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:111",
+          "link_to": "CHILD",
+          "mtu": 1280
+        }
+      }
+    },
+    "br1-ff00_0_110-2": {
+      "internal_addr": "127.0.1.10:31012",
+      "ctrl_addr": "127.0.1.10:31010",
+      "interfaces": {
+        "2": {
+          "underlay": {
+            "public": "127.0.1.6:50000",
+            "remote": "127.0.1.7:50000"
+          },
+          "bandwidth": 500,
+          "isd_as": "1-ff00:0:112",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     }
   },
-  "Overlay": "UDP/IPv4"
+  "control_service": {
+    "cs1-ff00_0_110-1": {
+      "addr": "127.0.1.12:31002"
+    }
+  }
 }

--- a/go/border/testdata/topology.json
+++ b/go/border/testdata/topology.json
@@ -1,57 +1,33 @@
 {
-    "Overlay": "UDP/IPv4",
-    "BorderRouters": {
-      "br1-ff00_0_111-1": {
-        "Interfaces": {
-          "11": {
-            "Overlay": "UDP/IPv4",
-            "RemoteOverlay": {
-              "OverlayPort": 50110,
-              "Addr": "127.0.0.110"
-            },
-            "PublicOverlay": {
-              "OverlayPort": 50011,
-              "Addr": "127.0.0.11"
-            },
-            "LinkTo": "PARENT",
-            "ISD_AS": "1-ff00:0:110",
-            "MTU": 1280,
-            "Bandwidth": 1000
+  "isd_as": "1-ff00:0:111",
+  "mtu": 1472,
+  "attributes": null,
+  "border_routers": {
+    "br1-ff00_0_111-1": {
+      "internal_addr": "127.0.0.1:41009",
+      "ctrl_addr": "127.0.0.2:41008",
+      "interfaces": {
+        "11": {
+          "underlay": {
+            "public": "127.0.0.11:50011",
+            "remote": "127.0.0.110:50110"
           },
-          "12": {
-            "Overlay": "UDP/IPv4",
-            "RemoteOverlay": {
-              "OverlayPort": 50120,
-              "Addr": "127.0.0.120"
-            },
-            "PublicOverlay": {
-              "OverlayPort": 50012,
-              "Addr": "127.0.0.12"
-            },
-            "LinkTo": "PARENT",
-            "ISD_AS": "1-ff00:0:120",
-            "MTU": 1280,
-            "Bandwidth": 1000
-          }
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:110",
+          "link_to": "PARENT",
+          "mtu": 1280
         },
-        "InternalAddrs": {
-          "IPv4": {
-            "PublicOverlay": {
-              "OverlayPort": 41009,
-              "Addr": "127.0.0.1"
-            }
-          }
-        },
-        "CtrlAddr": {
-          "IPv4": {
-            "Public": {
-              "Addr": "127.0.0.2",
-              "L4Port": 41008
-            }
-          }
+        "12": {
+          "underlay": {
+            "public": "127.0.0.12:50012",
+            "remote": "127.0.0.120:50120"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:120",
+          "link_to": "PARENT",
+          "mtu": 1280
         }
       }
-    },
-    "ISD_AS": "1-ff00:0:111",
-    "MTU": 1472
+    }
   }
+}

--- a/go/cs/beaconing/testdata/topology-core.json
+++ b/go/cs/beaconing/testdata/topology-core.json
@@ -1,88 +1,56 @@
 {
-  "Overlay": "UDP/IPv4",
-  "MTU": 1472,
-  "ISD_AS": "1-ff00:0:110",
-  "Attributes": ["authoritative", "core", "issuing", "voting"],
-  "BorderRouters": {
+  "isd_as": "1-ff00:0:110",
+  "mtu": 1472,
+  "attributes": [
+    "authoritative",
+    "core",
+    "issuing",
+    "voting"
+  ],
+  "border_routers": {
     "br1-ff00_0_111-1": {
-      "InternalAddrs": {
-        "IPv4": {
-          "PublicOverlay": {
-            "Addr": "127.0.0.17"
-          }
-        }
-      },
-      "CtrlAddr": {
-        "IPv4": {
-          "Public": {
-            "Addr": "127.0.0.17"
-          }
-        }
-      },
-      "Interfaces": {
-        "1129": {
-          "RemoteOverlay": {
-            "Addr": "127.0.0.4"
-          },
-          "MTU": 1280,
-          "PublicOverlay": {
-            "Addr": "127.0.0.5"
-          },
-          "Overlay": "UDP/IPv4",
-          "Bandwidth": 1000,
-          "ISD_AS": "1-ff00:0:120",
-          "LinkTo": "CORE"
-        },
+      "internal_addr": "127.0.0.17:0",
+      "ctrl_addr": "127.0.0.17:0",
+      "interfaces": {
         "1113": {
-          "RemoteOverlay": {
-            "Addr": "127.0.0.4"
+          "underlay": {
+            "public": "127.0.0.5:0",
+            "remote": "127.0.0.4:0"
           },
-          "MTU": 1280,
-          "PublicOverlay": {
-            "Addr": "127.0.0.5"
-          },
-          "Overlay": "UDP/IPv4",
-          "Bandwidth": 1000,
-          "ISD_AS": "1-ff00:0:130",
-          "LinkTo": "CORE"
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:130",
+          "link_to": "CORE",
+          "mtu": 1280
         },
         "1121": {
-          "RemoteOverlay": {
-            "Addr": "127.0.0.4"
+          "underlay": {
+            "public": "127.0.0.5:0",
+            "remote": "127.0.0.4:0"
           },
-          "MTU": 1280,
-          "PublicOverlay": {
-            "Addr": "127.0.0.5"
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:210",
+          "link_to": "CORE",
+          "mtu": 1280
+        },
+        "1129": {
+          "underlay": {
+            "public": "127.0.0.5:0",
+            "remote": "127.0.0.4:0"
           },
-          "Overlay": "UDP/IPv4",
-          "Bandwidth": 1000,
-          "ISD_AS": "2-ff00:0:210",
-          "LinkTo": "CORE"
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:120",
+          "link_to": "CORE",
+          "mtu": 1280
         },
         "42": {
-            "RemoteOverlay": {
-              "Addr": "127.0.0.4"
-            },
-            "MTU": 1280,
-            "PublicOverlay": {
-              "Addr": "127.0.0.5"
-            },
-            "Overlay": "UDP/IPv4",
-            "Bandwidth": 1000,
-            "ISD_AS": "1-ff00:0:111",
-            "LinkTo": "CHILD"
-          }
-      }
-    }
-  },
-  "PathService": {
-    "ps1-ff00_0_110-1": {
-      "Addrs": {
-        "IPv4": {
-          "Public": {
-            "L4Port": 31045,
-            "Addr": "127.0.0.86"
-          }
+          "underlay": {
+            "public": "127.0.0.5:0",
+            "remote": "127.0.0.4:0"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:111",
+          "link_to": "CHILD",
+          "mtu": 1280
         }
       }
     }

--- a/go/cs/beaconing/testdata/topology.json
+++ b/go/cs/beaconing/testdata/topology.json
@@ -1,113 +1,61 @@
 {
-  "Overlay": "UDP/IPv4",
-  "MTU": 1472,
-  "ISD_AS": "1-ff00:0:111",
-  "Attributes": [],
-  "BorderRouters": {
+  "isd_as": "1-ff00:0:111",
+  "mtu": 1472,
+  "attributes": [],
+  "border_routers": {
     "br1-ff00_0_111-1": {
-      "CtrlAddr": {
-        "IPv4": {
-          "Public": {
-            "L4Port": 31046,
-            "Addr": "127.0.0.81"
-          }
-        }
-      },
-      "Interfaces": {
+      "internal_addr": "127.0.0.81:31047",
+      "ctrl_addr": "127.0.0.81:31046",
+      "interfaces": {
+        "1417": {
+          "underlay": {
+            "public": "127.0.0.22:50000",
+            "remote": "127.0.0.23:50000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:112",
+          "link_to": "CHILD",
+          "mtu": 1472
+        },
         "2712": {
-          "Bandwidth": 1000,
-          "LinkTo": "PARENT",
-          "MTU": 1472,
-          "PublicOverlay": {
-            "Addr": "127.0.0.10",
-            "OverlayPort": 50000
+          "underlay": {
+            "public": "127.0.0.10:50000",
+            "remote": "127.0.0.11:50000"
           },
-          "RemoteOverlay": {
-            "Addr": "127.0.0.11",
-            "OverlayPort": 50000
-          },
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "1-ff00:0:120"
-        },
-        "2815": {
-          "Bandwidth": 1000,
-          "LinkTo": "PEER",
-          "MTU": 1472,
-          "PublicOverlay": {
-            "Addr": "127.0.0.18",
-            "OverlayPort": 50000
-          },
-          "RemoteOverlay": {
-            "Addr": "127.0.0.19",
-            "OverlayPort": 50000
-          },
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "1-ff00:0:121"
-        },
-        "2823": {
-          "Bandwidth": 1000,
-          "LinkTo": "PEER",
-          "MTU": 1472,
-          "PublicOverlay": {
-            "Addr": "127.0.0.12",
-            "OverlayPort": 50000
-          },
-          "RemoteOverlay": {
-            "Addr": "127.0.0.13",
-            "OverlayPort": 50000
-          },
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "2-ff00:0:211"
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:120",
+          "link_to": "PARENT",
+          "mtu": 1472
         },
         "2723": {
-          "Bandwidth": 1000,
-          "LinkTo": "PEER",
-          "MTU": 1472,
-          "PublicOverlay": {
-            "Addr": "127.0.0.20",
-            "OverlayPort": 50000
+          "underlay": {
+            "public": "127.0.0.20:50000",
+            "remote": "127.0.0.21:50000"
           },
-          "RemoteOverlay": {
-            "Addr": "127.0.0.21",
-            "OverlayPort": 50000
-          },
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "2-ff00:0:211"
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:211",
+          "link_to": "PEER",
+          "mtu": 1472
         },
-        "1417": {
-          "Bandwidth": 1000,
-          "LinkTo": "CHILD",
-          "MTU": 1472,
-          "PublicOverlay": {
-            "Addr": "127.0.0.22",
-            "OverlayPort": 50000
+        "2815": {
+          "underlay": {
+            "public": "127.0.0.18:50000",
+            "remote": "127.0.0.19:50000"
           },
-          "RemoteOverlay": {
-            "Addr": "127.0.0.23",
-            "OverlayPort": 50000
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:121",
+          "link_to": "PEER",
+          "mtu": 1472
+        },
+        "2823": {
+          "underlay": {
+            "public": "127.0.0.12:50000",
+            "remote": "127.0.0.13:50000"
           },
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "1-ff00:0:112"
-        }
-      },
-      "InternalAddrs": {
-        "IPv4": {
-          "PublicOverlay": {
-            "Addr": "127.0.0.81",
-            "OverlayPort": 31047
-          }
-        }
-      }
-    }
-  },
-  "PathService": {
-    "ps1-ff00_0_111-1": {
-      "Addrs": {
-        "IPv4": {
-          "Public": {
-            "L4Port": 31045,
-            "Addr": "127.0.0.86"
-          }
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:211",
+          "link_to": "PEER",
+          "mtu": 1472
         }
       }
     }

--- a/go/cs/handlers/testdata/topology_as1_132.json
+++ b/go/cs/handlers/testdata/topology_as1_132.json
@@ -1,53 +1,33 @@
 {
-  "ISD_AS": "1-ff00:0:132",
-  "Overlay": "UDP/IPv4",
-  "BorderRouters": {
+  "isd_as": "1-ff00:0:132",
+  "mtu": 1472,
+  "attributes": [],
+  "border_routers": {
     "br1-ff00_0_132-1": {
-      "InternalAddrs": {
-        "IPv4": {"PublicOverlay": {"Addr": "127.0.0.161", "OverlayPort": 50000}}
-      },
-      "CtrlAddr": {
-        "IPv4": {"Public": {"Addr": "10.1.0.1", "L4Port": 30052}}
-      },
-      "Interfaces": {
-        "1916": {
-          "LinkTo": "PARENT",
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "1-ff00:0:131",
-          "MTU": 1472,
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "Addr": "127.0.0.30",
-            "OverlayPort": 50000
-          },
-          "PublicOverlay": {
-            "Addr": "127.0.0.31",
-            "OverlayPort": 50000
-          }
-        },
+      "internal_addr": "127.0.0.161:50000",
+      "ctrl_addr": "10.1.0.1:30052",
+      "interfaces": {
         "1910": {
-          "LinkTo": "CHILD",
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "1-ff00:0:133",
-          "MTU": 1472,
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "Addr": "127.0.0.33",
-            "OverlayPort": 50000
+          "underlay": {
+            "public": "127.0.0.32:50000",
+            "remote": "127.0.0.33:50000"
           },
-          "PublicOverlay": {
-            "Addr": "127.0.0.32",
-            "OverlayPort": 50000
-          }
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:133",
+          "link_to": "CHILD",
+          "mtu": 1472
+        },
+        "1916": {
+          "underlay": {
+            "public": "127.0.0.31:50000",
+            "remote": "127.0.0.30:50000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:131",
+          "link_to": "PARENT",
+          "mtu": 1472
         }
       }
     }
-  },
-  "Attributes": [],
-  "MTU": 1472,
-  "PathService": {
-    "ps1-ff00_0_132-1": {"Addrs": {
-      "IPv4": {"Public": {"Addr": "127.0.0.165", "L4Port": 30066}}
-    }}
   }
 }

--- a/go/cs/handlers/testdata/topology_as2_211.json
+++ b/go/cs/handlers/testdata/topology_as2_211.json
@@ -1,98 +1,63 @@
 {
-  "ISD_AS": "2-ff00:0:211",
-  "Overlay": "UDP/IPv4",
-  "BorderRouters": {
+  "isd_as": "2-ff00:0:211",
+  "mtu": 1472,
+  "attributes": [],
+  "border_routers": {
     "br2-ff00_0_211-2": {
-      "InternalAddrs": {
-        "IPv4": {"PublicOverlay": {"Addr": "127.0.0.194", "OverlayPort": 50000}}
-      },
-      "CtrlAddr": {
-        "IPv4": {"Public": {"Addr": "10.1.0.1", "L4Port": 30091}}
-      },
-      "Interfaces": {
-        "2321": {
-          "LinkTo": "PARENT",
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "2-ff00:0:210",
-          "MTU": 1472,
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "Addr": "127.0.0.36",
-            "OverlayPort": 50000
-          },
-          "PublicOverlay": {
-            "Addr": "127.0.0.37",
-            "OverlayPort": 50000
-          }
-        },
+      "internal_addr": "127.0.0.194:50000",
+      "ctrl_addr": "10.1.0.1:30091",
+      "interfaces": {
         "2314": {
-          "LinkTo": "PEER",
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "1-ff00:0:111",
-          "MTU": 1472,
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "Addr": "127.0.0.14",
-            "OverlayPort": 50000
+          "underlay": {
+            "public": "127.0.0.15:50000",
+            "remote": "127.0.0.14:50000"
           },
-          "PublicOverlay": {
-            "Addr": "127.0.0.15",
-            "OverlayPort": 50000
-          }
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:111",
+          "link_to": "PEER",
+          "mtu": 1472
+        },
+        "2321": {
+          "underlay": {
+            "public": "127.0.0.37:50000",
+            "remote": "127.0.0.36:50000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:210",
+          "link_to": "PARENT",
+          "mtu": 1472
         },
         "2324": {
-          "LinkTo": "PEER",
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "2-ff00:0:221",
-          "MTU": 1472,
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "Addr": "127.0.0.39",
-            "OverlayPort": 50000
+          "underlay": {
+            "public": "127.0.0.38:50000",
+            "remote": "127.0.0.39:50000"
           },
-          "PublicOverlay": {
-            "Addr": "127.0.0.38",
-            "OverlayPort": 50000
-          }
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:221",
+          "link_to": "PEER",
+          "mtu": 1472
         },
         "2325": {
-          "LinkTo": "CHILD",
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "2-ff00:0:212",
-          "MTU": 1472,
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "Addr": "127.0.0.41",
-            "OverlayPort": 50000
+          "underlay": {
+            "public": "127.0.0.40:50000",
+            "remote": "127.0.0.41:50000"
           },
-          "PublicOverlay": {
-            "Addr": "127.0.0.40",
-            "OverlayPort": 50000
-          }
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:212",
+          "link_to": "CHILD",
+          "mtu": 1472
         },
         "2326": {
-          "LinkTo": "CHILD",
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "2-ff00:0:222",
-          "MTU": 1472,
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "Addr": "127.0.0.43",
-            "OverlayPort": 50000
+          "underlay": {
+            "public": "127.0.0.42:50000",
+            "remote": "127.0.0.43:50000"
           },
-          "PublicOverlay": {
-            "Addr": "127.0.0.42",
-            "OverlayPort": 50000
-          }
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:222",
+          "link_to": "CHILD",
+          "mtu": 1472
         }
       }
     }
-  },
-  "Attributes": [],
-  "MTU": 1472,
-  "PathService": {
-    "ps2-ff00_0_211-1": {"Addrs": {
-      "IPv4": {"Public": {"Addr": "127.0.0.200", "L4Port": 30093}}
-    }}
   }
 }

--- a/go/cs/handlers/testdata/topology_as2_222.json
+++ b/go/cs/handlers/testdata/topology_as2_222.json
@@ -1,53 +1,33 @@
 {
-  "ISD_AS": "2-ff00:0:222",
-  "Overlay": "UDP/IPv4",
-  "BorderRouters": {
+  "isd_as": "2-ff00:0:222",
+  "mtu": 1472,
+  "attributes": [],
+  "border_routers": {
     "br2-ff00_0_222-1": {
-      "InternalAddrs": {
-        "IPv4": {"PublicOverlay": {"Addr": "127.0.0.255", "OverlayPort": 50000}}
-      },
-      "CtrlAddr": {
-        "IPv4": {"Public": {"Addr": "10.1.0.1", "L4Port": 30071}}
-      },
-      "Interfaces": {
+      "internal_addr": "127.0.0.255:50000",
+      "ctrl_addr": "10.1.0.1:30071",
+      "interfaces": {
         "2623": {
-          "LinkTo": "PARENT",
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "2-ff00:0:211",
-          "MTU": 1472,
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "Addr": "127.0.0.42",
-            "OverlayPort": 50000
+          "underlay": {
+            "public": "127.0.0.43:50000",
+            "remote": "127.0.0.42:50000"
           },
-          "PublicOverlay": {
-            "Addr": "127.0.0.43",
-            "OverlayPort": 50000
-          }
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:211",
+          "link_to": "PARENT",
+          "mtu": 1472
         },
         "2624": {
-          "LinkTo": "PARENT",
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "2-ff00:0:221",
-          "MTU": 1472,
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "Addr": "127.0.0.46",
-            "OverlayPort": 50000
+          "underlay": {
+            "public": "127.0.0.47:50000",
+            "remote": "127.0.0.46:50000"
           },
-          "PublicOverlay": {
-            "Addr": "127.0.0.47",
-            "OverlayPort": 50000
-          }
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:221",
+          "link_to": "PARENT",
+          "mtu": 1472
         }
       }
     }
-  },
-  "Attributes": [],
-  "MTU": 1472,
-  "PathService": {
-    "ps2-ff00_0_222-1": {"Addrs": {
-      "IPv4": {"Public": {"Addr": "127.0.0.229", "L4Port": 30052}}
-    }}
   }
 }

--- a/go/cs/ifstate/testdata/topology.json
+++ b/go/cs/ifstate/testdata/topology.json
@@ -1,168 +1,83 @@
 {
-  "Overlay": "UDP/IPv4",
-  "MTU": 1472,
-  "ISD_AS": "1-ff00:0:111",
-  "Attributes": [],
-  "BorderRouters": {
-    "br1-ff00_0_111-2": {
-      "CtrlAddr": {
-        "IPv4": {
-          "Public": {
-            "L4Port": 31031,
-            "Addr": "127.0.0.82"
-          }
-        }
-      },
-      "InternalAddrs": {
-        "IPv4": {
-          "PublicOverlay": {
-            "OverlayPort": 31032,
-            "Addr": "127.0.0.82"
-          }
-        }
-      },
-      "Interfaces": {
-        "105": {
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "OverlayPort": 50000,
-            "Addr": "127.0.0.17"
+  "isd_as": "1-ff00:0:111",
+  "mtu": 1472,
+  "attributes": [],
+  "border_routers": {
+    "br1-ff00_0_111-1": {
+      "internal_addr": "127.0.0.81:31030",
+      "ctrl_addr": "127.0.0.81:31029",
+      "interfaces": {
+        "101": {
+          "underlay": {
+            "public": "127.0.0.12:50000",
+            "remote": "127.0.0.13:50000"
           },
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "1-ff00:0:130",
-          "PublicOverlay": {
-            "OverlayPort": 50000,
-            "Addr": "127.0.0.16"
-          },
-          "LinkTo": "PARENT",
-          "MTU": 1472
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:211",
+          "link_to": "PEER",
+          "mtu": 1472
         },
+        "104": {
+          "underlay": {
+            "public": "127.0.0.10:50000",
+            "remote": "127.0.0.11:50000"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:120",
+          "link_to": "PARENT",
+          "mtu": 1472
+        }
+      }
+    },
+    "br1-ff00_0_111-2": {
+      "internal_addr": "127.0.0.82:31032",
+      "ctrl_addr": "127.0.0.82:31031",
+      "interfaces": {
         "103": {
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "OverlayPort": 50000,
-            "Addr": "127.0.0.15"
+          "underlay": {
+            "public": "127.0.0.14:50000",
+            "remote": "127.0.0.15:50000"
           },
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "1-ff00:0:112",
-          "PublicOverlay": {
-            "OverlayPort": 50000,
-            "Addr": "127.0.0.14"
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:112",
+          "link_to": "CHILD",
+          "mtu": 1472
+        },
+        "105": {
+          "underlay": {
+            "public": "127.0.0.16:50000",
+            "remote": "127.0.0.17:50000"
           },
-          "LinkTo": "CHILD",
-          "MTU": 1472
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:130",
+          "link_to": "PARENT",
+          "mtu": 1472
         }
       }
     },
     "br1-ff00_0_111-3": {
-      "CtrlAddr": {
-        "IPv4": {
-          "Public": {
-            "L4Port": 31033,
-            "Addr": "127.0.0.83"
-          }
-        }
-      },
-      "InternalAddrs": {
-        "IPv4": {
-          "PublicOverlay": {
-            "OverlayPort": 31034,
-            "Addr": "127.0.0.83"
-          }
-        }
-      },
-      "Interfaces": {
+      "internal_addr": "127.0.0.83:31034",
+      "ctrl_addr": "127.0.0.83:31033",
+      "interfaces": {
         "100": {
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "OverlayPort": 50000,
-            "Addr": "127.0.0.19"
+          "underlay": {
+            "public": "127.0.0.18:50000",
+            "remote": "127.0.0.19:50000"
           },
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "1-ff00:0:121",
-          "PublicOverlay": {
-            "OverlayPort": 50000,
-            "Addr": "127.0.0.18"
-          },
-          "LinkTo": "PEER",
-          "MTU": 1472
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:121",
+          "link_to": "PEER",
+          "mtu": 1472
         },
         "102": {
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "OverlayPort": 50000,
-            "Addr": "127.0.0.21"
+          "underlay": {
+            "public": "127.0.0.20:50000",
+            "remote": "127.0.0.21:50000"
           },
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "2-ff00:0:211",
-          "PublicOverlay": {
-            "OverlayPort": 50000,
-            "Addr": "127.0.0.20"
-          },
-          "LinkTo": "PEER",
-          "MTU": 1472
-        }
-      }
-    },
-    "br1-ff00_0_111-1": {
-      "CtrlAddr": {
-        "IPv4": {
-          "Public": {
-            "L4Port": 31029,
-            "Addr": "127.0.0.81"
-          }
-        }
-      },
-      "InternalAddrs": {
-        "IPv4": {
-          "PublicOverlay": {
-            "OverlayPort": 31030,
-            "Addr": "127.0.0.81"
-          }
-        }
-      },
-      "Interfaces": {
-        "104": {
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "OverlayPort": 50000,
-            "Addr": "127.0.0.11"
-          },
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "1-ff00:0:120",
-          "PublicOverlay": {
-            "OverlayPort": 50000,
-            "Addr": "127.0.0.10"
-          },
-          "LinkTo": "PARENT",
-          "MTU": 1472
-        },
-        "101": {
-          "Bandwidth": 1000,
-          "RemoteOverlay": {
-            "OverlayPort": 50000,
-            "Addr": "127.0.0.13"
-          },
-          "Overlay": "UDP/IPv4",
-          "ISD_AS": "2-ff00:0:211",
-          "PublicOverlay": {
-            "OverlayPort": 50000,
-            "Addr": "127.0.0.12"
-          },
-          "LinkTo": "PEER",
-          "MTU": 1472
-        }
-      }
-    }
-  },
-  "PathService": {
-    "ps1-ff00_0_111-1": {
-      "Addrs": {
-        "IPv4": {
-          "Public": {
-            "L4Port": 31028,
-            "Addr": "127.0.0.86"
-          }
+          "bandwidth": 1000,
+          "isd_as": "2-ff00:0:211",
+          "link_to": "PEER",
+          "mtu": 1472
         }
       }
     }

--- a/go/cs/keepalive/testdata/topology.json
+++ b/go/cs/keepalive/testdata/topology.json
@@ -1,51 +1,32 @@
 {
-  "Overlay": "UDP/IPv4",
-  "MTU": 1472,
-  "ISD_AS": "1-ff00:0:111",
-  "Attributes": [],
-  "BorderRouters": {
+  "isd_as": "1-ff00:0:111",
+  "mtu": 1472,
+  "attributes": [],
+  "border_routers": {
     "br1-ff00_0_111-1": {
-      "InternalAddrs": {
-        "IPv4": {
-          "PublicOverlay": {
-            "Addr": "127.0.0.17"
-          }
-        }
-      },
-      "CtrlAddr": {
-        "IPv4": {
-          "Public": {
-            "Addr": "127.0.0.17"
-          }
-        }
-      },
-      "Interfaces": {
+      "internal_addr": "127.0.0.17:0",
+      "ctrl_addr": "127.0.0.17:0",
+      "interfaces": {
         "41": {
-          "RemoteOverlay": {
-            "Addr": "127.0.0.4"
+          "underlay": {
+            "public": "127.0.0.5:0",
+            "remote": "127.0.0.4:0"
           },
-          "MTU": 1280,
-          "PublicOverlay": {
-            "Addr": "127.0.0.5"
-          },
-          "Overlay": "UDP/IPv4",
-          "Bandwidth": 1000,
-          "ISD_AS": "1-ff00:0:110",
-          "LinkTo": "PARENT"
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:110",
+          "link_to": "PARENT",
+          "mtu": 1280
         },
         "42": {
-            "RemoteOverlay": {
-              "Addr": "127.0.0.4"
-            },
-            "MTU": 1280,
-            "PublicOverlay": {
-              "Addr": "127.0.0.5"
-            },
-            "Overlay": "UDP/IPv4",
-            "Bandwidth": 1000,
-            "ISD_AS": "1-ff00:0:110",
-            "LinkTo": "PARENT"
-          }
+          "underlay": {
+            "public": "127.0.0.5:0",
+            "remote": "127.0.0.4:0"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:110",
+          "link_to": "PARENT",
+          "mtu": 1280
+        }
       }
     }
   }

--- a/go/lib/infra/modules/itopo/internal/metrics/metrics.go
+++ b/go/lib/infra/modules/itopo/internal/metrics/metrics.go
@@ -73,9 +73,6 @@ func newCurrent() current {
 		timestamp: prom.NewGaugeVecWithLabels(Namespace, "", "creation_time_seconds",
 			"The creation time specified in the current topology."+
 				"Remains set for dynamic topology, even when inactive.", CurrentLabels{}),
-		expiry: prom.NewGaugeVecWithLabels(Namespace, "", "expiry_time_seconds",
-			"The expiry time specified in the current topology. Set to +Inf, if TTL is zero."+
-				"Remains set for dynamic topology, even when inactive.", CurrentLabels{}),
 		active: prom.NewGauge(Namespace, "", "dynamic_active",
 			"Indicate whether the dynamic topology is set and active. 0=inactive, 1=active."),
 	}
@@ -84,11 +81,6 @@ func newCurrent() current {
 // Timestamp returns the prometheus gauge.
 func (c current) Timestamp(l CurrentLabels) prometheus.Gauge {
 	return c.timestamp.WithLabelValues(l.Values()...)
-}
-
-// Expiry returns the prometheus gauge.
-func (c current) Expiry(l CurrentLabels) prometheus.Gauge {
-	return c.expiry.WithLabelValues(l.Values()...)
 }
 
 // Active returns the prometheus gauge.

--- a/go/lib/infra/modules/itopo/itopo.go
+++ b/go/lib/infra/modules/itopo/itopo.go
@@ -225,7 +225,6 @@ func (s *state) updateStatic(static *topology.RWTopology) {
 	call(s.config.Callbacks.OnUpdate)
 	cl := metrics.CurrentLabels{Type: metrics.Static}
 	metrics.Current.Timestamp(cl).Set(metrics.Timestamp(static.Timestamp))
-	metrics.Current.Expiry(cl).Set(metrics.Expiry(static.Expiry()))
 }
 
 func keepOld(newTopo, oldTopo *topology.RWTopology) bool {
@@ -234,16 +233,16 @@ func keepOld(newTopo, oldTopo *topology.RWTopology) bool {
 
 func topoEq(newTopo, oldTopo *topology.RWTopology) bool {
 	return cmp.Equal(newTopo, oldTopo, cmpopts.IgnoreFields(
-		topology.RWTopology{}, "Timestamp", "TTL"))
+		topology.RWTopology{}, "Timestamp"))
 }
 
 func expiresLater(newTopo, oldTopo *topology.RWTopology) bool {
 	if oldTopo == nil {
 		return true
 	}
-	newExpiry := newTopo.Expiry()
-	oldExpiry := oldTopo.Expiry()
-	return !oldExpiry.IsZero() && (newExpiry.IsZero() || newExpiry.After(oldExpiry))
+	newTS := newTopo.Timestamp
+	oldTS := oldTopo.Timestamp
+	return !oldTS.IsZero() && (newTS.IsZero() || newTS.After(oldTS))
 }
 
 func call(clbk func()) {

--- a/go/lib/infra/modules/itopo/itopo_test.go
+++ b/go/lib/infra/modules/itopo/itopo_test.go
@@ -196,15 +196,15 @@ func testNoModified(update updateTestFunc, prevTopo *topology.RWTopology,
 			SoMsg("err", err, ShouldBeNil)
 			SoMsg("updated", updated, ShouldBeFalse)
 		})
-		Convey("No update if expires earlier", func() {
-			topo.TTL -= 2 * time.Second
+		Convey("No update if topo older", func() {
+			topo.Timestamp = topo.Timestamp.Add(-2 * time.Second)
 			_, updated, err := update(topo)
 			SoMsg("err", err, ShouldBeNil)
 			SoMsg("updated", updated, ShouldBeFalse)
 		})
-		Convey("Update if expires later", func() {
+		Convey("Update if topo is newer", func() {
 			var wg xtest.Waiter
-			topo.TTL += 2 * time.Second
+			topo.Timestamp = topo.Timestamp.Add(2 * time.Second)
 			if updateCalled {
 				wg.Add(1)
 				clbks.onUpdate.EXPECT().Call().Do(wg.Done)

--- a/go/lib/infra/modules/itopo/testdata/topo.json
+++ b/go/lib/infra/modules/itopo/testdata/topo.json
@@ -1,118 +1,51 @@
 {
-    "Timestamp": 168570123,
-    "TimestampHuman": "1975-05-06 01:02:03.000000+0000",
-    "TTL": 3600,
-    "ISD_AS": "1-ff00:0:311",
-    "MTU": 1472,
-    "Overlay": "UDP/IPv4+6",
-    "Attributes": [],
-    "BorderRouters": {
-        "br1-ff00:0:311-1": {
-            "InternalAddrs": {
-                "IPv4": {
-                    "PublicOverlay": {
-                        "Addr": "10.1.0.1"
-                    }
-                },
-                "IPv6": {
-                    "PublicOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::1"
-                    }
-                }
-            },
-            "CtrlAddr": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "10.1.0.1",
-                        "L4Port": 30098
-                    }
-                },
-                "IPv6": {
-                    "Public": {
-                        "Addr": "2001:db8:a0b:12f0::1",
-                        "L4Port": 30098
-                    }
-                }
-            },
-            "Interfaces": {
-                "1": {
-                    "Overlay": "UDP/IPv4",
-                    "BindOverlay": {
-                        "Addr": "10.0.0.1"
-                    },
-                    "PublicOverlay": {
-                        "Addr": "192.0.2.1",
-                        "OverlayPort": 44997
-                    },
-                    "RemoteOverlay": {
-                        "Addr": "192.0.2.2",
-                        "OverlayPort": 44998
-                    },
-                    "Bandwidth": 1000,
-                    "ISD_AS": "1-ff00:0:312",
-                    "LinkTo": "PARENT",
-                    "MTU": 1472
-                }
-            }
-        },
-        "br1-ff00:0:311-2": {
-            "InternalAddrs": {
-                "IPv4": {
-                    "PublicOverlay": {
-                        "Addr": "10.1.0.2"
-                    }
-                }
-            },
-            "CtrlAddr": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "10.1.0.2",
-                        "L4Port": 30098
-                    }
-                }
-            },
-            "Interfaces": {
-                "2": {
-                    "Overlay": "UDP/IPv4",
-                    "BindOverlay": {
-                        "Addr": "10.0.0.2"
-                    },
-                    "PublicOverlay": {
-                        "Addr": "192.0.2.11",
-                        "OverlayPort": 44997
-                    },
-                    "RemoteOverlay": {
-                        "Addr": "192.0.2.12",
-                        "OverlayPort": 44998
-                    },
-                    "Bandwidth": 1000,
-                    "ISD_AS": "1-ff00:0:312",
-                    "LinkTo": "PARENT",
-                    "MTU": 1472
-                }
-            }
+  "timestamp": 168570123,
+  "timestamp_human": "1975-05-06 01:02:03.000000+0000",
+  "isd_as": "1-ff00:0:311",
+  "mtu": 1472,
+  "attributes": [],
+  "border_routers": {
+    "br1-ff00:0:311-1": {
+      "internal_addr": "10.1.0.1:0",
+      "ctrl_addr": "10.1.0.1:30098",
+      "interfaces": {
+        "1": {
+          "underlay": {
+            "public": "192.0.2.1:44997",
+            "remote": "192.0.2.2:44998",
+            "bind": "10.0.0.1"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:312",
+          "link_to": "PARENT",
+          "mtu": 1472
         }
+      }
     },
-    "ControlService": {
-        "cs1-ff00:0:311-1": {
-            "Addrs": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "127.0.0.66",
-                        "L4Port": 30081
-                    }
-                }
-            }
-        },
-        "cs1-ff00:0:311-2": {
-            "Addrs": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "127.0.0.67",
-                        "L4Port": 30073
-                    }
-                }
-            }
+    "br1-ff00:0:311-2": {
+      "internal_addr": "10.1.0.2:0",
+      "ctrl_addr": "10.1.0.2:30098",
+      "interfaces": {
+        "2": {
+          "underlay": {
+            "public": "192.0.2.11:44997",
+            "remote": "192.0.2.12:44998",
+            "bind": "10.0.0.2"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:312",
+          "link_to": "PARENT",
+          "mtu": 1472
         }
+      }
     }
+  },
+  "control_service": {
+    "cs1-ff00:0:311-1": {
+      "addr": "127.0.0.66:30081"
+    },
+    "cs1-ff00:0:311-2": {
+      "addr": "127.0.0.67:30073"
+    }
+  }
 }

--- a/go/lib/infra/modules/itopo/validate_test.go
+++ b/go/lib/infra/modules/itopo/validate_test.go
@@ -143,7 +143,7 @@ func testGenImmutable(v internalValidator, topo, oldTopo *topology.RWTopology, t
 		SoMsg("err", v.Immutable(topo, oldTopo), ShouldNotBeNil)
 	})
 	Convey("Changing a mutable field is allowed", func() {
-		topo.TTL = time.Second
+		topo.Timestamp = oldTopo.Timestamp.Add(time.Hour)
 	})
 }
 

--- a/go/lib/topology/export_test.go
+++ b/go/lib/topology/export_test.go
@@ -1,4 +1,5 @@
 // Copyright 2019 ETH Zurich
+// Copyright 2020 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,10 +16,6 @@
 package topology
 
 var (
-	RawAddrMapToTopoAddr           = rawAddrMapToTopoAddr
-	RawAddrMapExtractAddressInfo   = rawAddrMapExtractAddressInfo
-	RawBRAddrMapToUDPAddr          = rawBRAddrMapToUDPAddr
-	RawBRAddrMapExtractAddressInfo = rawBRAddrMapExtractAddressInfo
-	RawBRIntfRemoteBRAddr          = rawBRIntfRemoteBRAddr
-	RawBRIntfTopoBRAddr            = rawBRIntfTopoBRAddr
+	RawAddrToTopoAddr   = rawAddrToTopoAddr
+	RawBRIntfTopoBRAddr = rawBRIntfTopoBRAddr
 )

--- a/go/lib/topology/json/BUILD.bazel
+++ b/go/lib/topology/json/BUILD.bazel
@@ -20,7 +20,6 @@ go_test(
     deps = [
         "//go/lib/common:go_default_library",
         "//go/lib/scrypto/trc:go_default_library",
-        "//go/lib/topology/underlay:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/go/lib/topology/json/json.go
+++ b/go/lib/topology/json/json.go
@@ -30,161 +30,62 @@ import (
 
 // Topology is the JSON type for the entire AS topology file.
 type Topology struct {
-	Timestamp      int64  `json:"Timestamp"`
-	TimestampHuman string `json:"TimestampHuman"`
-	TTL            uint32 `json:"TTL"`
-	IA             string `json:"ISD_AS"`
-	Underlay       string `json:"Overlay"`
-	MTU            int    `json:"MTU"`
+	Timestamp      int64  `json:"timestamp,omitempty"`
+	TimestampHuman string `json:"timestamp_human,omitempty"`
+	IA             string `json:"isd_as"`
+	MTU            int    `json:"mtu"`
 	// Attributes are the primary AS attributes as described in
 	// https://github.com/scionproto/scion/blob/master/doc/ControlPlanePKI.md#primary-ases
 	// We use the []trc.Attribute type so that we don't validate according to
 	// trc.Attributes, because that contains a length 0 check which is not
 	// suitable for topology.
-	Attributes     []trc.Attribute        `json:"Attributes"`
-	BorderRouters  map[string]*BRInfo     `json:"BorderRouters,omitempty"`
-	ControlService map[string]*ServerInfo `json:"ControlService,omitempty"`
-	SIG            map[string]*ServerInfo `json:"SIG,omitempty"`
+	Attributes     []trc.Attribute        `json:"attributes"`
+	BorderRouters  map[string]*BRInfo     `json:"border_routers,omitempty"`
+	ControlService map[string]*ServerInfo `json:"control_service,omitempty"`
+	SIG            map[string]*ServerInfo `json:"sigs,omitempty"`
 }
 
 // ServerInfo contains the information for a SCION application running in the local AS.
 type ServerInfo struct {
-	Addrs NATSCIONAddressMap `json:"Addrs"`
-}
-
-// NATSCIONAddressMap maps address types (e.g., "IPv4") to their values.
-type NATSCIONAddressMap map[string]*NATSCIONAddress
-
-// NATSCIONAddress contains the address information for a single server socket. It is possible for a
-// server to have both a Public SCION address (i.e., globally scoped) and a Bind SCION address
-// (i.e., configured on the local machine). For example, 192.0.2.1 might be the public address, and
-// 10.0.0.1 might the bind address for the same socket. Note that some higher level libraries might
-// not include support for bind addresses.
-type NATSCIONAddress struct {
-	Public FullSCIONAddress `json:"Public"`
-	Bind   *Address         `json:"Bind,omitempty"`
-}
-
-// FullSCIONAddress describes a server's public SCION address and the associated underlay address.
-// The address can specify a custom underlay port for this socket (note that the JSON serialization
-// uses the old "overlay" term here), although usually this will be the AS default underlay port.
-type FullSCIONAddress struct {
-	Address
-	UnderlayPort int `json:"OverlayPort,omitempty"`
-}
-
-// Address is a standard layer 3 + layer 4 address.
-type Address struct {
-	Addr   string `json:"Addr"`
-	L4Port int    `json:"L4Port"`
+	Addr string `json:"addr"`
 }
 
 // BRInfo contains Border Router specific information.
 type BRInfo struct {
-	InternalAddrs UnderlayAddressMap               `json:"InternalAddrs"`
-	CtrlAddr      NATSCIONAddressMap               `json:"CtrlAddr"`
-	Interfaces    map[common.IFIDType]*BRInterface `json:"Interfaces"`
-}
-
-// UnderlayAddressMap maps address types (e.g., "UDP/IPv4") to underlay address values.
-type UnderlayAddressMap map[string]*NATUnderlayAddress
-
-// NATUnderlayAddress contains the information for a single underlay (data-plane) socket. It is
-// possible for an application to have both a Public Underlay address (i.e., globally scoped) and a
-// Bind Underlay address (i.e., configured on the local machine). For example, 192.0.2.1 might be
-// the public underlay address, and 10.0.0.1 might be the bind underlay address for the same socket.
-type NATUnderlayAddress struct {
-	PublicUnderlay UnderlayAddress `json:"PublicOverlay"`
-	BindUnderlay   *L3Address      `json:"BindOverlay,omitempty"`
+	InternalAddr string                           `json:"internal_addr"`
+	CtrlAddr     string                           `json:"ctrl_addr"`
+	Interfaces   map[common.IFIDType]*BRInterface `json:"interfaces"`
 }
 
 // BRInterface contains the information for an data-plane BR socket that is external (i.e., facing
 // the neighboring AS).
 type BRInterface struct {
-	Underlay       string           `json:"Overlay,omitempty"`
-	PublicUnderlay *UnderlayAddress `json:"PublicOverlay,omitempty"`
-	BindUnderlay   *L3Address       `json:"BindOverlay,omitempty"`
-	RemoteUnderlay *UnderlayAddress `json:"RemoteOverlay,omitempty"`
-	Bandwidth      int              `json:"Bandwidth"`
-	IA             string           `json:"ISD_AS"`
-	LinkTo         string           `json:"LinkTo"`
-	MTU            int              `json:"MTU"`
+	Underlay  Underlay `json:"underlay,omitempty"`
+	Bandwidth int      `json:"bandwidth"`
+	IA        string   `json:"isd_as"`
+	LinkTo    string   `json:"link_to"`
+	MTU       int      `json:"mtu"`
 }
 
-// UnderlayAddress is a standard layer 3 + layer 4 address. This is identical to the other basic
-// address type in this package, except the JSON property names are different.
-type UnderlayAddress struct {
-	Addr         string `json:"Addr"`
-	UnderlayPort int    `json:"OverlayPort,omitempty"`
-}
-
-// L3Address is a standard layer 3 address.
-type L3Address struct {
-	Addr string `json:"Addr"`
+// Underlay is the underlay information for a BR interface.
+type Underlay struct {
+	Public string `json:"public"`
+	Remote string `json:"remote"`
+	Bind   string `json:"bind,omitempty"`
 }
 
 func (i ServerInfo) String() string {
-	return fmt.Sprintf("Addr: %s", i.Addrs)
-}
-
-func (m NATSCIONAddressMap) String() string {
-	var s []string
-	for k, v := range m {
-		s = append(s, fmt.Sprintf("%s: %s", k, v))
-	}
-	return strings.Join(s, "\n")
-}
-
-func (a NATSCIONAddress) String() string {
-	var s []string
-	s = append(s, fmt.Sprintf("Public: %s", a.Public))
-	if a.Bind != nil {
-		s = append(s, fmt.Sprintf("Bind: %s", a.Bind))
-	}
-	return strings.Join(s, ", ")
-}
-
-func (a FullSCIONAddress) String() string {
-	return fmt.Sprintf("%s:%d/%d", a.Addr, a.L4Port, a.UnderlayPort)
-}
-
-func (a Address) String() string {
-	return fmt.Sprintf("%s:%d", a.Addr, a.L4Port)
+	return fmt.Sprintf("Addr: %s", i.Addr)
 }
 
 func (i BRInfo) String() string {
 	var s []string
-	s = append(s, fmt.Sprintf("Loc addrs:\n  %s\nControl addrs:\n  %s\nInterfaces:",
-		i.InternalAddrs, i.CtrlAddr))
+	s = append(s, fmt.Sprintf("Loc addrs:\n  %s\nControl addr:\n  %s\nInterfaces:",
+		i.InternalAddr, i.CtrlAddr))
 	for ifid, intf := range i.Interfaces {
 		s = append(s, fmt.Sprintf("%d: %+v", ifid, intf))
 	}
 	return strings.Join(s, "\n")
-}
-
-func (m UnderlayAddressMap) String() string {
-	var s []string
-	for k, v := range m {
-		s = append(s, fmt.Sprintf("%s: %s", k, v))
-	}
-	return strings.Join(s, "\n")
-}
-
-func (a NATUnderlayAddress) String() string {
-	var s []string
-	s = append(s, fmt.Sprintf("PublicOverlay: %s", a.PublicUnderlay))
-	if a.BindUnderlay != nil {
-		s = append(s, fmt.Sprintf("BindOverlay: %s", a.BindUnderlay))
-	}
-	return strings.Join(s, "\n")
-}
-
-func (a UnderlayAddress) String() string {
-	return fmt.Sprintf("%s:%d", a.Addr, a.UnderlayPort)
-}
-
-func (a L3Address) String() string {
-	return fmt.Sprintf("%s", a.Addr)
 }
 
 // Load parses a topology from its raw byte representation.

--- a/go/lib/topology/json/json_test.go
+++ b/go/lib/topology/json/json_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/scrypto/trc"
 	jsontopo "github.com/scionproto/scion/go/lib/topology/json"
-	"github.com/scionproto/scion/go/lib/topology/underlay"
 )
 
 var (
@@ -42,52 +41,16 @@ func TestLoadRawFromFile(t *testing.T) {
 		IA:             "6-ff00:0:362",
 		MTU:            1472,
 		Attributes:     []trc.Attribute{trc.Authoritative, trc.Core, trc.Issuing, trc.Voting},
-		Underlay:       underlay.UDPIPv46Name,
 		BorderRouters: map[string]*jsontopo.BRInfo{
 			"borderrouter6-f00:0:362-1": {
-				InternalAddrs: jsontopo.UnderlayAddressMap{
-					"IPv4": {
-						PublicUnderlay: jsontopo.UnderlayAddress{
-							Addr: "10.1.0.1",
-						},
-					},
-					"IPv6": {
-						PublicUnderlay: jsontopo.UnderlayAddress{
-							Addr: "2001:db8:a0b:12f0::1",
-						},
-					},
-				},
-				CtrlAddr: jsontopo.NATSCIONAddressMap{
-					"IPv4": &jsontopo.NATSCIONAddress{
-						Public: jsontopo.FullSCIONAddress{
-							Address: jsontopo.Address{
-								Addr:   "10.1.0.1",
-								L4Port: 30098,
-							},
-						},
-					},
-					"IPv6": &jsontopo.NATSCIONAddress{
-						Public: jsontopo.FullSCIONAddress{
-							Address: jsontopo.Address{
-								Addr:   "2001:db8:a0b:12f0::1",
-								L4Port: 30098,
-							},
-						},
-					},
-				},
+				InternalAddr: "10.1.0.1:0",
+				CtrlAddr:     "10.1.0.1:30098",
 				Interfaces: map[common.IFIDType]*jsontopo.BRInterface{
 					91: {
-						Underlay: "UDP/IPv4",
-						BindUnderlay: &jsontopo.L3Address{
-							Addr: "10.0.0.1",
-						},
-						PublicUnderlay: &jsontopo.UnderlayAddress{
-							Addr:         "192.0.2.1",
-							UnderlayPort: 4997,
-						},
-						RemoteUnderlay: &jsontopo.UnderlayAddress{
-							Addr:         "192.0.2.2",
-							UnderlayPort: 4998,
+						Underlay: jsontopo.Underlay{
+							Public: "192.0.2.1:4997",
+							Remote: "192.0.2.2:4998",
+							Bind:   "10.0.0.1",
 						},
 						Bandwidth: 100000,
 						IA:        "6-ff00:0:363",
@@ -97,49 +60,14 @@ func TestLoadRawFromFile(t *testing.T) {
 				},
 			},
 			"borderrouter6-f00:0:362-9": {
-				InternalAddrs: jsontopo.UnderlayAddressMap{
-					"IPv4": {
-						PublicUnderlay: jsontopo.UnderlayAddress{
-							Addr: "10.1.0.2",
-						},
-					},
-					"IPv6": {
-						PublicUnderlay: jsontopo.UnderlayAddress{
-							Addr: "2001:db8:a0b:12f0::2",
-						},
-					},
-				},
-				CtrlAddr: jsontopo.NATSCIONAddressMap{
-					"IPv4": &jsontopo.NATSCIONAddress{
-						Public: jsontopo.FullSCIONAddress{
-							Address: jsontopo.Address{
-								Addr:   "10.1.0.2",
-								L4Port: 30098,
-							},
-						},
-					},
-					"IPv6": &jsontopo.NATSCIONAddress{
-						Public: jsontopo.FullSCIONAddress{
-							Address: jsontopo.Address{
-								Addr:   "2001:db8:a0b:12f0::2",
-								L4Port: 30098,
-							},
-						},
-					},
-				},
+				InternalAddr: "[2001:db8:a0b:12f0::2]:0",
+				CtrlAddr:     "[2001:db8:a0b:12f0::2300]:30098",
 				Interfaces: map[common.IFIDType]*jsontopo.BRInterface{
 					32: {
-						Underlay: "UDP/IPv6",
-						BindUnderlay: &jsontopo.L3Address{
-							Addr: "2001:db8:a0b:12f0::8",
-						},
-						PublicUnderlay: &jsontopo.UnderlayAddress{
-							Addr:         "2001:db8:a0b:12f0::1",
-							UnderlayPort: 4997,
-						},
-						RemoteUnderlay: &jsontopo.UnderlayAddress{
-							Addr:         "2001:db8:a0b:12f0::2",
-							UnderlayPort: 4998,
+						Underlay: jsontopo.Underlay{
+							Public: "[2001:db8:a0b:12f0::1]:4997",
+							Remote: "[2001:db8:a0b:12f0::2]:4998",
+							Bind:   "2001:db8:a0b:12f0::8",
 						},
 						Bandwidth: 5000,
 						IA:        "6-ff00:0:364",
@@ -152,7 +80,7 @@ func TestLoadRawFromFile(t *testing.T) {
 	}
 
 	if *update {
-		b, err := json.MarshalIndent(referenceTopology, "", "    ")
+		b, err := json.MarshalIndent(referenceTopology, "", "  ")
 		require.NoError(t, err)
 		b = append(b, []byte("\n")...)
 		err = ioutil.WriteFile("testdata/topology.json", b, 0644)
@@ -167,7 +95,7 @@ func TestLoadRawFromFile(t *testing.T) {
 	t.Run("marshaled bytes match", func(t *testing.T) {
 		referenceTopologyBytes, err := ioutil.ReadFile("testdata/topology.json")
 		require.NoError(t, err)
-		topologyBytes, err := json.MarshalIndent(referenceTopology, "", "    ")
+		topologyBytes, err := json.MarshalIndent(referenceTopology, "", "  ")
 		require.NoError(t, err)
 		assert.Equal(t,
 			strings.TrimSpace(string(referenceTopologyBytes)),

--- a/go/lib/topology/json/testdata/topology.json
+++ b/go/lib/topology/json/testdata/topology.json
@@ -1,112 +1,48 @@
 {
-    "Timestamp": 168562800,
-    "TimestampHuman": "May  6 00:00:00 CET 1975",
-    "TTL": 0,
-    "ISD_AS": "6-ff00:0:362",
-    "Overlay": "UDP/IPv4+6",
-    "MTU": 1472,
-    "Attributes": [
-        "authoritative",
-        "core",
-        "issuing",
-        "voting"
-    ],
-    "BorderRouters": {
-        "borderrouter6-f00:0:362-1": {
-            "InternalAddrs": {
-                "IPv4": {
-                    "PublicOverlay": {
-                        "Addr": "10.1.0.1"
-                    }
-                },
-                "IPv6": {
-                    "PublicOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::1"
-                    }
-                }
-            },
-            "CtrlAddr": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "10.1.0.1",
-                        "L4Port": 30098
-                    }
-                },
-                "IPv6": {
-                    "Public": {
-                        "Addr": "2001:db8:a0b:12f0::1",
-                        "L4Port": 30098
-                    }
-                }
-            },
-            "Interfaces": {
-                "91": {
-                    "Overlay": "UDP/IPv4",
-                    "PublicOverlay": {
-                        "Addr": "192.0.2.1",
-                        "OverlayPort": 4997
-                    },
-                    "BindOverlay": {
-                        "Addr": "10.0.0.1"
-                    },
-                    "RemoteOverlay": {
-                        "Addr": "192.0.2.2",
-                        "OverlayPort": 4998
-                    },
-                    "Bandwidth": 100000,
-                    "ISD_AS": "6-ff00:0:363",
-                    "LinkTo": "CORE",
-                    "MTU": 1472
-                }
-            }
-        },
-        "borderrouter6-f00:0:362-9": {
-            "InternalAddrs": {
-                "IPv4": {
-                    "PublicOverlay": {
-                        "Addr": "10.1.0.2"
-                    }
-                },
-                "IPv6": {
-                    "PublicOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::2"
-                    }
-                }
-            },
-            "CtrlAddr": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "10.1.0.2",
-                        "L4Port": 30098
-                    }
-                },
-                "IPv6": {
-                    "Public": {
-                        "Addr": "2001:db8:a0b:12f0::2",
-                        "L4Port": 30098
-                    }
-                }
-            },
-            "Interfaces": {
-                "32": {
-                    "Overlay": "UDP/IPv6",
-                    "PublicOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::1",
-                        "OverlayPort": 4997
-                    },
-                    "BindOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::8"
-                    },
-                    "RemoteOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::2",
-                        "OverlayPort": 4998
-                    },
-                    "Bandwidth": 5000,
-                    "ISD_AS": "6-ff00:0:364",
-                    "LinkTo": "CHILD",
-                    "MTU": 4430
-                }
-            }
+  "timestamp": 168562800,
+  "timestamp_human": "May  6 00:00:00 CET 1975",
+  "isd_as": "6-ff00:0:362",
+  "mtu": 1472,
+  "attributes": [
+    "authoritative",
+    "core",
+    "issuing",
+    "voting"
+  ],
+  "border_routers": {
+    "borderrouter6-f00:0:362-1": {
+      "internal_addr": "10.1.0.1:0",
+      "ctrl_addr": "10.1.0.1:30098",
+      "interfaces": {
+        "91": {
+          "underlay": {
+            "public": "192.0.2.1:4997",
+            "remote": "192.0.2.2:4998",
+            "bind": "10.0.0.1"
+          },
+          "bandwidth": 100000,
+          "isd_as": "6-ff00:0:363",
+          "link_to": "CORE",
+          "mtu": 1472
         }
+      }
+    },
+    "borderrouter6-f00:0:362-9": {
+      "internal_addr": "[2001:db8:a0b:12f0::2]:0",
+      "ctrl_addr": "[2001:db8:a0b:12f0::2300]:30098",
+      "interfaces": {
+        "32": {
+          "underlay": {
+            "public": "[2001:db8:a0b:12f0::1]:4997",
+            "remote": "[2001:db8:a0b:12f0::2]:4998",
+            "bind": "2001:db8:a0b:12f0::8"
+          },
+          "bandwidth": 5000,
+          "isd_as": "6-ff00:0:364",
+          "link_to": "CHILD",
+          "mtu": 4430
+        }
+      }
     }
+  }
 }

--- a/go/lib/topology/raw.go
+++ b/go/lib/topology/raw.go
@@ -17,186 +17,78 @@ package topology
 
 import (
 	"net"
+	"strconv"
 
 	"github.com/scionproto/scion/go/lib/serrors"
 	jsontopo "github.com/scionproto/scion/go/lib/topology/json"
-	"github.com/scionproto/scion/go/lib/topology/underlay"
 )
 
-func rawAddrMapToTopoAddr(ram jsontopo.NATSCIONAddressMap) (*TopoAddr, error) {
-	addressInfo, mustBeIPv6 := rawAddrMapExtractAddressInfo(ram)
-	mustBeIPv4 := !mustBeIPv6
-	if addressInfo == nil {
-		return nil, serrors.WithCtx(errAtLeastOnePub, "address", ram)
-	}
-	if addressInfo.Bind != nil {
-		return nil, serrors.WithCtx(errBindNotSupported, "address", addressInfo.Bind)
-	}
-	if addressInfo.Public.UnderlayPort != 0 {
-		return nil, serrors.WithCtx(errCustomUnderlayPort,
-			"port", addressInfo.Public.UnderlayPort)
-	}
-
-	ipAddr, err := net.ResolveIPAddr("ip", addressInfo.Public.Address.Addr)
+func rawAddrToTopoAddr(rawAddr string) (*TopoAddr, error) {
+	a, err := rawAddrToUDPAddr(rawAddr)
 	if err != nil {
-		return nil, serrors.Wrap(errInvalidPub, err, "address", addressInfo.Public.Address.Addr)
+		return nil, err
 	}
-	// This can happen if the address is empty.
-	if ipAddr.IP == nil {
-		return nil, serrors.WithCtx(errInvalidPub, "address", addressInfo.Public.Address.Addr)
-	}
-
-	if mustBeIPv6 && ipAddr.IP.To4() != nil {
-		return nil, serrors.WithCtx(errInvalidPub, "address", addressInfo.Public.Address.Addr)
-	}
-	if mustBeIPv4 {
-		// Convert to 4-byte format to simplify testing
-		if ipAddr.IP = ipAddr.IP.To4(); ipAddr.IP == nil {
-			return nil, serrors.WithCtx(errInvalidPub,
-				"address", addressInfo.Public.Address.Addr)
-		}
-	}
-
 	return &TopoAddr{
-		SCIONAddress: &net.UDPAddr{
-			IP:   ipAddr.IP,
-			Port: addressInfo.Public.Address.L4Port,
-			Zone: ipAddr.Zone,
-		},
+		SCIONAddress: a,
 		UnderlayAddress: &net.UDPAddr{
-			IP:   append(ipAddr.IP[:0:0], ipAddr.IP...),
+			IP:   append(a.IP[:0:0], a.IP...),
 			Port: EndhostPort,
-			Zone: ipAddr.Zone,
+			Zone: a.Zone,
 		},
-	}, nil
-}
-
-func rawAddrMapExtractAddressInfo(
-	ram jsontopo.NATSCIONAddressMap) (info *jsontopo.NATSCIONAddress, is6 bool) {
-
-	a, ok := ram["IPv6"]
-	if ok {
-		return a, true
-	}
-	a, ok = ram["IPv4"]
-	if ok {
-		return a, false
-	}
-	return nil, false
-}
-
-func rawBRAddrMapToUDPAddr(m jsontopo.UnderlayAddressMap) (*net.UDPAddr, error) {
-	addressInfo, mustBeIPv6 := rawBRAddrMapExtractAddressInfo(m)
-	mustBeIPv4 := !mustBeIPv6
-	if addressInfo == nil {
-		return nil, serrors.WithCtx(errAtLeastOnePub, "address", m)
-	}
-	if addressInfo.BindUnderlay != nil {
-		return nil, serrors.WithCtx(errBindNotSupported, "address", addressInfo.BindUnderlay)
-	}
-
-	ipAddr, err := net.ResolveIPAddr("ip", addressInfo.PublicUnderlay.Addr)
-	if err != nil {
-		return nil, serrors.Wrap(errInvalidPub, err, "address", addressInfo.PublicUnderlay.Addr)
-	}
-	// This can happen if the address is empty.
-	if ipAddr.IP == nil {
-		return nil, serrors.WithCtx(errInvalidPub, "address", addressInfo.PublicUnderlay.Addr)
-	}
-
-	if mustBeIPv6 && ipAddr.IP.To4() != nil {
-		return nil, serrors.WithCtx(errInvalidPub, "address", addressInfo.PublicUnderlay.Addr)
-	}
-	if mustBeIPv4 {
-		// Convert to 4-byte format to simplify testing
-		if ipAddr.IP = ipAddr.IP.To4(); ipAddr.IP == nil {
-			return nil, serrors.WithCtx(errInvalidPub, "address", addressInfo.PublicUnderlay.Addr)
-		}
-	}
-
-	return &net.UDPAddr{
-		IP:   append(ipAddr.IP[:0:0], ipAddr.IP...),
-		Port: addressInfo.PublicUnderlay.UnderlayPort,
-		Zone: ipAddr.Zone,
-	}, nil
-}
-
-func rawBRAddrMapExtractAddressInfo(
-	m jsontopo.UnderlayAddressMap) (info *jsontopo.NATUnderlayAddress, is6 bool) {
-
-	a, ok := m["IPv6"]
-	if ok {
-		return a, true
-	}
-	a, ok = m["IPv4"]
-	if ok {
-		return a, false
-	}
-	return nil, false
-}
-
-func rawBRIntfRemoteBRAddr(b *jsontopo.BRInterface, o underlay.Type) (*net.UDPAddr, error) {
-	l3, err := net.ResolveIPAddr("ip", b.RemoteUnderlay.Addr)
-	if err != nil {
-		return nil, serrors.WrapStr("could not parse remote IP from string", err,
-			"input", b.RemoteUnderlay.Addr)
-	}
-	if l3.IP == nil {
-		return nil, serrors.New("empty remote IP", "input", b.RemoteUnderlay.Addr)
-	}
-	if !o.IsUDP() && (b.RemoteUnderlay.UnderlayPort != 0) {
-		return nil, serrors.WithCtx(errUnderlayPort, "addr", b.RemoteUnderlay)
-	}
-	// Convert to 4-byte format to simplify testing
-	if ipv4 := l3.IP.To4(); ipv4 != nil {
-		l3.IP = ipv4
-	}
-	return &net.UDPAddr{
-		IP:   l3.IP,
-		Port: b.RemoteUnderlay.UnderlayPort,
-		Zone: l3.Zone,
 	}, nil
 }
 
 func rawBRIntfTopoBRAddr(i *jsontopo.BRInterface) (*net.UDPAddr, error) {
-	if i.Underlay != "UDP/IPv4" && i.Underlay != "UDP/IPv6" {
-		return nil, serrors.WithCtx(errUnsupportedUnderlay, "underlay", i.Underlay)
+	rh, port, err := splitHostPort(i.Underlay.Public)
+	if err != nil {
+		return nil, err
 	}
-
-	mustBeIPv4 := i.Underlay == "UDP/IPv4"
-	mustBeIPv6 := i.Underlay == "UDP/IPv6"
-
-	var input string
-	if i.BindUnderlay != nil {
-		input = i.BindUnderlay.Addr
-	} else if i.PublicUnderlay != nil {
-		input = i.PublicUnderlay.Addr
+	var rawIP string
+	if i.Underlay.Bind != "" {
+		rawIP = i.Underlay.Bind
+	} else if rh != "" {
+		rawIP = rh
 	} else {
 		return nil, serrors.WithCtx(errUnderlayAddrNotFound, "underlay", i.Underlay)
 	}
+	return resolveToUDPAddr(rawIP, port)
+}
 
-	ipAddr, err := net.ResolveIPAddr("ip", input)
+func splitHostPort(rawAddr string) (string, int, error) {
+	rh, rp, err := net.SplitHostPort(rawAddr)
 	if err != nil {
-		return nil, serrors.WithCtx(err, "underlay", i.Underlay)
+		return "", 0, serrors.WrapStr("failed to split host port", err)
+	}
+	port, err := strconv.Atoi(rp)
+	if err != nil {
+		return "", 0, serrors.WrapStr("failed to parse port", err)
+	}
+	return rh, port, nil
+}
+
+func resolveToUDPAddr(rawIP string, port int) (*net.UDPAddr, error) {
+	ipAddr, err := net.ResolveIPAddr("ip", rawIP)
+	if err != nil {
+		return nil, serrors.WrapStr("failed to resolve ip", err, "raw", rawIP)
 	}
 	if ipAddr.IP == nil {
-		return nil, serrors.WithCtx(errInvalidPub, "address", i.PublicUnderlay.Addr)
+		return nil, serrors.New("missing/invalid IP", "raw", rawIP)
 	}
-	udpAddr := &net.UDPAddr{
-		IP:   ipAddr.IP,
+	// Convert to 4-byte format to simplify testing
+	if ip4 := ipAddr.IP.To4(); ip4 != nil {
+		ipAddr.IP = ip4
+	}
+	return &net.UDPAddr{
+		IP:   append(ipAddr.IP[:0:0], ipAddr.IP...),
+		Port: port,
 		Zone: ipAddr.Zone,
+	}, nil
+}
+
+func rawAddrToUDPAddr(rawAddr string) (*net.UDPAddr, error) {
+	rh, port, err := splitHostPort(rawAddr)
+	if err != nil {
+		return nil, err
 	}
-	if i.PublicUnderlay != nil {
-		udpAddr.Port = i.PublicUnderlay.UnderlayPort
-	}
-	if mustBeIPv4 {
-		// Convert to 4-byte format to simplify testing
-		if udpAddr.IP = udpAddr.IP.To4(); udpAddr.IP == nil {
-			return nil, serrors.WithCtx(errExpectedIPv4FoundIPv6, "address", i.PublicUnderlay.Addr)
-		}
-	}
-	if mustBeIPv6 && udpAddr.IP.To4() != nil {
-		return nil, serrors.WithCtx(errExpectedIPv6FoundIPv4, "address", i.PublicUnderlay.Addr)
-	}
-	return udpAddr, nil
+	return resolveToUDPAddr(rh, port)
 }

--- a/go/lib/topology/testdata/basic.json
+++ b/go/lib/topology/testdata/basic.json
@@ -1,230 +1,84 @@
 {
-    "Timestamp": 168570123,
-    "TimestampHuman": "1975-05-06 01:02:03.000000+0000",
-    "TTL": 3600,
-    "ISD_AS": "1-ff00:0:311",
-    "MTU": 1472,
-    "Overlay": "UDP/IPv4+6",
-    "Attributes": [],
-    "BorderRouters": {
-        "br1-ff00:0:311-1": {
-            "InternalAddrs": {
-                "IPv4": {
-                    "PublicOverlay": {
-                        "Addr": "10.1.0.1"
-                    }
-                },
-                "IPv6": {
-                    "PublicOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::1"
-                    }
-                }
-            },
-            "CtrlAddr": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "10.1.0.1",
-                        "L4Port": 30098
-                    }
-                },
-                "IPv6": {
-                    "Public": {
-                        "Addr": "2001:db8:a0b:12f0::1",
-                        "L4Port": 30098
-                    }
-                }
-            },
-            "Interfaces": {
-                "1": {
-                    "Overlay": "UDP/IPv4",
-                    "BindOverlay": {
-                        "Addr": "10.0.0.1"
-                    },
-                    "PublicOverlay": {
-                        "Addr": "192.0.2.1",
-                        "OverlayPort": 44997
-                    },
-                    "RemoteOverlay": {
-                        "Addr": "192.0.2.2",
-                        "OverlayPort": 44998
-                    },
-                    "Bandwidth": 1000,
-                    "ISD_AS": "1-ff00:0:312",
-                    "LinkTo": "PARENT",
-                    "MTU": 1472
-                },
-                "3": {
-                    "Overlay": "UDP/IPv6",
-                    "PublicOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::1",
-                        "OverlayPort": 44997
-                    },
-                    "RemoteOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::2",
-                        "OverlayPort": 44998
-                    },
-                    "BindOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::8"
-                    },
-                    "Bandwidth": 5000,
-                    "ISD_AS": "1-ff00:0:314",
-                    "LinkTo": "CHILD",
-                    "MTU": 4430
-                },
-                "8": {
-                    "Overlay": "UDP/IPv4",
-                    "BindOverlay": {
-                        "Addr": "10.0.0.2"
-                    },
-                    "PublicOverlay": {
-                        "Addr": "192.0.2.2",
-                        "OverlayPort": 44997
-                    },
-                    "RemoteOverlay": {
-                        "Addr": "192.0.2.3",
-                        "OverlayPort": 44998
-                    },
-                    "Bandwidth": 2000,
-                    "ISD_AS": "1-ff00:0:313",
-                    "LinkTo": "PEER",
-                    "MTU": 1480
-                }
-            }
+  "timestamp": 168570123,
+  "timestamp_human": "1975-05-06 01:02:03.000000+0000",
+  "isd_as": "1-ff00:0:311",
+  "mtu": 1472,
+  "attributes": [],
+  "border_routers": {
+    "br1-ff00:0:311-1": {
+      "internal_addr": "10.1.0.1:0",
+      "ctrl_addr": "10.1.0.1:30098",
+      "interfaces": {
+        "1": {
+          "underlay": {
+            "public": "192.0.2.1:44997",
+            "remote": "192.0.2.2:44998",
+            "bind": "10.0.0.1"
+          },
+          "bandwidth": 1000,
+          "isd_as": "1-ff00:0:312",
+          "link_to": "PARENT",
+          "mtu": 1472
         },
-        "br1-ff00:0:311-2": {
-            "InternalAddrs": {
-                "IPv6": {
-                    "PublicOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::1%some-internal-zone"
-                    }
-                }
-            },
-            "CtrlAddr": {
-                "IPv6": {
-                    "Public": {
-                        "Addr": "2001:db8:a0b:12f0::1%some-ctrl-zone",
-                        "L4Port": 30098
-                    }
-                }
-            },
-            "Interfaces": {
-                "11": {
-                    "Overlay": "UDP/IPv6",
-                    "PublicOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::1%some-public-zone",
-                        "OverlayPort": 44897
-                    },
-                    "RemoteOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::2%some-remote-zone",
-                        "OverlayPort": 44898
-                    },
-                    "BindOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::8%some-bind-zone"
-                    },
-                    "Bandwidth": 5000,
-                    "ISD_AS": "1-ff00:0:314",
-                    "LinkTo": "CHILD",
-                    "MTU": 4430
-                }
-            }
+        "3": {
+          "underlay": {
+            "public": "[2001:db8:a0b:12f0::1]:44997",
+            "remote": "[2001:db8:a0b:12f0::2]:44998",
+            "bind": "2001:db8:a0b:12f0::8"
+          },
+          "bandwidth": 5000,
+          "isd_as": "1-ff00:0:314",
+          "link_to": "CHILD",
+          "mtu": 4430
+        },
+        "8": {
+          "underlay": {
+            "public": "192.0.2.2:44997",
+            "remote": "192.0.2.3:44998",
+            "bind": "10.0.0.2"
+          },
+          "bandwidth": 2000,
+          "isd_as": "1-ff00:0:313",
+          "link_to": "PEER",
+          "mtu": 1480
         }
+      }
     },
-    "ControlService": {
-        "cs1-ff00:0:311-2": {
-            "Addrs": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "127.0.0.67",
-                        "L4Port": 30073
-                    }
-                }
-            }
-        },
-        "cs1-ff00:0:311-3": {
-            "Addrs": {
-                "IPv6": {
-                    "Public": {
-                        "Addr": "2001:db8:f00:b43::1",
-                        "L4Port": 23421
-                    }
-                }
-            }
-        },
-        "cs1-ff00:0:311-4": {
-            "Addrs": {
-                "IPv6": {
-                    "Public": {
-                        "Addr": "2001:db8:f00:b43::1%some-zone",
-                        "L4Port": 23425
-                    }
-                }
-            }
+    "br1-ff00:0:311-2": {
+      "internal_addr": "[2001:db8:a0b:12f0::1%some-internal-zone]:0",
+      "ctrl_addr": "[2001:db8:a0b:12f0::1%some-ctrl-zone]:30098",
+      "interfaces": {
+        "11": {
+          "underlay": {
+            "public": "[2001:db8:a0b:12f0::1%some-public-zone]:44897",
+            "remote": "[2001:db8:a0b:12f0::2%some-remote-zone]:44898",
+            "bind": "2001:db8:a0b:12f0::8%some-bind-zone"
+          },
+          "bandwidth": 5000,
+          "isd_as": "1-ff00:0:314",
+          "link_to": "CHILD",
+          "mtu": 4430
         }
-    },
-    "SibraService": {
-        "sb1-ff00:0:311-1": {
-            "Addrs": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "127.0.0.76",
-                        "L4Port": 30058
-                    }
-                }
-            }
-        },
-        "sb1-ff00:0:311-2": {
-            "Addrs": {
-                "IPv6": {
-                    "Public": {
-                        "Addr": "2001:db8:f00:b43::76",
-                        "L4Port": 30058
-                    }
-                }
-            }
-        }
-    },
-    "RainsService": {
-        "rs1-ff00:0:311-1": {
-            "Addrs": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "127.0.0.78",
-                        "L4Port": 30098
-                    }
-                }
-            }
-        },
-        "rs1-ff00:0:311-2": {
-            "Addrs": {
-                "IPv6": {
-                    "Public": {
-                        "Addr": "2001:db8:f00:b43::78",
-                        "L4Port": 30098
-                    }
-                }
-            }
-        }
-    },
-    "SIG": {
-        "sig1-ff00:0:311-1": {
-            "Addrs": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "127.0.0.82",
-                        "L4Port": 30100
-                    }
-                }
-            }
-        },
-        "sig1-ff00:0:311-2": {
-            "Addrs": {
-                "IPv6": {
-                    "Public": {
-                        "Addr": "2001:db8:f00:b43::82",
-                        "L4Port": 30100
-                    }
-                }
-            }
-        }
+      }
     }
+  },
+  "control_service": {
+    "cs1-ff00:0:311-2": {
+      "addr": "127.0.0.67:30073"
+    },
+    "cs1-ff00:0:311-3": {
+      "addr": "[2001:db8:f00:b43::1]:23421"
+    },
+    "cs1-ff00:0:311-4": {
+      "addr": "[2001:db8:f00:b43::1%some-zone]:23425"
+    }
+  },
+  "sigs": {
+    "sig1-ff00:0:311-1": {
+      "addr": "127.0.0.82:30100"
+    },
+    "sig1-ff00:0:311-2": {
+      "addr": "[2001:db8:f00:b43::82]:30100"
+    }
+  }
 }

--- a/go/lib/topology/testdata/core.json
+++ b/go/lib/topology/testdata/core.json
@@ -1,106 +1,48 @@
 {
-    "Timestamp": 168562800,
-    "TimestampHuman": "May  6 00:00:00 CET 1975",
-    "ISD_AS": "6-ff00:0:362",
-    "MTU": 1472,
-    "Attributes": ["authoritative", "core", "issuing", "voting"],
-    "Overlay": "UDP/IPv4+6",
-    "BorderRouters": {
-        "borderrouter6-ff00:0:362-1": {
-            "InternalAddrs": {
-                "IPv4": {
-                    "PublicOverlay": {
-                        "Addr": "10.1.0.1"
-                    }
-                },
-                "IPv6": {
-                    "PublicOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::1"
-                    }
-                }
-            },
-            "CtrlAddr": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "10.1.0.1",
-                        "L4Port": 30098
-                    }
-                },
-                "IPv6": {
-                    "Public": {
-                        "Addr": "2001:db8:a0b:12f0::1",
-                        "L4Port": 30098
-                    }
-                }
-            },
-            "Interfaces": {
-                "91": {
-                    "Overlay": "UDP/IPv4",
-                    "BindOverlay": {
-                        "Addr": "10.0.0.1"
-                    },
-                    "PublicOverlay": {
-                        "Addr": "192.0.2.1",
-                        "OverlayPort": 4997
-                    },
-                    "RemoteOverlay": {
-                        "Addr": "192.0.2.2",
-                        "OverlayPort": 4998
-                    },
-                    "Bandwidth": 100000,
-                    "ISD_AS": "6-ff00:0:363",
-                    "LinkTo": "CORE",
-                    "MTU": 1472
-                }
-            }
-        },
-        "borderrouter6-ff00:0:362-9": {
-            "InternalAddrs": {
-                "IPv4": {
-                    "PublicOverlay": {
-                        "Addr": "10.1.0.2"
-                    }
-                },
-                "IPv6": {
-                    "PublicOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::2"
-                    }
-                }
-            },
-            "CtrlAddr": {
-                "IPv4": {
-                    "Public": {
-                        "Addr": "10.1.0.2",
-                        "L4Port": 30098
-                    }
-                },
-                "IPv6": {
-                    "Public": {
-                        "Addr": "2001:db8:a0b:12f0::2",
-                        "L4Port": 30098
-                    }
-                }
-            },
-            "Interfaces": {
-                "32": {
-                    "Overlay": "UDP/IPv6",
-                    "PublicOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::1",
-                        "OverlayPort": 4997
-                    },
-                    "RemoteOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::2",
-                        "OverlayPort": 4998
-                    },
-                    "BindOverlay": {
-                        "Addr": "2001:db8:a0b:12f0::8"
-                    },
-                    "Bandwidth": 5000,
-                    "ISD_AS": "6-ff00:0:364",
-                    "LinkTo": "CHILD",
-                    "MTU": 4430
-                }
-            }
+  "timestamp": 168562800,
+  "timestamp_human": "May  6 00:00:00 CET 1975",
+  "isd_as": "6-ff00:0:362",
+  "mtu": 1472,
+  "attributes": [
+    "authoritative",
+    "core",
+    "issuing",
+    "voting"
+  ],
+  "border_routers": {
+    "borderrouter6-ff00:0:362-1": {
+      "internal_addr": "10.1.0.1:0",
+      "ctrl_addr": "10.1.0.1:30098",
+      "interfaces": {
+        "91": {
+          "underlay": {
+            "public": "192.0.2.1:4997",
+            "remote": "192.0.2.2:4998",
+            "bind": "10.0.0.1"
+          },
+          "bandwidth": 100000,
+          "isd_as": "6-ff00:0:363",
+          "link_to": "CORE",
+          "mtu": 1472
         }
+      }
+    },
+    "borderrouter6-ff00:0:362-9": {
+      "internal_addr": "[2001:db8:a0b:12f0::2]:0",
+      "ctrl_addr": "[2001:db8:a0b:12f0::2]:30098",
+      "interfaces": {
+        "32": {
+          "underlay": {
+            "public": "[2001:db8:a0b:12f0::1]:4997",
+            "remote": "[2001:db8:a0b:12f0::2]:4998",
+            "bind": "2001:db8:a0b:12f0::8"
+          },
+          "bandwidth": 5000,
+          "isd_as": "6-ff00:0:364",
+          "link_to": "CHILD",
+          "mtu": 4430
+        }
+      }
     }
+  }
 }

--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -35,7 +35,6 @@ import (
 func TestMeta(t *testing.T) {
 	c := MustLoadTopo(t, "testdata/basic.json")
 	assert.Equal(t, time.Unix(168570123, 0), c.Timestamp, "Field 'Timestamp'")
-	assert.Equal(t, time.Hour, c.TTL, "Field 'TTL'")
 	assert.Equal(t, addr.IA{I: 1, A: 0xff0000000311}, c.IA, "Field 'ISD_AS'")
 	assert.Equal(t, 1472, c.MTU, "Field 'MTU'")
 	assert.Empty(t, c.Attributes, "Field 'Attributes'")
@@ -46,12 +45,10 @@ func Test_Active(t *testing.T) {
 		c := MustLoadTopo(t, "testdata/basic.json")
 		assert.False(t, c.Active(c.Timestamp.Add(-time.Second)))
 		assert.True(t, c.Active(c.Timestamp))
-		assert.True(t, c.Active(c.Timestamp.Add(c.TTL-1)))
-		assert.False(t, c.Active(c.Timestamp.Add(time.Hour)))
+		assert.False(t, c.Active(c.Timestamp.Add(-time.Hour)))
 	})
 	t.Run("zero TTL", func(t *testing.T) {
 		c := MustLoadTopo(t, "testdata/basic.json")
-		c.TTL = 0
 		assert.False(t, c.Active(c.Timestamp.Add(-time.Second)))
 		assert.True(t, c.Active(c.Timestamp))
 		assert.True(t, c.Active(c.Timestamp.Add(100*time.Hour)))
@@ -59,7 +56,7 @@ func Test_Active(t *testing.T) {
 	})
 }
 
-func Test_BRs(t *testing.T) {
+func TestBRs(t *testing.T) {
 	c := MustLoadTopo(t, "testdata/basic.json")
 
 	brs := map[string]BRInfo{
@@ -138,23 +135,23 @@ func TestIFInfoMap(t *testing.T) {
 			ID:     1,
 			BRName: "br1-ff00:0:311-1",
 			InternalAddr: &net.UDPAddr{
-				IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+				IP:   net.ParseIP("10.1.0.1").To4(),
 				Port: 0,
 			},
 			CtrlAddrs: &TopoAddr{
 				SCIONAddress: &net.UDPAddr{
-					IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+					IP:   net.ParseIP("10.1.0.1").To4(),
 					Port: 30098,
 				},
-				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("2001:db8:a0b:12f0::1"), Port: 30041},
+				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("10.1.0.1").To4(), Port: 30041},
 			},
 			Underlay: underlay.UDPIPv4,
 			Local: &net.UDPAddr{
-				IP:   net.IP{10, 0, 0, 1},
+				IP:   net.IP{10, 0, 0, 1}.To4(),
 				Port: 44997,
 			},
 			Remote: &net.UDPAddr{
-				IP:   net.IP{192, 0, 2, 2},
+				IP:   net.IP{192, 0, 2, 2}.To4(),
 				Port: 44998,
 			},
 			Bandwidth: 1000,
@@ -166,15 +163,15 @@ func TestIFInfoMap(t *testing.T) {
 			ID:     3,
 			BRName: "br1-ff00:0:311-1",
 			InternalAddr: &net.UDPAddr{
-				IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+				IP:   net.ParseIP("10.1.0.1").To4(),
 				Port: 0,
 			},
 			CtrlAddrs: &TopoAddr{
 				SCIONAddress: &net.UDPAddr{
-					IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+					IP:   net.ParseIP("10.1.0.1").To4(),
 					Port: 30098,
 				},
-				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("2001:db8:a0b:12f0::1"), Port: 30041},
+				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("10.1.0.1").To4(), Port: 30041},
 			},
 			Underlay: underlay.UDPIPv6,
 			Local: &net.UDPAddr{
@@ -194,23 +191,23 @@ func TestIFInfoMap(t *testing.T) {
 			ID:     8,
 			BRName: "br1-ff00:0:311-1",
 			InternalAddr: &net.UDPAddr{
-				IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+				IP:   net.ParseIP("10.1.0.1").To4(),
 				Port: 0,
 			},
 			CtrlAddrs: &TopoAddr{
 				SCIONAddress: &net.UDPAddr{
-					IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+					IP:   net.ParseIP("10.1.0.1").To4(),
 					Port: 30098,
 				},
-				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("2001:db8:a0b:12f0::1"), Port: 30041},
+				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("10.1.0.1").To4(), Port: 30041},
 			},
 			Underlay: underlay.UDPIPv4,
 			Local: &net.UDPAddr{
-				IP:   net.IP{10, 0, 0, 2},
+				IP:   net.IP{10, 0, 0, 2}.To4(),
 				Port: 44997,
 			},
 			Remote: &net.UDPAddr{
-				IP:   net.IP{192, 0, 2, 3},
+				IP:   net.IP{192, 0, 2, 3}.To4(),
 				Port: 44998,
 			},
 			Bandwidth: 2000,
@@ -265,23 +262,23 @@ func TestIFInfoMapCoreAS(t *testing.T) {
 			ID:     91,
 			BRName: "borderrouter6-ff00:0:362-1",
 			InternalAddr: &net.UDPAddr{
-				IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+				IP:   net.ParseIP("10.1.0.1").To4(),
 				Port: 0,
 			},
 			CtrlAddrs: &TopoAddr{
 				SCIONAddress: &net.UDPAddr{
-					IP:   net.ParseIP("2001:db8:a0b:12f0::1"),
+					IP:   net.ParseIP("10.1.0.1").To4(),
 					Port: 30098,
 				},
-				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("2001:db8:a0b:12f0::1"), Port: 30041},
+				UnderlayAddress: &net.UDPAddr{IP: net.ParseIP("10.1.0.1").To4(), Port: 30041},
 			},
 			Underlay: underlay.UDPIPv4,
 			Local: &net.UDPAddr{
-				IP:   net.IP{10, 0, 0, 1},
+				IP:   net.IP{10, 0, 0, 1}.To4(),
 				Port: 4997,
 			},
 			Remote: &net.UDPAddr{
-				IP:   net.IP{192, 0, 2, 2},
+				IP:   net.IP{192, 0, 2, 2}.To4(),
 				Port: 4998,
 			},
 			Bandwidth: 100000,
@@ -357,177 +354,6 @@ func TestCopy(t *testing.T) {
 	assert.Equal(t, topo, newTopo)
 }
 
-func TestInternalDataPlanePort(t *testing.T) {
-	testCases := []struct {
-		Name            string
-		Map             jsontopo.UnderlayAddressMap
-		ExpectedAddress *net.UDPAddr
-		ExpectedError   assert.ErrorAssertionFunc
-	}{
-		{
-			Name:          "Empty",
-			Map:           jsontopo.UnderlayAddressMap{},
-			ExpectedError: assert.Error,
-		},
-		{
-			Name: "Bad IPv4 only",
-			Map: jsontopo.UnderlayAddressMap{
-				"IPv4": &jsontopo.NATUnderlayAddress{
-					PublicUnderlay: jsontopo.UnderlayAddress{
-						Addr:         "foo",
-						UnderlayPort: 42,
-					},
-				},
-			},
-			ExpectedError: assert.Error,
-		},
-		{
-			Name: "Good IPv4 only",
-			Map: jsontopo.UnderlayAddressMap{
-				"IPv4": &jsontopo.NATUnderlayAddress{
-					PublicUnderlay: jsontopo.UnderlayAddress{
-						Addr:         "127.0.0.1",
-						UnderlayPort: 42,
-					},
-				},
-			},
-			ExpectedError: assert.NoError,
-			ExpectedAddress: &net.UDPAddr{
-				IP:   net.IP{127, 0, 0, 1},
-				Port: 42,
-			},
-		},
-		{
-			Name: "IPv4 contains IPv6",
-			Map: jsontopo.UnderlayAddressMap{
-				"IPv4": &jsontopo.NATUnderlayAddress{
-					PublicUnderlay: jsontopo.UnderlayAddress{
-						Addr:         "::1",
-						UnderlayPort: 42,
-					},
-				},
-			},
-			ExpectedError: assert.Error,
-		},
-		{
-			Name: "IPv4 with bind underlay",
-			Map: jsontopo.UnderlayAddressMap{
-				"IPv4": &jsontopo.NATUnderlayAddress{
-					PublicUnderlay: jsontopo.UnderlayAddress{
-						Addr:         "127.0.0.1",
-						UnderlayPort: 42,
-					},
-					BindUnderlay: &jsontopo.L3Address{
-						Addr: "127.255.255.255",
-					},
-				},
-			},
-			ExpectedError: assert.Error,
-		},
-		{
-			Name: "Bad IPv6 only",
-			Map: jsontopo.UnderlayAddressMap{
-				"IPv6": &jsontopo.NATUnderlayAddress{
-					PublicUnderlay: jsontopo.UnderlayAddress{
-						Addr:         "foo",
-						UnderlayPort: 42,
-					},
-				},
-			},
-			ExpectedError: assert.Error,
-		},
-		{
-			Name: "Good IPv6 only",
-			Map: jsontopo.UnderlayAddressMap{
-				"IPv6": &jsontopo.NATUnderlayAddress{
-					PublicUnderlay: jsontopo.UnderlayAddress{
-						Addr:         "::1",
-						UnderlayPort: 42,
-					},
-				},
-			},
-			ExpectedError: assert.NoError,
-			ExpectedAddress: &net.UDPAddr{
-				IP:   net.ParseIP("::1"),
-				Port: 42,
-			},
-		},
-		{
-			Name: "Good IPv6 only with zone",
-			Map: jsontopo.UnderlayAddressMap{
-				"IPv6": &jsontopo.NATUnderlayAddress{
-					PublicUnderlay: jsontopo.UnderlayAddress{
-						Addr:         "::1%some-zone",
-						UnderlayPort: 42,
-					},
-				},
-			},
-			ExpectedError: assert.NoError,
-			ExpectedAddress: &net.UDPAddr{
-				IP:   net.ParseIP("::1"),
-				Port: 42,
-				Zone: "some-zone",
-			},
-		},
-		{
-			Name: "IPv6 contains IPv4",
-			Map: jsontopo.UnderlayAddressMap{
-				"IPv6": &jsontopo.NATUnderlayAddress{
-					PublicUnderlay: jsontopo.UnderlayAddress{
-						Addr:         "127.0.0.1",
-						UnderlayPort: 42,
-					},
-				},
-			},
-			ExpectedError: assert.Error,
-		},
-		{
-			Name: "IPv6 with bind underlay",
-			Map: jsontopo.UnderlayAddressMap{
-				"IPv6": &jsontopo.NATUnderlayAddress{
-					PublicUnderlay: jsontopo.UnderlayAddress{
-						Addr:         "::1",
-						UnderlayPort: 42,
-					},
-					BindUnderlay: &jsontopo.L3Address{
-						Addr: "2001:db8::1",
-					},
-				},
-			},
-			ExpectedError: assert.Error,
-		},
-		{
-			Name: "Prefer IPv6 to IPv4",
-			Map: jsontopo.UnderlayAddressMap{
-				"IPv4": &jsontopo.NATUnderlayAddress{
-					PublicUnderlay: jsontopo.UnderlayAddress{
-						Addr:         "127.0.0.1",
-						UnderlayPort: 42,
-					},
-				},
-				"IPv6": &jsontopo.NATUnderlayAddress{
-					PublicUnderlay: jsontopo.UnderlayAddress{
-						Addr:         "::1",
-						UnderlayPort: 73,
-					},
-				},
-			},
-			ExpectedError: assert.NoError,
-			ExpectedAddress: &net.UDPAddr{
-				IP:   net.ParseIP("::1"),
-				Port: 73,
-			},
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			topoBRAddr, err := RawBRAddrMapToUDPAddr(tc.Map)
-			tc.ExpectedError(t, err)
-			assert.Equal(t, tc.ExpectedAddress, topoBRAddr)
-		})
-	}
-}
-
 func TestExternalDataPlanePort(t *testing.T) {
 	testCases := []struct {
 		Name            string
@@ -543,17 +369,15 @@ func TestExternalDataPlanePort(t *testing.T) {
 		{
 			Name: "Empty with underlay",
 			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv4",
+				Underlay: jsontopo.Underlay{},
 			},
 			ExpectedError: assert.Error,
 		},
 		{
-			Name: "Bad IPv4 only",
+			Name: "Bad invalid public",
 			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv4",
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "foo",
-					UnderlayPort: 42,
+				Underlay: jsontopo.Underlay{
+					Public: "foo:42",
 				},
 			},
 			ExpectedError: assert.Error,
@@ -561,10 +385,8 @@ func TestExternalDataPlanePort(t *testing.T) {
 		{
 			Name: "Good IPv4 only",
 			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv4",
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "127.0.0.1",
-					UnderlayPort: 42,
+				Underlay: jsontopo.Underlay{
+					Public: "127.0.0.1:42",
 				},
 			},
 			ExpectedError: assert.NoError,
@@ -574,26 +396,11 @@ func TestExternalDataPlanePort(t *testing.T) {
 			},
 		},
 		{
-			Name: "IPv4 contains IPv6",
-			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv4",
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "::1",
-					UnderlayPort: 42,
-				},
-			},
-			ExpectedError: assert.Error,
-		},
-		{
 			Name: "IPv4 with bind underlay",
 			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv4",
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "127.0.0.1",
-					UnderlayPort: 42,
-				},
-				BindUnderlay: &jsontopo.L3Address{
-					Addr: "127.255.255.255",
+				Underlay: jsontopo.Underlay{
+					Public: "127.0.0.1:42",
+					Bind:   "127.255.255.255",
 				},
 			},
 			ExpectedError: assert.NoError,
@@ -603,40 +410,11 @@ func TestExternalDataPlanePort(t *testing.T) {
 			},
 		},
 		{
-			Name: "IPv4 with bad underlay",
+			Name: "IPv4 with bad bind",
 			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv4",
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "127.0.0.1",
-					UnderlayPort: 42,
-				},
-				BindUnderlay: &jsontopo.L3Address{
-					Addr: "foo",
-				},
-			},
-			ExpectedError: assert.Error,
-		},
-		{
-			Name: "IPv4 with IPv6 underlay",
-			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv4",
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "127.0.0.1",
-					UnderlayPort: 42,
-				},
-				BindUnderlay: &jsontopo.L3Address{
-					Addr: "::1",
-				},
-			},
-			ExpectedError: assert.Error,
-		},
-		{
-			Name: "Bad IPv6 only",
-			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv6",
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "foo",
-					UnderlayPort: 42,
+				Underlay: jsontopo.Underlay{
+					Public: "127.0.0.1:42",
+					Bind:   "foo",
 				},
 			},
 			ExpectedError: assert.Error,
@@ -644,10 +422,8 @@ func TestExternalDataPlanePort(t *testing.T) {
 		{
 			Name: "Good IPv6 only",
 			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv6",
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "::1",
-					UnderlayPort: 42,
+				Underlay: jsontopo.Underlay{
+					Public: "[::1]:42",
 				},
 			},
 			ExpectedError: assert.NoError,
@@ -659,10 +435,8 @@ func TestExternalDataPlanePort(t *testing.T) {
 		{
 			Name: "Good IPv6 only with zone",
 			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv6",
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "::1%some-zone",
-					UnderlayPort: 42,
+				Underlay: jsontopo.Underlay{
+					Public: "[::1%some-zone]:42",
 				},
 			},
 			ExpectedError: assert.NoError,
@@ -673,26 +447,11 @@ func TestExternalDataPlanePort(t *testing.T) {
 			},
 		},
 		{
-			Name: "IPv6 contains IPv4",
-			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv6",
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "127.0.0.1",
-					UnderlayPort: 42,
-				},
-			},
-			ExpectedError: assert.Error,
-		},
-		{
 			Name: "IPv6 with bind underlay",
 			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv6",
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "::1",
-					UnderlayPort: 42,
-				},
-				BindUnderlay: &jsontopo.L3Address{
-					Addr: "2001:db8::1",
+				Underlay: jsontopo.Underlay{
+					Public: "[::1]:42",
+					Bind:   "2001:db8::1",
 				},
 			},
 			ExpectedError: assert.NoError,
@@ -702,28 +461,11 @@ func TestExternalDataPlanePort(t *testing.T) {
 			},
 		},
 		{
-			Name: "IPv6 with bad underlay",
+			Name: "IPv6 with bad bind underlay",
 			Raw: &jsontopo.BRInterface{
-				Underlay: "UDP/IPv6",
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "::1",
-					UnderlayPort: 42,
-				},
-				BindUnderlay: &jsontopo.L3Address{
-					Addr: "foo",
-				},
-			},
-			ExpectedError: assert.Error,
-		},
-		{
-			Name: "IPv6 with IPv4 underlay",
-			Raw: &jsontopo.BRInterface{
-				PublicUnderlay: &jsontopo.UnderlayAddress{
-					Addr:         "::1",
-					UnderlayPort: 42,
-				},
-				BindUnderlay: &jsontopo.L3Address{
-					Addr: "127.0.0.1",
+				Underlay: jsontopo.Underlay{
+					Public: "[::1]:42",
+					Bind:   "foo",
 				},
 			},
 			ExpectedError: assert.Error,
@@ -740,119 +482,30 @@ func TestExternalDataPlanePort(t *testing.T) {
 
 func TestRawAddrMap_ToTopoAddr(t *testing.T) {
 	testCases := []struct {
-		name string
-		err  error
-		ram  jsontopo.NATSCIONAddressMap
-		addr *TopoAddr
+		name        string
+		assertError assert.ErrorAssertionFunc
+		raw         string
+		addr        *TopoAddr
 	}{
 		{
-			name: "No addresses",
-			err:  errAtLeastOnePub,
-			ram:  make(jsontopo.NATSCIONAddressMap),
-			addr: nil,
+			name:        "No addresses",
+			assertError: assert.Error,
+			raw:         "",
 		},
 		{
-			name: "IPv4 invalid address",
-			err:  errInvalidPub,
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv4": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "foo",
-							L4Port: 42,
-						},
-					},
-				},
-			},
-			addr: nil,
+			name:        "IPvX invalid address",
+			assertError: assert.Error,
+			raw:         "foo:42",
 		},
 		{
-			name: "IPv4 empty address",
-			err:  errInvalidPub,
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv4": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "",
-							L4Port: 42,
-						},
-					},
-				},
-			},
-			addr: nil,
+			name:        "IPv4 invalid port",
+			assertError: assert.Error,
+			raw:         "127.0.0.1:bar",
 		},
 		{
-			name: "IPv6 address in IPv4 property",
-			err:  errInvalidPub,
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv4": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "2001:db8:f00:b43::1",
-							L4Port: 42,
-						},
-					},
-				},
-			},
-			addr: nil,
-		},
-		{
-			name: "IPv4 address in IPv6 property",
-			err:  errInvalidPub,
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv6": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "192.168.1.1",
-							L4Port: 42,
-						},
-					},
-				},
-			},
-			addr: nil,
-		},
-		{
-			name: "IPv6 invalid address",
-			err:  errInvalidPub,
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv6": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "foo",
-							L4Port: 42,
-						},
-					},
-				},
-			},
-			addr: nil,
-		},
-		{
-			name: "IPv6 empty address",
-			err:  errInvalidPub,
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv6": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "",
-							L4Port: 42,
-						},
-					},
-				},
-			},
-			addr: nil,
-		},
-		{
-			name: "IPv4 good address",
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv4": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "192.168.1.1",
-							L4Port: 42,
-						},
-					},
-				},
-			},
+			name:        "IPv4 good address",
+			assertError: assert.NoError,
+			raw:         "192.168.1.1:42",
 			addr: &TopoAddr{
 				SCIONAddress: &net.UDPAddr{
 					IP:   net.IP{192, 168, 1, 1},
@@ -865,40 +518,9 @@ func TestRawAddrMap_ToTopoAddr(t *testing.T) {
 			},
 		},
 		{
-			name: "IPv6 good address",
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv6": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "2001:db8:f00:b43::1",
-							L4Port: 42,
-						},
-					},
-				},
-			},
-			addr: &TopoAddr{
-				SCIONAddress: &net.UDPAddr{
-					IP:   net.ParseIP("2001:db8:f00:b43::1"),
-					Port: 42,
-				},
-				UnderlayAddress: &net.UDPAddr{
-					IP:   net.ParseIP("2001:db8:f00:b43::1"),
-					Port: 30041,
-				},
-			},
-		},
-		{
-			name: "IPv6 good address with zone",
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv6": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "2001:db8:f00:b43::1%some-zone",
-							L4Port: 42,
-						},
-					},
-				},
-			},
+			name:        "IPv6 good address with zone",
+			assertError: assert.NoError,
+			raw:         "[2001:db8:f00:b43::1%some-zone]:42",
 			addr: &TopoAddr{
 				SCIONAddress: &net.UDPAddr{
 					IP:   net.ParseIP("2001:db8:f00:b43::1"),
@@ -913,89 +535,9 @@ func TestRawAddrMap_ToTopoAddr(t *testing.T) {
 			},
 		},
 		{
-			name: "IPv4 with bind",
-			err:  errBindNotSupported,
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv4": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "192.168.1.1",
-							L4Port: 42,
-						},
-					},
-					Bind: &jsontopo.Address{},
-				},
-			},
-			addr: nil,
-		},
-		{
-			name: "IPv6 with bind",
-			err:  errBindNotSupported,
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv6": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "2001:db8:f00:b43::1",
-							L4Port: 42,
-						},
-					},
-					Bind: &jsontopo.Address{},
-				},
-			},
-			addr: nil,
-		},
-		{
-			name: "IPv4 with custom underlay",
-			err:  errCustomUnderlayPort,
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv4": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "192.168.1.1",
-							L4Port: 42,
-						},
-						UnderlayPort: 73,
-					},
-				},
-			},
-			addr: nil,
-		},
-		{
-			name: "IPv6 with custom underlay",
-			err:  errCustomUnderlayPort,
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv6": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "2001:db8:f00:b43::1",
-							L4Port: 42,
-						},
-						UnderlayPort: 73,
-					},
-				},
-			},
-			addr: nil,
-		},
-		{
-			name: "IPv4 with IPv6",
-			ram: jsontopo.NATSCIONAddressMap{
-				"IPv4": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "192.168.1.1",
-							L4Port: 42,
-						},
-					},
-				},
-				"IPv6": &jsontopo.NATSCIONAddress{
-					Public: jsontopo.FullSCIONAddress{
-						Address: jsontopo.Address{
-							Addr:   "2001:db8:f00:b43::1",
-							L4Port: 42,
-						},
-					},
-				},
-			},
+			name:        "IPv6",
+			assertError: assert.NoError,
+			raw:         "[2001:db8:f00:b43::1]:42",
 			addr: &TopoAddr{
 				SCIONAddress: &net.UDPAddr{
 					IP:   net.ParseIP("2001:db8:f00:b43::1"),
@@ -1010,11 +552,9 @@ func TestRawAddrMap_ToTopoAddr(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			topoAddr, err := RawAddrMapToTopoAddr(tc.ram)
-			xtest.AssertErrorsIs(t, err, tc.err)
-			if tc.err == nil {
-				assert.Equal(t, tc.addr, topoAddr)
-			}
+			topoAddr, err := RawAddrToTopoAddr(tc.raw)
+			tc.assertError(t, err)
+			assert.Equal(t, tc.addr, topoAddr)
 		})
 	}
 }

--- a/python/topology/docker.py
+++ b/python/topology/docker.py
@@ -117,7 +117,7 @@ class DockerGenerator(object):
                 self.dc_conf['networks'][net_name]['enable_ipv6'] = True
 
     def _br_conf(self, topo_id, topo, base):
-        for k, _ in topo.get("BorderRouters", {}).items():
+        for k, _ in topo.get("border_routers", {}).items():
             disp_id = k
             entry = {
                 'image': docker_image(self.args, 'border'),
@@ -156,7 +156,7 @@ class DockerGenerator(object):
             self.dc_conf['services']['scion_%s' % k] = entry
 
     def _control_service_conf(self, topo_id, topo, base):
-        for k, v in topo.get("ControlService", {}).items():
+        for k, v in topo.get("control_service", {}).items():
             entry = {
                 'image': docker_image(self.args, 'cs'),
                 'container_name': self.prefix + k,
@@ -190,7 +190,7 @@ class DockerGenerator(object):
                 self._logs_vol()
             ]
         }
-        keys = list(topo.get("BorderRouters", {})) + list(topo.get("ControlService", {}))
+        keys = list(topo.get("border_routers", {})) + list(topo.get("control_service", {}))
         for disp_id in keys:
             entry = copy.deepcopy(base_entry)
             net_key = disp_id

--- a/python/topology/prometheus.py
+++ b/python/topology/prometheus.py
@@ -28,8 +28,7 @@ from lib.defines import DOCKER_COMPOSE_CONFIG_VERSION, PROM_FILE
 from lib.util import write_file
 from topology.common import (
     ArgsTopoDicts,
-    prom_addr_br,
-    prom_addr_infra,
+    prom_addr,
     prom_addr_dispatcher,
     sciond_ip,
 )
@@ -76,11 +75,12 @@ class PrometheusGenerator(object):
         config_dict = {}
         for topo_id, as_topo in self.args.topo_dicts.items():
             ele_dict = defaultdict(list)
-            for br_id, br_ele in as_topo["BorderRouters"].items():
-                ele_dict["BorderRouters"].append(prom_addr_br(br_id, br_ele, DEFAULT_BR_PROM_PORT))
-            for elem_id, elem in as_topo["ControlService"].items():
-                prom_addr = prom_addr_infra(self.args.docker, elem_id, elem, CS_PROM_PORT)
-                ele_dict["ControlService"].append(prom_addr)
+            for br_id, br_ele in as_topo["border_routers"].items():
+                a = prom_addr(br_ele["internal_addr"], DEFAULT_BR_PROM_PORT)
+                ele_dict["BorderRouters"].append(a)
+            for elem_id, elem in as_topo["control_service"].items():
+                a = prom_addr(elem["addr"], CS_PROM_PORT)
+                ele_dict["ControlService"].append(a)
             if self.args.docker:
                 host_dispatcher = prom_addr_dispatcher(self.args.docker, topo_id,
                                                        self.args.networks, DISP_PROM_PORT, "")

--- a/python/topology/supervisor.py
+++ b/python/topology/supervisor.py
@@ -62,14 +62,14 @@ class SupervisorGenerator(object):
 
     def _br_entries(self, topo, cmd, base):
         entries = []
-        for k, v in topo.get("BorderRouters", {}).items():
+        for k, v in topo.get("border_routers", {}).items():
             conf = os.path.join(base, k, BR_CONFIG_NAME)
             entries.append((k, [cmd, "-config", conf]))
         return entries
 
     def _control_service_entries(self, topo, base):
         entries = []
-        for k, v in topo.get("ControlService", {}).items():
+        for k, v in topo.get("control_service", {}).items():
             # only a single control service instance per AS is currently supported
             if k.endswith("-1"):
                 conf = os.path.join(base, k, CS_CONFIG_NAME)


### PR DESCRIPTION
This is a BREAKING CHANGE.
The topology format is simplified quite a bit:
- Only allow single address per service.
- Port and IP is merged in the same field.
- Remove/rename overlay -> underlay. (remove where not needed, rename where appropriate).
- Remove TTL, it's not needed anymore.
- Convert to snake_case

Fixes #2923

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3741)
<!-- Reviewable:end -->
