### PR TITLE
change default configs to docker-friendly values

### DIFF
--- a/go/lib/env/env.go
+++ b/go/lib/env/env.go
@@ -139,8 +139,6 @@ type SCIONDClient struct {
 	// FakeData can be used to replace the local SCIOND with a fake data source.
 	// It must point to a fake SCIOND configuration file.
 	FakeData string `toml:"fake_data,omitempty"`
-	// PathCount is the maximum number of paths returned to the user.
-	PathCount uint16 `toml:"path_count,omitempty"`
 }
 
 func (cfg *SCIONDClient) InitDefaults() {
@@ -205,7 +203,7 @@ func ReloadTopology(topologyPath string) {
 		return
 	}
 	if err := itopo.Update(topo); err != nil {
-		log.Error("Unable to set topology", "err", err)
+		log.Error("Unable to update topology", "err", err)
 		return
 	}
 	log.Info("Reloaded topology")

--- a/go/lib/env/envtest/config.go
+++ b/go/lib/env/envtest/config.go
@@ -54,7 +54,9 @@ func InitTestTracing(cfg *env.Tracing) {
 	cfg.Debug = true
 }
 
-func InitTestSCIOND(cfg *env.SCIONDClient) {}
+func InitTestSCIOND(cfg *env.SCIONDClient) {
+	cfg.Address = "garbage"
+}
 
 func CheckTest(t *testing.T, general *env.General, metrics *env.Metrics,
 	tracing *env.Tracing, sciond *env.SCIONDClient, id string) {
@@ -75,7 +77,7 @@ func CheckTest(t *testing.T, general *env.General, metrics *env.Metrics,
 
 func CheckTestGeneral(t *testing.T, cfg *env.General, id string) {
 	assert.Equal(t, id, cfg.ID)
-	assert.Equal(t, "/etc/scion", cfg.ConfigDir)
+	assert.Equal(t, "/share/conf", cfg.ConfigDir)
 	assert.Equal(t, filepath.Join(cfg.ConfigDir, env.TopologyFile), cfg.Topology())
 	assert.False(t, cfg.ReconnectToDispatcher)
 }

--- a/go/lib/env/features.go
+++ b/go/lib/env/features.go
@@ -22,7 +22,7 @@ import (
 
 var _ config.Config = (*Features)(nil)
 
-// Features contains all feautre flags. Add feature flags to this structure as
+// Features contains all feature flags. Add feature flags to this structure as
 // needed. Feature flags are always boolean. Don't use any other types here!
 type Features struct {
 	AllowRunAsRoot bool `toml:"allow_run_as_root,omitempty"`

--- a/go/lib/env/sample.go
+++ b/go/lib/env/sample.go
@@ -19,7 +19,7 @@ const generalSample = `
 id = "%s"
 
 # Directory for loading AS information, certs, keys, path policy, topology.
-config_dir = "/etc/scion"
+config_dir = "/share/conf"
 
 # Enable the snetproxy reconnecter. (default false)
 reconnect_to_dispatcher = false
@@ -30,15 +30,11 @@ const featuresSample = `
 `
 
 const sciondClientSample = `
-# Address of the SCIOND server the client should connect to.
+# Address of the SCIOND server the client should connect to. (default 127.0.0.1:30255)
 address = "127.0.0.1:30255"
 
 # Maximum time spent attempting to connect to sciond on start. (default 20s)
 initial_connect_period = "20s"
-
-# Maximum numer of paths provided by SCIOND.
-# Zero means that all the paths should be provided. (default 0)
-path_count = 0
 `
 
 const metricsSample = `
@@ -65,10 +61,10 @@ const quicSample = `
 address = ""
 
 # Certificate file to use for authenticating QUIC connections.
-cert_file = "/etc/scion/quic/tls.pem"
+cert_file = "/share/conf/quic/tls.pem"
 
 # Key file to use for authenticating QUIC connections.
-key_file = "/etc/scion/quic/tls.key"
+key_file = "/share/conf/quic/tls.key"
 
 # Enables SVC resolution for traffic to SVC
 # destinations in a way that is also compatible with control plane servers

--- a/go/sig/internal/sigcmn/common.go
+++ b/go/sig/internal/sigcmn/common.go
@@ -110,7 +110,7 @@ func initNetwork(cfg sigconfig.SigConf, sdCfg env.SCIONDClient,
 	}
 
 	ia, _ := sciondConn.LocalIA(context.Background())
-	pathResolver := pathmgr.New(sciondConn, pathmgr.Timers{}, sdCfg.PathCount)
+	pathResolver := pathmgr.New(sciondConn, pathmgr.Timers{}, 0)
 	network := &snet.SCIONNetwork{
 		LocalIA: ia,
 		Dispatcher: &snet.DefaultPacketDispatcherService{


### PR DESCRIPTION
The following configs change:
- default path for configuration file
- default path for QUIC certificate file
- default path for QUIC key file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3857)
<!-- Reviewable:end -->
