### PR TITLE
gateway: simplify defaults for policy file config

### DIFF
--- a/go/pkg/gateway/config/config.go
+++ b/go/pkg/gateway/config/config.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	"github.com/scionproto/scion/go/lib/config"
-	"github.com/scionproto/scion/go/lib/serrors"
 )
 
 // Defaults.
@@ -55,7 +54,7 @@ func (cfg *Gateway) Validate() error {
 		cfg.ID = "gateway"
 	}
 	if cfg.TrafficPolicy == "" {
-		return serrors.New("no traffic policy file path specified")
+		cfg.TrafficPolicy = DefaultSessionPoliciesFile
 	}
 	cfg.CtrlAddr = DefaultAddress(cfg.CtrlAddr, defaultCtrlPort)
 	cfg.DataAddr = DefaultAddress(cfg.DataAddr, defaultDataPort)

--- a/go/pkg/gateway/config/config.go
+++ b/go/pkg/gateway/config/config.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/scionproto/scion/go/lib/config"
+	"github.com/scionproto/scion/go/lib/serrors"
 )
 
 // Defaults.
@@ -47,8 +48,6 @@ type Gateway struct {
 	CtrlAddr string `toml:"ctrl_addr,omitempty"`
 	// Data plane address, for frames.
 	DataAddr string `toml:"data_addr,omitempty"`
-	// SCION dispatcher path.
-	Dispatcher string `toml:"dispatcher,omitempty"`
 }
 
 func (cfg *Gateway) Validate() error {
@@ -56,10 +55,7 @@ func (cfg *Gateway) Validate() error {
 		cfg.ID = "gateway"
 	}
 	if cfg.TrafficPolicy == "" {
-		cfg.TrafficPolicy = DefaultSessionPoliciesFile
-	}
-	if cfg.IPRoutingPolicy == "" {
-		cfg.IPRoutingPolicy = DefaultIPRoutingPolicyFile
+		return serrors.New("no traffic policy file path specified")
 	}
 	cfg.CtrlAddr = DefaultAddress(cfg.CtrlAddr, defaultCtrlPort)
 	cfg.DataAddr = DefaultAddress(cfg.DataAddr, defaultDataPort)

--- a/go/pkg/gateway/config/configtest/configtest.go
+++ b/go/pkg/gateway/config/configtest/configtest.go
@@ -26,7 +26,7 @@ func InitGateway(cfg *config.Gateway) {}
 
 func CheckGateway(t *testing.T, cfg *config.Gateway) {
 	assert.Equal(t, "gateway", cfg.ID)
-	assert.Equal(t, "/share/conf/traffic.policy", cfg.TrafficPolicy)
+	assert.Equal(t, config.DefaultSessionPoliciesFile, cfg.TrafficPolicy)
 	assert.Empty(t, cfg.IPRoutingPolicy)
 	assert.Equal(t, config.DefaultCtrlAddr, cfg.CtrlAddr)
 	assert.Equal(t, config.DefaultDataAddr, cfg.DataAddr)

--- a/go/pkg/gateway/config/configtest/configtest.go
+++ b/go/pkg/gateway/config/configtest/configtest.go
@@ -22,17 +22,14 @@ import (
 	"github.com/scionproto/scion/go/pkg/gateway/config"
 )
 
-func InitGateway(cfg *config.Gateway) {
-	cfg.Dispatcher = "garbage"
-}
+func InitGateway(cfg *config.Gateway) {}
 
 func CheckGateway(t *testing.T, cfg *config.Gateway) {
 	assert.Equal(t, "gateway", cfg.ID)
-	assert.Equal(t, config.DefaultSessionPoliciesFile, cfg.TrafficPolicy)
-	assert.Equal(t, config.DefaultIPRoutingPolicyFile, cfg.IPRoutingPolicy)
+	assert.Equal(t, "/share/conf/traffic.policy", cfg.TrafficPolicy)
+	assert.Empty(t, cfg.IPRoutingPolicy)
 	assert.Equal(t, config.DefaultCtrlAddr, cfg.CtrlAddr)
 	assert.Equal(t, config.DefaultDataAddr, cfg.DataAddr)
-	assert.Empty(t, cfg.Dispatcher)
 }
 
 func InitTunnel(cfg *config.Tunnel) {}

--- a/go/pkg/gateway/config/loader.go
+++ b/go/pkg/gateway/config/loader.go
@@ -22,6 +22,13 @@ import (
 	"github.com/scionproto/scion/go/pkg/worker"
 )
 
+// Default file paths
+const (
+	// FIXME(lukedirtwalker): cleanup traffic policy and use "session.policy"
+	// instead.
+	DefaultSessionPoliciesFile = "/share/conf/traffic.policy"
+)
+
 // Publisher publishes new configurations.
 type Publisher interface {
 	Publish(control.SessionPolicies, *routing.Policy)

--- a/go/pkg/gateway/config/loader_test.go
+++ b/go/pkg/gateway/config/loader_test.go
@@ -117,21 +117,6 @@ func TestLoaderRun(t *testing.T) {
 			}()
 			xtest.AssertReadReturnsBefore(t, doneCh, time.Second)
 		},
-		"missing routing policy file fails": func(t *testing.T, ctrl *gomock.Controller) {
-			loader := &config.Loader{
-				SessionPoliciesFile: "session.policy",
-				Publisher:           mock_config.NewMockPublisher(ctrl),
-				Trigger:             make(chan struct{}),
-				SessionPolicyParser: mock_control.NewMockSessionPolicyParser(ctrl),
-			}
-			doneCh := make(chan struct{})
-			go func() {
-				defer close(doneCh)
-				err := loader.Run()
-				assert.Error(t, err)
-			}()
-			xtest.AssertReadReturnsBefore(t, doneCh, time.Second)
-		},
 		"close before run immediately returns": func(t *testing.T, ctrl *gomock.Controller) {
 			loader := &config.Loader{
 				SessionPoliciesFile: "session.policy",
@@ -232,7 +217,7 @@ func TestLoaderRun(t *testing.T) {
 			logger.EXPECT().Info(gomock.Any(), gomock.Any())
 			loader := &config.Loader{
 				SessionPoliciesFile: spFile,
-				RoutingPolicyFile:   config.DefaultIPRoutingPolicyFile,
+				RoutingPolicyFile:   "",
 				Publisher:           publisher,
 				Trigger:             trigger,
 				SessionPolicyParser: parser,

--- a/go/pkg/gateway/config/sample.go
+++ b/go/pkg/gateway/config/sample.go
@@ -18,24 +18,14 @@ const gatewaySample = `
 # ID of the gateway (default "gateway")
 id = "gateway"
 
-# The traffic policy file. This file is required to exist. If empty, the gateway
-# attempts to read from the default location.
-# (default "/share/conf/traffic.policy")
-
-# The traffic policy file. If not set or empty, the gateway attempts to read the
-# policy from the default location. If set, the gateway will read the policy from
-# the specified location. If the file does not exist, the gateway will exit with
-# an error.
-# (default "/share/conf/traffic.policy")
+# The traffic policy file. This file is must exist. (required)
 traffic_policy_file = "/share/conf/traffic.policy"
 
-# The IP routing policy file. If not set or empty, the gateway attempts to read
-# the policy from the default location. If set, the gateway will read the policy
-# from the specified location. If the file is specified but does not exist, the
-# gateway will exit with an error. It the file is not specified and no file in the
-# default location exists, a default policy that rejects everything is used.
-# (default "/share/conf/ip_routing.policy")
-ip_routing_policy_file = "/share/conf/ip_routing.policy"
+# The IP routing policy file. If set, the gateway will read the policy
+# from the specified location. It no file is specified, a default policy
+# that rejects all IP prefix announcements is used.
+# (default "")
+ip_routing_policy_file = ""
 
 # The bind address for control messages. If the host part of the address is
 # empty, the gateway infers the address based on the route to the control
@@ -56,9 +46,6 @@ ctrl_addr = ":30256"
 #
 # (default ":30056")
 data_addr = ":30056"
-
-# Custom SCION dispatcher path (default "")
-dispatcher = ""
 `
 
 const tunnelSample = `

--- a/go/pkg/gateway/config/sample.go
+++ b/go/pkg/gateway/config/sample.go
@@ -18,7 +18,11 @@ const gatewaySample = `
 # ID of the gateway (default "gateway")
 id = "gateway"
 
-# The traffic policy file. This file is must exist. (required)
+# The traffic policy file. If not set or empty, the gateway attempts to read the
+# policy from the default location. If set, the gateway will read the policy from
+# the specified location. If the file does not exist, the gateway will exit with
+# an error.
+# (default "/share/conf/traffic.policy")
 traffic_policy_file = "/share/conf/traffic.policy"
 
 # The IP routing policy file. If set, the gateway will read the policy


### PR DESCRIPTION
The interpretation of the configured `ip_routing_policy_file`
configuration option was:
- if the value is identical to the default file path and the file does
  not exist, ignore it and return a default routing policy
- otherwise, read the file at the specified location (and fail if it
  doesn't exist)

Not only does this seem a bit convoluted, but it can also fail in
interesting ways; when the user does not want to specify an
`ip_routing_policy_file` and there is an error stat-ing the file at the
default location (e.g. no permission to read directory, error while
accessing network file system, etc.), the SIG would refuse to start.

Simplified to only handle the empty value as special default.
The consequence of this is that the configuration files now _must_
specify the `ip_routing_policy` file path if it should be loaded.

~~Also, removed the default for the `traffic_policy_file` option, making
this option mandatory in the configuration file.~~

Finally, removed the unused `dispatcher` configuration entry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3941)
<!-- Reviewable:end -->
