### PR TITLE
snet: add support for new SCION header

### DIFF
--- a/go/examples/pingpong/pingpong.go
+++ b/go/examples/pingpong/pingpong.go
@@ -228,7 +228,17 @@ func (c *client) run() {
 	if err != nil {
 		LogFatal("Unable to initialize SCION network", "err", err)
 	}
-	network := snet.NewNetwork(local.IA, ds, sd.RevHandler{Connector: sciondConn})
+	network := &snet.SCIONNetwork{
+		LocalIA: local.IA,
+		Dispatcher: &snet.DefaultPacketDispatcherService{
+			Dispatcher: ds,
+			SCMPHandler: snet.NewSCMPHandler(
+				sd.RevHandler{Connector: sciondConn},
+			),
+			// TODO(scrye): set this when we have CLI support for features
+			Version2: false,
+		},
+	}
 
 	// Connect to remote address. Note that currently the SCION library
 	// does not support automatic binding to local addresses, so the local
@@ -348,7 +358,18 @@ func (s server) run() {
 	if err != nil {
 		LogFatal("Unable to initialize SCION network", "err", err)
 	}
-	network := snet.NewNetwork(local.IA, ds, sd.RevHandler{Connector: sciondConn})
+	network := &snet.SCIONNetwork{
+		LocalIA: local.IA,
+		Dispatcher: &snet.DefaultPacketDispatcherService{
+			Dispatcher: ds,
+			SCMPHandler: snet.NewSCMPHandler(
+				sciond.RevHandler{Connector: sciondConn},
+			),
+			// TODO(scrye): set this when we have CLI support for features
+			Version2: false,
+		},
+	}
+
 	if err != nil {
 		LogFatal("Unable to initialize SCION network", "err", err)
 	}

--- a/go/integration/common.go
+++ b/go/integration/common.go
@@ -108,7 +108,17 @@ func InitNetwork() *snet.SCIONNetwork {
 	if err != nil {
 		LogFatal("Unable to initialize SCION network", "err", err)
 	}
-	n := snet.NewNetwork(Local.IA, ds, sciond.RevHandler{Connector: sciondConn})
+	n := &snet.SCIONNetwork{
+		LocalIA: Local.IA,
+		Dispatcher: &snet.DefaultPacketDispatcherService{
+			Dispatcher: ds,
+			SCMPHandler: snet.NewSCMPHandler(
+				sciond.RevHandler{Connector: sciondConn},
+			),
+			// TODO(scrye): set this when we have CLI support for features
+			Version2: false,
+		},
+	}
 	log.Debug("SCION network successfully initialized")
 	return n
 }

--- a/go/integration/end2end/main.go
+++ b/go/integration/end2end/main.go
@@ -107,6 +107,8 @@ func (s server) run() {
 		SCMPHandler: snet.NewSCMPHandler(
 			sciond.RevHandler{Connector: integration.SDConn()},
 		),
+		// TODO(scrye): set this when we have CLI support for features
+		Version2: false,
 	}
 	conn, port, err := connFactory.Register(context.Background(), integration.Local.IA,
 		integration.Local.Host, addr.SvcNone)
@@ -165,6 +167,8 @@ func (c client) run() int {
 		SCMPHandler: snet.NewSCMPHandler(
 			sciond.RevHandler{Connector: integration.SDConn()},
 		),
+		// TODO(scrye): set this when we have CLI support for features
+		Version2: false,
 	}
 
 	var err error

--- a/go/lib/infra/infraenv/infraenv.go
+++ b/go/lib/infra/infraenv/infraenv.go
@@ -81,6 +81,9 @@ type NetworkConfig struct {
 	// SVCRouter is used to discover the underlay addresses of intra-AS SVC
 	// servers.
 	SVCRouter messenger.LocalSVCRouter
+
+	// Version2 switches packets to SCION header format version 2.
+	Version2 bool
 }
 
 // Messenger initializes a SCION control-plane RPC endpoint using the specified
@@ -138,6 +141,7 @@ func (nc *NetworkConfig) AddressRewriter(
 	if connFactory == nil {
 		connFactory = &snet.DefaultPacketDispatcherService{
 			Dispatcher: reliable.NewDispatcher(""),
+			Version2:   nc.Version2,
 		}
 	}
 
@@ -187,6 +191,7 @@ func (nc *NetworkConfig) initUDPSocket(quicAddress string) (net.PacketConn, erro
 	packetDispatcher := svc.NewResolverPacketDispatcher(
 		&snet.DefaultPacketDispatcherService{
 			Dispatcher: dispatcherService,
+			Version2:   nc.Version2,
 		},
 		&LegacyForwardingHandler{
 			BaseHandler: &svc.BaseHandler{
@@ -214,6 +219,7 @@ func (nc *NetworkConfig) initQUICSocket() (net.PacketConn, error) {
 		Dispatcher: &snet.DefaultPacketDispatcherService{
 			Dispatcher:  dispatcherService,
 			SCMPHandler: ignoreSCMP{},
+			Version2:    nc.Version2,
 		},
 	}
 	udpAddr, err := net.ResolveUDPAddr("udp", nc.QUIC.Address)

--- a/go/lib/sciond/pathprobe/paths.go
+++ b/go/lib/sciond/pathprobe/paths.go
@@ -95,6 +95,9 @@ type Prober struct {
 	DstIA   addr.IA
 	LocalIA addr.IA
 	LocalIP net.IP
+
+	// Version2 switches packets to SCION header format version 2.
+	Version2 bool
 }
 
 // GetStatuses probes the paths and returns the statuses of the paths. The
@@ -119,6 +122,7 @@ func (p Prober) GetStatuses(ctx context.Context,
 		Dispatcher: &snet.DefaultPacketDispatcherService{
 			Dispatcher:  reliable.NewDispatcher(""),
 			SCMPHandler: scmpH,
+			Version2:    p.Version2,
 		},
 	}
 	snetConn, err := network.Listen(ctx, "udp", &net.UDPAddr{IP: p.LocalIP}, addr.SvcNone)

--- a/go/lib/snet/base.go
+++ b/go/lib/snet/base.go
@@ -34,6 +34,9 @@ type scionConnBase struct {
 
 	// Describes L4 protocol; currently only udp is implemented
 	net string
+
+	// version2 switches packets to SCION header format version 2.
+	version2 bool
 }
 
 func (c *scionConnBase) LocalAddr() net.Addr {

--- a/go/lib/snet/dispatcher.go
+++ b/go/lib/snet/dispatcher.go
@@ -45,6 +45,9 @@ type DefaultPacketDispatcherService struct {
 	// handler is nil, errors are returned back to applications every time an
 	// SCMP message is received.
 	SCMPHandler SCMPHandler
+
+	// Version2 switches packets to SCION header format version 2.
+	Version2 bool
 }
 
 func (s *DefaultPacketDispatcherService) Register(ctx context.Context, ia addr.IA,
@@ -54,7 +57,11 @@ func (s *DefaultPacketDispatcherService) Register(ctx context.Context, ia addr.I
 	if err != nil {
 		return nil, 0, err
 	}
-	return &SCIONPacketConn{conn: rconn, scmpHandler: s.SCMPHandler}, port, nil
+	return &SCIONPacketConn{
+		conn:        rconn,
+		scmpHandler: s.SCMPHandler,
+		version2:    s.Version2,
+	}, port, nil
 }
 
 // RevocationHandler is called by the default SCMP Handler whenever revocations are encountered.

--- a/go/pkg/cs/main.go
+++ b/go/pkg/cs/main.go
@@ -232,6 +232,7 @@ func (app *App) Run() int {
 		},
 		SVCResolutionFraction: Cfg.QUIC.ResolutionFraction,
 		SVCRouter:             messenger.NewSVCRouter(itopo.Provider()),
+		Version2:              Cfg.Features.HeaderV2,
 	}
 	msgr, err := nc.Messenger()
 	if err != nil {
@@ -458,6 +459,7 @@ func (app *App) Run() int {
 	}
 	pktDisp := &snet.DefaultPacketDispatcherService{
 		Dispatcher: dispatcherService,
+		Version2:   Cfg.Features.HeaderV2,
 	}
 	// We do not need to drain the connection, since the src address is spoofed
 	// to contain the topo address.
@@ -488,6 +490,7 @@ func (app *App) Run() int {
 			&onehop.OHPPacketDispatcherService{
 				PacketDispatcherService: &snet.DefaultPacketDispatcherService{
 					Dispatcher: reliable.NewDispatcher(""),
+					Version2:   Cfg.Features.HeaderV2,
 				},
 			},
 		),

--- a/go/pkg/showpaths/showpaths.go
+++ b/go/pkg/showpaths/showpaths.go
@@ -114,6 +114,8 @@ func Run(ctx context.Context, dst addr.IA, cfg Config) (*Result, error) {
 			DstIA:   dst,
 			LocalIA: localIA,
 			LocalIP: localIP,
+			// TODO(scrye): set this when we have CLI support for features
+			Version2: false,
 		}.GetStatuses(ctx, paths)
 		if err != nil {
 			serrors.WrapStr("failed to get status", err)

--- a/go/scion-pki/certs/renew.go
+++ b/go/scion-pki/certs/renew.go
@@ -389,6 +389,7 @@ func buildMsgr(ctx context.Context, ds reliable.Dispatcher, sds sciond.Service,
 			SCMPHandler: snet.NewSCMPHandler(
 				sciond.RevHandler{Connector: sdConn},
 			),
+			Version2: false, // TODO(scrye): set this to true when we have CLI support for features
 		},
 	}
 	conn, err := sn.Dial(ctx, "udp", local.Host, remote, addr.SvcNone)
@@ -408,6 +409,8 @@ func buildMsgr(ctx context.Context, ds reliable.Dispatcher, sds sciond.Service,
 					LocalIA: local.IA,
 					ConnFactory: &snet.DefaultPacketDispatcherService{
 						Dispatcher: ds,
+						// TODO(scrye): set this to true when we have CLI support for features
+						Version2: false,
 					},
 					LocalIP: local.Host.IP,
 					Payload: []byte{0x00, 0x00, 0x00, 0x00},

--- a/go/sig/main.go
+++ b/go/sig/main.go
@@ -83,7 +83,7 @@ func realMain() int {
 		log.Error("TUN device initialization failed", "err", err)
 		return 1
 	}
-	if err := sigcmn.Init(cfg.Sig, cfg.Sciond); err != nil {
+	if err := sigcmn.Init(cfg.Sig, cfg.Sciond, cfg.Features); err != nil {
 		log.Error("SIG common initialization failed", "err", err)
 		return 1
 	}

--- a/go/tools/showpaths/paths.go
+++ b/go/tools/showpaths/paths.go
@@ -94,6 +94,8 @@ func main() {
 			DstIA:   dstIA,
 			LocalIA: localIA,
 			LocalIP: localIP,
+			// TODO(scrye): set this when we have CLI support for features
+			Version2: false,
 		}.GetStatuses(ctx, paths)
 		if err != nil {
 			LogFatal("Failed to get status", "err", err)


### PR DESCRIPTION
Also:
- plugs feature flag support to all snet using applications
with the exception of the border router. Note that CLI tools need
need a CLI flag to be added to enable the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3810)
<!-- Reviewable:end -->
