### PR TITLE
staticinfo extension, only add if configured

### DIFF
--- a/go/cs/beaconing/extender.go
+++ b/go/cs/beaconing/extender.go
@@ -66,8 +66,6 @@ func (s *segExtender) extend(pseg *seg.PathSegment, inIfid, egIfid common.IFIDTy
 	if err != nil {
 		return err
 	}
-	staticInfoPeers := createPeerMap(s.cfg)
-	staticInfo := GenerateStaticinfo(s.cfg.StaticInfoCfg, staticInfoPeers, egIfid, inIfid)
 	meta := s.cfg.Signer.Meta()
 	asEntry := &seg.ASEntry{
 		RawIA:      meta.Src.IA.IAInt(),
@@ -77,7 +75,11 @@ func (s *segExtender) extend(pseg *seg.PathSegment, inIfid, egIfid common.IFIDTy
 		MTU:        s.cfg.MTU,
 		HopEntries: hopEntries,
 	}
-	asEntry.Exts.StaticInfo = &staticInfo
+	if s.cfg.StaticInfoCfg != nil {
+		staticInfoPeers := createPeerMap(s.cfg)
+		staticInfo := s.cfg.StaticInfoCfg.generateStaticinfo(staticInfoPeers, egIfid, inIfid)
+		asEntry.Exts.StaticInfo = &staticInfo
+	}
 	if err := pseg.AddASEntry(asEntry, s.cfg.Signer); err != nil {
 		return err
 	}

--- a/go/cs/beaconing/extender_config.go
+++ b/go/cs/beaconing/extender_config.go
@@ -45,7 +45,7 @@ type ExtenderConf struct {
 	// task contains an identifier specific to the task that uses the extender.
 	task string
 	// StaticInfoCfg contains the Configdata used for the StaticInfo Extension.
-	StaticInfoCfg StaticInfoCfg
+	StaticInfoCfg *StaticInfoCfg
 }
 
 // InitDefaults initializes the default values, if not set.

--- a/go/cs/beaconing/staticinfo_config.go
+++ b/go/cs/beaconing/staticinfo_config.go
@@ -1,3 +1,17 @@
+// Copyright 2020 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package beaconing
 
 import (

--- a/go/cs/beaconing/staticinfo_config.go
+++ b/go/cs/beaconing/staticinfo_config.go
@@ -188,31 +188,31 @@ func (cfgdata StaticInfoCfg) gatherGeo() seg.GeoInfo {
 }
 
 // ParseStaticInfoCfg parses data from a config file into a StaticInfoCfg struct.
-func ParseStaticInfoCfg(file string) (StaticInfoCfg, error) {
+func ParseStaticInfoCfg(file string) (*StaticInfoCfg, error) {
 	raw, err := ioutil.ReadFile(file)
 	if err != nil {
-		return StaticInfoCfg{}, serrors.WrapStr("failed to read static info config: ",
+		return nil, serrors.WrapStr("failed to read static info config: ",
 			err, "file", file)
 	}
 	var cfg StaticInfoCfg
 	if err := json.Unmarshal(raw, &cfg); err != nil {
-		return StaticInfoCfg{}, serrors.WrapStr("failed to parse static info config: ",
+		return nil, serrors.WrapStr("failed to parse static info config: ",
 			err, "file ", file)
 	}
-	return cfg, nil
+	return &cfg, nil
 }
 
-// GenerateStaticinfo creates a StaticinfoExtn struct and
+// generateStaticinfo creates a StaticinfoExtn struct and
 // populates it with data extracted from configdata.
-func GenerateStaticinfo(configdata StaticInfoCfg, peers map[common.IFIDType]struct{},
+func (cfgdata StaticInfoCfg) generateStaticinfo(peers map[common.IFIDType]struct{},
 	egifID common.IFIDType, inifID common.IFIDType) seg.StaticInfoExtn {
 
 	return seg.StaticInfoExtn{
-		Latency:   configdata.gatherLatency(peers, egifID, inifID),
-		Bandwidth: configdata.gatherBW(peers, egifID, inifID),
-		Linktype:  configdata.gatherLinkType(peers, egifID),
-		Geo:       configdata.gatherGeo(),
-		Note:      configdata.Note,
-		Hops:      configdata.gatherHops(peers, egifID, inifID),
+		Latency:   cfgdata.gatherLatency(peers, egifID, inifID),
+		Bandwidth: cfgdata.gatherBW(peers, egifID, inifID),
+		Linktype:  cfgdata.gatherLinkType(peers, egifID),
+		Geo:       cfgdata.gatherGeo(),
+		Note:      cfgdata.Note,
+		Hops:      cfgdata.gatherHops(peers, egifID, inifID),
 	}
 }

--- a/go/cs/beaconing/staticinfo_config_test.go
+++ b/go/cs/beaconing/staticinfo_config_test.go
@@ -202,7 +202,7 @@ func TestGenerateStaticinfo(t *testing.T) {
 			Note: "asdf",
 		},
 	}
-	actual := GenerateStaticinfo(test.configData,
+	actual := test.configData.generateStaticinfo(
 		test.peers, test.egIfid, test.inIfid)
 	assert.Equal(t, test.expected.Latency.Egresslatency,
 		actual.Latency.Egresslatency)

--- a/go/cs/beaconing/staticinfo_config_test.go
+++ b/go/cs/beaconing/staticinfo_config_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package beaconing
 
 import (
@@ -9,8 +23,8 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
 )
 
-func getTestConfigData() StaticInfoCfg {
-	return StaticInfoCfg{
+func getTestConfigData() *StaticInfoCfg {
+	return &StaticInfoCfg{
 		Latency: map[common.IFIDType]InterfaceLatencies{
 			1: {
 				Inter: 30,
@@ -99,7 +113,7 @@ func TestParsing(t *testing.T) {
 // TestGenerateStaticinfo tests whether or not GenerateStaticinfo works properly.
 func TestGenerateStaticinfo(t *testing.T) {
 	test := struct {
-		configData StaticInfoCfg
+		configData *StaticInfoCfg
 		peers      map[common.IFIDType]struct{}
 		egIfid     common.IFIDType
 		inIfid     common.IFIDType

--- a/go/cs/main.go
+++ b/go/cs/main.go
@@ -79,7 +79,7 @@ import (
 var (
 	cfg config.Config
 
-	staticInfoCfg beaconing.StaticInfoCfg
+	staticInfoCfg *beaconing.StaticInfoCfg
 
 	intfs *ifstate.Interfaces
 	tasks *periodicTasks

--- a/go/lib/ctrl/seg/staticinfo_extn.go
+++ b/go/lib/ctrl/seg/staticinfo_extn.go
@@ -1,3 +1,17 @@
+// Copyright 2020 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package seg
 
 import "github.com/scionproto/scion/go/lib/common"


### PR DESCRIPTION
Currently static info was always added to the beacons even if there was no configuration,
This PR changes this behavior to only add static info if there is a configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3755)
<!-- Reviewable:end -->
