### PR TITLE
ping: attach error details if there are interfaces down on the path

### DIFF
--- a/go/pkg/ping/ping.go
+++ b/go/pkg/ping/ping.go
@@ -313,7 +313,8 @@ func (h scmpHandler) handle(pkt *snet.Packet) (snet.SCMPEchoReply, error) {
 		return snet.SCMPEchoReply{}, serrors.New("internal connectivity is down",
 			"isd_as", s.IA, "ingress", s.Ingress, "egress", s.Egress)
 	default:
-		return snet.SCMPEchoReply{}, serrors.New("not SCMPEchoReply", "type", common.TypeOf(pkt.Payload))
+		return snet.SCMPEchoReply{}, serrors.New("not SCMPEchoReply",
+			"type", common.TypeOf(pkt.Payload))
 	}
 	r := pkt.Payload.(snet.SCMPEchoReply)
 	if r.Identifier != h.id {

--- a/go/pkg/ping/ping.go
+++ b/go/pkg/ping/ping.go
@@ -304,11 +304,20 @@ func (h scmpHandler) handle(pkt *snet.Packet) (snet.SCMPEchoReply, error) {
 	if pkt.Payload == nil {
 		return snet.SCMPEchoReply{}, serrors.New("no v2 payload found")
 	}
-	r, ok := pkt.Payload.(snet.SCMPEchoReply)
-	if !ok {
-		return snet.SCMPEchoReply{}, serrors.New("not SCMPEchoReply",
-			"type", common.TypeOf(pkt.Payload))
+	var errDetail []interface{}
+	switch s := pkt.Payload.(type) {
+	case snet.SCMPEchoReply:
+	case snet.SCMPExternalInterfaceDown:
+		errDetail = []interface{}{"IA", s.IA, "interface", s.Interface}
+	case snet.SCMPInternalConnectivityDown:
+		errDetail = []interface{}{"IA", s.IA, "ingress", s.Ingress, "egress", s.Egress}
+	default:
+		errDetail = []interface{}{"type", common.TypeOf(pkt.Payload)}
 	}
+	if len(errDetail) > 0 {
+		return snet.SCMPEchoReply{}, serrors.New("not SCMPEchoReply", errDetail...)
+	}
+	r := pkt.Payload.(snet.SCMPEchoReply)
 	if r.Identifier != h.id {
 		return snet.SCMPEchoReply{}, serrors.New("wrong SCMP ID",
 			"expected", h.id, "actual", r.Identifier)

--- a/go/pkg/ping/ping.go
+++ b/go/pkg/ping/ping.go
@@ -304,18 +304,16 @@ func (h scmpHandler) handle(pkt *snet.Packet) (snet.SCMPEchoReply, error) {
 	if pkt.Payload == nil {
 		return snet.SCMPEchoReply{}, serrors.New("no v2 payload found")
 	}
-	var errDetail []interface{}
 	switch s := pkt.Payload.(type) {
 	case snet.SCMPEchoReply:
 	case snet.SCMPExternalInterfaceDown:
-		errDetail = []interface{}{"IA", s.IA, "interface", s.Interface}
+		return snet.SCMPEchoReply{}, serrors.New("external interface is down",
+			"isd_as", s.IA, "interface", s.Interface)
 	case snet.SCMPInternalConnectivityDown:
-		errDetail = []interface{}{"IA", s.IA, "ingress", s.Ingress, "egress", s.Egress}
+		return snet.SCMPEchoReply{}, serrors.New("internal connectivity is down",
+			"isd_as", s.IA, "ingress", s.Ingress, "egress", s.Egress)
 	default:
-		errDetail = []interface{}{"type", common.TypeOf(pkt.Payload)}
-	}
-	if len(errDetail) > 0 {
-		return snet.SCMPEchoReply{}, serrors.New("not SCMPEchoReply", errDetail...)
+		return snet.SCMPEchoReply{}, serrors.New("not SCMPEchoReply", "type", common.TypeOf(pkt.Payload))
 	}
 	r := pkt.Payload.(snet.SCMPEchoReply)
 	if r.Identifier != h.id {


### PR DESCRIPTION
When processing the response to an echo request, create specialized errors for replies that indicate that interfaces were down on the path.

The following error detail is added:
- SCMPExternalInterfaceDown: the offending ISD-AS and the interface identifier
- SCMPInternalConnectivityDown: the offending ISD-AS and the ingress/egress interface identifiers 

This helps pinpoint connectivity issues on a SCION path that is used for pinging.

An example output for the `scion` tool after the change looks like this:

    ERROR: external interface is down isd_as="1-ff00:0:110" interface="42"


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4011)
<!-- Reviewable:end -->
