### PR TITLE
cmd/scion: showpaths color, --no-color flag

### DIFF
--- a/go/pkg/showpaths/showpaths.go
+++ b/go/pkg/showpaths/showpaths.go
@@ -62,12 +62,22 @@ type Hop struct {
 
 // Human writes human readable output to the writer.
 func (r Result) Human(w io.Writer, showExpiration, colored bool) {
+	noColor := color.New()
+	keys := noColor
+	values := noColor
+	header := noColor
+	statusGood := noColor
+	statusBad := noColor
 	if colored {
-		r.coloredHuman(w, showExpiration)
-		return
+		keys = color.New(color.FgHiCyan)
+		values = noColor
+		header = color.New(color.FgHiBlack)
+		statusGood = color.New(color.FgGreen)
+		statusBad = color.New(color.FgRed)
 	}
+
 	sectionHeader := func(intfs int) {
-		fmt.Fprintf(w, "%d Hops:\n", (intfs/2)+1)
+		header.Fprintf(w, "%d Hops:\n", (intfs/2)+1)
 	}
 	sectionHeader(len(r.Paths[0].Hops))
 	for i, path := range r.Paths {
@@ -75,31 +85,7 @@ func (r Result) Human(w io.Writer, showExpiration, colored bool) {
 			sectionHeader(len(path.Hops))
 		}
 
-		fmt.Fprintf(w, "[%2d] %s", i, path.FullPath)
-		if showExpiration {
-			ttl := time.Until(path.Expiry).Truncate(time.Second)
-			fmt.Fprintf(w, " Expires: %s (%s)", path.Expiry, ttl)
-		}
-		if path.Status != "" {
-			fmt.Fprintf(w, " Status: %s LocalIP: %s", path.Status, path.Local)
-		}
-		fmt.Fprintln(w)
-	}
-}
-
-func (r Result) coloredHuman(w io.Writer, showExpiration bool) {
-	keys := color.New(color.FgHiCyan)
-	values := color.New(color.FgWhite)
-	sectionHeader := func(intfs int) {
-		color.New(color.FgHiBlack).Fprintf(w, "%d Hops:\n", (intfs/2)+1)
-	}
-	sectionHeader(len(r.Paths[0].Hops))
-	for i, path := range r.Paths {
-		if i != 0 && len(r.Paths[i-1].Hops) != len(path.Hops) {
-			sectionHeader(len(path.Hops))
-		}
-
-		entries := []string{app.ColorPath(path.FullPath)}
+		entries := []string{app.ColorPath(path.FullPath, app.WithDisableColor(!colored))}
 		if showExpiration {
 			ttl := time.Until(path.Expiry).Truncate(time.Second)
 			entries = append(entries, fmt.Sprintf("%s: %s (%s)",
@@ -107,9 +93,9 @@ func (r Result) coloredHuman(w io.Writer, showExpiration bool) {
 			)
 		}
 		if path.Status != "" {
-			statusColor := color.New(color.FgRed)
+			statusColor := statusBad
 			if strings.EqualFold(path.Status, string(pathprobe.StatusAlive)) {
-				statusColor = color.New(color.FgGreen)
+				statusColor = statusGood
 			}
 			entries = append(entries, fmt.Sprintf("%s: %s",
 				keys.Sprint("Status"), statusColor.Sprint(path.Status)),

--- a/go/scion/ping.go
+++ b/go/scion/ping.go
@@ -168,7 +168,7 @@ On other errors, ping will exit with code 2.
 	}
 
 	cmd.Flags().BoolVarP(&flags.interactive, "interactive", "i", false, "interactive mode")
-	cmd.Flags().BoolVar(&flags.noColor, "no_color", false, "disable colored output")
+	cmd.Flags().BoolVar(&flags.noColor, "no-color", false, "disable colored output")
 	cmd.Flags().DurationVar(&flags.timeout, "timeout", time.Second, "timeout per packet")
 	cmd.Flags().IPVar(&flags.local, "local", nil, "IP address to listen on")
 	cmd.Flags().StringVar(&flags.sciond, "sciond", sciond.DefaultAPIAddress, "SCION Daemon address")
@@ -178,12 +178,12 @@ On other errors, ping will exit with code 2.
 	cmd.Flags().BoolVar(&flags.refresh, "refresh", false, "set refresh flag for path request")
 	cmd.Flags().DurationVar(&flags.interval, "interval", time.Second, "time between packets")
 	cmd.Flags().Uint16VarP(&flags.count, "count", "c", 0, "total number of packets to send")
-	cmd.Flags().UintVarP(&flags.size, "payload_size", "s", 0,
+	cmd.Flags().UintVarP(&flags.size, "payload-size", "s", 0,
 		`number of bytes to be sent in addition to the SCION Header and SCMP echo header;
 the total size of the packet is still variable size due to the variable size of
 the SCION path.`,
 	)
-	cmd.Flags().BoolVar(&flags.maxMTU, "max_mtu", false,
+	cmd.Flags().BoolVar(&flags.maxMTU, "max-mtu", false,
 		`choose the payload size such that the sent SCION packet including the SCION Header,
 SCMP echo header and payload are equal to the MTU of the path. This flag overrides the
 'payload_size' flag.`)

--- a/go/scion/showpaths.go
+++ b/go/scion/showpaths.go
@@ -116,7 +116,7 @@ On other errors, showpaths will exit with code 2.
 		"Do not probe the paths and print the health status")
 	cmd.Flags().BoolVarP(&flags.json, "json", "j", false,
 		"Write the output as machine readable json")
-	cmd.Flags().BoolVar(&flags.noColor, "no_color", false, "disable colored output")
+	cmd.Flags().BoolVar(&flags.noColor, "no-color", false, "disable colored output")
 	cmd.Flags().IPVarP(&flags.cfg.Local, "local", "l", nil,
 		"Optional local IP address to use for probing health checks")
 


### PR DESCRIPTION
Amendment to #3876, missed one value.

Additionally, change the `--no_color` option to the more traditional
kebab case `--no-color`, same for the (few) other occurrences of snake
case in flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3914)
<!-- Reviewable:end -->
