### PR TITLE
scmp: add payload size support to scmp echo

### DIFF
--- a/go/tools/scmp/BUILD.bazel
+++ b/go/tools/scmp/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/sciond:go_default_library",
+        "//go/lib/serrors:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/snet/addrutil:go_default_library",
         "//go/lib/sock/reliable:go_default_library",
@@ -16,6 +17,7 @@ go_library(
         "//go/tools/scmp/echo:go_default_library",
         "//go/tools/scmp/recordpath:go_default_library",
         "//go/tools/scmp/traceroute:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
     ],
 )
 

--- a/go/tools/scmp/cmn/BUILD.bazel
+++ b/go/tools/scmp/cmn/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
-        "//go/lib/env:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/scmp:go_default_library",
         "//go/lib/scrypto:go_default_library",

--- a/go/tools/scmp/echo/echo.go
+++ b/go/tools/scmp/echo/echo.go
@@ -75,7 +75,7 @@ func sendPkts() {
 		}
 		cmn.Stats.Sent += 1
 		// More packets?
-		if cmn.Count != 0 && cmn.Stats.Sent == cmn.Count {
+		if cmn.Count != 0 && cmn.Stats.Sent == uint(cmn.Count) {
 			break
 		}
 		// Update packet fields

--- a/go/tools/scmp/scmp_integration/main.go
+++ b/go/tools/scmp/scmp_integration/main.go
@@ -35,15 +35,15 @@ func realMain() int {
 	defer log.Flush()
 
 	cmnArgs := []string{
-		"-timeout", "4s",
-		"-sciond", integration.SCIOND,
-		"-remote", integration.DstAddrPattern,
+		"--timeout", "4s",
+		"--sciond", integration.SCIOND,
 	}
 	if *integration.Docker {
 		cmnArgs = append(cmnArgs,
-			"-local", integration.SrcHostReplace,
+			"--local", integration.SrcHostReplace,
 		)
 	}
+	cmnArgs = append(cmnArgs, integration.DstAddrPattern)
 
 	testCases := []struct {
 		Name string


### PR DESCRIPTION
Also simplifies argument processing by refactoring scmp echo
to use cobra.

The remote address as a positional argument instead of a -remote flag.
For example, `scmp echo 64-2:0:a,[10.0.2.162]`.

`scmp` now uses POSIX style flags (prefixed with double dash, --)
instead of Go style flags (in other words, now use `--refresh` instead of
`-refresh`). scmp command lines that use Go style flags now have changed
semantics (e.g., `-refresh` actually means setting the `-r`, `-e`, `-f`,
etc. flags). Please ensure all scripts containing the old CLI flags have
been inspected and updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3795)
<!-- Reviewable:end -->
