### PR TITLE
BFD: enable underlay implementation

### DIFF
--- a/go/cs/cs.go
+++ b/go/cs/cs.go
@@ -361,7 +361,6 @@ func run(file string) error {
 		Requests: libmetrics.NewPromCounter(metrics.DiscoveryRequestsTotal),
 	}
 	dpb.RegisterDiscoveryServiceServer(quicServer, ds)
-	dpb.RegisterDiscoveryServiceServer(tcpServer, ds)
 
 	dsHealth := health.NewServer()
 	dsHealth.SetServingStatus("discovery", healthpb.HealthCheckResponse_SERVING)

--- a/go/integration/common.go
+++ b/go/integration/common.go
@@ -62,7 +62,7 @@ func addFlags() {
 	flag.Var((*snet.UDPAddr)(&Local), "local", "(Mandatory) address to listen on")
 	flag.StringVar(&Mode, "mode", ModeClient, "Run in "+ModeClient+" or "+ModeServer+" mode")
 	flag.StringVar(&Progress, "progress", "", "Socket to write progress to")
-	flag.StringVar(&sciondAddr, "sciond", sciond.DefaultSCIONDAddress, "SCIOND address")
+	flag.StringVar(&sciondAddr, "sciond", sciond.DefaultAPIAddress, "SCION Daemon address")
 	flag.IntVar(&Attempts, "attempts", 1, "Number of attempts before giving up")
 	flag.StringVar(&logConsole, "log.console", "info", "Console logging level: debug|info|error")
 	flag.StringVar(&features, "features", "",

--- a/go/lib/env/env.go
+++ b/go/lib/env/env.go
@@ -143,7 +143,7 @@ type SCIONDClient struct {
 
 func (cfg *SCIONDClient) InitDefaults() {
 	if cfg.Address == "" {
-		cfg.Address = sciond.DefaultSCIONDAddress
+		cfg.Address = sciond.DefaultAPIAddress
 	}
 	if cfg.InitialConnectPeriod.Duration == 0 {
 		cfg.InitialConnectPeriod.Duration = SciondInitConnectPeriod

--- a/go/lib/env/envtest/config.go
+++ b/go/lib/env/envtest/config.go
@@ -97,6 +97,6 @@ func CheckTestTracing(t *testing.T, cfg *env.Tracing) {
 }
 
 func CheckTestSciond(t *testing.T, cfg *env.SCIONDClient, id string) {
-	assert.Equal(t, sciond.DefaultSCIONDAddress, cfg.Address)
+	assert.Equal(t, sciond.DefaultAPIAddress, cfg.Address)
 	assert.Equal(t, env.SciondInitConnectPeriod, cfg.InitialConnectPeriod.Duration)
 }

--- a/go/lib/infra/infraenv/infraenv.go
+++ b/go/lib/infra/infraenv/infraenv.go
@@ -129,9 +129,8 @@ func (nc *NetworkConfig) QUICStack() (*QUICStack, error) {
 	return &QUICStack{
 		Listener: squic.NewConnListener(listener),
 		Dialer: &squic.ConnDialer{
-			Conn:       client,
-			TLSConfig:  tlsConfig,
-			QUICConfig: nil,
+			Conn:      client,
+			TLSConfig: tlsConfig,
 		},
 		RedirectCloser: cancel,
 	}, nil

--- a/go/lib/integration/binary.go
+++ b/go/lib/integration/binary.go
@@ -116,7 +116,7 @@ func (bi *binaryIntegration) StartServer(ctx context.Context, dst *snet.UDPAddr)
 	if needSCIOND(args) {
 		sciond, err := GetSCIONDAddress(GenFile(SCIONDAddressesFile), dst.IA)
 		if err != nil {
-			return nil, serrors.WrapStr("unable to determine SCIOND address", err)
+			return nil, serrors.WrapStr("unable to determine SCION Daemon address", err)
 		}
 		args = replacePattern(SCIOND, sciond, args)
 	}
@@ -185,7 +185,7 @@ func (bi *binaryIntegration) StartClient(ctx context.Context,
 	if needSCIOND(args) {
 		sciond, err := GetSCIONDAddress(GenFile(SCIONDAddressesFile), src.IA)
 		if err != nil {
-			return nil, serrors.WrapStr("unable to determine SCIOND address", err)
+			return nil, serrors.WrapStr("unable to determine SCION Daemon address", err)
 		}
 		args = replacePattern(SCIOND, sciond, args)
 	}

--- a/go/lib/integration/cmd.go
+++ b/go/lib/integration/cmd.go
@@ -43,7 +43,7 @@ func (c Cmd) Template(src, dst *snet.UDPAddr) (Cmd, error) {
 	if needSCIOND(args) {
 		sciond, err := GetSCIONDAddress(GenFile(SCIONDAddressesFile), src.IA)
 		if err != nil {
-			return Cmd{}, serrors.WrapStr("unable to determine SCIOND address", err)
+			return Cmd{}, serrors.WrapStr("unable to determine SCION Daemon address", err)
 		}
 		args = replacePattern(SCIOND, sciond, args)
 	}

--- a/go/lib/integration/integration.go
+++ b/go/lib/integration/integration.go
@@ -434,5 +434,5 @@ func GetSCIONDAddress(networksFile string, ia addr.IA) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("[%v]:%d", addresses[ia.String()], sciond.DefaultSCIONDPort), nil
+	return fmt.Sprintf("[%v]:%d", addresses[ia.String()], sciond.DefaultAPIPort), nil
 }

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -46,10 +46,10 @@ var (
 )
 
 const (
-	// DefaultSCIONDAddress contains the system default for a SCIOND socket.
-	DefaultSCIONDAddress = "127.0.0.1:30255"
-	// DefaultSCIONDPort contains the default port for a SCIOND client API socket.
-	DefaultSCIONDPort = 30255
+	// DefaultAPIAddress contains the system default for a daemon API socket.
+	DefaultAPIAddress = "127.0.0.1:30255"
+	// DefaultAPIPort contains the default port for a daemon client API socket.
+	DefaultAPIPort = 30255
 )
 
 // NewService returns a SCIOND API connection factory.
@@ -79,7 +79,7 @@ type Connector interface {
 	// ASInfo requests from SCIOND information about AS ia, the zero IA can be
 	// use to detect the local IA.
 	ASInfo(ctx context.Context, ia addr.IA) (ASInfo, error)
-	// IFInfo requests from SCIOND addresses and ports of interfaces. Slice
+	// IFInfo requests from SCION Daemon addresses and ports of interfaces. Slice
 	// ifs contains interface IDs of BRs. If empty, a fresh (i.e., uncached)
 	// answer containing all interfaces is returned.
 	IFInfo(ctx context.Context, ifs []common.IFIDType) (map[common.IFIDType]*net.UDPAddr, error)

--- a/go/lib/snet/squic/squic.go
+++ b/go/lib/snet/squic/squic.go
@@ -55,7 +55,7 @@ func Init(keyPath, pemPath string) error {
 	return nil
 }
 
-// Dial dials using quic over the scion network.
+// Dial dials using QUIC over the SCION network.
 func Dial(network *snet.SCIONNetwork, listen *net.UDPAddr, remote *snet.UDPAddr,
 	svc addr.HostSVC, quicConfig *quic.Config) (quic.Session, error) {
 

--- a/go/pkg/router/dataplane_test.go
+++ b/go/pkg/router/dataplane_test.go
@@ -297,6 +297,7 @@ func TestDataPlaneRun(t *testing.T) {
 							disc := layers.BFDDiscriminator(i)
 							raw := postInternalBFD(disc, k.(*net.UDPAddr))
 							copy(m[i].Buffers[0], raw)
+							m[i].Addr = &net.UDPAddr{IP: net.IP{10, 0, 200, 200}}
 							m[i].Buffers[0] = m[i].Buffers[0][:len(raw)]
 							m[i].N = len(raw)
 							expectRemoteDiscriminators[disc] = struct{}{}
@@ -1068,7 +1069,8 @@ func TestProcessPkt(t *testing.T) {
 			buffer := gopacket.NewSerializeBuffer()
 			origMsg := make([]byte, len(input.Buffers[0]))
 			copy(origMsg, input.Buffers[0])
-			result, err := dp.ProcessPkt(tc.srcInterface, input, slayers.SCION{}, origMsg, buffer)
+			result, err := dp.ProcessPkt(tc.srcInterface, input, slayers.SCION{}, origMsg,
+				buffer)
 			tc.assertFunc(t, err)
 			if err != nil {
 				return

--- a/go/pkg/router/export_test.go
+++ b/go/pkg/router/export_test.go
@@ -46,7 +46,8 @@ func (d *DataPlane) FakeStart() {
 
 func (d *DataPlane) ProcessPkt(ifID uint16, m *ipv4.Message, s slayers.SCION,
 	origPacket []byte, b gopacket.SerializeBuffer) (ProcessResult, error) {
-	result, err := d.processPkt(ifID, m.Buffers[0], s, origPacket, b)
+
+	result, err := d.processPkt(ifID, m.Buffers[0], m.Addr, s, origPacket, b)
 	return ProcessResult{processResult: result}, err
 }
 

--- a/go/pkg/sciond/BUILD.bazel
+++ b/go/pkg/sciond/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -13,9 +13,10 @@ go_library(
         "//go/lib/pathdb:go_default_library",
         "//go/lib/prom:go_default_library",
         "//go/lib/revcache:go_default_library",
+        "//go/lib/sciond:go_default_library",
         "//go/lib/serrors:go_default_library",
+        "//go/lib/topology:go_default_library",
         "//go/pkg/grpc:go_default_library",
-        "//go/pkg/proto/daemon:go_default_library",
         "//go/pkg/sciond/fetcher:go_default_library",
         "//go/pkg/sciond/internal/servers:go_default_library",
         "//go/pkg/trust:go_default_library",
@@ -23,6 +24,12 @@ go_library(
         "//go/pkg/trust/metrics:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
-        "@org_golang_google_grpc//:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["sciond_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/go/pkg/sciond/config/config.go
+++ b/go/pkg/sciond/config/config.go
@@ -109,7 +109,7 @@ type SDConfig struct {
 
 func (cfg *SDConfig) InitDefaults() {
 	if cfg.Address == "" {
-		cfg.Address = sciond.DefaultSCIONDAddress
+		cfg.Address = sciond.DefaultAPIAddress
 	}
 	if cfg.QueryInterval.Duration == 0 {
 		cfg.QueryInterval.Duration = DefaultQueryInterval

--- a/go/pkg/sciond/config/config_test.go
+++ b/go/pkg/sciond/config/config_test.go
@@ -57,6 +57,6 @@ func CheckTestConfig(t *testing.T, cfg *Config, id string) {
 }
 
 func CheckTestSDConfig(t *testing.T, cfg *SDConfig, id string) {
-	assert.Equal(t, sciond.DefaultSCIONDAddress, cfg.Address)
+	assert.Equal(t, sciond.DefaultAPIAddress, cfg.Address)
 	assert.Equal(t, DefaultQueryInterval, cfg.QueryInterval.Duration)
 }

--- a/go/pkg/sciond/sciond_test.go
+++ b/go/pkg/sciond/sciond_test.go
@@ -1,0 +1,59 @@
+// Copyright 2030 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sciond_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/scionproto/scion/go/pkg/sciond"
+)
+
+func TestAPIAddress(t *testing.T) {
+	testCases := map[string]struct {
+		Input    string
+		Expected string
+	}{
+		"valid": {
+			Input:    "127.0.0.1:8081",
+			Expected: "127.0.0.1:8081",
+		},
+		"valid, no port": {
+			Input:    "127.0.0.1",
+			Expected: "127.0.0.1:30255",
+		},
+		"valid, empty port": {
+			Input:    "[::]:",
+			Expected: "[::]:30255",
+		},
+		"hostname, zero port": {
+			Input:    "daemon:0",
+			Expected: "daemon:30255",
+		},
+		"garbage": {
+			Input:    "127.0.0.1::1:1]::1:1",
+			Expected: "[127.0.0.1::1:1]::1:1]:30255",
+		},
+	}
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			addr := sciond.APIAddress(tc.Input)
+			assert.Equal(t, tc.Expected, addr)
+		})
+	}
+}

--- a/go/pkg/sig/config/config.go
+++ b/go/pkg/sig/config/config.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	DefaultCtrlPort    = 30256
-	DefaultEncapPort   = 30056
+	DefaultDataPort    = 30056
 	DefaultTunName     = "sig"
 	DefaultTunRTableId = 11
 )
@@ -78,12 +78,16 @@ type SigConf struct {
 	ID string `toml:"id,omitempty"`
 	// The SIG config json file. (required)
 	SIGConfig string `toml:"sig_config,omitempty"`
-	// IP the bind IP address (optional, default determined based on route to control service)
-	IP net.IP `toml:"ip,omitempty"`
+	// CtrlAddr is the bind IP address for control messages
+	// (optional, default determined based on route to control service)
+	CtrlAddr net.IP `toml:"ctrl_addr,omitempty"`
 	// Control data port, e.g. keepalives. (default DefaultCtrlPort)
 	CtrlPort uint16 `toml:"ctrl_port,omitempty"`
-	// Encapsulation data port. (default DefaultEncapPort)
-	EncapPort uint16 `toml:"encap_port,omitempty"`
+	// DataAddr is the bind IP address for encapsulated traffic
+	// (optional, defaults to CtrlAddr)
+	DataAddr net.IP `toml:"data_addr,omitempty"`
+	// Encapsulation data port. (default DefaultDataPort)
+	DataPort uint16 `toml:"data_port,omitempty"`
 	// Name of TUN device to create. (default DefaultTunName)
 	Tun string `toml:"tun,omitempty"`
 	// TunRTableId the id of the routing table used in the SIG. (default DefaultTunRTableId)
@@ -109,8 +113,8 @@ func (cfg *SigConf) Validate() error {
 	if cfg.CtrlPort == 0 {
 		cfg.CtrlPort = DefaultCtrlPort
 	}
-	if cfg.EncapPort == 0 {
-		cfg.EncapPort = DefaultEncapPort
+	if cfg.DataPort == 0 {
+		cfg.DataPort = DefaultDataPort
 	}
 	if cfg.Tun == "" {
 		cfg.Tun = DefaultTunName

--- a/go/pkg/sig/config/configtest/configtest.go
+++ b/go/pkg/sig/config/configtest/configtest.go
@@ -26,9 +26,9 @@ import (
 func CheckTestSIG(t *testing.T, cfg *config.SigConf, id string) {
 	assert.Equal(t, id, cfg.ID)
 	assert.Equal(t, "/etc/scion/sig/sig.json", cfg.SIGConfig)
-	assert.Equal(t, net.ParseIP("192.0.2.100"), cfg.IP)
+	assert.Equal(t, net.ParseIP("192.0.2.100"), cfg.CtrlAddr)
 	assert.Equal(t, config.DefaultCtrlPort, int(cfg.CtrlPort))
-	assert.Equal(t, config.DefaultEncapPort, int(cfg.EncapPort))
+	assert.Equal(t, config.DefaultDataPort, int(cfg.DataPort))
 	assert.Equal(t, config.DefaultTunName, cfg.Tun)
 	assert.Equal(t, config.DefaultTunRTableId, cfg.TunRTableId)
 }

--- a/go/pkg/sig/config/sample.go
+++ b/go/pkg/sig/config/sample.go
@@ -23,14 +23,18 @@ id = "%s"
 # The SIG config json file. (required)
 sig_config = "/etc/scion/sig/sig.json"
 
-# The bind IP address. (optional, default determined based on route to control service)
-ip = "192.0.2.100"
+# The bind IP address for control messages.
+# (optional, default determined based on route to control service)
+ctrl_addr = "192.0.2.100"
 
 # Control data port, e.g. keepalives. (default 30256)
 ctrl_port = 30256
 
-# Encapsulation data port. (default 30056)
-encap_port = 30056
+# The bind IP address for encapsulated traffic (optional, defaults to ctrl_addr)
+data_addr = "192.0.2.101"
+
+# Encapsulated data port. (default 30056)
+data_port = 30056
 
 # Name of TUN device to create. (default "sig")
 tun = "sig"

--- a/go/scion-pki/certs/renew.go
+++ b/go/scion-pki/certs/renew.go
@@ -266,8 +266,8 @@ schema. For more information on JSON schemas, see https://json-schema.org/.
 	cmd.MarkFlagRequired("trc")
 	cmd.Flags().DurationVar(&flags.timeout, "timeout", 5*time.Second,
 		"Timeout for command")
-	cmd.Flags().StringVar(&flags.sciondAddr, "sciond", sciond.DefaultSCIONDAddress,
-		"SCIOND address")
+	cmd.Flags().StringVar(&flags.sciondAddr, "sciond", sciond.DefaultAPIAddress,
+		"SCION Daemon address")
 	cmd.Flags().StringVar(&flags.dispatcherPath, "dispatcher", reliable.DefaultDispPath,
 		"Dispatcher socket path")
 	cmd.Flags().IPVarP(&flags.listen, "local", "l", nil,

--- a/go/scion/ping.go
+++ b/go/scion/ping.go
@@ -157,7 +157,7 @@ func newPing(pather CommandPather) *cobra.Command {
 	cmd.Flags().BoolVar(&flags.noColor, "no_color", false, "disable colored output")
 	cmd.Flags().DurationVar(&flags.timeout, "timeout", time.Second, "timeout per packet")
 	cmd.Flags().IPVar(&flags.local, "local", nil, "IP address to listen on")
-	cmd.Flags().StringVar(&flags.sciond, "sciond", sciond.DefaultSCIONDAddress, "SCIOND address")
+	cmd.Flags().StringVar(&flags.sciond, "sciond", sciond.DefaultAPIAddress, "SCION Daemon address")
 	cmd.Flags().StringVar(&flags.dispatcher, "dispatcher", reliable.DefaultDispPath,
 		"dispatcher socket")
 	cmd.Flags().BoolVar(&flags.refresh, "refresh", false, "set refresh flag for path request")

--- a/go/scion/showpaths.go
+++ b/go/scion/showpaths.go
@@ -131,7 +131,7 @@ Available operators:
 	}
 
 	cmd.Flags().StringVar(&flags.cfg.SCIOND, "sciond",
-		sciond.DefaultSCIONDAddress, "SCION Deamon address")
+		sciond.DefaultAPIAddress, "SCION Deamon address")
 	cmd.Flags().DurationVar(&flags.timeout, "timeout", 5*time.Second, "Timeout")
 	cmd.Flags().StringVar(&flags.cfg.Sequence, "sequence",
 		"", "sequence space separated list of HPs")

--- a/go/scion/traceroute.go
+++ b/go/scion/traceroute.go
@@ -134,7 +134,7 @@ func newTraceroute(pather CommandPather) *cobra.Command {
 	cmd.Flags().IPVar(&flags.local, "local", nil, "IP address to listen on")
 	cmd.Flags().StringVar(&flags.dispatcher, "dispatcher", reliable.DefaultDispPath,
 		"dispatcher socket")
-	cmd.Flags().StringVar(&flags.sciond, "sciond", sciond.DefaultSCIONDAddress, "SCIOND address")
+	cmd.Flags().StringVar(&flags.sciond, "sciond", sciond.DefaultAPIAddress, "SCION Daemon address")
 	return cmd
 }
 

--- a/go/sciond/BUILD.bazel
+++ b/go/sciond/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//go/lib/topology:go_default_library",
         "//go/pkg/command:go_default_library",
         "//go/pkg/grpc:go_default_library",
+        "//go/pkg/proto/daemon:go_default_library",
         "//go/pkg/sciond:go_default_library",
         "//go/pkg/sciond/config:go_default_library",
         "//go/pkg/sciond/fetcher:go_default_library",
@@ -38,5 +39,6 @@ go_library(
         "//go/pkg/trust/compat:go_default_library",
         "//go/pkg/trust/metrics:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
     ],
 )

--- a/go/sig/internal/sigcmn/common.go
+++ b/go/sig/internal/sigcmn/common.go
@@ -62,7 +62,7 @@ func Init(cfg sigconfig.SigConf, sdCfg env.SCIONDClient, features env.Features) 
 		return common.NewBasicError("Error creating local SCION Network context", err)
 	}
 
-	ip := cfg.IP
+	ip := cfg.CtrlAddr
 	if len(ip) == 0 || ip.IsUnspecified() {
 		ip, err = findDefaultLocalIP(context.Background(), sciondConn)
 		if err != nil {
@@ -73,7 +73,7 @@ func Init(cfg sigconfig.SigConf, sdCfg env.SCIONDClient, features env.Features) 
 	CtrlAddr = ip
 	CtrlPort = int(cfg.CtrlPort)
 	DataAddr = ip
-	DataPort = int(cfg.EncapPort)
+	DataPort = int(cfg.DataPort)
 	conn, err := network.Listen(context.Background(), "udp",
 		&net.UDPAddr{IP: CtrlAddr, Port: CtrlPort}, addr.SvcSIG)
 	if err != nil {

--- a/python/topology/sig.py
+++ b/python/topology/sig.py
@@ -153,7 +153,7 @@ class SIGGenerator(object):
             'sig': {
                 'id': name,
                 'sig_config': 'conf/sig.json',
-                'ip': str(net[ipv]),
+                'ctrl_addr': str(net[ipv]),
             },
             'sciond_connection': {
                 'address': socket_address_str(sciond_ip, SD_API_PORT),


### PR DESCRIPTION
Various other changes
- cs: deregister discovery API from TCP server
- intra-AS bfd uses underlay source address/port
- daemon: use default API port if unspecified 

Co-authored-by: Dominik Roos <roos@anapaya.net>
Co-authored-by: Lukas Vogel <vogel@anapaya.net>
Co-authored-by: Sergiu Costea <costea@anapaya.net>
Co-authored-by: Martin Sustrik <sustrik@anapaya.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3902)
<!-- Reviewable:end -->
