### PR TITLE
cs: remove unused beaconing configuration options

### DIFF
--- a/go/cs/config/bs_sample.go
+++ b/go/cs/config/bs_sample.go
@@ -15,13 +15,6 @@
 package config
 
 const bsSample = `
-# The interval between sending interface keepalives. (default 1s)
-keepalive_interval = "1s"
-
-# The timeout until an interface that has not received keepalives
-# is considered expired. (default 3s)
-keepalive_timeout = "3s"
-
 # The interval between originating beacons. (default 5s)
 origination_interval = "5s"
 
@@ -30,16 +23,6 @@ propagation_interval = "5s"
 
 # The interval between registering beacons. (default 5s)
 registration_interval = "5s"
-
-# The interval between checking for expired interfaces to revoke. (default 200ms)
-expired_check_interval = "200ms"
-
-# The revocation TTL. (default 10s)
-rev_ttl = "10s"
-
-# The amount of time before the expiry of an existing revocation where the revoker can reissue a
-# new revocation. (default 5s)
-rev_overlap = "5s"
 `
 
 const policiesSample = `

--- a/go/cs/config/config.go
+++ b/go/cs/config/config.go
@@ -19,9 +19,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/config"
-	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/env"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/serrors"
@@ -32,12 +30,6 @@ import (
 )
 
 const (
-	// DefaultKeepaliveInterval is the default interval between sending
-	// interface keepalives.
-	DefaultKeepaliveInterval = time.Second
-	// DefaultKeepaliveTimeout is the timeout indicating how long an interface
-	// can receive no keepalive default until it is considered expired.
-	DefaultKeepaliveTimeout = 3 * time.Second
 	// DefaultOriginationInterval is the default interval between originating
 	// beacons in a core BS.
 	DefaultOriginationInterval = 5 * time.Second
@@ -45,25 +37,11 @@ const (
 	DefaultPropagationInterval = 5 * time.Second
 	// DefaultRegistrationInterval is the default interval between registering segments.
 	DefaultRegistrationInterval = 5 * time.Second
-	// DefaultExpiredCheckInterval is the default interval between checking for
-	// expired interfaces.
-	DefaultExpiredCheckInterval = 200 * time.Millisecond
-	// DefaultRevTTL is the default revocation TTL.
-	DefaultRevTTL = path_mgmt.MinRevTTL
-	// DefaultRevOverlap specifies the default for how long before the expiry of an existing
-	// revocation the revoker can reissue a new revocation.
-	DefaultRevOverlap = DefaultRevTTL / 2
 	// DefaultQueryInterval is the default interval after which the segment
 	// cache expires.
 	DefaultQueryInterval = 5 * time.Minute
 	// DefaultMaxASValidity is the default validity period for renewed AS certificates.
 	DefaultMaxASValidity = 3 * 24 * time.Hour
-)
-
-// Error values
-const (
-	ErrKeyConf   common.ErrMsg = "Unable to load KeyConf"
-	ErrCustomers common.ErrMsg = "Unable to load Customers"
 )
 
 var _ config.Config = (*Config)(nil)
@@ -175,25 +153,12 @@ var _ config.Config = (*BSConfig)(nil)
 
 // BSConfig holds the configuration specific to the beacon server.
 type BSConfig struct {
-	// KeepaliveInterval is the interval between sending interface keepalives.
-	KeepaliveInterval util.DurWrap `toml:"keepalive_interval,omitempty"`
-	// KeepaliveTimeout is the timeout indicating how long an interface can
-	// receive no keepalive until it is considered expired.
-	KeepaliveTimeout util.DurWrap `toml:"keepalive_timeout,omitempty"`
 	// OriginationInterval is the interval between originating beacons in a core BS.
 	OriginationInterval util.DurWrap `toml:"origination_interval,omitempty"`
 	// PropagationInterval is the interval between propagating beacons.
 	PropagationInterval util.DurWrap `toml:"propagation_interval,omitempty"`
 	// RegistrationInterval is the interval between registering segments.
 	RegistrationInterval util.DurWrap `toml:"registration_interval,omitempty"`
-	// ExpiredCheckInterval is the interval between checking whether interfaces
-	// have expired and should be revoked.
-	ExpiredCheckInterval util.DurWrap `toml:"expired_check_interval,omitempty"`
-	// RevTTL is the revocation TTL. (default 10s)
-	RevTTL util.DurWrap `toml:"rev_ttl,omitempty"`
-	// RevOverlap specifies for how long before the expiry of an existing revocation the revoker
-	// can reissue a new revocation. (default 5s)
-	RevOverlap util.DurWrap `toml:"rev_overlap,omitempty"`
 	// Policies contains the policy files.
 	Policies Policies `toml:"policies,omitempty"`
 }
@@ -204,12 +169,6 @@ func (cfg *BSConfig) InitDefaults() {
 
 // Validate validates that all durations are set.
 func (cfg *BSConfig) Validate() error {
-	if cfg.KeepaliveInterval.Duration == 0 {
-		initDurWrap(&cfg.KeepaliveInterval, DefaultKeepaliveInterval)
-	}
-	if cfg.KeepaliveTimeout.Duration == 0 {
-		initDurWrap(&cfg.KeepaliveTimeout, DefaultKeepaliveTimeout)
-	}
 	if cfg.OriginationInterval.Duration == 0 {
 		initDurWrap(&cfg.OriginationInterval, DefaultOriginationInterval)
 	}
@@ -218,22 +177,6 @@ func (cfg *BSConfig) Validate() error {
 	}
 	if cfg.RegistrationInterval.Duration == 0 {
 		initDurWrap(&cfg.RegistrationInterval, DefaultRegistrationInterval)
-	}
-	if cfg.ExpiredCheckInterval.Duration == 0 {
-		initDurWrap(&cfg.ExpiredCheckInterval, DefaultExpiredCheckInterval)
-	}
-	if cfg.RevTTL.Duration == 0 {
-		initDurWrap(&cfg.RevTTL, DefaultRevTTL)
-	}
-	if cfg.RevTTL.Duration < path_mgmt.MinRevTTL {
-		return serrors.New("rev_ttl must be equal or greater than MinRevTTL",
-			"MinRevTTL", path_mgmt.MinRevTTL)
-	}
-	if cfg.RevOverlap.Duration == 0 {
-		initDurWrap(&cfg.RevOverlap, DefaultRevOverlap)
-	}
-	if cfg.RevOverlap.Duration > cfg.RevTTL.Duration {
-		return serrors.New("rev_overlap cannot be greater than rev_ttl")
 	}
 	return nil
 }

--- a/go/cs/config/config_test.go
+++ b/go/cs/config/config_test.go
@@ -17,15 +17,12 @@ package config
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	"github.com/pelletier/go-toml"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/env/envtest"
 	"github.com/scionproto/scion/go/lib/log/logtest"
-	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/pkg/api/apitest"
 	storagetest "github.com/scionproto/scion/go/pkg/storage/test"
 )
@@ -77,8 +74,6 @@ func CheckTestBSConfig(t *testing.T, cfg *BSConfig) {
 	assert.Equal(t, DefaultOriginationInterval, cfg.OriginationInterval.Duration)
 	assert.Equal(t, DefaultPropagationInterval, cfg.PropagationInterval.Duration)
 	assert.Equal(t, DefaultRegistrationInterval, cfg.RegistrationInterval.Duration)
-	assert.Equal(t, DefaultRevTTL, cfg.RevTTL.Duration)
-	assert.Equal(t, DefaultRevOverlap, cfg.RevOverlap.Duration)
 	CheckTestPolicies(t, &cfg.Policies)
 }
 

--- a/go/cs/config/config_test.go
+++ b/go/cs/config/config_test.go
@@ -41,20 +41,6 @@ func TestConfigSample(t *testing.T) {
 	CheckTestConfig(t, &cfg, idSample)
 }
 
-func TestInvalidTTL(t *testing.T) {
-	cfg := BSConfig{}
-	cfg.InitDefaults()
-	err := cfg.Validate()
-	assert.NoError(t, err)
-	cfg.RevOverlap = util.DurWrap{Duration: cfg.RevTTL.Duration + time.Second}
-	err = cfg.Validate()
-	assert.Error(t, err)
-	cfg.InitDefaults()
-	cfg.RevTTL = util.DurWrap{Duration: path_mgmt.MinRevTTL - time.Second}
-	err = cfg.Validate()
-	assert.Error(t, err)
-}
-
 func InitTestConfig(cfg *Config) {
 	apitest.InitConfig(&cfg.API)
 	envtest.InitTest(&cfg.General, &cfg.Metrics, &cfg.Tracing, nil)
@@ -88,12 +74,9 @@ func CheckTestConfig(t *testing.T, cfg *Config, id string) {
 }
 
 func CheckTestBSConfig(t *testing.T, cfg *BSConfig) {
-	assert.Equal(t, DefaultKeepaliveTimeout, cfg.KeepaliveTimeout.Duration)
-	assert.Equal(t, DefaultKeepaliveInterval, cfg.KeepaliveInterval.Duration)
 	assert.Equal(t, DefaultOriginationInterval, cfg.OriginationInterval.Duration)
 	assert.Equal(t, DefaultPropagationInterval, cfg.PropagationInterval.Duration)
 	assert.Equal(t, DefaultRegistrationInterval, cfg.RegistrationInterval.Duration)
-	assert.Equal(t, DefaultExpiredCheckInterval, cfg.ExpiredCheckInterval.Duration)
 	assert.Equal(t, DefaultRevTTL, cfg.RevTTL.Duration)
 	assert.Equal(t, DefaultRevOverlap, cfg.RevOverlap.Duration)
 	CheckTestPolicies(t, &cfg.Policies)


### PR DESCRIPTION
Remove the following `beaconing` configuration options that are no longer in use:
* `keepalive_interval`
* `keepalive_timeout`
* `expired_check_interval`
* `rev_ttl`
* `rev_overlap`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3986)
<!-- Reviewable:end -->
