### PR TITLE
control: fix HP server setup and enable acceptance

### DIFF
--- a/acceptance/hidden_paths/BUILD.bazel
+++ b/acceptance/hidden_paths/BUILD.bazel
@@ -38,13 +38,13 @@ py_binary(
     deps = [":test_lib"],
 )
 
-# py_test(
-#   name = "test",
-#   size = "large",
-#   srcs = ["test.py"],
-#   args = [],
-#   deps = [":test_lib"],
-#)
+py_test(
+    name = "test",
+    size = "large",
+    srcs = ["test.py"],
+    args = [],
+    deps = [":test_lib"],
+)
 
 container_bundle(
     name = "testcontainers",


### PR DESCRIPTION
The hidden paths server handlers were registered after the server
was already running, causing the gRPC library to shut down the app.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3949)
<!-- Reviewable:end -->
