### PR TITLE
Remove obsolete limit on path segments in SegReply

### DIFF
--- a/go/cs/segreq/helpers.go
+++ b/go/cs/segreq/helpers.go
@@ -42,50 +42,21 @@ func (c *CoreChecker) IsCore(ctx context.Context, ia addr.IA) (bool, error) {
 
 func segsToRecs(ctx context.Context, segs segfetcher.Segments) []*seg.Meta {
 	logger := log.FromCtx(ctx)
-	lup, lcore, ldown := limit(len(segs.Up), len(segs.Core), len(segs.Down), 9)
 	recs := make([]*seg.Meta, 0, len(segs.Up)+len(segs.Core)+len(segs.Down))
-	for i := range segs.Up {
-		if i == lup {
-			break
-		}
-		s := segs.Up[i]
+	for _, s := range segs.Up {
 		logger.Trace(fmt.Sprintf("[segReqHandler:collectSegs] up %v -> %v",
 			s.FirstIA(), s.LastIA()), "seg", s.GetLoggingID())
 		recs = append(recs, seg.NewMeta(s, proto.PathSegType_up))
 	}
-	for i := range segs.Core {
-		if i == lcore {
-			break
-		}
-		s := segs.Core[i]
+	for _, s := range segs.Core {
 		logger.Trace(fmt.Sprintf("[segReqHandler:collectSegs] core %v -> %v",
 			s.FirstIA(), s.LastIA()), "seg", s.GetLoggingID())
 		recs = append(recs, seg.NewMeta(s, proto.PathSegType_core))
 	}
-	for i := range segs.Down {
-		if i == ldown {
-			break
-		}
-		s := segs.Down[i]
+	for _, s := range segs.Down {
 		logger.Trace(fmt.Sprintf("[segReqHandler:collectSegs] down %v -> %v",
 			s.FirstIA(), s.LastIA()), "seg", s.GetLoggingID())
 		recs = append(recs, seg.NewMeta(s, proto.PathSegType_down))
 	}
 	return recs
-}
-
-// XXX(roosd): Dirty hack to avoid exceeding jumbo frames until quic is implemented.
-// Revert tainted code after quic is implemented.
-func limit(upSegs, coreSegs, downSegs, all int) (int, int, int) {
-	for upSegs+coreSegs+downSegs > all {
-		switch {
-		case upSegs >= coreSegs && upSegs >= downSegs:
-			upSegs--
-		case coreSegs >= upSegs && coreSegs >= downSegs:
-			coreSegs--
-		default:
-			downSegs--
-		}
-	}
-	return upSegs, coreSegs, downSegs
 }


### PR DESCRIPTION
An arbitrary limit to 9 path segments in a SegReply was implemented some time ago as a hack to avoid exceeding MTU. This is no longer necessary as QUIC is now used as transport for these path segment requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3765)
<!-- Reviewable:end -->
