### PR TITLE
colibri: replace spath usage

### DIFF
--- a/go/cs/reservation/BUILD.bazel
+++ b/go/cs/reservation/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//go/lib/colibri/reservation:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/serrors:go_default_library",
-        "//go/lib/spath:go_default_library",
         "//go/lib/util:go_default_library",
     ],
 )

--- a/go/cs/reservation/BUILD.bazel
+++ b/go/cs/reservation/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/lib/colibri/reservation:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/serrors:go_default_library",
         "//go/lib/util:go_default_library",
     ],

--- a/go/cs/reservation/conf/BUILD.bazel
+++ b/go/cs/reservation/conf/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/cs/reservation:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/serrors:go_default_library",
     ],
 )
@@ -18,7 +17,6 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
-        "//go/lib/common:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/go/cs/reservation/conf/capacities_test.go
+++ b/go/cs/reservation/conf/capacities_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
@@ -37,9 +36,9 @@ func TestJson(t *testing.T) {
 		"using all keys": {
 			filename: "caps1.json",
 			cap: Capacities{c: capacities{
-				CapIn: map[common.IFIDType]uint64{1: 100, 2: 200, 3: 300},
-				CapEg: map[common.IFIDType]uint64{1: 100, 2: 200, 3: 40},
-				In2Eg: map[common.IFIDType]map[common.IFIDType]uint64{
+				CapIn: map[uint16]uint64{1: 100, 2: 200, 3: 300},
+				CapEg: map[uint16]uint64{1: 100, 2: 200, 3: 40},
+				In2Eg: map[uint16]map[uint16]uint64{
 					1: {2: 10, 3: 20},
 					2: {1: 10, 3: 20},
 					3: {1: 10, 2: 20},
@@ -50,7 +49,7 @@ func TestJson(t *testing.T) {
 		"big num no float": {
 			filename: "caps2.json",
 			cap: Capacities{c: capacities{
-				CapIn: map[common.IFIDType]uint64{1: bigint},
+				CapIn: map[uint16]uint64{1: bigint},
 			},
 			},
 		},
@@ -82,9 +81,9 @@ func TestValidation(t *testing.T) {
 		"okay": {
 			okay: true,
 			cap: Capacities{c: capacities{
-				CapIn: map[common.IFIDType]uint64{1: 100, 2: 200, 3: 300},
-				CapEg: map[common.IFIDType]uint64{1: 100, 2: 200, 3: 40},
-				In2Eg: map[common.IFIDType]map[common.IFIDType]uint64{
+				CapIn: map[uint16]uint64{1: 100, 2: 200, 3: 300},
+				CapEg: map[uint16]uint64{1: 100, 2: 200, 3: 40},
+				In2Eg: map[uint16]map[uint16]uint64{
 					1: {2: 10, 3: 20},
 					2: {1: 10, 3: 20},
 					3: {1: 10, 2: 20},
@@ -95,8 +94,8 @@ func TestValidation(t *testing.T) {
 		"too much ingress": {
 			okay: false,
 			cap: Capacities{c: capacities{
-				CapIn: map[common.IFIDType]uint64{1: 10},
-				In2Eg: map[common.IFIDType]map[common.IFIDType]uint64{
+				CapIn: map[uint16]uint64{1: 10},
+				In2Eg: map[uint16]map[uint16]uint64{
 					1: {2: 10, 3: 1},
 				},
 			},
@@ -105,9 +104,9 @@ func TestValidation(t *testing.T) {
 		"too much egress": {
 			okay: false,
 			cap: Capacities{c: capacities{
-				CapIn: map[common.IFIDType]uint64{1: 100, 2: 100, 3: 100},
-				CapEg: map[common.IFIDType]uint64{1: 100, 2: 100, 3: 100},
-				In2Eg: map[common.IFIDType]map[common.IFIDType]uint64{
+				CapIn: map[uint16]uint64{1: 100, 2: 100, 3: 100},
+				CapEg: map[uint16]uint64{1: 100, 2: 100, 3: 100},
+				In2Eg: map[uint16]map[uint16]uint64{
 					1: {2: 90, 3: 1},
 					3: {2: 20, 1: 1},
 				},
@@ -117,9 +116,9 @@ func TestValidation(t *testing.T) {
 		"ingress to itself (reflection not allowed)": {
 			okay: false,
 			cap: Capacities{c: capacities{
-				CapIn: map[common.IFIDType]uint64{1: 100, 2: 100, 3: 100},
-				CapEg: map[common.IFIDType]uint64{1: 100, 2: 100, 3: 100},
-				In2Eg: map[common.IFIDType]map[common.IFIDType]uint64{
+				CapIn: map[uint16]uint64{1: 100, 2: 100, 3: 100},
+				CapEg: map[uint16]uint64{1: 100, 2: 100, 3: 100},
+				In2Eg: map[uint16]map[uint16]uint64{
 					1: {1: 10, 3: 1},
 				},
 			},
@@ -128,9 +127,9 @@ func TestValidation(t *testing.T) {
 		"too few ingress capacities": {
 			okay: false,
 			cap: Capacities{c: capacities{
-				CapIn: map[common.IFIDType]uint64{1: 100, 3: 100},
-				CapEg: map[common.IFIDType]uint64{1: 100, 2: 100, 3: 100},
-				In2Eg: map[common.IFIDType]map[common.IFIDType]uint64{
+				CapIn: map[uint16]uint64{1: 100, 3: 100},
+				CapEg: map[uint16]uint64{1: 100, 2: 100, 3: 100},
+				In2Eg: map[uint16]map[uint16]uint64{
 					1: {2: 0, 3: 0},
 					2: {1: 0, 3: 0},
 					3: {1: 0, 2: 0},
@@ -141,9 +140,9 @@ func TestValidation(t *testing.T) {
 		"too few egress capacities": {
 			okay: false,
 			cap: Capacities{c: capacities{
-				CapIn: map[common.IFIDType]uint64{1: 100, 2: 100, 3: 100},
-				CapEg: map[common.IFIDType]uint64{1: 100, 3: 100},
-				In2Eg: map[common.IFIDType]map[common.IFIDType]uint64{
+				CapIn: map[uint16]uint64{1: 100, 2: 100, 3: 100},
+				CapEg: map[uint16]uint64{1: 100, 3: 100},
+				In2Eg: map[uint16]map[uint16]uint64{
 					1: {2: 0, 3: 0},
 					2: {1: 0, 3: 0},
 					3: {1: 0, 2: 0},
@@ -169,9 +168,9 @@ func TestValidation(t *testing.T) {
 
 func TestCapacities(t *testing.T) {
 	c := &Capacities{c: capacities{
-		CapIn: map[common.IFIDType]uint64{1: 100, 2: 100, 3: 100},
-		CapEg: map[common.IFIDType]uint64{1: 100, 2: 100, 3: 100},
-		In2Eg: map[common.IFIDType]map[common.IFIDType]uint64{
+		CapIn: map[uint16]uint64{1: 100, 2: 100, 3: 100},
+		CapEg: map[uint16]uint64{1: 100, 2: 100, 3: 100},
+		In2Eg: map[uint16]map[uint16]uint64{
 			1: {2: 12, 3: 13},
 			2: {1: 21, 3: 23},
 			3: {1: 31, 2: 32},
@@ -189,17 +188,17 @@ func cloneCapacities(c *Capacities) *Capacities {
 	ret := &Capacities{}
 	copy(ret.inIfs, c.inIfs)
 	copy(ret.egIfs, c.egIfs)
-	ret.c.CapIn = make(map[common.IFIDType]uint64)
+	ret.c.CapIn = make(map[uint16]uint64)
 	for k, v := range c.c.CapIn {
 		ret.c.CapIn[k] = v
 	}
-	ret.c.CapEg = make(map[common.IFIDType]uint64)
+	ret.c.CapEg = make(map[uint16]uint64)
 	for k, v := range c.c.CapEg {
 		ret.c.CapEg[k] = v
 	}
-	ret.c.In2Eg = make(map[common.IFIDType]map[common.IFIDType]uint64)
+	ret.c.In2Eg = make(map[uint16]map[uint16]uint64)
 	for k, v := range c.c.In2Eg {
-		m := make(map[common.IFIDType]uint64)
+		m := make(map[uint16]uint64)
 		for k, v := range v {
 			m[k] = v
 		}

--- a/go/cs/reservation/e2e/BUILD.bazel
+++ b/go/cs/reservation/e2e/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//go/cs/reservation/segment:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
         "//go/lib/serrors:go_default_library",
-        "//go/lib/spath:go_default_library",
     ],
 )
 
@@ -29,6 +28,7 @@ go_test(
     deps = [
         "//go/cs/reservation/segment:go_default_library",
         "//go/cs/reservation/segmenttest:go_default_library",
+        "//go/cs/reservation/test:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
         "//go/lib/util:go_default_library",
         "//go/lib/xtest:go_default_library",

--- a/go/cs/reservation/e2e/request.go
+++ b/go/cs/reservation/e2e/request.go
@@ -20,7 +20,6 @@ import (
 	base "github.com/scionproto/scion/go/cs/reservation"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
 	"github.com/scionproto/scion/go/lib/serrors"
-	"github.com/scionproto/scion/go/lib/spath"
 )
 
 // Request is the base struct for any type of COLIBRI e2e request.
@@ -33,7 +32,7 @@ type Request struct {
 
 // NewRequest constructs the e2e Request type.
 func NewRequest(ts time.Time, id *reservation.E2EID, idx reservation.IndexNumber,
-	path *spath.Path) (*Request, error) {
+	path base.ColibriPath) (*Request, error) {
 
 	metadata, err := base.NewRequestMetadata(path)
 	if err != nil {

--- a/go/cs/reservation/e2e/request_test.go
+++ b/go/cs/reservation/e2e/request_test.go
@@ -38,7 +38,7 @@ func TestNewRequest(t *testing.T) {
 	require.Equal(t, util.SecsToTime(1), r.Timestamp)
 	require.Equal(t, id, &r.ID)
 	require.Equal(t, reservation.IndexNumber(1), r.Index)
-	require.Equal(t, test.NewTestPath(), r.RequestMetadata.PathDeleteme())
+	require.Equal(t, test.NewTestPath(), r.RequestMetadata.Path())
 }
 
 func TestNewSetupRequest(t *testing.T) {

--- a/go/cs/reservation/e2e/request_test.go
+++ b/go/cs/reservation/e2e/request_test.go
@@ -38,7 +38,7 @@ func TestNewRequest(t *testing.T) {
 	require.Equal(t, util.SecsToTime(1), r.Timestamp)
 	require.Equal(t, id, &r.ID)
 	require.Equal(t, reservation.IndexNumber(1), r.Index)
-	require.Equal(t, segmenttest.NewTestPath(), r.RequestMetadata.Path())
+	require.Equal(t, segmenttest.NewTestPath(), r.RequestMetadata.PathDeleteme())
 }
 
 func TestNewSetupRequest(t *testing.T) {

--- a/go/cs/reservation/e2e/request_test.go
+++ b/go/cs/reservation/e2e/request_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/scionproto/scion/go/cs/reservation/segmenttest"
+	"github.com/scionproto/scion/go/cs/reservation/test"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
 	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/lib/xtest"
@@ -28,17 +28,17 @@ import (
 func TestNewRequest(t *testing.T) {
 	_, err := NewRequest(util.SecsToTime(1), nil, 1, nil)
 	require.Error(t, err)
-	_, err = NewRequest(util.SecsToTime(1), nil, 1, segmenttest.NewTestPath())
+	_, err = NewRequest(util.SecsToTime(1), nil, 1, test.NewTestPath())
 	require.Error(t, err)
 	id, err := reservation.NewE2EID(xtest.MustParseAS("ff00:0:111"),
 		xtest.MustParseHexString("beefcafebeefcafebeef"))
 	require.NoError(t, err)
-	r, err := NewRequest(util.SecsToTime(1), id, 1, segmenttest.NewTestPath())
+	r, err := NewRequest(util.SecsToTime(1), id, 1, test.NewTestPath())
 	require.NoError(t, err)
 	require.Equal(t, util.SecsToTime(1), r.Timestamp)
 	require.Equal(t, id, &r.ID)
 	require.Equal(t, reservation.IndexNumber(1), r.Index)
-	require.Equal(t, segmenttest.NewTestPath(), r.RequestMetadata.PathDeleteme())
+	require.Equal(t, test.NewTestPath(), r.RequestMetadata.PathDeleteme())
 }
 
 func TestNewSetupRequest(t *testing.T) {
@@ -47,7 +47,7 @@ func TestNewSetupRequest(t *testing.T) {
 	id, err := reservation.NewE2EID(xtest.MustParseAS("ff00:0:111"),
 		xtest.MustParseHexString("beefcafebeefcafebeef"))
 	require.NoError(t, err)
-	path := segmenttest.NewTestPath()
+	path := test.NewTestPath()
 	baseReq, err := NewRequest(util.SecsToTime(1), id, 1, path)
 	require.NoError(t, err)
 	_, err = NewSetupRequest(baseReq, nil, nil, 5, nil)
@@ -188,7 +188,7 @@ func TestInterface(t *testing.T) {
 	id, err := reservation.NewE2EID(xtest.MustParseAS("ff00:0:111"),
 		xtest.MustParseHexString("beefcafebeefcafebeef"))
 	require.NoError(t, err)
-	path := segmenttest.NewTestPath()
+	path := test.NewTestPath()
 	baseReq, err := NewRequest(util.SecsToTime(1), id, 1, path)
 	require.NoError(t, err)
 	segmentIDs := []reservation.SegmentID{*newTestSegmentID(t)}

--- a/go/cs/reservation/e2e/reservation_test.go
+++ b/go/cs/reservation/e2e/reservation_test.go
@@ -46,7 +46,7 @@ func TestValidate(t *testing.T) {
 
 	// invalid segment reservation
 	r = newReservation()
-	r.SegmentReservations[0].Path = segment.Path{}
+	r.SegmentReservations[0].Path = segment.ReservationTransparentPath{}
 	err = r.Validate()
 	require.Error(t, err)
 

--- a/go/cs/reservation/e2e/response.go
+++ b/go/cs/reservation/e2e/response.go
@@ -20,7 +20,6 @@ import (
 	base "github.com/scionproto/scion/go/cs/reservation"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
 	"github.com/scionproto/scion/go/lib/serrors"
-	"github.com/scionproto/scion/go/lib/spath"
 )
 
 // Response is the base struct for any type of COLIBRI e2e response.
@@ -34,7 +33,7 @@ type Response struct {
 
 // NewResponse contructs the segment Response type.
 func NewResponse(ts time.Time, id *reservation.E2EID, idx reservation.IndexNumber,
-	path *spath.Path, accepted bool, failedHop uint8) (*Response, error) {
+	path base.ColibriPath, accepted bool, failedHop uint8) (*Response, error) {
 
 	metadata, err := base.NewRequestMetadata(path)
 	if err != nil {

--- a/go/cs/reservation/request.go
+++ b/go/cs/reservation/request.go
@@ -39,17 +39,7 @@ func (m *RequestMetadata) Path() ColibriPath {
 	return m.path
 }
 
-// NumberOfHops returns the number of hops in this reservation.
-func (m *RequestMetadata) NumberOfHops() int {
-	return m.path.NumberOfHops()
-}
-
-// IndexOfCurrentHop returns the 0-based index of the current hop.
-func (m *RequestMetadata) IndexOfCurrentHop() int {
-	return m.path.IndexOfCurrentHop()
-}
-
 // IsLastAS returns true if this hop is the last one (this AS is the destination).
 func (m *RequestMetadata) IsLastAS() bool {
-	return m.IndexOfCurrentHop() == m.NumberOfHops()-1
+	return m.path.IndexOfCurrentHop() == m.path.NumberOfHops()-1
 }

--- a/go/cs/reservation/request.go
+++ b/go/cs/reservation/request.go
@@ -16,38 +16,37 @@ package reservation
 
 import (
 	"github.com/scionproto/scion/go/lib/serrors"
-	"github.com/scionproto/scion/go/lib/spath"
 )
 
 // RequestMetadata contains information about the request, such as its forwarding path.
 // This base struct can be used by any request or response packets.
 type RequestMetadata struct {
-	path spath.Path // the path the packet came / will go with
+	path ColibriPath // the path the packet came / will go with
 }
 
 // NewRequestMetadata constructs the base Request type.
-func NewRequestMetadata(path *spath.Path) (*RequestMetadata, error) {
+func NewRequestMetadata(path ColibriPath) (*RequestMetadata, error) {
 	if path == nil {
 		return nil, serrors.New("new request with nil path")
 	}
 	return &RequestMetadata{
-		path: *path.Copy(),
+		path: path.Copy(),
 	}, nil
 }
 
-// Path returns the spath.Path in this metadata.
-func (m *RequestMetadata) PathDeleteme() *spath.Path {
-	return &m.path
+// Path returns the ColibriPath in this metadata.
+func (m *RequestMetadata) PathDeleteme() ColibriPath {
+	return m.path
 }
 
 // NumberOfHops returns the number of hops in this reservation.
 func (m *RequestMetadata) NumberOfHops() int {
-	return (len(m.path.Raw) - spath.InfoFieldLength) / spath.HopFieldLength
+	return m.path.NumberOfHops()
 }
 
 // IndexOfCurrentHop returns the 0-based index of the current hop.
 func (m *RequestMetadata) IndexOfCurrentHop() int {
-	return (m.path.HopOff - spath.InfoFieldLength) / spath.HopFieldLength
+	return m.path.IndexOfCurrentHop()
 }
 
 // IsLastAS returns true if this hop is the last one (this AS is the destination).

--- a/go/cs/reservation/request.go
+++ b/go/cs/reservation/request.go
@@ -36,7 +36,7 @@ func NewRequestMetadata(path *spath.Path) (*RequestMetadata, error) {
 }
 
 // Path returns the spath.Path in this metadata.
-func (m *RequestMetadata) Path() *spath.Path {
+func (m *RequestMetadata) PathDeleteme() *spath.Path {
 	return &m.path
 }
 

--- a/go/cs/reservation/request.go
+++ b/go/cs/reservation/request.go
@@ -35,7 +35,7 @@ func NewRequestMetadata(path ColibriPath) (*RequestMetadata, error) {
 }
 
 // Path returns the ColibriPath in this metadata.
-func (m *RequestMetadata) PathDeleteme() ColibriPath {
+func (m *RequestMetadata) Path() ColibriPath {
 	return m.path
 }
 

--- a/go/cs/reservation/reservationdbtest/BUILD.bazel
+++ b/go/cs/reservation/reservationdbtest/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//go/cs/reservationstorage/backend:go_default_library",
         "//go/lib/addr:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/util:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",

--- a/go/cs/reservation/reservationdbtest/reservationdbtest.go
+++ b/go/cs/reservation/reservationdbtest/reservationdbtest.go
@@ -29,7 +29,6 @@ import (
 	"github.com/scionproto/scion/go/cs/reservationstorage/backend"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
@@ -328,7 +327,7 @@ func testGetSegmentRsvsFromIFPair(ctx context.Context, t *testing.T, db backend.
 	expected = []*segment.Reservation{r1, r3}
 	require.ElementsMatch(t, expected, rsvs)
 	// no matches
-	var inexistentIngress common.IFIDType = 222
+	var inexistentIngress uint16 = 222
 	rsvs, err = db.GetSegmentRsvsFromIFPair(ctx, &inexistentIngress, nil)
 	require.NoError(t, err)
 	require.Len(t, rsvs, 0)

--- a/go/cs/reservation/reservationdbtest/reservationdbtest.go
+++ b/go/cs/reservation/reservationdbtest/reservationdbtest.go
@@ -655,7 +655,7 @@ func newToken() *reservation.Token {
 func newTestReservation(t *testing.T) *segment.Reservation {
 	t.Helper()
 	r := segment.NewReservation()
-	r.Path = segment.Path{}
+	r.Path = segment.ReservationTransparentPath{}
 	r.ID.ASID = xtest.MustParseAS("ff00:0:1")
 	r.Ingress = 0
 	r.Egress = 1

--- a/go/cs/reservation/segment/BUILD.bazel
+++ b/go/cs/reservation/segment/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//go/lib/colibri/reservation:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/serrors:go_default_library",
-        "//go/lib/spath:go_default_library",
     ],
 )
 

--- a/go/cs/reservation/segment/BUILD.bazel
+++ b/go/cs/reservation/segment/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//go/cs/reservation:go_default_library",
         "//go/lib/addr:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/serrors:go_default_library",
     ],
 )

--- a/go/cs/reservation/segment/admission/impl/BUILD.bazel
+++ b/go/cs/reservation/segment/admission/impl/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//go/cs/reservationstorage/backend:go_default_library",
         "//go/lib/addr:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/serrors:go_default_library",
     ],
 )
@@ -26,7 +25,6 @@ go_test(
         "//go/cs/reservation/segment:go_default_library",
         "//go/cs/reservationstorage/backend/mock_backend:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/util:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",

--- a/go/cs/reservation/segment/admission/impl/stateless.go
+++ b/go/cs/reservation/segment/admission/impl/stateless.go
@@ -24,7 +24,6 @@ import (
 	"github.com/scionproto/scion/go/cs/reservationstorage/backend"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/serrors"
 )
 
@@ -193,7 +192,7 @@ type demPerSource map[addr.AS]demands
 // this is, all cap. requested demands from all reservations, grouped by source, that enter
 // the AS at "ingress" and exit at "egress". It also stores all the source demands that enter
 // the AS at "ingress", and the source demands that exit the AS at "egress".
-func (a *StatelessAdmission) computeTempDemands(ctx context.Context, ingress common.IFIDType,
+func (a *StatelessAdmission) computeTempDemands(ctx context.Context, ingress uint16,
 	req *segment.SetupReq) (demPerSource, error) {
 
 	// TODO(juagargi) consider adding a call to db to get all srcDem,inDem,egDem grouped by source
@@ -243,7 +242,7 @@ func (a *StatelessAdmission) computeTempDemands(ctx context.Context, ingress com
 // demsPerSrc must hold the inDem, egDem and srcDem of all reservations, grouped by source, and
 // for an ingress interface = ingress parameter.
 func (a *StatelessAdmission) transitDemand(ctx context.Context, req *segment.SetupReq,
-	ingress common.IFIDType, demsPerSrc demPerSource) (uint64, error) {
+	ingress uint16, demsPerSrc demPerSource) (uint64, error) {
 
 	capIn := a.Capacities.CapacityIngress(ingress)
 	capEg := a.Capacities.CapacityEgress(req.Egress)

--- a/go/cs/reservation/segment/path.go
+++ b/go/cs/reservation/segment/path.go
@@ -24,19 +24,21 @@ import (
 	"github.com/scionproto/scion/go/lib/serrors"
 )
 
-// Path represents a reservation path, in the reservation order.
-// TODO(juagargi) there exists a ColibriPath that should superseed this type. Remove this.
-type Path []PathStepWithIA
+// ReservationTransparentPath represents a reservation path, in the reservation order.
+// This path is seen only in the source of a segment reservation.
+// TODO(juagargi) there exists a ColibriPath that could be used instead, if we only
+// need equality. If we need to know the IDs of the transit ASes, it won't be possible.
+type ReservationTransparentPath []PathStepWithIA
 
-var _ io.Reader = (*Path)(nil)
+var _ io.Reader = (*ReservationTransparentPath)(nil)
 
 // NewPathFromRaw constructs a new Path from the byte representation.
-func NewPathFromRaw(buff []byte) (Path, error) {
+func NewPathFromRaw(buff []byte) (ReservationTransparentPath, error) {
 	if len(buff)%PathStepWithIALen != 0 {
 		return nil, serrors.New("buffer input is not a multiple of a path step", "len", len(buff))
 	}
 	steps := len(buff) / PathStepWithIALen
-	p := make(Path, steps)
+	p := make(ReservationTransparentPath, steps)
 	for i := 0; i < steps; i++ {
 		offset := i * PathStepWithIALen
 		p[i].Ingress = binary.BigEndian.Uint16(buff[offset:])
@@ -47,7 +49,7 @@ func NewPathFromRaw(buff []byte) (Path, error) {
 }
 
 // Validate returns an error if there is invalid data.
-func (p Path) Validate() error {
+func (p ReservationTransparentPath) Validate() error {
 	if len(p) < 2 {
 		return serrors.New("invalid path length", "len", len(p))
 	}
@@ -61,8 +63,8 @@ func (p Path) Validate() error {
 	return nil
 }
 
-// Equal returns true if both Path contain the same values.
-func (p Path) Equal(o Path) bool {
+// Equal returns true if both ReservationTransparentPath contain the same values.
+func (p ReservationTransparentPath) Equal(o ReservationTransparentPath) bool {
 	if len(p) != len(o) {
 		return false
 	}
@@ -75,9 +77,9 @@ func (p Path) Equal(o Path) bool {
 }
 
 // GetSrcIA returns the source IA in the path or a zero IA if the path is nil (it's not the
-// source AS of the reservation and has no access to the Path of the reservation).
+// source AS of the reservation and has no access to the path of the reservation).
 // If the Path is not nil, it assumes is valid, i.e. it has at least length 2.
-func (p Path) GetSrcIA() addr.IA {
+func (p ReservationTransparentPath) GetSrcIA() addr.IA {
 	if len(p) == 0 {
 		return addr.IA{}
 	}
@@ -85,24 +87,24 @@ func (p Path) GetSrcIA() addr.IA {
 }
 
 // GetDstIA returns the source IA in the path or a zero IA if the path is nil (it's not the
-// source AS of the reservation and has no access to the Path of the reservation).
-// If the Path is not nil, it assumes is valid, i.e. it has at least length 2.
-func (p Path) GetDstIA() addr.IA {
+// source AS of the reservation and has no access to the path of the reservation).
+// If the path is not nil, it assumes is valid, i.e. it has at least length 2.
+func (p ReservationTransparentPath) GetDstIA() addr.IA {
 	if len(p) == 0 {
 		return addr.IA{}
 	}
 	return p[len(p)-1].IA
 }
 
-// Len returns the length of this Path in bytes, when serialized.
-func (p Path) Len() int {
+// Len returns the length of this path in bytes, when serialized.
+func (p ReservationTransparentPath) Len() int {
 	if len(p) == 0 {
 		return 0
 	}
 	return len(p) * PathStepWithIALen
 }
 
-func (p Path) Read(buff []byte) (int, error) {
+func (p ReservationTransparentPath) Read(buff []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
@@ -118,8 +120,8 @@ func (p Path) Read(buff []byte) (int, error) {
 	return p.Len(), nil
 }
 
-// ToRaw returns a buffer representing this Path.
-func (p Path) ToRaw() []byte {
+// ToRaw returns a buffer representing this ReservationTransparentPath.
+func (p ReservationTransparentPath) ToRaw() []byte {
 	if len(p) == 0 {
 		return nil
 	}
@@ -128,7 +130,7 @@ func (p Path) ToRaw() []byte {
 	return buff
 }
 
-func (p Path) String() string {
+func (p ReservationTransparentPath) String() string {
 	strs := make([]string, len(p))
 	for i, s := range p {
 		strs[i] = s.String()
@@ -136,7 +138,8 @@ func (p Path) String() string {
 	return strings.Join(strs, ">")
 }
 
-// PathStep is one hop of the Path. For a source AS Ingress will be invalid. Conversely for dst.
+// PathStep is one hop of the ReservationTransparentPath.
+// For a source AS Ingress will be invalid. Conversely for dst.
 type PathStep struct {
 	Ingress uint16
 	Egress  uint16

--- a/go/cs/reservation/segment/path_test.go
+++ b/go/cs/reservation/segment/path_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestValidatePath(t *testing.T) {
 	tc := map[string]struct {
-		Path    segment.Path
+		Path    segment.ReservationTransparentPath
 		IsValid bool
 	}{
 		"src-dst": {
@@ -58,8 +58,8 @@ func TestValidatePath(t *testing.T) {
 
 func TestEqualPath(t *testing.T) {
 	tc := map[string]struct {
-		Path1   segment.Path
-		Path2   segment.Path
+		Path1   segment.ReservationTransparentPath
+		Path2   segment.ReservationTransparentPath
 		IsEqual bool
 	}{
 		"eq1": {
@@ -81,7 +81,7 @@ func TestEqualPath(t *testing.T) {
 		},
 		"eq4": {
 			Path1:   nil,
-			Path2:   make(segment.Path, 0),
+			Path2:   make(segment.ReservationTransparentPath, 0),
 			IsEqual: true,
 		},
 		"neq1": {
@@ -123,7 +123,7 @@ func TestGetIAs(t *testing.T) {
 	p = nil
 	require.Equal(t, xtest.MustParseIA("0-0"), p.GetSrcIA())
 	require.Equal(t, xtest.MustParseIA("0-0"), p.GetDstIA())
-	p = make(segment.Path, 0)
+	p = make(segment.ReservationTransparentPath, 0)
 	require.Equal(t, xtest.MustParseIA("0-0"), p.GetSrcIA())
 	require.Equal(t, xtest.MustParseIA("0-0"), p.GetDstIA())
 }
@@ -131,11 +131,11 @@ func TestGetIAs(t *testing.T) {
 func TestPathLen(t *testing.T) {
 	p := segmenttest.NewPathFromComponents(0, "1-ff00:0:1", 1, 1, "1-ff00:0:2", 0)
 	require.Equal(t, 2*12, p.Len())
-	p = segment.Path{}
+	p = segment.ReservationTransparentPath{}
 	require.Equal(t, 0, p.Len())
 	p = nil
 	require.Equal(t, 0, p.Len())
-	p = make(segment.Path, 0)
+	p = make(segment.ReservationTransparentPath, 0)
 	require.Equal(t, 0, p.Len())
 }
 
@@ -171,7 +171,7 @@ func TestToFromBinary(t *testing.T) {
 	// empty and nil path
 	p = nil
 	require.Empty(t, p.ToRaw())
-	p = make(segment.Path, 0)
+	p = make(segment.ReservationTransparentPath, 0)
 	require.Empty(t, p.ToRaw())
 }
 

--- a/go/cs/reservation/segment/path_test.go
+++ b/go/cs/reservation/segment/path_test.go
@@ -130,7 +130,7 @@ func TestGetIAs(t *testing.T) {
 
 func TestPathLen(t *testing.T) {
 	p := segmenttest.NewPathFromComponents(0, "1-ff00:0:1", 1, 1, "1-ff00:0:2", 0)
-	require.Equal(t, 8*6, p.Len())
+	require.Equal(t, 2*12, p.Len())
 	p = segment.Path{}
 	require.Equal(t, 0, p.Len())
 	p = nil
@@ -146,10 +146,10 @@ func TestToFromBinary(t *testing.T) {
 	require.Error(t, err)
 	_, err = p.Read(buff)
 	require.Error(t, err)
-	buff = make([]byte, 2*3*8)
+	buff = make([]byte, 2*12)
 	c, err := p.Read(buff)
 	require.NoError(t, err)
-	require.Equal(t, 2*3*8, c)
+	require.Equal(t, 2*12, c)
 
 	anotherP, err := segment.NewPathFromRaw(buff)
 	require.NoError(t, err)

--- a/go/cs/reservation/segment/request.go
+++ b/go/cs/reservation/segment/request.go
@@ -19,7 +19,6 @@ import (
 
 	base "github.com/scionproto/scion/go/cs/reservation"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/serrors"
 )
 
@@ -30,8 +29,8 @@ type Request struct {
 	ID                   reservation.SegmentID   // the ID this request refers to
 	Index                reservation.IndexNumber // the index this request refers to
 	Timestamp            time.Time               // the mandatory timestamp
-	Ingress              common.IFIDType         // the interface the traffic uses to enter the AS
-	Egress               common.IFIDType         // the interface the traffic uses to leave the AS
+	Ingress              uint16                  // the interface the traffic uses to enter the AS
+	Egress               uint16                  // the interface the traffic uses to leave the AS
 	Reservation          *Reservation            // nil if no reservation yet
 }
 

--- a/go/cs/reservation/segment/request.go
+++ b/go/cs/reservation/segment/request.go
@@ -21,7 +21,6 @@ import (
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/serrors"
-	"github.com/scionproto/scion/go/lib/spath"
 )
 
 // Request is the base struct for any type of COLIBRI segment request.
@@ -38,25 +37,13 @@ type Request struct {
 
 // NewRequest constructs the segment Request type.
 func NewRequest(ts time.Time, id *reservation.SegmentID, idx reservation.IndexNumber,
-	path *spath.Path) (*Request, error) {
+	path base.ColibriPath) (*Request, error) {
 
 	metadata, err := base.NewRequestMetadata(path)
 	if err != nil {
 		return nil, serrors.WrapStr("new segment request", err)
 	}
-	hf, err := path.GetHopField(path.HopOff)
-	if err != nil {
-		return nil, serrors.WrapStr("cannot get ingress and egress IFIDs from the setup request",
-			err, "hop_off", path.HopOff)
-	}
-	ingressIFID, egressIFID := hf.ConsIngress, hf.ConsEgress
-	infField, err := path.GetInfoField(path.InfOff)
-	if err != nil {
-		return nil, serrors.WrapStr("cannot obtain infofield from spath", err)
-	}
-	if !infField.ConsDir {
-		egressIFID, ingressIFID = ingressIFID, egressIFID
-	}
+	ingressIFID, egressIFID := path.IngressEgressIFIDs()
 	if id == nil {
 		return nil, serrors.New("new segment request with nil ID")
 	}

--- a/go/cs/reservation/segment/reservation.go
+++ b/go/cs/reservation/segment/reservation.go
@@ -19,7 +19,6 @@ import (
 
 	base "github.com/scionproto/scion/go/cs/reservation"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/serrors"
 )
 
@@ -28,8 +27,8 @@ type Reservation struct {
 	ID           reservation.SegmentID
 	Indices      Indices                  // existing indices in this reservation
 	activeIndex  int                      // -1 <= activeIndex < len(Indices)
-	Ingress      common.IFIDType          // igress interface ID: reservation packets enter
-	Egress       common.IFIDType          // egress interface ID: reservation packets leave
+	Ingress      uint16                   // igress interface ID: reservation packets enter
+	Egress       uint16                   // egress interface ID: reservation packets leave
 	Path         Path                     // empty if not at the source of the reservation
 	PathType     reservation.PathType     // the type of path (up,core,down)
 	PathEndProps reservation.PathEndProps // the properties for stitching and start/end

--- a/go/cs/reservation/segment/reservation.go
+++ b/go/cs/reservation/segment/reservation.go
@@ -25,14 +25,14 @@ import (
 // Reservation represents a segment reservation.
 type Reservation struct {
 	ID           reservation.SegmentID
-	Indices      Indices                  // existing indices in this reservation
-	activeIndex  int                      // -1 <= activeIndex < len(Indices)
-	Ingress      uint16                   // igress interface ID: reservation packets enter
-	Egress       uint16                   // egress interface ID: reservation packets leave
-	Path         Path                     // empty if not at the source of the reservation
-	PathType     reservation.PathType     // the type of path (up,core,down)
-	PathEndProps reservation.PathEndProps // the properties for stitching and start/end
-	TrafficSplit reservation.SplitCls     // the traffic split between control and data planes
+	Indices      Indices                    // existing indices in this reservation
+	activeIndex  int                        // -1 <= activeIndex < len(Indices)
+	Ingress      uint16                     // igress interface ID: reservation packets enter
+	Egress       uint16                     // egress interface ID: reservation packets leave
+	Path         ReservationTransparentPath // empty if not at the source of the reservation
+	PathType     reservation.PathType       // the type of path (up,core,down)
+	PathEndProps reservation.PathEndProps   // the properties for stitching and start/end
+	TrafficSplit reservation.SplitCls       // the traffic split between control and data planes
 }
 
 func NewReservation() *Reservation {

--- a/go/cs/reservation/segment/reservation_test.go
+++ b/go/cs/reservation/segment/reservation_test.go
@@ -98,7 +98,7 @@ func TestReservationValidate(t *testing.T) {
 	err := r.Validate()
 	require.NoError(t, err)
 	// wrong path
-	r.Path = segment.Path{}
+	r.Path = segment.ReservationTransparentPath{}
 	err = r.Validate()
 	require.Error(t, err)
 	// more than one active index

--- a/go/cs/reservation/segment/response.go
+++ b/go/cs/reservation/segment/response.go
@@ -20,7 +20,6 @@ import (
 	base "github.com/scionproto/scion/go/cs/reservation"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
 	"github.com/scionproto/scion/go/lib/serrors"
-	"github.com/scionproto/scion/go/lib/spath"
 )
 
 // Response is the base struct for any type of COLIBRI segment response.
@@ -36,7 +35,7 @@ var _ base.MessageWithPath = (*Response)(nil)
 
 // NewResponse contructs the segment Response type.
 func NewResponse(ts time.Time, id *reservation.SegmentID, idx reservation.IndexNumber,
-	path *spath.Path, accepted bool, failedHop uint8) (*Response, error) {
+	path base.ColibriPath, accepted bool, failedHop uint8) (*Response, error) {
 
 	metadata, err := base.NewRequestMetadata(path)
 	if err != nil {

--- a/go/cs/reservation/segmenttest/BUILD.bazel
+++ b/go/cs/reservation/segmenttest/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//go/cs/reservation/segment:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
         "//go/lib/common:go_default_library",
-        "//go/lib/spath:go_default_library",
         "//go/lib/xtest:go_default_library",
     ],
 )

--- a/go/cs/reservation/segmenttest/BUILD.bazel
+++ b/go/cs/reservation/segmenttest/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//go/cs/reservation/segment:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/xtest:go_default_library",
     ],
 )

--- a/go/cs/reservation/segmenttest/common.go
+++ b/go/cs/reservation/segmenttest/common.go
@@ -18,7 +18,6 @@ import (
 	"github.com/scionproto/scion/go/cs/reservation/segment"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
@@ -49,24 +48,4 @@ func NewReservation() *segment.Reservation {
 	r.ID = *segID
 	r.Path = NewPathFromComponents(0, "1-ff00:0:1", 1, 1, "1-ff00:0:2", 0)
 	return r
-}
-
-// NewTestPath returns a new path with one segment consisting on 3 hopfields: (0,2)->(1,2)->(1,0).
-func NewTestPath() *spath.Path {
-	path := &spath.Path{
-		InfOff: 0,
-		HopOff: spath.InfoFieldLength + spath.HopFieldLength, // second hop field
-		Raw:    make([]byte, spath.InfoFieldLength+3*spath.HopFieldLength),
-	}
-	inf := spath.InfoField{ConsDir: true, ISD: 1, Hops: 3}
-	inf.Write(path.Raw)
-
-	hf := &spath.HopField{ConsEgress: 2}
-	hf.Write(path.Raw[spath.InfoFieldLength:])
-	hf = &spath.HopField{ConsIngress: 1, ConsEgress: 2}
-	hf.Write(path.Raw[spath.InfoFieldLength+spath.HopFieldLength:])
-	hf = &spath.HopField{ConsIngress: 1}
-	hf.Write(path.Raw[spath.InfoFieldLength+spath.HopFieldLength*2:])
-
-	return path
 }

--- a/go/cs/reservation/segmenttest/common.go
+++ b/go/cs/reservation/segmenttest/common.go
@@ -20,11 +20,11 @@ import (
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
-func NewPathFromComponents(chain ...interface{}) segment.Path {
+func NewPathFromComponents(chain ...interface{}) segment.ReservationTransparentPath {
 	if len(chain)%3 != 0 {
 		panic("wrong number of arguments")
 	}
-	p := segment.Path{}
+	p := segment.ReservationTransparentPath{}
 	for i := 0; i < len(chain); i += 3 {
 		p = append(p, segment.PathStepWithIA{
 			PathStep: segment.PathStep{

--- a/go/cs/reservation/segmenttest/common.go
+++ b/go/cs/reservation/segmenttest/common.go
@@ -17,7 +17,6 @@ package segmenttest
 import (
 	"github.com/scionproto/scion/go/cs/reservation/segment"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/xtest"
 )
 
@@ -29,8 +28,8 @@ func NewPathFromComponents(chain ...interface{}) segment.Path {
 	for i := 0; i < len(chain); i += 3 {
 		p = append(p, segment.PathStepWithIA{
 			PathStep: segment.PathStep{
-				Ingress: common.IFIDType(chain[i].(int)),
-				Egress:  common.IFIDType(chain[i+2].(int)),
+				Ingress: uint16(chain[i].(int)),
+				Egress:  uint16(chain[i+2].(int)),
 			},
 			IA: xtest.MustParseIA(chain[i+1].(string)),
 		})

--- a/go/cs/reservation/sqlite/BUILD.bazel
+++ b/go/cs/reservation/sqlite/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//go/cs/reservationstorage/backend:go_default_library",
         "//go/lib/addr:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/infra/modules/db:go_default_library",
         "//go/lib/serrors:go_default_library",
         "//go/lib/util:go_default_library",

--- a/go/cs/reservation/sqlite/db.go
+++ b/go/cs/reservation/sqlite/db.go
@@ -33,7 +33,6 @@ import (
 	"github.com/scionproto/scion/go/cs/reservationstorage/backend"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/infra/modules/db"
 	"github.com/scionproto/scion/go/lib/serrors"
 	"github.com/scionproto/scion/go/lib/util"
@@ -188,7 +187,7 @@ func (x *executor) GetAllSegmentRsvs(ctx context.Context) ([]*segment.Reservatio
 
 // GetSegmentRsvsFromIFPair returns all segment reservations that enter this AS at
 // the specified ingress and exit at that egress.
-func (x *executor) GetSegmentRsvsFromIFPair(ctx context.Context, ingress, egress *common.IFIDType) (
+func (x *executor) GetSegmentRsvsFromIFPair(ctx context.Context, ingress, egress *uint16) (
 	[]*segment.Reservation, error) {
 
 	conditions := make([]string, 0, 2)
@@ -401,8 +400,8 @@ type rsvFields struct {
 	RowID        int
 	AsID         uint64
 	Suffix       uint32
-	Ingress      common.IFIDType
-	Egress       common.IFIDType
+	Ingress      uint16
+	Egress       uint16
 	Path         []byte
 	EndProps     int
 	TrafficSplit int

--- a/go/cs/reservation/sqlite/db.go
+++ b/go/cs/reservation/sqlite/db.go
@@ -162,8 +162,8 @@ func (x *executor) GetSegmentRsvsFromSrcDstIA(ctx context.Context, srcIA, dstIA 
 }
 
 // GetSegmentRsvFromPath searches for a segment reservation with the specified path.
-func (x *executor) GetSegmentRsvFromPath(ctx context.Context, path segment.Path) (
-	*segment.Reservation, error) {
+func (x *executor) GetSegmentRsvFromPath(ctx context.Context,
+	path segment.ReservationTransparentPath) (*segment.Reservation, error) {
 
 	rsvs, err := getSegReservations(ctx, x.db, "WHERE path = ?", []interface{}{path.ToRaw()})
 	if err != nil {

--- a/go/cs/reservation/test/BUILD.bazel
+++ b/go/cs/reservation/test/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["path.go"],
+    importpath = "github.com/scionproto/scion/go/cs/reservation/test",
+    visibility = ["//visibility:public"],
+    deps = ["//go/cs/reservation:go_default_library"],
+)

--- a/go/cs/reservation/test/path.go
+++ b/go/cs/reservation/test/path.go
@@ -1,0 +1,57 @@
+// Copyright 2020 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	base "github.com/scionproto/scion/go/cs/reservation"
+)
+
+type TestColibriPath struct {
+	HopCount   int
+	CurrentHop int
+	Ingress    uint16
+	Egress     uint16
+}
+
+var _ base.ColibriPath = (*TestColibriPath)(nil)
+
+func (p *TestColibriPath) Copy() base.ColibriPath {
+	return p
+}
+
+func (p *TestColibriPath) Reverse() error {
+	return nil
+}
+
+func (p *TestColibriPath) NumberOfHops() int {
+	return p.HopCount
+}
+
+func (p *TestColibriPath) IndexOfCurrentHop() int {
+	return p.CurrentHop
+}
+
+func (p *TestColibriPath) IngressEgressIFIDs() (uint16, uint16) {
+	return p.Ingress, p.Egress
+}
+
+// NewTestPath returns a new path with one segment consisting on 3 hopfields: (0,2)->(1,2)->(1,0).
+func NewTestPath() base.ColibriPath {
+	path := TestColibriPath{
+		Ingress: 1,
+		Egress:  2,
+	}
+	return &path
+}

--- a/go/cs/reservation/translate/BUILD.bazel
+++ b/go/cs/reservation/translate/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//go/lib/colibri/reservation:go_default_library",
         "//go/lib/ctrl/colibri_mgmt:go_default_library",
         "//go/lib/serrors:go_default_library",
-        "//go/lib/spath:go_default_library",
         "//go/proto:go_default_library",
     ],
 )
@@ -31,7 +30,7 @@ go_test(
     deps = [
         "//go/cs/reservation/e2e:go_default_library",
         "//go/cs/reservation/segment:go_default_library",
-        "//go/cs/reservation/segmenttest:go_default_library",
+        "//go/cs/reservation/test:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/ctrl/colibri_mgmt:go_default_library",

--- a/go/cs/reservation/translate/BUILD.bazel
+++ b/go/cs/reservation/translate/BUILD.bazel
@@ -32,7 +32,6 @@ go_test(
         "//go/cs/reservation/segment:go_default_library",
         "//go/cs/reservation/test:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/ctrl/colibri_mgmt:go_default_library",
         "//go/lib/util:go_default_library",
         "//go/lib/xtest:go_default_library",

--- a/go/cs/reservation/translate/fromctrl.go
+++ b/go/cs/reservation/translate/fromctrl.go
@@ -392,7 +392,8 @@ func newResponseSegmentTeardown(ctrl *colibri_mgmt.SegmentTeardownRes, resp *col
 }
 
 func newResponseSegmentIndexConfirmation(ctrl *colibri_mgmt.SegmentIndexConfirmationRes,
-	resp *colibri_mgmt.Response, ts time.Time, path base.ColibriPath) (base.MessageWithPath, error) {
+	resp *colibri_mgmt.Response, ts time.Time,
+	path base.ColibriPath) (base.MessageWithPath, error) {
 
 	id, err := NewSegmentIDFromCtrl(ctrl.Base.ID)
 	if err != nil {

--- a/go/cs/reservation/translate/fromctrl.go
+++ b/go/cs/reservation/translate/fromctrl.go
@@ -24,13 +24,12 @@ import (
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
 	"github.com/scionproto/scion/go/lib/ctrl/colibri_mgmt"
 	"github.com/scionproto/scion/go/lib/serrors"
-	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/proto"
 )
 
 // NewMsgFromCtrl takes a colibri ctrl message and returns a new application type.
-// the spath.Path comes from the scion packet that encapsulates the ctrl payload.
-func NewMsgFromCtrl(ctrl *colibri_mgmt.ColibriRequestPayload, path *spath.Path) (
+// the ColibriPath comes from the  packet that encapsulates the ctrl payload.
+func NewMsgFromCtrl(ctrl *colibri_mgmt.ColibriRequestPayload, path base.ColibriPath) (
 	base.MessageWithPath, error) {
 
 	if ctrl == nil {
@@ -89,7 +88,7 @@ func NewE2EIDFromCtrl(ctrl *colibri_mgmt.E2EReservationID) (
 	return id, nil
 }
 
-func newRequestFromCtrl(ctrl *colibri_mgmt.Request, ts time.Time, path *spath.Path) (
+func newRequestFromCtrl(ctrl *colibri_mgmt.Request, ts time.Time, path base.ColibriPath) (
 	base.MessageWithPath, error) {
 
 	if ctrl == nil {
@@ -121,7 +120,7 @@ func newRequestFromCtrl(ctrl *colibri_mgmt.Request, ts time.Time, path *spath.Pa
 	}
 }
 
-func newResponseFromCtrl(ctrl *colibri_mgmt.Response, ts time.Time, path *spath.Path) (
+func newResponseFromCtrl(ctrl *colibri_mgmt.Response, ts time.Time, path base.ColibriPath) (
 	base.MessageWithPath, error) {
 
 	if ctrl == nil {
@@ -151,9 +150,9 @@ func newResponseFromCtrl(ctrl *colibri_mgmt.Response, ts time.Time, path *spath.
 
 // newRequestSegmentSetup constructs a SetupReq from its control message counterpart.
 // The timestamp comes from the wrapping ColibriRequestPayload,
-// and the spath from the wrapping SCION packet.
+// and the path from the wrapping packet.
 func newRequestSegmentSetup(ctrl *colibri_mgmt.SegmentSetup, ts time.Time,
-	path *spath.Path) (*segment.SetupReq, error) {
+	path base.ColibriPath) (*segment.SetupReq, error) {
 
 	id, err := NewSegmentIDFromCtrl(ctrl.Base.ID)
 	if err != nil {
@@ -191,7 +190,7 @@ func newRequestSegmentSetup(ctrl *colibri_mgmt.SegmentSetup, ts time.Time,
 
 // NewTelesRequestFromCtrlMsg constucts the app type from its control message counterpart.
 func newRequestSegmentTelesSetup(ctrl *colibri_mgmt.SegmentTelesSetup, ts time.Time,
-	path *spath.Path) (*segment.SetupTelesReq, error) {
+	path base.ColibriPath) (*segment.SetupTelesReq, error) {
 
 	if ctrl.BaseID == nil || ctrl.Setup == nil {
 		return nil, serrors.New("illegal ctrl telescopic setup received", "base_id", ctrl.BaseID,
@@ -213,7 +212,7 @@ func newRequestSegmentTelesSetup(ctrl *colibri_mgmt.SegmentTelesSetup, ts time.T
 }
 
 func newRequestSegmentTeardown(ctrl *colibri_mgmt.SegmentTeardownReq, ts time.Time,
-	path *spath.Path) (*segment.TeardownReq, error) {
+	path base.ColibriPath) (*segment.TeardownReq, error) {
 
 	id, err := NewSegmentIDFromCtrl(ctrl.Base.ID)
 	if err != nil {
@@ -229,7 +228,7 @@ func newRequestSegmentTeardown(ctrl *colibri_mgmt.SegmentTeardownReq, ts time.Ti
 }
 
 func newRequestSegmentIndexConfirmation(ctrl *colibri_mgmt.SegmentIndexConfirmation, ts time.Time,
-	path *spath.Path) (*segment.IndexConfirmationReq, error) {
+	path base.ColibriPath) (*segment.IndexConfirmationReq, error) {
 
 	id, err := NewSegmentIDFromCtrl(ctrl.Base.ID)
 	if err != nil {
@@ -250,7 +249,7 @@ func newRequestSegmentIndexConfirmation(ctrl *colibri_mgmt.SegmentIndexConfirmat
 }
 
 func newRequestSegmentCleanup(ctrl *colibri_mgmt.SegmentCleanup, ts time.Time,
-	path *spath.Path) (*segment.CleanupReq, error) {
+	path base.ColibriPath) (*segment.CleanupReq, error) {
 
 	id, err := NewSegmentIDFromCtrl(ctrl.Base.ID)
 	if err != nil {
@@ -266,7 +265,7 @@ func newRequestSegmentCleanup(ctrl *colibri_mgmt.SegmentCleanup, ts time.Time,
 }
 
 func newRequestE2ESetup(ctrl *colibri_mgmt.E2ESetup, ts time.Time,
-	path *spath.Path) (base.MessageWithPath, error) {
+	path base.ColibriPath) (base.MessageWithPath, error) {
 
 	id, err := NewE2EIDFromCtrl(ctrl.Base.ID)
 	if err != nil {
@@ -316,7 +315,7 @@ func newRequestE2ESetup(ctrl *colibri_mgmt.E2ESetup, ts time.Time,
 }
 
 func newRequestE2ECleanup(ctrl *colibri_mgmt.E2ECleanup, ts time.Time,
-	path *spath.Path) (*e2e.CleanupReq, error) {
+	path base.ColibriPath) (*e2e.CleanupReq, error) {
 
 	id, err := NewE2EIDFromCtrl(ctrl.Base.ID)
 	if err != nil {
@@ -333,7 +332,7 @@ func newRequestE2ECleanup(ctrl *colibri_mgmt.E2ECleanup, ts time.Time,
 
 // the failedHop parameter won't be used if the response is successful.
 func newResponseSegmentSetup(ctrl *colibri_mgmt.SegmentSetupRes, resp *colibri_mgmt.Response,
-	ts time.Time, path *spath.Path) (base.MessageWithPath, error) {
+	ts time.Time, path base.ColibriPath) (base.MessageWithPath, error) {
 
 	id, err := NewSegmentIDFromCtrl(ctrl.Base.ID)
 	if err != nil {
@@ -369,7 +368,7 @@ func newResponseSegmentSetup(ctrl *colibri_mgmt.SegmentSetupRes, resp *colibri_m
 }
 
 func newResponseSegmentTeardown(ctrl *colibri_mgmt.SegmentTeardownRes, resp *colibri_mgmt.Response,
-	ts time.Time, path *spath.Path) (base.MessageWithPath, error) {
+	ts time.Time, path base.ColibriPath) (base.MessageWithPath, error) {
 
 	id, err := NewSegmentIDFromCtrl(ctrl.Base.ID)
 	if err != nil {
@@ -393,7 +392,7 @@ func newResponseSegmentTeardown(ctrl *colibri_mgmt.SegmentTeardownRes, resp *col
 }
 
 func newResponseSegmentIndexConfirmation(ctrl *colibri_mgmt.SegmentIndexConfirmationRes,
-	resp *colibri_mgmt.Response, ts time.Time, path *spath.Path) (base.MessageWithPath, error) {
+	resp *colibri_mgmt.Response, ts time.Time, path base.ColibriPath) (base.MessageWithPath, error) {
 
 	id, err := NewSegmentIDFromCtrl(ctrl.Base.ID)
 	if err != nil {
@@ -417,7 +416,7 @@ func newResponseSegmentIndexConfirmation(ctrl *colibri_mgmt.SegmentIndexConfirma
 }
 
 func newResponseSegmentCleanup(ctrl *colibri_mgmt.SegmentCleanupRes, resp *colibri_mgmt.Response,
-	ts time.Time, path *spath.Path) (base.MessageWithPath, error) {
+	ts time.Time, path base.ColibriPath) (base.MessageWithPath, error) {
 
 	id, err := NewSegmentIDFromCtrl(ctrl.Base.ID)
 	if err != nil {
@@ -441,7 +440,7 @@ func newResponseSegmentCleanup(ctrl *colibri_mgmt.SegmentCleanupRes, resp *colib
 }
 
 func newResponseE2ESetup(ctrl *colibri_mgmt.E2ESetupRes, resp *colibri_mgmt.Response,
-	ts time.Time, path *spath.Path) (base.MessageWithPath, error) {
+	ts time.Time, path base.ColibriPath) (base.MessageWithPath, error) {
 
 	id, err := NewE2EIDFromCtrl(ctrl.Base.ID)
 	if err != nil {
@@ -478,7 +477,7 @@ func newResponseE2ESetup(ctrl *colibri_mgmt.E2ESetupRes, resp *colibri_mgmt.Resp
 }
 
 func newResponseE2EClenaup(ctrl *colibri_mgmt.E2ECleanupRes, resp *colibri_mgmt.Response,
-	ts time.Time, path *spath.Path) (base.MessageWithPath, error) {
+	ts time.Time, path base.ColibriPath) (base.MessageWithPath, error) {
 
 	id, err := NewE2EIDFromCtrl(ctrl.Base.ID)
 	if err != nil {

--- a/go/cs/reservation/translate/fromctrl_test.go
+++ b/go/cs/reservation/translate/fromctrl_test.go
@@ -56,7 +56,7 @@ func TestNewRequestSegmentSetupFromCtrl(t *testing.T) {
 	p := segmenttest.NewTestPath()
 	r, err = newRequestSegmentSetup(ctrlMsg, ts, p)
 	require.NoError(t, err)
-	require.Equal(t, p, r.Path())
+	require.Equal(t, p, r.PathDeleteme())
 	checkRequest(t, ctrlMsg, r, ts)
 	require.Equal(t, common.IFIDType(1), r.Ingress)
 	require.Equal(t, common.IFIDType(2), r.Egress)

--- a/go/cs/reservation/translate/fromctrl_test.go
+++ b/go/cs/reservation/translate/fromctrl_test.go
@@ -56,7 +56,7 @@ func TestNewRequestSegmentSetupFromCtrl(t *testing.T) {
 	p := test.NewTestPath()
 	r, err = newRequestSegmentSetup(ctrlMsg, ts, p)
 	require.NoError(t, err)
-	require.Equal(t, p, r.PathDeleteme())
+	require.Equal(t, p, r.Path())
 	checkRequest(t, ctrlMsg, r, ts)
 	require.Equal(t, common.IFIDType(1), r.Ingress)
 	require.Equal(t, common.IFIDType(2), r.Egress)

--- a/go/cs/reservation/translate/fromctrl_test.go
+++ b/go/cs/reservation/translate/fromctrl_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/scionproto/scion/go/cs/reservation/e2e"
 	"github.com/scionproto/scion/go/cs/reservation/segment"
-	"github.com/scionproto/scion/go/cs/reservation/segmenttest"
+	"github.com/scionproto/scion/go/cs/reservation/test"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
 	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/colibri_mgmt"
@@ -53,7 +53,7 @@ func TestNewRequestSegmentSetupFromCtrl(t *testing.T) {
 	ts := util.SecsToTime(1)
 	r, err := newRequestSegmentSetup(ctrlMsg, ts, nil)
 	require.Error(t, err) // missing path
-	p := segmenttest.NewTestPath()
+	p := test.NewTestPath()
 	r, err = newRequestSegmentSetup(ctrlMsg, ts, p)
 	require.NoError(t, err)
 	require.Equal(t, p, r.PathDeleteme())
@@ -67,7 +67,7 @@ func TestNewRequestSegmentTelesSetup(t *testing.T) {
 	ts := util.SecsToTime(1)
 	r, err := newRequestSegmentTelesSetup(ctrlMsg, ts, nil)
 	require.Error(t, err) // path is nil
-	r, err = newRequestSegmentTelesSetup(ctrlMsg, ts, segmenttest.NewTestPath())
+	r, err = newRequestSegmentTelesSetup(ctrlMsg, ts, test.NewTestPath())
 	require.NoError(t, err)
 	checkRequest(t, ctrlMsg.Setup, &r.SetupReq, ts)
 	require.Equal(t, xtest.MustParseAS("ff00:cafe:1"), r.BaseID.ASID)
@@ -79,7 +79,7 @@ func TestNewRequestSegmentTeardown(t *testing.T) {
 	ts := util.SecsToTime(1)
 	r, err := newRequestSegmentTeardown(ctrlMsg, ts, nil)
 	require.Error(t, err) // path is nil
-	r, err = newRequestSegmentTeardown(ctrlMsg, ts, segmenttest.NewTestPath())
+	r, err = newRequestSegmentTeardown(ctrlMsg, ts, test.NewTestPath())
 	require.NoError(t, err)
 	checkIDs(t, ctrlMsg.Base.ID, &r.ID)
 	require.Equal(t, ctrlMsg.Base.Index, uint8(r.Index))
@@ -90,7 +90,7 @@ func TestNewRequestSegmentIndexConfirmation(t *testing.T) {
 	ts := util.SecsToTime(1)
 	r, err := newRequestSegmentIndexConfirmation(ctrlMsg, ts, nil)
 	require.Error(t, err) // nil path
-	r, err = newRequestSegmentIndexConfirmation(ctrlMsg, ts, segmenttest.NewTestPath())
+	r, err = newRequestSegmentIndexConfirmation(ctrlMsg, ts, test.NewTestPath())
 	require.NoError(t, err)
 	checkIDs(t, ctrlMsg.Base.ID, &r.ID)
 	require.Equal(t, ctrlMsg.Base.Index, uint8(r.Index))
@@ -102,7 +102,7 @@ func TestNewRequestSegmentCleanup(t *testing.T) {
 	ts := util.SecsToTime(1)
 	r, err := newRequestSegmentCleanup(ctrlMsg, ts, nil)
 	require.Error(t, err) // nil path
-	r, err = newRequestSegmentCleanup(ctrlMsg, ts, segmenttest.NewTestPath())
+	r, err = newRequestSegmentCleanup(ctrlMsg, ts, test.NewTestPath())
 	require.NoError(t, err)
 	checkIDs(t, ctrlMsg.Base.ID, &r.ID)
 	require.Equal(t, ctrlMsg.Base.Index, uint8(r.Index))
@@ -113,7 +113,7 @@ func TestNewRequestE2ESetupSuccess(t *testing.T) {
 	ts := util.SecsToTime(1)
 	_, err := newRequestE2ESetup(ctrlMsg, ts, nil)
 	require.Error(t, err)
-	s, err := newRequestE2ESetup(ctrlMsg, ts, segmenttest.NewTestPath())
+	s, err := newRequestE2ESetup(ctrlMsg, ts, test.NewTestPath())
 	require.NoError(t, err)
 	require.IsType(t, &e2e.SetupReqSuccess{}, s)
 	r := s.(*e2e.SetupReqSuccess)
@@ -141,7 +141,7 @@ func TestNewRequestE2ESetupFailure(t *testing.T) {
 	ts := util.SecsToTime(1)
 	_, err := newRequestE2ESetup(ctrlMsg, ts, nil)
 	require.Error(t, err)
-	s, err := newRequestE2ESetup(ctrlMsg, ts, segmenttest.NewTestPath())
+	s, err := newRequestE2ESetup(ctrlMsg, ts, test.NewTestPath())
 	require.NoError(t, err)
 	require.IsType(t, &e2e.SetupReqFailure{}, s)
 	r := s.(*e2e.SetupReqFailure)
@@ -169,7 +169,7 @@ func TestNewRequestE2ECleanup(t *testing.T) {
 	ts := util.SecsToTime(1)
 	r, err := newRequestE2ECleanup(ctrlMsg, ts, nil)
 	require.Error(t, err)
-	r, err = newRequestE2ECleanup(ctrlMsg, ts, segmenttest.NewTestPath())
+	r, err = newRequestE2ECleanup(ctrlMsg, ts, test.NewTestPath())
 	require.NoError(t, err)
 	checkE2EIDs(t, ctrlMsg.Base.ID, &r.ID)
 	require.Equal(t, ctrlMsg.Base.Index, uint8(r.Index))
@@ -204,7 +204,7 @@ func TestNewResponseSegmentSetup(t *testing.T) {
 			_, err := newResponseSegmentSetup(tc.Ctrl.SegmentSetup, tc.Ctrl, ts, nil)
 			require.Error(t, err)
 			r, err := newResponseSegmentSetup(tc.Ctrl.SegmentSetup, tc.Ctrl, ts,
-				segmenttest.NewTestPath())
+				test.NewTestPath())
 			require.NoError(t, err)
 			require.NotNil(t, r)
 			if tc.Ctrl.Accepted {
@@ -252,7 +252,7 @@ func TestNewResponseSegmentTeardown(t *testing.T) {
 			_, err := newResponseSegmentTeardown(tc.Ctrl.SegmentTeardown, tc.Ctrl, ts, nil)
 			require.Error(t, err) // no path
 			r, err := newResponseSegmentTeardown(tc.Ctrl.SegmentTeardown, tc.Ctrl, ts,
-				segmenttest.NewTestPath())
+				test.NewTestPath())
 			require.NoError(t, err)
 			require.NotNil(t, r)
 			if tc.Ctrl.Accepted {
@@ -300,7 +300,7 @@ func TestNewResponseSegmentIndexConfirmation(t *testing.T) {
 				tc.Ctrl, ts, nil)
 			require.Error(t, err) // no path
 			r, err := newResponseSegmentIndexConfirmation(tc.Ctrl.SegmentIndexConfirmation,
-				tc.Ctrl, ts, segmenttest.NewTestPath())
+				tc.Ctrl, ts, test.NewTestPath())
 			require.NoError(t, err)
 			require.NotNil(t, r)
 			if tc.Ctrl.Accepted {
@@ -347,7 +347,7 @@ func TestNewResponseSegmentCleanup(t *testing.T) {
 			_, err := newResponseSegmentCleanup(tc.Ctrl.SegmentCleanup, tc.Ctrl, ts, nil)
 			require.Error(t, err) // no path
 			r, err := newResponseSegmentCleanup(tc.Ctrl.SegmentCleanup, tc.Ctrl, ts,
-				segmenttest.NewTestPath())
+				test.NewTestPath())
 			require.NoError(t, err)
 			require.NotNil(t, r)
 			if tc.Ctrl.Accepted {
@@ -392,7 +392,7 @@ func TestNewResponseE2ESetup(t *testing.T) {
 			ts := util.SecsToTime(1)
 			_, err := newResponseE2ESetup(tc.Ctrl.E2ESetup, tc.Ctrl, ts, nil)
 			require.Error(t, err) // no path
-			r, err := newResponseE2ESetup(tc.Ctrl.E2ESetup, tc.Ctrl, ts, segmenttest.NewTestPath())
+			r, err := newResponseE2ESetup(tc.Ctrl.E2ESetup, tc.Ctrl, ts, test.NewTestPath())
 			require.NoError(t, err)
 			require.NotNil(t, r)
 			if tc.Ctrl.Accepted {
@@ -440,7 +440,7 @@ func TestNewResponseE2EClenaup(t *testing.T) {
 			_, err := newResponseE2EClenaup(tc.Ctrl.E2ECleanup, tc.Ctrl, ts, nil)
 			require.Error(t, err) // no path
 			r, err := newResponseE2EClenaup(tc.Ctrl.E2ECleanup, tc.Ctrl, ts,
-				segmenttest.NewTestPath())
+				test.NewTestPath())
 			require.NoError(t, err)
 			require.NotNil(t, r)
 			if tc.Ctrl.Accepted {

--- a/go/cs/reservation/translate/fromctrl_test.go
+++ b/go/cs/reservation/translate/fromctrl_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/scionproto/scion/go/cs/reservation/segment"
 	"github.com/scionproto/scion/go/cs/reservation/test"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/colibri_mgmt"
 	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/lib/xtest"
@@ -58,8 +57,8 @@ func TestNewRequestSegmentSetupFromCtrl(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, p, r.Path())
 	checkRequest(t, ctrlMsg, r, ts)
-	require.Equal(t, common.IFIDType(1), r.Ingress)
-	require.Equal(t, common.IFIDType(2), r.Egress)
+	require.EqualValues(t, 1, r.Ingress)
+	require.EqualValues(t, 2, r.Egress)
 }
 
 func TestNewRequestSegmentTelesSetup(t *testing.T) {

--- a/go/cs/reservation/translate/toctrl_test.go
+++ b/go/cs/reservation/translate/toctrl_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/scionproto/scion/go/cs/reservation/segmenttest"
+	"github.com/scionproto/scion/go/cs/reservation/test"
 	"github.com/scionproto/scion/go/lib/ctrl/colibri_mgmt"
 	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/proto"
@@ -49,7 +49,7 @@ func TestNewCtrlE2EReservationID(t *testing.T) {
 func TestNewSegmentSetup(t *testing.T) {
 	ctrl := newTestSetup()
 	ts := util.SecsToTime(1)
-	r, err := newRequestSegmentSetup(ctrl, ts, segmenttest.NewTestPath())
+	r, err := newRequestSegmentSetup(ctrl, ts, test.NewTestPath())
 	require.NoError(t, err)
 	newCtrl := newSegmentSetup(r)
 	require.Equal(t, ctrl, newCtrl)
@@ -357,7 +357,7 @@ func TestNewCtrlFromMsg(t *testing.T) {
 		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			msg, err := NewMsgFromCtrl(tc.Ctrl, segmenttest.NewTestPath())
+			msg, err := NewMsgFromCtrl(tc.Ctrl, test.NewTestPath())
 			require.NoError(t, err)
 			newCtrl, err := NewCtrlFromMsg(msg, tc.Renewal)
 			require.NoError(t, err)

--- a/go/cs/reservation/types.go
+++ b/go/cs/reservation/types.go
@@ -16,7 +16,6 @@ package reservation
 
 import (
 	"github.com/scionproto/scion/go/lib/common"
-	"github.com/scionproto/scion/go/lib/spath"
 )
 
 // Capacities describes what a capacity description must offer.
@@ -28,8 +27,21 @@ type Capacities interface {
 	CapacityEgress(egress common.IFIDType) uint64
 }
 
+// ColibriPath is a path of type COLIBRI.
+// This type will be moved to its right place in slayers once the header has been approved.
+// TODO(juagargi): move the type to slayers.
+type ColibriPath interface {
+	Copy() ColibriPath
+	// Reverse reverses the contained path.
+	Reverse() error
+	NumberOfHops() int
+	IndexOfCurrentHop() int
+	// TODO(juagargi) replace common.IFIDType with uint16
+	IngressEgressIFIDs() (common.IFIDType, common.IFIDType)
+}
+
 // MessageWithPath is used to send messages from the COLIBRI service via the BR.
 type MessageWithPath interface {
-	PathDeleteme() *spath.Path
+	PathDeleteme() ColibriPath
 	// Payload() []byte
 }

--- a/go/cs/reservation/types.go
+++ b/go/cs/reservation/types.go
@@ -14,17 +14,13 @@
 
 package reservation
 
-import (
-	"github.com/scionproto/scion/go/lib/common"
-)
-
 // Capacities describes what a capacity description must offer.
 type Capacities interface {
-	IngressInterfaces() []common.IFIDType
-	EgressInterfaces() []common.IFIDType
-	Capacity(from, to common.IFIDType) uint64
-	CapacityIngress(ingress common.IFIDType) uint64
-	CapacityEgress(egress common.IFIDType) uint64
+	IngressInterfaces() []uint16
+	EgressInterfaces() []uint16
+	Capacity(from, to uint16) uint64
+	CapacityIngress(ingress uint16) uint64
+	CapacityEgress(egress uint16) uint64
 }
 
 // ColibriPath is a path of type COLIBRI.
@@ -36,8 +32,7 @@ type ColibriPath interface {
 	Reverse() error
 	NumberOfHops() int
 	IndexOfCurrentHop() int
-	// TODO(juagargi) replace common.IFIDType with uint16
-	IngressEgressIFIDs() (common.IFIDType, common.IFIDType)
+	IngressEgressIFIDs() (uint16, uint16)
 }
 
 // MessageWithPath is used to send messages from the COLIBRI service via the BR.

--- a/go/cs/reservation/types.go
+++ b/go/cs/reservation/types.go
@@ -42,6 +42,6 @@ type ColibriPath interface {
 
 // MessageWithPath is used to send messages from the COLIBRI service via the BR.
 type MessageWithPath interface {
-	PathDeleteme() ColibriPath
+	Path() ColibriPath
 	// Payload() []byte
 }

--- a/go/cs/reservation/types.go
+++ b/go/cs/reservation/types.go
@@ -30,6 +30,6 @@ type Capacities interface {
 
 // MessageWithPath is used to send messages from the COLIBRI service via the BR.
 type MessageWithPath interface {
-	Path() *spath.Path
+	PathDeleteme() *spath.Path
 	// Payload() []byte
 }

--- a/go/cs/reservationstorage/backend/BUILD.bazel
+++ b/go/cs/reservationstorage/backend/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//go/cs/reservation/segment:go_default_library",
         "//go/lib/addr:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/infra/modules/db:go_default_library",
     ],
 )

--- a/go/cs/reservationstorage/backend/db.go
+++ b/go/cs/reservationstorage/backend/db.go
@@ -33,7 +33,7 @@ type ReserverOnly interface {
 	GetSegmentRsvsFromSrcDstIA(ctx context.Context, srcIA, dstIA addr.IA) (
 		[]*segment.Reservation, error)
 	// GetSegmentRsvFromPath searches for a segment reservation with the specified path.
-	GetSegmentRsvFromPath(ctx context.Context, path segment.Path) (
+	GetSegmentRsvFromPath(ctx context.Context, path segment.ReservationTransparentPath) (
 		*segment.Reservation, error)
 
 	// NewSegmentRsv creates a new segment reservation in the DB, with an unused reservation ID.

--- a/go/cs/reservationstorage/backend/db.go
+++ b/go/cs/reservationstorage/backend/db.go
@@ -24,7 +24,6 @@ import (
 	"github.com/scionproto/scion/go/cs/reservation/segment"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/infra/modules/db"
 )
 
@@ -48,7 +47,7 @@ type TransitOnly interface {
 	GetAllSegmentRsvs(ctx context.Context) ([]*segment.Reservation, error)
 	// GetSegmentRsvsFromIFPair returns all segment reservations that enter this AS at
 	// the specified ingress and exit at that egress. Used by setup req.
-	GetSegmentRsvsFromIFPair(ctx context.Context, ingress, egress *common.IFIDType) (
+	GetSegmentRsvsFromIFPair(ctx context.Context, ingress, egress *uint16) (
 		[]*segment.Reservation, error)
 }
 

--- a/go/cs/reservationstorage/backend/mock_backend/BUILD.bazel
+++ b/go/cs/reservationstorage/backend/mock_backend/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//go/cs/reservationstorage/backend:go_default_library",
         "//go/lib/addr:go_default_library",
         "//go/lib/colibri/reservation:go_default_library",
-        "//go/lib/common:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
     ],
 )

--- a/go/cs/reservationstorage/backend/mock_backend/backend.go
+++ b/go/cs/reservationstorage/backend/mock_backend/backend.go
@@ -159,7 +159,7 @@ func (mr *MockDBMockRecorder) GetSegmentRsvFromID(arg0, arg1 interface{}) *gomoc
 }
 
 // GetSegmentRsvFromPath mocks base method
-func (m *MockDB) GetSegmentRsvFromPath(arg0 context.Context, arg1 segment.Path) (*segment.Reservation, error) {
+func (m *MockDB) GetSegmentRsvFromPath(arg0 context.Context, arg1 segment.ReservationTransparentPath) (*segment.Reservation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSegmentRsvFromPath", arg0, arg1)
 	ret0, _ := ret[0].(*segment.Reservation)
@@ -396,7 +396,7 @@ func (mr *MockTransactionMockRecorder) GetSegmentRsvFromID(arg0, arg1 interface{
 }
 
 // GetSegmentRsvFromPath mocks base method
-func (m *MockTransaction) GetSegmentRsvFromPath(arg0 context.Context, arg1 segment.Path) (*segment.Reservation, error) {
+func (m *MockTransaction) GetSegmentRsvFromPath(arg0 context.Context, arg1 segment.ReservationTransparentPath) (*segment.Reservation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSegmentRsvFromPath", arg0, arg1)
 	ret0, _ := ret[0].(*segment.Reservation)

--- a/go/cs/reservationstorage/backend/mock_backend/backend.go
+++ b/go/cs/reservationstorage/backend/mock_backend/backend.go
@@ -13,7 +13,6 @@ import (
 	backend "github.com/scionproto/scion/go/cs/reservationstorage/backend"
 	addr "github.com/scionproto/scion/go/lib/addr"
 	reservation "github.com/scionproto/scion/go/lib/colibri/reservation"
-	common "github.com/scionproto/scion/go/lib/common"
 	reflect "reflect"
 	time "time"
 )
@@ -175,7 +174,7 @@ func (mr *MockDBMockRecorder) GetSegmentRsvFromPath(arg0, arg1 interface{}) *gom
 }
 
 // GetSegmentRsvsFromIFPair mocks base method
-func (m *MockDB) GetSegmentRsvsFromIFPair(arg0 context.Context, arg1, arg2 *common.IFIDType) ([]*segment.Reservation, error) {
+func (m *MockDB) GetSegmentRsvsFromIFPair(arg0 context.Context, arg1, arg2 *uint16) ([]*segment.Reservation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSegmentRsvsFromIFPair", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*segment.Reservation)
@@ -412,7 +411,7 @@ func (mr *MockTransactionMockRecorder) GetSegmentRsvFromPath(arg0, arg1 interfac
 }
 
 // GetSegmentRsvsFromIFPair mocks base method
-func (m *MockTransaction) GetSegmentRsvsFromIFPair(arg0 context.Context, arg1, arg2 *common.IFIDType) ([]*segment.Reservation, error) {
+func (m *MockTransaction) GetSegmentRsvsFromIFPair(arg0 context.Context, arg1, arg2 *uint16) ([]*segment.Reservation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSegmentRsvsFromIFPair", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*segment.Reservation)

--- a/go/cs/reservationstore/store.go
+++ b/go/cs/reservationstore/store.go
@@ -53,9 +53,9 @@ func (s *Store) AdmitSegmentReservation(ctx context.Context, req *segment.SetupR
 	if err := s.validateAuthenticators(&req.RequestMetadata); err != nil {
 		return nil, serrors.WrapStr("error validating request", err, "id", req.ID)
 	}
-	if req.IndexOfCurrentHop() != len(req.AllocTrail) {
+	if req.Path().IndexOfCurrentHop() != len(req.AllocTrail) {
 		return nil, serrors.New("inconsistent number of hops",
-			"len_alloctrail", len(req.AllocTrail), "hf_count", req.IndexOfCurrentHop())
+			"len_alloctrail", len(req.AllocTrail), "hf_count", req.Path().IndexOfCurrentHop())
 	}
 
 	response, err := s.prepareFailureSegmentResp(&req.Request)
@@ -504,7 +504,7 @@ func (s *Store) prepareFailureSegmentResp(req *segment.Request) (*segment.Respon
 	}
 
 	response, err := segment.NewResponse(time.Now(), &req.ID, req.Index, revPath,
-		false, uint8(req.IndexOfCurrentHop()))
+		false, uint8(req.Path().IndexOfCurrentHop()))
 	if err != nil {
 		return nil, serrors.WrapStr("cannot construct segment response", err)
 	}
@@ -520,7 +520,7 @@ func (s *Store) prepareFailureE2EResp(req *e2e.Request) (*e2e.Response, error) {
 	}
 
 	response, err := e2e.NewResponse(time.Now(), &req.ID, req.Index, revPath,
-		false, uint8(req.IndexOfCurrentHop()))
+		false, uint8(req.Path().IndexOfCurrentHop()))
 	if err != nil {
 		return nil, serrors.WrapStr("cannot construct e2e response", err)
 	}

--- a/go/cs/reservationstore/store.go
+++ b/go/cs/reservationstore/store.go
@@ -498,7 +498,7 @@ func (s *Store) validateAuthenticators(req *base.RequestMetadata) error {
 // prepareFailureSegmentResp will create a failure segment response, which
 // is sent in the reverse path that the request had.
 func (s *Store) prepareFailureSegmentResp(req *segment.Request) (*segment.Response, error) {
-	revPath := req.Path().Copy()
+	revPath := req.PathDeleteme().Copy()
 	if err := revPath.Reverse(); err != nil {
 		return nil, serrors.WrapStr("cannot reverse path for response", err)
 	}
@@ -514,7 +514,7 @@ func (s *Store) prepareFailureSegmentResp(req *segment.Request) (*segment.Respon
 // prepareFailureE2EResp will create a failure e2e response, which
 // is sent in the reverse path that the request had.
 func (s *Store) prepareFailureE2EResp(req *e2e.Request) (*e2e.Response, error) {
-	revPath := req.Path().Copy()
+	revPath := req.PathDeleteme().Copy()
 	if err := revPath.Reverse(); err != nil {
 		return nil, serrors.WrapStr("cannot reverse path for response", err)
 	}

--- a/go/cs/reservationstore/store.go
+++ b/go/cs/reservationstore/store.go
@@ -498,7 +498,7 @@ func (s *Store) validateAuthenticators(req *base.RequestMetadata) error {
 // prepareFailureSegmentResp will create a failure segment response, which
 // is sent in the reverse path that the request had.
 func (s *Store) prepareFailureSegmentResp(req *segment.Request) (*segment.Response, error) {
-	revPath := req.PathDeleteme().Copy()
+	revPath := req.Path().Copy()
 	if err := revPath.Reverse(); err != nil {
 		return nil, serrors.WrapStr("cannot reverse path for response", err)
 	}
@@ -514,7 +514,7 @@ func (s *Store) prepareFailureSegmentResp(req *segment.Request) (*segment.Respon
 // prepareFailureE2EResp will create a failure e2e response, which
 // is sent in the reverse path that the request had.
 func (s *Store) prepareFailureE2EResp(req *e2e.Request) (*e2e.Response, error) {
-	revPath := req.PathDeleteme().Copy()
+	revPath := req.Path().Copy()
 	if err := revPath.Reverse(); err != nil {
 		return nil, serrors.WrapStr("cannot reverse path for response", err)
 	}

--- a/go/lib/colibri/reservation/BUILD.bazel
+++ b/go/lib/colibri/reservation/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/serrors:go_default_library",
-        "//go/lib/spath:go_default_library",
         "//go/lib/util:go_default_library",
     ],
 )
@@ -18,7 +17,6 @@ go_test(
     srcs = ["types_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//go/lib/spath:go_default_library",
         "//go/lib/xtest:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/go/lib/colibri/reservation/types.go
+++ b/go/lib/colibri/reservation/types.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/serrors"
-	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/lib/util"
 )
 
@@ -337,7 +336,7 @@ func (f *InfoField) Read(b []byte) (int, error) {
 	b[5] = byte(f.RLC)
 	b[6] = byte(f.Idx<<4) | uint8(f.PathType)
 	b[7] = 0 // b[7] is padding
-	return 8, nil
+	return InfoFieldLen, nil
 }
 
 // ToRaw returns the serial representation of the InfoField.
@@ -451,10 +450,52 @@ func (bs AllocationBeads) MinMax() BWCls {
 	return min
 }
 
+// HopField is a COLIBRI HopField.
+// TODO(juagargi) move to slayers
+type HopField struct {
+	Ingress uint16
+	Egress  uint16
+	Mac     [4]byte
+}
+
+const HopFieldLen = 8
+
+// HopFieldFromRaw builds a HopField from a raw buffer.
+func HopFieldFromRaw(raw []byte) (*HopField, error) {
+	if len(raw) < HopFieldLen {
+		return nil, serrors.New("buffer too small for HopField", "min_size", HopFieldLen,
+			"current_size", len(raw))
+	}
+	hf := HopField{
+		Ingress: binary.BigEndian.Uint16(raw[:2]),
+		Egress:  binary.BigEndian.Uint16(raw[2:4]),
+	}
+	copy(hf.Mac[:], raw[4:8])
+	return &hf, nil
+}
+
+func (hf *HopField) Read(b []byte) (int, error) {
+	if len(b) < HopFieldLen {
+		return 0, serrors.New("buffer too small for HopField", "min_size", HopFieldLen,
+			"current_size", len(b))
+	}
+	binary.BigEndian.PutUint16(b[:2], hf.Ingress)
+	binary.BigEndian.PutUint16(b[2:4], hf.Egress)
+	copy(b[4:], hf.Mac[:])
+	return HopFieldLen, nil
+}
+
+// ToRaw returns the serial representation of the HopField.
+func (hf *HopField) ToRaw() []byte {
+	buff := make([]byte, HopFieldLen)
+	hf.Read(buff) // discard returned values
+	return buff
+}
+
 // Token is used in the data plane to forward COLIBRI packets.
 type Token struct {
 	InfoField
-	HopFields []spath.HopField
+	HopFields []HopField
 }
 
 // Validate will return an error for invalid values. It will not check the hop fields' validity.
@@ -471,11 +512,11 @@ func TokenFromRaw(raw []byte) (*Token, error) {
 		return nil, nil
 	}
 	rawHFs := len(raw) - InfoFieldLen
-	if rawHFs < 0 || rawHFs%spath.HopFieldLength != 0 {
-		return nil, serrors.New("buffer too small", "min_size", InfoFieldLen,
+	if rawHFs < 0 || rawHFs%HopFieldLen != 0 {
+		return nil, serrors.New("buffer too small for Token", "min_size", InfoFieldLen,
 			"current_size", len(raw))
 	}
-	numHFs := rawHFs / spath.HopFieldLength
+	numHFs := rawHFs / HopFieldLen
 	inf, err := InfoFieldFromRaw(raw[:InfoFieldLen])
 	if err != nil {
 		return nil, err
@@ -484,11 +525,11 @@ func TokenFromRaw(raw []byte) (*Token, error) {
 		InfoField: *inf,
 	}
 	if numHFs > 0 {
-		t.HopFields = make([]spath.HopField, numHFs)
+		t.HopFields = make([]HopField, numHFs)
 	}
 	for i := 0; i < numHFs; i++ {
-		offset := InfoFieldLen + i*spath.HopFieldLength
-		hf, err := spath.HopFFromRaw(raw[offset : offset+spath.HopFieldLength])
+		offset := InfoFieldLen + i*HopFieldLen
+		hf, err := HopFieldFromRaw(raw[offset : offset+HopFieldLen])
 		if err != nil {
 			return nil, err
 		}
@@ -502,7 +543,7 @@ func (t *Token) Len() int {
 	if t == nil {
 		return 0
 	}
-	return InfoFieldLen + len(t.HopFields)*spath.HopFieldLength
+	return InfoFieldLen + len(t.HopFields)*HopFieldLen
 }
 
 // Read serializes this Token to the passed buffer.
@@ -516,8 +557,8 @@ func (t *Token) Read(b []byte) (int, error) {
 		return 0, err
 	}
 	for i := 0; i < len(t.HopFields); i++ {
-		t.HopFields[i].Write(b[offset : offset+spath.HopFieldLength])
-		offset += spath.HopFieldLength
+		t.HopFields[i].Read(b[offset : offset+HopFieldLen])
+		offset += HopFieldLen
 	}
 	return offset, nil
 }

--- a/go/lib/colibri/reservation/types.go
+++ b/go/lib/colibri/reservation/types.go
@@ -101,6 +101,8 @@ type E2EID struct {
 
 const E2EIDLen = 16
 
+var _ io.Reader = (*E2EID)(nil)
+
 // NewE2EID returns a new E2EID
 func NewE2EID(AS addr.AS, suffix []byte) (*E2EID, error) {
 	if len(suffix) != 10 {
@@ -129,6 +131,7 @@ func E2EIDFromRaw(raw []byte) (*E2EID, error) {
 	return E2EIDFromRawBuffers(raw[:6], raw[6:])
 }
 
+// Read serializes this E2EID into the buffer.
 func (id *E2EID) Read(raw []byte) (int, error) {
 	if len(raw) < E2EIDLen {
 		return 0, serrors.New("buffer too small", "actual", len(raw), "min", E2EIDLen)
@@ -287,6 +290,8 @@ type InfoField struct {
 
 // InfoFieldLen is the length in bytes of the InfoField.
 const InfoFieldLen = 8
+
+var _ io.Reader = (*InfoField)(nil)
 
 // Validate will return an error for invalid values.
 func (f *InfoField) Validate() error {
@@ -460,6 +465,8 @@ type HopField struct {
 
 const HopFieldLen = 8
 
+var _ io.Reader = (*HopField)(nil)
+
 // HopFieldFromRaw builds a HopField from a raw buffer.
 func HopFieldFromRaw(raw []byte) (*HopField, error) {
 	if len(raw) < HopFieldLen {
@@ -474,6 +481,7 @@ func HopFieldFromRaw(raw []byte) (*HopField, error) {
 	return &hf, nil
 }
 
+// Read serializes this HopField into the buffer.
 func (hf *HopField) Read(b []byte) (int, error) {
 	if len(b) < HopFieldLen {
 		return 0, serrors.New("buffer too small for HopField", "min_size", HopFieldLen,
@@ -497,6 +505,8 @@ type Token struct {
 	InfoField
 	HopFields []HopField
 }
+
+var _ io.Reader = (*Token)(nil)
 
 // Validate will return an error for invalid values. It will not check the hop fields' validity.
 func (t *Token) Validate() error {

--- a/go/lib/common/defs.go
+++ b/go/lib/common/defs.go
@@ -41,6 +41,9 @@ const (
 )
 
 // IFIDType is the type for interface IDs.
+//
+// Deprecated: with version 2 of the SCION header, there is no interface ID type anymore.
+// Use the appropriate type depending on the path type.
 type IFIDType uint64
 
 func (ifid IFIDType) String() string {


### PR DESCRIPTION
- Some COLIBRI types were using `spath` internally. Replace them with an interface that provides the functionality that the COLIBRI path type will, and add a mock for the tests.
- Deprecate `common.IFIDType`.
- Adapt code to use `uint16` as interface IDs, instead of `common.IFIDType`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3905)
<!-- Reviewable:end -->
