### PR TITLE
doc: add Authenticator End-to-End option

### DIFF
--- a/doc/protocols/authenticator-option.rst
+++ b/doc/protocols/authenticator-option.rst
@@ -1,0 +1,63 @@
+.. _authenticator-option:
+
+**************************
+SCION Authenticator Option
+**************************
+
+This document describes the Authenticator :ref:`End-to-End option <end-to-end-options>`.
+This option allows to add authentication data to a SCION packet, providing
+crpytographic assurance of authenticity and and data integrity.
+This option only transports the authentication data, i.e. it explicitly is not
+concerned with establishing or identifying keys to create or verify the
+authentication data.
+
+
+Format of the Authenticator Option
+==================================
+Alignment requirement: 4n + 1::
+
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+                    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                    |   OptType=2   |  OptDataLen   |  Algorithm    |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                          Authenticator ...                    |
+    |                                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+OptType
+  8-bit value 2
+OptDataLen
+  Unsigned 8-bit integer denoting the length of the full option data (1 + length of Authenticator). 
+  The length depends on algorithm used.
+Algorithm
+  8-bit identifier of the cryptographic algorithm used.
+Authenticator
+  Variable-length field, Algorithm specific data.
+
+Algorithms
+----------
+======= ============= ======================================= =============
+Decimal Algorithm     Description                             Reference
+======= ============= ======================================= =============
+0       AES-CMAC      16-byte MAC                             [`RFC 4493 <https://tools.ietf.org/html/rfc4493>`_]
+1       AES-GMAC      16-byte MAC with a 12-byte nonce        [`NIST SP 800-38D <https://dx.doi.org/10.6028/NIST.SP.800-38D>`_]
+16      HMAC-SHA256   32-byte MAC                             [`RFC 2104 <https://tools.ietf.org/html/rfc2104>`_].
+32      Ed25519       64-byte digital signature               [`RFC 8032 <https://tools.ietf.org/html/rfc8032>`_]
+253                   use for experimentation and testing
+254                   use for experimentation and testing
+255                   reserved
+======= ============= ======================================= =============
+
+.. note:: Only AES-CMAC will be implemented at first, the rest are just defined as placeholders.
+
+
+Authenticated Data
+==================
+
+The authenticator for a packet is computed over the concatenation of
+
+1. the SCION packet's :ref:`Pseudo Header <pseudo-header-upper-layer-checksum>`,
+2. the entire upper-layer payload data.

--- a/doc/protocols/authenticator-option.rst
+++ b/doc/protocols/authenticator-option.rst
@@ -11,7 +11,6 @@ This option only transports the authentication data, i.e., it explicitly is not
 concerned with establishing or identifying keys to create or verify the
 authentication data.
 
-
 Format of the Authenticator Option
 ==================================
 Alignment requirement: 4n + 1::
@@ -43,16 +42,10 @@ Algorithms
 Decimal Algorithm     Description                             Reference
 ======= ============= ======================================= =============
 0       AES-CMAC      16-byte MAC                             [`RFC 4493 <https://tools.ietf.org/html/rfc4493>`_]
-1       AES-GMAC      16-byte MAC with a 12-byte nonce        [`NIST SP 800-38D <https://dx.doi.org/10.6028/NIST.SP.800-38D>`_]
-16      HMAC-SHA256   32-byte MAC                             [`RFC 2104 <https://tools.ietf.org/html/rfc2104>`_].
-32      Ed25519       64-byte digital signature               [`RFC 8032 <https://tools.ietf.org/html/rfc8032>`_]
 253                   use for experimentation and testing
 254                   use for experimentation and testing
 255                   reserved
 ======= ============= ======================================= =============
-
-.. note:: Only AES-CMAC will be implemented at first, the rest are just defined as placeholders.
-
 
 Authenticated Data
 ==================

--- a/doc/protocols/authenticator-option.rst
+++ b/doc/protocols/authenticator-option.rst
@@ -1,13 +1,13 @@
 .. _authenticator-option:
 
-**************************
-SCION Authenticator Option
-**************************
+*********************************
+SCION Packet Authenticator Option
+*********************************
 
 This document describes the Authenticator :ref:`End-to-End option <end-to-end-options>`.
 This option allows to add authentication data to a SCION packet, providing
 crpytographic assurance of authenticity and and data integrity.
-This option only transports the authentication data, i.e. it explicitly is not
+This option only transports the authentication data, i.e., it explicitly is not
 concerned with establishing or identifying keys to create or verify the
 authentication data.
 

--- a/doc/protocols/extension-header.rst
+++ b/doc/protocols/extension-header.rst
@@ -98,7 +98,7 @@ Decimal Option
 ======= =================================
 0       :ref:`Pad1 Option <pad-1-option>`
 1       :ref:`PadN Option <pad-n-option>`
-2       :ref:`Authenticator Option <authenticator-option>`
+2       :ref:`SCION Packet Authenticator Option <authenticator-option>`
 253     use for experimentation and testing
 254     use for experimentation and testing
 255     reserved

--- a/doc/protocols/extension-header.rst
+++ b/doc/protocols/extension-header.rst
@@ -41,6 +41,21 @@ Options
 
 The Hop-by-Hop Options header is aligned to 4 bytes.
 
+Assigned Option Types
+---------------------
+
+The following option types are assigned for Hop-by-Hop options:
+
+======= =================================
+Decimal Option
+======= =================================
+0       :ref:`Pad1 Option <pad-1-option>`
+1       :ref:`PadN Option <pad-n-option>`
+253     use for experimentation and testing
+254     use for experimentation and testing
+255     reserved
+======= =================================
+
 .. _end-to-end-options:
 
 End-to-End Options Header
@@ -72,6 +87,22 @@ Options
     TLV-encoded options, as described below.
 
 The End-to-End Options header is aligned to 4 bytes.
+
+Assigned Option Types
+---------------------
+
+The following option types are assigned for End-to-End options:
+
+======= =================================
+Decimal Option
+======= =================================
+0       :ref:`Pad1 Option <pad-1-option>`
+1       :ref:`PadN Option <pad-n-option>`
+2       :ref:`Authenticator Option <authenticator-option>`
+253     use for experimentation and testing
+254     use for experimentation and testing
+255     reserved
+======= =================================
 
 TLV-encoded Options
 ===================
@@ -114,6 +145,8 @@ There are two padding options that are used when necessary to align subsequent
 options and to pad out the containing header to a multiple of 4 bytes in length.
 These padding options must be recognized by all SCION implementations:
 
+.. _pad-1-option:
+
 Pad1 Option
 -----------
 Alignment requirement: none::
@@ -131,6 +164,8 @@ Alignment requirement: none::
 The Pad1 option is used to insert 1 byte of padding into the Options area of a
 header.  If more than one byte of padding is required, the PadN option,
 described next, should be used, rather han multiple Pad1 options.
+
+.. _pad-n-option:
 
 PadN Option
 -----------

--- a/doc/protocols/index.rst
+++ b/doc/protocols/index.rst
@@ -11,5 +11,6 @@ This page contains SCION control and data plane protocols and specifications.
    scion-header
    extension-header
    scmp
+   authenticator-option
    sig
    bfd


### PR DESCRIPTION
The Authenticator End-to-End option roughly follows what was previously
described in the SCION book as the "SCION Packet Security Extension". As
the name implies, however, this does not intend to be applicable for
packet encryption -- I think that encrypted packets can be more
appropriately represented by a separate next-header type analogous to IP
Encapsulating Security Payload.

This Authenticator option will be used for authenticated SCMP (to be described in a separate document, see #3969).

[doc]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4014)
<!-- Reviewable:end -->
