### PR TITLE
snet: move MTU/Expiry to separate snet.PathMetadata interface

### DIFF
--- a/acceptance/sig_failover/testdata/1-ff00_0_110/sig/fake_sciond.json
+++ b/acceptance/sig_failover/testdata/1-ff00_0_110/sig/fake_sciond.json
@@ -4,15 +4,31 @@
             "reply_start_timestamp": 0,
             "paths": [
                 {
-                    "fingerprint": "PathAAAA",
+                    "interfaces": [
+                      {
+                        "ia": "1-ff00:0:110",
+                        "id": 1
+                      },
+                      {
+                        "ia": "1-ff00:0:111",
+                        "id": 1
+                      }
+                    ],
                     "next_hop": "242.254.100.3:50000",
-                    "ia": "1-ff00:0:111",
                     "expiration_timestamp": 7200
                 },
                 {
-                    "fingerprint": "PathBBBB",
+                    "interfaces": [
+                      {
+                        "ia": "1-ff00:0:110",
+                        "id": 2
+                      },
+                      {
+                        "ia": "1-ff00:0:111",
+                        "id": 2
+                      }
+                    ],
                     "next_hop": "242.254.100.4:50000",
-                    "ia": "1-ff00:0:111",
                     "expiration_timestamp": 7200
                 }
             ]

--- a/acceptance/sig_failover/testdata/1-ff00_0_111/sig/fake_sciond.json
+++ b/acceptance/sig_failover/testdata/1-ff00_0_111/sig/fake_sciond.json
@@ -4,15 +4,31 @@
             "reply_start_timestamp": 0,
             "paths": [
                 {
-                    "fingerprint": "PathAAAA",
+                    "interfaces": [
+                      {
+                        "ia": "1-ff00:0:111",
+                        "id": 1
+                      },
+                      {
+                        "ia": "1-ff00:0:110",
+                        "id": 1
+                      }
+                    ],
                     "next_hop": "242.254.200.3:50000",
-                    "ia": "1-ff00:0:110",
                     "expiration_timestamp": 7200
                 },
                 {
-                    "fingerprint": "PathBBBB",
+                    "interfaces": [
+                      {
+                        "ia": "1-ff00:0:111",
+                        "id": 2
+                      },
+                      {
+                        "ia": "1-ff00:0:110",
+                        "id": 2
+                      }
+                    ],
                     "next_hop": "242.254.200.4:50000",
-                    "ia": "1-ff00:0:110",
                     "expiration_timestamp": 7200
                 }
             ]

--- a/acceptance/sig_short_exp_time/testdata/1-ff00_0_110/sig/fake_sciond.json
+++ b/acceptance/sig_short_exp_time/testdata/1-ff00_0_110/sig/fake_sciond.json
@@ -4,9 +4,17 @@
             "reply_start_timestamp": 0,
             "paths": [
                 {
-                    "fingerprint": "PathAAAAExpiresSoon",
+                    "interfaces": [
+                      {
+                        "ia": "1-ff00:0:110",
+                        "id": 1
+                      },
+                      {
+                        "ia": "1-ff00:0:111",
+                        "id": 1
+                      }
+                    ],
                     "next_hop": "242.254.100.3:50000",
-                    "ia": "1-ff00:0:111",
                     "expiration_timestamp": 10
                 }
             ]
@@ -15,15 +23,31 @@
             "reply_start_timestamp": 5,
             "paths": [
                 {
-                    "fingerprint": "PathAAAAExpiresSoon",
+                    "interfaces": [
+                      {
+                        "ia": "1-ff00:0:110",
+                        "id": 1
+                      },
+                      {
+                        "ia": "1-ff00:0:111",
+                        "id": 1
+                      }
+                    ],
                     "next_hop": "242.254.100.3:50000",
-                    "ia": "1-ff00:0:111",
                     "expiration_timestamp": 10
                 },
                 {
-                    "fingerprint": "PathBBBBExpiresLate",
+                    "interfaces": [
+                      {
+                        "ia": "1-ff00:0:110",
+                        "id": 2
+                      },
+                      {
+                        "ia": "1-ff00:0:111",
+                        "id": 2
+                      }
+                    ],
                     "next_hop": "242.254.100.4:50000",
-                    "ia": "1-ff00:0:111",
                     "expiration_timestamp": 7200
                 }
             ]

--- a/acceptance/sig_short_exp_time/testdata/1-ff00_0_111/sig/fake_sciond.json
+++ b/acceptance/sig_short_exp_time/testdata/1-ff00_0_111/sig/fake_sciond.json
@@ -4,9 +4,17 @@
             "seconds": 0,
             "paths": [
                 {
-                    "fingerprint": "PathAAAAExpiresSoon",
+                    "interfaces": [
+                      {
+                        "ia": "1-ff00:0:111",
+                        "id": 1
+                      },
+                      {
+                        "ia": "1-ff00:0:110",
+                        "id": 1
+                      }
+                    ],
                     "next_hop": "242.254.200.3:50000",
-                    "ia": "1-ff00:0:110",
                     "expiry_seconds": 10
                 }
             ]
@@ -15,15 +23,31 @@
             "reply_start_timestamp": 5,
             "paths": [
                 {
-                    "fingerprint": "PathAAAAExpiresSoon",
+                    "interfaces": [
+                      {
+                        "ia": "1-ff00:0:111",
+                        "id": 1
+                      },
+                      {
+                        "ia": "1-ff00:0:110",
+                        "id": 1
+                      }
+                    ],
                     "next_hop": "242.254.200.3:50000",
-                    "ia": "1-ff00:0:110",
                     "expiration_timestamp": 10
                 },
                 {
-                    "fingerprint": "PathBBBBExpiresLate",
+                    "interfaces": [
+                      {
+                        "ia": "1-ff00:0:111",
+                        "id": 2
+                      },
+                      {
+                        "ia": "1-ff00:0:110",
+                        "id": 2
+                      }
+                    ],
                     "next_hop": "242.254.200.4:50000",
-                    "ia": "1-ff00:0:110",
                     "expiration_timestamp": 7200
                 }
             ]

--- a/go/cs/segutil/router.go
+++ b/go/cs/segutil/router.go
@@ -17,8 +17,6 @@ package segutil
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/binary"
 	"fmt"
 	"net"
 	"strings"
@@ -117,18 +115,6 @@ type path struct {
 type pathMetadata struct {
 	mtu    uint16
 	expiry time.Time
-}
-
-func (p path) Fingerprint() snet.PathFingerprint {
-	if len(p.interfaces) == 0 {
-		return ""
-	}
-	h := sha256.New()
-	for _, intf := range p.interfaces {
-		binary.Write(h, binary.BigEndian, intf.IA().IAInt())
-		binary.Write(h, binary.BigEndian, intf.ID())
-	}
-	return snet.PathFingerprint(h.Sum(nil))
 }
 
 func (p path) UnderlayNextHop() *net.UDPAddr {

--- a/go/cs/segutil/router.go
+++ b/go/cs/segutil/router.go
@@ -95,8 +95,10 @@ func (r *Router) translate(comb *combinator.Path, dst addr.IA) (path, error) {
 		interfaces: make([]pathInterface, 0, len(comb.Interfaces)),
 		underlay:   nextHop,
 		spath:      sp,
-		mtu:        comb.Mtu,
-		expiry:     comb.ComputeExpTime(),
+		metadata: pathMetadata{
+			mtu:    comb.Mtu,
+			expiry: comb.ComputeExpTime(),
+		},
 	}
 	for _, intf := range comb.Interfaces {
 		p.interfaces = append(p.interfaces, pathInterface{ia: intf.IA(), ifid: intf.ID()})
@@ -108,9 +110,13 @@ type path struct {
 	interfaces []pathInterface
 	underlay   *net.UDPAddr
 	spath      *spath.Path
-	mtu        uint16
-	expiry     time.Time
 	dst        addr.IA
+	metadata   pathMetadata
+}
+
+type pathMetadata struct {
+	mtu    uint16
+	expiry time.Time
 }
 
 func (p path) Fingerprint() snet.PathFingerprint {
@@ -161,12 +167,8 @@ func (p path) Destination() addr.IA {
 	return p.interfaces[len(p.interfaces)-1].IA()
 }
 
-func (p path) MTU() uint16 {
-	return p.mtu
-}
-
-func (p path) Expiry() time.Time {
-	return p.expiry
+func (p path) Metadata() snet.PathMetadata {
+	return p.metadata
 }
 
 func (p path) Copy() snet.Path {
@@ -174,15 +176,14 @@ func (p path) Copy() snet.Path {
 		interfaces: append(p.interfaces[:0:0], p.interfaces...),
 		underlay:   p.UnderlayNextHop(), // creates copy
 		spath:      p.Path(),            // creates copy
-		mtu:        p.mtu,
-		expiry:     p.expiry,
+		metadata:   p.metadata,
 	}
 }
 
 func (p path) String() string {
 	hops := p.fmtInterfaces()
 	return fmt.Sprintf("Hops: [%s] MTU: %d, NextHop: %s",
-		strings.Join(hops, ">"), p.mtu, p.underlay)
+		strings.Join(hops, ">"), p.Metadata().MTU(), p.UnderlayNextHop())
 }
 
 func (p path) fmtInterfaces() []string {
@@ -200,4 +201,12 @@ func (p path) fmtInterfaces() []string {
 	intf = p.interfaces[len(p.interfaces)-1]
 	hops = append(hops, fmt.Sprintf("%d %s", intf.ID(), intf.IA()))
 	return hops
+}
+
+func (m pathMetadata) MTU() uint16 {
+	return m.mtu
+}
+
+func (m pathMetadata) Expiry() time.Time {
+	return m.expiry
 }

--- a/go/lib/infra/messenger/addr.go
+++ b/go/lib/infra/messenger/addr.go
@@ -150,7 +150,7 @@ func (r AddressRewriter) buildFullAddress(ctx context.Context,
 	}()
 
 	// SVC addresses in the local AS get resolved via topology lookup
-	if p.Fingerprint() == "" { //when local AS
+	if len(p.Interfaces()) == 0 { //when local AS
 		ov, err := r.SVCRouter.GetUnderlay(s.SVC)
 		if err != nil {
 			return nil, common.NewBasicError("Unable to resolve underlay", err)

--- a/go/lib/infra/messenger/addr_test.go
+++ b/go/lib/infra/messenger/addr_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -470,11 +469,7 @@ func (t *testPath) Destination() addr.IA {
 	panic("not implemented")
 }
 
-func (t *testPath) MTU() uint16 {
-	panic("not implemented")
-}
-
-func (t *testPath) Expiry() time.Time {
+func (t *testPath) Metadata() snet.PathMetadata {
 	panic("not implemented")
 }
 

--- a/go/lib/infra/messenger/addr_test.go
+++ b/go/lib/infra/messenger/addr_test.go
@@ -97,7 +97,7 @@ func TestRedirectQUIC(t *testing.T) {
 		router.EXPECT().Route(gomock.Any(), gomock.Any()).Return(path, nil)
 		path.EXPECT().Path().Return(nil)
 		path.EXPECT().UnderlayNextHop().Return(&net.UDPAddr{IP: net.ParseIP("10.1.1.1")})
-		path.EXPECT().Fingerprint().Return(snet.PathFingerprint("foo"))
+		path.EXPECT().Interfaces().Return(make([]snet.PathInterface, 1)) // just non-empty
 
 		aw := messenger.AddressRewriter{
 			Router:                router,
@@ -131,7 +131,7 @@ func TestRedirectQUIC(t *testing.T) {
 		router.EXPECT().Route(gomock.Any(), gomock.Any()).Return(path, nil)
 		path.EXPECT().Path().Return(nil)
 		path.EXPECT().UnderlayNextHop().Return(&net.UDPAddr{IP: net.ParseIP("10.1.1.1")})
-		path.EXPECT().Fingerprint().Return(snet.PathFingerprint("foo"))
+		path.EXPECT().Interfaces().Return(make([]snet.PathInterface, 1)) // just non-empty
 
 		aw := messenger.AddressRewriter{
 			Router:                router,
@@ -161,7 +161,7 @@ func TestRedirectQUIC(t *testing.T) {
 		router.EXPECT().Route(gomock.Any(), gomock.Any()).Return(path, nil)
 		path.EXPECT().Path().Return(nil)
 		path.EXPECT().UnderlayNextHop().Return(&net.UDPAddr{IP: net.ParseIP("10.1.1.1")})
-		path.EXPECT().Fingerprint().Return(snet.PathFingerprint(""))
+		path.EXPECT().Interfaces().Return(nil)
 		svcRouter := mock_messenger.NewMockLocalSVCRouter(ctrl)
 		svcRouter.EXPECT().GetUnderlay(addr.SvcBS).Return(
 			&net.UDPAddr{IP: net.ParseIP("10.1.1.1")}, nil,
@@ -233,7 +233,7 @@ func TestBuildFullAddress(t *testing.T) {
 		path := mock_snet.NewMockPath(ctrl)
 		path.EXPECT().Path().Return(&spath.Path{})
 		path.EXPECT().UnderlayNextHop().Return(&net.UDPAddr{})
-		path.EXPECT().Fingerprint().Return(snet.PathFingerprint("foo"))
+		path.EXPECT().Interfaces().Return(make([]snet.PathInterface, 1)) // just non-empty
 		router.EXPECT().Route(gomock.Any(), gomock.Any()).Return(path, nil)
 		input := &snet.SVCAddr{IA: remoteIA, SVC: addr.SvcBS}
 		a, err := aw.BuildFullAddress(context.Background(), input)
@@ -265,7 +265,7 @@ func TestBuildFullAddress(t *testing.T) {
 		svcRouter.EXPECT().GetUnderlay(addr.SvcBS).Return(underlayAddr, nil)
 
 		path := mock_snet.NewMockPath(ctrl)
-		path.EXPECT().Fingerprint()
+		path.EXPECT().Interfaces()
 		path.EXPECT().Path()
 		path.EXPECT().UnderlayNextHop()
 		router.EXPECT().Route(gomock.Any(), gomock.Any()).Return(path, nil)
@@ -292,7 +292,7 @@ func TestBuildFullAddress(t *testing.T) {
 		svcRouter.EXPECT().GetUnderlay(addr.SvcBS).Return(nil, errors.New("err"))
 
 		path := mock_snet.NewMockPath(ctrl)
-		path.EXPECT().Fingerprint()
+		path.EXPECT().Interfaces()
 		path.EXPECT().Path()
 		path.EXPECT().UnderlayNextHop()
 		router.EXPECT().Route(gomock.Any(), gomock.Any()).Return(path, nil)
@@ -448,10 +448,6 @@ func initResolver(resolver *mock_messenger.MockResolver, f func(*mock_messenger.
 }
 
 type testPath struct{}
-
-func (t *testPath) Fingerprint() snet.PathFingerprint {
-	panic("not implemented")
-}
 
 func (t *testPath) UnderlayNextHop() *net.UDPAddr {
 	panic("not implemented")

--- a/go/lib/pathmgr/pathmgr.go
+++ b/go/lib/pathmgr/pathmgr.go
@@ -286,8 +286,8 @@ func apsToPs(aps spathmeta.AppPathSet) pathpol.PathSet {
 
 func psToAps(ps pathpol.PathSet) spathmeta.AppPathSet {
 	aps := make(spathmeta.AppPathSet)
-	for _, path := range ps {
-		aps[path.Fingerprint()] = path.(snet.Path)
+	for key, path := range ps {
+		aps[key] = path.(snet.Path)
 	}
 	return aps
 }

--- a/go/lib/pathmgr/syncpaths.go
+++ b/go/lib/pathmgr/syncpaths.go
@@ -104,9 +104,9 @@ func (sp *SyncPaths) Destroy() {
 
 func setSubtract(x, y spathmeta.AppPathSet) spathmeta.AppPathSet {
 	result := make(spathmeta.AppPathSet)
-	for _, ap := range x {
-		if _, ok := y[ap.Fingerprint()]; !ok {
-			result.Add(ap)
+	for key, ap := range x {
+		if _, ok := y[key]; !ok {
+			result[key] = ap
 		}
 	}
 	return result

--- a/go/lib/pathmgr/util_test.go
+++ b/go/lib/pathmgr/util_test.go
@@ -16,8 +16,6 @@
 package pathmgr_test
 
 import (
-	"crypto/sha256"
-	"encoding/binary"
 	"strconv"
 	"strings"
 	"testing"
@@ -54,7 +52,6 @@ func createPath(t testing.TB, ctrl *gomock.Controller, desc string) snet.Path {
 		})
 	}
 	path.EXPECT().Interfaces().Return(interfaces).AnyTimes()
-	path.EXPECT().Fingerprint().Return(fingerprint(interfaces)).AnyTimes()
 	return path
 }
 
@@ -64,18 +61,6 @@ func mustIfID(t testing.TB, s string) common.IFIDType {
 		t.Fatalf("Failed to parse interface: %s", s)
 	}
 	return common.IFIDType(ifID)
-}
-
-func fingerprint(interfaces []snet.PathInterface) snet.PathFingerprint {
-	if len(interfaces) == 0 {
-		return ""
-	}
-	h := sha256.New()
-	for _, intf := range interfaces {
-		binary.Write(h, binary.BigEndian, intf.IA().IAInt())
-		binary.Write(h, binary.BigEndian, intf.ID())
-	}
-	return snet.PathFingerprint(h.Sum(nil))
 }
 
 type intf struct {

--- a/go/lib/pathpol/pathset.go
+++ b/go/lib/pathpol/pathset.go
@@ -25,6 +25,4 @@ type PathSet map[snet.PathFingerprint]Path
 type Path interface {
 	// Interfaces returns all the interfaces of this path.
 	Interfaces() []snet.PathInterface
-	// Returns a string that uniquely identifies this path.
-	Fingerprint() snet.PathFingerprint
 }

--- a/go/lib/pathpol/policy_test.go
+++ b/go/lib/pathpol/policy_test.go
@@ -639,7 +639,6 @@ func (p PathProvider) GetPaths(src, dst addr.IA) PathSet {
 		}
 		result[snet.PathFingerprint(key.String())] = &testPath{
 			interfaces: pathIntfs,
-			key:        snet.PathFingerprint(key.String()),
 		}
 	}
 	return result
@@ -647,14 +646,11 @@ func (p PathProvider) GetPaths(src, dst addr.IA) PathSet {
 
 type testPath struct {
 	interfaces []snet.PathInterface
-	key        snet.PathFingerprint
 }
 
 func (p *testPath) Interfaces() []snet.PathInterface {
 	return p.interfaces
 }
-
-func (p *testPath) Fingerprint() snet.PathFingerprint { return p.key }
 
 type testPathIntf struct {
 	ia   addr.IA

--- a/go/lib/sciond/apitypes.go
+++ b/go/lib/sciond/apitypes.go
@@ -16,8 +16,6 @@ package sciond
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/binary"
 	"fmt"
 	"net"
 	"strings"
@@ -161,18 +159,6 @@ func pathReplyEntryToMetadata(pe PathReplyEntry) pathMetadata {
 		mtu:    pe.Path.Mtu,
 		expiry: pe.Path.Expiry(),
 	}
-}
-
-func (p path) Fingerprint() snet.PathFingerprint {
-	if len(p.interfaces) == 0 {
-		return ""
-	}
-	h := sha256.New()
-	for _, intf := range p.interfaces {
-		binary.Write(h, binary.BigEndian, intf.IA().IAInt())
-		binary.Write(h, binary.BigEndian, intf.ID())
-	}
-	return snet.PathFingerprint(h.Sum(nil))
 }
 
 func (p path) UnderlayNextHop() *net.UDPAddr {

--- a/go/lib/sciond/fake/fake_test.go
+++ b/go/lib/sciond/fake/fake_test.go
@@ -30,12 +30,14 @@ func TestJSONConversion(t *testing.T) {
 				ReplyStartTimestamp: 0,
 				Paths: []*fake.Path{
 					{
-						JSONFingerprint: "Foo",
+						JSONInterfaces: []fake.PathInterface{
+							{JSONIA: xtest.MustParseIA("1-ff00:0:ffff"), JSONID: 1},
+							{JSONIA: xtest.MustParseIA("1-ff00:0:1"), JSONID: 1},
+						},
 						JSONNextHop: &fake.UDPAddr{
 							IP:   net.IP{192, 168, 0, 1},
 							Port: 80,
 						},
-						JSONIA:                  xtest.MustParseIA("1-ff00:0:1"),
 						JSONExpirationTimestamp: 7200,
 					},
 				},
@@ -69,12 +71,14 @@ func TestPaths(t *testing.T) {
 				ReplyStartTimestamp: 0,
 				Paths: []*fake.Path{
 					{
-						JSONFingerprint: "Foo",
+						JSONInterfaces: []fake.PathInterface{
+							{JSONIA: xtest.MustParseIA("1-ff00:0:ffff"), JSONID: 1},
+							{JSONIA: xtest.MustParseIA("1-ff00:0:1"), JSONID: 1},
+						},
 						JSONNextHop: &fake.UDPAddr{
 							IP:   net.IP{10, 0, 0, 1},
 							Port: 80,
 						},
-						JSONIA:                  xtest.MustParseIA("1-ff00:0:1"),
 						JSONExpirationTimestamp: 7200,
 					},
 				},
@@ -83,12 +87,14 @@ func TestPaths(t *testing.T) {
 				ReplyStartTimestamp: 1,
 				Paths: []*fake.Path{
 					{
-						JSONFingerprint: "Foo2",
+						JSONInterfaces: []fake.PathInterface{
+							{JSONIA: xtest.MustParseIA("1-ff00:0:ffff"), JSONID: 1},
+							{JSONIA: xtest.MustParseIA("2-ff00:0:2"), JSONID: 1},
+						},
 						JSONNextHop: &fake.UDPAddr{
 							IP:   net.IP{10, 0, 0, 2},
 							Port: 80,
 						},
-						JSONIA:                  xtest.MustParseIA("2-ff00:0:2"),
 						JSONExpirationTimestamp: 10800,
 					},
 				},
@@ -106,10 +112,12 @@ func TestPaths(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(paths))
-	//assert.Equal(t, "Foo", string(paths[0].Fingerprint()))
+	assert.NotEqual(t, "", string(snet.Fingerprint(paths[0])))
+	assert.Equal(t, snet.Fingerprint(script.Entries[0].Paths[0]), snet.Fingerprint(paths[0]))
 	assert.Equal(t, &net.UDPAddr{IP: net.IP{10, 0, 0, 1}, Port: 80}, paths[0].UnderlayNextHop())
 	assert.Equal(t, fake.DummyPath(), paths[0].Path())
-	assert.Equal(t, []snet.PathInterface{}, paths[0].Interfaces())
+	assert.Equal(t, 2, len(paths[0].Interfaces()))
+	assert.Equal(t, paths[0].Destination(), paths[0].Interfaces()[1].IA())
 	assert.Equal(t, xtest.MustParseIA("1-ff00:0:1"), paths[0].Destination())
 	assert.Equal(t, uint16(1472), paths[0].Metadata().MTU())
 	// path valid for more than an hour, but less than three
@@ -127,10 +135,12 @@ func TestPaths(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(paths))
-	// assert.Equal(t, "Foo2", string(paths[0].Fingerprint()))
+	assert.NotEqual(t, "", string(snet.Fingerprint(paths[0])))
+	assert.Equal(t, snet.Fingerprint(script.Entries[1].Paths[0]), snet.Fingerprint(paths[0]))
 	assert.Equal(t, &net.UDPAddr{IP: net.IP{10, 0, 0, 2}, Port: 80}, paths[0].UnderlayNextHop())
 	assert.Equal(t, fake.DummyPath(), paths[0].Path())
-	assert.Equal(t, []snet.PathInterface{}, paths[0].Interfaces())
+	assert.Equal(t, 2, len(paths[0].Interfaces()))
+	assert.Equal(t, paths[0].Destination(), paths[0].Interfaces()[1].IA())
 	assert.Equal(t, xtest.MustParseIA("2-ff00:0:2"), paths[0].Destination())
 	assert.Equal(t, uint16(1472), paths[0].Metadata().MTU())
 	// path valid for more than two hours, but less than four
@@ -140,13 +150,15 @@ func TestPaths(t *testing.T) {
 
 func TestPathCopy(t *testing.T) {
 	path := fake.Path{
-		JSONFingerprint: "foo",
+		JSONInterfaces: []fake.PathInterface{
+			{JSONIA: xtest.MustParseIA("1-ff00:0:ffff"), JSONID: 1},
+			{JSONIA: xtest.MustParseIA("1-ff00:0:1"), JSONID: 1},
+		},
 		JSONNextHop: &fake.UDPAddr{
 			IP:   net.IP{192, 168, 0, 1},
 			Port: 80,
 			Zone: "abc",
 		},
-		JSONIA: xtest.MustParseIA("1-ff00:0:1"),
 	}
 
 	copyPath := path.Copy()

--- a/go/lib/sciond/fake/fake_test.go
+++ b/go/lib/sciond/fake/fake_test.go
@@ -106,7 +106,7 @@ func TestPaths(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(paths))
-	assert.Equal(t, "Foo", string(paths[0].Fingerprint()))
+	//assert.Equal(t, "Foo", string(paths[0].Fingerprint()))
 	assert.Equal(t, &net.UDPAddr{IP: net.IP{10, 0, 0, 1}, Port: 80}, paths[0].UnderlayNextHop())
 	assert.Equal(t, fake.DummyPath(), paths[0].Path())
 	assert.Equal(t, []snet.PathInterface{}, paths[0].Interfaces())
@@ -127,7 +127,7 @@ func TestPaths(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 1, len(paths))
-	assert.Equal(t, "Foo2", string(paths[0].Fingerprint()))
+	// assert.Equal(t, "Foo2", string(paths[0].Fingerprint()))
 	assert.Equal(t, &net.UDPAddr{IP: net.IP{10, 0, 0, 2}, Port: 80}, paths[0].UnderlayNextHop())
 	assert.Equal(t, fake.DummyPath(), paths[0].Path())
 	assert.Equal(t, []snet.PathInterface{}, paths[0].Interfaces())

--- a/go/lib/sciond/fake/fake_test.go
+++ b/go/lib/sciond/fake/fake_test.go
@@ -111,10 +111,10 @@ func TestPaths(t *testing.T) {
 	assert.Equal(t, fake.DummyPath(), paths[0].Path())
 	assert.Equal(t, []snet.PathInterface{}, paths[0].Interfaces())
 	assert.Equal(t, xtest.MustParseIA("1-ff00:0:1"), paths[0].Destination())
-	assert.Equal(t, uint16(1472), paths[0].MTU())
+	assert.Equal(t, uint16(1472), paths[0].Metadata().MTU())
 	// path valid for more than an hour, but less than three
-	assert.True(t, paths[0].Expiry().After(time.Now().Add(time.Hour)))
-	assert.True(t, paths[0].Expiry().Before(time.Now().Add(3*time.Hour)))
+	assert.True(t, paths[0].Metadata().Expiry().After(time.Now().Add(time.Hour)))
+	assert.True(t, paths[0].Metadata().Expiry().Before(time.Now().Add(3*time.Hour)))
 
 	time.Sleep(time.Second)
 
@@ -132,10 +132,10 @@ func TestPaths(t *testing.T) {
 	assert.Equal(t, fake.DummyPath(), paths[0].Path())
 	assert.Equal(t, []snet.PathInterface{}, paths[0].Interfaces())
 	assert.Equal(t, xtest.MustParseIA("2-ff00:0:2"), paths[0].Destination())
-	assert.Equal(t, uint16(1472), paths[0].MTU())
+	assert.Equal(t, uint16(1472), paths[0].Metadata().MTU())
 	// path valid for more than two hours, but less than four
-	assert.True(t, paths[0].Expiry().After(time.Now().Add(2*time.Hour)))
-	assert.True(t, paths[0].Expiry().Before(time.Now().Add(4*time.Hour)))
+	assert.True(t, paths[0].Metadata().Expiry().After(time.Now().Add(2*time.Hour)))
+	assert.True(t, paths[0].Metadata().Expiry().Before(time.Now().Add(4*time.Hour)))
 }
 
 func TestPathCopy(t *testing.T) {

--- a/go/lib/sciond/fake/testdata/sd.json
+++ b/go/lib/sciond/fake/testdata/sd.json
@@ -4,9 +4,17 @@
         "reply_start_timestamp": 0,
         "paths": [
           {
-            "fingerprint": "Foo",
+            "interfaces": [
+              {
+                "ia": "1-ff00:0:ffff",
+                "id": 1
+              },
+              {
+                "ia": "1-ff00:0:1",
+                "id": 1
+              }
+            ],
             "next_hop": "192.168.0.1:80",
-            "ia": "1-ff00:0:1",
             "expiration_timestamp": 7200
           }
         ]

--- a/go/lib/snet/mock_snet/snet.go
+++ b/go/lib/snet/mock_snet/snet.go
@@ -266,20 +266,6 @@ func (mr *MockPathMockRecorder) Destination() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destination", reflect.TypeOf((*MockPath)(nil).Destination))
 }
 
-// Expiry mocks base method
-func (m *MockPath) Expiry() time.Time {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Expiry")
-	ret0, _ := ret[0].(time.Time)
-	return ret0
-}
-
-// Expiry indicates an expected call of Expiry
-func (mr *MockPathMockRecorder) Expiry() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expiry", reflect.TypeOf((*MockPath)(nil).Expiry))
-}
-
 // Fingerprint mocks base method
 func (m *MockPath) Fingerprint() snet.PathFingerprint {
 	m.ctrl.T.Helper()
@@ -308,18 +294,18 @@ func (mr *MockPathMockRecorder) Interfaces() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Interfaces", reflect.TypeOf((*MockPath)(nil).Interfaces))
 }
 
-// MTU mocks base method
-func (m *MockPath) MTU() uint16 {
+// Metadata mocks base method
+func (m *MockPath) Metadata() snet.PathMetadata {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MTU")
-	ret0, _ := ret[0].(uint16)
+	ret := m.ctrl.Call(m, "Metadata")
+	ret0, _ := ret[0].(snet.PathMetadata)
 	return ret0
 }
 
-// MTU indicates an expected call of MTU
-func (mr *MockPathMockRecorder) MTU() *gomock.Call {
+// Metadata indicates an expected call of Metadata
+func (mr *MockPathMockRecorder) Metadata() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MTU", reflect.TypeOf((*MockPath)(nil).MTU))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metadata", reflect.TypeOf((*MockPath)(nil).Metadata))
 }
 
 // Path mocks base method

--- a/go/lib/snet/mock_snet/snet.go
+++ b/go/lib/snet/mock_snet/snet.go
@@ -266,20 +266,6 @@ func (mr *MockPathMockRecorder) Destination() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destination", reflect.TypeOf((*MockPath)(nil).Destination))
 }
 
-// Fingerprint mocks base method
-func (m *MockPath) Fingerprint() snet.PathFingerprint {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Fingerprint")
-	ret0, _ := ret[0].(snet.PathFingerprint)
-	return ret0
-}
-
-// Fingerprint indicates an expected call of Fingerprint
-func (mr *MockPathMockRecorder) Fingerprint() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fingerprint", reflect.TypeOf((*MockPath)(nil).Fingerprint))
-}
-
 // Interfaces mocks base method
 func (m *MockPath) Interfaces() []snet.PathInterface {
 	m.ctrl.T.Helper()

--- a/go/lib/snet/path.go
+++ b/go/lib/snet/path.go
@@ -56,11 +56,9 @@ type Path interface {
 	// Destination is the AS the path points to. Empty paths return the local
 	// AS of the router that created them.
 	Destination() addr.IA
-	// MTU returns the MTU of the path. If the result is zero, MTU is unknown.
-	MTU() uint16
-	// Expiry returns the expiration time of the path. If the result is a zero
-	// value expiration time is unknown.
-	Expiry() time.Time
+	// Metadata returns supplementary information about this path.
+	// Returns nil if the metadata is not available.
+	Metadata() PathMetadata
 	// Copy create a copy of the path.
 	Copy() Path
 }
@@ -73,6 +71,14 @@ type PathInterface interface {
 	ID() common.IFIDType
 	// IA is the ISD AS identifier of the interface.
 	IA() addr.IA
+}
+
+// PathMetadata contains supplementary information about a path.
+type PathMetadata interface {
+	// MTU returns the MTU of the path.
+	MTU() uint16
+	// Expiry returns the expiration time of the path.
+	Expiry() time.Time
 }
 
 // partialPath is a path object with incomplete metadata. It is used as a
@@ -107,12 +113,8 @@ func (p *partialPath) Destination() addr.IA {
 	return p.destination
 }
 
-func (p *partialPath) MTU() uint16 {
-	return 0
-}
-
-func (p *partialPath) Expiry() time.Time {
-	return time.Time{}
+func (p *partialPath) Metadata() PathMetadata {
+	return nil
 }
 
 func (p *partialPath) Copy() Path {

--- a/go/lib/spath/spathmeta/apppath.go
+++ b/go/lib/spath/spathmeta/apppath.go
@@ -40,7 +40,7 @@ func NewAppPathSet(paths []snet.Path) AppPathSet {
 
 // Add adds the given path to the path set.
 func (aps AppPathSet) Add(path snet.Path) {
-	aps[path.Fingerprint()] = path
+	aps[snet.Fingerprint(path)] = path
 }
 
 func (aps AppPathSet) Copy() AppPathSet {

--- a/go/lib/svc/resolver.go
+++ b/go/lib/svc/resolver.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"net"
-	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
@@ -200,12 +199,8 @@ func (p *path) Destination() addr.IA {
 	return p.destination
 }
 
-func (p *path) MTU() uint16 {
-	return 0
-}
-
-func (p *path) Expiry() time.Time {
-	return time.Time{}
+func (p *path) Metadata() snet.PathMetadata {
+	return nil
 }
 
 func (p *path) Copy() snet.Path {

--- a/go/lib/svc/resolver.go
+++ b/go/lib/svc/resolver.go
@@ -179,10 +179,6 @@ type path struct {
 	destination addr.IA
 }
 
-func (p *path) Fingerprint() snet.PathFingerprint {
-	return ""
-}
-
 func (p *path) UnderlayNextHop() *net.UDPAddr {
 	return p.underlay
 }

--- a/go/pkg/sciond/fetcher/filter.go
+++ b/go/pkg/sciond/fetcher/filter.go
@@ -38,7 +38,7 @@ func pathsToPs(paths []*combinator.Path) pathpol.PathSet {
 	ps := make(pathpol.PathSet, len(paths))
 	for _, path := range paths {
 		wp := newPathWrap(path)
-		ps[wp.Fingerprint()] = wp
+		ps[wp.key] = wp
 	}
 	return ps
 }
@@ -71,5 +71,4 @@ func newPathWrap(p *combinator.Path) pathWrap {
 	}
 }
 
-func (p pathWrap) Interfaces() []snet.PathInterface  { return p.intfs }
-func (p pathWrap) Fingerprint() snet.PathFingerprint { return p.key }
+func (p pathWrap) Interfaces() []snet.PathInterface { return p.intfs }

--- a/go/pkg/showpaths/showpaths.go
+++ b/go/pkg/showpaths/showpaths.go
@@ -138,8 +138,8 @@ func Run(ctx context.Context, dst addr.IA, cfg Config) (*Result, error) {
 			FullPath:    path,
 			Fingerprint: fingerprint,
 			NextHop:     nextHop,
-			Expiry:      path.Expiry(),
-			MTU:         path.MTU(),
+			Expiry:      path.Metadata().Expiry(),
+			MTU:         path.Metadata().MTU(),
 			Local:       localIP,
 			Hops:        []Hop{},
 		}

--- a/go/pkg/showpaths/showpaths.go
+++ b/go/pkg/showpaths/showpaths.go
@@ -127,7 +127,8 @@ func Run(ctx context.Context, dst addr.IA, cfg Config) (*Result, error) {
 	res := &Result{Destination: dst}
 	for _, path := range paths {
 		fingerprint := "local"
-		if fp := path.Fingerprint().String(); fp != "" {
+		if len(path.Interfaces()) > 0 {
+			fp := snet.Fingerprint(path).String()
 			fingerprint = fp[:16]
 		}
 		var nextHop string

--- a/go/scion/ping.go
+++ b/go/scion/ping.go
@@ -104,7 +104,8 @@ func newPing(pather CommandPather) *cobra.Command {
 			}
 			pldSize := int(flags.size)
 			if flags.maxMTU {
-				pldSize, err = calcMaxPldSize(local, remote, int(path.MTU()), features.HeaderV2)
+				mtu := int(path.Metadata().MTU())
+				pldSize, err = calcMaxPldSize(local, remote, mtu, features.HeaderV2)
 				if err != nil {
 					return err
 				}

--- a/go/sig/egress/iface/sesspath.go
+++ b/go/sig/egress/iface/sesspath.go
@@ -41,7 +41,8 @@ func (sp *SessPath) Path() snet.Path {
 }
 
 func (sp *SessPath) IsCloseToExpiry() bool {
-	return sp.Path().Expiry().Before(time.Now().Add(SafetyInterval))
+	metadata := sp.Path().Metadata()
+	return metadata == nil || metadata.Expiry().Before(time.Now().Add(SafetyInterval))
 }
 
 func (sp *SessPath) Copy() *SessPath {

--- a/go/sig/egress/worker/worker.go
+++ b/go/sig/egress/worker/worker.go
@@ -230,7 +230,9 @@ func (w *worker) resetFrame(f *frame) {
 			w.currPathEntry = remote.SessPath.Path()
 		}
 		if w.currPathEntry != nil {
-			mtu = w.currPathEntry.MTU()
+			if md := w.currPathEntry.Metadata(); md != nil {
+				mtu = md.MTU()
+			}
 			pathLen = uint16(len(w.currPathEntry.Path().Raw))
 		}
 	}

--- a/go/sig/internal/snetmigrate/path.go
+++ b/go/sig/internal/snetmigrate/path.go
@@ -27,10 +27,6 @@ type emptyPath struct {
 	source addr.IA
 }
 
-func (p *emptyPath) Fingerprint() snet.PathFingerprint {
-	return ""
-}
-
 func (p *emptyPath) UnderlayNextHop() *net.UDPAddr {
 	return nil
 }

--- a/go/sig/internal/snetmigrate/path.go
+++ b/go/sig/internal/snetmigrate/path.go
@@ -16,7 +16,6 @@ package snetmigrate
 
 import (
 	"net"
-	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/snet"
@@ -48,12 +47,8 @@ func (p *emptyPath) Destination() addr.IA {
 	return p.source
 }
 
-func (p *emptyPath) MTU() uint16 {
-	return 0
-}
-
-func (p *emptyPath) Expiry() time.Time {
-	return time.Time{}
+func (p *emptyPath) Metadata() snet.PathMetadata {
+	return nil
 }
 
 func (p *emptyPath) Copy() snet.Path {

--- a/go/tools/scmp/main.go
+++ b/go/tools/scmp/main.go
@@ -229,7 +229,7 @@ func setPathAndMtu() {
 	cmn.PathEntry = path
 	cmn.Remote.Path = path.Path()
 	cmn.Remote.NextHop = path.UnderlayNextHop()
-	cmn.Mtu = path.MTU()
+	cmn.Mtu = path.Metadata().MTU()
 }
 
 // setLocalASInfo queries the local AS information from SCIOND; sets cmn.LocalIA and localMtu.

--- a/go/tools/showpaths/paths.go
+++ b/go/tools/showpaths/paths.go
@@ -104,8 +104,10 @@ func main() {
 	for i, path := range paths {
 		fmt.Printf("[%2d] %s", i, fmt.Sprintf("%s", path))
 		if *expiration {
-			fmt.Printf(" Expires: %s (%s)", path.Expiry(),
-				time.Until(path.Expiry()).Truncate(time.Second))
+			if md := path.Metadata(); md != nil {
+				fmt.Printf(" Expires: %s (%s)", md.Expiry(),
+					time.Until(md.Expiry()).Truncate(time.Second))
+			}
 		}
 		if *status {
 			fmt.Printf(" Status: %s", pathStatuses[pathprobe.PathKey(path)])


### PR DESCRIPTION
Add additional interface for (optional) path metadata on snet.Path.
This new snet.PathMetadata interface will be extended to add support for
the information in the StaticInfo beacon extension (Geo information,
Latency, Bandwidth, etc) as a next step.

Having a separate interface for the metadata clarifies that some
instances of snet.Path (e.g. the `partialPath` constructed from raw
forwarding information) do not have any of this metadata available.
Thus, moving the existing MTU and Expiry fields to this new interface
feels quite natural.

Additionally, remove `Fingerprint` from the `snet.Path` interface.
`Fingerprint` can be implemented in terms of snet.Path, so it does not
need to be part of the interface. Make this a simple helper function 
in `snet` instead.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3839)
<!-- Reviewable:end -->
