### PR TITLE
slayers: check for repetition of extension headers

### DIFF
--- a/doc/protocols/extension-header.rst
+++ b/doc/protocols/extension-header.rst
@@ -16,7 +16,7 @@ Hop-by-Hop Options Header
 
 The Hop-by-Hop Options header is used to carry optional information that may be
 examined and processed by every node along a packet's delivery path. The
-Hop-by-Hop Options header is identified by a Next Header value of ``0`` in the
+Hop-by-Hop Options header is identified by a Next Header value of ``200`` in the
 SCION common header and has the following format::
 
      0                   1                   2                   3
@@ -63,7 +63,7 @@ End-to-End Options Header
 
 The End-to-end  Options header is used to carry optional information that may be
 examined and processed by sender and/or receiver of the packet.  The End-to-end
-Options header is identified by a Next Header value of ``0xfd`` in the SCION
+Options header is identified by a Next Header value of ``201`` in the SCION
 common header and has the following format::
 
      0                   1                   2                   3

--- a/go/lib/common/l4.go
+++ b/go/lib/common/l4.go
@@ -38,7 +38,7 @@ var L4Protocols = map[L4ProtocolType]bool{
 func (p L4ProtocolType) String() string {
 	switch p {
 	case L4None:
-		return "None/HopByHop"
+		return "None"
 	case L4SCMP:
 		return "SCMP"
 	case L4TCP:
@@ -47,6 +47,8 @@ func (p L4ProtocolType) String() string {
 		return "UDP"
 	case L4BFD:
 		return "BFD"
+	case HopByHopClass:
+		return "HopByHop"
 	case End2EndClass:
 		return "End2End"
 	}

--- a/go/lib/slayers/layertypes.go
+++ b/go/lib/slayers/layertypes.go
@@ -48,8 +48,20 @@ var (
 		},
 	)
 
-	LayerTypeHopByHopExtn              gopacket.LayerType
-	LayerTypeEndToEndExtn              gopacket.LayerType
+	LayerTypeHopByHopExtn = gopacket.RegisterLayerType(
+		1003,
+		gopacket.LayerTypeMetadata{
+			Name:    "HopByHopExtn",
+			Decoder: gopacket.DecodeFunc(decodeHopByHopExtn),
+		},
+	)
+	LayerTypeEndToEndExtn = gopacket.RegisterLayerType(
+		1004,
+		gopacket.LayerTypeMetadata{
+			Name:    "EndToEndExtn",
+			Decoder: gopacket.DecodeFunc(decodeEndToEndExtn),
+		},
+	)
 	LayerTypeSCMPExternalInterfaceDown = gopacket.RegisterLayerType(
 		1005,
 		gopacket.LayerTypeMetadata{
@@ -100,20 +112,3 @@ var (
 		},
 	)
 )
-
-func init() {
-	LayerTypeHopByHopExtn = gopacket.RegisterLayerType(
-		1003,
-		gopacket.LayerTypeMetadata{
-			Name:    "HopByHopExtn",
-			Decoder: gopacket.DecodeFunc(decodeHopByHopExtn),
-		},
-	)
-	LayerTypeEndToEndExtn = gopacket.RegisterLayerType(
-		1004,
-		gopacket.LayerTypeMetadata{
-			Name:    "EndToEndExtn",
-			Decoder: gopacket.DecodeFunc(decodeEndToEndExtn),
-		},
-	)
-}


### PR DESCRIPTION
The hop-by-hop and end-to-end extension headers can occur at most once
each in a scion packet, and they must be in the correct order, first
HBH, then E2E.
Both the serialization and decode logic had only checked the order
constraint, i.e. it checked that NextHdr of E2E is not HBH. There
was no check for repeated headers.

Note: this check is important not only for adherence to the protocol specifications, but also because gopacket's DecodingLayerParser cannot sensibly handle packets with repeated layer types. 

Fixed in two places:
- split up the scionNextLayerType helper function into three related but
  separate parts: scionNextLayerType (for use in the SCION base packet),
  scionNextLayerTypeAfterHBH and scionNextLayerTypeAfterE2E.
  These functions now don't allow the transition back to the same layer.

  golang trick: this allows to move the registration of the layer type
  to a variable instead of init, as it breaks the initialization cycle.
  We get a compile time guarantee that none of the layers is its own
  NextLayerType.

- check NextHdr for repetition in both serialize and decode

The first part is not strictly necessary, but I think that it helps to
clarify what's going on.

Also:
- fix extension protocol identifier in some places in the docs
- fix protocol identifier string representation for HopByHop extension

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4049)
<!-- Reviewable:end -->
