### PR TITLE
tools: add topodot

### DIFF
--- a/tools/topodot.py
+++ b/tools/topodot.py
@@ -39,11 +39,16 @@ def fmt_attrs(attrs: Dict[str, str]):
 
 
 def link_attrs(link: Link) -> Dict[str, str]:
-    attrs = {}
+    attrs = {
+        'headlabel': link.a.ifid,
+        'taillabel': link.b.ifid,
+    }
     if link.type in [LinkType.CORE, LinkType.PEER]:
+        attrs['constraint'] = 'false'
         attrs['dir'] = 'none'
     if link.type == LinkType.PEER:
         attrs['constraint'] = 'false'
+        attrs['dir'] = 'none'
         attrs['style'] = 'dotted'
     return attrs
 

--- a/tools/topodot.py
+++ b/tools/topodot.py
@@ -1,13 +1,47 @@
 #!/usr/bin/env python3
 
+# Copyright 2021 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
 import sys
+import tempfile
 import yaml
 
-from python.topology.topo import LinkEP
-from python.lib.types import LinkType
+from plumbum import cli, local
+from typing import Dict, List, NamedTuple
 
-from plumbum import cli
-from typing import NamedTuple, Dict
+from python.lib.types import LinkType
+from python.topology.topo import LinkEP
+
+
+class TopoDot(cli.Application):
+    show = cli.Flag(["-s", "--show"],
+                    help="Run dot and show the graph, instead of only outputting the dot file.")
+
+    def main(self, topofile):
+        if self.show:
+            prefix = pathlib.PurePath(topofile).stem + '-'
+            with tempfile.NamedTemporaryFile(prefix=prefix, suffix='.png') as tmp:
+                dot = local['dot']
+                xdg_open = local['xdg-open']
+                p = dot.popen(('-Tpng', '-o', tmp.name), encoding='utf-8')
+                p.stdin.write(topodot(topofile))
+                p.communicate()
+                xdg_open(tmp.name)
+        else:
+            sys.stdout.write(topodot(topofile))
 
 
 class Link(NamedTuple):
@@ -16,22 +50,17 @@ class Link(NamedTuple):
     type: str
 
 
-class TopoDot(cli.Application):
-    def main(self, topofile):
-        with open(topofile, 'r') as f:
-            topo_config = yaml.safe_load(f)
-        sys.stdout.write(topodot(topo_config))
-
-
-def topodot(topo_config):
+def topodot(topofile) -> str:
+    with open(topofile, 'r') as f:
+        topo_config = yaml.safe_load(f)
     links = topo_links(topo_config)
+    return 'digraph topo {\n%s\n}\n' % \
+           '\n'.join('\t"%s" -> "%s"%s' %
+                     (link.a, link.b, fmt_attrs(link_attrs(link)))
+                     for link in links)
 
-    return 'digraph topo {\n' + '\n'.join('\t "%s" -> "%s"%s' %
-                                          (link.a, link.b, fmt_attrs(link_attrs(link)))
-                                          for link in links) + '\n}\n'
 
-
-def fmt_attrs(attrs: Dict[str, str]):
+def fmt_attrs(attrs: Dict[str, str]) -> str:
     if attrs:
         return '[' + ';'.join('%s=%s' % (k, v) for k, v in attrs.items()) + ']'
     else:
@@ -42,6 +71,8 @@ def link_attrs(link: Link) -> Dict[str, str]:
     attrs = {
         'headlabel': link.a.ifid,
         'taillabel': link.b.ifid,
+        'labelfontcolor': 'gray50',
+        'labelfontsize': '10.0',
     }
     if link.type in [LinkType.CORE, LinkType.PEER]:
         attrs['constraint'] = 'false'
@@ -53,7 +84,7 @@ def link_attrs(link: Link) -> Dict[str, str]:
     return attrs
 
 
-def topo_links(topo_config):
+def topo_links(topo_config) -> List[Link]:
     return [
         Link(a=LinkEP(link['a']),
              b=LinkEP(link['b']),

--- a/tools/topodot.py
+++ b/tools/topodot.py
@@ -69,8 +69,8 @@ def fmt_attrs(attrs: Dict[str, str]) -> str:
 
 def link_attrs(link: Link) -> Dict[str, str]:
     attrs = {
-        'headlabel': link.a.ifid,
-        'taillabel': link.b.ifid,
+        'taillabel': link.a.ifid,
+        'headlabel': link.b.ifid,
         'labelfontcolor': 'gray50',
         'labelfontsize': '10.0',
     }

--- a/tools/topodot.py
+++ b/tools/topodot.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+import sys
+import yaml
+
+from python.topology.topo import LinkEP
+from python.lib.types import LinkType
+
+from plumbum import cli
+from typing import NamedTuple, Dict
+
+
+class Link(NamedTuple):
+    a: LinkEP
+    b: LinkEP
+    type: str
+
+
+class TopoDot(cli.Application):
+    def main(self, topofile):
+        with open(topofile, 'r') as f:
+            topo_config = yaml.safe_load(f)
+        sys.stdout.write(topodot(topo_config))
+
+
+def topodot(topo_config):
+    links = topo_links(topo_config)
+
+    return 'digraph topo {\n' + '\n'.join('\t "%s" -> "%s"%s' %
+                                          (link.a, link.b, fmt_attrs(link_attrs(link)))
+                                          for link in links) + '\n}\n'
+
+
+def fmt_attrs(attrs: Dict[str, str]):
+    if attrs:
+        return '[' + ';'.join('%s=%s' % (k, v) for k, v in attrs.items()) + ']'
+    else:
+        return ''
+
+
+def link_attrs(link: Link) -> Dict[str, str]:
+    attrs = {}
+    if link.type in [LinkType.CORE, LinkType.PEER]:
+        attrs['dir'] = 'none'
+    if link.type == LinkType.PEER:
+        attrs['constraint'] = 'false'
+        attrs['style'] = 'dotted'
+    return attrs
+
+
+def topo_links(topo_config):
+    return [
+        Link(a=LinkEP(link['a']),
+             b=LinkEP(link['b']),
+             type=link['linkAtoB'].lower())
+        for link in topo_config['links']
+    ]
+
+
+if __name__ == "__main__":
+    TopoDot.run()


### PR DESCRIPTION
A simple script `topodot` to visualize the AS topology represented by `*.topo`-files using `dot`.
By default, this will output a description of the graph in the DOT language. When the `--show` option is passed, it will directly call dot to render the graph and open the resulting image file.

Implementation note: this doesn't use any graphviz python library as these don't really add much abstraction and it would just be an unnecessary additional dependency to deal with.

I've had this lying around for a rather long time and used it occasionally to find my way through `default.topo`. Perhaps it can be helpful to others too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4025)
<!-- Reviewable:end -->
