### PR TITLE
topogen: enable console logging

### DIFF
--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -307,6 +307,8 @@ class GoGenerator(object):
                 'level': self.log_level,
             },
         }
+        if self.args.docker:
+            entry['console'] = {'level': self.log_level}
         return entry
 
     def _metrics_entry(self, infra_elem, base_port):


### PR DESCRIPTION
With #3751 the log collection is broken on CI.

This is a workaround that logs to console in a docker topology, such
that the logs are not lost on CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3757)
<!-- Reviewable:end -->
