### PR TITLE
router: reduce per-packet allocations

### DIFF
--- a/go/pkg/router/BUILD.bazel
+++ b/go/pkg/router/BUILD.bazel
@@ -33,7 +33,6 @@ go_library(
         "@com_github_google_gopacket//layers:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
-        "@org_golang_x_net//ipv4:go_default_library",
     ],
 )
 

--- a/go/pkg/router/dataplane.go
+++ b/go/pkg/router/dataplane.go
@@ -77,7 +77,6 @@ type bfdSession interface {
 type BatchConn interface {
 	ReadBatch(underlayconn.Messages) (int, error)
 	WriteTo([]byte, *net.UDPAddr) (int, error)
-	WriteBatch(underlayconn.Messages) (int, error)
 	Close() error
 }
 

--- a/go/pkg/router/dataplane.go
+++ b/go/pkg/router/dataplane.go
@@ -483,7 +483,10 @@ func (d *DataPlane) Run() error {
 				if result.OutConn == nil { // e.g. BFD case no message is forwarded
 					continue
 				}
-				outAddr, _ := result.OutAddr.(*net.UDPAddr)
+				var outAddr *net.UDPAddr
+				if result.OutAddr != nil {
+					outAddr = result.OutAddr.(*net.UDPAddr)
+				}
 				_, err = result.OutConn.WriteTo(result.OutPkt, outAddr)
 				if err != nil {
 					log.Debug("Error writing packet", "err", err)

--- a/go/pkg/router/export_test.go
+++ b/go/pkg/router/export_test.go
@@ -17,11 +17,9 @@ package router
 import (
 	"net"
 
-	"github.com/google/gopacket"
 	"golang.org/x/net/ipv4"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/slayers"
 	"github.com/scionproto/scion/go/lib/topology"
 )
 
@@ -56,10 +54,10 @@ func (d *DataPlane) FakeStart() {
 	d.running = true
 }
 
-func (d *DataPlane) ProcessPkt(ifID uint16, m *ipv4.Message, s slayers.SCION,
-	origPacket []byte, b gopacket.SerializeBuffer) (ProcessResult, error) {
+func (d *DataPlane) ProcessPkt(ifID uint16, m *ipv4.Message) (ProcessResult, error) {
 
-	result, err := d.processPkt(ifID, m.Buffers[0], m.Addr, s, origPacket, b, d.macFactory())
+	p := newPacketProcessor(d, ifID)
+	result, err := p.processPkt(m.Buffers[0], m.Addr)
 	return ProcessResult{processResult: result}, err
 }
 

--- a/go/pkg/router/export_test.go
+++ b/go/pkg/router/export_test.go
@@ -33,7 +33,7 @@ func NewDP(
 	external map[uint16]BatchConn,
 	linkTypes map[uint16]topology.LinkType,
 	internal BatchConn,
-	internalNextHops map[uint16]net.Addr,
+	internalNextHops map[uint16]*net.UDPAddr,
 	svc map[addr.HostSVC][]*net.UDPAddr,
 	local addr.IA,
 	key []byte) *DataPlane {
@@ -57,7 +57,13 @@ func (d *DataPlane) FakeStart() {
 func (d *DataPlane) ProcessPkt(ifID uint16, m *ipv4.Message) (ProcessResult, error) {
 
 	p := newPacketProcessor(d, ifID)
-	result, err := p.processPkt(m.Buffers[0], m.Addr)
+	var srcAddr *net.UDPAddr
+	// for real packets received from ReadBatch this is always non-nil.
+	// Allow nil in test cases for brevity.
+	if m.Addr != nil {
+		srcAddr = m.Addr.(*net.UDPAddr)
+	}
+	result, err := p.processPkt(m.Buffers[0], srcAddr)
 	return ProcessResult{processResult: result}, err
 }
 

--- a/go/pkg/router/mock_router/mock.go
+++ b/go/pkg/router/mock_router/mock.go
@@ -7,6 +7,7 @@ package mock_router
 import (
 	gomock "github.com/golang/mock/gomock"
 	conn "github.com/scionproto/scion/go/lib/underlay/conn"
+	net "net"
 	reflect "reflect"
 )
 
@@ -75,4 +76,19 @@ func (m *MockBatchConn) WriteBatch(arg0 conn.Messages) (int, error) {
 func (mr *MockBatchConnMockRecorder) WriteBatch(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteBatch", reflect.TypeOf((*MockBatchConn)(nil).WriteBatch), arg0)
+}
+
+// WriteTo mocks base method
+func (m *MockBatchConn) WriteTo(arg0 []byte, arg1 *net.UDPAddr) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WriteTo", arg0, arg1)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WriteTo indicates an expected call of WriteTo
+func (mr *MockBatchConnMockRecorder) WriteTo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteTo", reflect.TypeOf((*MockBatchConn)(nil).WriteTo), arg0, arg1)
 }

--- a/go/pkg/router/mock_router/mock.go
+++ b/go/pkg/router/mock_router/mock.go
@@ -63,21 +63,6 @@ func (mr *MockBatchConnMockRecorder) ReadBatch(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadBatch", reflect.TypeOf((*MockBatchConn)(nil).ReadBatch), arg0)
 }
 
-// WriteBatch mocks base method
-func (m *MockBatchConn) WriteBatch(arg0 conn.Messages) (int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteBatch", arg0)
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WriteBatch indicates an expected call of WriteBatch
-func (mr *MockBatchConnMockRecorder) WriteBatch(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteBatch", reflect.TypeOf((*MockBatchConn)(nil).WriteBatch), arg0)
-}
-
 // WriteTo mocks base method
 func (m *MockBatchConn) WriteTo(arg0 []byte, arg1 *net.UDPAddr) (int, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Avoid allocating scionPacketProcessor; re-organized packet processing
functions. The scionPacketProcessor is now the main entry point for
packet processing and contains all the pre-allocated per-packet state.

Avoid allocation of message buffer for writing with WriteBatch.
We could just pre-allocate a buffer, but as we always write a batch of
size one, just use WriteTo instead.
For writing single packets, this is both more convenient and faster.
Additional benefit: Read/WriteBatch make rather large allocations
internally (see golang/go#26838) which is
avoided by using WriteTo.

The largest remaining allocations when processing SCION packets are:
- ReadBatch allocates temporary storage internally (as mentioned above).
  This is by far the biggest culprit, it accounts for almost 80% (after
  the changes in this patch).
- slayers/path.NewPath called during slayers.SCION.DecodeFromBytes:
  Could be avoided by reusing Path objects, but requires larger changes.
- slayers/path/scion.Raw.GetCurrentHopField and GetCurrentInfoField, called during parsePath:
  Both return pointer types. Should be possible to change this to value
  types instead, but requires larger changes.
- DataPlane.resolveLocalDst: allocates IP and UDPAddr. Can only really
  be fixed with better address types.
- slayers/path.FullMAC. Allocates both input and output. The function
  interface could be changed to allow reuse of the input buffer.
  The output buffer cannot be reused with this CMAC library.

Depends on (or actually includes) #4029.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4030)
<!-- Reviewable:end -->
