### PR TITLE
allow virtual environments to run the topology generator

### DIFF
--- a/python/integration/set_ipv6_addr.py
+++ b/python/integration/set_ipv6_addr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright 2018 ETH Zurich
 # Copyright 2020 ETH Zurich, Anapaya Systems
 #

--- a/python/topology/generator.py
+++ b/python/topology/generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright 2014 ETH Zurich
 # Copyright 2018 ETH Zurich, Anapaya Systems
 #


### PR DESCRIPTION
Having the shebang as `#!/usr/bin/python3` prevents the topology generator from being run directly by `scion.sh` if we want to run under a python virtual environment.

Modify also the shebang for `python/integration/set_ipv6_addr.py`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4015)
<!-- Reviewable:end -->
