### PR TITLE
make: build without code gen by default

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,7 +31,7 @@ steps:
     command:
       - mkdir -p /tmp/test-artifacts
       - cp go.mod go.sum go_deps.bzl /tmp/test-artifacts/
-      - make godeps -B
+      - make go_deps.bzl -B
       - bazel-${BUILDKITE_PIPELINE_SLUG}/external/go_sdk/bin/go mod tidy
       - diff -u /tmp/test-artifacts/go.mod go.mod
       - diff -u /tmp/test-artifacts/go.sum go.sum

--- a/Makefile
+++ b/Makefile
@@ -29,25 +29,13 @@ gogen:
 	$(MAKE) -C go/proto
 
 protobuf:
-	bazel build //go/pkg/proto/control_plane:proto_srcs \
-		//go/pkg/proto/crypto:proto_srcs \
-		//go/pkg/proto/discovery:proto_srcs \
-		//go/pkg/proto/daemon:proto_srcs \
-		//go/pkg/proto/gateway:proto_srcs
-
+	bazel build --output_groups=go_generated_srcs //go/pkg/proto/...
 	rm -f go/pkg/proto/*/*.pb.go
-
-	tar -kxf bazel-bin/go/pkg/proto/control_plane/proto_srcs.tar -C go/pkg/proto/control_plane
-	tar -kxf bazel-bin/go/pkg/proto/crypto/proto_srcs.tar -C go/pkg/proto/crypto
-	tar -kxf bazel-bin/go/pkg/proto/discovery/proto_srcs.tar -C go/pkg/proto/discovery
-	tar -kxf bazel-bin/go/pkg/proto/daemon/proto_srcs.tar -C go/pkg/proto/daemon
-	tar -kxf bazel-bin/go/pkg/proto/gateway/proto_srcs.tar -C go/pkg/proto/gateway
-
+	cp -r bazel-bin/go/pkg/proto/*/go_default_library_/github.com/scionproto/scion/go/pkg/proto/* go/pkg/proto
 	chmod 0644 go/pkg/proto/*/*.pb.go
 
 mocks:
-	./tools/gomocks
-	bazel run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build $(GAZELLE_DIRS)
+	tools/gomocks
 
 gazelle:
 	bazel run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build $(GAZELLE_DIRS)

--- a/Makefile
+++ b/Makefile
@@ -1,59 +1,51 @@
-.PHONY: all clean protobuf protobuf_clean godeps gogen mocks bazel gazelle setcap licenses
+.PHONY: all bazel clean gazelle gogen licenses mocks protobuf setcap
+.NOTPARALLEL:
 
 GAZELLE_MODE?=fix
 GAZELLE_DIRS=./go ./acceptance
 
-all: bazel
+build: bazel
+
+# all: performs the code-generation steps and then builds; the generated code
+# is git controlled, and therefore this is only necessary when changing the
+# sources for the code generation.
+# Note: built in correct order, because .NOTPARALLEL.
+all: go_deps.bzl gogen protobuf mocks gazelle licenses build
 
 clean:
 	bazel clean
 	rm -f bin/*
-	if [ -e go/vendor ]; then rm -r go/vendor; fi  # Cleanup from old setup with vendor
 
-gogen:
-	$(MAKE) -C go/proto
-
-ifndef GODEPS_SKIP
-godeps: go_deps.bzl
-else
-godeps:
-	@echo "godeps: skipped"
-endif
-
-go_deps.bzl: protobuf go.mod
-	@tools/godeps.sh
-
-protobuf: protobuf_clean
-	bazel build //go/pkg/proto/control_plane:proto_srcs
-	tar -kxf bazel-bin/go/pkg/proto/control_plane/proto_srcs.tar -C go/pkg/proto/control_plane
-	chmod 0644 go/pkg/proto/control_plane/*.pb.go
-
-	bazel build //go/pkg/proto/crypto:proto_srcs
-	tar -kxf bazel-bin/go/pkg/proto/crypto/proto_srcs.tar -C go/pkg/proto/crypto
-	chmod 0644 go/pkg/proto/crypto/*.pb.go
-
-	bazel build //go/pkg/proto/discovery:proto_srcs
-	tar -kxf bazel-bin/go/pkg/proto/discovery/proto_srcs.tar -C go/pkg/proto/discovery
-	chmod 0644 go/pkg/proto/discovery/*.pb.go
-
-	bazel build //go/pkg/proto/daemon:proto_srcs
-	tar -kxf bazel-bin/go/pkg/proto/daemon/proto_srcs.tar -C go/pkg/proto/daemon
-	chmod 0644 go/pkg/proto/daemon/*.pb.go
-
-	bazel build //go/pkg/proto/gateway:proto_srcs
-	tar -kxf bazel-bin/go/pkg/proto/gateway/proto_srcs.tar -C go/pkg/proto/gateway
-	chmod 0644 go/pkg/proto/gateway/*.pb.go
-
-protobuf_clean:
-	rm -f go/pkg/proto/*/*.pb.go
-
-bazel: godeps gogen
+bazel:
 	rm -f bin/*
 	bazel build //:scion //:scion-ci
 	tar -kxf bazel-bin/scion.tar -C bin
 	tar -kxf bazel-bin/scion-ci.tar -C bin
 
-mocks: protobuf
+go_deps.bzl: go.mod
+	@tools/godeps.sh
+
+gogen:
+	$(MAKE) -C go/proto
+
+protobuf:
+	bazel build //go/pkg/proto/control_plane:proto_srcs \
+		//go/pkg/proto/crypto:proto_srcs \
+		//go/pkg/proto/discovery:proto_srcs \
+		//go/pkg/proto/daemon:proto_srcs \
+		//go/pkg/proto/gateway:proto_srcs
+
+	rm -f go/pkg/proto/*/*.pb.go
+
+	tar -kxf bazel-bin/go/pkg/proto/control_plane/proto_srcs.tar -C go/pkg/proto/control_plane
+	tar -kxf bazel-bin/go/pkg/proto/crypto/proto_srcs.tar -C go/pkg/proto/crypto
+	tar -kxf bazel-bin/go/pkg/proto/discovery/proto_srcs.tar -C go/pkg/proto/discovery
+	tar -kxf bazel-bin/go/pkg/proto/daemon/proto_srcs.tar -C go/pkg/proto/daemon
+	tar -kxf bazel-bin/go/pkg/proto/gateway/proto_srcs.tar -C go/pkg/proto/gateway
+
+	chmod 0644 go/pkg/proto/*/*.pb.go
+
+mocks:
 	./tools/gomocks
 	bazel run //:gazelle -- update -mode=$(GAZELLE_MODE) -index=false -external=external -exclude go/vendor -exclude docker/_build $(GAZELLE_DIRS)
 

--- a/go/pkg/proto/control_plane/BUILD.bazel
+++ b/go/pkg/proto/control_plane/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_proto_library(
     name = "go_default_library",
@@ -10,15 +9,4 @@ go_proto_library(
     deps = [
         "//go/pkg/proto/crypto:go_default_library",
     ],
-)
-
-filegroup(
-    name = "proto_src_files",
-    srcs = [":go_default_library"],
-    output_group = "go_generated_srcs",
-)
-
-pkg_tar(
-    name = "proto_srcs",
-    srcs = [":proto_src_files"],
 )

--- a/go/pkg/proto/crypto/BUILD.bazel
+++ b/go/pkg/proto/crypto/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_proto_library(
     name = "go_default_library",
@@ -7,15 +6,4 @@ go_proto_library(
     importpath = "github.com/scionproto/scion/go/pkg/proto/crypto",
     proto = "//proto/crypto/v1:crypto",
     visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "proto_src_files",
-    srcs = [":go_default_library"],
-    output_group = "go_generated_srcs",
-)
-
-pkg_tar(
-    name = "proto_srcs",
-    srcs = [":proto_src_files"],
 )

--- a/go/pkg/proto/daemon/BUILD.bazel
+++ b/go/pkg/proto/daemon/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_proto_library(
     name = "go_default_library",
@@ -7,15 +6,4 @@ go_proto_library(
     importpath = "github.com/scionproto/scion/go/pkg/proto/daemon",
     proto = "//proto/daemon/v1:daemon",
     visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "proto_src_files",
-    srcs = [":go_default_library"],
-    output_group = "go_generated_srcs",
-)
-
-pkg_tar(
-    name = "proto_srcs",
-    srcs = [":proto_src_files"],
 )

--- a/go/pkg/proto/discovery/BUILD.bazel
+++ b/go/pkg/proto/discovery/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_proto_library(
     name = "go_default_library",
@@ -10,15 +9,4 @@ go_proto_library(
     deps = [
         "//go/pkg/proto/crypto:go_default_library",
     ],
-)
-
-filegroup(
-    name = "proto_src_files",
-    srcs = [":go_default_library"],
-    output_group = "go_generated_srcs",
-)
-
-pkg_tar(
-    name = "proto_srcs",
-    srcs = [":proto_src_files"],
 )

--- a/go/pkg/proto/gateway/BUILD.bazel
+++ b/go/pkg/proto/gateway/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 go_proto_library(
     name = "go_default_library",
@@ -7,15 +6,4 @@ go_proto_library(
     importpath = "github.com/scionproto/scion/go/pkg/proto/gateway",
     proto = "//proto/gateway/v1:gateway",
     visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "proto_src_files",
-    srcs = [":go_default_library"],
-    output_group = "go_generated_srcs",
-)
-
-pkg_tar(
-    name = "proto_srcs",
-    srcs = [":proto_src_files"],
 )

--- a/tools/godeps.sh
+++ b/tools/godeps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script uses gazelle to generate go_deps.bzl from go.mod.
-# You don't need to invoke this directly, just run `make godeps`.
+# You don't need to invoke this directly, just run `make go_deps.bzl`.
 
 set -e
 


### PR DESCRIPTION
By default, `make` (or `make build`) only builds.
An explicit `make all` will additionally run all the code-generation
steps for the checked-in generated code, in the right order.

For the protobuf code generation step, the multiple bazel invocations
are combined to both improve readablity of the Makefile and the output,
and to make make run quiter.

Note that the order of the code generation steps is different than
before; previously `protobuf` forced itself to run before generating
`go_deps.bzl` -- this doesn't seem to make sense as the protobuf code
generation will never automatically affect the `go.mod` file. The other
way around is more conceivable, changes to `go.mod` propagating to
`go_deps.bzl` and so affecting the protobuf code generation.
Additionally, `all` now also includes the `licenses` target, just for
good measure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3911)
<!-- Reviewable:end -->
