### PR TITLE
segfetcher: do recursive request in parallel

### DIFF
--- a/go/cs/segreq/fetcher.go
+++ b/go/cs/segreq/fetcher.go
@@ -104,7 +104,8 @@ func newRouter(cfg FetcherConfig, fetcher *segfetcher.Fetcher) snet.Router {
 				cfg.TopoProvider.Get().Core(),
 				cfg.Inspector,
 				cfg.PathDB),
-			Fetcher: fetcher,
+			Fetcher:  fetcher,
+			HeaderV2: cfg.HeaderV2,
 		},
 	}
 }

--- a/go/lib/infra/modules/segfetcher/BUILD.bazel
+++ b/go/lib/infra/modules/segfetcher/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//go/lib/topology:go_default_library",
         "//go/pkg/trust:go_default_library",
         "//go/proto:go_default_library",
+        "@com_github_opentracing_opentracing_go//:go_default_library",
     ],
 )
 


### PR DESCRIPTION
The destination provider might itself fetch segments and thus might take
quite some time. We should not let the first request block other
requests. Therefore execute the dst provider also in the request go
routine.

This should improve stability of the new path lookup.

Also create separate spans for each request so that it becomes easier to
debug what is going on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3836)
<!-- Reviewable:end -->
