### PR TITLE
topo: allow marshalling RWTopology

### DIFF
--- a/go/lib/infra/modules/itopo/BUILD.bazel
+++ b/go/lib/infra/modules/itopo/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//go/lib/common:go_default_library",
         "//go/lib/infra/modules/itopo/internal/metrics:go_default_library",
         "//go/lib/log:go_default_library",
+        "//go/lib/scrypto/trc:go_default_library",
         "//go/lib/serrors:go_default_library",
         "//go/lib/topology:go_default_library",
         "//go/proto:go_default_library",

--- a/go/lib/infra/modules/itopo/validate.go
+++ b/go/lib/infra/modules/itopo/validate.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/scrypto/trc"
 	"github.com/scionproto/scion/go/lib/serrors"
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/proto"
@@ -89,7 +90,7 @@ func (v *generalValidator) Immutable(topo, oldTopo *topology.RWTopology) error {
 		return common.NewBasicError("IA is immutable", nil,
 			"expected", oldTopo.IA, "actual", topo.IA)
 	}
-	if !topo.Attributes.Equal(oldTopo.Attributes) {
+	if !trc.Attributes(topo.Attributes).Equal(trc.Attributes(oldTopo.Attributes)) {
 		return common.NewBasicError("Attributes are immutable", nil,
 			"expected", oldTopo.Attributes, "actual", topo.Attributes)
 	}

--- a/go/lib/topology/interface.go
+++ b/go/lib/topology/interface.go
@@ -204,7 +204,7 @@ func (t *topologyS) MakeHostInfos(st proto.ServiceType) []net.UDPAddr {
 }
 
 func (t *topologyS) Core() bool {
-	return t.Topology.Attributes.Contains(trc.Core)
+	return trc.Attributes(t.Topology.Attributes).Contains(trc.Core)
 }
 
 func (t *topologyS) BR(name string) (BRInfo, bool) {

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -59,7 +59,7 @@ type (
 	RWTopology struct {
 		Timestamp  time.Time
 		IA         addr.IA
-		Attributes trc.Attributes
+		Attributes []trc.Attribute
 		MTU        int
 
 		BR        map[string]BRInfo
@@ -225,7 +225,8 @@ func (t *RWTopology) populateBR(raw *jsontopo.Topology) error {
 				return err
 			}
 			ifinfo.LinkType = LinkTypeFromString(rawIntf.LinkTo)
-			if err = ifinfo.CheckLinks(t.Attributes.Contains(trc.Core), name); err != nil {
+			isCore := trc.Attributes(t.Attributes).Contains(trc.Core)
+			if err = ifinfo.CheckLinks(isCore, name); err != nil {
 				return err
 			}
 			// These fields are only necessary for the border router.


### PR DESCRIPTION
Change the `Attributes` field type to []trc.Attribute in order to
allow marshalling the RWTopology for non-primary ASes.

fixes #3745

With the X509 style certificates, the `trc` package will eventually be removed, and we need to revisit this to have a clean solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3746)
<!-- Reviewable:end -->
