### PR TITLE
sig: remove ConfigName from sigconfig

### DIFF
--- a/go/pkg/sig/sigconfig/conf.go
+++ b/go/pkg/sig/sigconfig/conf.go
@@ -71,10 +71,6 @@ func (cfg *Config) Sample(dst io.Writer, path config.Path, _ config.CtxMap) {
 	)
 }
 
-func (cfg *Config) ConfigName() string {
-	return "sig_config"
-}
-
 var _ config.Config = (*SigConf)(nil)
 
 // SigConf contains the configuration specific to the SIG.


### PR DESCRIPTION
This is not used anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3803)
<!-- Reviewable:end -->
