### PR TITLE
dispatcher: fix panic on read error

### DIFF
--- a/go/lib/underlay/conn/conn.go
+++ b/go/lib/underlay/conn/conn.go
@@ -277,7 +277,7 @@ func (c *connUDPBase) Read(b common.RawBytes) (int, *ReadMeta, error) {
 	}
 	if c.Remote != nil {
 		c.readMeta.Src = c.Remote
-	} else {
+	} else if src != nil {
 		c.readMeta.Src = &net.UDPAddr{
 			IP:   src.IP,
 			Port: src.Port,


### PR DESCRIPTION
Fix nil pointer dereference panic in error case of Read from unconnected
underlay conn.
This is only a minor edge case; the problem only occured on read errors
which the dispatcher considers fatal anyway.  However, the panic did
mask the cause for the read error (in my case, too many open files) from
the logs.
Note that the router uses connected underay conns, which use a different
code path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3925)
<!-- Reviewable:end -->
