### PR TITLE
COLIBRI backend continuation

### DIFF
--- a/go/cs/reservation/BUILD.bazel
+++ b/go/cs/reservation/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -12,5 +12,15 @@ go_library(
         "//go/lib/colibri/reservation:go_default_library",
         "//go/lib/serrors:go_default_library",
         "//go/lib/spath:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["index_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/lib/colibri/reservation:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/cs/reservation/e2e/index.go
+++ b/go/cs/reservation/e2e/index.go
@@ -27,7 +27,7 @@ type Index struct {
 	Idx        reservation.IndexNumber
 	Expiration time.Time
 	AllocBW    reservation.BWCls // also present in the token
-	Token      reservation.Token
+	Token      *reservation.Token
 }
 
 type Indices []Index
@@ -37,3 +37,5 @@ var _ base.IndicesInterface = (*Indices)(nil)
 func (idxs Indices) Len() int                                     { return len(idxs) }
 func (idxs Indices) GetIndexNumber(i int) reservation.IndexNumber { return idxs[i].Idx }
 func (idxs Indices) GetExpiration(i int) time.Time                { return idxs[i].Expiration }
+func (idxs Indices) GetAllocBW(i int) reservation.BWCls           { return idxs[i].AllocBW }
+func (idxs Indices) GetToken(i int) *reservation.Token            { return idxs[i].Token }

--- a/go/cs/reservation/index_test.go
+++ b/go/cs/reservation/index_test.go
@@ -1,0 +1,150 @@
+// Copyright 2020 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reservation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/go/lib/colibri/reservation"
+)
+
+func TestValidateIndices(t *testing.T) {
+	idxs := make(Indices, 0)
+	// up to 3 indices per expiration time
+	expTime := time.Unix(1, 0)
+	idx, err := idxs.NewIndex(expTime)
+	require.NoError(t, err)
+	require.Equal(t, reservation.IndexNumber(0), idx)
+	idx, err = idxs.NewIndex(expTime)
+	require.NoError(t, err)
+	require.Equal(t, reservation.IndexNumber(1), idx)
+	idx, err = idxs.NewIndex(expTime)
+	require.NoError(t, err)
+	require.Equal(t, reservation.IndexNumber(2), idx)
+	idxs = idxs[:1]
+	// exp time is less
+	_, err = idxs.NewIndex(expTime.Add(-1 * time.Millisecond))
+	require.Error(t, err)
+	require.Len(t, idxs, 1)
+	// exp time is same
+	idx, err = idxs.NewIndex(expTime)
+	require.NoError(t, err)
+	require.Len(t, idxs, 2)
+	require.True(t, idxs[1].Idx == idx)
+	require.True(t, idxs[1].Expiration == expTime)
+	require.Equal(t, reservation.IndexNumber(1), idx)
+	idx, err = idxs.NewIndex(expTime)
+	require.NoError(t, err)
+	require.Len(t, idxs, 3)
+	require.True(t, idxs[2].Idx == idx)
+	require.True(t, idxs[2].Expiration == expTime)
+	require.Equal(t, reservation.IndexNumber(2), idx)
+	// too many indices for the same exp time
+	_, err = idxs.NewIndex(expTime)
+	require.Error(t, err)
+	require.Len(t, idxs, 3)
+	// exp time is greater
+	expTime = expTime.Add(time.Second)
+	idx, err = idxs.NewIndex(expTime)
+	require.NoError(t, err)
+	require.Len(t, idxs, 4)
+	require.True(t, idxs[3].Idx == idx)
+	require.True(t, idxs[3].Expiration == expTime)
+	require.Equal(t, reservation.IndexNumber(3), idx)
+	// index number rollover
+	idxs = Indices{}
+	idxs.NewIndex(expTime)
+	require.Len(t, idxs, 1)
+	idxs[0].Idx = idxs[0].Idx.Sub(1)
+	idx, err = idxs.NewIndex(expTime)
+	require.NoError(t, err)
+	require.True(t, idxs[1].Idx == idx)
+	require.True(t, idxs[1].Expiration == expTime)
+	require.Equal(t, reservation.IndexNumber(0), idx)
+	// more than 16 indices
+	idxs = Indices{}
+	for i := 0; i < 16; i++ {
+		expTime := time.Unix(int64(i), 0)
+		_, err = idxs.NewIndex(expTime)
+		require.NoError(t, err)
+	}
+	require.Len(t, idxs, 16)
+	_, err = idxs.NewIndex(expTime.Add(time.Hour))
+	require.Error(t, err)
+	// exp time is before
+	idxs = Indices{}
+	expTime = time.Unix(1, 0)
+	idxs.NewIndex(expTime)
+	idxs.NewIndex(expTime)
+	idxs[1].Expiration = expTime.Add(-1 * time.Second)
+	err = ValidateIndices(idxs)
+	require.Error(t, err)
+	// non consecutive indices
+	idxs = Indices{}
+	expTime = time.Unix(1, 0)
+	idxs.NewIndex(expTime)
+	idxs.NewIndex(expTime)
+	idxs[1].Idx = 2
+	err = ValidateIndices(idxs)
+	require.Error(t, err)
+	// more than three indices per exp time
+	idxs = Indices{}
+	idxs.NewIndex(expTime)
+	idxs.NewIndex(expTime)
+	idxs.NewIndex(expTime)
+	require.Len(t, idxs, 3)
+	err = ValidateIndices(idxs)
+	require.NoError(t, err)
+	_, err = idxs.NewIndex(expTime)
+	require.Error(t, err)
+}
+
+type Index struct {
+	Idx        reservation.IndexNumber
+	Expiration time.Time
+}
+
+type Indices []Index
+
+var _ IndicesInterface = (*Indices)(nil)
+
+func (idxs Indices) Len() int                                     { return len(idxs) }
+func (idxs Indices) GetIndexNumber(i int) reservation.IndexNumber { return idxs[i].Idx }
+func (idxs Indices) GetExpiration(i int) time.Time                { return idxs[i].Expiration }
+func (idxs Indices) GetAllocBW(i int) reservation.BWCls           { return reservation.BWCls(0) }
+func (idxs Indices) GetToken(i int) *reservation.Token            { return nil }
+
+func (idxs *Indices) NewIndex(expTime time.Time) (reservation.IndexNumber, error) {
+	idx := reservation.IndexNumber(0)
+	if len(*idxs) > 0 {
+		idx = (*idxs)[len(*idxs)-1].Idx.Add(1)
+	}
+	index := Index{
+		Idx:        idx,
+		Expiration: expTime,
+	}
+	newIndices := make(Indices, len(*idxs)+1)
+	copy(newIndices, *idxs)
+	newIndices[len(newIndices)-1] = index
+	err := ValidateIndices(newIndices)
+	if err != nil {
+		return reservation.IndexNumber(0), err
+	}
+	*idxs = newIndices
+	return idx, nil
+}

--- a/go/cs/reservation/reservationdbtest/BUILD.bazel
+++ b/go/cs/reservation/reservationdbtest/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//go/cs/reservation/segment:go_default_library",
         "//go/cs/reservation/segmenttest:go_default_library",
         "//go/cs/reservationstorage/backend:go_default_library",
+        "//go/lib/addr:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",

--- a/go/cs/reservation/reservationdbtest/BUILD.bazel
+++ b/go/cs/reservation/reservationdbtest/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//go/cs/reservationstorage/backend:go_default_library",
         "//go/lib/addr:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
+        "//go/lib/common:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/go/cs/reservation/reservationdbtest/BUILD.bazel
+++ b/go/cs/reservation/reservationdbtest/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//go/cs/reservation/segment:go_default_library",
         "//go/cs/reservation/segmenttest:go_default_library",
         "//go/cs/reservationstorage/backend:go_default_library",
+        "//go/lib/colibri/reservation:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/go/cs/reservation/reservationdbtest/reservationdbtest.go
+++ b/go/cs/reservation/reservationdbtest/reservationdbtest.go
@@ -53,7 +53,6 @@ func TestDB(t *testing.T, db TestableDB) {
 func testNewSegmentRsv(ctx context.Context, t *testing.T, db backend.DB) {
 	r := newTestReservation(t)
 	r.Indices = segment.Indices{}
-	ctx := context.Background()
 	// no indices
 	err := db.NewSegmentRsv(ctx, r)
 	require.Error(t, err)
@@ -68,11 +67,10 @@ func testNewSegmentRsv(ctx context.Context, t *testing.T, db backend.DB) {
 	require.Equal(t, *token, r.Indices[0].Token)
 }
 
-func testNewSegmentRsvWithID(t *testing.T, db backend.DB) {
+func testNewSegmentRsvWithID(ctx context.Context, t *testing.T, db backend.DB) {
 	r := newTestReservation(t)
 	copy(r.ID.Suffix[:], xtest.MustParseHexString("beefcafe"))
 	r.Indices = segment.Indices{}
-	ctx := context.Background()
 	// no indices
 	err := db.NewSegmentRsvWithID(ctx, r)
 	require.Error(t, err)
@@ -88,10 +86,9 @@ func testNewSegmentRsvWithID(t *testing.T, db backend.DB) {
 	require.Equal(t, r, r2)
 }
 
-func testNewSegmentIndex(t *testing.T, db backend.DB) {
+func testNewSegmentIndex(ctx context.Context, t *testing.T, db backend.DB) {
 	r := newTestReservation(t)
 	r.Indices = segment.Indices{}
-	ctx := context.Background()
 	// no index
 	err := db.NewSegmentRsv(ctx, r)
 	require.Error(t, err)
@@ -121,9 +118,8 @@ func testNewSegmentIndex(t *testing.T, db backend.DB) {
 	require.Equal(t, r, r2)
 }
 
-func testGetSegmentRsvFromID(t *testing.T, db backend.DB) {
+func testGetSegmentRsvFromID(ctx context.Context, t *testing.T, db backend.DB) {
 	r := newTestReservation(t)
-	ctx := context.Background()
 	err := db.NewSegmentRsv(ctx, r)
 	require.NoError(t, err)
 	// create new index
@@ -155,9 +151,8 @@ func testGetSegmentRsvFromID(t *testing.T, db backend.DB) {
 	require.Equal(t, r, r2)
 }
 
-func testGetSegmentRsvsFromSrcDstIA(t *testing.T, db backend.DB) {
+func testGetSegmentRsvsFromSrcDstIA(ctx context.Context, t *testing.T, db backend.DB) {
 	r := newTestReservation(t)
-	ctx := context.Background()
 	err := db.NewSegmentRsv(ctx, r)
 	require.NoError(t, err)
 	rsvs, err := db.GetSegmentRsvsFromSrcDstIA(ctx, r.Path.GetSrcIA(), r.Path.GetDstIA())
@@ -188,11 +183,10 @@ func newToken() *reservation.Token {
 func newTestReservation(t *testing.T) *segment.Reservation {
 	t.Helper()
 	r := segment.NewReservation()
-	p := segmenttest.NewPathFromComponents(0, "1-ff00:0:1", 1, 1, "1-ff00:0:2", 0)
-	r.Path = &p
+	r.Path = segmenttest.NewPathFromComponents(0, "1-ff00:0:1", 1, 1, "1-ff00:0:2", 0)
 	r.ID.ASID = xtest.MustParseAS("ff00:0:1")
-	r.IngressIFID = 0
-	r.EgressIFID = 1
+	r.Ingress = 0
+	r.Egress = 1
 	r.TrafficSplit = 3
 	r.PathEndProps = reservation.EndLocal | reservation.StartLocal
 	expTime := time.Unix(1, 0)

--- a/go/cs/reservation/reservationdbtest/reservationdbtest.go
+++ b/go/cs/reservation/reservationdbtest/reservationdbtest.go
@@ -164,6 +164,7 @@ func testGetSegmentRsvFromID(ctx context.Context, t *testing.T, db backend.DB) {
 
 func testGetSegmentRsvsFromSrcDstIA(ctx context.Context, t *testing.T, db backend.DB) {
 	r := newTestReservation(t)
+	r.Path = segmenttest.NewPathFromComponents(0, "1-ff00:0:1", 1, 1, "1-ff00:0:2", 0)
 	err := db.NewSegmentRsv(ctx, r)
 	require.NoError(t, err)
 	rsvs, err := db.GetSegmentRsvsFromSrcDstIA(ctx, r.Path.GetSrcIA(), r.Path.GetDstIA())
@@ -172,6 +173,7 @@ func testGetSegmentRsvsFromSrcDstIA(ctx context.Context, t *testing.T, db backen
 	require.Equal(t, r, rsvs[0])
 	// another reservation with same source and destination
 	r2 := newTestReservation(t)
+	r2.Path = segmenttest.NewPathFromComponents(0, "1-ff00:0:1", 1, 2, "1-ff00:0:2", 0)
 	err = db.NewSegmentRsv(ctx, r2)
 	require.NoError(t, err)
 	rsvs, err = db.GetSegmentRsvsFromSrcDstIA(ctx, r.Path.GetSrcIA(), r.Path.GetDstIA())
@@ -246,7 +248,7 @@ func newToken() *reservation.Token {
 func newTestReservation(t *testing.T) *segment.Reservation {
 	t.Helper()
 	r := segment.NewReservation()
-	r.Path = segmenttest.NewPathFromComponents(0, "1-ff00:0:1", 1, 1, "1-ff00:0:2", 0)
+	r.Path = segment.Path{}
 	r.ID.ASID = xtest.MustParseAS("ff00:0:1")
 	r.Ingress = 0
 	r.Egress = 1

--- a/go/cs/reservation/reservationdbtest/reservationdbtest.go
+++ b/go/cs/reservation/reservationdbtest/reservationdbtest.go
@@ -78,6 +78,15 @@ func testNewSegmentRsv(ctx context.Context, t *testing.T, db backend.DB) {
 	// same path should fail
 	err = db.NewSegmentRsv(ctx, r)
 	require.Error(t, err)
+	// different ASID should start with the lowest suffix
+	r = newTestReservation(t)
+	r.ID.ASID = xtest.MustParseAS("ff00:1234:1")
+	err = db.NewSegmentRsv(ctx, r)
+	require.NoError(t, err)
+	require.Equal(t, xtest.MustParseHexString("00000001"), r.ID.Suffix[:])
+	rsv, err = db.GetSegmentRsvFromID(ctx, &r.ID)
+	require.NoError(t, err)
+	require.Equal(t, r, rsv)
 }
 
 func testPersistSegmentRsv(ctx context.Context, t *testing.T, db backend.DB) {

--- a/go/cs/reservation/reservationdbtest/reservationdbtest.go
+++ b/go/cs/reservation/reservationdbtest/reservationdbtest.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/go/cs/reservation/segment"
+	"github.com/scionproto/scion/go/cs/reservation/segmenttest"
 	"github.com/scionproto/scion/go/cs/reservationstorage/backend"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
 	"github.com/scionproto/scion/go/lib/xtest"
@@ -36,6 +37,7 @@ func TestDB(t *testing.T, db TestableDB) {
 	tests := map[string]func(context.Context, *testing.T, backend.DB){
 		"insert segment reservations create ID": testNewSegmentRsv,
 		"insert segment index":                  testNewSegmentIndex,
+		"get segment reservation from ID":       testGetSegmentRsvFromID,
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -65,26 +67,88 @@ func testNewSegmentRsv(ctx context.Context, t *testing.T, db backend.DB) {
 
 func testNewSegmentIndex(ctx context.Context, t *testing.T, db backend.DB) {
 	r := segment.NewReservation()
-	db.NewSegmentRsv(ctx, r)
-	expTime := time.Unix(1, 0)
-	_, err := r.NewIndex(expTime, *newToken())
-	r.Indices[0].Token.BWCls = 2
+
+	p := segmenttest.NewPathFromComponents(0, "1-ff00:0:1", 1, 1, "1-ff00:0:2", 0)
+	r.Path = &p
+	r.ID.ASID = xtest.MustParseAS("ff00:0:1")
+	r.IngressIFID = 1
+	r.EgressIFID = 2
+	r.TrafficSplit = 3
+	r.PathEndProps = reservation.EndLocal | reservation.EndTransfer | reservation.StartLocal
 	ctx := context.Background()
+	// no index
+	err := db.NewSegmentRsv(ctx, r)
+	require.Error(t, err)
+	// one index (add 3, remove 2 to change its IndexNumber)
+	expTime := time.Unix(1, 0)
+	_, err = r.NewIndex(expTime, *newToken())
+	require.NoError(t, err)
+	_, err = r.NewIndex(expTime, *newToken())
+	require.NoError(t, err)
+	_, err = r.NewIndex(expTime, *newToken())
+	require.NoError(t, err)
+	err = r.RemoveIndex(1)
+	require.NoError(t, err)
+	require.Len(t, r.Indices, 1)
+	r.SetIndexConfirmed(reservation.IndexNumber(2))
+	err = r.SetIndexConfirmed(2)
+	require.NoError(t, err)
+	r.Indices[0].MinBW = 3
+	r.Indices[0].MaxBW = 4
+	r.Indices[0].AllocBW = 5
+	r.Indices[0].Token.BWCls = 2
 	err = db.NewSegmentRsv(ctx, r)
 	require.NoError(t, err)
-	// create new index
-	idx, err := r.NewIndex(expTime, *newToken())
-	r.Indices[1].Token.BWCls = 3
-	require.NoError(t, err)
-	err = db.NewSegmentIndex(ctx, r, idx)
-	require.NoError(t, err)
+	// read the reservation
 	r2, err := db.GetSegmentRsvFromID(ctx, &r.ID)
 	require.NoError(t, err)
 	require.Equal(t, r, r2)
 }
 
 func testGetSegmentRsvFromID(t *testing.T, db backend.DB) {
-
+	r := segment.NewReservation()
+	p := segmenttest.NewPathFromComponents(0, "1-ff00:0:1", 1, 1, "1-ff00:0:2", 0)
+	r.Path = &p
+	r.ID.ASID = xtest.MustParseAS("ff00:0:1")
+	r.IngressIFID = 1
+	r.EgressIFID = 2
+	r.TrafficSplit = 3
+	r.PathEndProps = reservation.EndLocal | reservation.StartLocal
+	expTime := time.Unix(1, 0)
+	_, err := r.NewIndex(expTime, *newToken())
+	require.NoError(t, err)
+	r.Indices[0].Token.BWCls = 2
+	err = r.SetIndexConfirmed(0)
+	require.NoError(t, err)
+	ctx := context.Background()
+	err = db.NewSegmentRsv(ctx, r)
+	require.NoError(t, err)
+	// create new index
+	idx, err := r.NewIndex(expTime, *newToken())
+	require.NoError(t, err)
+	r.Indices[1].Token.BWCls = 3
+	err = db.NewSegmentIndex(ctx, r, idx)
+	require.NoError(t, err)
+	r2, err := db.GetSegmentRsvFromID(ctx, &r.ID)
+	require.NoError(t, err)
+	require.Equal(t, r, r2)
+	// 14 more indices for a total of 16
+	require.Len(t, r.Indices, 2)
+	for i := 2; i < 16; i++ {
+		expTime = time.Unix(int64(i), 0)
+		idx, err = r.NewIndex(expTime, *newToken())
+		require.NoError(t, err)
+		r.Indices[i].MinBW = reservation.BWCls(i)
+		r.Indices[i].MaxBW = reservation.BWCls(i)
+		r.Indices[i].AllocBW = reservation.BWCls(i)
+		r.Indices[i].Token.BWCls = reservation.BWCls(i)
+		err = db.NewSegmentIndex(ctx, r, idx)
+		require.NoError(t, err)
+	}
+	require.Len(t, r.Indices, 16)
+	r2, err = db.GetSegmentRsvFromID(ctx, &r.ID)
+	require.NoError(t, err)
+	require.Equal(t, r, r2)
 }
 
 // newToken just returns a token that can be serialized. This one has two HopFields.

--- a/go/cs/reservation/reservationdbtest/reservationdbtest.go
+++ b/go/cs/reservation/reservationdbtest/reservationdbtest.go
@@ -143,10 +143,10 @@ func testGetSegmentRsvFromID(ctx context.Context, t *testing.T, db backend.DB) {
 	require.NoError(t, err)
 	// create new index
 	expTime := time.Unix(1, 0)
-	idx, err := r.NewIndex(expTime, *newToken())
+	_, err = r.NewIndex(expTime, *newToken())
 	require.NoError(t, err)
 	r.Indices[1].Token.BWCls = 3
-	err = db.NewSegmentIndex(ctx, r, idx)
+	err = db.PersistSegmentRsv(ctx, r)
 	require.NoError(t, err)
 	r2, err := db.GetSegmentRsvFromID(ctx, &r.ID)
 	require.NoError(t, err)
@@ -155,16 +155,16 @@ func testGetSegmentRsvFromID(ctx context.Context, t *testing.T, db backend.DB) {
 	require.Len(t, r.Indices, 2)
 	for i := 2; i < 16; i++ {
 		expTime = time.Unix(int64(i), 0)
-		idx, err = r.NewIndex(expTime, *newToken())
+		_, err = r.NewIndex(expTime, *newToken())
 		require.NoError(t, err)
 		r.Indices[i].MinBW = reservation.BWCls(i)
 		r.Indices[i].MaxBW = reservation.BWCls(i)
 		r.Indices[i].AllocBW = reservation.BWCls(i)
 		r.Indices[i].Token.BWCls = reservation.BWCls(i)
-		err = db.NewSegmentIndex(ctx, r, idx)
-		require.NoError(t, err)
 	}
 	require.Len(t, r.Indices, 16)
+	err = db.PersistSegmentRsv(ctx, r)
+	require.NoError(t, err)
 	r2, err = db.GetSegmentRsvFromID(ctx, &r.ID)
 	require.NoError(t, err)
 	require.Equal(t, r, r2)

--- a/go/cs/reservation/reservationdbtest/reservationdbtest.go
+++ b/go/cs/reservation/reservationdbtest/reservationdbtest.go
@@ -278,7 +278,7 @@ func testGetSegmentRsvsFromIFPair(ctx context.Context, t *testing.T, db backend.
 	require.NoError(t, err)
 	require.Len(t, rsvs, 0)
 	// bad query
-	rsvs, err = db.GetSegmentRsvsFromIFPair(ctx, nil, nil)
+	_, err = db.GetSegmentRsvsFromIFPair(ctx, nil, nil)
 	require.Error(t, err)
 }
 

--- a/go/cs/reservation/segment/BUILD.bazel
+++ b/go/cs/reservation/segment/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//go/cs/reservation:go_default_library",
         "//go/cs/reservation/segmenttest:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
         "//go/lib/common:go_default_library",

--- a/go/cs/reservation/segment/BUILD.bazel
+++ b/go/cs/reservation/segment/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "export_test.go",
+        "index_test.go",
         "path_test.go",
         "request_test.go",
         "reservation_test.go",

--- a/go/cs/reservation/segment/index.go
+++ b/go/cs/reservation/segment/index.go
@@ -69,7 +69,7 @@ type Index struct {
 	MinBW      reservation.BWCls
 	MaxBW      reservation.BWCls
 	AllocBW    reservation.BWCls
-	Token      reservation.Token
+	Token      *reservation.Token
 }
 
 // NewIndex creates a new Index without yet linking it to any reservation.
@@ -82,7 +82,7 @@ func NewIndex(idx reservation.IndexNumber, expiration time.Time, state IndexStat
 		MinBW:      minBW,
 		MaxBW:      maxBW,
 		AllocBW:    allocBW,
-		Token:      *token,
+		Token:      token,
 	}
 }
 
@@ -99,6 +99,8 @@ var _ base.IndicesInterface = (*Indices)(nil)
 func (idxs Indices) Len() int                                     { return len(idxs) }
 func (idxs Indices) GetIndexNumber(i int) reservation.IndexNumber { return idxs[i].Idx }
 func (idxs Indices) GetExpiration(i int) time.Time                { return idxs[i].Expiration }
+func (idxs Indices) GetAllocBW(i int) reservation.BWCls           { return idxs[i].AllocBW }
+func (idxs Indices) GetToken(i int) *reservation.Token            { return idxs[i].Token }
 
 // Sort sorts these Indices according to their index number modulo 16, e.g. [14, 15, 0, 1].
 func (idxs *Indices) Sort() {

--- a/go/cs/reservation/segment/index.go
+++ b/go/cs/reservation/segment/index.go
@@ -100,13 +100,16 @@ func (idxs Indices) Len() int                                     { return len(i
 func (idxs Indices) GetIndexNumber(i int) reservation.IndexNumber { return idxs[i].Idx }
 func (idxs Indices) GetExpiration(i int) time.Time                { return idxs[i].Expiration }
 
-// Sort sorts these Indices.
+// Sort sorts these Indices according to their index number modulo 16, e.g. [14, 15, 0, 1].
 func (idxs *Indices) Sort() {
 	if len(*idxs) < 2 {
 		return
 	}
 	sort.Slice(*idxs, func(i, j int) bool {
-		return (*idxs)[i].Idx < (*idxs)[j].Idx
+		a, b := (*idxs)[i], (*idxs)[j]
+		distance := b.Idx.Sub(a.Idx)
+		return a.Expiration.Before(b.Expiration) ||
+			(a.Expiration.Equal(b.Expiration) && distance < 3)
 	})
 	// find a discontinuity and rotate
 	i := 1

--- a/go/cs/reservation/segment/index.go
+++ b/go/cs/reservation/segment/index.go
@@ -15,6 +15,7 @@
 package segment
 
 import (
+	"sort"
 	"time"
 
 	base "github.com/scionproto/scion/go/cs/reservation"
@@ -71,6 +72,20 @@ type Index struct {
 	Token      reservation.Token
 }
 
+// NewIndex creates a new Index without yet linking it to any reservation.
+func NewIndex(idx reservation.IndexNumber, expiration time.Time, state IndexState,
+	minBW, maxBW, allocBW reservation.BWCls, token *reservation.Token) *Index {
+	return &Index{
+		Idx:        idx,
+		Expiration: expiration,
+		state:      state,
+		MinBW:      minBW,
+		MaxBW:      maxBW,
+		AllocBW:    allocBW,
+		Token:      *token,
+	}
+}
+
 // State returns the read-only state.
 func (index *Index) State() IndexState {
 	return index.state
@@ -84,3 +99,21 @@ var _ base.IndicesInterface = (*Indices)(nil)
 func (idxs Indices) Len() int                                     { return len(idxs) }
 func (idxs Indices) GetIndexNumber(i int) reservation.IndexNumber { return idxs[i].Idx }
 func (idxs Indices) GetExpiration(i int) time.Time                { return idxs[i].Expiration }
+
+// Sort sorts these Indices.
+func (idxs *Indices) Sort() {
+	if len(*idxs) < 2 {
+		return
+	}
+	sort.Slice(*idxs, func(i, j int) bool {
+		return (*idxs)[i].Idx < (*idxs)[j].Idx
+	})
+	// find a discontinuity and rotate
+	i := 1
+	for ; i < len(*idxs); i++ {
+		if (*idxs)[i-1].Idx.Add(1) != (*idxs)[i].Idx.Add(0) {
+			break
+		}
+	}
+	*idxs = append((*idxs)[i:], (*idxs)[:i]...)
+}

--- a/go/cs/reservation/segment/index_test.go
+++ b/go/cs/reservation/segment/index_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	base "github.com/scionproto/scion/go/cs/reservation"
 	"github.com/scionproto/scion/go/cs/reservation/segment"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
 )
@@ -54,8 +55,10 @@ func TestIndicesSort(t *testing.T) {
 func newIndices(idxs ...int) segment.Indices {
 	indices := make(segment.Indices, len(idxs))
 	for i, idx := range idxs {
-		idx := segment.NewIndex(reservation.IndexNumber(idx), time.Unix(1, 0), segment.IndexPending,
-			reservation.BWCls(1), reservation.BWCls(1), reservation.BWCls(1), &reservation.Token{})
+		expTime := time.Unix(int64(i/3+1), 0)
+		idx := segment.NewIndex(reservation.IndexNumber(idx), expTime,
+			segment.IndexPending, reservation.BWCls(1), reservation.BWCls(1), reservation.BWCls(1),
+			&reservation.Token{})
 		indices[i] = *idx
 	}
 	return indices
@@ -63,10 +66,7 @@ func newIndices(idxs ...int) segment.Indices {
 
 func checkIndicesSorted(t *testing.T, idxs segment.Indices) {
 	t.Helper()
-	if len(idxs) < 2 {
-		return
-	}
-	for i := 1; i < len(idxs); i++ {
-		require.Equal(t, idxs[i-1].Idx.Add(1), idxs[i].Idx)
-	}
+	// validate according to valid indices criteria
+	err := base.ValidateIndices(idxs)
+	require.NoError(t, err)
 }

--- a/go/cs/reservation/segment/index_test.go
+++ b/go/cs/reservation/segment/index_test.go
@@ -19,9 +19,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/scionproto/scion/go/cs/reservation/segment"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIndicesSort(t *testing.T) {

--- a/go/cs/reservation/segment/index_test.go
+++ b/go/cs/reservation/segment/index_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// package segment_test
+package segment_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/scionproto/scion/go/cs/reservation/segment"
+	"github.com/scionproto/scion/go/lib/colibri/reservation"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIndicesSort(t *testing.T) {
+	indices := newIndices(2, 3, 1)
+	indices.Sort()
+	require.Len(t, indices, 3)
+	checkIndicesSorted(t, indices)
+	// one element
+	indices = newIndices(2)
+	indices.Sort()
+	require.Len(t, indices, 1)
+	require.Equal(t, 2, int(indices[0].Idx))
+	// empty
+	indices = segment.Indices{}
+	indices.Sort()
+	require.Len(t, indices, 0)
+	// wrap around
+	indices = newIndices(0, 1, 15)
+	indices.Sort()
+	require.Len(t, indices, 3)
+	checkIndicesSorted(t, indices)
+	// full 16 elements
+	indices = newIndices(14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+	indices.Sort()
+	require.Len(t, indices, 16)
+	checkIndicesSorted(t, indices)
+}
+
+func newIndices(idxs ...int) segment.Indices {
+	indices := make(segment.Indices, len(idxs))
+	for i, idx := range idxs {
+		idx := segment.NewIndex(reservation.IndexNumber(idx), time.Unix(1, 0), segment.IndexPending,
+			reservation.BWCls(1), reservation.BWCls(1), reservation.BWCls(1), &reservation.Token{})
+		indices[i] = *idx
+	}
+	return indices
+}
+
+func checkIndicesSorted(t *testing.T, idxs segment.Indices) {
+	t.Helper()
+	if len(idxs) < 2 {
+		return
+	}
+	for i := 1; i < len(idxs); i++ {
+		require.Equal(t, idxs[i-1].Idx.Add(1), idxs[i].Idx)
+	}
+}

--- a/go/cs/reservation/segment/index_test.go
+++ b/go/cs/reservation/segment/index_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package segment_test
 package segment_test
 
 import (
@@ -58,7 +57,7 @@ func newIndices(idxs ...int) segment.Indices {
 		expTime := time.Unix(int64(i/3+1), 0)
 		idx := segment.NewIndex(reservation.IndexNumber(idx), expTime,
 			segment.IndexPending, reservation.BWCls(1), reservation.BWCls(1), reservation.BWCls(1),
-			&reservation.Token{})
+			nil)
 		indices[i] = *idx
 	}
 	return indices

--- a/go/cs/reservation/segment/path.go
+++ b/go/cs/reservation/segment/path.go
@@ -16,7 +16,9 @@ package segment
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
+	"strings"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
@@ -126,6 +128,14 @@ func (p Path) ToRaw() []byte {
 	return buff
 }
 
+func (p Path) String() string {
+	strs := make([]string, len(p))
+	for i, s := range p {
+		strs[i] = s.String()
+	}
+	return strings.Join(strs, ">")
+}
+
 // PathStep is one hop of the Path. For a source AS Ingress will be invalid. Conversely for dst.
 type PathStep struct {
 	Ingress common.IFIDType
@@ -140,3 +150,7 @@ type PathStepWithIA struct {
 
 // PathStepWithIALen amounts for Ingress+Egress+IA.
 const PathStepWithIALen = 8 + 8 + 8
+
+func (s *PathStepWithIA) String() string {
+	return fmt.Sprintf("%d %s %d", s.Ingress, s.IA.String(), s.Egress)
+}

--- a/go/cs/reservation/segment/path.go
+++ b/go/cs/reservation/segment/path.go
@@ -121,7 +121,7 @@ func (p Path) Read(buff []byte) (int, error) {
 // ToRaw returns a buffer representing this Path.
 func (p Path) ToRaw() []byte {
 	if len(p) == 0 {
-		return []byte{}
+		return nil
 	}
 	buff := make([]byte, p.Len())
 	p.Read(buff)

--- a/go/cs/reservation/segment/path_test.go
+++ b/go/cs/reservation/segment/path_test.go
@@ -174,3 +174,8 @@ func TestToFromBinary(t *testing.T) {
 	p = make(segment.Path, 0)
 	require.Empty(t, p.ToRaw())
 }
+
+func TestString(t *testing.T) {
+	p := segmenttest.NewPathFromComponents(0, "1-ff00:0:1", 1, 1, "1-ff00:0:2", 0)
+	require.Equal(t, "0 1-ff00:0:1 1>1 1-ff00:0:2 0", p.String())
+}

--- a/go/cs/reservation/segment/reservation.go
+++ b/go/cs/reservation/segment/reservation.go
@@ -114,6 +114,15 @@ func (r *Reservation) NewIndex(expTime time.Time) (reservation.IndexNumber, erro
 	return r.Indices[len(r.Indices)-1].Idx, nil
 }
 
+// Index finds the Index with that IndexNumber and returns a pointer to it.
+func (r *Reservation) Index(idx reservation.IndexNumber) (*Index, error) {
+	sliceIndex, err := base.FindIndex(r.Indices, idx)
+	if err != nil {
+		return nil, err
+	}
+	return &r.Indices[sliceIndex], nil
+}
+
 // SetIndexConfirmed sets the index as IndexPending (confirmed but not active). If the requested
 // index has state active, it will emit an error.
 func (r *Reservation) SetIndexConfirmed(idx reservation.IndexNumber) error {

--- a/go/cs/reservation/segment/reservation.go
+++ b/go/cs/reservation/segment/reservation.go
@@ -95,7 +95,9 @@ func (r *Reservation) ActiveIndex() *Index {
 
 // NewIndex creates a new index in this reservation and returns a pointer to it.
 // Parameters of this index can be changed using the pointer, except for the state.
-func (r *Reservation) NewIndex(expTime time.Time) (reservation.IndexNumber, error) {
+func (r *Reservation) NewIndex(expTime time.Time, token reservation.Token) (
+	reservation.IndexNumber, error) {
+
 	idx := reservation.IndexNumber(0)
 	if len(r.Indices) > 0 {
 		idx = r.Indices[len(r.Indices)-1].Idx.Add(1)
@@ -106,6 +108,7 @@ func (r *Reservation) NewIndex(expTime time.Time) (reservation.IndexNumber, erro
 		Expiration: expTime,
 		Idx:        idx,
 		state:      IndexTemporary,
+		Token:      token,
 	}
 	if err := base.ValidateIndices(newIndices); err != nil {
 		return 0, err

--- a/go/cs/reservation/segment/reservation.go
+++ b/go/cs/reservation/segment/reservation.go
@@ -95,6 +95,8 @@ func (r *Reservation) ActiveIndex() *Index {
 
 // NewIndex creates a new index in this reservation and returns a pointer to it.
 // Parameters of this index can be changed using the pointer, except for the state.
+// The expiration times must always be greater or equal than those in previous indices.
+// TODO(juagargi) we need two ways of creating an index: from the source AS or from transit AS.
 func (r *Reservation) NewIndex(expTime time.Time, token reservation.Token) (
 	reservation.IndexNumber, error) {
 
@@ -150,6 +152,7 @@ func (r *Reservation) SetIndexActive(idx reservation.IndexNumber) error {
 	if r.activeIndex == sliceIndex {
 		return nil // already active
 	}
+	// valid states are Pending (nominal) and Active (reconstructing from DB needs this)
 	if r.Indices[sliceIndex].state != IndexPending && r.Indices[sliceIndex].state != IndexActive {
 		return serrors.New("attempt to activate a non confirmed index", "index_number", idx,
 			"state", r.Indices[sliceIndex].state)

--- a/go/cs/reservation/segment/reservation.go
+++ b/go/cs/reservation/segment/reservation.go
@@ -97,7 +97,7 @@ func (r *Reservation) ActiveIndex() *Index {
 // Parameters of this index can be changed using the pointer, except for the state.
 // The expiration times must always be greater or equal than those in previous indices.
 // TODO(juagargi) we need two ways of creating an index: from the source AS or from transit AS.
-func (r *Reservation) NewIndex(expTime time.Time, token reservation.Token) (
+func (r *Reservation) NewIndex(expTime time.Time, token *reservation.Token) (
 	reservation.IndexNumber, error) {
 
 	idx := reservation.IndexNumber(0)

--- a/go/cs/reservation/segment/reservation.go
+++ b/go/cs/reservation/segment/reservation.go
@@ -150,7 +150,7 @@ func (r *Reservation) SetIndexActive(idx reservation.IndexNumber) error {
 	if r.activeIndex == sliceIndex {
 		return nil // already active
 	}
-	if r.Indices[sliceIndex].state != IndexPending {
+	if r.Indices[sliceIndex].state != IndexPending && r.Indices[sliceIndex].state != IndexActive {
 		return serrors.New("attempt to activate a non confirmed index", "index_number", idx,
 			"state", r.Indices[sliceIndex].state)
 	}

--- a/go/cs/reservation/segment/reservation.go
+++ b/go/cs/reservation/segment/reservation.go
@@ -93,30 +93,56 @@ func (r *Reservation) ActiveIndex() *Index {
 	return &r.Indices[r.activeIndex]
 }
 
-// NewIndex creates a new index in this reservation and returns a pointer to it.
-// Parameters of this index can be changed using the pointer, except for the state.
-// The expiration times must always be greater or equal than those in previous indices.
 // TODO(juagargi) we need two ways of creating an index: from the source AS or from transit AS.
-func (r *Reservation) NewIndex(expTime time.Time, token *reservation.Token) (
-	reservation.IndexNumber, error) {
+
+// NewIndexAtSource creates a new index. The associated token is created from the arguments, and
+// automatically linked to the index. This function should be called only from the
+// AS originating the reservation.
+// The expiration times must always be greater or equal than those in previous indices.
+func (r *Reservation) NewIndexAtSource(expTime time.Time, minBW, maxBW, allocBW reservation.BWCls,
+	rlc reservation.RLC, pathType reservation.PathType) (reservation.IndexNumber, error) {
 
 	idx := reservation.IndexNumber(0)
 	if len(r.Indices) > 0 {
 		idx = r.Indices[len(r.Indices)-1].Idx.Add(1)
 	}
+	tok := &reservation.Token{
+		InfoField: reservation.InfoField{
+			Idx:            idx,
+			ExpirationTick: reservation.TickFromTime(expTime),
+			BWCls:          allocBW,
+			RLC:            rlc,
+			PathType:       pathType,
+		},
+	}
+	index := NewIndex(idx, expTime, IndexTemporary, minBW, maxBW, allocBW, tok)
+	return r.addIndex(index)
+}
+
+// NewIndexFromToken creates a new index. The token argument is used to populate several
+// fields of the index. The token is not stored (on-path ASes don't need the token).
+// This function should be called from an AS that is on the reservation path
+// but not the originating one.
+func (r *Reservation) NewIndexFromToken(tok *reservation.Token, minBW, maxBW reservation.BWCls) (
+	reservation.IndexNumber, error) {
+
+	if tok == nil {
+		return 0, serrors.New("token is nil")
+	}
+	index := NewIndex(tok.Idx, tok.ExpirationTick.ToTime(), IndexTemporary, minBW, maxBW,
+		tok.BWCls, nil)
+	return r.addIndex(index)
+}
+
+func (r *Reservation) addIndex(index *Index) (reservation.IndexNumber, error) {
 	newIndices := make(Indices, len(r.Indices)+1)
 	copy(newIndices, r.Indices)
-	newIndices[len(newIndices)-1] = Index{
-		Expiration: expTime,
-		Idx:        idx,
-		state:      IndexTemporary,
-		Token:      token,
-	}
+	newIndices[len(newIndices)-1] = *index
 	if err := base.ValidateIndices(newIndices); err != nil {
 		return 0, err
 	}
 	r.Indices = newIndices
-	return r.Indices[len(r.Indices)-1].Idx, nil
+	return index.Idx, nil
 }
 
 // Index finds the Index with that IndexNumber and returns a pointer to it.

--- a/go/cs/reservation/segment/reservation_test.go
+++ b/go/cs/reservation/segment/reservation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/scionproto/scion/go/cs/reservation/segment"
 	"github.com/scionproto/scion/go/cs/reservation/segmenttest"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
+	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 func TestNewIndex(t *testing.T) {
@@ -30,35 +31,37 @@ func TestNewIndex(t *testing.T) {
 	r := segmenttest.NewReservation()
 	require.Len(t, r.Indices, 0)
 	expTime := time.Unix(1, 0)
-	idx, err := r.NewIndex(expTime)
+	token := newToken()
+	idx, err := r.NewIndex(expTime, *token)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 1)
-	require.True(t, r.Indices[0].Idx == idx)
-	require.True(t, r.Indices[0].Expiration == expTime)
+	require.Equal(t, idx, r.Indices[0].Idx)
+	require.Equal(t, expTime, r.Indices[0].Expiration)
+	require.Equal(t, *token, r.Indices[0].Token)
 	require.Equal(t, reservation.IndexNumber(0), idx)
 
 	// up to 3 indices per expiration time
-	idx, err = r.NewIndex(expTime)
+	idx, err = r.NewIndex(expTime, reservation.Token{})
 	require.NoError(t, err)
 	require.Equal(t, reservation.IndexNumber(1), idx)
-	idx, err = r.NewIndex(expTime)
+	idx, err = r.NewIndex(expTime, reservation.Token{})
 	require.NoError(t, err)
 	require.Equal(t, reservation.IndexNumber(2), idx)
 	r.Indices = r.Indices[:1]
 
 	// exp time is less
-	_, err = r.NewIndex(expTime.Add(-1 * time.Millisecond))
+	_, err = r.NewIndex(expTime.Add(-1*time.Millisecond), reservation.Token{})
 	require.Error(t, err)
 	require.Len(t, r.Indices, 1)
 
 	// exp time is same
-	idx, err = r.NewIndex(expTime)
+	idx, err = r.NewIndex(expTime, reservation.Token{})
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 2)
 	require.True(t, r.Indices[1].Idx == idx)
 	require.True(t, r.Indices[1].Expiration == expTime)
 	require.Equal(t, reservation.IndexNumber(1), idx)
-	idx, err = r.NewIndex(expTime)
+	idx, err = r.NewIndex(expTime, reservation.Token{})
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 3)
 	require.True(t, r.Indices[2].Idx == idx)
@@ -66,13 +69,13 @@ func TestNewIndex(t *testing.T) {
 	require.Equal(t, reservation.IndexNumber(2), idx)
 
 	// too many indices for the same exp time
-	_, err = r.NewIndex(expTime)
+	_, err = r.NewIndex(expTime, reservation.Token{})
 	require.Error(t, err)
 	require.Len(t, r.Indices, 3)
 
 	// exp time is greater
 	expTime = expTime.Add(time.Second)
-	idx, err = r.NewIndex(expTime)
+	idx, err = r.NewIndex(expTime, reservation.Token{})
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 4)
 	require.True(t, r.Indices[3].Idx == idx)
@@ -81,10 +84,10 @@ func TestNewIndex(t *testing.T) {
 
 	// index number rollover
 	r = segmenttest.NewReservation()
-	r.NewIndex(expTime)
+	r.NewIndex(expTime, reservation.Token{})
 	require.Len(t, r.Indices, 1)
 	r.Indices[0].Idx = r.Indices[0].Idx.Sub(1)
-	idx, err = r.NewIndex(expTime)
+	idx, err = r.NewIndex(expTime, reservation.Token{})
 	require.NoError(t, err)
 	require.True(t, r.Indices[1].Idx == idx)
 	require.True(t, r.Indices[1].Expiration == expTime)
@@ -98,7 +101,7 @@ func TestReservationValidate(t *testing.T) {
 	// more than 16 indices
 	for i := 0; i < 16; i++ {
 		expTime := time.Unix(int64(i), 0)
-		r.NewIndex(expTime)
+		r.NewIndex(expTime, reservation.Token{})
 	}
 	require.Len(t, r.Indices, 16)
 	err = r.Validate()
@@ -121,15 +124,15 @@ func TestReservationValidate(t *testing.T) {
 	// exp time is before
 	r = segmenttest.NewReservation()
 	expTime := time.Unix(1, 0)
-	r.NewIndex(expTime)
-	r.NewIndex(expTime)
+	r.NewIndex(expTime, reservation.Token{})
+	r.NewIndex(expTime, reservation.Token{})
 	r.Indices[1].Expiration = expTime.Add(-1 * time.Second)
 	err = r.Validate()
 	require.Error(t, err)
 
 	// non consecutive indices
 	r.Indices = r.Indices[:1] // remove tainted index
-	r.NewIndex(expTime)
+	r.NewIndex(expTime, reservation.Token{})
 	err = r.Validate()
 	require.NoError(t, err)
 	r.Indices[1].Idx = 2
@@ -138,11 +141,11 @@ func TestReservationValidate(t *testing.T) {
 
 	// more than three indices per exp time
 	r.Indices = r.Indices[:1]
-	r.NewIndex(expTime)
-	r.NewIndex(expTime)
+	r.NewIndex(expTime, reservation.Token{})
+	r.NewIndex(expTime, reservation.Token{})
 	err = r.Validate()
 	require.NoError(t, err)
-	_, err = r.NewIndex(expTime.Add(time.Second))
+	_, err = r.NewIndex(expTime.Add(time.Second), reservation.Token{})
 	require.NoError(t, err)
 	r.Indices[3].Expiration = expTime
 	r.Indices[3].Idx = 3
@@ -151,7 +154,7 @@ func TestReservationValidate(t *testing.T) {
 
 	// more than one active index
 	r.Indices = r.Indices[:1]
-	r.NewIndex(expTime)
+	r.NewIndex(expTime, reservation.Token{})
 	r.Indices[0].SetStateForTesting(segment.IndexActive)
 	r.Indices[1].SetStateForTesting(segment.IndexActive)
 	err = r.Validate()
@@ -179,9 +182,9 @@ func TestReservationValidate(t *testing.T) {
 func TestIndex(t *testing.T) {
 	r := segmenttest.NewReservation()
 	expTime := time.Unix(1, 0)
-	r.NewIndex(expTime)
-	idx, _ := r.NewIndex(expTime)
-	r.NewIndex(expTime)
+	r.NewIndex(expTime, reservation.Token{})
+	idx, _ := r.NewIndex(expTime, reservation.Token{})
+	r.NewIndex(expTime, reservation.Token{})
 	require.Len(t, r.Indices, 3)
 	index, err := r.Index(idx)
 	require.NoError(t, err)
@@ -198,7 +201,7 @@ func TestIndex(t *testing.T) {
 func TestSetIndexConfirmed(t *testing.T) {
 	r := segmenttest.NewReservation()
 	expTime := time.Unix(1, 0)
-	id, _ := r.NewIndex(expTime)
+	id, _ := r.NewIndex(expTime, reservation.Token{})
 	require.Equal(t, segment.IndexTemporary, r.Indices[0].State())
 	err := r.SetIndexConfirmed(id)
 	require.NoError(t, err)
@@ -215,7 +218,7 @@ func TestSetIndexActive(t *testing.T) {
 	expTime := time.Unix(1, 0)
 
 	// index not confirmed
-	idx, _ := r.NewIndex(expTime)
+	idx, _ := r.NewIndex(expTime, reservation.Token{})
 	err := r.SetIndexActive(idx)
 	require.Error(t, err)
 
@@ -231,8 +234,8 @@ func TestSetIndexActive(t *testing.T) {
 	require.NoError(t, err)
 
 	// remove previous indices
-	r.NewIndex(expTime)
-	idx, _ = r.NewIndex(expTime)
+	r.NewIndex(expTime, reservation.Token{})
+	idx, _ = r.NewIndex(expTime, reservation.Token{})
 	require.Len(t, r.Indices, 3)
 	require.Equal(t, 0, r.GetActiveIndexForTesting())
 	r.SetIndexConfirmed(idx)
@@ -246,14 +249,14 @@ func TestSetIndexActive(t *testing.T) {
 func TestRemoveIndex(t *testing.T) {
 	r := segmenttest.NewReservation()
 	expTime := time.Unix(1, 0)
-	idx, _ := r.NewIndex(expTime)
+	idx, _ := r.NewIndex(expTime, reservation.Token{})
 	err := r.RemoveIndex(idx)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 0)
 
 	// remove second index
-	idx, _ = r.NewIndex(expTime)
-	idx2, _ := r.NewIndex(expTime)
+	idx, _ = r.NewIndex(expTime, reservation.Token{})
+	idx2, _ := r.NewIndex(expTime, reservation.Token{})
 	err = r.RemoveIndex(idx)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 1)
@@ -263,9 +266,9 @@ func TestRemoveIndex(t *testing.T) {
 
 	// remove also removes older indices
 	expTime = expTime.Add(time.Second)
-	r.NewIndex(expTime)
-	idx, _ = r.NewIndex(expTime)
-	idx2, _ = r.NewIndex(expTime)
+	r.NewIndex(expTime, reservation.Token{})
+	idx, _ = r.NewIndex(expTime, reservation.Token{})
+	idx2, _ = r.NewIndex(expTime, reservation.Token{})
 	require.Len(t, r.Indices, 4)
 	err = r.RemoveIndex(idx)
 	require.NoError(t, err)
@@ -273,4 +276,14 @@ func TestRemoveIndex(t *testing.T) {
 	require.True(t, r.Indices[0].Idx == idx2)
 	err = r.Validate()
 	require.NoError(t, err)
+}
+
+// newToken just returns a token that can be serialized. This one has two HopFields.
+func newToken() *reservation.Token {
+	t, err := reservation.TokenFromRaw(xtest.MustParseHexString(
+		"16ebdb4f0d042500003f001002bad1ce003f001002facade"))
+	if err != nil {
+		panic("invalid serialized token")
+	}
+	return t
 }

--- a/go/cs/reservation/segment/reservation_test.go
+++ b/go/cs/reservation/segment/reservation_test.go
@@ -176,6 +176,25 @@ func TestReservationValidate(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestIndex(t *testing.T) {
+	r := segmenttest.NewReservation()
+	expTime := time.Unix(1, 0)
+	r.NewIndex(expTime)
+	idx, _ := r.NewIndex(expTime)
+	r.NewIndex(expTime)
+	require.Len(t, r.Indices, 3)
+	index, err := r.Index(idx)
+	require.NoError(t, err)
+	require.Equal(t, &r.Indices[1], index)
+	_, err = r.Index(reservation.IndexNumber(4))
+	require.Error(t, err)
+	r.SetIndexConfirmed(idx)
+	r.SetIndexActive(idx)
+	index, err = r.Index(idx)
+	require.NoError(t, err)
+	require.Equal(t, &r.Indices[0], index)
+}
+
 func TestSetIndexConfirmed(t *testing.T) {
 	r := segmenttest.NewReservation()
 	expTime := time.Unix(1, 0)

--- a/go/cs/reservation/segment/reservation_test.go
+++ b/go/cs/reservation/segment/reservation_test.go
@@ -32,36 +32,36 @@ func TestNewIndex(t *testing.T) {
 	require.Len(t, r.Indices, 0)
 	expTime := time.Unix(1, 0)
 	token := newToken()
-	idx, err := r.NewIndex(expTime, *token)
+	idx, err := r.NewIndex(expTime, token)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 1)
 	require.Equal(t, idx, r.Indices[0].Idx)
 	require.Equal(t, expTime, r.Indices[0].Expiration)
-	require.Equal(t, *token, r.Indices[0].Token)
+	require.Equal(t, token, r.Indices[0].Token)
 	require.Equal(t, reservation.IndexNumber(0), idx)
 
 	// up to 3 indices per expiration time
-	idx, err = r.NewIndex(expTime, reservation.Token{})
+	idx, err = r.NewIndex(expTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, reservation.IndexNumber(1), idx)
-	idx, err = r.NewIndex(expTime, reservation.Token{})
+	idx, err = r.NewIndex(expTime, nil)
 	require.NoError(t, err)
 	require.Equal(t, reservation.IndexNumber(2), idx)
 	r.Indices = r.Indices[:1]
 
 	// exp time is less
-	_, err = r.NewIndex(expTime.Add(-1*time.Millisecond), reservation.Token{})
+	_, err = r.NewIndex(expTime.Add(-1*time.Millisecond), nil)
 	require.Error(t, err)
 	require.Len(t, r.Indices, 1)
 
 	// exp time is same
-	idx, err = r.NewIndex(expTime, reservation.Token{})
+	idx, err = r.NewIndex(expTime, nil)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 2)
 	require.True(t, r.Indices[1].Idx == idx)
 	require.True(t, r.Indices[1].Expiration == expTime)
 	require.Equal(t, reservation.IndexNumber(1), idx)
-	idx, err = r.NewIndex(expTime, reservation.Token{})
+	idx, err = r.NewIndex(expTime, nil)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 3)
 	require.True(t, r.Indices[2].Idx == idx)
@@ -69,13 +69,13 @@ func TestNewIndex(t *testing.T) {
 	require.Equal(t, reservation.IndexNumber(2), idx)
 
 	// too many indices for the same exp time
-	_, err = r.NewIndex(expTime, reservation.Token{})
+	_, err = r.NewIndex(expTime, nil)
 	require.Error(t, err)
 	require.Len(t, r.Indices, 3)
 
 	// exp time is greater
 	expTime = expTime.Add(time.Second)
-	idx, err = r.NewIndex(expTime, reservation.Token{})
+	idx, err = r.NewIndex(expTime, nil)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 4)
 	require.True(t, r.Indices[3].Idx == idx)
@@ -84,10 +84,10 @@ func TestNewIndex(t *testing.T) {
 
 	// index number rollover
 	r = segmenttest.NewReservation()
-	r.NewIndex(expTime, reservation.Token{})
+	r.NewIndex(expTime, nil)
 	require.Len(t, r.Indices, 1)
 	r.Indices[0].Idx = r.Indices[0].Idx.Sub(1)
-	idx, err = r.NewIndex(expTime, reservation.Token{})
+	idx, err = r.NewIndex(expTime, nil)
 	require.NoError(t, err)
 	require.True(t, r.Indices[1].Idx == idx)
 	require.True(t, r.Indices[1].Expiration == expTime)
@@ -101,7 +101,7 @@ func TestReservationValidate(t *testing.T) {
 	// more than 16 indices
 	for i := 0; i < 16; i++ {
 		expTime := time.Unix(int64(i), 0)
-		r.NewIndex(expTime, reservation.Token{})
+		r.NewIndex(expTime, nil)
 	}
 	require.Len(t, r.Indices, 16)
 	err = r.Validate()
@@ -124,15 +124,15 @@ func TestReservationValidate(t *testing.T) {
 	// exp time is before
 	r = segmenttest.NewReservation()
 	expTime := time.Unix(1, 0)
-	r.NewIndex(expTime, reservation.Token{})
-	r.NewIndex(expTime, reservation.Token{})
+	r.NewIndex(expTime, nil)
+	r.NewIndex(expTime, nil)
 	r.Indices[1].Expiration = expTime.Add(-1 * time.Second)
 	err = r.Validate()
 	require.Error(t, err)
 
 	// non consecutive indices
 	r.Indices = r.Indices[:1] // remove tainted index
-	r.NewIndex(expTime, reservation.Token{})
+	r.NewIndex(expTime, nil)
 	err = r.Validate()
 	require.NoError(t, err)
 	r.Indices[1].Idx = 2
@@ -141,11 +141,11 @@ func TestReservationValidate(t *testing.T) {
 
 	// more than three indices per exp time
 	r.Indices = r.Indices[:1]
-	r.NewIndex(expTime, reservation.Token{})
-	r.NewIndex(expTime, reservation.Token{})
+	r.NewIndex(expTime, nil)
+	r.NewIndex(expTime, nil)
 	err = r.Validate()
 	require.NoError(t, err)
-	_, err = r.NewIndex(expTime.Add(time.Second), reservation.Token{})
+	_, err = r.NewIndex(expTime.Add(time.Second), nil)
 	require.NoError(t, err)
 	r.Indices[3].Expiration = expTime
 	r.Indices[3].Idx = 3
@@ -154,7 +154,7 @@ func TestReservationValidate(t *testing.T) {
 
 	// more than one active index
 	r.Indices = r.Indices[:1]
-	r.NewIndex(expTime, reservation.Token{})
+	r.NewIndex(expTime, nil)
 	r.Indices[0].SetStateForTesting(segment.IndexActive)
 	r.Indices[1].SetStateForTesting(segment.IndexActive)
 	err = r.Validate()
@@ -182,9 +182,9 @@ func TestReservationValidate(t *testing.T) {
 func TestIndex(t *testing.T) {
 	r := segmenttest.NewReservation()
 	expTime := time.Unix(1, 0)
-	r.NewIndex(expTime, reservation.Token{})
-	idx, _ := r.NewIndex(expTime, reservation.Token{})
-	r.NewIndex(expTime, reservation.Token{})
+	r.NewIndex(expTime, nil)
+	idx, _ := r.NewIndex(expTime, nil)
+	r.NewIndex(expTime, nil)
 	require.Len(t, r.Indices, 3)
 	index, err := r.Index(idx)
 	require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestIndex(t *testing.T) {
 func TestSetIndexConfirmed(t *testing.T) {
 	r := segmenttest.NewReservation()
 	expTime := time.Unix(1, 0)
-	id, _ := r.NewIndex(expTime, reservation.Token{})
+	id, _ := r.NewIndex(expTime, nil)
 	require.Equal(t, segment.IndexTemporary, r.Indices[0].State())
 	err := r.SetIndexConfirmed(id)
 	require.NoError(t, err)
@@ -218,7 +218,7 @@ func TestSetIndexActive(t *testing.T) {
 	expTime := time.Unix(1, 0)
 
 	// index not confirmed
-	idx, _ := r.NewIndex(expTime, reservation.Token{})
+	idx, _ := r.NewIndex(expTime, nil)
 	err := r.SetIndexActive(idx)
 	require.Error(t, err)
 
@@ -234,8 +234,8 @@ func TestSetIndexActive(t *testing.T) {
 	require.NoError(t, err)
 
 	// remove previous indices
-	r.NewIndex(expTime, reservation.Token{})
-	idx, _ = r.NewIndex(expTime, reservation.Token{})
+	r.NewIndex(expTime, nil)
+	idx, _ = r.NewIndex(expTime, nil)
 	require.Len(t, r.Indices, 3)
 	require.Equal(t, 0, r.GetActiveIndexForTesting())
 	r.SetIndexConfirmed(idx)
@@ -249,14 +249,14 @@ func TestSetIndexActive(t *testing.T) {
 func TestRemoveIndex(t *testing.T) {
 	r := segmenttest.NewReservation()
 	expTime := time.Unix(1, 0)
-	idx, _ := r.NewIndex(expTime, reservation.Token{})
+	idx, _ := r.NewIndex(expTime, nil)
 	err := r.RemoveIndex(idx)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 0)
 
 	// remove second index
-	idx, _ = r.NewIndex(expTime, reservation.Token{})
-	idx2, _ := r.NewIndex(expTime, reservation.Token{})
+	idx, _ = r.NewIndex(expTime, nil)
+	idx2, _ := r.NewIndex(expTime, nil)
 	err = r.RemoveIndex(idx)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 1)
@@ -266,9 +266,9 @@ func TestRemoveIndex(t *testing.T) {
 
 	// remove also removes older indices
 	expTime = expTime.Add(time.Second)
-	r.NewIndex(expTime, reservation.Token{})
-	idx, _ = r.NewIndex(expTime, reservation.Token{})
-	idx2, _ = r.NewIndex(expTime, reservation.Token{})
+	r.NewIndex(expTime, nil)
+	idx, _ = r.NewIndex(expTime, nil)
+	idx2, _ = r.NewIndex(expTime, nil)
 	require.Len(t, r.Indices, 4)
 	err = r.RemoveIndex(idx)
 	require.NoError(t, err)
@@ -281,7 +281,7 @@ func TestRemoveIndex(t *testing.T) {
 // newToken just returns a token that can be serialized. This one has two HopFields.
 func newToken() *reservation.Token {
 	t, err := reservation.TokenFromRaw(xtest.MustParseHexString(
-		"16ebdb4f0d042500003f001002bad1ce003f001002facade"))
+		"0000000000040500003f001002bad1ce003f001002facade"))
 	if err != nil {
 		panic("invalid serialized token")
 	}

--- a/go/cs/reservation/segment/reservation_test.go
+++ b/go/cs/reservation/segment/reservation_test.go
@@ -23,155 +23,103 @@ import (
 	"github.com/scionproto/scion/go/cs/reservation/segment"
 	"github.com/scionproto/scion/go/cs/reservation/segmenttest"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
-	"github.com/scionproto/scion/go/lib/xtest"
 )
 
-func TestNewIndex(t *testing.T) {
-	// TODO(juagargi) move out of segment and to cs/reservation test
+func TestNewIndexAtSource(t *testing.T) {
 	r := segmenttest.NewReservation()
 	require.Len(t, r.Indices, 0)
 	expTime := time.Unix(1, 0)
-	token := newToken()
-	idx, err := r.NewIndex(expTime, token)
+	idx, err := r.NewIndexAtSource(expTime, 1, 3, 2, 5, reservation.CorePath)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 1)
+	require.Equal(t, reservation.IndexNumber(0), idx)
 	require.Equal(t, idx, r.Indices[0].Idx)
 	require.Equal(t, expTime, r.Indices[0].Expiration)
-	require.Equal(t, token, r.Indices[0].Token)
-	require.Equal(t, reservation.IndexNumber(0), idx)
-
-	// up to 3 indices per expiration time
-	idx, err = r.NewIndex(expTime, nil)
-	require.NoError(t, err)
-	require.Equal(t, reservation.IndexNumber(1), idx)
-	idx, err = r.NewIndex(expTime, nil)
-	require.NoError(t, err)
-	require.Equal(t, reservation.IndexNumber(2), idx)
-	r.Indices = r.Indices[:1]
-
-	// exp time is less
-	_, err = r.NewIndex(expTime.Add(-1*time.Millisecond), nil)
-	require.Error(t, err)
-	require.Len(t, r.Indices, 1)
-
-	// exp time is same
-	idx, err = r.NewIndex(expTime, nil)
+	require.Equal(t, segment.IndexTemporary, r.Indices[0].State())
+	require.Equal(t, reservation.BWCls(1), r.Indices[0].MinBW)
+	require.Equal(t, reservation.BWCls(3), r.Indices[0].MaxBW)
+	require.Equal(t, reservation.BWCls(2), r.Indices[0].AllocBW)
+	require.NotNil(t, r.Indices[0].Token)
+	tok := &reservation.Token{
+		InfoField: reservation.InfoField{
+			ExpirationTick: reservation.TickFromTime(expTime),
+			BWCls:          2,
+			RLC:            5,
+			Idx:            idx,
+			PathType:       reservation.CorePath,
+		},
+	}
+	require.Equal(t, tok, r.Indices[0].Token)
+	// add a second index
+	idx, err = r.NewIndexAtSource(expTime, 1, 3, 2, 5, reservation.CorePath)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 2)
-	require.True(t, r.Indices[1].Idx == idx)
-	require.True(t, r.Indices[1].Expiration == expTime)
 	require.Equal(t, reservation.IndexNumber(1), idx)
-	idx, err = r.NewIndex(expTime, nil)
+	require.Equal(t, idx, r.Indices[1].Idx)
+	// remove first index and add another one
+	r.Indices = r.Indices[1:]
+	idx, err = r.NewIndexAtSource(expTime, 1, 3, 2, 5, reservation.CorePath)
 	require.NoError(t, err)
-	require.Len(t, r.Indices, 3)
-	require.True(t, r.Indices[2].Idx == idx)
-	require.True(t, r.Indices[2].Expiration == expTime)
+	require.Len(t, r.Indices, 2)
 	require.Equal(t, reservation.IndexNumber(2), idx)
-
-	// too many indices for the same exp time
-	_, err = r.NewIndex(expTime, nil)
-	require.Error(t, err)
-	require.Len(t, r.Indices, 3)
-
-	// exp time is greater
-	expTime = expTime.Add(time.Second)
-	idx, err = r.NewIndex(expTime, nil)
-	require.NoError(t, err)
-	require.Len(t, r.Indices, 4)
-	require.True(t, r.Indices[3].Idx == idx)
-	require.True(t, r.Indices[3].Expiration == expTime)
-	require.Equal(t, reservation.IndexNumber(3), idx)
-
-	// index number rollover
-	r = segmenttest.NewReservation()
-	r.NewIndex(expTime, nil)
-	require.Len(t, r.Indices, 1)
-	r.Indices[0].Idx = r.Indices[0].Idx.Sub(1)
-	idx, err = r.NewIndex(expTime, nil)
-	require.NoError(t, err)
-	require.True(t, r.Indices[1].Idx == idx)
-	require.True(t, r.Indices[1].Expiration == expTime)
-	require.Equal(t, reservation.IndexNumber(0), idx)
+	require.Equal(t, idx, r.Indices[1].Idx)
 }
+
+func TestNewIndexFromToken(t *testing.T) {
+	r := segmenttest.NewReservation()
+	require.Len(t, r.Indices, 0)
+	expTime := time.Unix(1, 0)
+	tok := &reservation.Token{
+		InfoField: reservation.InfoField{
+			ExpirationTick: reservation.TickFromTime(expTime),
+			BWCls:          2,
+			RLC:            5,
+			Idx:            reservation.IndexNumber(6),
+			PathType:       reservation.CorePath,
+		},
+	}
+	idx, err := r.NewIndexFromToken(tok, 1, 3)
+	require.NoError(t, err)
+	require.Equal(t, tok.Idx, idx)
+	require.Equal(t, tok.ExpirationTick.ToTime(), r.Indices[0].Expiration)
+	require.Equal(t, segment.IndexTemporary, r.Indices[0].State())
+	require.Equal(t, reservation.BWCls(1), r.Indices[0].MinBW)
+	require.Equal(t, reservation.BWCls(3), r.Indices[0].MaxBW)
+	require.Equal(t, tok.BWCls, r.Indices[0].AllocBW)
+	require.Nil(t, r.Indices[0].Token)
+	// nil token
+	_, err = r.NewIndexFromToken(nil, 0, 0)
+	require.Error(t, err)
+}
+
 func TestReservationValidate(t *testing.T) {
 	r := segmenttest.NewReservation()
 	err := r.Validate()
 	require.NoError(t, err)
-
-	// more than 16 indices
-	for i := 0; i < 16; i++ {
-		expTime := time.Unix(int64(i), 0)
-		r.NewIndex(expTime, nil)
-	}
-	require.Len(t, r.Indices, 16)
-	err = r.Validate()
-	require.NoError(t, err)
-	r.Indices = append(r.Indices, r.Indices[15])
-	r.Indices[16].Idx.Add(1) // rollover
-	err = r.Validate()
-	require.Error(t, err)
-
 	// wrong path
 	r.Path = segment.Path{}
 	err = r.Validate()
 	require.Error(t, err)
-
-	r = segmenttest.NewReservation()
-	r.SetActiveIndexForTesting(0)
-	err = r.Validate()
-	require.Error(t, err)
-
-	// exp time is before
-	r = segmenttest.NewReservation()
-	expTime := time.Unix(1, 0)
-	r.NewIndex(expTime, nil)
-	r.NewIndex(expTime, nil)
-	r.Indices[1].Expiration = expTime.Add(-1 * time.Second)
-	err = r.Validate()
-	require.Error(t, err)
-
-	// non consecutive indices
-	r.Indices = r.Indices[:1] // remove tainted index
-	r.NewIndex(expTime, nil)
-	err = r.Validate()
-	require.NoError(t, err)
-	r.Indices[1].Idx = 2
-	err = r.Validate()
-	require.Error(t, err)
-
-	// more than three indices per exp time
-	r.Indices = r.Indices[:1]
-	r.NewIndex(expTime, nil)
-	r.NewIndex(expTime, nil)
-	err = r.Validate()
-	require.NoError(t, err)
-	_, err = r.NewIndex(expTime.Add(time.Second), nil)
-	require.NoError(t, err)
-	r.Indices[3].Expiration = expTime
-	r.Indices[3].Idx = 3
-	err = r.Validate()
-	require.Error(t, err)
-
 	// more than one active index
-	r.Indices = r.Indices[:1]
-	r.NewIndex(expTime, nil)
+	expTime := time.Unix(1, 0)
+	r = segmenttest.NewReservation()
+	r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
+	r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
+	require.Len(t, r.Indices, 2)
 	r.Indices[0].SetStateForTesting(segment.IndexActive)
 	r.Indices[1].SetStateForTesting(segment.IndexActive)
 	err = r.Validate()
 	require.Error(t, err)
-
 	// ID not set
 	r = segmenttest.NewReservation()
 	r.ID = reservation.SegmentID{}
 	err = r.Validate()
 	require.Error(t, err)
-
 	// starts in this AS but ingress nonzero
 	r = segmenttest.NewReservation()
 	r.Ingress = 1
 	err = r.Validate()
 	require.Error(t, err)
-
 	// Does not start in this AS but ingress empty
 	r = segmenttest.NewReservation()
 	r.Path = nil
@@ -182,9 +130,9 @@ func TestReservationValidate(t *testing.T) {
 func TestIndex(t *testing.T) {
 	r := segmenttest.NewReservation()
 	expTime := time.Unix(1, 0)
-	r.NewIndex(expTime, nil)
-	idx, _ := r.NewIndex(expTime, nil)
-	r.NewIndex(expTime, nil)
+	r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
+	idx, _ := r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
+	r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
 	require.Len(t, r.Indices, 3)
 	index, err := r.Index(idx)
 	require.NoError(t, err)
@@ -201,7 +149,7 @@ func TestIndex(t *testing.T) {
 func TestSetIndexConfirmed(t *testing.T) {
 	r := segmenttest.NewReservation()
 	expTime := time.Unix(1, 0)
-	id, _ := r.NewIndex(expTime, nil)
+	id, _ := r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
 	require.Equal(t, segment.IndexTemporary, r.Indices[0].State())
 	err := r.SetIndexConfirmed(id)
 	require.NoError(t, err)
@@ -218,7 +166,7 @@ func TestSetIndexActive(t *testing.T) {
 	expTime := time.Unix(1, 0)
 
 	// index not confirmed
-	idx, _ := r.NewIndex(expTime, nil)
+	idx, _ := r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
 	err := r.SetIndexActive(idx)
 	require.Error(t, err)
 
@@ -234,8 +182,8 @@ func TestSetIndexActive(t *testing.T) {
 	require.NoError(t, err)
 
 	// remove previous indices
-	r.NewIndex(expTime, nil)
-	idx, _ = r.NewIndex(expTime, nil)
+	r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
+	idx, _ = r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
 	require.Len(t, r.Indices, 3)
 	require.Equal(t, 0, r.GetActiveIndexForTesting())
 	r.SetIndexConfirmed(idx)
@@ -249,14 +197,14 @@ func TestSetIndexActive(t *testing.T) {
 func TestRemoveIndex(t *testing.T) {
 	r := segmenttest.NewReservation()
 	expTime := time.Unix(1, 0)
-	idx, _ := r.NewIndex(expTime, nil)
+	idx, _ := r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
 	err := r.RemoveIndex(idx)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 0)
 
 	// remove second index
-	idx, _ = r.NewIndex(expTime, nil)
-	idx2, _ := r.NewIndex(expTime, nil)
+	idx, _ = r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
+	idx2, _ := r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
 	err = r.RemoveIndex(idx)
 	require.NoError(t, err)
 	require.Len(t, r.Indices, 1)
@@ -266,9 +214,9 @@ func TestRemoveIndex(t *testing.T) {
 
 	// remove also removes older indices
 	expTime = expTime.Add(time.Second)
-	r.NewIndex(expTime, nil)
-	idx, _ = r.NewIndex(expTime, nil)
-	idx2, _ = r.NewIndex(expTime, nil)
+	r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
+	idx, _ = r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
+	idx2, _ = r.NewIndexAtSource(expTime, 0, 0, 0, 0, reservation.CorePath)
 	require.Len(t, r.Indices, 4)
 	err = r.RemoveIndex(idx)
 	require.NoError(t, err)
@@ -276,14 +224,4 @@ func TestRemoveIndex(t *testing.T) {
 	require.True(t, r.Indices[0].Idx == idx2)
 	err = r.Validate()
 	require.NoError(t, err)
-}
-
-// newToken just returns a token that can be serialized. This one has two HopFields.
-func newToken() *reservation.Token {
-	t, err := reservation.TokenFromRaw(xtest.MustParseHexString(
-		"0000000000040500003f001002bad1ce003f001002facade"))
-	if err != nil {
-		panic("invalid serialized token")
-	}
-	return t
 }

--- a/go/cs/reservation/sqlite/db.go
+++ b/go/cs/reservation/sqlite/db.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"database/sql"
 	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -117,104 +120,63 @@ type executor struct {
 func (x *executor) GetSegmentRsvFromID(ctx context.Context, ID *reservation.SegmentID) (
 	*segment.Reservation, error) {
 
-	const query = `SELECT rsv.inout_ingress,rsv.inout_egress,rsv.path,rsv.end_props,
-		rsv.traffic_split,rsv.active_index,
-		idx.index_number,idx.expiration,idx.state,idx.min_bw,idx.max_bw,idx.alloc_bw,idx.token
-		FROM seg_reservation as rsv
-		INNER JOIN seg_index AS idx ON rsv.row_id = idx.reservation
-		WHERE rsv.id_as = $1 AND rsv.id_suffix = $2;`
-	rows, err := x.db.QueryContext(ctx, query, ID.ASID, binary.BigEndian.Uint32(ID.Suffix[:]))
+	params := []interface{}{
+		ID.ASID,
+		binary.BigEndian.Uint32(ID.Suffix[:]),
+	}
+	rsvs, err := getSegReservations(ctx, x.db, "WHERE id_as = $1 AND id_suffix = $2", params)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-
-	indices := segment.Indices{}
-	var ingressIFID, egressIFID common.IFIDType
-	var activeIdx, endProps, trafficSplit int
-	var idx, expiration, state, minBW, maxBW, allocBW int32
-	var path, token []byte
-	insertIndex := func() error {
-		tok, err := reservation.TokenFromRaw(token)
-		if err != nil {
-			return db.NewDataError("invalid stored token", err)
-		}
-		index := segment.NewIndex(reservation.IndexNumber(idx),
-			time.Unix(int64(expiration), 0), segment.IndexState(state), reservation.BWCls(minBW),
-			reservation.BWCls(maxBW), reservation.BWCls(allocBW), tok)
-		indices = append(indices, *index)
-		return nil
+	switch len(rsvs) {
+	case 0:
+		return nil, nil
+	case 1:
+		return rsvs[0], nil
+	default:
+		return nil, db.NewDataError("more than 1 segment reservation found for an ID", nil,
+			"count", len(rsvs), "id.asid", ID.ASID, "id.suffix", hex.EncodeToString(ID.Suffix[:]))
 	}
-	if rows.Next() {
-		if err := rows.Scan(&ingressIFID, &egressIFID, &path, &endProps, &trafficSplit, &activeIdx,
-			&idx, &expiration, &state, &minBW, &maxBW, &allocBW, &token); err != nil {
-			return nil, err
-		}
-		if err != nil {
-			return nil, db.NewTxError("cannot read index row", err)
-		}
-		insertIndex()
-	}
-	for rows.Next() {
-		var dummy []byte
-		err := rows.Scan(&dummy, &dummy, &dummy, &dummy, &dummy, &dummy,
-			&idx, &expiration, &state, &minBW, &maxBW, &allocBW, &token)
-		if err != nil {
-			return nil, db.NewTxError("cannot read index row", err)
-		}
-		insertIndex()
-	}
-	// sort indices so they are consecutive modulo 16
-	indices.Sort()
-	// reconstruct reservation
-	rsv := segment.NewReservation()
-	rsv.ID = *ID
-	rsv.Ingress = ingressIFID
-	rsv.Egress = egressIFID
-	p, err := segment.NewPathFromRaw(path)
-	if err != nil {
-		return nil, err
-	}
-	rsv.Path = p
-	rsv.PathEndProps = reservation.PathEndProps(endProps)
-	rsv.TrafficSplit = reservation.SplitCls(trafficSplit)
-	rsv.Indices = indices
-	if activeIdx != -1 {
-		if err := rsv.SetIndexActive(reservation.IndexNumber(activeIdx)); err != nil {
-			return nil, err
-		}
-	}
-	return rsv, nil
 }
 
 // GetSegmentRsvFromSrcDstAS returns all reservations that start at src AS and end in dst AS.
 func (x *executor) GetSegmentRsvFromSrcDstAS(ctx context.Context, srcIA, dstIA addr.IA) (
 	[]*segment.Reservation, error) {
 
-	x.Lock()
-	defer x.Unlock()
-
-	query := `SELECT r.reservation_id, r.ingress, r.egress
-	FROM seg_reservation r
-	WHERE r.src_as = ?1 AND r.dst_as = ?2`
-	rows, err := x.db.QueryContext(ctx, query, srcIA.IAInt(), dstIA.IAInt())
-	if err != nil {
-		return nil, db.NewReadError("error obtaining segment reservations", err)
+	conditions := make([]string, 0, 2)
+	params := make([]interface{}, 0, 2)
+	if !srcIA.IsZero() {
+		conditions = append(conditions, "src_ia = $1")
+		params = append(params, srcIA)
 	}
-	defer rows.Close()
-	for rows.Next() {
-		if err := rows.Scan(); err != nil {
-			return nil, db.NewReadError("error reading segment reservation", err)
-		}
+	if !dstIA.IsZero() {
+		conditions = append(conditions, fmt.Sprintf("dst_ia = $%d", len(conditions)+1))
+		params = append(params, dstIA)
 	}
-	return nil, nil
+	if len(conditions) == 0 {
+		return nil, serrors.New("no src or dst ia provided")
+	}
+	condition := fmt.Sprintf("WHERE %s", strings.Join(conditions, " AND "))
+	return getSegReservations(ctx, x.db, condition, params)
 }
 
 // GetSegmentRsvFromPath searches for a segment reservation with the specified path.
 func (x *executor) GetSegmentRsvFromPath(ctx context.Context, path *segment.Path) (
 	*segment.Reservation, error) {
 
-	return nil, nil
+	rsvs, err := getSegReservations(ctx, x.db, "WHERE path = $1", []interface{}{path})
+	if err != nil {
+		return nil, err
+	}
+	switch len(rsvs) {
+	case 0:
+		return nil, nil
+	case 1:
+		return rsvs[0], nil
+	default:
+		return nil, db.NewDataError("more than 1 segment reservation found for a path", nil,
+			"path", path.String())
+	}
 }
 
 // GetSegmentRsvsFromIFPair returns all segment reservations that enter this AS at
@@ -222,7 +184,8 @@ func (x *executor) GetSegmentRsvFromPath(ctx context.Context, path *segment.Path
 func (x *executor) GetSegmentRsvsFromIFPair(ctx context.Context, ingress, egress common.IFIDType) (
 	[]*segment.Reservation, error) {
 
-	return nil, nil
+	return getSegReservations(ctx, x.db, "WHERE inout_ingress = $1 AND inout_egress = $2",
+		[]interface{}{ingress, egress})
 }
 
 // NewSegmentRsv creates a new segment reservation in the DB, with an unused reservation ID.
@@ -351,12 +314,7 @@ func insertNewSegReservation(ctx context.Context, x db.Sqler, rsv *segment.Reser
 	suffix uint32) error {
 
 	const query = `INSERT INTO seg_reservation (id_as, id_suffix, ingress, egress,
-		path, src_as, dst_as,active_index) VALUES ($1, $2, $3, $4, $5, $6, $7, -1)`
-	res, err := x.ExecContext(ctx, query, rsv.Path.GetSrcIA().A, suffix,
-		rsv.Ingress, rsv.Egress,
-		rsv.Path.ToRaw(), rsv.Path.GetSrcIA().IAInt(), rsv.Path.GetDstIA().IAInt())
-	const query = `INSERT INTO seg_reservation (id_as, id_suffix, ingress, egress,
-		path, end_props, traffic_split, src_as, dst_as,active_index)
+		path, end_props, traffic_split, src_ia, dst_ia,active_index)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, -1)`
 	res, err := x.ExecContext(ctx, query, rsv.Path.GetSrcIA().A, suffix,
 		rsv.Ingress, rsv.Egress, rsv.Path.ToRaw(), rsv.PathEndProps,
@@ -392,4 +350,97 @@ func insertNewIndex(ctx context.Context, x db.Sqler, segID *reservation.SegmentI
 	_, err := x.ExecContext(ctx, query, segID.ASID, suffix, index.Idx, uint32(index.Expiration.Unix()),
 		index.State(), index.MinBW, index.MaxBW, index.AllocBW, index.Token.ToRaw())
 	return err
+}
+
+func getSegReservations(ctx context.Context, x db.Sqler, condition string, params []interface{}) (
+	[]*segment.Reservation, error) {
+
+	const queryTmpl = `SELECT row_id,id_as,id_suffix,inout_ingress,inout_egress,path,
+		end_props,traffic_split,active_index
+		FROM seg_reservation %s;`
+	query := fmt.Sprintf(queryTmpl, condition)
+
+	rows, err := x.QueryContext(ctx, query, params...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	type rsvFields struct {
+		RowID        int
+		AsID         uint64
+		Suffix       uint32
+		Ingress      common.IFIDType
+		Egress       common.IFIDType
+		Path         []byte
+		EndProps     int
+		TrafficSplit int
+		ActiveIndex  int
+	}
+	reservationFields := []*rsvFields{}
+	for rows.Next() {
+		var f rsvFields
+		err := rows.Scan(&f.RowID, &f.AsID, &f.Suffix, &f.Ingress, &f.Egress, &f.Path,
+			&f.EndProps, &f.TrafficSplit, &f.ActiveIndex)
+		if err != nil {
+			return nil, err
+		}
+		reservationFields = append(reservationFields, &f)
+	}
+	reservations := []*segment.Reservation{}
+	for _, rf := range reservationFields {
+		indices, err := getSegIndices(ctx, x, rf.RowID)
+		if err != nil {
+			return nil, err
+		}
+
+		rsv := segment.NewReservation()
+		rsv.ID.ASID = addr.AS(rf.AsID)
+		binary.BigEndian.PutUint32(rsv.ID.Suffix[:], rf.Suffix)
+		rsv.IngressIFID = rf.Ingress
+		rsv.EgressIFID = rf.Egress
+		p := segment.NewPathFromRaw(rf.Path)
+		rsv.Path = &p
+		rsv.PathEndProps = reservation.PathEndProps(rf.EndProps)
+		rsv.TrafficSplit = reservation.SplitCls(rf.TrafficSplit)
+		rsv.Indices = *indices
+		if rf.ActiveIndex != -1 {
+			if err := rsv.SetIndexActive(reservation.IndexNumber(rf.ActiveIndex)); err != nil {
+				return nil, err
+			}
+		}
+		reservations = append(reservations, rsv)
+	}
+	return reservations, nil
+}
+
+// the rowID argument is the reservation row ID the indices belong to.
+func getSegIndices(ctx context.Context, x db.Sqler, rowID int) (*segment.Indices, error) {
+	const query = `SELECT index_number,expiration,state,min_bw,max_bw,alloc_bw,token
+		FROM seg_index WHERE reservation=$1;`
+	rows, err := x.QueryContext(ctx, query, rowID)
+	if err != nil {
+		return nil, db.NewReadError("cannot list indices", err)
+	}
+
+	indices := segment.Indices{}
+	var idx, expiration, state, minBW, maxBW, allocBW int32
+	var token []byte
+	for rows.Next() {
+		err := rows.Scan(&idx, &expiration, &state, &minBW, &maxBW, &allocBW, &token)
+		if err != nil {
+			return nil, db.NewReadError("could not get index values", err)
+		}
+		tok, err := reservation.TokenFromRaw(token)
+		if err != nil {
+			return nil, db.NewReadError("invalid stored token", err)
+		}
+		index := segment.NewIndex(reservation.IndexNumber(idx),
+			time.Unix(int64(expiration), 0), segment.IndexState(state), reservation.BWCls(minBW),
+			reservation.BWCls(maxBW), reservation.BWCls(allocBW), tok)
+		indices = append(indices, *index)
+	}
+	// sort indices so they are consecutive modulo 16
+	indices.Sort()
+	return &indices, nil
 }

--- a/go/cs/reservation/sqlite/db.go
+++ b/go/cs/reservation/sqlite/db.go
@@ -251,8 +251,8 @@ func (x *executor) DeleteExpiredIndices(ctx context.Context, now time.Time) (int
 }
 
 // DeleteSegmentRsv removes the segment reservation
-func (x *executor) DeleteSegmentRsv(ctx context.Context, ID reservation.SegmentID) error {
-	return nil
+func (x *executor) DeleteSegmentRsv(ctx context.Context, ID *reservation.SegmentID) error {
+	return deleteSegmentRsv(ctx, x.db, ID)
 }
 
 // GetE2ERsvFromID finds the end to end resevation given its ID.

--- a/go/cs/reservation/sqlite/db.go
+++ b/go/cs/reservation/sqlite/db.go
@@ -139,8 +139,8 @@ func (x *executor) GetSegmentRsvFromID(ctx context.Context, ID *reservation.Segm
 	}
 }
 
-// GetSegmentRsvFromSrcDstAS returns all reservations that start at src AS and end in dst AS.
-func (x *executor) GetSegmentRsvFromSrcDstAS(ctx context.Context, srcIA, dstIA addr.IA) (
+// GetSegmentRsvsFromSrcDstIA returns all reservations that start at src AS and end in dst AS.
+func (x *executor) GetSegmentRsvsFromSrcDstIA(ctx context.Context, srcIA, dstIA addr.IA) (
 	[]*segment.Reservation, error) {
 
 	conditions := make([]string, 0, 2)

--- a/go/cs/reservation/sqlite/db.go
+++ b/go/cs/reservation/sqlite/db.go
@@ -158,16 +158,6 @@ func (x *executor) GetSegmentRsvsFromIFPair(ctx context.Context, ingress, egress
 	return nil, nil
 }
 
-func insertNewSegReservation(ctx context.Context, x db.Sqler, rsv *segment.Reservation,
-	suffix uint32) error {
-	const query = `INSERT INTO seg_reservation (id_as, id_suffix, ingress ,egress,
-		path, src_as, dst_as) VALUES ($1, $2, $3, $4, $5, $6, $7)`
-	_, err := x.ExecContext(ctx, query, rsv.Path.GetSrcIA().A, suffix,
-		rsv.Ingress, rsv.Egress,
-		rsv.Path.ToRaw(), rsv.Path.GetSrcIA().IAInt(), rsv.Path.GetDstIA().IAInt())
-	return err
-}
-
 // NewSegmentRsv creates a new segment reservation in the DB, with an unused reservation ID.
 // The created ID is set in the reservation pointer argument.
 func (x *executor) NewSegmentRsv(ctx context.Context, rsv *segment.Reservation) error {
@@ -280,4 +270,14 @@ func newSuffix(ctx context.Context, x db.Sqler, ASID addr.AS) (uint32, error) {
 		return 0, serrors.WrapStr("unexpected error getting new suffix", err)
 	}
 	return suffix, nil
+}
+
+func insertNewSegReservation(ctx context.Context, x db.Sqler, rsv *segment.Reservation,
+	suffix uint32) error {
+	const query = `INSERT INTO seg_reservation (id_as, id_suffix, ingress ,egress,
+		path, src_as, dst_as) VALUES ($1, $2, $3, $4, $5, $6, $7)`
+	_, err := x.ExecContext(ctx, query, rsv.Path.GetSrcIA().A, suffix,
+		rsv.Ingress, rsv.Egress,
+		rsv.Path.ToRaw(), rsv.Path.GetSrcIA().IAInt(), rsv.Path.GetDstIA().IAInt())
+	return err
 }

--- a/go/cs/reservation/sqlite/db.go
+++ b/go/cs/reservation/sqlite/db.go
@@ -339,7 +339,7 @@ func insertNewSegReservation(ctx context.Context, x db.Sqler, rsv *segment.Reser
 	const query = `INSERT INTO seg_reservation (id_as, id_suffix, ingress, egress,
 		path, end_props, traffic_split, src_ia, dst_ia,active_index)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, -1)`
-	res, err := x.ExecContext(ctx, query, rsv.Path.GetSrcIA().A, suffix,
+	res, err := x.ExecContext(ctx, query, rsv.ID.ASID, suffix,
 		rsv.Ingress, rsv.Egress, rsv.Path.ToRaw(), rsv.PathEndProps,
 		rsv.TrafficSplit, rsv.Path.GetSrcIA().IAInt(), rsv.Path.GetDstIA().IAInt())
 	if err != nil {

--- a/go/cs/reservation/sqlite/db.go
+++ b/go/cs/reservation/sqlite/db.go
@@ -161,10 +161,10 @@ func (x *executor) GetSegmentRsvsFromSrcDstIA(ctx context.Context, srcIA, dstIA 
 }
 
 // GetSegmentRsvFromPath searches for a segment reservation with the specified path.
-func (x *executor) GetSegmentRsvFromPath(ctx context.Context, path *segment.Path) (
+func (x *executor) GetSegmentRsvFromPath(ctx context.Context, path segment.Path) (
 	*segment.Reservation, error) {
 
-	rsvs, err := getSegReservations(ctx, x.db, "WHERE path = $1", []interface{}{path})
+	rsvs, err := getSegReservations(ctx, x.db, "WHERE path = $1", []interface{}{path.ToRaw()})
 	if err != nil {
 		return nil, err
 	}

--- a/go/cs/reservation/sqlite/db.go
+++ b/go/cs/reservation/sqlite/db.go
@@ -147,11 +147,11 @@ func (x *executor) GetSegmentRsvsFromSrcDstIA(ctx context.Context, srcIA, dstIA 
 	params := make([]interface{}, 0, 2)
 	if !srcIA.IsZero() {
 		conditions = append(conditions, "src_ia = $1")
-		params = append(params, srcIA)
+		params = append(params, srcIA.IAInt())
 	}
 	if !dstIA.IsZero() {
 		conditions = append(conditions, fmt.Sprintf("dst_ia = $%d", len(conditions)+1))
-		params = append(params, dstIA)
+		params = append(params, dstIA.IAInt())
 	}
 	if len(conditions) == 0 {
 		return nil, serrors.New("no src or dst ia provided")

--- a/go/cs/reservation/sqlite/db.go
+++ b/go/cs/reservation/sqlite/db.go
@@ -247,18 +247,14 @@ func (x *executor) SetSegmentActiveIndex(ctx context.Context, rsv *segment.Reser
 	return nil
 }
 
-// NewSegmentRsvIndex stores a new index for a segment reservation.
+// NewSegmentIndex stores a new index for a segment reservation.
 func (x *executor) NewSegmentIndex(ctx context.Context, rsv *segment.Reservation,
-	idx reservation.IndexNumber, tok *reservation.Token) error {
+	idx reservation.IndexNumber) error {
 
 	index, err := rsv.Index(idx)
 	if err != nil {
 		return db.NewInputDataError("invalid index number", err)
 	}
-	if tok == nil {
-		return db.NewInputDataError("token argument is nil", nil)
-	}
-	index.Token = *tok
 	return insertNewIndex(ctx, x.db, &rsv.ID, index)
 }
 

--- a/go/cs/reservation/sqlite/db.go
+++ b/go/cs/reservation/sqlite/db.go
@@ -235,7 +235,7 @@ func (x *executor) NewSegmentRsvWithID(ctx context.Context, rsv *segment.Reserva
 }
 
 // SetActiveIndex updates the active index for the segment reservation.
-func (x *executor) SetSegmentActiveIndex(ctx context.Context, rsv *segment.Reservation,
+func (x *executor) SetSegmentIndexActive(ctx context.Context, rsv *segment.Reservation,
 	idx reservation.IndexNumber) error {
 
 	index, err := rsv.Index(idx)

--- a/go/cs/reservation/sqlite/db.go
+++ b/go/cs/reservation/sqlite/db.go
@@ -366,8 +366,9 @@ func insertNewSegReservation(ctx context.Context, x db.Sqler, rsv *segment.Reser
 		min_bw, max_bw, alloc_bw, token) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`
 
 	for _, index := range rsv.Indices {
-		_, err := x.ExecContext(ctx, queryIndex, rsvRowID, index.Idx, uint32(index.Expiration.Unix()),
-			index.State(), index.MinBW, index.MaxBW, index.AllocBW, index.Token.ToRaw())
+		_, err := x.ExecContext(ctx, queryIndex, rsvRowID, index.Idx,
+			uint32(index.Expiration.Unix()), index.State(), index.MinBW, index.MaxBW,
+			index.AllocBW, index.Token.ToRaw())
 		if err != nil {
 			return err
 		}
@@ -383,8 +384,9 @@ func insertNewIndex(ctx context.Context, x db.Sqler, segID *reservation.SegmentI
 		(SELECT row_id FROM seg_reservation WHERE id_as=$1 AND id_suffix=$2),
 		$3,$4,$5,$6,$7,$8,$9)`
 	suffix := binary.BigEndian.Uint32(segID.Suffix[:])
-	_, err := x.ExecContext(ctx, query, segID.ASID, suffix, index.Idx, uint32(index.Expiration.Unix()),
-		index.State(), index.MinBW, index.MaxBW, index.AllocBW, index.Token.ToRaw())
+	_, err := x.ExecContext(ctx, query, segID.ASID, suffix, index.Idx,
+		uint32(index.Expiration.Unix()), index.State(), index.MinBW, index.MaxBW,
+		index.AllocBW, index.Token.ToRaw())
 	return err
 }
 

--- a/go/cs/reservation/sqlite/db_test.go
+++ b/go/cs/reservation/sqlite/db_test.go
@@ -97,9 +97,10 @@ func addSegRsvRows(t testing.TB, b *Backend, asid addr.AS, firstSuffix, lastSuff
 	t.Helper()
 	ctx := context.Background()
 	query := `INSERT INTO seg_reservation (id_as, id_suffix, ingress, egress, path,
-		src_as, dst_as, active_index) VALUES ($1, $2, $3, $4, $5, $6, $7, -1)`
+		end_props, traffic_split, src_as, dst_as, active_index)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, -1)`
 	for suffix := firstSuffix; suffix <= lastSuffix; suffix++ {
-		_, err := b.db.ExecContext(ctx, query, asid, suffix, 0, 0, nil, nil, nil)
+		_, err := b.db.ExecContext(ctx, query, asid, suffix, 0, 0, nil, 0, 0, nil, nil)
 		require.NoError(t, err)
 	}
 }

--- a/go/cs/reservation/sqlite/db_test.go
+++ b/go/cs/reservation/sqlite/db_test.go
@@ -71,7 +71,8 @@ func TestRaceForSuffix(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint32(3), suffix2)
 	rsv := &segment.Reservation{
-		ID: reservation.SegmentID{ASID: asid},
+		ID:      reservation.SegmentID{ASID: asid},
+		Indices: segment.Indices{segment.Index{}},
 	}
 	err = insertNewSegReservation(ctx, db.db, rsv, suffix1)
 	require.NoError(t, err)

--- a/go/cs/reservation/sqlite/db_test.go
+++ b/go/cs/reservation/sqlite/db_test.go
@@ -97,7 +97,7 @@ func addSegRsvRows(t testing.TB, b *Backend, asid addr.AS, firstSuffix, lastSuff
 	t.Helper()
 	ctx := context.Background()
 	query := `INSERT INTO seg_reservation (id_as, id_suffix, ingress, egress, path,
-		end_props, traffic_split, src_as, dst_as, active_index)
+		end_props, traffic_split, src_ia, dst_ia, active_index)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, -1)`
 	for suffix := firstSuffix; suffix <= lastSuffix; suffix++ {
 		_, err := b.db.ExecContext(ctx, query, asid, suffix, 0, 0, nil, 0, 0, nil, nil)

--- a/go/cs/reservation/sqlite/db_test.go
+++ b/go/cs/reservation/sqlite/db_test.go
@@ -87,15 +87,17 @@ func BenchmarkNewSuffix100K(b *testing.B) { benchmarkNewSuffix(b, 100000) }
 func BenchmarkNewSuffix1M(b *testing.B)   { benchmarkNewSuffix(b, 1000000) }
 
 func newDB(t testing.TB) *Backend {
+	t.Helper()
 	db, err := New("file::memory:")
 	require.NoError(t, err)
 	return db
 }
 
 func addSegRsvRows(t testing.TB, b *Backend, asid addr.AS, firstSuffix, lastSuffix uint32) {
+	t.Helper()
 	ctx := context.Background()
 	query := `INSERT INTO seg_reservation (id_as, id_suffix, ingress, egress, path,
-		src_as, dst_as) VALUES ($1, $2, $3, $4, $5, $6, $7)`
+		src_as, dst_as, active_index) VALUES ($1, $2, $3, $4, $5, $6, $7, -1)`
 	for suffix := firstSuffix; suffix <= lastSuffix; suffix++ {
 		_, err := b.db.ExecContext(ctx, query, asid, suffix, 0, 0, nil, nil, nil)
 		require.NoError(t, err)

--- a/go/cs/reservation/sqlite/schema.go
+++ b/go/cs/reservation/sqlite/schema.go
@@ -43,7 +43,7 @@ const (
 		max_bw	INTEGER NOT NULL,
 		alloc_bw	INTEGER NOT NULL,
 		token	BLOB,
-		PRIMARY KEY(Reservation,index_number),
+		PRIMARY KEY(reservation,index_number),
 		FOREIGN KEY(reservation) REFERENCES seg_reservation(row_id) ON DELETE CASCADE
 	);
 	CREATE TABLE e2e_reservation (

--- a/go/cs/reservation/sqlite/schema.go
+++ b/go/cs/reservation/sqlite/schema.go
@@ -36,7 +36,8 @@ const (
 		dst_ia INTEGER,
 		active_index	INTEGER NOT NULL,
 		PRIMARY KEY(row_id),
-		UNIQUE(id_as,id_suffix)
+		UNIQUE(id_as,id_suffix),
+		UNIQUE(path)
 	);
 	CREATE TABLE seg_index (
 		reservation	INTEGER NOT NULL,

--- a/go/cs/reservation/sqlite/schema.go
+++ b/go/cs/reservation/sqlite/schema.go
@@ -30,6 +30,8 @@ const (
 		ingress	INTEGER NOT NULL,
 		egress	INTEGER NOT NULL,
 		path	BLOB,
+		end_props	INTEGER NOT NULL,
+		traffic_split	INTEGER NOT NULL,
 		src_as INTEGER,
 		dst_as INTEGER,
 		active_index	INTEGER NOT NULL,

--- a/go/cs/reservation/sqlite/schema.go
+++ b/go/cs/reservation/sqlite/schema.go
@@ -32,8 +32,8 @@ const (
 		path	BLOB,
 		end_props	INTEGER NOT NULL,
 		traffic_split	INTEGER NOT NULL,
-		src_as INTEGER,
-		dst_as INTEGER,
+		src_ia INTEGER,
+		dst_ia INTEGER,
 		active_index	INTEGER NOT NULL,
 		PRIMARY KEY(row_id),
 		UNIQUE(id_as,id_suffix)

--- a/go/cs/reservation/sqlite/schema.go
+++ b/go/cs/reservation/sqlite/schema.go
@@ -22,6 +22,7 @@ const (
 	// Schema is the SQLite database layout.
 	// TODO(juagargi) explain the DB structure here or in the design markdown.
 	// TODO(juagargi) create appropriate SQL indices.
+	// TODO(juagargi) path should be unique if not null
 	Schema = `CREATE TABLE seg_reservation (
 		row_id	INTEGER,
 		id_as	INTEGER NOT NULL,
@@ -31,6 +32,7 @@ const (
 		path	BLOB,
 		src_as INTEGER,
 		dst_as INTEGER,
+		active_index	INTEGER NOT NULL,
 		PRIMARY KEY(row_id),
 		UNIQUE(id_as,id_suffix)
 	);

--- a/go/cs/reservation/sqlite/schema.go
+++ b/go/cs/reservation/sqlite/schema.go
@@ -20,9 +20,7 @@ const (
 	// to prevent data corruption between incompatible database schemas.
 	SchemaVersion = 1
 	// Schema is the SQLite database layout.
-	// TODO(juagargi) explain the DB structure here or in the design markdown.
 	// TODO(juagargi) create appropriate SQL indices.
-	// TODO(juagargi) path should be unique if not null
 	Schema = `CREATE TABLE seg_reservation (
 		row_id	INTEGER,
 		id_as	INTEGER NOT NULL,

--- a/go/cs/reservationstorage/backend/db.go
+++ b/go/cs/reservationstorage/backend/db.go
@@ -53,18 +53,17 @@ type TransitOnly interface {
 // ReserverAndTransit contains the functionality for any AS that has a COLIBRI service.
 type ReserverAndTransit interface {
 	// GetSegmentRsvFromID will return the reservation with that ID.
-	// If an IndexNumber is specified it will populate its indices only with that one.
-	// If the ID is not found, or the index (if specified) is not found, an error will be returned.
 	// Used by setup/renew req/resp. and any request.
-	GetSegmentRsvFromID(ctx context.Context, ID reservation.SegmentID,
-		idx *reservation.IndexNumber) (*segment.Reservation, error)
-	// SetActiveIndex updates the active index. Used in index confirmation.
-	SetSegmentActiveIndex(ctx context.Context, rsv segment.Reservation,
+	GetSegmentRsvFromID(ctx context.Context, ID *reservation.SegmentID) (
+		*segment.Reservation, error)
+	// SetSegmentActiveIndex updates the active index. Used in index confirmation.
+	SetSegmentActiveIndex(ctx context.Context, rsv *segment.Reservation,
 		idx reservation.IndexNumber) error
-	// NewSegmentRsvIndex stores a new index for a segment reservation. Used in setup/renew.
+	// NewSegmentIndex stores a new index for a segment reservation. The token must not be nil.
+	// Used in setup/renew.
 	NewSegmentIndex(ctx context.Context, rsv *segment.Reservation,
-		idx reservation.IndexNumber) error
-	// UpdateSegmentRsvIndex updates an index of a segment rsv. Used in setup/renew response.
+		idx reservation.IndexNumber, tok *reservation.Token) error
+	// UpdateSegmentIndex updates an index of a segment rsv. Used in setup/renew response.
 	UpdateSegmentIndex(ctx context.Context, rsv *segment.Reservation,
 		idx reservation.IndexNumber) error
 	// DeleteSegmentIndex removes the index from the DB. Used in cleanup.

--- a/go/cs/reservationstorage/backend/db.go
+++ b/go/cs/reservationstorage/backend/db.go
@@ -46,7 +46,7 @@ type ReserverOnly interface {
 type TransitOnly interface {
 	// GetSegmentRsvsFromIFPair returns all segment reservations that enter this AS at
 	// the specified ingress and exit at that egress. Used by setup req.
-	GetSegmentRsvsFromIFPair(ctx context.Context, ingress, egress common.IFIDType) (
+	GetSegmentRsvsFromIFPair(ctx context.Context, ingress, egress *common.IFIDType) (
 		[]*segment.Reservation, error)
 
 	// NewSegmentRsvWithID creates a new segment reservation in the DB, storing it with the

--- a/go/cs/reservationstorage/backend/db.go
+++ b/go/cs/reservationstorage/backend/db.go
@@ -48,10 +48,6 @@ type TransitOnly interface {
 	// the specified ingress and exit at that egress. Used by setup req.
 	GetSegmentRsvsFromIFPair(ctx context.Context, ingress, egress *common.IFIDType) (
 		[]*segment.Reservation, error)
-
-	// NewSegmentRsvWithID creates a new segment reservation in the DB, storing it with the
-	// provided ID. It the ID was used already an error will be returned. Used by setup req.
-	NewSegmentRsvWithID(ctx context.Context, rsv *segment.Reservation) error
 }
 
 // ReserverAndTransit contains the functionality for any AS that has a COLIBRI service.
@@ -62,18 +58,6 @@ type ReserverAndTransit interface {
 		*segment.Reservation, error)
 	// PersistSegmentRsv ensures the DB contains the reservation as represented in rsv.
 	PersistSegmentRsv(ctx context.Context, rsv *segment.Reservation) error
-	// TODO(juagargi) remove
-	SetSegmentIndexActive(ctx context.Context, rsv *segment.Reservation,
-		idx reservation.IndexNumber) error
-	// TODO(juagargi) remove
-	NewSegmentIndex(ctx context.Context, rsv *segment.Reservation,
-		idx reservation.IndexNumber) error
-	// TODO(juagargi) remove
-	UpdateSegmentIndex(ctx context.Context, rsv *segment.Reservation,
-		idx reservation.IndexNumber) error
-	// TODO(juagargi) remove
-	DeleteSegmentIndex(ctx context.Context, rsv *segment.Reservation,
-		idx reservation.IndexNumber) error
 	// DeleteSegmentRsv removes the segment reservation. Used in teardown.
 	DeleteSegmentRsv(ctx context.Context, ID reservation.SegmentID) error
 

--- a/go/cs/reservationstorage/backend/db.go
+++ b/go/cs/reservationstorage/backend/db.go
@@ -59,7 +59,7 @@ type ReserverAndTransit interface {
 	// PersistSegmentRsv ensures the DB contains the reservation as represented in rsv.
 	PersistSegmentRsv(ctx context.Context, rsv *segment.Reservation) error
 	// DeleteSegmentRsv removes the segment reservation. Used in teardown.
-	DeleteSegmentRsv(ctx context.Context, ID reservation.SegmentID) error
+	DeleteSegmentRsv(ctx context.Context, ID *reservation.SegmentID) error
 
 	// DeleteExpiredIndices will remove expired indices from the DB. If a reservation is left
 	// without any index after removing the expired ones, it will also be removed.

--- a/go/cs/reservationstorage/backend/db.go
+++ b/go/cs/reservationstorage/backend/db.go
@@ -59,10 +59,9 @@ type ReserverAndTransit interface {
 	// SetSegmentActiveIndex updates the active index. Used in index confirmation.
 	SetSegmentActiveIndex(ctx context.Context, rsv *segment.Reservation,
 		idx reservation.IndexNumber) error
-	// NewSegmentIndex stores a new index for a segment reservation. The token must not be nil.
-	// Used in setup/renew.
+	// NewSegmentIndex stores a new index for a segment reservation. Used in setup/renew.
 	NewSegmentIndex(ctx context.Context, rsv *segment.Reservation,
-		idx reservation.IndexNumber, tok *reservation.Token) error
+		idx reservation.IndexNumber) error
 	// UpdateSegmentIndex updates an index of a segment rsv. Used in setup/renew response.
 	UpdateSegmentIndex(ctx context.Context, rsv *segment.Reservation,
 		idx reservation.IndexNumber) error

--- a/go/cs/reservationstorage/backend/db.go
+++ b/go/cs/reservationstorage/backend/db.go
@@ -30,8 +30,8 @@ import (
 
 // ReserverOnly has the methods available to the AS that starts the reservation.
 type ReserverOnly interface {
-	// GetSegmentRsvFromSrcDstAS returns all reservations that start at src AS and end in dst AS.
-	GetSegmentRsvFromSrcDstAS(ctx context.Context, srcIA, dstIA addr.IA) (
+	// GetSegmentRsvsFromSrcDstIA returns all reservations that start at src AS and end in dst AS.
+	GetSegmentRsvsFromSrcDstIA(ctx context.Context, srcIA, dstIA addr.IA) (
 		[]*segment.Reservation, error)
 	// GetSegmentRsvFromPath searches for a segment reservation with the specified path.
 	GetSegmentRsvFromPath(ctx context.Context, path *segment.Path) (
@@ -48,6 +48,7 @@ type TransitOnly interface {
 	// the specified ingress and exit at that egress. Used by setup req.
 	GetSegmentRsvsFromIFPair(ctx context.Context, ingress, egress common.IFIDType) (
 		[]*segment.Reservation, error)
+	// TODO(juagargi) function to store a reservation with a provided ID
 }
 
 // ReserverAndTransit contains the functionality for any AS that has a COLIBRI service.

--- a/go/cs/reservationstorage/backend/db.go
+++ b/go/cs/reservationstorage/backend/db.go
@@ -34,7 +34,7 @@ type ReserverOnly interface {
 	GetSegmentRsvsFromSrcDstIA(ctx context.Context, srcIA, dstIA addr.IA) (
 		[]*segment.Reservation, error)
 	// GetSegmentRsvFromPath searches for a segment reservation with the specified path.
-	GetSegmentRsvFromPath(ctx context.Context, path *segment.Path) (
+	GetSegmentRsvFromPath(ctx context.Context, path segment.Path) (
 		*segment.Reservation, error)
 
 	// NewSegmentRsv creates a new segment reservation in the DB, with an unused reservation ID.

--- a/go/cs/reservationstorage/backend/db.go
+++ b/go/cs/reservationstorage/backend/db.go
@@ -48,7 +48,10 @@ type TransitOnly interface {
 	// the specified ingress and exit at that egress. Used by setup req.
 	GetSegmentRsvsFromIFPair(ctx context.Context, ingress, egress common.IFIDType) (
 		[]*segment.Reservation, error)
-	// TODO(juagargi) function to store a reservation with a provided ID
+
+	// NewSegmentRsvWithID creates a new segment reservation in the DB, storing it with the
+	// provided ID. It the ID was used already an error will be returned. Used by setup req.
+	NewSegmentRsvWithID(ctx context.Context, rsv *segment.Reservation) error
 }
 
 // ReserverAndTransit contains the functionality for any AS that has a COLIBRI service.

--- a/go/cs/reservationstorage/backend/db.go
+++ b/go/cs/reservationstorage/backend/db.go
@@ -60,8 +60,8 @@ type ReserverAndTransit interface {
 	// Used by setup/renew req/resp. and any request.
 	GetSegmentRsvFromID(ctx context.Context, ID *reservation.SegmentID) (
 		*segment.Reservation, error)
-	// SetSegmentActiveIndex updates the active index. Used in index confirmation.
-	SetSegmentActiveIndex(ctx context.Context, rsv *segment.Reservation,
+	// SetSegmentIndexActive updates the active index. Used in index confirmation.
+	SetSegmentIndexActive(ctx context.Context, rsv *segment.Reservation,
 		idx reservation.IndexNumber) error
 	// NewSegmentIndex stores a new index for a segment reservation. Used in setup/renew.
 	NewSegmentIndex(ctx context.Context, rsv *segment.Reservation,

--- a/go/cs/reservationstorage/backend/db.go
+++ b/go/cs/reservationstorage/backend/db.go
@@ -60,16 +60,18 @@ type ReserverAndTransit interface {
 	// Used by setup/renew req/resp. and any request.
 	GetSegmentRsvFromID(ctx context.Context, ID *reservation.SegmentID) (
 		*segment.Reservation, error)
-	// SetSegmentIndexActive updates the active index. Used in index confirmation.
+	// PersistSegmentRsv ensures the DB contains the reservation as represented in rsv.
+	PersistSegmentRsv(ctx context.Context, rsv *segment.Reservation) error
+	// TODO(juagargi) remove
 	SetSegmentIndexActive(ctx context.Context, rsv *segment.Reservation,
 		idx reservation.IndexNumber) error
-	// NewSegmentIndex stores a new index for a segment reservation. Used in setup/renew.
+	// TODO(juagargi) remove
 	NewSegmentIndex(ctx context.Context, rsv *segment.Reservation,
 		idx reservation.IndexNumber) error
-	// UpdateSegmentIndex updates an index of a segment rsv. Used in setup/renew response.
+	// TODO(juagargi) remove
 	UpdateSegmentIndex(ctx context.Context, rsv *segment.Reservation,
 		idx reservation.IndexNumber) error
-	// DeleteSegmentIndex removes the index from the DB. Used in cleanup.
+	// TODO(juagargi) remove
 	DeleteSegmentIndex(ctx context.Context, rsv *segment.Reservation,
 		idx reservation.IndexNumber) error
 	// DeleteSegmentRsv removes the segment reservation. Used in teardown.

--- a/go/lib/colibri/reservation/types.go
+++ b/go/lib/colibri/reservation/types.go
@@ -393,3 +393,10 @@ func (t *Token) Read(b []byte) (int, error) {
 	}
 	return offset, nil
 }
+
+// ToRaw returns the serial representation of the Token.
+func (t *Token) ToRaw() []byte {
+	buff := make([]byte, t.Len())
+	t.Read(buff) // safely ignore errors as they can only come from buffer size
+	return buff
+}

--- a/go/lib/colibri/reservation/types.go
+++ b/go/lib/colibri/reservation/types.go
@@ -135,6 +135,10 @@ func TickFromTime(t time.Time) Tick {
 	return Tick(util.TimeToSecs(t) / 4)
 }
 
+func (t Tick) ToTime() time.Time {
+	return util.SecsToTime(uint32(t) * 4)
+}
+
 // BWCls is the bandwidth class. bandwidth = 16 * sqrt(2^(BWCls - 1)). 0 <= bwcls <= 63 .
 type BWCls uint8
 
@@ -362,7 +366,9 @@ func TokenFromRaw(raw []byte) (*Token, error) {
 	}
 	t := Token{
 		InfoField: *inf,
-		HopFields: make([]spath.HopField, numHFs),
+	}
+	if numHFs > 0 {
+		t.HopFields = make([]spath.HopField, numHFs)
 	}
 	for i := 0; i < numHFs; i++ {
 		offset := InfoFieldLen + i*spath.HopFieldLength

--- a/go/lib/colibri/reservation/types.go
+++ b/go/lib/colibri/reservation/types.go
@@ -347,6 +347,9 @@ func (t *Token) Validate() error {
 
 // TokenFromRaw builds a Token from the passed bytes buffer.
 func TokenFromRaw(raw []byte) (*Token, error) {
+	if raw == nil {
+		return nil, nil
+	}
 	rawHFs := len(raw) - InfoFieldLen
 	if rawHFs < 0 || rawHFs%spath.HopFieldLength != 0 {
 		return nil, serrors.New("buffer too small", "min_size", InfoFieldLen,
@@ -374,6 +377,9 @@ func TokenFromRaw(raw []byte) (*Token, error) {
 
 // Len returns the number of bytes of this token if serialized.
 func (t *Token) Len() int {
+	if t == nil {
+		return 0
+	}
 	return InfoFieldLen + len(t.HopFields)*spath.HopFieldLength
 }
 
@@ -397,6 +403,8 @@ func (t *Token) Read(b []byte) (int, error) {
 // ToRaw returns the serial representation of the Token.
 func (t *Token) ToRaw() []byte {
 	buff := make([]byte, t.Len())
-	t.Read(buff) // safely ignore errors as they can only come from buffer size
+	if t != nil {
+		t.Read(buff) // safely ignore errors as they can only come from buffer size
+	}
 	return buff
 }

--- a/go/lib/colibri/reservation/types_test.go
+++ b/go/lib/colibri/reservation/types_test.go
@@ -255,6 +255,12 @@ func TestTokenRead(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestTokenToRaw(t *testing.T) {
+	tok := newToken()
+	raw := newTokenRaw()
+	require.Equal(t, raw, tok.ToRaw())
+}
+
 func newInfoField() InfoField {
 	return InfoField{
 		ExpirationTick: 384555855,

--- a/go/lib/colibri/reservation/types_test.go
+++ b/go/lib/colibri/reservation/types_test.go
@@ -69,6 +69,14 @@ func TestTickFromTime(t *testing.T) {
 	require.Equal(t, Tick(1), TickFromTime(time.Unix(4, 0)))
 }
 
+func TestTickToTime(t *testing.T) {
+	require.Equal(t, time.Unix(0, 0), Tick(0).ToTime())
+	require.Equal(t, time.Unix(4, 0), Tick(1).ToTime())
+	require.Equal(t, time.Unix(0, 0), TickFromTime(time.Unix(0, 0)).ToTime())
+	require.Equal(t, time.Unix(0, 0), TickFromTime(time.Unix(3, 999999)).ToTime())
+	require.Equal(t, time.Unix(4, 0), TickFromTime(time.Unix(4, 0)).ToTime())
+}
+
 func TestValidateBWCls(t *testing.T) {
 	for i := 0; i < 64; i++ {
 		c := BWCls(i)

--- a/go/lib/colibri/reservation/types_test.go
+++ b/go/lib/colibri/reservation/types_test.go
@@ -108,6 +108,13 @@ func TestIndexNumberArithmetic(t *testing.T) {
 	require.Equal(t, IndexNumber(0), x)
 	x = idx.Sub(IndexNumber(2))
 	require.Equal(t, IndexNumber(15), x)
+	// distance from 2 to 0 = 0 - 2 = 14 mod 16
+	x = IndexNumber(2)
+	distance := IndexNumber(0).Sub(x)
+	require.Equal(t, IndexNumber(14), distance)
+	// distance from 2 to 4
+	distance = IndexNumber(4).Sub(x)
+	require.Equal(t, IndexNumber(2), distance)
 }
 
 func TestValidatePathType(t *testing.T) {


### PR DESCRIPTION
- [x] getter DB functions
- [x] UTs
- [x] Rebase after #3778 (first proper commit is `a30df` "refactor, move private function to bottom")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3787)
<!-- Reviewable:end -->
