### PR TITLE
properly send ohp packet for header v2

### DIFF
--- a/go/lib/hpkt/BUILD.bazel
+++ b/go/lib/hpkt/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//go/lib/scmp:go_default_library",
         "//go/lib/serrors:go_default_library",
         "//go/lib/slayers:go_default_library",
-        "//go/lib/slayers/path:go_default_library",
         "//go/lib/slayers/path/onehop:go_default_library",
         "//go/lib/slayers/path/scion:go_default_library",
         "//go/lib/spath:go_default_library",

--- a/go/lib/spath/BUILD.bazel
+++ b/go/lib/spath/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/serrors:go_default_library",
+        "//go/lib/slayers/path:go_default_library",
         "//go/lib/slayers/path/onehop:go_default_library",
         "//go/lib/slayers/path/scion:go_default_library",
         "//go/lib/util:go_default_library",

--- a/go/pkg/cs/main.go
+++ b/go/pkg/cs/main.go
@@ -677,10 +677,11 @@ func (t *PeriodicTasks) startRevoker() (*periodic.Runner, error) {
 func (t *PeriodicTasks) StartKeepaliveSender(a *net.UDPAddr) (*periodic.Runner, error) {
 	s := &keepalive.Sender{
 		Sender: &onehop.Sender{
-			Conn: t.conn,
-			IA:   t.TopoProvider.Get().IA(),
-			MAC:  t.genMac(),
-			Addr: a,
+			Conn:     t.conn,
+			IA:       t.TopoProvider.Get().IA(),
+			MAC:      t.genMac(),
+			Addr:     a,
+			HeaderV2: t.headerV2,
 		},
 		Signer:       infra.NullSigner,
 		TopoProvider: t.TopoProvider,
@@ -698,10 +699,11 @@ func (t *PeriodicTasks) startOriginator(a *net.UDPAddr) (*periodic.Runner, error
 		Extender: t.extender("propagator", topo, maxExpTimeFactory(t.store, beacon.PropPolicy)),
 		BeaconSender: &onehop.BeaconSender{
 			Sender: onehop.Sender{
-				Conn: t.conn,
-				IA:   topo.IA(),
-				MAC:  t.genMac(),
-				Addr: a,
+				Conn:     t.conn,
+				IA:       topo.IA(),
+				MAC:      t.genMac(),
+				Addr:     a,
+				HeaderV2: t.headerV2,
 			},
 			AddressRewriter:  t.addressRewriter,
 			QUICBeaconSender: t.msgr,
@@ -720,10 +722,11 @@ func (t *PeriodicTasks) startPropagator(a *net.UDPAddr) (*periodic.Runner, error
 		Extender: t.extender("propagator", topo, maxExpTimeFactory(t.store, beacon.PropPolicy)),
 		BeaconSender: &onehop.BeaconSender{
 			Sender: onehop.Sender{
-				Conn: t.conn,
-				IA:   topo.IA(),
-				MAC:  t.genMac(),
-				Addr: a,
+				Conn:     t.conn,
+				IA:       topo.IA(),
+				MAC:      t.genMac(),
+				Addr:     a,
+				HeaderV2: t.headerV2,
 			},
 			AddressRewriter:  t.addressRewriter,
 			QUICBeaconSender: t.msgr,


### PR DESCRIPTION
Instead of converting OHP packets in hpkt write we need to do it
correctly in the onehop sender, so that we can set the correct MAC value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3826)
<!-- Reviewable:end -->
