### PR TITLE
ci: clean shutdown

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -100,6 +100,7 @@ steps:
     - ./scion.sh run && sleep 10
     - ./bin/cert_req_integration -log.console warn
     - ./bin/pp_integration -log.console warn
+    - false
     - ./bin/scmp_integration -log.console warn
     - ./bin/end2end_integration -log.console warn
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -79,7 +79,7 @@ steps:
       - ./integration/revocation_test.sh
     key: revocation_tests
     plugins:
-      - scionproto/metahook#0.3.0:
+      - scionproto/metahook#v0.3.0:
           post-command: |
             echo "--- Shutting down SCION topology"
             ./scion.sh stop
@@ -102,7 +102,7 @@ steps:
     - ./bin/scmp_integration -log.console warn
     - ./bin/end2end_integration -log.console warn
     plugins:
-      - scionproto/metahook#0.3.0:
+      - scionproto/metahook#v0.3.0:
           post-command: |
             echo "--- Shutting down SCION topology"
             ./scion.sh stop
@@ -126,7 +126,7 @@ steps:
     - ./bin/scmp_integration -d -log.console warn
     - ./bin/end2end_integration -d -log.console warn
     plugins:
-      - scionproto/metahook#0.3.0:
+      - scionproto/metahook#v0.3.0:
           post-command: |
             echo "--- Shutting down SCION topology"
             ./scion.sh stop
@@ -148,7 +148,7 @@ steps:
     - sleep 10
     - ./bin/end2end_integration -d -log.console warn
     plugins:
-      - scionproto/metahook#0.3.0:
+      - scionproto/metahook#v0.3.0:
           post-command: |
             echo "--- Shutting down SCION topology"
             ./scion.sh stop

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -79,7 +79,12 @@ steps:
       - ./integration/revocation_test.sh
     key: revocation_tests
     plugins:
-      - scionproto/scion#v0.1.0: {}
+      - improbable-eng/metahook#0.3.0:
+          post-command: |
+            echo "--- Shutting down SCION topology"
+            ./scion.sh stop
+            echo "SCION topology successfully shut down"
+
     artifact_paths:
       - "artifacts.out/**/*"
     retry:
@@ -98,7 +103,12 @@ steps:
     - ./bin/scmp_integration -log.console warn
     - ./bin/end2end_integration -log.console warn
     plugins:
-      - scionproto/scion#v0.1.0: {}
+      - improbable-eng/metahook#0.3.0:
+          post-command: |
+            echo "--- Shutting down SCION topology"
+            ./scion.sh stop
+            echo "SCION topology successfully shut down"
+
     artifact_paths:
       - "artifacts.out/**/*"
     timeout_in_minutes: 10
@@ -118,7 +128,12 @@ steps:
     - ./bin/scmp_integration -d -log.console warn
     - ./bin/end2end_integration -d -log.console warn
     plugins:
-      - scionproto/scion#v0.1.0: {}
+      - improbable-eng/metahook#0.3.0:
+          post-command: |
+            echo "--- Shutting down SCION topology"
+            ./scion.sh stop
+            echo "SCION topology successfully shut down"
+
     artifact_paths:
       - "artifacts.out/**/*"
     timeout_in_minutes: 10
@@ -136,7 +151,12 @@ steps:
     - sleep 10
     - ./bin/end2end_integration -d -log.console warn
     plugins:
-      - scionproto/scion#v0.1.0: {}
+      - improbable-eng/metahook#0.3.0:
+          post-command: |
+            echo "--- Shutting down SCION topology"
+            ./scion.sh stop
+            echo "SCION topology successfully shut down"
+
     artifact_paths:
       - "artifacts.out/**/*"
     timeout_in_minutes: 10

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -79,12 +79,11 @@ steps:
       - ./integration/revocation_test.sh
     key: revocation_tests
     plugins:
-      - improbable-eng/metahook#0.3.0:
+      - scionproto/metahook#0.3.0:
           post-command: |
             echo "--- Shutting down SCION topology"
             ./scion.sh stop
             echo "SCION topology successfully shut down"
-
     artifact_paths:
       - "artifacts.out/**/*"
     retry:
@@ -100,16 +99,14 @@ steps:
     - ./scion.sh run && sleep 10
     - ./bin/cert_req_integration -log.console warn
     - ./bin/pp_integration -log.console warn
-    - false
     - ./bin/scmp_integration -log.console warn
     - ./bin/end2end_integration -log.console warn
     plugins:
-      - improbable-eng/metahook#0.3.0:
+      - scionproto/metahook#0.3.0:
           post-command: |
             echo "--- Shutting down SCION topology"
             ./scion.sh stop
             echo "SCION topology successfully shut down"
-
     artifact_paths:
       - "artifacts.out/**/*"
     timeout_in_minutes: 10
@@ -129,12 +126,11 @@ steps:
     - ./bin/scmp_integration -d -log.console warn
     - ./bin/end2end_integration -d -log.console warn
     plugins:
-      - improbable-eng/metahook#0.3.0:
+      - scionproto/metahook#0.3.0:
           post-command: |
             echo "--- Shutting down SCION topology"
             ./scion.sh stop
             echo "SCION topology successfully shut down"
-
     artifact_paths:
       - "artifacts.out/**/*"
     timeout_in_minutes: 10
@@ -152,12 +148,11 @@ steps:
     - sleep 10
     - ./bin/end2end_integration -d -log.console warn
     plugins:
-      - improbable-eng/metahook#0.3.0:
+      - scionproto/metahook#0.3.0:
           post-command: |
             echo "--- Shutting down SCION topology"
             ./scion.sh stop
             echo "SCION topology successfully shut down"
-
     artifact_paths:
       - "artifacts.out/**/*"
     timeout_in_minutes: 10

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,6 +78,8 @@ steps:
       - ./bin/end2end_integration -log.console warn
       - ./integration/revocation_test.sh
     key: revocation_tests
+    plugins:
+      - scionproto/scion#v0.1.0: {}
     artifact_paths:
       - "artifacts.out/**/*"
     retry:
@@ -95,6 +97,8 @@ steps:
     - ./bin/pp_integration -log.console warn
     - ./bin/scmp_integration -log.console warn
     - ./bin/end2end_integration -log.console warn
+    plugins:
+      - scionproto/scion#v0.1.0: {}
     artifact_paths:
       - "artifacts.out/**/*"
     timeout_in_minutes: 10
@@ -113,6 +117,8 @@ steps:
     - ./bin/pp_integration -d -log.console warn
     - ./bin/scmp_integration -d -log.console warn
     - ./bin/end2end_integration -d -log.console warn
+    plugins:
+      - scionproto/scion#v0.1.0: {}
     artifact_paths:
       - "artifacts.out/**/*"
     timeout_in_minutes: 10
@@ -129,6 +135,8 @@ steps:
     - docker-compose -f gen/scion-dc.yml -p scion up -d $(docker-compose -f gen/scion-dc.yml config --services | grep tester)
     - sleep 10
     - ./bin/end2end_integration -d -log.console warn
+    plugins:
+      - scionproto/scion#v0.1.0: {}
     artifact_paths:
       - "artifacts.out/**/*"
     timeout_in_minutes: 10

--- a/scion.sh
+++ b/scion.sh
@@ -35,7 +35,6 @@ cmd_topology() {
     if is_docker_be; then
         ./tools/quiet ./tools/dc run utils_chowner
     fi
-    run_jaeger
     #FIXME(lukedirtwalker): Re-enalbe for v2 trust: load_cust_keys
     if [ ! -e "gen-certs/tls.pem" -o ! -e "gen-certs/tls.key" ]; then
         local old=$(umask)
@@ -121,6 +120,8 @@ run_setup() {
     local sciond_dir="/run/shm/sciond"
     [ -d "$sciond_dir" ] || mkdir "$sciond_dir"
     [ $(stat -c "%U" "$sciond_dir") == "$LOGNAME" ] || { sudo -p "Fixing ownership of $sciond_dir - [sudo] password for %p: " chown $LOGNAME: "$sciond_dir"; }
+
+    run_jaeger
 }
 
 cmd_stop() {
@@ -130,6 +131,7 @@ cmd_stop() {
     else
         ./tools/quiet ./supervisor/supervisor.sh stop all
     fi
+    stop_jaeger
     if [ "$1" = "clean" ]; then
         python/integration/set_ipv6_addr.py -d
     fi


### PR DESCRIPTION
This PR adds the SCION buildkite plugin that does a clean shutdown of
the topology after the command.

Additionally, jaeger is started and stopped with `./scion.sh {run,stop}`
such that it is included in the clean shutdown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3749)
<!-- Reviewable:end -->
