### PR TITLE
cs: don't verify RemoteOutIf in beaconing

### DIFF
--- a/go/cs/beacon/beacon.go
+++ b/go/cs/beacon/beacon.go
@@ -56,7 +56,7 @@ func (b Beacon) Diversity(other Beacon) int {
 }
 
 func link(entry *seg.ASEntry) (addr.IA, common.IFIDType) {
-	return entry.IA(), entry.HopEntries[0].RemoteOutIF
+	return entry.IA(), common.IFIDType(entry.HopEntries[0].HopField.ConsIngress)
 }
 
 // BeaconOrErr contains a read-only beacon or an error.

--- a/go/cs/beaconing/extender_test.go
+++ b/go/cs/beaconing/extender_test.go
@@ -450,9 +450,7 @@ func TestDefaultExtenderExtend(t *testing.T) {
 			t.Run("hop entry check", func(t *testing.T) {
 				intf := intfs.Get(tc.egress)
 				ia := intf.TopoInfo().IA
-				remote := intf.TopoInfo().RemoteIFID
 				assert.Equal(t, ia, entry.HopEntries[0].OutIA())
-				assert.Equal(t, remote, entry.HopEntries[0].RemoteOutIF)
 
 				assert.Equal(t, uint16(tc.ingress), entry.HopEntries[0].HopField.ConsIngress)
 				assert.Equal(t, uint16(tc.egress), entry.HopEntries[0].HopField.ConsEgress)
@@ -462,9 +460,7 @@ func TestDefaultExtenderExtend(t *testing.T) {
 			t.Run("peer entry check", func(t *testing.T) {
 				intf := intfs.Get(tc.egress)
 				ia := intf.TopoInfo().IA
-				remote := intf.TopoInfo().RemoteIFID
 				assert.Equal(t, ia, entry.HopEntries[1].OutIA())
-				assert.Equal(t, remote, entry.HopEntries[1].RemoteOutIF)
 
 				assert.Equal(t, uint16(peer), entry.HopEntries[1].HopField.ConsIngress)
 				assert.Equal(t, uint16(tc.egress), entry.HopEntries[1].HopField.ConsEgress)

--- a/go/cs/beaconing/handler.go
+++ b/go/cs/beaconing/handler.go
@@ -187,10 +187,6 @@ func (h *handler) validateASEntry(b beacon.Beacon) error {
 			return common.NewBasicError("Out IA of hop entry does not match local IA", nil,
 				"index", i, "expected", h.ia, "actual", hopEntry.OutIA())
 		}
-		if hopEntry.RemoteOutIF != b.InIfId {
-			return common.NewBasicError("RemoteOutIF of hop entry does not match ingress interface",
-				nil, "expected", b.InIfId, "actual", hopEntry.RemoteOutIF)
-		}
 	}
 	return nil
 }

--- a/go/cs/beaconing/handler_test.go
+++ b/go/cs/beaconing/handler_test.go
@@ -156,17 +156,6 @@ func TestNewHandler(t *testing.T) {
 		res := handler.Handle(defaultTestReq(rw, pseg))
 		assert.Equal(t, res, infra.MetricsErrInvalid)
 	})
-	t.Run("Invalid remote out interface", func(t *testing.T) {
-		pseg := testBeacon(g, []common.IFIDType{graph.If_120_A_110_X}).Segment
-		asEntry := pseg.ASEntries[pseg.MaxAEIdx()]
-		asEntry.HopEntries[0].RemoteOutIF = 42
-		raw, err := asEntry.Pack()
-		require.NoError(t, err)
-		pseg.RawASEntries[pseg.MaxAEIdx()].Blob = raw
-		res := handler.Handle(defaultTestReq(rw, pseg))
-		assert.Equal(t, res, infra.MetricsErrInvalid)
-	})
-
 	t.Run("Verification error", func(t *testing.T) {
 		verifier := mock_infra.NewMockVerifier(mctrl)
 		verifier.EXPECT().WithIA(gomock.Any()).Return(verifier)


### PR DESCRIPTION
Also for v2 don't set it.

Since we want to get rid of keepalives, which also detect remote
interfaces we have to stop using remote interface IDs. Except for
peering links we don't really need to know the remote interface ID. For
peering links we should add the remote ID to the topology file once we
implement support for peering links.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3832)
<!-- Reviewable:end -->
