### PR TITLE
build/test: reduce make usage

### DIFF
--- a/acceptance/common/scion.py
+++ b/acceptance/common/scion.py
@@ -42,10 +42,9 @@ class SCION(ABC):
         pass
 
     @LogExec(logger, 'running topology')
-    def run(self, nobuild=True):
+    def run(self):
         """ Run the scion infrastructure. """
-        args = ['nobuild'] if nobuild else []
-        self.scion_sh('run', *args)
+        self.scion_sh('run', 'nobuild')
 
     @abstractmethod
     def execute(self, isd_as: ISD_AS, cmd: str, *args: str) -> str:

--- a/acceptance/lib.sh
+++ b/acceptance/lib.sh
@@ -28,6 +28,13 @@ stop_infra() {
     ./scion.sh stop
 }
 
+build_binaries() {
+    rm bin/*
+    bazel build //:scion //:scion-ci
+    tar -kxf bazel-bin/scion.tar -C bin
+    tar -kxf bazel-bin/scion-ci.tar -C bin
+}
+
 build_docker_tester() {
     make -C docker test
 }
@@ -52,7 +59,7 @@ global_setup() {
     run_command stop_infra ${out_dir:+$out_dir/global_setup_pre_clean.out}
     find logs -mindepth 1 -maxdepth 1 -not -path '*/\.*' -exec rm -r {} +
     print_green "[-->-------]" "Building local code"
-    run_command make ${out_dir:+$out_dir/global_setup_make.out}
+    run_command build_binaries ${out_dir:+$out_dir/global_setup_make.out}
     print_green "[--->------]" "Building per-app docker images"
     run_command build_docker_perapp ${out_dir:+$out_dir/global_setup_docker_perapp.out}
     print_green "[---->-----]" "Building tester docker images"

--- a/scion.sh
+++ b/scion.sh
@@ -53,10 +53,17 @@ cmd_topology() {
     fi
 }
 
+build_binaries() {
+    rm bin/*
+    bazel build //:scion //:scion-ci
+    tar -kxf bazel-bin/scion.tar -C bin
+    tar -kxf bazel-bin/scion-ci.tar -C bin
+}
+
 cmd_run() {
     if [ "$1" != "nobuild" ]; then
         echo "Compiling..."
-        make -s || exit 1
+        build_binaries || exit 1
         if is_docker_be; then
             echo "Build perapp images"
             ./tools/quiet make -C docker prod


### PR DESCRIPTION
Calling make directly does some extra work that is not needed.
For example it rebuilds all protobufs etc, we check in a separate
build step that those files are still up to date.

Also remove the nobuild option in the acceptance libs, it's always
true.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3910)
<!-- Reviewable:end -->
