### PR TITLE
log: avoid double span wrapping

### DIFF
--- a/go/lib/log/context.go
+++ b/go/lib/log/context.go
@@ -42,6 +42,9 @@ func FromCtx(ctx context.Context) Logger {
 		return Root()
 	}
 	if logger := ctx.Value(loggerKey); logger != nil {
+		if _, ok := logger.(Span); ok {
+			return logger.(Logger)
+		}
 		return attachSpan(ctx, logger.(Logger))
 	}
 	// Logger not found in ctx, make sure we never return a nil root


### PR DESCRIPTION
Avoid wrapping a span logger inside of another span logger.

When calling `log.FromCtx`, the logger inside the context is wrapped
with a span logger. If the logger is already a span logger, it is not
wrapped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3833)
<!-- Reviewable:end -->
