### PR TITLE
router: sanity checks for one-hop path

### DIFF
--- a/acceptance/router_multi/conf/topology.json
+++ b/acceptance/router_multi/conf/topology.json
@@ -23,7 +23,7 @@
             "remote": "192.168.13.3:40000"
           },
           "bandwidth": 1000,
-          "isd_as": "2-ff00:0:3",
+          "isd_as": "1-ff00:0:3",
           "link_to": "PARENT",
           "mtu": 8000
         },

--- a/go/integration/braccept/cases/bfd.go
+++ b/go/integration/braccept/cases/bfd.go
@@ -78,7 +78,7 @@ func ExternalBFD(artifactsDir string, mac hash.Hash) runner.Case {
 	}
 	udp.SetNetworkLayerForChecksum(ip)
 	localIA, _ := addr.IAFromString("1-ff00:0:1")
-	remoteIA, _ := addr.IAFromString("2-ff00:0:3")
+	remoteIA, _ := addr.IAFromString("1-ff00:0:3")
 	ohp := &onehop.Path{
 		Info: path.InfoField{
 			ConsDir:   true,

--- a/go/pkg/router/export_test.go
+++ b/go/pkg/router/export_test.go
@@ -36,12 +36,14 @@ func NewDP(
 	internalNextHops map[uint16]*net.UDPAddr,
 	svc map[addr.HostSVC][]*net.UDPAddr,
 	local addr.IA,
+	neighbors map[uint16]addr.IA,
 	key []byte) *DataPlane {
 
 	dp := &DataPlane{
 		localIA:          local,
 		external:         external,
 		linkTypes:        linkTypes,
+		neighborIAs:      neighbors,
 		internalNextHops: internalNextHops,
 		svc:              &services{m: svc},
 		internal:         internal,


### PR DESCRIPTION
Previously used the source IA of the packet to determine whether the
packet was entering or leaving the local AS. This would seemingly have
allowed a mischievous neighbor AS to relay OHP packets to any other
external interface of a router.
Now the direction is inferred from the router interface on which the
packet was received.

Also add more specific sanity checks for src/dstIA of OHP packets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4052)
<!-- Reviewable:end -->
