### PR TITLE
slayers: add extension skipper layer

### DIFF
--- a/go/lib/slayers/doc.go
+++ b/go/lib/slayers/doc.go
@@ -43,8 +43,8 @@ decoding. The following can be used to decode any SCION packet (including HBH an
 that have either a SCION/UDP or SCMP payload:
 
 	var scn slayers.SCION
-	var hbh slayers.HopByHopExtn
-	var e2e slayers.EndToEndExtn
+	var hbh slayers.HopByHopExtnSkipper
+	var e2e slayers.EndToEndExtnSkipper
 	var udp slayers.UDP
 	var scmp slayers.SCMP
 	var pld gopacket.Payload
@@ -64,6 +64,9 @@ even branching based on layer type... it'll handle an (scn, e2e, udp) or (scn, h
 Note: Great care has been taken to only lazily parse the SCION header, however, HBH and E2E
 extensions are currently eagerly parsed (if they exist). Thus, handling packets containing these
 extensions will be much slower (see the package benchmarks for reference).
+When using the DecodingLayerParser, the extensions can be explicitly skipped by using the
+HopByHop/EndToEndExtnSkipper layer. The content of this Skipper-layer can be decoded into the full
+representation when necessary.
 
 Creating Packet Data
 

--- a/go/lib/slayers/extn_test.go
+++ b/go/lib/slayers/extn_test.go
@@ -392,6 +392,96 @@ func TestExtnOrderDecode(t *testing.T) {
 				assert.NoError(t, packet.ErrorLayer().Error())
 			}
 		})
+		t.Run(fmt.Sprintf("decode skip %s", c.name), func(t *testing.T) {
+			raw := prepRawPacketWithExtn(t, c.extns...)
+			var (
+				scn slayers.SCION
+				e2e slayers.EndToEndExtnSkipper
+				hbh slayers.HopByHopExtnSkipper
+				udp slayers.UDP
+				pld gopacket.Payload
+			)
+			parser := gopacket.NewDecodingLayerParser(slayers.LayerTypeSCION,
+				&scn, &e2e, &hbh, &udp, &pld,
+			)
+			decoded := []gopacket.LayerType{}
+			err := parser.DecodeLayers(raw, &decoded)
+			if c.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestExtnSkipDecode(t *testing.T) {
+	cases := []struct {
+		name string
+		hbh  bool
+		e2e  bool
+	}{
+		{
+			name: "none",
+		},
+		{
+			name: "e2e",
+			e2e:  true,
+		},
+		{
+			name: "hbh",
+			hbh:  true,
+		},
+		{
+			name: "hbh e2e",
+			e2e:  true,
+			hbh:  true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			extns := []common.L4ProtocolType{}
+			if c.hbh {
+				extns = append(extns, common.HopByHopClass)
+			}
+			if c.e2e {
+				extns = append(extns, common.End2EndClass)
+			}
+			raw := prepRawPacketWithExtn(t, extns...)
+			var (
+				scn slayers.SCION
+				e2e slayers.EndToEndExtnSkipper
+				hbh slayers.HopByHopExtnSkipper
+				udp slayers.UDP
+				pld gopacket.Payload
+			)
+			parser := gopacket.NewDecodingLayerParser(slayers.LayerTypeSCION,
+				&scn, &e2e, &hbh, &udp, &pld,
+			)
+			decoded := []gopacket.LayerType{}
+			err := parser.DecodeLayers(raw, &decoded)
+			require.NoError(t, err)
+
+			// decoded should be: SCION, the expected extension headers, and the UDP + payload
+			expected := []gopacket.LayerType{slayers.LayerTypeSCION}
+			if c.hbh {
+				expected = append(expected, slayers.LayerTypeHopByHopExtn)
+			}
+			if c.e2e {
+				expected = append(expected, slayers.LayerTypeEndToEndExtn)
+			}
+			expected = append(expected, slayers.LayerTypeSCIONUDP)
+			expected = append(expected, gopacket.LayerTypePayload)
+			assert.Equal(t, expected, decoded)
+
+			// check that the skipper "captured" the expected part of the packet
+			if c.hbh {
+				assert.Equal(t, hbh.Contents[2:], rawTLVOptionsXY)
+			}
+			if c.e2e {
+				assert.Equal(t, e2e.Contents[2:], rawTLVOptionsXY)
+			}
+		})
 	}
 }
 
@@ -426,7 +516,11 @@ func prepPacketWithExtn(t *testing.T,
 func prepRawPacketWithExtn(t *testing.T, extns ...common.L4ProtocolType) []byte {
 	t.Helper()
 
-	scn := prepPacket(t, extns[0])
+	first := common.L4UDP
+	if len(extns) > 0 {
+		first = extns[0]
+	}
+	scn := prepPacket(t, first)
 	buf := gopacket.NewSerializeBuffer()
 	require.NoError(t, scn.SerializeTo(buf, gopacket.SerializeOptions{FixLengths: true}))
 
@@ -434,16 +528,17 @@ func prepRawPacketWithExtn(t *testing.T, extns ...common.L4ProtocolType) []byte 
 	// logic checks for the correct ordering of the extensions, but we want to
 	// create packets with bad order.
 	for i := range extns {
-		b, err := buf.AppendBytes(slayers.LineLen)
+		b, err := buf.AppendBytes(2 + len(rawTLVOptionsXY))
 		require.NoError(t, err)
 		next := common.L4UDP
 		if i+1 < len(extns) {
 			next = extns[i+1]
 		}
 		b[0] = uint8(next)
-		b[1] = 0 // one LineLen
+		b[1] = 6 // ExtLen, see rawTLVOptionsXY
+		copy(b[2:], rawTLVOptionsXY)
 	}
-	buf.AppendBytes(8) // dummy UDP payload
+	buf.AppendBytes(9) // dummy UDP with 1 byte payload
 
 	return buf.Bytes()
 }

--- a/go/lib/slayers/slayers_test.go
+++ b/go/lib/slayers/slayers_test.go
@@ -509,6 +509,25 @@ func BenchmarkDecodeLayerParserExtn(b *testing.B) {
 	}
 }
 
+func BenchmarkDecodeLayerParserExtnSkipper(b *testing.B) {
+	raw := xtest.MustReadFromFile(b, rawFullPktFilename)
+	var scn slayers.SCION
+	var hbh slayers.HopByHopExtnSkipper
+	var e2e slayers.EndToEndExtnSkipper
+	var udp slayers.UDP
+	var scmp slayers.SCMP
+	var pld gopacket.Payload
+	parser := gopacket.NewDecodingLayerParser(
+		slayers.LayerTypeSCION, &scn, &hbh, &e2e, &udp, &scmp, &pld,
+	)
+	decoded := []gopacket.LayerType{}
+	for i := 0; i < b.N; i++ {
+		if err := parser.DecodeLayers(raw, &decoded); err != nil {
+			b.Fatalf("error: %v\n", err)
+		}
+	}
+}
+
 func mkPayload(plen int) []byte {
 	b := make([]byte, plen)
 	for i := 0; i < plen; i++ {

--- a/go/lib/snet/packet.go
+++ b/go/lib/snet/packet.go
@@ -295,14 +295,16 @@ type Packet struct {
 func (p *Packet) Decode() error {
 	var (
 		scionLayer slayers.SCION
+		hbhLayer   slayers.HopByHopExtnSkipper
+		e2eLayer   slayers.EndToEndExtnSkipper
 		udpLayer   slayers.UDP
 		scmpLayer  slayers.SCMP
 	)
 	parser := gopacket.NewDecodingLayerParser(
-		slayers.LayerTypeSCION, &scionLayer, &udpLayer, &scmpLayer,
+		slayers.LayerTypeSCION, &scionLayer, &hbhLayer, &e2eLayer, &udpLayer, &scmpLayer,
 	)
 	parser.IgnoreUnsupported = true
-	decoded := make([]gopacket.LayerType, 3)
+	decoded := make([]gopacket.LayerType, 0, 4)
 	if err := parser.DecodeLayers(p.Bytes, &decoded); err != nil {
 		return err
 	}


### PR DESCRIPTION
Add HopByHopExtnSkipper and EndToEndExtnSkipper layers.
These layers allow to decode SCION packets including extension headers
without decoding the individual TLV options.
This can be used, for example, to peek at the L4 protocol type.

Inspired by gopacket's IPv6ExtensionSkipper layer; a notable difference
is that we have different skipper layers for the different extension
types, and that we check for valid order and no repetition of the
extension types.

Added skipper layers to packet parsing in dispatcher and snet to accept
packets with extension headers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4050)
<!-- Reviewable:end -->
