### PR TITLE
make: add make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ bazel:
 	tar -kxf bazel-bin/scion.tar -C bin
 	tar -kxf bazel-bin/scion-ci.tar -C bin
 
+test:
+	bazel test --config=unit --test_output=errors
+
 go_deps.bzl: go.mod
 	@tools/godeps.sh
 

--- a/scion.sh
+++ b/scion.sh
@@ -51,17 +51,10 @@ cmd_topology() {
     fi
 }
 
-build_binaries() {
-    rm bin/*
-    bazel build //:scion //:scion-ci
-    tar -kxf bazel-bin/scion.tar -C bin
-    tar -kxf bazel-bin/scion-ci.tar -C bin
-}
-
 cmd_run() {
     if [ "$1" != "nobuild" ]; then
         echo "Compiling..."
-        build_binaries || exit 1
+        make -s build || exit 1
         if is_docker_be; then
             echo "Build perapp images"
             bazel run -c opt //docker:prod
@@ -228,7 +221,7 @@ is_supervisor() {
 
 cmd_test(){
     echo "deprecated, use"
-    echo "bazel test --config=unit"
+    echo "make test"
     echo "instead"
     exit 1
 }


### PR DESCRIPTION
Because after running `make` I want to run `make test` (and also `make lint` but that'd be a bit more work).

Also: replace `build_binaries` in scion.sh with equivalent `make build`.
This `build_binaries` snippet had been copied explicitly because `make build` used to do what is now `make all`, which was too much.
Closes #3996
GitOrigin-RevId: d8db5071246e14433e957bab14af0fb79591fa81

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/3997)
<!-- Reviewable:end -->
