### PR TITLE
log: allow configuring stacktrace level

### DIFF
--- a/go/lib/log/config.go
+++ b/go/lib/log/config.go
@@ -24,6 +24,8 @@ import (
 const (
 	// DefaultConsoleLevel is the default log level for the console.
 	DefaultConsoleLevel = "info"
+	// DefaultStacktraceLevel is the default log level for which stack traces are included.
+	DefaultStacktraceLevel = "error"
 )
 
 // Config is the configuration for the logger.
@@ -61,6 +63,8 @@ type ConsoleConfig struct {
 	Level string `toml:"level,omitempty"`
 	// Format of the console logging. (human|json)
 	Format string `toml:"format,omitempty"`
+	// StacktraceLevel sets from which level stacktraces are included.
+	StacktraceLevel string `toml:"stacktrace_level,omitempty"`
 }
 
 // InitDefaults populates unset fields in cfg to their default values (if they
@@ -71,5 +75,8 @@ func (c *ConsoleConfig) InitDefaults() {
 	}
 	if !strings.EqualFold(c.Format, "json") {
 		c.Format = "human"
+	}
+	if c.StacktraceLevel == "" {
+		c.StacktraceLevel = DefaultStacktraceLevel
 	}
 }

--- a/go/lib/log/logtest/config.go
+++ b/go/lib/log/logtest/config.go
@@ -29,4 +29,5 @@ func InitTestLogging(cfg *log.Config) {}
 func CheckTestLogging(t *testing.T, cfg *log.Config, id string) {
 	assert.Equal(t, log.DefaultConsoleLevel, cfg.Console.Level)
 	assert.Equal(t, "human", cfg.Console.Format)
+	assert.Equal(t, log.DefaultStacktraceLevel, cfg.Console.StacktraceLevel)
 }

--- a/go/lib/log/sample.go
+++ b/go/lib/log/sample.go
@@ -18,6 +18,10 @@ const loggingConsoleSample = `
 # Console logging level (debug|info|error) (default info)
 level = "info"
 
+# Log a stacktrace for all messages at or above the given level. If the value
+# is 'none', no stacktrace is included. (debug|info|error|none) (default error)
+stacktrace_level = "error"
+
 # Logging fromat (human|json) (default human)
 format = "human"
 `


### PR DESCRIPTION
Add a config option to set the stacktrace level for logging.
Also allow disabling it completely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3913)
<!-- Reviewable:end -->
