### PR TITLE
trust: add gRPC Dialer over TLS/QUIC/SCION

### DIFF
--- a/go/pkg/grpc/BUILD.bazel
+++ b/go/pkg/grpc/BUILD.bazel
@@ -19,5 +19,6 @@ go_library(
         "@com_github_opentracing_opentracing_go//:go_default_library",
         "@com_github_uber_jaeger_client_go//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials:go_default_library",
     ],
 )


### PR DESCRIPTION
TLSQUICDialer dials a gRPC connection over TLS/QUIC/SCION, which can be used for secure inter-AS communication

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3886)
<!-- Reviewable:end -->
