### PR TITLE
remove unused path resolver from snet.NewNetwork

### DIFF
--- a/go/border/rctrl/ctrl.go
+++ b/go/border/rctrl/ctrl.go
@@ -53,7 +53,7 @@ func Control(sRevInfoQ chan rpkt.RawSRevCallbackArgs, dispatcherReconnect bool) 
 	if dispatcherReconnect {
 		dispatcherService = reconnect.NewDispatcherService(dispatcherService)
 	}
-	scionNetwork := snet.NewCustomNetworkWithPR(ia,
+	scionNetwork := snet.NewCustomNetwork(ia,
 		&snet.DefaultPacketDispatcherService{
 			Dispatcher: dispatcherService,
 		},

--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -229,10 +229,7 @@ func (c *client) run() {
 	if err != nil {
 		LogFatal("Unable to initialize SCION network", "err", err)
 	}
-	network := snet.NewNetworkWithPR(local.IA, ds, sd.Querier{
-		Connector: sciondConn,
-		IA:        local.IA,
-	}, sd.RevHandler{Connector: sciondConn})
+	network := snet.NewNetwork(local.IA, ds, sd.RevHandler{Connector: sciondConn})
 
 	// Connect to remote address. Note that currently the SCION library
 	// does not support automatic binding to local addresses, so the local
@@ -352,10 +349,7 @@ func (s server) run() {
 	if err != nil {
 		LogFatal("Unable to initialize SCION network", "err", err)
 	}
-	network := snet.NewNetworkWithPR(local.IA, ds, &sd.Querier{
-		Connector: sciondConn,
-		IA:        local.IA,
-	}, sd.RevHandler{Connector: sciondConn})
+	network := snet.NewNetwork(local.IA, ds, sd.RevHandler{Connector: sciondConn})
 	if err != nil {
 		LogFatal("Unable to initialize SCION network", "err", err)
 	}

--- a/go/integration/common.go
+++ b/go/integration/common.go
@@ -109,10 +109,7 @@ func InitNetwork() *snet.SCIONNetwork {
 	if err != nil {
 		LogFatal("Unable to initialize SCION network", "err", err)
 	}
-	n := snet.NewNetworkWithPR(Local.IA, ds, sciond.Querier{
-		Connector: sciondConn,
-		IA:        Local.IA,
-	}, sciond.RevHandler{Connector: sciondConn})
+	n := snet.NewNetwork(Local.IA, ds, sciond.RevHandler{Connector: sciondConn})
 	log.Debug("SCION network successfully initialized")
 	return n
 }

--- a/go/lib/infra/infraenv/infraenv.go
+++ b/go/lib/infra/infraenv/infraenv.go
@@ -195,7 +195,7 @@ func (nc *NetworkConfig) initUDPSocket(quicAddress string) (net.PacketConn, erro
 			ExpectedPayload: resolutionRequestPayload,
 		},
 	)
-	network := snet.NewCustomNetworkWithPR(nc.IA, packetDispatcher)
+	network := snet.NewCustomNetwork(nc.IA, packetDispatcher)
 	conn, err := network.Listen(context.Background(), "udp", nc.Public, nc.SVC)
 	if err != nil {
 		return nil, common.NewBasicError("Unable to listen on SCION", err)
@@ -209,7 +209,7 @@ func (nc *NetworkConfig) initQUICSocket() (net.PacketConn, error) {
 		dispatcherService = reconnect.NewDispatcherService(dispatcherService)
 	}
 
-	network := snet.NewCustomNetworkWithPR(nc.IA,
+	network := snet.NewCustomNetwork(nc.IA,
 		&snet.DefaultPacketDispatcherService{
 			Dispatcher:  dispatcherService,
 			SCMPHandler: ignoreSCMP{},

--- a/go/lib/sciond/pathprobe/paths.go
+++ b/go/lib/sciond/pathprobe/paths.go
@@ -110,7 +110,7 @@ func (p Prober) GetStatuses(ctx context.Context,
 	// the path is alive.
 	pathStatuses := make(map[string]Status, len(paths))
 	scmpH := &scmpHandler{statuses: pathStatuses}
-	network := snet.NewCustomNetworkWithPR(p.LocalIA,
+	network := snet.NewCustomNetwork(p.LocalIA,
 		&snet.DefaultPacketDispatcherService{
 			Dispatcher:  reliable.NewDispatcher(""),
 			SCMPHandler: scmpH,

--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -62,12 +62,12 @@ type Conn struct {
 	scionConnReader
 }
 
-func newConn(base *scionConnBase, querier PathQuerier, conn PacketConn) *Conn {
+func newConn(base *scionConnBase, conn PacketConn) *Conn {
 	c := &Conn{
 		conn:          conn,
 		scionConnBase: *base,
 	}
-	c.scionConnWriter = *newScionConnWriter(&c.scionConnBase, querier, conn)
+	c.scionConnWriter = *newScionConnWriter(&c.scionConnBase, conn)
 	c.scionConnReader = *newScionConnReader(&c.scionConnBase, conn)
 	return c
 }

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -60,16 +60,12 @@ var _ Network = (*SCIONNetwork)(nil)
 // SCIOND, Dispatcher and Path resolver.
 type SCIONNetwork struct {
 	dispatcher PacketDispatcherService
-	// pathResolver references the default source of paths for a Network. This
-	// is set to nil when operating on a SCIOND-less Network.
-	querier PathQuerier
-	localIA addr.IA
+	localIA    addr.IA
 }
 
-// NewNetworkWithPR creates a new networking context with path resolver pr. A
-// nil path resolver means the Network will run without SCIOND.
-func NewNetworkWithPR(ia addr.IA, dispatcher reliable.Dispatcher,
-	querier PathQuerier, revHandler RevocationHandler) *SCIONNetwork {
+// NewNetwork creates a new networking context.
+func NewNetwork(ia addr.IA, dispatcher reliable.Dispatcher,
+	revHandler RevocationHandler) *SCIONNetwork {
 
 	return &SCIONNetwork{
 		dispatcher: &DefaultPacketDispatcherService{
@@ -78,14 +74,13 @@ func NewNetworkWithPR(ia addr.IA, dispatcher reliable.Dispatcher,
 				revocationHandler: revHandler,
 			},
 		},
-		querier: querier,
 		localIA: ia,
 	}
 }
 
-// NewCustomNetworkWithPR is similar to NewNetworkWithPR, while giving control
-// over packet processing via pktDispatcher.
-func NewCustomNetworkWithPR(ia addr.IA, pktDispatcher PacketDispatcherService) *SCIONNetwork {
+// NewCustomNetwork is similar to NewNetwork, while giving control over packet
+// processing via pktDispatcher.
+func NewCustomNetwork(ia addr.IA, pktDispatcher PacketDispatcherService) *SCIONNetwork {
 
 	return &SCIONNetwork{
 		dispatcher: pktDispatcher,
@@ -163,5 +158,5 @@ func (n *SCIONNetwork) Listen(ctx context.Context, network string, listen *net.U
 		conn.listen.Port = int(port)
 	}
 	log.Debug("Registered with dispatcher", "addr", &UDPAddr{IA: n.localIA, Host: conn.listen})
-	return newConn(conn, n.querier, packetConn), nil
+	return newConn(conn, packetConn), nil
 }

--- a/go/lib/snet/writer.go
+++ b/go/lib/snet/writer.go
@@ -36,8 +36,7 @@ type scionConnWriter struct {
 	buffer common.RawBytes
 }
 
-func newScionConnWriter(base *scionConnBase, querier PathQuerier,
-	conn PacketConn) *scionConnWriter {
+func newScionConnWriter(base *scionConnBase, conn PacketConn) *scionConnWriter {
 
 	return &scionConnWriter{
 		base:   base,

--- a/go/sig/internal/sigcmn/common.go
+++ b/go/sig/internal/sigcmn/common.go
@@ -102,10 +102,7 @@ func initNetworkWithFakeSCIOND(cfg sigconfig.SigConf,
 		return nil, nil, serrors.WrapStr("unable to initialize fake SCIOND service", err)
 	}
 	pathResolver := pathmgr.New(sciondConn, pathmgr.Timers{}, sdCfg.PathCount)
-	network := snet.NewNetworkWithPR(cfg.IA, Dispatcher, &snetmigrate.PathQuerier{
-		Resolver: pathResolver,
-		IA:       cfg.IA,
-	}, pathResolver)
+	network := snet.NewNetwork(cfg.IA, Dispatcher, pathResolver)
 	return network, pathResolver, nil
 }
 
@@ -118,10 +115,7 @@ func initNetworkWithRealSCIOND(cfg sigconfig.SigConf,
 	for tries := 0; time.Now().Before(deadline); tries++ {
 		resolver, err := snetmigrate.ResolverFromSD(sdCfg.Address, sdCfg.PathCount)
 		if err == nil {
-			return snet.NewNetworkWithPR(cfg.IA, Dispatcher, &snetmigrate.PathQuerier{
-				Resolver: resolver,
-				IA:       cfg.IA,
-			}, resolver), resolver, nil
+			return snet.NewNetwork(cfg.IA, Dispatcher, resolver), resolver, nil
 		}
 		log.Debug("SIG is retrying to get NewNetwork", "err", err)
 		retErr = err


### PR DESCRIPTION
Remove unused `querier` from `snet.NewNetworkWithPR`.  Rename `snet.NewNetworkWithPR` to `snet.NewNetwork` and `snet.NewCustomNetworkWithPR` to `snet.NewCustomNetwork`, accordingly.

This is an API breaking change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3771)
<!-- Reviewable:end -->
