### PR TITLE
cs: more robust retry mechanism for seg requests

### DIFF
--- a/go/cs/segreq/fetcher.go
+++ b/go/cs/segreq/fetcher.go
@@ -91,9 +91,8 @@ func NewFetcher(cfg FetcherConfig) *segfetcher.Fetcher {
 			},
 		},
 		Requester: &segfetcher.DefaultRequester{
-			RPC:           cfg.RPC,
-			DstProvider:   d,
-			TimeoutFactor: 0.33,
+			RPC:         cfg.RPC,
+			DstProvider: d,
 		},
 		Metrics: segfetcher.NewFetcherMetrics("control"),
 	}

--- a/go/lib/infra/modules/segfetcher/grpc/requester.go
+++ b/go/lib/infra/modules/segfetcher/grpc/requester.go
@@ -17,12 +17,25 @@ package grpc
 import (
 	"context"
 	"net"
+	"time"
 
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
 	"github.com/scionproto/scion/go/lib/infra/modules/segfetcher"
 	"github.com/scionproto/scion/go/lib/serrors"
 	"github.com/scionproto/scion/go/pkg/grpc"
 	cppb "github.com/scionproto/scion/go/pkg/proto/control_plane"
+)
+
+const (
+	// DefaultRPCDialTimeout is the timeout used for dialing the gRPC ClientConn.
+	// This is shorter than the typical context deadline for the request.
+	// Having a separate, more aggressive timeout for dialing allows to abort
+	// quickly. This allows the surrounding infrastructure to retry quickly -- in
+	// the case where this request goes over SCION/QUIC, retries are used to
+	// route around broken paths.
+	// This timeout needs to be long enough to allow for service address
+	// resolution and the QUIC handshake to complete (two roundtrips).
+	DefaultRPCDialTimeout time.Duration = 1 * time.Second
 )
 
 // Requester fetches segments from a remote using gRPC.
@@ -34,11 +47,14 @@ type Requester struct {
 func (f *Requester) Segments(ctx context.Context, req segfetcher.Request,
 	server net.Addr) ([]*seg.Meta, error) {
 
-	conn, err := f.Dialer.Dial(ctx, server)
+	dialCtx, cancelF := context.WithTimeout(ctx, DefaultRPCDialTimeout)
+	defer cancelF()
+	conn, err := f.Dialer.Dial(dialCtx, server)
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Close()
+
 	client := cppb.NewSegmentLookupServiceClient(conn)
 	rep, err := client.Segments(ctx,
 		&cppb.SegmentsRequest{

--- a/go/lib/snet/squic/net.go
+++ b/go/lib/snet/squic/net.go
@@ -146,7 +146,7 @@ func (d ConnDialer) Dial(ctx context.Context, dst net.Addr) (net.Conn, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, serrors.WrapStr("dialing QUIC/SCION, after loop", err)
 	}
-	stream, err := session.OpenStream()
+	stream, err := session.OpenStreamSync(ctx)
 	if err != nil {
 		session.CloseWithError(OpenStreamError, "")
 		return nil, serrors.WrapStr("opening stream", err)

--- a/go/lib/snet/squic/net.go
+++ b/go/lib/snet/squic/net.go
@@ -146,7 +146,7 @@ func (d ConnDialer) Dial(ctx context.Context, dst net.Addr) (net.Conn, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, serrors.WrapStr("dialing QUIC/SCION, after loop", err)
 	}
-	stream, err := session.OpenStreamSync(ctx)
+	stream, err := session.OpenStream()
 	if err != nil {
 		session.CloseWithError(OpenStreamError, "")
 		return nil, serrors.WrapStr("opening stream", err)


### PR DESCRIPTION
The current path management mechanism for segment requests is random
selection and retry. Previously, the full request deadline was divided
into three equal time slots and (at most) three attempts were made.
This has two problems:
- Each time slot is short and potentially simply too short to make the
  entire request (in particular for high latency connections). Thus,
  every try may fail even if it hit a working path and if the full
  request deadline would leave enough time to succeed.
- We give up after three failed attempts and do not use the
  remaining time until the request deadline to probe more paths.

These two main changes attempt to alleviate these problems and increase the
chances of success:
- Limit only the time for dialing a gRPC connection for each try; once
  it has dialed succesfully, we give the entire request deadline to each
  try.
- Allow an unlimited number of retries within the request deadline.

~~Additionally, the Dialer now uses `OpenStream` instead of
`OpenStreamSync`. This avoids an unnecessary roundtrip during dialing
which also contributes to increasing the chances of a successful request
within the request deadline.~~

**Note 1**: none of this is really relevant for segment requests from sciond
to CS as these go locally via TCP. This entire retry mechanism is in the
shared logic though and so it is still applied there. This should be
harmless.

**Note 2**: this is an improvement on a temporary solution. The longer term plan is
to replace this with tracking path health more explicitly by using longer lived
gRPC connections, as described in [doc/grpc.rst](https://scion.docs.anapaya.net/en/latest/grpc.html).

**Note 3**: in SCIONLab, this change increases the success chance of certain path
lookups (within the default 5s timeout of showpaths) from 0% to ~70-80%.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3993)
<!-- Reviewable:end -->
