### PR TITLE
topology: replace 'foo' in the tests with a hostname that fails

### DIFF
--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -377,7 +377,7 @@ func TestExternalDataPlanePort(t *testing.T) {
 			Name: "Bad invalid public",
 			Raw: &jsontopo.BRInterface{
 				Underlay: jsontopo.Underlay{
-					Public: "foo:42",
+					Public: "thishostdoesnotexist:42",
 				},
 			},
 			ExpectedError: assert.Error,
@@ -414,7 +414,7 @@ func TestExternalDataPlanePort(t *testing.T) {
 			Raw: &jsontopo.BRInterface{
 				Underlay: jsontopo.Underlay{
 					Public: "127.0.0.1:42",
-					Bind:   "foo",
+					Bind:   "thishostdoesnotexist",
 				},
 			},
 			ExpectedError: assert.Error,
@@ -465,7 +465,7 @@ func TestExternalDataPlanePort(t *testing.T) {
 			Raw: &jsontopo.BRInterface{
 				Underlay: jsontopo.Underlay{
 					Public: "[::1]:42",
-					Bind:   "foo",
+					Bind:   "thishostdoesnotexist",
 				},
 			},
 			ExpectedError: assert.Error,
@@ -495,7 +495,7 @@ func TestRawAddrMap_ToTopoAddr(t *testing.T) {
 		{
 			name:        "IPvX invalid address",
 			assertError: assert.Error,
-			raw:         "foo:42",
+			raw:         "thishostdoesnotexist:42",
 		},
 		{
 			name:        "IPv4 invalid port",


### PR DESCRIPTION
`foo` is used in a test to represent a name that will fail to resolve. But it
works sometimes (e.g. in the ETH). Change it to some more weird name so
it fails resolving it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3786)
<!-- Reviewable:end -->
