### PR TITLE
snet: simplify reader code

### DIFF
--- a/go/lib/snet/base.go
+++ b/go/lib/snet/base.go
@@ -31,9 +31,6 @@ type scionConnBase struct {
 
 	// Reference to SCION networking context
 	scionNet *SCIONNetwork
-
-	// Describes L4 protocol; currently only udp is implemented
-	net string
 }
 
 func (c *scionConnBase) LocalAddr() net.Addr {

--- a/go/lib/snet/reader.go
+++ b/go/lib/snet/reader.go
@@ -41,6 +41,8 @@ func newScionConnReader(base *scionConnBase, conn PacketConn) *scionConnReader {
 
 // ReadFrom reads data into b, returning the length of copied data and the
 // address of the sender.
+// If a message is too long to fit in the supplied buffer, excess bytes may be
+// discarded.
 func (c *scionConnReader) ReadFrom(b []byte) (int, net.Addr, error) {
 	n, a, err := c.read(b)
 	return n, a, err
@@ -48,6 +50,8 @@ func (c *scionConnReader) ReadFrom(b []byte) (int, net.Addr, error) {
 
 // Read reads data into b from a connection with a fixed remote address. If the
 // remote address for the connection is unknown, Read returns an error.
+// If a message is too long to fit in the supplied buffer, excess bytes may be
+// discarded.
 func (c *scionConnReader) Read(b []byte) (int, error) {
 	n, _, err := c.read(b)
 	return n, err

--- a/go/lib/snet/reader.go
+++ b/go/lib/snet/reader.go
@@ -81,17 +81,18 @@ func (c *scionConnReader) read(b []byte) (int, *UDPAddr, error) {
 	// Extract remote address.
 	// Copy the address data to prevent races. See
 	// https://github.com/scionproto/scion/issues/1659.
-	remote := &UDPAddr{}
-	remote.IA = pkt.Source.IA
-	remote.Host = CopyUDPAddr(&net.UDPAddr{
-		IP:   pkt.Source.Host.IP(),
-		Port: int(udp.SrcPort),
-	})
-	remote.Path = pkt.Path.Copy()
+	remote := &UDPAddr{
+		IA: pkt.Source.IA,
+		Host: CopyUDPAddr(&net.UDPAddr{
+			IP:   pkt.Source.Host.IP(),
+			Port: int(udp.SrcPort),
+		}),
+		Path:    pkt.Path.Copy(),
+		NextHop: CopyUDPAddr(&lastHop),
+	}
 	if err = remote.Path.Reverse(); err != nil {
 		return 0, nil, serrors.WrapStr("unable to reverse path on received packet", err)
 	}
-	remote.NextHop = CopyUDPAddr(&lastHop)
 	return n, remote, nil
 }
 

--- a/go/lib/snet/snet.go
+++ b/go/lib/snet/snet.go
@@ -132,7 +132,6 @@ func (n *SCIONNetwork) Listen(ctx context.Context, network string, listen *net.U
 		return nil, serrors.New("unspecified listen IP not supported")
 	}
 	conn := &scionConnBase{
-		net:      network,
 		scionNet: n,
 		svc:      svc,
 		listen:   CopyUDPAddr(listen),


### PR DESCRIPTION
Simplify the somewhat verbose/confusing packet read code in
`snet.scionConnReader`.

* Remove the unnecessary check `if c.base.net == "udp"`. This is always
  true and would require major changes to snet to become false.
  Remove the unnecessary corresponding member in `snet.scionConnBase`.

* Remove redundant type assertions for UDPPayload

* Simplify payload copy

* Do not return a "buffer too small" error.
  `net.UDPConn` does not return an error in this case and it seems to
  make sense to behave in the same way.
  Note that even if we do want to return an error, we should do so
  _after_ copying the part of the payload that does fit into the buffer,
  otherwise the message is just lost entirely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3984)
<!-- Reviewable:end -->
