### PR TITLE
showpaths: show extended metadata

### DIFF
--- a/go/lib/snet/path.go
+++ b/go/lib/snet/path.go
@@ -144,6 +144,19 @@ const (
 	LinkTypeOpennet
 )
 
+func (lt LinkType) String() string {
+	switch lt {
+	case LinkTypeDirect:
+		return "direct"
+	case LinkTypeMultihop:
+		return "multihop"
+	case LinkTypeOpennet:
+		return "opennet"
+	default:
+		return "unset"
+	}
+}
+
 // GeoCoordinates describes a geographical position (of a border router on the path).
 type GeoCoordinates struct {
 	// Latitude of the geographic coordinate, in the WGS 84 datum.

--- a/go/pkg/showpaths/BUILD.bazel
+++ b/go/pkg/showpaths/BUILD.bazel
@@ -17,6 +17,5 @@ go_library(
         "//go/lib/snet/addrutil:go_default_library",
         "//go/pkg/app:go_default_library",
         "//go/pkg/pathprobe:go_default_library",
-        "@com_github_fatih_color//:go_default_library",
     ],
 )

--- a/go/pktgen/pktgen.go
+++ b/go/pktgen/pktgen.go
@@ -127,7 +127,7 @@ func run(cfg flags, dst *snet.UDPAddr) error {
 	}
 	path, err := app.ChoosePath(ctx, sdConn, dst.IA,
 		cfg.interactive, cfg.refresh, cfg.sequence,
-		app.WithDisableColor(cfg.noColor))
+		app.DefaultColorScheme(cfg.noColor))
 	if err != nil {
 		return serrors.WrapStr("fetching paths", err)
 	}

--- a/go/scion/ping.go
+++ b/go/scion/ping.go
@@ -104,7 +104,7 @@ On other errors, ping will exit with code 2.
 			span.SetTag("src.isd_as", info.IA)
 			path, err := app.ChoosePath(traceCtx, sd, remote.IA,
 				flags.interactive, flags.refresh, flags.sequence,
-				app.WithDisableColor(flags.noColor))
+				app.DefaultColorScheme(flags.noColor))
 			if err != nil {
 				return err
 			}

--- a/go/scion/showpaths.go
+++ b/go/scion/showpaths.go
@@ -35,13 +35,13 @@ import (
 
 func newShowpaths(pather CommandPather) *cobra.Command {
 	var flags struct {
-		timeout    time.Duration
-		cfg        showpaths.Config
-		expiration bool
-		json       bool
-		logLevel   string
-		noColor    bool
-		tracer     string
+		timeout  time.Duration
+		cfg      showpaths.Config
+		extended bool
+		json     bool
+		logLevel string
+		noColor  bool
+		tracer   string
 	}
 
 	v := viper.NewWithOptions(
@@ -53,7 +53,7 @@ func newShowpaths(pather CommandPather) *cobra.Command {
 		Short:   "Display paths to a SCION AS",
 		Aliases: []string{"sp"},
 		Args:    cobra.ExactArgs(1),
-		Example: fmt.Sprintf(`  %[1]s showpaths 1-ff00:0:110 --expiration
+		Example: fmt.Sprintf(`  %[1]s showpaths 1-ff00:0:110 --extended
   %[1]s showpaths 1-ff00:0:110 --local 127.0.0.55 --json
   %[1]s showpaths 1-ff00:0:111 --sequence="0-0#2 0*" # outgoing IfID=2
   %[1]s showpaths 1-ff00:0:111 --sequence="0* 0-0#41" # incoming IfID=41 at dstIA
@@ -114,7 +114,7 @@ On other errors, showpaths will exit with code 2.
 			if len(res.Paths) == 0 {
 				return app.WithExitCode(serrors.New("no path found"), 1)
 			}
-			res.Human(os.Stdout, flags.expiration, !flags.noColor)
+			res.Human(os.Stdout, flags.extended, !flags.noColor)
 			if res.Alive() == 0 && !flags.cfg.NoProbe {
 				return app.WithExitCode(serrors.New("no path alive"), 1)
 			}
@@ -128,8 +128,8 @@ On other errors, showpaths will exit with code 2.
 	cmd.Flags().StringVar(&flags.cfg.Sequence, "sequence", "", app.SequenceUsage)
 	cmd.Flags().IntVarP(&flags.cfg.MaxPaths, "maxpaths", "m", 10,
 		"Maximum number of paths that are displayed")
-	cmd.Flags().BoolVarP(&flags.expiration, "expiration", "e", false,
-		"Show path expiration information")
+	cmd.Flags().BoolVarP(&flags.extended, "extended", "e", false,
+		"Show extended path meta data information")
 	cmd.Flags().BoolVarP(&flags.cfg.Refresh, "refresh", "r", false,
 		"Set refresh flag for SCION Deamon path request")
 	cmd.Flags().BoolVar(&flags.cfg.NoProbe, "no-probe", false,

--- a/go/scion/traceroute.go
+++ b/go/scion/traceroute.go
@@ -98,7 +98,7 @@ On other errors, traceroute will exit with code 2.
 			span.SetTag("src.isd_as", info.IA)
 			path, err := app.ChoosePath(traceCtx, sd, remote.IA,
 				flags.interactive, flags.refresh, flags.sequence,
-				app.WithDisableColor(flags.noColor))
+				app.DefaultColorScheme(flags.noColor))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Replace `--expiry` flag with `--extended`. The `--extended` flag will print
extended metadata items. If there are no metadata entries present the
same format as the current `--expiry` flag is produced.

Also restructure colored path output to allow line wrapping for the entries.

Example output with some dummy data:
```
Available paths to 1-ff00:0:112
3 Hops:
[0] Hops: [1-ff00:0:111 41>1 1-ff00:0:110 2>1 1-ff00:0:112]
    MTU: 1280
    NextHop: 127.0.0.17:31014
    Expires: 2020-11-26 01:48:02 +0000 UTC (5h57m31s)
    Latency: 134ms
    Bandwidth: 1000000Kbit/s (information incomplete)
    Geo: [47.37639,8.548056 > 48.858223,2.2945 ("Eiffel Tower, 7th arrondissement, Paris, France") > 48.8738,2.295 ("Place Charles de Gaulle, 8th arrondissement, Paris, France") > N/A]
    LinkType: [direct, unset]
    InternalHops: [1-ff00:0:110: 1]
    Notes: [1-ff00:0:111: "Note from 111", 1-ff00:0:110: "Omelette au fromage"]
    Status: alive
    LocalIP: 127.0.0.1
```

Replaces #3779

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3942)
<!-- Reviewable:end -->
