### PR TITLE
sig: remove default prometheus address

### DIFF
--- a/go/sig/main.go
+++ b/go/sig/main.go
@@ -72,7 +72,7 @@ func realMain() int {
 	defer log.Flush()
 	defer env.LogAppStopped("SIG", cfg.Sig.ID)
 	defer log.HandlePanic()
-	if err := validateConfig(); err != nil {
+	if err := cfg.Validate(); err != nil {
 		log.Error("Configuration validation failed", "err", err)
 		return 1
 	}
@@ -138,16 +138,6 @@ func setupBasic() error {
 	}
 	prom.ExportElementID(cfg.Sig.ID)
 	return env.LogAppStarted("SIG", cfg.Sig.ID)
-}
-
-func validateConfig() error {
-	if err := cfg.Validate(); err != nil {
-		return err
-	}
-	if cfg.Metrics.Prometheus == "" {
-		cfg.Metrics.Prometheus = "127.0.0.1:30456"
-	}
-	return nil
 }
 
 func setupTun() (io.ReadWriteCloser, error) {


### PR DESCRIPTION
The SIG was setting a default prometheus address, contrary to what is
documented; the docs explicitly say that if the address is unset, the
metrics will not be exported. This default value would also make it
impossible to disable exporting metrics.

Remove the undocumented, unneeded default value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3850)
<!-- Reviewable:end -->
