### PR TITLE
cs: infer QUIC address

### DIFF
--- a/go/lib/env/env.go
+++ b/go/lib/env/env.go
@@ -291,8 +291,7 @@ func (cfg *Tracing) NewTracer(id string) (opentracing.Tracer, io.Closer, error) 
 
 // QUIC contains configuration for control-plane speakers.
 type QUIC struct {
-	ResolutionFraction float64 `toml:"resolution_fraction,omitempty"`
-	Address            string  `toml:"address,omitempty"`
+	Address string `toml:"address,omitempty"`
 }
 
 func (cfg *QUIC) Sample(dst io.Writer, path config.Path, _ config.CtxMap) {

--- a/go/lib/env/sample.go
+++ b/go/lib/env/sample.go
@@ -56,21 +56,7 @@ agent = "localhost:6831"
 `
 
 const quicSample = `
-# The address to start a QUIC server on (ip:port). If not set, a QUIC server is
-# not started. (default "")
+# The address to start a QUIC server on (ip:port). If not set, a QUIC server on
+# the public IP and a high port is started. (default "")
 address = ""
-
-# Enables SVC resolution for traffic to SVC
-# destinations in a way that is also compatible with control plane servers
-# that do not implement the SVC Resolution Mechanism. The value represents
-# the percentage of time, out of the total available context timeout,
-# spent attempting to perform SVC resolution. If SVCResolutionFraction is
-# 0 or less, SVC resolution is never attempted. If it is between 0 and 1,
-# the remaining context timeout is multiplied by the value, and that
-# amount of time is spent waiting for an SVC resolution reply from the
-# server. If this times out, the data packet is sent with an SVC
-# destination. If the value is 1 or more, then legacy behavior is
-# disabled, and data packets are never sent to SVC destinations unless the
-# resolution step is successful.
-resolution_fraction = 0.0
 `

--- a/go/lib/infra/infraenv/infraenv.go
+++ b/go/lib/infra/infraenv/infraenv.go
@@ -100,7 +100,7 @@ func (nc *NetworkConfig) TCPStack() (net.Listener, error) {
 
 func (nc *NetworkConfig) QUICStack() (*QUICStack, error) {
 	if nc.QUIC.Address == "" {
-		return nil, serrors.New("QUIC address required")
+		nc.QUIC.Address = net.JoinHostPort(nc.Public.IP.String(), "0")
 	}
 	client, server, err := nc.initQUICSockets()
 	if err != nil {

--- a/python/topology/generator.py
+++ b/python/topology/generator.py
@@ -40,9 +40,6 @@ def add_arguments(parser):
                         help='Network to create subnets in (E.g. "127.0.0.0/8"')
     parser.add_argument('-o', '--output-dir', default=GEN_PATH,
                         help='Output directory')
-    parser.add_argument('-f', '--svcfrac', type=float, default=0.4,
-                        help='Attempt SVC resolution in RPC calls for a fraction of\
-                        available timeout')
     parser.add_argument('--random-ifids', action='store_true',
                         help='Generate random IFIDs')
     parser.add_argument('--docker-registry', help='Specify docker registry to pull images from')

--- a/python/topology/go.py
+++ b/python/topology/go.py
@@ -28,12 +28,10 @@ from python.topology.common import (
     ArgsTopoDicts,
     DISP_CONFIG_NAME,
     docker_host,
-    join_host_port,
     prom_addr,
     prom_addr_dispatcher,
     sciond_ip,
     sciond_name,
-    split_host_port,
     translate_features,
     SD_API_PORT,
     SD_CONFIG_NAME,
@@ -126,7 +124,6 @@ class GoGenerator(object):
             },
             'tracing': self._tracing_entry(),
             'metrics': self._metrics_entry(infra_elem, CS_PROM_PORT),
-            'quic': self._quic_conf_entry(CS_QUIC_PORT, self.args.svcfrac, infra_elem),
             'features': translate_features(self.args.features),
         }
         if ca:
@@ -166,7 +163,6 @@ class GoGenerator(object):
             },
             'tracing': self._tracing_entry(),
             'metrics': self._metrics_entry(infra_elem, CO_PROM_PORT),
-            'quic': self._quic_conf_entry(CO_QUIC_PORT, self.args.svcfrac, infra_elem),
             'features': translate_features(self.args.features),
         }
         return raw_entry
@@ -313,14 +309,4 @@ class GoGenerator(object):
         a = prom_addr(infra_elem['addr'], base_port)
         return {
             'prometheus': a,
-        }
-
-    def _quic_conf_entry(self, port, svcfrac, elem=None):
-        addr = '127.0.0.1' if elem is None else split_host_port(elem['addr'])[0]
-        if self.args.docker and elem is not None:
-            _, port = split_host_port(elem['addr'])
-            port += 1
-        return {
-            'address':  join_host_port(addr, port),
-            'resolution_fraction': svcfrac,
         }


### PR DESCRIPTION
If the QUIC address is not set, infer it from the public address and
run it on a high port.

Additionally, remove the service resolution fraction, as it is no longer
used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3917)
<!-- Reviewable:end -->
