### PR TITLE
scion: use default text color to fix light-mode

### DIFF
--- a/go/pkg/app/path.go
+++ b/go/pkg/app/path.go
@@ -69,7 +69,7 @@ type colorOptions struct {
 func applyColorOptions(opts ...ColorOption) colorOptions {
 	o := colorOptions{
 		keys:   color.New(color.FgHiCyan),
-		values: color.New(color.FgWhite),
+		values: color.New(),
 		link:   color.New(color.FgHiMagenta),
 		intf:   color.New(color.FgYellow),
 	}


### PR DESCRIPTION
Using "white" as text color is invisible in color schemes with light backgrounds.
Just use the default text color instead to make this legible for both light and dark background color schemes.

#### Light:
Before (unreadable :boom: ):
![light-broken](https://user-images.githubusercontent.com/42933359/93209484-7cbd7900-f75e-11ea-9ddc-139a8d253b2e.png)

After:
![light-fixed](https://user-images.githubusercontent.com/42933359/93209560-965ec080-f75e-11ea-8a4b-7d406841dad9.png)


#### Dark:
Before:
![dark-before](https://user-images.githubusercontent.com/42933359/93209600-a24a8280-f75e-11ea-9dbc-a1e4a11810b3.png)
After (basically unchanged):
![dark-after](https://user-images.githubusercontent.com/42933359/93209603-a4144600-f75e-11ea-8b55-33ab8777f1d0.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3876)
<!-- Reviewable:end -->
