### PR TITLE
router: use ConstantTimeCompare for MACs

### DIFF
--- a/go/lib/epic/epic.go
+++ b/go/lib/epic/epic.go
@@ -15,9 +15,9 @@
 package epic
 
 import (
-	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/subtle"
 	"encoding/binary"
 	"math"
 	"time"
@@ -119,7 +119,7 @@ func VerifyHVF(auth []byte, pktID epic.PktID, s *slayers.SCION,
 		return err
 	}
 
-	if !bytes.Equal(hvf, mac) {
+	if subtle.ConstantTimeCompare(hvf, mac) == 0 {
 		return serrors.New("epic hop validation field verification failed",
 			"hvf in packet", hvf, "calculated mac", mac)
 	}


### PR DESCRIPTION
Using `bytes.Equal` combined with an immediate SCMP response on invalid
MACs appears to enable timing based guessing attacks.

With a quick search for `bytes.Equal` through the code base, I found no
further occurences of such comparison on secret values (as far as I can
tell at a glance).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4028)
<!-- Reviewable:end -->
