### PR TITLE
router: avoid per-packet allocations for MAC

### DIFF
--- a/go/pkg/router/export_test.go
+++ b/go/pkg/router/export_test.go
@@ -59,7 +59,7 @@ func (d *DataPlane) FakeStart() {
 func (d *DataPlane) ProcessPkt(ifID uint16, m *ipv4.Message, s slayers.SCION,
 	origPacket []byte, b gopacket.SerializeBuffer) (ProcessResult, error) {
 
-	result, err := d.processPkt(ifID, m.Buffers[0], m.Addr, s, origPacket, b)
+	result, err := d.processPkt(ifID, m.Buffers[0], m.Addr, s, origPacket, b, d.macFactory())
 	return ProcessResult{processResult: result}, err
 }
 


### PR DESCRIPTION
Avoid creating a separate CMAC hasher, each with a separate AES block
cipher object, for each MAC computation/verification.
This was responsible for a very large portion of allocations during
forwarding. Additionally, reusing the hasher amortizes the cost of the
internal initialization of both the AES block cipher (key expansion) and
CMAC (subkey derivation).
The CMAC hasher is not goroutine safe, so care must be taken to not
share it by accident.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4029)
<!-- Reviewable:end -->
