### PR TITLE
topogen: create flatter gen/ structure

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,7 +11,6 @@ pkg_tar(
     name = "scion",
     srcs = [
         "//go/border",
-        "//go/border-router",
         "//go/cs",
         "//go/dispatcher",
         "//go/posix-router",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,6 +11,7 @@ pkg_tar(
     name = "scion",
     srcs = [
         "//go/border",
+        "//go/border-router",
         "//go/cs",
         "//go/dispatcher",
         "//go/posix-router",

--- a/acceptance/brutil/conf/as.yml
+++ b/acceptance/brutil/conf/as.yml
@@ -1,5 +1,0 @@
-CertChainVersion: 0
-PathSegmentTTL: 21600
-PropagateTime: 5
-RegisterPath: true
-RegisterTime: 5

--- a/acceptance/brutil/docker-compose.yml
+++ b/acceptance/brutil/docker-compose.yml
@@ -2,6 +2,9 @@ version: "2.4"
 x-br: &br
   environment:
     SCION_BR_DISABLE_IFSTATE_MGMT: ""
+  command:
+    - --config
+    - /share/conf/br.toml
   user: "$USER_ID:$GROUP_ID"
   image: scion_border_debug
   network_mode: "service:dispatcher"
@@ -12,6 +15,9 @@ x-br: &br
     - "${TEST_ARTIFACTS_DIR}/conf:/share/conf"
 services:
   dispatcher:
+    command:
+    - --config
+    - /share/conf/disp.toml
     image: scion_dispatcher
     network_mode: none
     user: "$USER_ID:$GROUP_ID"

--- a/acceptance/bs_add_link_acceptance/test
+++ b/acceptance/bs_add_link_acceptance/test
@@ -29,7 +29,7 @@ from plumbum.path.local import LocalPath
 
 from acceptance.common.log import LogExec, init_log
 from acceptance.common.base import CmdBase, set_name, TestBase, TestState
-from acceptance.common.scion import svc_names_from_path, SCIONDocker
+from acceptance.common.scion import SCIONDocker
 from acceptance.common.tools import DC
 
 set_name(__file__)
@@ -155,6 +155,7 @@ class TestRun(CmdBase):
         """
         for cs_config in cs_configs:
             cp(cs_config.parent / 'topology.json', cs_config.parent / cs_config.stem)
+
 
 if __name__ == '__main__':
     init_log()

--- a/acceptance/bs_add_link_acceptance/test
+++ b/acceptance/bs_add_link_acceptance/test
@@ -123,9 +123,10 @@ class TestRun(CmdBase):
         logger.info('Initial end2end failed as expected, restoring topologies')
         files = topology_files()
         self.restore_topologies(files)
-        names = svc_names_from_path([f.parent for f in files])
-        logging.info('Reloading services: %s' % names)
-        self.scion.reload_svc(names)
+        svc_names = svc_names_from_path([f.parent for f in files])
+        cs_names = [s for s in svc_names if s.startswith('cs')]
+        logging.info('Reloading services: %s' % cs_names)
+        self.scion.reload_svc(cs_names)
         time.sleep(2)
         self.scion.run_end2end()
 

--- a/acceptance/bs_add_link_acceptance/test
+++ b/acceptance/bs_add_link_acceptance/test
@@ -56,7 +56,7 @@ def topology_files() -> LocalPath:
     Return the paths to all topology files for beacon servers in
     AS 1-ff00:0:110 and 1-ff00:0:111.
     """
-    return local.path('gen/ISD1') // 'ASff00_0_11[0,1]/cs*/topology.json'
+    return local.path('gen/') // 'ASff00_0_11[0,1]/topology.json'
 
 
 @Test.subcommand('setup')
@@ -123,7 +123,7 @@ class TestRun(CmdBase):
         logger.info('Initial end2end failed as expected, restoring topologies')
         files = topology_files()
         self.restore_topologies(files)
-        names = svc_names_from_path(files)
+        names = svc_names_from_path([f.parent for f in files])
         logging.info('Reloading services: %s' % names)
         self.scion.reload_svc(names)
         time.sleep(2)

--- a/acceptance/bs_add_link_acceptance/test
+++ b/acceptance/bs_add_link_acceptance/test
@@ -52,7 +52,7 @@ class Test(TestBase):
     """
 
 
-def find_cs_configs() -> List[LocalPath]:
+def cs_config_files() -> List[LocalPath]:
     """
     Return the paths to the cs  config files in AS 1-ff00:0:110 and 1-ff00:0:111.
     """
@@ -73,7 +73,7 @@ class TestSetup(CmdBase):
             self.docker_status()
 
     def modify_topologies(self):
-        cs_configs = find_cs_configs()
+        cs_configs = cs_config_files()
         cs_dirs = self.copy_cs_configs(cs_configs)
 
         topos = self.load_topologies(cs_dirs)
@@ -83,7 +83,7 @@ class TestSetup(CmdBase):
     def copy_cs_configs(self, cs_configs):
         """
         Copy configuration files shared between the different services (topology.json, crypto/, ..)
-        into separate subdirectory for the CS, it is "unshared" and can be modified without
+        into separate subdirectory for the CS, so that it is "unshared" and can be modified without
         affecting the other services (routers, sciond, ...).
         :returns: new subdirectories for CS configs
         """
@@ -139,7 +139,7 @@ class TestRun(CmdBase):
     def main(self):
         self.scion.run_end2end(expect_fail=True)
         logger.info('Initial end2end failed as expected, restoring topologies')
-        cs_configs = find_cs_configs()
+        cs_configs = cs_config_files()
         self.restore_topologies(cs_configs)
         names = [cs_config.stem for cs_config in cs_configs]
         logging.info('Reloading services: %s' % names)

--- a/acceptance/bs_add_link_acceptance/test
+++ b/acceptance/bs_add_link_acceptance/test
@@ -22,6 +22,7 @@ from typing import Dict, List
 
 from plumbum.cmd import (
     cp,
+    mkdir,
 )
 from plumbum import local
 from plumbum.path.local import LocalPath
@@ -51,12 +52,11 @@ class Test(TestBase):
     """
 
 
-def topology_files() -> LocalPath:
+def find_cs_configs() -> List[LocalPath]:
     """
-    Return the paths to all topology files for beacon servers in
-    AS 1-ff00:0:110 and 1-ff00:0:111.
+    Return the paths to the cs  config files in AS 1-ff00:0:110 and 1-ff00:0:111.
     """
-    return local.path('gen/') // 'ASff00_0_11[0,1]/topology.json'
+    return local.path('gen') // 'ASff00_0_11[0,1]/cs*.toml'
 
 
 @Test.subcommand('setup')
@@ -73,19 +73,37 @@ class TestSetup(CmdBase):
             self.docker_status()
 
     def modify_topologies(self):
-        files = topology_files()
-        self.backup_topologies(files)
-        topos = self.load_topologies(files)
+        cs_configs = find_cs_configs()
+        cs_dirs = self.copy_cs_configs(cs_configs)
+
+        topos = self.load_topologies(cs_dirs)
         filtered = self.filter_interfaces(topos, ['1-ff00:0:110', '1-ff00:0:111'])
         self.dump_topologies(filtered)
 
-    @staticmethod
-    def backup_topologies(files: LocalPath):
-        for file in files:
-            cp(file, file+'~')
+    def copy_cs_configs(self, cs_configs):
+        """
+        Copy configuration files shared between the different services (topology.json, crypto/, ..)
+        into separate subdirectory for the CS, it is "unshared" and can be modified without
+        affecting the other services (routers, sciond, ...).
+        :returns: new subdirectories for CS configs
+        """
+        cs_dirs = []
+        for cs_config in cs_configs:
+            self.scion.set_configs({'general.config_dir': '/share/conf/%s/' % cs_config.stem},
+                                   [cs_config])
+            base = cs_config.parent
+            cs_dir = base / cs_config.stem
+            cs_dirs.append(cs_dir)
+            mkdir(cs_dir)
+            srcs = [base / n for n in ['crypto', 'keys', 'certs', 'topology.json']]
+            cp('-r', *srcs, cs_dir)
+
+        return cs_dirs
 
     @staticmethod
-    def load_topologies(files: LocalPath) -> Dict[str, Dict]:
+    def load_topologies(cs_dirs: List[LocalPath]) -> Dict[str, Dict]:
+
+        files = [cs_dir / 'topology.json' for cs_dir in cs_dirs]
         topos = {}
         for file in files:
             logger.debug('loading topology: %s', file)
@@ -121,20 +139,22 @@ class TestRun(CmdBase):
     def main(self):
         self.scion.run_end2end(expect_fail=True)
         logger.info('Initial end2end failed as expected, restoring topologies')
-        files = topology_files()
-        self.restore_topologies(files)
-        svc_names = svc_names_from_path([f.parent for f in files])
-        cs_names = [s for s in svc_names if s.startswith('cs')]
-        logging.info('Reloading services: %s' % cs_names)
-        self.scion.reload_svc(cs_names)
+        cs_configs = find_cs_configs()
+        self.restore_topologies(cs_configs)
+        names = [cs_config.stem for cs_config in cs_configs]
+        logging.info('Reloading services: %s' % names)
+        self.scion.reload_svc(names)
         time.sleep(2)
         self.scion.run_end2end()
 
     @staticmethod
-    def restore_topologies(files: LocalPath):
-        for file in files:
-            cp(file+'~', file)
-
+    def restore_topologies(cs_configs: List[LocalPath]):
+        """
+        Copy unmodified topology.json file from shared AS directory and overwrite the
+        modified file in the CS's config subdirectory.
+        """
+        for cs_config in cs_configs:
+            cp(cs_config.parent / 'topology.json', cs_config.parent / cs_config.stem)
 
 if __name__ == '__main__':
     init_log()

--- a/acceptance/cert_renewal_acceptance/test
+++ b/acceptance/cert_renewal_acceptance/test
@@ -149,7 +149,7 @@ class TestRun(CmdBase):
                 args[i] = str(args[i].relative_to(local.path('.')))
 
         logger.info('Requesting certificate chain renewal: %s' % rel(chain))
-        print(self.scion.execute(isd_as, './bin/scion-pki', 'certs', 'renew', *args))
+        logger.info(self.scion.execute(isd_as, './bin/scion-pki', 'certs', 'renew', *args))
 
         logger.info('Verify renewed certificate chain')
         verify_out = local['./bin/scion-pki']('certs', 'verify', chain,

--- a/acceptance/cert_renewal_acceptance/test
+++ b/acceptance/cert_renewal_acceptance/test
@@ -25,7 +25,6 @@ from typing import List
 
 from plumbum import local
 from plumbum.path.local import LocalPath
-from plumbum.commands.processes import ProcessExecutionError
 
 from acceptance.common.base import CmdBase, TestBase, TestState, set_name
 from acceptance.common.log import LogExec, init_log
@@ -75,32 +74,32 @@ class TestSetup(CmdBase):
 class TestRun(CmdBase):
     @LogExec(logger, 'run')
     def main(self):
-        cs_dirs = local.path('gen') // 'ISD*/AS*/cs*'
+        cs_configs = local.path('gen') // 'AS*/cs*.toml'
         isd_ases = []
 
         logger.info('==> Start renewal process')
-        for cs_dir in cs_dirs:
-            isd_as = ISD_AS(cs_dir.name[2:len(cs_dir.name)-2])
+        for cs_config in cs_configs:
+            isd_as = ISD_AS(cs_config.stem[2:len(cs_config.stem)-2])
             isd_ases.append(isd_as)
 
             logging.info('===> Start renewal: %s' % isd_as)
-            self._renewal_request(cs_dir, isd_as)
+            self._renewal_request(cs_config, isd_as)
 
         logger.info('==> Remove original private keys')
-        for cs_dir in cs_dirs:
-            orig_key = cs_dir / 'crypto/as/cp-as.key'
+        for cs_config in cs_configs:
+            orig_key = cs_config.parent / 'crypto/as/cp-as.key'
             logger.info('Removing original private key for %s: %s' % (isd_as, rel(orig_key)))
             orig_key.delete()
 
         logger.info('==> Check key and certificate reloads')
-        self._check_key_cert(cs_dirs)
+        self._check_key_cert(cs_configs)
 
         logger.info("==> Check connectivity")
         self.scion.run_end2end()
 
         logger.info('==> Shutting down control servers and purging caches')
-        for cs_dir in cs_dirs:
-            files = local.path('gen-cache') // ('%s*' % cs_dir.name)
+        for cs_config in cs_configs:
+            files = local.path('gen-cache') // ('%s*' % cs_config.stem)
             for db_file in files:
                 db_file.delete()
             logger.info('Deleted files: %s' % [file.name for file in files])
@@ -111,7 +110,8 @@ class TestRun(CmdBase):
         logger.info('==> Check connectivity')
         self.scion.run_end2end()
 
-    def _renewal_request(self, cs_dir: LocalPath, isd_as: ISD_AS):
+    def _renewal_request(self, cs_config: LocalPath, isd_as: ISD_AS):
+        cs_dir = cs_config.parent
         csr = cs_dir / 'crypto/as/csr.json'
         logger.info('Generating CSR for: %s' % rel(csr))
         template = {
@@ -142,7 +142,7 @@ class TestRun(CmdBase):
         ]
         if not self.no_docker:
             chain.touch()
-            args += ['--local', self._disp_ip(cs_dir.name)]
+            args += ['--local', self._disp_ip(cs_config.stem)]
 
         for i in range(len(args)):
             if isinstance(args[i], LocalPath):
@@ -156,15 +156,15 @@ class TestRun(CmdBase):
                                               '--trc', 'gen/trcs/ISD1-B1-S1.trc')
         logger.info(str(verify_out).rstrip('\n'))
 
-    def _check_key_cert(self, cs_dirs: List[LocalPath]):
+    def _check_key_cert(self, cs_configs: List[LocalPath]):
         not_ready = []
-        for cs_dir in cs_dirs:
-            not_ready.append(cs_dir)
+        for cs_config in cs_configs:
+            not_ready.append(cs_config)
 
         for _ in range(5):
             logger.info('Checking if all control servers have reloaded the key and certificate...')
-            for cs_dir in not_ready:
-                conn = HTTPConnection(self._http_endpoint(cs_dir))
+            for cs_config in not_ready:
+                conn = HTTPConnection(self._http_endpoint(cs_config))
                 conn.request('GET', '/signer')
                 resp = conn.getresponse()
                 if resp.status != 200:
@@ -172,21 +172,22 @@ class TestRun(CmdBase):
                     continue
 
                 pld = json.loads(resp.read().decode('utf-8'))
+                cs_dir = cs_config.parent
                 if pld['subject_key_id'] != self._extract_skid(cs_dir / 'crypto/as/renewed.pem'):
                     continue
                 logger.info('Control server successfully loaded new key and certificate: %s' %
-                            rel(cs_dir))
-                not_ready.remove(cs_dir)
+                            rel(cs_config))
+                not_ready.remove(cs_config)
             if not not_ready:
                 break
             time.sleep(3)
         else:
             logger.error('Control servers without reloaded key and certificate: %s' %
-                         [cs_dir.name for cs_dir in not_ready])
+                         [cs_config.name for cs_config in not_ready])
             sys.exit(1)
 
-    def _http_endpoint(self, cs_dir: LocalPath):
-        with open(cs_dir / 'cs.toml', 'r') as f:
+    def _http_endpoint(self, cs_config: LocalPath):
+        with open(cs_config, 'r') as f:
             cfg = toml.load(f)
             return cfg['metrics']['prometheus']
 

--- a/acceptance/common/README.md
+++ b/acceptance/common/README.md
@@ -78,7 +78,7 @@ class TestSetup(CmdBase):
         self.scion.topology('topology/tiny.topo')
         # Modify the logging config for all beacon servers
         self.scion.set_configs({'log.file.level': 'debug'},
-                               local.path('gen/ISD1') // '*/bs*/bs.toml')
+                               local.path('gen/) // '*/bs*.toml')
         # Run the scion topology.
         self.scion.run()
         # Start the tester container in the dockerized topology.

--- a/acceptance/common/scion.py
+++ b/acceptance/common/scion.py
@@ -162,18 +162,17 @@ class SCIONSupervisor(SCION):
         self.end2end(*args, retcode=code)
 
 
-def svc_names_from_path(files: LocalPath) -> List[str]:
+def svc_names_from_path(dirs: List[LocalPath]) -> List[str]:
     """
-    Return all service names based on the path to a file in the gen directory.
-    E.g. gen/ISD1/ASff00_0_110/bs1-ff00_0_110/bs.toml will return
-    [bs1-ff00_0_110].
+    Return all service names based on the path to one or multiple AS directories
+    in the gen directory.
+    E.g. gen/ASff00_0_110/ with a the file gen/ASff00_0_110/bs1-ff00_0_110.toml
+    will return [bs1-ff00_0_110].
     """
     names = set()
-    for file in files:
-        if file.is_file():
-            names.add(file.dirname.name)
-        else:
-            names.add(file.name)
+    for d in dirs:
+        names.union(f.stem for f in d.list()
+                    if f.is_file() and f.suffix == '.toml')
     return list(names)
 
 

--- a/acceptance/common/scion.py
+++ b/acceptance/common/scion.py
@@ -162,20 +162,6 @@ class SCIONSupervisor(SCION):
         self.end2end(*args, retcode=code)
 
 
-def svc_names_from_path(dirs: List[LocalPath]) -> List[str]:
-    """
-    Return all service names based on the path to one or multiple AS directories
-    in the gen directory.
-    E.g. gen/ASff00_0_110/ with a the file gen/ASff00_0_110/bs1-ff00_0_110.toml
-    will return [bs1-ff00_0_110].
-    """
-    names = set()
-    for d in dirs:
-        names.update(f.stem for f in d.list()
-                     if f.is_file() and f.suffix == '.toml')
-    return list(names)
-
-
 def sciond_addr(isd_as: ISD_AS, port: bool = True):
     """
     Return the SCION Daemon address for the given AS.

--- a/acceptance/common/scion.py
+++ b/acceptance/common/scion.py
@@ -171,8 +171,8 @@ def svc_names_from_path(dirs: List[LocalPath]) -> List[str]:
     """
     names = set()
     for d in dirs:
-        names.union(f.stem for f in d.list()
-                    if f.is_file() and f.suffix == '.toml')
+        names.update(f.stem for f in d.list()
+                     if f.is_file() and f.suffix == '.toml')
     return list(names)
 
 

--- a/acceptance/common/test_scion.py
+++ b/acceptance/common/test_scion.py
@@ -12,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import shutil
-import tempfile
 import unittest
-from typing import Any, Dict, List
-
-from plumbum import local
+from typing import Any, Dict
 
 from acceptance.common.scion import (
     merge_dict,
     path_to_dict,
-    svc_names_from_path,
 )
 
 
@@ -68,31 +62,3 @@ class PathToDictTestCase(unittest.TestCase):
     def test_path_to_dict(self):
         d = path_to_dict('a.b.c', 'd')
         self.assertEqual(d, {'a': {'b': {'c': 'd'}}}, 'wrong dictionary')
-
-
-class SvcNameFromPathTestCase(unittest.TestCase):
-
-    def setUp(self):
-        self.dir = local.path(tempfile.mkdtemp())
-        files = ['AS1/bs1.toml', 'AS1/topology.json', 'AS2/bs2.toml', 'AS2/cs2.toml']
-        self._touch_files(files)
-
-    def tearDown(self):
-        shutil.rmtree(self.dir)
-
-    def test_directory(self):
-        path = local.path(self.dir) / 'AS2'
-        actual = svc_names_from_path([path])
-        self.assertEqual(set(actual), {'bs2', 'cs2'}, 'wrong service names')
-
-    def test_directories(self):
-        path = local.path(self.dir) // 'AS*'
-        actual = svc_names_from_path(path)
-        self.assertEqual(set(actual), {'bs1', 'bs2', 'cs2'}, 'wrong service names')
-
-    def _touch_files(self, names: List[str]):
-        for name in names:
-            file = self.dir / name
-            file.dirname.mkdir()
-            with open(os.path.join(self.dir, name), 'a'):
-                pass

--- a/acceptance/common/test_scion.py
+++ b/acceptance/common/test_scion.py
@@ -74,21 +74,21 @@ class SvcNameFromPathTestCase(unittest.TestCase):
 
     def setUp(self):
         self.dir = local.path(tempfile.mkdtemp())
-        files = ['bs1/toml', 'bs1/topo', 'bs2/toml', 'cs1/toml']
+        files = ['AS1/bs1.toml', 'AS1/topology.json', 'AS2/bs2.toml', 'AS2/cs2.toml']
         self._touch_files(files)
 
     def tearDown(self):
         shutil.rmtree(self.dir)
 
-    def test_multiple_paths_same_name(self):
-        path = local.path(self.dir) // '*/*'
-        actual = svc_names_from_path(path)
-        self.assertEqual(set(actual), {'bs1', 'bs2', 'cs1'}, 'wrong service names')
-
     def test_directory(self):
-        path = local.path(self.dir) // 'bs*'
+        path = local.path(self.dir) / 'AS2'
+        actual = svc_names_from_path([path])
+        self.assertEqual(set(actual), {'bs2', 'cs2'}, 'wrong service names')
+
+    def test_directories(self):
+        path = local.path(self.dir) // 'AS*'
         actual = svc_names_from_path(path)
-        self.assertEqual(set(actual), {'bs1', 'bs2'}, 'wrong service names')
+        self.assertEqual(set(actual), {'bs1', 'bs2', 'cs2'}, 'wrong service names')
 
     def _touch_files(self, names: List[str]):
         for name in names:

--- a/acceptance/sig_failover/BUILD.bazel
+++ b/acceptance/sig_failover/BUILD.bazel
@@ -22,8 +22,7 @@ container_image(
 container_image(
     name = "dispatcher1",
     base = "//docker:dispatcher_debug",
-    entrypoint = [
-        "/app/dispatcher",
+    cmd = [
         "-config",
         "/disp.toml",
     ],
@@ -33,8 +32,7 @@ container_image(
 container_image(
     name = "dispatcher2",
     base = "//docker:dispatcher_debug",
-    entrypoint = [
-        "/app/dispatcher",
+    cmd = [
         "-config",
         "/disp.toml",
     ],
@@ -44,8 +42,7 @@ container_image(
 container_image(
     name = "sig1",
     base = "//docker:sig_debug",
-    entrypoint = [
-        "/app/sig",
+    cmd = [
         "-config",
         "/sig.toml",
     ],
@@ -59,8 +56,7 @@ container_image(
 container_image(
     name = "sig2",
     base = "//docker:sig_debug",
-    entrypoint = [
-        "/app/sig",
+    cmd = [
         "-config",
         "/sig.toml",
     ],

--- a/acceptance/sig_reload_acceptance/test
+++ b/acceptance/sig_reload_acceptance/test
@@ -8,7 +8,7 @@ TEST_NAME="sig_reload"
 
 SRC_IA_FILE="$(ia_file $SRC_IA)"
 SRC_AS_FILE="$(as_file $SRC_IA)"
-SIG_JSON="gen/ISD1/AS$SRC_AS_FILE/sig$SRC_IA_FILE/cfg.json"
+SIG_JSON="gen/AS$SRC_AS_FILE/sig$SRC_IA_FILE/cfg.json"
 
 test_run() {
     set -e

--- a/acceptance/sig_reload_acceptance/test
+++ b/acceptance/sig_reload_acceptance/test
@@ -8,7 +8,7 @@ TEST_NAME="sig_reload"
 
 SRC_IA_FILE="$(ia_file $SRC_IA)"
 SRC_AS_FILE="$(as_file $SRC_IA)"
-SIG_JSON="gen/AS$SRC_AS_FILE/sig$SRC_IA_FILE/cfg.json"
+SIG_JSON="gen/AS$SRC_AS_FILE/sig.json"
 
 test_run() {
     set -e

--- a/acceptance/sig_short_exp_time/BUILD.bazel
+++ b/acceptance/sig_short_exp_time/BUILD.bazel
@@ -22,8 +22,7 @@ container_image(
 container_image(
     name = "dispatcher1",
     base = "//docker:dispatcher_debug",
-    entrypoint = [
-        "/app/dispatcher",
+    cmd = [
         "-config",
         "/disp.toml",
     ],
@@ -33,8 +32,7 @@ container_image(
 container_image(
     name = "dispatcher2",
     base = "//docker:dispatcher_debug",
-    entrypoint = [
-        "/app/dispatcher",
+    cmd = [
         "-config",
         "/disp.toml",
     ],
@@ -44,8 +42,7 @@ container_image(
 container_image(
     name = "sig1",
     base = "//docker:sig_debug",
-    entrypoint = [
-        "/app/sig",
+    cmd = [
         "-config",
         "/sig.toml",
     ],
@@ -59,8 +56,7 @@ container_image(
 container_image(
     name = "sig2",
     base = "//docker:sig_debug",
-    entrypoint = [
-        "/app/sig",
+    cmd = [
         "-config",
         "/sig.toml",
     ],

--- a/acceptance/topo_cs_reload/BUILD.bazel
+++ b/acceptance/topo_cs_reload/BUILD.bazel
@@ -24,8 +24,7 @@ go_test(
 container_image(
     name = "dispatcher",
     base = "//docker:dispatcher_debug",
-    entrypoint = [
-        "/app/dispatcher",
+    cmd = [
         "--config",
         "/disp.toml",
     ],
@@ -35,8 +34,7 @@ container_image(
 container_image(
     name = "cs",
     base = "//docker:cs_debug",
-    entrypoint = [
-        "/app/cs",
+    cmd = [
         "--config",
         "/cs.toml",
     ],

--- a/acceptance/topo_cs_reload/testdata/gen_crypto.sh
+++ b/acceptance/topo_cs_reload/testdata/gen_crypto.sh
@@ -18,7 +18,7 @@ CONFDIR=`mktemp -d`
 mkdir -p $CONFDIR/certs $CONFDIR/keys $CONFDIR/crypto
 
 mv $TMP/trcs/*.trc $CONFDIR/certs
-mv $TMP/ISD1/AS*/crypto/* $CONFDIR/crypto
+mv $TMP/AS*/crypto/* $CONFDIR/crypto
 
 base64_pwd_gen > $CONFDIR/keys/master0.key
 base64_pwd_gen > $CONFDIR/keys/master1.key

--- a/acceptance/topo_sd_reload/BUILD.bazel
+++ b/acceptance/topo_sd_reload/BUILD.bazel
@@ -22,8 +22,7 @@ go_test(
 container_image(
     name = "dispatcher",
     base = "//docker:dispatcher_debug",
-    entrypoint = [
-        "/app/dispatcher",
+    cmd = [
         "--config",
         "/disp.toml",
     ],
@@ -33,8 +32,7 @@ container_image(
 container_image(
     name = "sciond",
     base = "//docker:sciond_debug",
-    entrypoint = [
-        "/app/sciond",
+    cmd = [
         "--config",
         "/sd.toml",
     ],

--- a/acceptance/trc_update_acceptance/test
+++ b/acceptance/trc_update_acceptance/test
@@ -19,19 +19,16 @@ import json
 import time
 import toml
 import sys
-import yaml
 from http.client import HTTPConnection
 from typing import List
 
 from plumbum import local
 from plumbum.path.local import LocalPath
-from plumbum.commands.processes import ProcessExecutionError
 
 from acceptance.common.base import CmdBase, TestBase, TestState, set_name
 from acceptance.common.log import LogExec, init_log
-from acceptance.common.scion import sciond_addr, SCIONDocker
+from acceptance.common.scion import SCIONDocker
 from acceptance.common.tools import DC
-from python.lib.scion_addr import ISD_AS
 
 
 set_name(__file__)
@@ -76,7 +73,7 @@ class TestRun(CmdBase):
         logger.info('==> Generate TRC update')
         local['./bin/scion-pki']('testcrypto', 'update', '-o', 'gen')
 
-        target = 'gen/ISD1/ASff00_0_110/cs1-ff00_0_110-1/crypto/as'
+        target = 'gen/ASff00_0_110/cs1-ff00_0_110-1/crypto/as'
         logger.info('==> Copy to %s' % target)
         local['cp']('gen/trcs/ISD1-B1-S2.trc', target)
 

--- a/acceptance/trc_update_acceptance/test
+++ b/acceptance/trc_update_acceptance/test
@@ -68,12 +68,12 @@ class TestSetup(CmdBase):
 class TestRun(CmdBase):
     @LogExec(logger, 'run')
     def main(self):
-        cs_dirs = local.path('gen') // 'ISD*/AS*/cs*'
+        cs_configs = local.path('gen') // 'AS*/cs*.toml'
 
         logger.info('==> Generate TRC update')
         local['./bin/scion-pki']('testcrypto', 'update', '-o', 'gen')
 
-        target = 'gen/ASff00_0_110/cs1-ff00_0_110-1/crypto/as'
+        target = 'gen/ASff00_0_110/crypto/as'
         logger.info('==> Copy to %s' % target)
         local['cp']('gen/trcs/ISD1-B1-S2.trc', target)
 
@@ -81,14 +81,14 @@ class TestRun(CmdBase):
         time.sleep(10)
 
         logger.info('==> Check TRC update received')
-        self._check_update_received(cs_dirs)
+        self._check_update_received(cs_configs)
 
         logger.info("==> Check connectivity")
         self.scion.run_end2end()
 
         logger.info('==> Shutting down control servers and purging caches')
-        for cs_dir in cs_dirs:
-            files = local.path('gen-cache') // ('%s*' % cs_dir.name)
+        for cs_config in cs_configs:
+            files = local.path('gen-cache') // ('%s*' % cs_config.stem)
             for db_file in files:
                 db_file.delete()
             logger.info('Deleted files: %s' % [file.name for file in files])
@@ -99,15 +99,15 @@ class TestRun(CmdBase):
         logger.info('==> Check connectivity')
         self.scion.run_end2end()
 
-    def _check_update_received(self, cs_dirs: List[LocalPath]):
+    def _check_update_received(self, cs_configs: List[LocalPath]):
         not_ready = []
-        for cs_dir in cs_dirs:
-            not_ready.append(cs_dir)
+        for cs_config in cs_configs:
+            not_ready.append(cs_config)
 
         for _ in range(5):
             logger.info('Checking if all control servers have received the TRC update...')
-            for cs_dir in not_ready:
-                conn = HTTPConnection(self._http_endpoint(cs_dir))
+            for cs_config in not_ready:
+                conn = HTTPConnection(self._http_endpoint(cs_config))
                 conn.request('GET', '/signer')
                 resp = conn.getresponse()
                 if resp.status != 200:
@@ -117,18 +117,18 @@ class TestRun(CmdBase):
                 pld = json.loads(resp.read().decode('utf-8'))
                 if pld['trc_id']['serial_number'] != 2:
                     continue
-                logger.info('Control server received TRC update: %s' % rel(cs_dir))
-                not_ready.remove(cs_dir)
+                logger.info('Control server received TRC update: %s' % rel(cs_config))
+                not_ready.remove(cs_config)
             if not not_ready:
                 break
             time.sleep(3)
         else:
             logger.error('Control servers that have not received TRC update: %s' %
-                         [cs_dir.name for cs_dir in not_ready])
+                         [cs_config.stem for cs_config in not_ready])
             sys.exit(1)
 
-    def _http_endpoint(self, cs_dir: LocalPath):
-        with open(cs_dir / 'cs.toml', 'r') as f:
+    def _http_endpoint(self, cs_config: LocalPath):
+        with open(cs_config, 'r') as f:
             cfg = toml.load(f)
             return cfg['metrics']['prometheus']
 

--- a/docker/BUILD.bazel
+++ b/docker/BUILD.bazel
@@ -41,11 +41,11 @@ scion_app_images(
     name = "border",
     appdir = "/app",
     binary = "//go/border:border",
-    entrypoint = ["/app/border"],
     cmd = [
         "--config",
         "/share/conf/br.toml",
     ],
+    entrypoint = ["/app/border"],
     workdir = "/share",
 )
 
@@ -53,11 +53,11 @@ scion_app_images(
     name = "posix-router",
     appdir = "/app",
     binary = "//go/posix-router",
-    entrypoint = ["/app/posix-router"],
     cmd = [
         "--config",
         "/share/conf/br.toml",
     ],
+    entrypoint = ["/app/posix-router"],
     workdir = "/share",
 )
 
@@ -65,11 +65,11 @@ scion_app_images(
     name = "cs",
     appdir = "/app",
     binary = "//go/cs:cs",
-    entrypoint = ["/app/cs"],
     cmd = [
         "--config",
         "/share/conf/cs.toml",
     ],
+    entrypoint = ["/app/cs"],
     workdir = "/share",
 )
 
@@ -77,11 +77,11 @@ scion_app_images(
     name = "dispatcher",
     appdir = "/app",
     binary = "//go/dispatcher:dispatcher",
-    entrypoint = ["/app/dispatcher"],
     cmd = [
         "--config",
         "/share/conf/disp.toml",
     ],
+    entrypoint = ["/app/dispatcher"],
     workdir = "/share",
 )
 
@@ -89,11 +89,11 @@ scion_app_images(
     name = "sciond",
     appdir = "/app",
     binary = "//go/sciond:sciond",
-    entrypoint = ["/app/sciond"],
     cmd = [
         "--config",
         "/share/conf/sd.toml",
     ],
+    entrypoint = ["/app/sciond"],
     workdir = "/share",
 )
 
@@ -102,10 +102,10 @@ scion_app_images(
     appdir = "/app",
     binary = "//go/sig:sig",
     caps = "cap_net_admin+ei",
-    entrypoint = ["/app/sig"],
     cmd = [
         "--config",
         "/share/conf/sig.toml",
     ],
+    entrypoint = ["/app/sig"],
     workdir = "/share",
 )

--- a/docker/BUILD.bazel
+++ b/docker/BUILD.bazel
@@ -41,8 +41,10 @@ scion_app_images(
     name = "border",
     appdir = "/app",
     binary = "//go/border:border",
-    entrypoint = [
-        "/app/border",
+    entrypoint = ["/app/border"],
+    cmd = [
+        "--config",
+        "/share/conf/br.toml",
     ],
     workdir = "/share",
 )
@@ -51,8 +53,8 @@ scion_app_images(
     name = "posix-router",
     appdir = "/app",
     binary = "//go/posix-router",
-    entrypoint = [
-        "/app/posix-router",
+    entrypoint = ["/app/posix-router"],
+    cmd = [
         "--config",
         "/share/conf/br.toml",
     ],
@@ -63,8 +65,10 @@ scion_app_images(
     name = "cs",
     appdir = "/app",
     binary = "//go/cs:cs",
-    entrypoint = [
-        "/app/cs",
+    entrypoint = ["/app/cs"],
+    cmd = [
+        "--config",
+        "/share/conf/cs.toml",
     ],
     workdir = "/share",
 )
@@ -73,8 +77,10 @@ scion_app_images(
     name = "dispatcher",
     appdir = "/app",
     binary = "//go/dispatcher:dispatcher",
-    entrypoint = [
-        "/app/dispatcher",
+    entrypoint = ["/app/dispatcher"],
+    cmd = [
+        "--config",
+        "/share/conf/disp.toml",
     ],
     workdir = "/share",
 )
@@ -83,8 +89,10 @@ scion_app_images(
     name = "sciond",
     appdir = "/app",
     binary = "//go/sciond:sciond",
-    entrypoint = [
-        "/app/sciond",
+    entrypoint = ["/app/sciond"],
+    cmd = [
+        "--config",
+        "/share/conf/sd.toml",
     ],
     workdir = "/share",
 )
@@ -94,8 +102,10 @@ scion_app_images(
     appdir = "/app",
     binary = "//go/sig:sig",
     caps = "cap_net_admin+ei",
-    entrypoint = [
-        "/app/sig",
+    entrypoint = ["/app/sig"],
+    cmd = [
+        "--config",
+        "/share/conf/sig.toml",
     ],
     workdir = "/share",
 )

--- a/docker/BUILD.bazel
+++ b/docker/BUILD.bazel
@@ -43,8 +43,6 @@ scion_app_images(
     binary = "//go/border:border",
     entrypoint = [
         "/app/border",
-        "--config",
-        "/share/conf/br.toml",
     ],
     workdir = "/share",
 )
@@ -67,8 +65,6 @@ scion_app_images(
     binary = "//go/cs:cs",
     entrypoint = [
         "/app/cs",
-        "--config",
-        "/share/conf/cs.toml",
     ],
     workdir = "/share",
 )
@@ -79,8 +75,6 @@ scion_app_images(
     binary = "//go/dispatcher:dispatcher",
     entrypoint = [
         "/app/dispatcher",
-        "--config",
-        "/share/conf/disp.toml",
     ],
     workdir = "/share",
 )
@@ -91,8 +85,6 @@ scion_app_images(
     binary = "//go/sciond:sciond",
     entrypoint = [
         "/app/sciond",
-        "--config",
-        "/share/conf/sd.toml",
     ],
     workdir = "/share",
 )
@@ -104,8 +96,6 @@ scion_app_images(
     caps = "cap_net_admin+ei",
     entrypoint = [
         "/app/sig",
-        "--config",
-        "/share/conf/sig.toml",
     ],
     workdir = "/share",
 )

--- a/docker/caps.bzl
+++ b/docker/caps.bzl
@@ -147,11 +147,12 @@ setcap = rule(
 )
 
 # same as container_image, except that it allows to set capabilities on one binary
-def container_image_setcap(name, entrypoint, caps_binary = None, caps = None, **kwargs):
+def container_image_setcap(name, entrypoint, cmd = None, caps_binary = None, caps = None, **kwargs):
     if not caps:
         # Fast path. If no caps are to be set, skip the setcap dance.
         container_image(
             name = name,
+            cmd = cmd,
             entrypoint = entrypoint,
             visibility = ["//visibility:public"],
             **kwargs
@@ -159,6 +160,7 @@ def container_image_setcap(name, entrypoint, caps_binary = None, caps = None, **
     else:
         container_image(
             name = name + "_nocap",
+            cmd = cmd,
             entrypoint = entrypoint,
             **kwargs
         )
@@ -171,6 +173,7 @@ def container_image_setcap(name, entrypoint, caps_binary = None, caps = None, **
         container_image(
             name = name,
             base = name + "_withcap.tar",
+            cmd = cmd,
             entrypoint = entrypoint,
             visibility = ["//visibility:public"],
         )

--- a/docker/scion_app.bzl
+++ b/docker/scion_app.bzl
@@ -48,7 +48,7 @@ def scion_app_base():
 #   workdir - working directory
 #   entrypoint - a list of strings that add up to the command line
 #   caps - capabilities to set on the binary
-def scion_app_images(name, binary, appdir, workdir, entrypoint, caps = None):
+def scion_app_images(name, binary, appdir, workdir, entrypoint, cmd = None, caps = None):
     pkg_tar(
         name = "%s_docker_files" % name,
         srcs = [binary],
@@ -61,6 +61,7 @@ def scion_app_images(name, binary, appdir, workdir, entrypoint, caps = None):
         base = "//docker:app_base",
         tars = [":%s_docker_files" % name],
         workdir = workdir,
+        cmd = cmd,
         entrypoint = entrypoint,
         caps_binary = "%s/%s" % (appdir, name),
         caps = caps,
@@ -71,6 +72,7 @@ def scion_app_images(name, binary, appdir, workdir, entrypoint, caps = None):
         base = "//docker:app_base_debug",
         tars = [":%s_docker_files" % name],
         workdir = workdir,
+        cmd = cmd,
         entrypoint = entrypoint,
         caps_binary = "%s/%s" % (appdir, name),
         caps = caps,

--- a/go/lib/integration/integration.go
+++ b/go/lib/integration/integration.go
@@ -221,7 +221,7 @@ var DispAddr HostAddr = func(ia addr.IA) *snet.UDPAddr {
 	if a := loadAddr(ia); a != nil {
 		return a
 	}
-	path := GenFile(fmt.Sprintf("ISD%d/AS%s/endhost/topology.json", ia.I, ia.A.FileFmt()))
+	path := GenFile(fmt.Sprintf("AS%s/topology.json", ia.A.FileFmt()))
 	topo, err := topology.RWTopologyFromJSONFile(path)
 	if err != nil {
 		log.Error("Error loading topology", "err", err)

--- a/go/scion-pki/testcrypto/testcrypto.go
+++ b/go/scion-pki/testcrypto/testcrypto.go
@@ -526,11 +526,11 @@ func flatten(out string) error {
 			return serrors.WithCtx(err, "file", trc)
 		}
 	}
-	pems, err := filepath.Glob(fmt.Sprintf("%s/ISD*/AS*/crypto/*/ISD*-AS*.pem", out))
+	pems, err := filepath.Glob(fmt.Sprintf("%s/AS*/crypto/*/ISD*-AS*.pem", out))
 	if err != nil {
 		return err
 	}
-	crts, err := filepath.Glob(fmt.Sprintf("%s/ISD*/AS*/crypto/*/ISD*-AS*.crt", out))
+	crts, err := filepath.Glob(fmt.Sprintf("%s/AS*/crypto/*/ISD*-AS*.crt", out))
 	if err != nil {
 		return err
 	}

--- a/go/scion-pki/testcrypto/testcrypto.go
+++ b/go/scion-pki/testcrypto/testcrypto.go
@@ -547,18 +547,18 @@ func cleanup(cfg config) error {
 	gid := os.Getegid()
 	uid := os.Geteuid()
 	cmd := exec.Command("sh", "-c", withLib(`docker_exec "`+
-		fmt.Sprintf("chown %d:%d /workdir/*/*/crypto/*/*.key && ", uid, gid)+
-		`chmod 0666 /workdir/*/*/crypto/*/*.key && `+
-		`rm -f /workdir/*/*/crypto/*/cp-*.crt && `+
-		`rm -f /workdir/*/*/crypto/*/regular-*.crt && `+
-		`rm -f /workdir/*/*/crypto/*/sensitive-*.crt && `+
-		`rm -f /workdir/*/*/crypto/*/*.cnf && `+
-		`rm -f /workdir/*/*/crypto/*/*.csr && `+
-		`rm -f /workdir/*/*/crypto/voting/ISD-B1-S1.*.trc && `+
-		`rm -f /workdir/*/*/crypto/voting/*.der && `+
+		fmt.Sprintf("chown %d:%d /workdir/*/crypto/*/*.key && ", uid, gid)+
+		`chmod 0666 /workdir/*/crypto/*/*.key && `+
+		`rm -f /workdir/*/crypto/*/cp-*.crt && `+
+		`rm -f /workdir/*/crypto/*/regular-*.crt && `+
+		`rm -f /workdir/*/crypto/*/sensitive-*.crt && `+
+		`rm -f /workdir/*/crypto/*/*.cnf && `+
+		`rm -f /workdir/*/crypto/*/*.csr && `+
+		`rm -f /workdir/*/crypto/voting/ISD-B1-S1.*.trc && `+
+		`rm -f /workdir/*/crypto/voting/*.der && `+
 		`rm -f /workdir/*/*.der && `+
-		`rm -rf /workdir/*/*/crypto/*/certificates && `+
-		`rm -rf /workdir/*/*/crypto/*/database"`, cfg.lib))
+		`rm -rf /workdir/*/crypto/*/certificates && `+
+		`rm -rf /workdir/*/crypto/*/database"`, cfg.lib))
 	cmd.Env = []string{"CONTAINER_NAME=" + cfg.container}
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	return cmd.Run()
@@ -589,19 +589,19 @@ func trcDir(isd addr.ISD, base string) string {
 }
 
 func keyDir(ia addr.IA, base string) string {
-	return fmt.Sprintf("%s/ISD%d/AS%s/keys", base, ia.I, ia.A.FileFmt())
+	return fmt.Sprintf("%s/AS%s/keys", base, ia.A.FileFmt())
 }
 
 func certDir(ia addr.IA, base string) string {
-	return fmt.Sprintf("%s/ISD%d/AS%s/certs", base, ia.I, ia.A.FileFmt())
+	return fmt.Sprintf("%s/AS%s/certs", base, ia.A.FileFmt())
 }
 
 func cryptoASDir(ia addr.IA, base string) string {
-	return fmt.Sprintf("%s/ISD%d/AS%s/crypto/as", base, ia.I, ia.A.FileFmt())
+	return fmt.Sprintf("%s/AS%s/crypto/as", base, ia.A.FileFmt())
 }
 
 func cryptoCADir(ia addr.IA, base string) string {
-	return fmt.Sprintf("%s/ISD%d/AS%s/crypto/ca", base, ia.I, ia.A.FileFmt())
+	return fmt.Sprintf("%s/AS%s/crypto/ca", base, ia.A.FileFmt())
 }
 
 func cryptoCAClientDir(ia addr.IA, base string) string {
@@ -609,7 +609,7 @@ func cryptoCAClientDir(ia addr.IA, base string) string {
 }
 
 func cryptoVotingDir(ia addr.IA, base string) string {
-	return fmt.Sprintf("%s/ISD%d/AS%s/crypto/voting", base, ia.I, ia.A.FileFmt())
+	return fmt.Sprintf("%s/AS%s/crypto/voting", base, ia.A.FileFmt())
 }
 
 func chainName(ia addr.IA) string {

--- a/python/topology/cert.py
+++ b/python/topology/cert.py
@@ -55,19 +55,10 @@ class CertGenerator(object):
 
     def _copy_files(self, topo_dicts):
         cp = local['cp']
+        mkdir = local['mkdir']
         # Copy the certs and key dir for all elements.
         for topo_id, as_topo in topo_dicts.items():
             base = local.path(self.args.output_dir)
-            crypto_dir = base / topo_id.ISD() / topo_id.AS_file()
             as_dir = local.path(topo_id.base_dir(self.args.output_dir))
-            cp('-r', crypto_dir / 'crypto', as_dir / 'crypto')
-            cp('-r', crypto_dir / 'certs', as_dir / 'certs')
-            cp(base // '*/trcs/*.trc', as_dir / 'certs')
-        # Copy the customers dir for all certificate servers.
-        for topo_id, as_topo in topo_dicts.items():
-            as_dir = local.path(topo_id.base_dir(self.args.output_dir))
-            custom_dir = as_dir / 'customers'
-            if not custom_dir.exists():
-                continue
-            for elem in as_topo["ControlService"]:
-                cp('-r', as_dir / 'customers', as_dir / elem / 'customers')
+            mkdir('-p', as_dir / 'certs')
+            cp(base // '*/trcs/*.trc', as_dir / 'certs/')

--- a/python/topology/cert.py
+++ b/python/topology/cert.py
@@ -22,7 +22,8 @@ from collections import defaultdict
 
 from plumbum import local
 
-from python.topology.common import ArgsTopoConfig, srv_iter
+from python.lib.util import write_file
+from python.topology.common import ArgsTopoConfig
 
 
 class CertGenArgs(ArgsTopoConfig):
@@ -47,22 +48,21 @@ class CertGenerator(object):
     def _master_keys(self, topo_dicts):
         for topo_id, as_topo in topo_dicts.items():
             base = topo_id.base_dir(self.args.output_dir)
-            with open(os.path.join(base, 'keys', 'master0.key'), 'w') as f:
-                f.write(base64.b64encode(os.urandom(16)).decode())
-            with open(os.path.join(base, 'keys', 'master1.key'), 'w') as f:
-                f.write(base64.b64encode(os.urandom(16)).decode())
+            write_file(os.path.join(base, 'keys', 'master0.key'),
+                       base64.b64encode(os.urandom(16)).decode())
+            write_file(os.path.join(base, 'keys', 'master1.key'),
+                       base64.b64encode(os.urandom(16)).decode())
 
     def _copy_files(self, topo_dicts):
         cp = local['cp']
         # Copy the certs and key dir for all elements.
-        for topo_id, as_topo, base in srv_iter(
-                topo_dicts, self.args.output_dir, common=True):
-            elem_dir = local.path(base)
-            as_dir = elem_dir.dirname
-            cp('-r', as_dir / 'crypto', elem_dir / 'crypto')
-            cp('-r', as_dir / 'certs', elem_dir / 'certs')
-            cp('-r', as_dir / 'keys', elem_dir / 'keys')
-            cp(as_dir.dirname.dirname // '*/trcs/*.trc', elem_dir / 'certs')
+        for topo_id, as_topo in topo_dicts.items():
+            base = local.path(self.args.output_dir)
+            crypto_dir = base / topo_id.ISD() / topo_id.AS_file()
+            as_dir = local.path(topo_id.base_dir(self.args.output_dir))
+            cp('-r', crypto_dir / 'crypto', as_dir / 'crypto')
+            cp('-r', crypto_dir / 'certs', as_dir / 'certs')
+            cp(base // '*/trcs/*.trc', as_dir / 'certs')
         # Copy the customers dir for all certificate servers.
         for topo_id, as_topo in topo_dicts.items():
             as_dir = local.path(topo_id.base_dir(self.args.output_dir))

--- a/python/topology/common.py
+++ b/python/topology/common.py
@@ -85,10 +85,6 @@ class TopoID(ISD_AS):
         return "%s-%s" % (self.isd_str(), self.as_file_fmt())
 
     def base_dir(self, out_dir):
-        #return os.path.join(out_dir, self.ISD(), self.AS_file())
-        return os.path.join(out_dir, self.AS_file())
-
-    def base_dir_flat(self, out_dir):
         return os.path.join(out_dir, self.AS_file())
 
     def __lt__(self, other):

--- a/python/topology/common.py
+++ b/python/topology/common.py
@@ -85,7 +85,11 @@ class TopoID(ISD_AS):
         return "%s-%s" % (self.isd_str(), self.as_file_fmt())
 
     def base_dir(self, out_dir):
-        return os.path.join(out_dir, self.ISD(), self.AS_file())
+        #return os.path.join(out_dir, self.ISD(), self.AS_file())
+        return os.path.join(out_dir, self.AS_file())
+
+    def base_dir_flat(self, out_dir):
+        return os.path.join(out_dir, self.AS_file())
 
     def __lt__(self, other):
         return str(self) < str(other)
@@ -149,6 +153,12 @@ def srv_iter(topo_dicts, out_dir, common=False):
                 yield topo_id, as_topo, os.path.join(base, elem)
         if common:
             yield topo_id, as_topo, os.path.join(base, COMMON_DIR)
+
+
+def as_iter(topo_dicts, out_dir):
+    for topo_id, as_topo in topo_dicts.items():
+        base = topo_id.base_dir(out_dir)
+        yield topo_id, as_topo, base
 
 
 def docker_image(args, image):

--- a/python/topology/common.py
+++ b/python/topology/common.py
@@ -141,22 +141,6 @@ def prom_addr_dispatcher(docker, topo_id,
     return None
 
 
-def srv_iter(topo_dicts, out_dir, common=False):
-    for topo_id, as_topo in topo_dicts.items():
-        base = topo_id.base_dir(out_dir)
-        for service in SCION_SERVICE_NAMES:
-            for elem in as_topo[service]:
-                yield topo_id, as_topo, os.path.join(base, elem)
-        if common:
-            yield topo_id, as_topo, os.path.join(base, COMMON_DIR)
-
-
-def as_iter(topo_dicts, out_dir):
-    for topo_id, as_topo in topo_dicts.items():
-        base = topo_id.base_dir(out_dir)
-        yield topo_id, as_topo, base
-
-
 def docker_image(args, image):
     if args.docker_registry:
         image = '%s/%s' % (args.docker_registry, image)

--- a/python/topology/docker.py
+++ b/python/topology/docker.py
@@ -152,9 +152,9 @@ class DockerGenerator(object):
                 'user': self.user,
                 'volumes': [
                     self._disp_vol(disp_id),
-                    '%s:/share/conf:ro' % os.path.join(base, k)
+                    '%s:/share/conf:ro' % base
                 ],
-                'command': []
+                'command': ['--config', '/share/conf/%s.toml' % k]
             }
             self.dc_conf['services']['scion_%s' % k] = entry
 
@@ -169,10 +169,10 @@ class DockerGenerator(object):
                 'volumes': [
                     self._cache_vol(),
                     self._certs_vol(),
-                    '%s:/share/conf:ro' % os.path.join(base, k),
+                    '%s:/share/conf:ro' % base,
                     self._disp_vol(k),
                 ],
-                'command': []
+                'command': ['--config', '/share/conf/%s.toml' % k]
             }
             self.dc_conf['services']['scion_%s' % k] = entry
 
@@ -207,8 +207,9 @@ class DockerGenerator(object):
             entry['networks'][self.bridges[net['net']]] = {'%s_address' % ipv: ip}
             entry['container_name'] = '%sdisp_%s' % (self.prefix, disp_id)
             entry['volumes'].append(self._disp_vol(disp_id))
-            conf = '%s:/share/conf:rw' % os.path.join(base, 'disp_%s' % disp_id)
+            conf = '%s:/share/conf:rw' % base
             entry['volumes'].append(conf)
+            entry['command'] = ['--config', '/share/conf/disp_%s.toml' % disp_id]
 
             self.dc_conf['services']['scion_disp_%s' % disp_id] = entry
             self.dc_conf['volumes'][self._disp_vol(disp_id).split(':')[0]] = None
@@ -233,11 +234,12 @@ class DockerGenerator(object):
                 self._disp_vol(disp_id),
                 self._cache_vol(),
                 self._certs_vol(),
-                '%s:/share/conf:ro' % os.path.join(base, 'endhost'),
+                '%s:/share/conf:ro' % base
             ],
             'networks': {
                 self.bridges[net['net']]: {'%s_address' % ipv: ip}
-            }
+            },
+            'command': ['--config', '/share/conf/sd.toml'],
         }
         self.dc_conf['services'][name] = entry
 

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -270,15 +270,14 @@ class GoGenerator(object):
 
     def _gen_disp_docker(self):
         for topo_id, topo in self.args.topo_dicts.items():
-            elem = "disp_sig_%s" % topo_id.file_fmt()
-            elem_dir = os.path.join(topo_id.base_dir(self.args.output_dir), elem)
-            disp_conf = self._build_disp_conf(elem, topo_id)
-            write_file(os.path.join(elem_dir, DISP_CONFIG_NAME), toml.dumps(disp_conf))
-            for k in list(topo.get("border_routers", {})) + list(topo.get("control_service", {})):
+            base = topo_id.base_dir(self.args.output_dir)
+            elem_ids = ['sig_%s' % topo_id.file_fmt()] + \
+                list(topo.get("border_routers", {})) + \
+                list(topo.get("control_service", {}))
+            for k in elem_ids:
                 disp_id = 'disp_%s' % k
-                elem_dir = os.path.join(topo_id.base_dir(self.args.output_dir), disp_id)
                 disp_conf = self._build_disp_conf(disp_id, topo_id)
-                write_file(os.path.join(elem_dir, DISP_CONFIG_NAME), toml.dumps(disp_conf))
+                write_file(os.path.join(base, f'{disp_id}.toml'), toml.dumps(disp_conf))
 
     def _build_disp_conf(self, name, topo_id=None):
         prometheus_addr = prom_addr_dispatcher(self.args.docker, topo_id,

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -27,9 +27,6 @@ from typing import Mapping
 from python.lib.util import write_file
 from python.topology.common import (
     ArgsTopoDicts,
-    BR_CONFIG_NAME,
-    COMMON_DIR,
-    CS_CONFIG_NAME,
     DISP_CONFIG_NAME,
     docker_host,
     join_host_port,
@@ -80,10 +77,10 @@ class GoGenerator(object):
             for k, v in topo.get("border_routers", {}).items():
                 base = topo_id.base_dir(self.args.output_dir)
                 br_conf = self._build_br_conf(topo_id, topo["isd_as"], base, k, v)
-                write_file(os.path.join(base, k, BR_CONFIG_NAME), toml.dumps(br_conf))
+                write_file(os.path.join(base, f"{k}.toml"), toml.dumps(br_conf))
 
     def _build_br_conf(self, topo_id, ia, base, name, v):
-        config_dir = '/share/conf' if self.args.docker else os.path.join(base, name)
+        config_dir = '/share/conf' if self.args.docker else base
         raw_entry = {
             'general': {
                 'id': name,
@@ -106,12 +103,11 @@ class GoGenerator(object):
                     base = topo_id.base_dir(self.args.output_dir)
                     bs_conf = self._build_control_service_conf(
                         topo_id, topo["isd_as"], base, elem_id, elem, ca)
-                    write_file(os.path.join(base, elem_id,
-                                            CS_CONFIG_NAME), toml.dumps(bs_conf))
+                    write_file(os.path.join(base, f"{elem_id}.toml"),
+                               toml.dumps(bs_conf))
 
     def _build_control_service_conf(self, topo_id, ia, base, name, infra_elem, ca):
-        config_dir = '/share/conf' if self.args.docker else os.path.join(
-            base, name)
+        config_dir = '/share/conf' if self.args.docker else base
         raw_entry = {
             'general': {
                 'id': name,
@@ -157,7 +153,7 @@ class GoGenerator(object):
                                yaml.dump(rsvps, default_flow_style=False))
 
     def _build_co_conf(self, topo_id, ia, base, name, infra_elem):
-        config_dir = '/share/conf' if self.args.docker else os.path.join(base, name)
+        config_dir = '/share/conf' if self.args.docker else base
         raw_entry = {
             'general': {
                 'ID': name,
@@ -234,11 +230,11 @@ class GoGenerator(object):
         for topo_id, topo in self.args.topo_dicts.items():
             base = topo_id.base_dir(self.args.output_dir)
             sciond_conf = self._build_sciond_conf(topo_id, topo["isd_as"], base)
-            write_file(os.path.join(base, COMMON_DIR, SD_CONFIG_NAME), toml.dumps(sciond_conf))
+            write_file(os.path.join(base, SD_CONFIG_NAME), toml.dumps(sciond_conf))
 
     def _build_sciond_conf(self, topo_id, ia, base):
         name = sciond_name(topo_id)
-        config_dir = '/share/conf' if self.args.docker else os.path.join(base, COMMON_DIR)
+        config_dir = '/share/conf' if self.args.docker else base
         ip = sciond_ip(self.args.docker, topo_id, self.args.networks)
         raw_entry = {
             'general': {

--- a/python/topology/sig.py
+++ b/python/topology/sig.py
@@ -76,8 +76,9 @@ class SIGGenerator(object):
             'networks': {},
             'volumes': [
                 self._disp_vol(topo_id),
-                '%s:/share/conf:rw' % os.path.join(base, 'disp_sig_%s' % topo_id.file_fmt()),
-            ]
+                '%s:/share/conf:rw' % base,
+            ],
+            'command': ['--config', '/share/conf/disp_sig_%s.toml' % topo_id.file_fmt()],
         }
 
         net = self.args.networks['sig%s' % topo_id.file_fmt()][0]
@@ -113,7 +114,7 @@ class SIGGenerator(object):
             'volumes': [
                 self._disp_vol(topo_id),
                 '/dev/net/tun:/dev/net/tun',
-                '%s/sig%s:/share/conf' % (base, topo_id.file_fmt()),
+                '%s:/share/conf' % base,
             ],
             'network_mode': 'service:%s' % disp_id,
         }
@@ -127,8 +128,8 @@ class SIGGenerator(object):
             net = self.args.networks['sig%s' % t_id.file_fmt()][0]
             sig_cfg['ASes'][str(t_id)]['Nets'].append(net['net'])
 
-        cfg = os.path.join(topo_id.base_dir(self.args.output_dir), 'sig%s' % topo_id.file_fmt(),
-                           "cfg.json")
+        cfg = os.path.join(topo_id.base_dir(self.args.output_dir),
+                           "sig.json")
         contents_json = json.dumps(sig_cfg, default=json_default, indent=2)
         write_file(cfg, contents_json + '\n')
 
@@ -149,7 +150,7 @@ class SIGGenerator(object):
         sig_conf = {
             'sig': {
                 'id': name,
-                'sig_config': 'conf/cfg.json',
+                'sig_config': 'conf/sig.json',
                 'ip': str(net[ipv]),
             },
             'sciond_connection': {
@@ -165,7 +166,7 @@ class SIGGenerator(object):
             },
             'features': self.args.features,
         }
-        path = os.path.join(topo_id.base_dir(self.args.output_dir), name, SIG_CONFIG_NAME)
+        path = os.path.join(topo_id.base_dir(self.args.output_dir), SIG_CONFIG_NAME)
         write_file(path, toml.dumps(sig_conf))
 
     def _disp_vol(self, topo_id):

--- a/python/topology/sig.py
+++ b/python/topology/sig.py
@@ -117,6 +117,7 @@ class SIGGenerator(object):
                 '%s:/share/conf' % base,
             ],
             'network_mode': 'service:%s' % disp_id,
+            'command': ['--config', '/share/conf/sig.toml'],
         }
 
     def _sig_json(self, topo_id):

--- a/python/topology/supervisor.py
+++ b/python/topology/supervisor.py
@@ -108,7 +108,6 @@ class SupervisorGenerator(object):
         cmd_args = ["bin/dispatcher", "--config", os.path.join(conf_dir, DISP_CONFIG_NAME)]
         return (name, self._common_entry(name, cmd_args))
 
-
     def _add_prog(self, config, name, entry):
         config["program:%s" % name] = entry
 

--- a/python/topology/supervisor.py
+++ b/python/topology/supervisor.py
@@ -19,15 +19,13 @@
 # Stdlib
 import configparser
 import os
+import shlex
 from io import StringIO
 
 # SCION
 from python.lib.util import write_file
 from python.topology.common import (
     ArgsTopoDicts,
-    BR_CONFIG_NAME,
-    COMMON_DIR,
-    CS_CONFIG_NAME,
     DISP_CONFIG_NAME,
     FEATURE_HEADER_V2,
     SD_CONFIG_NAME,
@@ -67,7 +65,7 @@ class SupervisorGenerator(object):
     def _br_entries(self, topo, cmd, base):
         entries = []
         for k, v in topo.get("border_routers", {}).items():
-            conf = os.path.join(base, k, BR_CONFIG_NAME)
+            conf = os.path.join(base, f"{k}.toml")
             entries.append((k, [cmd, "--config", conf]))
         return entries
 
@@ -76,7 +74,7 @@ class SupervisorGenerator(object):
         for k, v in topo.get("control_service", {}).items():
             # only a single control service instance per AS is currently supported
             if k.endswith("-1"):
-                conf = os.path.join(base, k, CS_CONFIG_NAME)
+                conf = os.path.join(base, f"{k}.toml")
                 entries.append((k, ["bin/cs", "--config", conf]))
         return entries
 
@@ -90,12 +88,10 @@ class SupervisorGenerator(object):
         base = topo_id.base_dir(self.args.output_dir)
         for elem, entry in sorted(entries, key=lambda x: x[0]):
             names.append(elem)
-            elem_dir = os.path.join(base, elem)
-            self._write_elem_conf(elem, entry, elem_dir, topo_id)
+            self._write_elem_conf(elem, entry, os.path.join(base, f"supervisord-{elem}.conf"))
         sd_name = "sd%s" % topo_id.file_fmt()
         names.append(sd_name)
-        conf_dir = os.path.join(base, COMMON_DIR)
-        config["program:%s" % sd_name] = self._sciond_entry(sd_name, conf_dir)
+        config["program:%s" % sd_name] = self._sciond_entry(sd_name, base)
         config["group:as%s" % topo_id.file_fmt()] = {
             "programs": ",".join(names)}
         text = StringIO()
@@ -104,40 +100,37 @@ class SupervisorGenerator(object):
             self.args.output_dir), SUPERVISOR_CONF)
         write_file(conf_path, text.getvalue())
 
-    def _write_elem_conf(self, elem, entry, elem_dir, topo_id=None):
+    def _write_elem_conf(self, elem, entry, path):
         config = configparser.ConfigParser(interpolation=None)
-        prog = self._common_entry(elem, entry, elem_dir)
+        prog = self._common_entry(elem, entry)
         if elem.startswith("br"):
             prog['environment'] += ',GODEBUG="cgocheck=0"'
         config["program:%s" % elem] = prog
         text = StringIO()
         config.write(text)
-        write_file(os.path.join(elem_dir, SUPERVISOR_CONF), text.getvalue())
+        write_file(path, text.getvalue())
 
     def _write_dispatcher_conf(self):
         elem = "dispatcher"
         elem_dir = os.path.join(self.args.output_dir, elem)
         config_file_path = os.path.join(elem_dir, DISP_CONFIG_NAME)
-        self._write_elem_conf(
-            elem, ["bin/dispatcher", "--config", config_file_path], elem_dir)
+        self._write_elem_conf(elem,
+                              ["bin/dispatcher", "--config", config_file_path],
+                              os.path.join(elem_dir, SUPERVISOR_CONF))
 
-    def _common_entry(self, name, cmd_args, elem_dir=None):
+    def _common_entry(self, name, cmd_args):
         entry = {
             'autostart': 'false',
             'autorestart': 'false',
             'environment': 'TZ=UTC',
-            'stdout_logfile': "NONE",
-            'stderr_logfile': "NONE",
+            'stdout_logfile': f"logs/{name}.log",
+            'redirect_stderr': True,
             'startretries': 0,
             'startsecs': 5,
             'priority': 100,
-            'command': self._mk_cmd(name, cmd_args),
+            'command': ' '.join(shlex.quote(a) for a in cmd_args),
         }
         if name == "dispatcher":
             entry['startsecs'] = 1
             entry['priority'] = 50
         return entry
-
-    def _mk_cmd(self, name, cmd_args):
-        return "bash -c 'exec %s &>logs/%s.log'" % (
-            " ".join(['"%s"' % arg for arg in cmd_args]), name)

--- a/python/topology/topo.py
+++ b/python/topology/topo.py
@@ -42,7 +42,6 @@ from python.topology.common import (
     join_host_port,
     json_default,
     SCION_SERVICE_NAMES,
-    as_iter,
     TopoID
 )
 from python.topology.net import (
@@ -137,7 +136,7 @@ class TopoGenerator(object):
             networks[k] = v
         self._iterate(self._generate_as_topo)
         self._iterate(self._generate_as_list)
-        self._write_as_topos()
+        self._iterate(self._write_as_topo)
         self._write_as_list()
         self._write_ifids()
         return self.topo_dicts, networks
@@ -361,13 +360,11 @@ class TopoGenerator(object):
             key = "Non-core"
         self.as_list[key].append(str(topo_id))
 
-    def _write_as_topos(self):
-        # TODO use self._iterate (or replace that with as_iter)
-        for topo_id, as_topo, base in as_iter(self.topo_dicts, self.args.output_dir):
-            path = os.path.join(base, TOPO_FILE)
-            contents_json = json.dumps(self.topo_dicts[topo_id],
-                                       default=json_default, indent=2)
-            write_file(path, contents_json + '\n')
+    def _write_as_topo(self, topo_id, _as_conf):
+        path = os.path.join(topo_id.base_dir(self.args.output_dir), TOPO_FILE)
+        contents_json = json.dumps(self.topo_dicts[topo_id],
+                                   default=json_default, indent=2)
+        write_file(path, contents_json + '\n')
 
     def _write_as_list(self):
         list_path = os.path.join(self.args.output_dir, AS_LIST_FILE)

--- a/python/topology/topo.py
+++ b/python/topology/topo.py
@@ -42,7 +42,7 @@ from python.topology.common import (
     join_host_port,
     json_default,
     SCION_SERVICE_NAMES,
-    srv_iter,
+    as_iter,
     TopoID
 )
 from python.topology.net import (
@@ -362,8 +362,8 @@ class TopoGenerator(object):
         self.as_list[key].append(str(topo_id))
 
     def _write_as_topos(self):
-        for topo_id, as_topo, base in srv_iter(
-                self.topo_dicts, self.args.output_dir, common=True):
+        # TODO use self._iterate (or replace that with as_iter)
+        for topo_id, as_topo, base in as_iter(self.topo_dicts, self.args.output_dir):
             path = os.path.join(base, TOPO_FILE)
             contents_json = json.dumps(self.topo_dicts[topo_id],
                                        default=json_default, indent=2)

--- a/scion.sh
+++ b/scion.sh
@@ -386,23 +386,6 @@ cmd_clean() {
     make -s clean
 }
 
-cmd_sciond() {
-    [ -n "$1" ] || { echo "ISD-AS argument required"; exit 1; }
-    # Convert the ISD-AS argument into an array, where the first element is the
-    # ISD, and the second is the AS.
-    IFS=- read -a ia <<< $1
-    ISD=${ia[0]:?No ISD provided}
-    AS=${ia[1]:?No AS provided}
-    ADDR=${2:-127.0.0.1}
-    GENDIR=gen/ISD${ISD}/AS${AS}/endhost
-    [ -d "$GENDIR" ] || { echo "Topology directory for $ISD-$AS doesn't exist: $GENDIR"; exit 1; }
-    APIADDR="/run/shm/sciond/${ISD}-${AS}.sock"
-    PYTHONPATH=python/:. python/bin/sciond --addr $ADDR --api-addr $APIADDR sd${ISD}-${AS} $GENDIR &
-    echo "Sciond running for $ISD-$AS (pid $!)"
-    wait
-    exit $?
-}
-
 traces_name() {
     local name=jaeger_read_badger_traces
     echo "$name"
@@ -444,10 +427,6 @@ cmd_help() {
 	        All arguments or options are passed to topology/generator.py
 	    $PROGRAM run [nobuild]
 	        Run network.
-	    $PROGRAM sciond ISD-AS [ADDR]
-	        Start sciond with provided ISD and AS parameters, and bind to ADDR.
-	        ISD-AS must be in file format (e.g., 1-ff00_0_133). If ADDR is not
-	        supplied, sciond will bind to 127.0.0.1.
 	    $PROGRAM mstart PROCESS
 	        Start multiple processes
 	    $PROGRAM stop

--- a/supervisor/supervisord.conf
+++ b/supervisor/supervisord.conf
@@ -55,4 +55,4 @@ supervisor.ctl_factory = supervisorwildcards.controllerplugin:make_wildcards_con
 match_group = 1
 
 [include]
-files = ../gen/dispatcher/supervisord.conf ../gen/ISD*/AS*/*/supervisord.conf ../gen/ISD*/AS*/supervisord.conf ../gen/AS*/supervisord*.conf
+files = ../gen/dispatcher/supervisord.conf ../gen/AS*/supervisord.conf

--- a/supervisor/supervisord.conf
+++ b/supervisor/supervisord.conf
@@ -55,4 +55,4 @@ supervisor.ctl_factory = supervisorwildcards.controllerplugin:make_wildcards_con
 match_group = 1
 
 [include]
-files = ../gen/dispatcher/supervisord.conf ../gen/AS*/supervisord.conf
+files = ../gen/supervisord.conf

--- a/supervisor/supervisord.conf
+++ b/supervisor/supervisord.conf
@@ -55,4 +55,4 @@ supervisor.ctl_factory = supervisorwildcards.controllerplugin:make_wildcards_con
 match_group = 1
 
 [include]
-files = ../gen/dispatcher/supervisord.conf ../gen/ISD*/AS*/*/supervisord.conf ../gen/ISD*/AS*/supervisord.conf
+files = ../gen/dispatcher/supervisord.conf ../gen/ISD*/AS*/*/supervisord.conf ../gen/ISD*/AS*/supervisord.conf ../gen/AS*/supervisord*.conf


### PR DESCRIPTION
Make the `gen/` directory structure flatter to make it easier to navigate. Avoid the replication of `topology.json`, certs, keys etc. in per-service configuration subdirectories, to allow straight-forward manipulation of e.g. the topology configuration.

Additionally, some clean-up of the supervisor config; set `stdout_logfile` and enable `redirect_stderr` instead of doing this manually in the invoked command with `bash -c 'exec %s &>logs/%s.log'`.

### Why?
The flatter hierarchy is simpler to navigate and easier to manipulate as there are no replicated configuration files to worry about.
For these reasons, I would like to adopt this flatter configuration tree for the configuration that we generate from SCIONLab (installed in `/etc/scion`). Technically, this is unrelated to whether or not this PR is merged. However, to avoid users/developers having to worry about two slightly different configuration setups, it would be great to change adapt this "upstream" setup here too.

### Before
Before the change, the (relevant parts of the) `gen/` directory hierarchy looked like this:
```
gen
├── dispatcher/
├── ISD1
│   ├── ASff00_0_110
│   │   ├── br1-ff00_0_110-1
│   │   │   ├── br.toml
│   │   │   ├── certs/
│   │   │   ├── crypto/
│   │   │   ├── keys/
│   │   │   ├── supervisord.conf
│   │   │   └── topology.json
│   │   ├── br1-ff00_0_110-2
│   │   │   ├── br.toml
│   │   │   ├── certs/
│   │   │   ├── crypto/
│   │   │   ├── keys/
│   │   │   ├── supervisord.conf
│   │   │   └── topology.json
│   │   ├── certs/
│   │   ├── crypto/
│   │   ├── cs1-ff00_0_110-1
│   │   │   ├── certs/
│   │   │   ├── crypto/
│   │   │   ├── cs.toml
│   │   │   ├── keys/
│   │   │   ├── supervisord.conf
│   │   │   └── topology.json
│   │   ├── endhost
│   │   │   ├── certs/
│   │   │   ├── crypto/
│   │   │   ├── keys/
│   │   │   ├── sd.toml
│   │   │   └── topology.json
│   │   ├── keys/
│   │   ├── prometheus/
│   │   ├── prometheus.yml
│   │   └── supervisord.conf
│   ├── ASff00_0_.../
│   ├── ASff00_0_.../
│   └── trcs
│       └── ISD1-B1-S1.trc
├── ...
```


### After
```
gen
├── dispatcher/
├── ASff00_0_110
│   ├── certs/
│   ├── crypto/
│   ├── keys/
│   ├── br1-ff00_0_110-1.toml
│   ├── br1-ff00_0_110-2.toml
│   ├── cs1-ff00_0_110-1.toml
│   ├── sd.toml
│   ├── prometheus/
│   ├── prometheus.yml
│   └── topology.json
├── ASff00_0_.../
├── ASff00_0_.../
├── ISD1
│   └── trcs
│       └── ISD1-B1-S1.trc
├── supervisord.conf
├── ...
```

--- 
Still TODO:
* [x] update the testcrypto generation to avoid creating the old ISD/AS structure
* [x] maybe combine supervisord.conf files into a single file per AS.
* [x] check how this affects the docker setup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3877)
<!-- Reviewable:end -->
