### PR TITLE
daemon/snet/showpaths: allow zero for hop latency

### DIFF
--- a/go/lib/infra/modules/combinator/staticinfo_accumulator.go
+++ b/go/lib/infra/modules/combinator/staticinfo_accumulator.go
@@ -103,7 +103,12 @@ func collectLatency(p pathInfo) []time.Duration {
 	// 2)
 	latencies := make([]time.Duration, len(p.Interfaces)-1)
 	for i := 0; i+1 < len(p.Interfaces); i++ {
-		latencies[i] = hopLatencies[makeHopKey(p.Interfaces[i], p.Interfaces[i+1])]
+		l, ok := hopLatencies[makeHopKey(p.Interfaces[i], p.Interfaces[i+1])]
+		if ok {
+			latencies[i] = l
+		} else {
+			latencies[i] = snet.LatencyUnset
+		}
 	}
 
 	return latencies
@@ -114,9 +119,6 @@ func collectLatency(p pathInfo) []time.Duration {
 func addHopLatency(m map[hopKey]time.Duration, a, b snet.PathInterface, v time.Duration) {
 	// Skip incomplete entries; not strictly necessary, we'd just not look this up
 	if a.ID == 0 || b.ID == 0 {
-		return
-	}
-	if v == 0 {
 		return
 	}
 	k := makeHopKey(a, b)
@@ -165,9 +167,6 @@ func collectBandwidth(p pathInfo) []uint64 {
 func addHopBandwidth(m map[hopKey]uint64, a, b snet.PathInterface, v uint64) {
 	// Skip incomplete entries; not strictly necessary, we'd just not look this up
 	if a.ID == 0 || b.ID == 0 {
-		return
-	}
-	if v == 0 {
 		return
 	}
 	k := makeHopKey(a, b)
@@ -282,9 +281,6 @@ func collectInternalHops(p pathInfo) []uint32 {
 func addHopInternalHops(m map[hopKey]uint32, a, b snet.PathInterface, v uint32) {
 	// Skip incomplete entries; not strictly necessary, we'd just not look this up
 	if a.ID == 0 || b.ID == 0 {
-		return
-	}
-	if v == 0 {
 		return
 	}
 	k := makeHopKey(a, b)

--- a/go/lib/infra/modules/combinator/staticinfo_accumulator.go
+++ b/go/lib/infra/modules/combinator/staticinfo_accumulator.go
@@ -104,11 +104,10 @@ func collectLatency(p pathInfo) []time.Duration {
 	latencies := make([]time.Duration, len(p.Interfaces)-1)
 	for i := 0; i+1 < len(p.Interfaces); i++ {
 		l, ok := hopLatencies[makeHopKey(p.Interfaces[i], p.Interfaces[i+1])]
-		if ok {
-			latencies[i] = l
-		} else {
-			latencies[i] = snet.LatencyUnset
+		if !ok {
+			l = snet.LatencyUnset
 		}
+		latencies[i] = l
 	}
 
 	return latencies
@@ -119,6 +118,9 @@ func collectLatency(p pathInfo) []time.Duration {
 func addHopLatency(m map[hopKey]time.Duration, a, b snet.PathInterface, v time.Duration) {
 	// Skip incomplete entries; not strictly necessary, we'd just not look this up
 	if a.ID == 0 || b.ID == 0 {
+		return
+	}
+	if v < 0 {
 		return
 	}
 	k := makeHopKey(a, b)
@@ -167,6 +169,9 @@ func collectBandwidth(p pathInfo) []uint64 {
 func addHopBandwidth(m map[hopKey]uint64, a, b snet.PathInterface, v uint64) {
 	// Skip incomplete entries; not strictly necessary, we'd just not look this up
 	if a.ID == 0 || b.ID == 0 {
+		return
+	}
+	if v == 0 {
 		return
 	}
 	k := makeHopKey(a, b)
@@ -281,6 +286,9 @@ func collectInternalHops(p pathInfo) []uint32 {
 func addHopInternalHops(m map[hopKey]uint32, a, b snet.PathInterface, v uint32) {
 	// Skip incomplete entries; not strictly necessary, we'd just not look this up
 	if a.ID == 0 || b.ID == 0 {
+		return
+	}
+	if v == 0 {
 		return
 	}
 	k := makeHopKey(a, b)

--- a/go/lib/snet/path.go
+++ b/go/lib/snet/path.go
@@ -26,8 +26,14 @@ import (
 	"github.com/scionproto/scion/go/lib/spath"
 )
 
-// MaxSegTTL is the maximum expiry for a path segment. It's one day in seconds.
-const MaxSegTTL = 24 * 60 * 60
+const (
+	// MaxSegTTL is the maximum expiry for a path segment. It's one day in seconds.
+	MaxSegTTL = 24 * 60 * 60
+
+	// LatencyUnset is the default value for a Latency entry in PathMetadata for
+	// which no latency was announced.
+	LatencyUnset time.Duration = -1
+)
 
 // Path is an abstract representation of a path. Most applications do not need
 // access to the raw internals.
@@ -84,7 +90,8 @@ type PathMetadata struct {
 	// Latency lists the latencies between any two consecutive interfaces.
 	// Entry i describes the latency between interface i and i+1.
 	// Consequently, there are N-1 entries for N interfaces.
-	// A 0-value indicates that the AS did not announce a latency for this hop.
+	// A negative value (LatencyUnset) indicates that the AS did not announce a
+	// latency for this hop.
 	Latency []time.Duration
 
 	// Bandwidth lists the bandwidth between any two consecutive interfaces, in Kbit/s.

--- a/go/lib/snet/path.go
+++ b/go/lib/snet/path.go
@@ -27,9 +27,6 @@ import (
 )
 
 const (
-	// MaxSegTTL is the maximum expiry for a path segment. It's one day in seconds.
-	MaxSegTTL = 24 * 60 * 60
-
 	// LatencyUnset is the default value for a Latency entry in PathMetadata for
 	// which no latency was announced.
 	LatencyUnset time.Duration = -1

--- a/go/pkg/showpaths/showpaths.go
+++ b/go/pkg/showpaths/showpaths.go
@@ -147,8 +147,10 @@ func humanLatency(p *snet.PathMetadata) string {
 	complete := true
 	var tot time.Duration
 	for _, v := range p.Latency {
-		complete = complete && v > 0
-		tot += v
+		complete = complete && v >= 0
+		if v >= 0 {
+			tot += v
+		}
 	}
 	if complete {
 		return fmt.Sprint(tot)


### PR DESCRIPTION
Allow to use zero for the latency metadata of each hop. Zero can be a sensible value for this; for example when multiple interfaces are part of the same router instance, then it makes sense to announce zero for the latency between these interfaces.

Use negative value (-1 nanosecond) to represent undefined values internally, instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4005)
<!-- Reviewable:end -->
