### PR TITLE
router: add metric to track service instance count

### DIFF
--- a/go/pkg/router/metrics.go
+++ b/go/pkg/router/metrics.go
@@ -30,6 +30,8 @@ type Metrics struct {
 	BFDInterfaceStateChanges  *prometheus.CounterVec
 	BFDPacketsSent            *prometheus.CounterVec
 	BFDPacketsReceived        *prometheus.CounterVec
+	ServiceInstanceCount      *prometheus.GaugeVec
+	ServiceInstanceChanges    *prometheus.CounterVec
 	SiblingReachable          *prometheus.GaugeVec
 	SiblingBFDPacketsSent     *prometheus.CounterVec
 	SiblingBFDPacketsReceived *prometheus.CounterVec
@@ -103,6 +105,21 @@ func NewMetrics() *Metrics {
 				Help: "Number of BFD packets received.",
 			},
 			[]string{"interface", "isd_as", "neighbor_isd_as"},
+		),
+		ServiceInstanceCount: promauto.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "router_service_instance_count",
+				Help: "Number of service instances known by the data plane.",
+			},
+			[]string{"service", "isd_as"},
+		),
+		ServiceInstanceChanges: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "router_service_instance_changes_total",
+				Help: "Number of total service instance changes. Both addition and removal of a " +
+					"service instance is accumulated.",
+			},
+			[]string{"service", "isd_as"},
 		),
 		SiblingReachable: promauto.NewGaugeVec(
 			prometheus.GaugeOpts{


### PR DESCRIPTION
Add two metrics to track the number of service instances known to the
data plane.

    # HELP router_service_instance_changes_total Number of total service instance changes. Both addition and removal of a service instance is accumulated
    # TYPE router_service_instance_changes_total counter
    router_service_instance_changes_total{isd_as="1-ff00:0:110",service="CS"} 11
    router_service_instance_changes_total{isd_as="1-ff00:0:110",service="DS"} 11
    # HELP router_service_instance_count Number of service instances known by the data plane.
    # TYPE router_service_instance_count gauge
    router_service_instance_count{isd_as="1-ff00:0:110",service="CS"} 3
    router_service_instance_count{isd_as="1-ff00:0:110",service="DS"} 3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3918)
<!-- Reviewable:end -->
