### PR TITLE
doc: update SCMP spec

### DIFF
--- a/doc/protocols/scmp.rst
+++ b/doc/protocols/scmp.rst
@@ -296,10 +296,11 @@ Parameter Problem
 |              | 35 - Non-local delivery                                   |br||
 |              |                                                               |
 |              | 48 - Invalid path                                         |br||
-|              | 49 - Unknown hop field interface                          |br||
-|              | 50 - Invalid hop field MAC                                |br||
-|              | 51 - Path expired                                         |br||
-|              | 52 - Invalid segment change                               |br||
+|              | 49 - Unknown hop field ingress interface                  |br||
+|              | 50 - Unknown hop field egress interface                   |br||
+|              | 51 - Invalid hop field MAC                                |br||
+|              | 52 - Path expired                                         |br||
+|              | 53 - Invalid segment change                               |br||
 |              |                                                               |
 |              | 64 - Invalid extension header                             |br||
 |              | 65 - Unknown hop-by-hop option                            |br||
@@ -333,7 +334,7 @@ A **Parameter Problem** error message with code 35 SHOULD be originated in
 response to a packet that is on the last hop of its path, but the destination
 ISD-AS does not match the local ISD-AS.
 
-Codes 48-52 describe problems related to the path header. 49-52 are more
+Codes 48-53 describe problems related to the path header. 49-52 are more
 granular subsets of 48.
 
 Codes 64-66 describe problems related to extension headers. 65-66 are more

--- a/doc/protocols/scmp.rst
+++ b/doc/protocols/scmp.rst
@@ -296,8 +296,8 @@ Parameter Problem
 |              | 35 - Non-local delivery                                   |br||
 |              |                                                               |
 |              | 48 - Invalid path                                         |br||
-|              | 49 - Unknown hop field ingress interface                  |br||
-|              | 50 - Unknown hop field egress interface                   |br||
+|              | 49 - Unknown hop field cons ingress interface             |br||
+|              | 50 - Unknown hop field cons egress interface              |br||
 |              | 51 - Invalid hop field MAC                                |br||
 |              | 52 - Path expired                                         |br||
 |              | 53 - Invalid segment change                               |br||
@@ -334,7 +334,7 @@ A **Parameter Problem** error message with code 35 SHOULD be originated in
 response to a packet that is on the last hop of its path, but the destination
 ISD-AS does not match the local ISD-AS.
 
-Codes 48-53 describe problems related to the path header. 49-52 are more
+Codes 48-53 describe problems related to the path header. 49-53 are more
 granular subsets of 48.
 
 Codes 64-66 describe problems related to extension headers. 65-66 are more


### PR DESCRIPTION
Introduce error code to differentiate between unknown ingress and egress
interface, where the pointer is the offset to the hop field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3861)
<!-- Reviewable:end -->
