### PR TITLE
cs: limit retries for seg requests

### DIFF
--- a/go/cs/segreq/fetcher.go
+++ b/go/cs/segreq/fetcher.go
@@ -93,7 +93,7 @@ func NewFetcher(cfg FetcherConfig) *segfetcher.Fetcher {
 		Requester: &segfetcher.DefaultRequester{
 			RPC:         cfg.RPC,
 			DstProvider: d,
-			MaxTries:    20,
+			MaxRetries:  20,
 		},
 		Metrics: segfetcher.NewFetcherMetrics("control"),
 	}

--- a/go/cs/segreq/fetcher.go
+++ b/go/cs/segreq/fetcher.go
@@ -93,6 +93,7 @@ func NewFetcher(cfg FetcherConfig) *segfetcher.Fetcher {
 		Requester: &segfetcher.DefaultRequester{
 			RPC:         cfg.RPC,
 			DstProvider: d,
+			MaxTries:    20,
 		},
 		Metrics: segfetcher.NewFetcherMetrics("control"),
 	}

--- a/go/lib/infra/modules/segfetcher/requester_test.go
+++ b/go/lib/infra/modules/segfetcher/requester_test.go
@@ -61,7 +61,7 @@ func TestRequester(t *testing.T) {
 	rootCtrl := gomock.NewController(t)
 	defer rootCtrl.Finish()
 	tg := newTestGraph(rootCtrl)
-	const maxTries = 13
+	const maxRetries = 13
 
 	tests := map[string]struct {
 		Reqs   segfetcher.Requests
@@ -99,7 +99,7 @@ func TestRequester(t *testing.T) {
 				// req1 expriences unspecific error, retries until maxTries
 				req1 := req_210_110
 				expectedErr1 := errors.New("no attempts left")
-				api.EXPECT().Segments(gomock.Any(), gomock.Eq(req1), gomock.Any()).Times(maxTries).
+				api.EXPECT().Segments(gomock.Any(), gomock.Eq(req1), gomock.Any()).Times(maxRetries+1).
 					Return(nil, errors.New("some error"))
 				// req2 sees ErrNotReachable, aborts immediately after first try
 				req2 := req_210_120
@@ -169,7 +169,7 @@ func TestRequester(t *testing.T) {
 			requester := segfetcher.DefaultRequester{
 				RPC:         rpc,
 				DstProvider: dstProvider,
-				MaxTries:    maxTries,
+				MaxRetries:  maxRetries,
 			}
 			var replies []segfetcher.ReplyOrErr
 			for r := range requester.Request(ctx, test.Reqs) {

--- a/go/lib/infra/modules/segfetcher/requester_test.go
+++ b/go/lib/infra/modules/segfetcher/requester_test.go
@@ -61,6 +61,7 @@ func TestRequester(t *testing.T) {
 	rootCtrl := gomock.NewController(t)
 	defer rootCtrl.Finish()
 	tg := newTestGraph(rootCtrl)
+	const maxTries = 13
 
 	tests := map[string]struct {
 		Reqs   segfetcher.Requests
@@ -95,20 +96,23 @@ func TestRequester(t *testing.T) {
 		"Cores only": {
 			Reqs: segfetcher.Requests{req_210_110, req_210_120, req_210_130},
 			Expect: func(api *mock_segfetcher.MockRPC) []segfetcher.ReplyOrErr {
+				// req1 expriences unspecific error, retries until maxTries
 				req1 := req_210_110
-				api.EXPECT().Segments(gomock.Any(), gomock.Eq(req1), gomock.Any()).AnyTimes().
+				expectedErr1 := errors.New("no attempts left")
+				api.EXPECT().Segments(gomock.Any(), gomock.Eq(req1), gomock.Any()).Times(maxTries).
 					Return(nil, errors.New("some error"))
+				// req2 sees ErrNotReachable, aborts immediately after first try
 				req2 := req_210_120
-				reply2 := []*seg.Meta{tg.seg210_120_core}
+				expectedErr2 := segfetcher.ErrNotReachable
 				api.EXPECT().Segments(gomock.Any(), gomock.Eq(req2), gomock.Any()).
-					Return(reply2, nil)
+					Return(nil, segfetcher.ErrNotReachable)
 				req3 := req_210_130
 				reply3 := []*seg.Meta{tg.seg210_130_core}
 				api.EXPECT().Segments(gomock.Any(), gomock.Eq(req3), gomock.Any()).
 					Return(reply3, nil)
 				return []segfetcher.ReplyOrErr{
-					{Req: req_210_110, Err: context.DeadlineExceeded},
-					{Req: req_210_120, Segments: reply2},
+					{Req: req_210_110, Err: expectedErr1},
+					{Req: req_210_120, Err: expectedErr2},
 					{Req: req_210_130, Segments: reply3},
 				}
 			},
@@ -165,6 +169,7 @@ func TestRequester(t *testing.T) {
 			requester := segfetcher.DefaultRequester{
 				RPC:         rpc,
 				DstProvider: dstProvider,
+				MaxTries:    maxTries,
 			}
 			var replies []segfetcher.ReplyOrErr
 			for r := range requester.Request(ctx, test.Reqs) {

--- a/go/lib/infra/modules/segfetcher/requester_test.go
+++ b/go/lib/infra/modules/segfetcher/requester_test.go
@@ -99,8 +99,8 @@ func TestRequester(t *testing.T) {
 				// req1 expriences unspecific error, retries until maxTries
 				req1 := req_210_110
 				expectedErr1 := errors.New("no attempts left")
-				api.EXPECT().Segments(gomock.Any(), gomock.Eq(req1), gomock.Any()).Times(maxRetries+1).
-					Return(nil, errors.New("some error"))
+				api.EXPECT().Segments(gomock.Any(), gomock.Eq(req1), gomock.Any()).
+					Times(maxRetries+1).Return(nil, errors.New("some error"))
 				// req2 sees ErrNotReachable, aborts immediately after first try
 				req2 := req_210_120
 				expectedErr2 := segfetcher.ErrNotReachable


### PR DESCRIPTION
This fixes a regression introduced in #3993; certain types of errors, in
particular `ErrNotReachable` indicating that there is no path to the
server where the request should be made at, occur very quickly and will
not be fixed by retrying.
When each try fails very quickly, the retry mechanism would just busy
wait until the request context ends.

Abort immediately in case of `ErrNotReachable`.
Also limit the number of retries to catch any other cases of quickly
failing attempts; the number of allowed retries is currently 20, which
should be ample to keep exploring paths even when the request deadline
is generous, but low enough to make sure that run away retries are not
too much of a nuisance.

The retry limit applied for seg reqs from sciond to the CS is set to 1;
these retries are not useful here (TCP, no paths to explore).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4000)
<!-- Reviewable:end -->
