### PR TITLE
topology: add gateway,interface ID mapping

### DIFF
--- a/go/lib/topology/json/json.go
+++ b/go/lib/topology/json/json.go
@@ -89,8 +89,9 @@ type BRInfo struct {
 
 // GatewayInfo contains SCION gateway information.
 type GatewayInfo struct {
-	CtrlAddr string `json:"ctrl_addr"`
-	DataAddr string `json:"data_addr"`
+	CtrlAddr   string `json:"ctrl_addr"`
+	DataAddr   string `json:"data_addr"`
+	Interfaces []int  `json:"allow_interfaces,omitempty"`
 }
 
 // BRInterface contains the information for an data-plane BR socket that is external (i.e., facing

--- a/go/lib/topology/testdata/basic.json
+++ b/go/lib/topology/testdata/basic.json
@@ -86,7 +86,8 @@
   "sigs": {
     "sig1-ff00:0:311-1": {
       "ctrl_addr": "127.0.0.82:30100",
-      "data_addr": "127.0.0.82:30101"
+      "data_addr": "127.0.0.82:30101",
+      "allow_interfaces": [1,3,5]
     },
     "sig2-ff00:0:311-1": {
       "ctrl_addr": "[2001:db8:f00:b43::1%some-zone]:23425",

--- a/go/lib/topology/topology.go
+++ b/go/lib/topology/topology.go
@@ -74,6 +74,7 @@ type (
 	GatewayInfo struct {
 		CtrlAddr *TopoAddr
 		DataAddr *net.UDPAddr
+		AllowIFs []common.IFIDType
 	}
 
 	// BRInfo is a list of AS-wide unique interface IDs for a router. These IDs are also used
@@ -484,9 +485,14 @@ func gatewayMapFromRaw(ras map[string]*jsontopo.GatewayInfo) (map[string]Gateway
 			return nil, serrors.WrapStr("could not parse data address", err,
 				"address", svc.DataAddr, "process_name", name)
 		}
+		var ifs []common.IFIDType
+		for _, i := range svc.Interfaces {
+			ifs = append(ifs, common.IFIDType(i))
+		}
 		ret[name] = GatewayInfo{
 			CtrlAddr: c,
 			DataAddr: d,
+			AllowIFs: ifs,
 		}
 	}
 	return ret, nil

--- a/go/lib/topology/topology_test.go
+++ b/go/lib/topology/topology_test.go
@@ -148,6 +148,7 @@ func TestServiceDetails(t *testing.T) {
 				IP:   net.IP{127, 0, 0, 82},
 				Port: 30101,
 			},
+			AllowIFs: []common.IFIDType{1, 3, 5},
 		},
 		"sig2-ff00:0:311-1": {
 			CtrlAddr: &TopoAddr{


### PR DESCRIPTION
The DS will then attach the mapping to Gateway discovery replies. This
means all traffic that targets a remote gateway should flow only through
the interface IDs attached to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3919)
<!-- Reviewable:end -->
