### PR TITLE
fix default monitoring port for sig

### DIFF
--- a/go/sig/main.go
+++ b/go/sig/main.go
@@ -140,7 +140,7 @@ func validateConfig() error {
 		return err
 	}
 	if cfg.Metrics.Prometheus == "" {
-		cfg.Metrics.Prometheus = "127.0.0.1:1281"
+		cfg.Metrics.Prometheus = "127.0.0.1:30456"
 	}
 	return nil
 }


### PR DESCRIPTION
The default port doesn't match the official port ranges
as described in https://github.com/scionproto/scion/wiki/Default-port-ranges

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3793)
<!-- Reviewable:end -->
