### PR TITLE
sciond: don't panic on shutdown

### DIFF
--- a/go/cs/main.go
+++ b/go/cs/main.go
@@ -168,7 +168,6 @@ func realMain() int {
 		Port: nc.Public.Port,
 		Zone: nc.Public.Zone,
 	})
-	defer tcpMsgr.CloseServer()
 
 	trustDB, err := cfg.TrustDB.New()
 	if err != nil {
@@ -313,6 +312,7 @@ func realMain() int {
 		defer log.HandlePanic()
 		tcpMsgr.ListenAndServe()
 	}()
+	defer tcpMsgr.CloseServer()
 
 	dispatcherService := reliable.NewDispatcher("")
 	if cfg.General.ReconnectToDispatcher {

--- a/go/lib/infra/messenger/tcp/messenger.go
+++ b/go/lib/infra/messenger/tcp/messenger.go
@@ -213,6 +213,9 @@ func (m *Messenger) ListenAndServe() {
 }
 
 func (m *Messenger) CloseServer() error {
+	if m.listener == nil {
+		return nil
+	}
 	return m.listener.Close()
 }
 

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -109,7 +109,6 @@ func realMain() int {
 	}
 
 	msger := tcp.NewClientMessenger(tcp.Client{TopologyProvider: itopo.Provider()})
-	defer msger.CloseServer()
 
 	trustDB, err := cfg.TrustDB.New()
 	if err != nil {


### PR DESCRIPTION
SCIOND runs a tcp-messenger in client mode. There was a superfluous
deferred `CloseServer` call that panicked on shutdown.

Changes:
- Remove deferred `CloseServer` call on tcp-messenger in client mode
- Don't panic when calling `CloseServer` on a tcp-messenger with nil listener
- Move deferred `CloseServer` call in CS to the appropriate place

fixes #3766

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3769)
<!-- Reviewable:end -->
