### PR TITLE
scion-utils: fix traceroute output for intermediate hops

### DIFF
--- a/go/pkg/traceroute/traceroute.go
+++ b/go/pkg/traceroute/traceroute.go
@@ -289,7 +289,7 @@ func (h scmpHandler) Handle(pkt *snet.Packet) error {
 		Reply:    r,
 		Remote: &snet.UDPAddr{
 			IA:   pkt.Source.IA,
-			Host: &net.UDPAddr{IP: pkt.Destination.Host.IP()},
+			Host: &net.UDPAddr{IP: pkt.Source.Host.IP()},
 			Path: pkt.Path.Copy(),
 		},
 		Error: err,


### PR DESCRIPTION
Output the `IA,IP_hop` of the intermediate hops, not `IA,IP_local`

Output the IP address of the hop that is replying to the traceroute, not
the local IP on which the reply was received.

Fixes #3955

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3956)
<!-- Reviewable:end -->
