### PR TITLE
posix-gateway: fix go routine leak in dataplane session

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/vishvananda/netlink v0.0.0-20170924180554-177f1ceba557
 	github.com/vishvananda/netns v0.0.0-20170219233438-54f0e4339ce7 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0
+	go.uber.org/goleak v1.1.10
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/net v0.0.0-20200927032502-5d4f70055728

--- a/go.sum
+++ b/go.sum
@@ -522,6 +522,8 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
+go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
@@ -678,6 +680,7 @@ golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114 h1:DnSr2mCsxyCE6ZgIkmcWUQY2R5cH/6wL7eIxEmQOMSE=

--- a/go/pkg/gateway/dataplane/BUILD.bazel
+++ b/go/pkg/gateway/dataplane/BUILD.bazel
@@ -54,11 +54,11 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/log:go_default_library",
         "//go/lib/mocks/io/mock_io:go_default_library",
         "//go/lib/mocks/net/mock_net:go_default_library",
         "//go/lib/pktcls:go_default_library",
         "//go/lib/ringbuf:go_default_library",
+        "//go/lib/serrors:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/snet/mock_snet:go_default_library",
         "//go/lib/spath:go_default_library",
@@ -70,5 +70,6 @@ go_test(
         "@com_github_google_gopacket//layers:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
+        "@org_uber_go_goleak//:go_default_library",
     ],
 )

--- a/go/pkg/gateway/dataplane/encoder.go
+++ b/go/pkg/gateway/dataplane/encoder.go
@@ -39,7 +39,7 @@ import (
 const (
 	// Length of the frame header, in bytes.
 	hdrLen = 16
-	// Location of indidual fields in the frame header.
+	// Location of individual fields in the frame header.
 	versionPos = 0
 	sessPos    = 1
 	indexPos   = 2

--- a/go/pkg/gateway/dataplane/sender.go
+++ b/go/pkg/gateway/dataplane/sender.go
@@ -50,14 +50,13 @@ func newSender(sessID uint8, conn net.PacketConn, path snet.Path,
 	localAddr := conn.LocalAddr().(*net.UDPAddr)
 	addrLen := addr.IABytes*2 + len(localAddr.IP) + len(gatewayAddr.IP)
 	pathLen := len(path.Path().Raw)
-	mtu := path.Metadata().MTU - slayers.CmnHdrLen - uint16(addrLen) - uint16(pathLen) -
-		udpHdrLen
+	mtu := int(path.Metadata().MTU) - slayers.CmnHdrLen - addrLen - pathLen - udpHdrLen
 	if mtu < minMTU {
 		return nil, serrors.New("insufficient MTU", "mtu", mtu, "minMTU", minMTU)
 	}
 
 	c := &sender{
-		encoder: newEncoder(sessID, NewStreamID(), mtu),
+		encoder: newEncoder(sessID, NewStreamID(), uint16(mtu)),
 		conn:    conn,
 		address: &snet.UDPAddr{
 			IA:      path.Destination(),

--- a/go/pkg/gateway/dataplane/sender_test.go
+++ b/go/pkg/gateway/dataplane/sender_test.go
@@ -16,7 +16,6 @@ package dataplane
 
 import (
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -24,9 +23,9 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/mocks/net/mock_net"
 )
 
@@ -46,8 +45,7 @@ func waitForFrames() {
 }
 
 func TestMain(m *testing.M) {
-	log.Discard()
-	os.Exit(m.Run())
+	goleak.VerifyTestMain(m)
 }
 
 func TestSender(t *testing.T) {

--- a/go_deps.bzl
+++ b/go_deps.bzl
@@ -1997,6 +1997,12 @@ def go_deps():
         version = "v1.6.0",
     )
     go_repository(
+        name = "org_uber_go_goleak",
+        importpath = "go.uber.org/goleak",
+        sum = "h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=",
+        version = "v1.1.10",
+    )
+    go_repository(
         name = "org_uber_go_multierr",
         importpath = "go.uber.org/multierr",
         sum = "h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=",


### PR DESCRIPTION
Fix a go routine leak in the dataplane session.

Before this patch, the gateway would leak go routines whenever paths
are updated, or when path updates fail.

With this patch, both of these cases are handled, and no go routines
are leaked in `Session.SetPaths` anymore.

Additionally, this patch fixes a bug where tiny MTU would cause a
uint16 underflow, resulting in a huge frame size.

GitOrigin-RevId: 30e7715fe84820f0c39384497c85cbcc9509f90b

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3979)
<!-- Reviewable:end -->
