### PR TITLE
topogen: allocate ipv4 subnets for docker

### DIFF
--- a/acceptance/common.sh
+++ b/acceptance/common.sh
@@ -52,13 +52,6 @@ fail() {
 }
 
 #######################################
-# Returns whether this script is running in docker
-#######################################
-is_running_in_docker() {
-    cut -d: -f 3 /proc/1/cgroup | grep -q '^/docker/'
-}
-
-#######################################
 # Return the ip of the container
 # Arguments:
 #   Name of the container

--- a/go/integration/BUILD.bazel
+++ b/go/integration/BUILD.bazel
@@ -15,5 +15,6 @@ go_library(
         "//go/lib/snet:go_default_library",
         "//go/lib/sock/reliable:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@com_github_uber_jaeger_client_go//:go_default_library",
     ],
 )

--- a/integration/common.sh
+++ b/integration/common.sh
@@ -39,10 +39,6 @@ is_docker_be() {
     [ -f gen/scion-dc.yml ]
 }
 
-is_running_in_docker() {
-    cut -d: -f 3 /proc/1/cgroup | grep -q '^/docker/'
-}
-
 usage() {
     echo "Usage: $0: [-b brs]"
     exit 1

--- a/integration/integration_test.sh
+++ b/integration/integration_test.sh
@@ -33,13 +33,9 @@ shutdown() {
     fi
 }
 
-if is_running_in_docker; then
-    log "Starting scion (without building)"
-    ./scion.sh run nobuild | grep -v "started" || exit 1
-else
-     log "Starting scion"
-    ./scion.sh run | grep -v "started" || exit 1
-fi
+log "Starting scion"
+./scion.sh run | grep -v "started" || exit 1
+
 log "Scion status:"
 ./scion.sh status || exit 1
 if is_docker_be; then

--- a/python/topology/config.py
+++ b/python/topology/config.py
@@ -23,6 +23,8 @@ import logging
 import os
 import sys
 from io import StringIO
+from ipaddress import ip_network
+from typing import Mapping
 
 # SCION
 from python.lib.defines import (
@@ -41,6 +43,7 @@ from python.topology.docker import DockerGenArgs, DockerGenerator
 from python.topology.go import GoGenArgs, GoGenerator
 from python.topology.jaeger import JaegerGenArgs, JaegerGenerator
 from python.topology.net import (
+    NetworkDescription,
     SubnetGenerator,
     DEFAULT_NETWORK,
 )
@@ -81,8 +84,8 @@ class ConfigGenerator(object):
         Configure default network.
         """
         defaults = self.topo_config.get("defaults", {})
-        self.subnet_gen4 = SubnetGenerator(DEFAULT_NETWORK, self.args.docker, self.args.in_docker)
-        self.subnet_gen6 = SubnetGenerator(DEFAULT6_NETWORK, self.args.docker, self.args.in_docker)
+        self.subnet_gen4 = SubnetGenerator(DEFAULT_NETWORK, self.args.docker)
+        self.subnet_gen6 = SubnetGenerator(DEFAULT6_NETWORK, self.args.docker)
         self.default_mtu = defaults.get("mtu", DEFAULT_MTU)
 
     def generate_all(self):
@@ -90,7 +93,8 @@ class ConfigGenerator(object):
         Generate all needed files.
         """
         self._ensure_uniq_ases()
-        topo_dicts, self.networks = self._generate_topology()
+        topo_dicts, self.all_networks = self._generate_topology()
+        self.networks = remove_v4_nets(self.all_networks)
         self._generate_with_topo(topo_dicts)
         self._write_networks_conf(self.networks, NETWORKS_FILE)
         self._write_sciond_conf(self.networks, SCIOND_ADDRESSES_FILE)
@@ -160,7 +164,7 @@ class ConfigGenerator(object):
         docker_gen.generate()
 
     def _docker_args(self, topo_dicts):
-        return DockerGenArgs(self.args, topo_dicts, self.networks)
+        return DockerGenArgs(self.args, topo_dicts, self.all_networks)
 
     def _generate_prom_conf(self, topo_dicts):
         args = self._prometheus_args(topo_dicts)
@@ -179,23 +183,35 @@ class ConfigGenerator(object):
             for path, value in ca_files[int(isd)].items():
                 write_file(os.path.join(base, path), value.decode())
 
-    def _write_networks_conf(self, networks, out_file):
+    def _write_networks_conf(self,
+                             networks: Mapping[ip_network, NetworkDescription],
+                             out_file: str):
         config = configparser.ConfigParser(interpolation=None)
-        for i, net in enumerate(networks):
+        for net, net_desc in networks.items():
             sub_conf = {}
-            for prog, ip_net in networks[net].items():
+            for prog, ip_net in net_desc.ip_net.items():
                 sub_conf[prog] = ip_net.ip
             config[net] = sub_conf
         text = StringIO()
         config.write(text)
         write_file(os.path.join(self.args.output_dir, out_file), text.getvalue())
 
-    def _write_sciond_conf(self, networks, out_file):
+    def _write_sciond_conf(self, networks: Mapping[ip_network, NetworkDescription], out_file: str):
         d = dict()
-        for i, net in enumerate(networks):
-            for prog, ip_net in networks[net].items():
+        for net_desc in networks.values():
+            for prog, ip_net in net_desc.ip_net.items():
                 if prog.startswith("sd"):
                     ia = prog[2:].replace("_", ":")
                     d[ia] = str(ip_net.ip)
         with open(os.path.join(self.args.output_dir, out_file), mode="w") as f:
             json.dump(d, f, sort_keys=True, indent=4)
+
+
+def remove_v4_nets(nets: Mapping[ip_network, NetworkDescription]
+                   ) -> Mapping[ip_network, NetworkDescription]:
+    res = {}
+    for net, net_desc in nets.items():
+        if net_desc.name.endswith('_v4'):
+            continue
+        res[net] = net_desc
+    return res

--- a/python/topology/generator.py
+++ b/python/topology/generator.py
@@ -45,8 +45,6 @@ def add_arguments(parser):
                         available timeout')
     parser.add_argument('--random-ifids', action='store_true',
                         help='Generate random IFIDs')
-    parser.add_argument('--in-docker', action='store_true',
-                        help='Set if running in a docker container')
     parser.add_argument('--docker-registry', help='Specify docker registry to pull images from')
     parser.add_argument('--image-tag', help='Docker image tag')
     parser.add_argument('--sig', action='store_true',

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -20,6 +20,8 @@
 import os
 import toml
 import yaml
+from ipaddress import ip_network
+from typing import Mapping
 
 # SCION
 from python.lib.util import write_file
@@ -41,7 +43,7 @@ from python.topology.common import (
     CO_CONFIG_NAME,
 )
 
-from python.topology.net import socket_address_str
+from python.topology.net import socket_address_str, NetworkDescription
 
 from python.topology.prometheus import (
     CS_PROM_PORT,
@@ -57,7 +59,7 @@ CO_QUIC_PORT = 30357
 
 
 class GoGenArgs(ArgsTopoDicts):
-    def __init__(self, args, topo_dicts, networks):
+    def __init__(self, args, topo_dicts, networks: Mapping[ip_network, NetworkDescription]):
         super().__init__(args, topo_dicts)
         self.networks = networks
 
@@ -298,7 +300,7 @@ class GoGenerator(object):
         }
 
     def _tracing_entry(self):
-        docker_ip = docker_host(self.args.in_docker, self.args.docker)
+        docker_ip = docker_host(self.args.docker)
         entry = {
             'enabled': True,
             'debug': True,

--- a/python/topology/jaeger.py
+++ b/python/topology/jaeger.py
@@ -43,7 +43,7 @@ class JaegerGenerator(object):
                    yaml.dump(dc_conf, default_flow_style=False))
 
     def _generate_dc(self):
-        name = 'jaeger-docker' if self.args.in_docker else 'jaeger'
+        name = 'jaeger'
         entry = {
             'version': '2',
             'services': {

--- a/python/topology/prometheus.py
+++ b/python/topology/prometheus.py
@@ -19,6 +19,8 @@
 # Stdlib
 import os
 from collections import defaultdict
+from ipaddress import ip_network
+from typing import Mapping
 
 # External packages
 import yaml
@@ -32,6 +34,9 @@ from python.topology.common import (
     prom_addr_dispatcher,
     sciond_ip,
 )
+from python.topology.net import (
+    NetworkDescription
+)
 
 CS_PROM_PORT = 30452
 SCIOND_PROM_PORT = 30455
@@ -44,7 +49,7 @@ PROM_DC_FILE = "prom-dc.yml"
 
 
 class PrometheusGenArgs(ArgsTopoDicts):
-    def __init__(self, args, topo_dicts, networks):
+    def __init__(self, args, topo_dicts, networks: Mapping[ip_network, NetworkDescription]):
         super().__init__(args, topo_dicts)
         self.networks = networks
 
@@ -145,12 +150,11 @@ class PrometheusGenerator(object):
         write_file(targets_path, yaml.dump(target_config, default_flow_style=False))
 
     def _write_dc_file(self):
-        name_prefix = 'prometheus'
-        name = '%s_docker' % name_prefix if self.args.in_docker else name_prefix
+        name = 'prometheus'
         prom_dc = {
             'version': DOCKER_COMPOSE_CONFIG_VERSION,
             'services': {
-                name_prefix: {
+                name: {
                     'image': 'prom/prometheus:v2.6.0',
                     'container_name': name,
                     'network_mode': 'host',

--- a/python/topology/sig.py
+++ b/python/topology/sig.py
@@ -56,7 +56,7 @@ class SIGGenerator(object):
         self.dc_conf = args.dc_conf
         self.user_spec = os.environ.get('SCION_USERSPEC', '$LOGNAME')
         self.output_base = os.environ.get('SCION_OUTPUT_BASE', os.getcwd())
-        self.prefix = 'docker_' if self.args.in_docker else ''
+        self.prefix = ''
 
     def generate(self):
         for topo_id, topo in self.args.topo_dicts.items():

--- a/scion.sh
+++ b/scion.sh
@@ -30,7 +30,6 @@ cmd_topology() {
     tar --overwrite -xf bazel-bin/scion-topo.tar -C bin
 
     echo "Create topology, configuration, and execution files."
-    is_running_in_docker && set -- "$@" --in-docker
     python/topology/generator.py "$@"
     if is_docker_be; then
         ./tools/quiet ./tools/dc run utils_chowner
@@ -220,10 +219,6 @@ is_docker_be() {
 
 is_supervisor() {
    [ -f gen/dispatcher/supervisord.conf ]
-}
-
-is_running_in_docker() {
-    cut -d: -f 3 /proc/1/cgroup | grep -q '^/docker/'
 }
 
 cmd_test(){

--- a/tools/dc
+++ b/tools/dc
@@ -85,7 +85,6 @@ dc() {
     local project="$1"
     local dc_file="gen/$1-dc.yml"
     shift
-    is_running_in_docker && project="${project}_docker"
     COMPOSE_FILE="$dc_file" docker-compose -p "$project" --no-ansi "$@"
 }
 
@@ -131,10 +130,6 @@ glob_match() {
 service_running() {
     cntr="$(cmd_scion ps -q $1)"
     [ -n "$cntr" ] && [ -n "$(docker ps -q --no-trunc | grep $cntr)" ]
-}
-
-is_running_in_docker() {
-    cut -d: -f 3 /proc/1/cgroup | grep -q '^/docker/'
 }
 
 PROGRAM="${0##*/}"


### PR DESCRIPTION
If we just specify an IPv6 subnet in a docker network, docker-compose chooses
an IPv4 subnet which might overlap with another IPv4 network that we allocated.
This will make the topology fail able to start. This commit prevents this and
should fix a few CI errors.

Also remove the `--in-docker` flag and supporting code, because it is no longer needed.
Also add extra_hosts entry for jaeger tracing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3840)
<!-- Reviewable:end -->
