### PR TITLE
disable revocation verification

### DIFF
--- a/go/cs/ifstate/revoker_test.go
+++ b/go/cs/ifstate/revoker_test.go
@@ -306,8 +306,8 @@ func checkRevocation(t *testing.T, srev *path_mgmt.SignedRevInfo,
 	revokedIfId common.IFIDType, verifier revVerifier, topoProvider topology.Provider) {
 
 	Convey("Check revocation", func() {
-		revInfo, err := srev.VerifiedRevInfo(context.Background(), verifier)
-		SoMsg("No verification err expected", err, ShouldBeNil)
+		revInfo, err := srev.RevInfo()
+		SoMsg("No err expected", err, ShouldBeNil)
 		SoMsg("correct ifId", revInfo.IfID, ShouldEqual, revokedIfId)
 		SoMsg("correct IA", revInfo.RawIsdas, ShouldEqual, ia.IAInt())
 		SoMsg("correct linkType", revInfo.LinkType,

--- a/go/cs/revocation/BUILD.bazel
+++ b/go/cs/revocation/BUILD.bazel
@@ -27,12 +27,10 @@ go_test(
     deps = [
         "//go/cs/metrics:go_default_library",
         "//go/cs/revocation/mock_revocation:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/ctrl:go_default_library",
         "//go/lib/ctrl/ack:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/infra:go_default_library",
-        "//go/lib/infra/messenger:go_default_library",
         "//go/lib/infra/mock_infra:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/scrypto/cppki:go_default_library",

--- a/go/cs/revocation/handler.go
+++ b/go/cs/revocation/handler.go
@@ -73,7 +73,7 @@ func (h *handler) Handle(request *infra.Request) *infra.HandlerResult {
 	defer cancelF()
 
 	sendAck := messenger.SendAckHelper(subCtx, rw)
-	revInfo, err := revocation.VerifiedRevInfo(subCtx, h.verifier)
+	revInfo, err := revocation.RevInfo()
 	if err != nil {
 		logger.Info("[RevHandler] Parsing/Verifying failed",
 			"signer", revocation.Sign.Src, "err", err)

--- a/go/lib/ctrl/path_mgmt/rev_info.go
+++ b/go/lib/ctrl/path_mgmt/rev_info.go
@@ -192,19 +192,6 @@ func (sr *SignedRevInfo) RevInfo() (*RevInfo, error) {
 	return sr.revInfo, err
 }
 
-// VerifiedRevInfo verifies the signature and returns the revocation
-// information or an error in case the verification fails.
-func (sr *SignedRevInfo) VerifiedRevInfo(ctx context.Context, verifier Verifier) (*RevInfo, error) {
-	var err error
-	if sr.revInfo == nil {
-		sr.revInfo, err = NewRevInfoFromRaw(sr.Blob)
-	}
-	if err != nil {
-		return sr.revInfo, err
-	}
-	return sr.revInfo, verifier.Verify(ctx, sr.Blob, sr.Sign)
-}
-
 func (sr *SignedRevInfo) Pack() (common.RawBytes, error) {
 	return proto.PackRoot(sr)
 }

--- a/go/lib/infra/modules/segverifier/segverifier.go
+++ b/go/lib/infra/modules/segverifier/segverifier.go
@@ -194,7 +194,7 @@ func verifyRevInfo(ctx context.Context, verifier infra.Verifier, server net.Addr
 func VerifyRevInfo(ctx context.Context, verifier infra.Verifier, server net.Addr,
 	signedRevInfo *path_mgmt.SignedRevInfo) error {
 
-	if _, err := signedRevInfo.VerifiedRevInfo(ctx, verifier.WithServer(server)); err != nil {
+	if _, err := signedRevInfo.RevInfo(); err != nil {
 		return serrors.Wrap(ErrRevocation, err, "rev", signedRevInfo)
 	}
 	return nil

--- a/go/lib/xtest/matchers/matchers.go
+++ b/go/lib/xtest/matchers/matchers.go
@@ -18,7 +18,6 @@ package matchers
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -92,7 +91,7 @@ func (m *SignedRevs) Matches(x interface{}) bool {
 	}
 	revInfos := make(map[path_mgmt.RevInfo]*path_mgmt.RevInfo)
 	for _, rev := range sRevs {
-		revInfo, err := rev.VerifiedRevInfo(context.Background(), m.Verifier)
+		revInfo, err := rev.RevInfo()
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
This will allow us to proceed with the new revocation mechanism in a
non-breaking way. In this commit we disable verification later we can
disable signing. Then we can gradually move revocation
creation to the dataplane.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3822)
<!-- Reviewable:end -->
