### PR TITLE
fix nil pointer panic in rpc backoff logic

### DIFF
--- a/go/lib/infra/rpc/rpc.go
+++ b/go/lib/infra/rpc/rpc.go
@@ -160,6 +160,7 @@ func (c *Client) Request(ctx context.Context, request *Request, address net.Addr
 		select {
 		case <-time.After(sleep + time.Duration(mrand.Int()%5000)*time.Microsecond):
 		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
 

--- a/go/lib/infra/rpc/rpc.go
+++ b/go/lib/infra/rpc/rpc.go
@@ -163,7 +163,7 @@ func (c *Client) Request(ctx context.Context, request *Request, address net.Addr
 		}
 	}
 	if ctx.Err() != nil {
-		return nil, err
+		return nil, ctx.Err()
 	}
 
 	stream, err := session.OpenStream()

--- a/go/lib/infra/rpc/rpc.go
+++ b/go/lib/infra/rpc/rpc.go
@@ -160,8 +160,10 @@ func (c *Client) Request(ctx context.Context, request *Request, address net.Addr
 		select {
 		case <-time.After(sleep + time.Duration(mrand.Int()%5000)*time.Microsecond):
 		case <-ctx.Done():
-			return nil, ctx.Err()
 		}
+	}
+	if ctx.Err() != nil {
+		return nil, err
 	}
 
 	stream, err := session.OpenStream()


### PR DESCRIPTION
If we don't get a session within the context we should error out instead of trying to OpenStream on a nil session.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3770)
<!-- Reviewable:end -->
