### PR TITLE
border: do not log an error for SVC_NONE dst addresses

### DIFF
--- a/go/border/BUILD.bazel
+++ b/go/border/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//go/border/rctrl:go_default_library",
         "//go/border/rctx:go_default_library",
         "//go/border/rpkt:go_default_library",
+        "//go/lib/addr:go_default_library",
         "//go/lib/assert:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/env:go_default_library",


### PR DESCRIPTION
At the moment, this is used by path probes. (see #1801)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3797)
<!-- Reviewable:end -->
