### PR TITLE
border router: avoid MAC allocations at runtime

### DIFF
--- a/go/cs/beaconing/extender.go
+++ b/go/cs/beaconing/extender.go
@@ -247,7 +247,8 @@ func (s *DefaultExtender) createHopF(ingress, egress uint16, ts time.Time,
 	beta uint16) (path.HopField, []byte) {
 
 	expTime := s.MaxExpTime()
-	input := path.MACInput(beta, util.TimeToSecs(ts), expTime, ingress, egress)
+	input := make([]byte, path.MACBufferSize)
+	path.MACInput(beta, util.TimeToSecs(ts), expTime, ingress, egress, input)
 
 	mac := s.MAC()
 	// Write must not return an error: https://godoc.org/hash#Hash

--- a/go/cs/beaconing/extender.go
+++ b/go/cs/beaconing/extender.go
@@ -247,8 +247,7 @@ func (s *DefaultExtender) createHopF(ingress, egress uint16, ts time.Time,
 	beta uint16) (path.HopField, []byte) {
 
 	expTime := s.MaxExpTime()
-	input := make([]byte, path.MACBufferSize)
-	path.MACInput(beta, util.TimeToSecs(ts), expTime, ingress, egress, input)
+	input := path.MACInput(beta, util.TimeToSecs(ts), expTime, ingress, egress, nil)
 
 	mac := s.MAC()
 	// Write must not return an error: https://godoc.org/hash#Hash

--- a/go/cs/beaconing/extender.go
+++ b/go/cs/beaconing/extender.go
@@ -247,7 +247,8 @@ func (s *DefaultExtender) createHopF(ingress, egress uint16, ts time.Time,
 	beta uint16) (path.HopField, []byte) {
 
 	expTime := s.MaxExpTime()
-	input := path.MACInput(beta, util.TimeToSecs(ts), expTime, ingress, egress, nil)
+	input := make([]byte, path.MACBufferSize)
+	path.MACInput(beta, util.TimeToSecs(ts), expTime, ingress, egress, input)
 
 	mac := s.MAC()
 	// Write must not return an error: https://godoc.org/hash#Hash

--- a/go/integration/braccept/cases/bfd.go
+++ b/go/integration/braccept/cases/bfd.go
@@ -90,7 +90,12 @@ func ExternalBFD(artifactsDir string, mac hash.Hash) runner.Case {
 			ConsEgress:  131,
 		},
 	}
-	ohp.FirstHop.Mac = path.MAC(mac, &ohp.Info, &ohp.FirstHop)
+	var err error
+	ohp.FirstHop.Mac, err = path.MAC(mac, &ohp.Info, &ohp.FirstHop,
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	scionL := &slayers.SCION{
 		Version:      0,
 		TrafficClass: 0xb8,
@@ -101,7 +106,7 @@ func ExternalBFD(artifactsDir string, mac hash.Hash) runner.Case {
 		DstIA:        localIA,
 		SrcIA:        remoteIA,
 	}
-	err := scionL.SetSrcAddr(&net.IPAddr{IP: net.IP{192, 168, 13, 3}})
+	err = scionL.SetSrcAddr(&net.IPAddr{IP: net.IP{192, 168, 13, 3}})
 	if err != nil {
 		panic(err)
 	}

--- a/go/integration/braccept/cases/bfd.go
+++ b/go/integration/braccept/cases/bfd.go
@@ -90,12 +90,7 @@ func ExternalBFD(artifactsDir string, mac hash.Hash) runner.Case {
 			ConsEgress:  131,
 		},
 	}
-	var err error
-	ohp.FirstHop.Mac, err = path.MAC(mac, &ohp.Info, &ohp.FirstHop,
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	ohp.FirstHop.Mac = path.MAC(mac, &ohp.Info, &ohp.FirstHop, nil)
 	scionL := &slayers.SCION{
 		Version:      0,
 		TrafficClass: 0xb8,
@@ -106,7 +101,7 @@ func ExternalBFD(artifactsDir string, mac hash.Hash) runner.Case {
 		DstIA:        localIA,
 		SrcIA:        remoteIA,
 	}
-	err = scionL.SetSrcAddr(&net.IPAddr{IP: net.IP{192, 168, 13, 3}})
+	err := scionL.SetSrcAddr(&net.IPAddr{IP: net.IP{192, 168, 13, 3}})
 	if err != nil {
 		panic(err)
 	}

--- a/go/integration/braccept/cases/child_to_child_xover.go
+++ b/go/integration/braccept/cases/child_to_child_xover.go
@@ -93,9 +93,18 @@ func ChildToChildXover(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/child_to_child_xover.go
+++ b/go/integration/braccept/cases/child_to_child_xover.go
@@ -93,18 +93,9 @@ func ChildToChildXover(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/child_to_internal.go
+++ b/go/integration/braccept/cases/child_to_internal.go
@@ -84,12 +84,7 @@ func ChildToInternalHost(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 141},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{
@@ -196,12 +191,7 @@ func ChildToInternalHostShortcut(artifactsDir string, mac hash.Hash) runner.Case
 			{ConsIngress: 191, ConsEgress: 141},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{
@@ -319,12 +309,7 @@ func ChildToInternalParent(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 911},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{

--- a/go/integration/braccept/cases/child_to_internal.go
+++ b/go/integration/braccept/cases/child_to_internal.go
@@ -84,7 +84,12 @@ func ChildToInternalHost(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 141},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{
@@ -191,7 +196,12 @@ func ChildToInternalHostShortcut(artifactsDir string, mac hash.Hash) runner.Case
 			{ConsIngress: 191, ConsEgress: 141},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{
@@ -309,7 +319,12 @@ func ChildToInternalParent(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 911},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{

--- a/go/integration/braccept/cases/child_to_parent.go
+++ b/go/integration/braccept/cases/child_to_parent.go
@@ -92,12 +92,7 @@ func ChildToParent(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 311},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{

--- a/go/integration/braccept/cases/child_to_parent.go
+++ b/go/integration/braccept/cases/child_to_parent.go
@@ -92,7 +92,12 @@ func ChildToParent(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 311},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{

--- a/go/integration/braccept/cases/internal_to_child.go
+++ b/go/integration/braccept/cases/internal_to_child.go
@@ -89,12 +89,7 @@ func InternalHostToChild(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[0].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[0],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[0].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[0], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -218,12 +213,7 @@ func InternalParentToChild(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/internal_to_child.go
+++ b/go/integration/braccept/cases/internal_to_child.go
@@ -89,7 +89,12 @@ func InternalHostToChild(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[0].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[0])
+	var err error
+	sp.HopFields[0].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[0],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -213,7 +218,12 @@ func InternalParentToChild(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/jumbo.go
+++ b/go/integration/braccept/cases/jumbo.go
@@ -93,12 +93,7 @@ func JumboPacket(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/jumbo.go
+++ b/go/integration/braccept/cases/jumbo.go
@@ -93,7 +93,12 @@ func JumboPacket(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/onehop.go
+++ b/go/integration/braccept/cases/onehop.go
@@ -67,12 +67,7 @@ func IncomingOneHop(artifactsDir string, mac hash.Hash) runner.Case {
 		FirstHop:  path.HopField{ConsIngress: 0, ConsEgress: 311},
 		SecondHop: path.HopField{ConsIngress: 0, ConsEgress: 0},
 	}
-	var err error
-	ohp.FirstHop.Mac, err = path.MAC(mac, &ohp.Info, &ohp.FirstHop,
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	ohp.FirstHop.Mac = path.MAC(mac, &ohp.Info, &ohp.FirstHop, nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -115,11 +110,7 @@ func IncomingOneHop(artifactsDir string, mac hash.Hash) runner.Case {
 	udp.SrcPort, udp.DstPort = 30001, 30041
 	// Second hop in OHP should have been set by BR.
 	ohp.SecondHop.ConsIngress = 131
-	ohp.SecondHop.Mac, err = path.MAC(mac, &ohp.Info, &ohp.SecondHop,
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	ohp.SecondHop.Mac = path.MAC(mac, &ohp.Info, &ohp.SecondHop, nil)
 
 	if err := gopacket.SerializeLayers(want, options,
 		ethernet, ip, udp, scionL, scionudp, gopacket.Payload(payload),
@@ -171,12 +162,7 @@ func OutgoingOneHop(artifactsDir string, mac hash.Hash) runner.Case {
 		FirstHop: path.HopField{ConsIngress: 0, ConsEgress: 141},
 		// Don't set the second hop. It is supposed to be set by the remote BR.
 	}
-	var err error
-	ohp.FirstHop.Mac, err = path.MAC(mac, &ohp.Info, &ohp.FirstHop,
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	ohp.FirstHop.Mac = path.MAC(mac, &ohp.Info, &ohp.FirstHop, nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/onehop.go
+++ b/go/integration/braccept/cases/onehop.go
@@ -67,7 +67,12 @@ func IncomingOneHop(artifactsDir string, mac hash.Hash) runner.Case {
 		FirstHop:  path.HopField{ConsIngress: 0, ConsEgress: 311},
 		SecondHop: path.HopField{ConsIngress: 0, ConsEgress: 0},
 	}
-	ohp.FirstHop.Mac = path.MAC(mac, &ohp.Info, &ohp.FirstHop)
+	var err error
+	ohp.FirstHop.Mac, err = path.MAC(mac, &ohp.Info, &ohp.FirstHop,
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -110,7 +115,11 @@ func IncomingOneHop(artifactsDir string, mac hash.Hash) runner.Case {
 	udp.SrcPort, udp.DstPort = 30001, 30041
 	// Second hop in OHP should have been set by BR.
 	ohp.SecondHop.ConsIngress = 131
-	ohp.SecondHop.Mac = path.MAC(mac, &ohp.Info, &ohp.SecondHop)
+	ohp.SecondHop.Mac, err = path.MAC(mac, &ohp.Info, &ohp.SecondHop,
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	if err := gopacket.SerializeLayers(want, options,
 		ethernet, ip, udp, scionL, scionudp, gopacket.Payload(payload),
@@ -162,7 +171,12 @@ func OutgoingOneHop(artifactsDir string, mac hash.Hash) runner.Case {
 		FirstHop: path.HopField{ConsIngress: 0, ConsEgress: 141},
 		// Don't set the second hop. It is supposed to be set by the remote BR.
 	}
-	ohp.FirstHop.Mac = path.MAC(mac, &ohp.Info, &ohp.FirstHop)
+	var err error
+	ohp.FirstHop.Mac, err = path.MAC(mac, &ohp.Info, &ohp.FirstHop,
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/parent_to_child.go
+++ b/go/integration/braccept/cases/parent_to_child.go
@@ -93,12 +93,7 @@ func ParentToChild(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/parent_to_child.go
+++ b/go/integration/braccept/cases/parent_to_child.go
@@ -93,7 +93,12 @@ func ParentToChild(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/parent_to_internal.go
+++ b/go/integration/braccept/cases/parent_to_internal.go
@@ -80,7 +80,12 @@ func ParentToInternalHost(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 131, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -194,7 +199,12 @@ func ParentToInternalHostMultiSegment(artifactsDir string, mac hash.Hash) runner
 			{ConsIngress: 131, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[3].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[3])
+	var err error
+	sp.HopFields[3].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[3],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/parent_to_internal.go
+++ b/go/integration/braccept/cases/parent_to_internal.go
@@ -80,12 +80,7 @@ func ParentToInternalHost(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 131, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -199,12 +194,7 @@ func ParentToInternalHostMultiSegment(artifactsDir string, mac hash.Hash) runner
 			{ConsIngress: 131, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[3].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[3],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[3].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[3], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_dest_unreachable.go
+++ b/go/integration/braccept/cases/scmp_dest_unreachable.go
@@ -84,7 +84,12 @@ func SCMPDestinationUnreachable(artifactsDir string, mac hash.Hash) runner.Case 
 			{ConsIngress: 131, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_dest_unreachable.go
+++ b/go/integration/braccept/cases/scmp_dest_unreachable.go
@@ -84,12 +84,7 @@ func SCMPDestinationUnreachable(artifactsDir string, mac hash.Hash) runner.Case 
 			{ConsIngress: 131, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_expired_hop.go
+++ b/go/integration/braccept/cases/scmp_expired_hop.go
@@ -94,12 +94,7 @@ func SCMPExpiredHop(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -258,18 +253,9 @@ func SCMPExpiredHopAfterXover(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -439,18 +425,9 @@ func SCMPExpiredHopAfterXoverConsDir(artifactsDir string, mac hash.Hash) runner.
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -624,18 +601,9 @@ func SCMPExpiredHopAfterXoverInternal(artifactsDir string, mac hash.Hash) runner
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -796,18 +764,9 @@ func SCMPExpiredHopAfterXoverInternalConsDir(artifactsDir string, mac hash.Hash)
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_expired_hop.go
+++ b/go/integration/braccept/cases/scmp_expired_hop.go
@@ -94,7 +94,12 @@ func SCMPExpiredHop(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -253,9 +258,18 @@ func SCMPExpiredHopAfterXover(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -425,9 +439,18 @@ func SCMPExpiredHopAfterXoverConsDir(artifactsDir string, mac hash.Hash) runner.
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -601,9 +624,18 @@ func SCMPExpiredHopAfterXoverInternal(artifactsDir string, mac hash.Hash) runner
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -764,9 +796,18 @@ func SCMPExpiredHopAfterXoverInternalConsDir(artifactsDir string, mac hash.Hash)
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_invalid_pkt.go
+++ b/go/integration/braccept/cases/scmp_invalid_pkt.go
@@ -81,12 +81,7 @@ func SCMPBadPktLen(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -237,12 +232,7 @@ func SCMPQuoteCut(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -399,12 +389,7 @@ func NoSCMPReplyForSCMPError(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_invalid_pkt.go
+++ b/go/integration/braccept/cases/scmp_invalid_pkt.go
@@ -81,7 +81,12 @@ func SCMPBadPktLen(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -232,7 +237,12 @@ func SCMPQuoteCut(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -389,7 +399,12 @@ func NoSCMPReplyForSCMPError(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_invalid_segment_change.go
+++ b/go/integration/braccept/cases/scmp_invalid_segment_change.go
@@ -94,17 +94,8 @@ func SCMPParentToParentXover(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 911},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -275,17 +266,8 @@ func SCMPParentToChildXover(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 811, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -457,18 +439,9 @@ func SCMPChildToParentXover(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 911},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -640,18 +613,9 @@ func SCMPInternalXover(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	// sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_invalid_segment_change.go
+++ b/go/integration/braccept/cases/scmp_invalid_segment_change.go
@@ -94,8 +94,17 @@ func SCMPParentToParentXover(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 911},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -266,8 +275,17 @@ func SCMPParentToChildXover(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 811, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -439,9 +457,18 @@ func SCMPChildToParentXover(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 911},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -613,9 +640,18 @@ func SCMPInternalXover(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	// sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_invalid_segment_change_local.go
+++ b/go/integration/braccept/cases/scmp_invalid_segment_change_local.go
@@ -94,8 +94,17 @@ func SCMPParentToParentLocalXover(artifactsDir string, mac hash.Hash) runner.Cas
 			{ConsIngress: 0, ConsEgress: 311},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -266,8 +275,17 @@ func SCMPParentToChildLocalXover(artifactsDir string, mac hash.Hash) runner.Case
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -439,9 +457,18 @@ func SCMPChildToParentLocalXover(artifactsDir string, mac hash.Hash) runner.Case
 			{ConsIngress: 0, ConsEgress: 311},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_invalid_segment_change_local.go
+++ b/go/integration/braccept/cases/scmp_invalid_segment_change_local.go
@@ -94,17 +94,8 @@ func SCMPParentToParentLocalXover(artifactsDir string, mac hash.Hash) runner.Cas
 			{ConsIngress: 0, ConsEgress: 311},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -275,17 +266,8 @@ func SCMPParentToChildLocalXover(artifactsDir string, mac hash.Hash) runner.Case
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -457,18 +439,9 @@ func SCMPChildToParentLocalXover(artifactsDir string, mac hash.Hash) runner.Case
 			{ConsIngress: 0, ConsEgress: 311},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_traceroute.go
+++ b/go/integration/braccept/cases/scmp_traceroute.go
@@ -81,7 +81,12 @@ func SCMPTracerouteIngress(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 211},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{
@@ -222,7 +227,12 @@ func SCMPTracerouteIngressConsDir(artifactsDir string, mac hash.Hash) runner.Cas
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -367,7 +377,11 @@ func SCMPTracerouteEgress(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 211},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], make([]byte, 16))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{
@@ -508,7 +522,12 @@ func SCMPTracerouteEgressConsDir(artifactsDir string, mac hash.Hash) runner.Case
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -666,9 +685,18 @@ func SCMPTracerouteEgressAfterXover(artifactsDir string, mac hash.Hash) runner.C
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], make([]byte,
+		path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2])
+	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], make([]byte,
+		path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -810,7 +838,12 @@ func SCMPTracerouteInternal(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[0].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[0])
+	var err error
+	sp.HopFields[0].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[0],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_traceroute.go
+++ b/go/integration/braccept/cases/scmp_traceroute.go
@@ -81,12 +81,7 @@ func SCMPTracerouteIngress(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 211},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{
@@ -227,12 +222,7 @@ func SCMPTracerouteIngressConsDir(artifactsDir string, mac hash.Hash) runner.Cas
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -377,11 +367,7 @@ func SCMPTracerouteEgress(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 211},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{
@@ -522,12 +508,7 @@ func SCMPTracerouteEgressConsDir(artifactsDir string, mac hash.Hash) runner.Case
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -685,18 +666,9 @@ func SCMPTracerouteEgressAfterXover(artifactsDir string, mac hash.Hash) runner.C
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], make([]byte,
-		path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
-	sp.HopFields[2].Mac, err = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], make([]byte,
-		path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[2].Mac = path.MAC(mac, sp.InfoFields[1], sp.HopFields[2], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -838,12 +810,7 @@ func SCMPTracerouteInternal(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[0].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[0],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[0].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[0], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_traceroute.go
+++ b/go/integration/braccept/cases/scmp_traceroute.go
@@ -378,7 +378,7 @@ func SCMPTracerouteEgress(artifactsDir string, mac hash.Hash) runner.Case {
 		},
 	}
 	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], make([]byte, 16))
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], make([]byte, path.MACBufferSize))
 	if err != nil {
 		panic(err)
 	}

--- a/go/integration/braccept/cases/scmp_unknown_hop.go
+++ b/go/integration/braccept/cases/scmp_unknown_hop.go
@@ -93,12 +93,7 @@ func SCMPUnknownHop(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -253,12 +248,7 @@ func SCMPUnknownHopEgress(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 161, ConsEgress: 0},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/scmp_unknown_hop.go
+++ b/go/integration/braccept/cases/scmp_unknown_hop.go
@@ -93,7 +93,12 @@ func SCMPUnknownHop(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 411, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,
@@ -248,7 +253,12 @@ func SCMPUnknownHopEgress(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 161, ConsEgress: 0},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/svc.go
+++ b/go/integration/braccept/cases/svc.go
@@ -84,12 +84,7 @@ func SVC(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 141},
 		},
 	}
-	var err error
-	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/cases/svc.go
+++ b/go/integration/braccept/cases/svc.go
@@ -84,7 +84,12 @@ func SVC(artifactsDir string, mac hash.Hash) runner.Case {
 			{ConsIngress: 0, ConsEgress: 141},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1])
+	var err error
+	sp.HopFields[1].Mac, err = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/go/integration/braccept/runner/compare_test.go
+++ b/go/integration/braccept/runner/compare_test.go
@@ -81,7 +81,11 @@ func prepareSCION(t *testing.T, diff string) gopacket.Packet {
 			{ConsIngress: 0, ConsEgress: 311},
 		},
 	}
-	sp.HopFields[1].Mac = path.MAC(hash(), sp.InfoFields[0], sp.HopFields[1])
+	sp.HopFields[1].Mac, err = path.MAC(hash(), sp.InfoFields[0], sp.HopFields[1],
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{

--- a/go/integration/braccept/runner/compare_test.go
+++ b/go/integration/braccept/runner/compare_test.go
@@ -81,11 +81,7 @@ func prepareSCION(t *testing.T, diff string) gopacket.Packet {
 			{ConsIngress: 0, ConsEgress: 311},
 		},
 	}
-	sp.HopFields[1].Mac, err = path.MAC(hash(), sp.InfoFields[0], sp.HopFields[1],
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		panic(err)
-	}
+	sp.HopFields[1].Mac = path.MAC(hash(), sp.InfoFields[0], sp.HopFields[1], nil)
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	scionL := &slayers.SCION{

--- a/go/lib/epic/epic.go
+++ b/go/lib/epic/epic.go
@@ -37,7 +37,11 @@ const (
 	MaxClockSkew time.Duration = time.Second
 	// TimestampResolution denotes the resolution of the epic timestamp
 	TimestampResolution = 21 * time.Microsecond
+	// MACBufferSize denotes the buffer size of the CBC input and output.
+	MACBufferSize = 64
 )
+
+var zeroInitVector = make([]byte, 16)
 
 // CreateTimestamp returns the epic timestamp, which encodes the current time (now) relative to the
 // input timestamp. The input timestamp must not be in the future (compared to the current time),
@@ -146,8 +150,6 @@ func initEpicMac(key []byte) (cipher.BlockMode, error) {
 		return nil, serrors.New("Unable to initialize AES cipher")
 	}
 
-	// Zero initialization vector
-	zeroInitVector := make([]byte, 16)
 	// CBC-MAC = CBC-Encryption with zero initialization vector
 	mode := cipher.NewCBCEncrypter(block, zeroInitVector)
 	return mode, nil

--- a/go/lib/epic/epic.go
+++ b/go/lib/epic/epic.go
@@ -204,5 +204,7 @@ func prepareMacInput(pktID epic.PktID, s *slayers.SCION, timestamp uint32,
 	copy(inputBuffer[offset:], srcAddr[:l])
 	offset += l
 	binary.BigEndian.PutUint16(inputBuffer[offset:], s.PayloadLen)
+	offset += 2
+	copy(inputBuffer[offset:inputLength], zeroInitVector)
 	return inputBuffer[:inputLength], nil
 }

--- a/go/lib/epic/epic.go
+++ b/go/lib/epic/epic.go
@@ -87,6 +87,9 @@ func VerifyTimestamp(timestamp time.Time, epicTS uint32, now time.Time) error {
 // CalcMac derives the EPIC MAC (PHVF/LHVF) given the full 16 bytes of the SCION path type
 // MAC (auth), the EPIC packet ID (pktID), the timestamp in the Info Field (timestamp),
 // and the SCION common/address header (s).
+// If the same buffer is provided in subsequent calls to this function, the previously returned
+// EPIC MAC may get overwritten. Only the most recently returned EPIC MAC is guaranteed to be
+// valid.
 func CalcMac(auth []byte, pktID epic.PktID, s *slayers.SCION,
 	timestamp uint32, buffer []byte) ([]byte, error) {
 

--- a/go/lib/epic/epic.go
+++ b/go/lib/epic/epic.go
@@ -91,8 +91,7 @@ func CalcMac(auth []byte, pktID epic.PktID, s *slayers.SCION,
 	timestamp uint32, inputBuffer []byte, outputBuffer []byte) ([]byte, error) {
 
 	if len(outputBuffer) < MACBufferSize {
-		return nil, serrors.New("output buffer too small", "provided", len(outputBuffer),
-			"expected", MACBufferSize)
+		outputBuffer = make([]byte, MACBufferSize)
 	}
 
 	// Initialize cryptographic MAC function
@@ -189,8 +188,7 @@ func prepareMacInput(pktID epic.PktID, s *slayers.SCION, timestamp uint32,
 	nrBlocks := int(math.Ceil((23 + float64(l)) / 16))
 	inputLength := 16 * nrBlocks
 	if len(inputBuffer) < inputLength {
-		return nil, serrors.New("input buffer too small", "provided", len(inputBuffer),
-			"expected", inputLength)
+		inputBuffer = make([]byte, inputLength)
 	}
 
 	// Fill input

--- a/go/lib/epic/epic_test.go
+++ b/go/lib/epic/epic_test.go
@@ -58,7 +58,8 @@ func TestPrepareMacInput(t *testing.T) {
 	for name, tc := range testCases {
 		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
-			got, err := libepic.PrepareMacInput(e.PktID, tc.ScionHeader, ts)
+			got, err := libepic.PrepareMacInput(e.PktID, tc.ScionHeader, ts,
+				make([]byte, libepic.MACBufferSize))
 			tc.errorFunc(t, err)
 			assert.Equal(t, tc.Want, got)
 		})
@@ -204,9 +205,11 @@ func TestVerifyHVF(t *testing.T) {
 	authLast := []byte("f5fcc4ce2250db36")
 
 	// Generate PHVF and LHVF
-	PHVF, err := libepic.CalcMac(authPenultimate, pktID, s, timestamp)
+	PHVF, err := libepic.CalcMac(authPenultimate, pktID, s, timestamp,
+		make([]byte, libepic.MACBufferSize), make([]byte, libepic.MACBufferSize))
 	assert.NoError(t, err)
-	LHVF, err := libepic.CalcMac(authLast, pktID, s, timestamp)
+	LHVF, err := libepic.CalcMac(authLast, pktID, s, timestamp,
+		make([]byte, libepic.MACBufferSize), make([]byte, libepic.MACBufferSize))
 	assert.NoError(t, err)
 
 	testCases := map[string]struct {
@@ -319,7 +322,8 @@ func TestVerifyHVF(t *testing.T) {
 		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
 			err = libepic.VerifyHVF(tc.Authenticator, tc.PktID,
-				tc.ScionHeader, tc.Timestamp, tc.HVF)
+				tc.ScionHeader, tc.Timestamp, tc.HVF,
+				make([]byte, libepic.MACBufferSize), make([]byte, libepic.MACBufferSize))
 			tc.errorFunc(t, err)
 		})
 	}

--- a/go/lib/epic/epic_test.go
+++ b/go/lib/epic/epic_test.go
@@ -205,11 +205,9 @@ func TestVerifyHVF(t *testing.T) {
 	authLast := []byte("f5fcc4ce2250db36")
 
 	// Generate PHVF and LHVF
-	PHVF, err := libepic.CalcMac(authPenultimate, pktID, s, timestamp,
-		make([]byte, libepic.MACBufferSize), make([]byte, libepic.MACBufferSize))
+	PHVF, err := libepic.CalcMac(authPenultimate, pktID, s, timestamp, nil, nil)
 	assert.NoError(t, err)
-	LHVF, err := libepic.CalcMac(authLast, pktID, s, timestamp,
-		make([]byte, libepic.MACBufferSize), make([]byte, libepic.MACBufferSize))
+	LHVF, err := libepic.CalcMac(authLast, pktID, s, timestamp, nil, nil)
 	assert.NoError(t, err)
 
 	testCases := map[string]struct {

--- a/go/lib/epic/epic_test.go
+++ b/go/lib/epic/epic_test.go
@@ -385,7 +385,6 @@ func createScionCmnAddrHdr() *slayers.SCION {
 	}
 	ip4Addr := &net.IPAddr{IP: net.ParseIP("10.0.0.100")}
 	spkt.SetSrcAddr(ip4Addr)
-	spkt.SrcAddrLen = 0
 	return spkt
 }
 

--- a/go/lib/epic/epic_test.go
+++ b/go/lib/epic/epic_test.go
@@ -38,16 +38,12 @@ func TestPrepareMacInput(t *testing.T) {
 		Want        []byte
 	}{
 		"Correct input": {
-			ScionHeader: createScionCmnAddrHdr(0),
+			ScionHeader: createScionCmnAddrHdr(),
 			errorFunc:   assert.NoError,
 			Want: []byte(
 				"\x00\x4a\xf9\xf0\x70\x00\x00\x00\x01\x02\x00\x00\x03" +
 					"\x00\x02\xff\x00\x00\x00\x02\x22\x0a\x00\x00\x64\x00\x78" +
 					"\x00\x00\x00\x00\x00"),
-		},
-		"Invalid source address length": {
-			ScionHeader: createScionCmnAddrHdr(3),
-			errorFunc:   assert.Error,
 		},
 		"SCION header nil": {
 			ScionHeader: nil,
@@ -58,10 +54,15 @@ func TestPrepareMacInput(t *testing.T) {
 	for name, tc := range testCases {
 		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
-			got, err := libepic.PrepareMacInput(e.PktID, tc.ScionHeader, ts,
-				make([]byte, libepic.MACBufferSize))
+			inputBuffer := make([]byte, libepic.MACBufferSize)
+			inputLength, err := libepic.PrepareMacInput(e.PktID, tc.ScionHeader, ts,
+				inputBuffer)
 			tc.errorFunc(t, err)
-			assert.Equal(t, tc.Want, got)
+
+			if err == nil {
+				got := inputBuffer[:inputLength]
+				assert.Equal(t, tc.Want, got)
+			}
 		})
 	}
 }
@@ -191,7 +192,7 @@ func TestVerifyTimestamp(t *testing.T) {
 
 func TestVerifyHVF(t *testing.T) {
 	// Create packet
-	s := createScionCmnAddrHdr(0)
+	s := createScionCmnAddrHdr()
 	now := time.Now().Truncate(time.Second)
 	timestamp := uint32(now.Add(-time.Minute).Unix())
 	epicTS, _ := libepic.CreateTimestamp(now.Add(-time.Minute), time.Now())
@@ -205,9 +206,9 @@ func TestVerifyHVF(t *testing.T) {
 	authLast := []byte("f5fcc4ce2250db36")
 
 	// Generate PHVF and LHVF
-	PHVF, err := libepic.CalcMac(authPenultimate, pktID, s, timestamp, nil, nil)
+	PHVF, err := libepic.CalcMac(authPenultimate, pktID, s, timestamp, nil)
 	assert.NoError(t, err)
-	LHVF, err := libepic.CalcMac(authLast, pktID, s, timestamp, nil, nil)
+	LHVF, err := libepic.CalcMac(authLast, pktID, s, timestamp, nil)
 	assert.NoError(t, err)
 
 	testCases := map[string]struct {
@@ -321,7 +322,7 @@ func TestVerifyHVF(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err = libepic.VerifyHVF(tc.Authenticator, tc.PktID,
 				tc.ScionHeader, tc.Timestamp, tc.HVF,
-				make([]byte, libepic.MACBufferSize), make([]byte, libepic.MACBufferSize))
+				make([]byte, libepic.MACBufferSize))
 			tc.errorFunc(t, err)
 		})
 	}
@@ -377,14 +378,14 @@ func TestCoreFromPktCounter(t *testing.T) {
 	}
 }
 
-func createScionCmnAddrHdr(srcAddrLen slayers.AddrLen) *slayers.SCION {
+func createScionCmnAddrHdr() *slayers.SCION {
 	spkt := &slayers.SCION{
 		SrcIA:      xtest.MustParseIA("2-ff00:0:222"),
 		PayloadLen: 120,
 	}
 	ip4Addr := &net.IPAddr{IP: net.ParseIP("10.0.0.100")}
 	spkt.SetSrcAddr(ip4Addr)
-	spkt.SrcAddrLen = srcAddrLen
+	spkt.SrcAddrLen = 0
 	return spkt
 }
 

--- a/go/lib/epic/export_test.go
+++ b/go/lib/epic/export_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/scionproto/scion/go/lib/slayers/path/epic"
 )
 
-func PrepareMacInput(pktID epic.PktID, s *slayers.SCION, timestamp uint32) ([]byte, error) {
-	return prepareMacInput(pktID, s, timestamp)
+func PrepareMacInput(pktID epic.PktID, s *slayers.SCION, timestamp uint32,
+	inputBuffer []byte) ([]byte, error) {
+
+	return prepareMacInput(pktID, s, timestamp, inputBuffer)
 }

--- a/go/lib/epic/export_test.go
+++ b/go/lib/epic/export_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func PrepareMacInput(pktID epic.PktID, s *slayers.SCION, timestamp uint32,
-	inputBuffer []byte) ([]byte, error) {
+	inputBuffer []byte) (int, error) {
 
 	return prepareMacInput(pktID, s, timestamp, inputBuffer)
 }

--- a/go/lib/slayers/path/mac.go
+++ b/go/lib/slayers/path/mac.go
@@ -24,27 +24,29 @@ const MACBufferSize = 16
 // MAC calculates the HopField MAC according to
 // https://scion.docs.anapaya.net/en/latest/protocols/scion-header.html#hop-field-mac-computation
 // this method does not modify info or hf.
-func MAC(h hash.Hash, info *InfoField, hf *HopField, inputBuffer []byte) []byte {
-	return FullMAC(h, info, hf, inputBuffer)[0:6]
+// Modifying the provided buffer after calling this function may change the returned HopField MAC.
+func MAC(h hash.Hash, info *InfoField, hf *HopField, buffer []byte) []byte {
+	return FullMAC(h, info, hf, buffer)[0:6]
 }
 
 // FullMAC calculates the HopField MAC according to
 // https://scion.docs.anapaya.net/en/latest/protocols/scion-header.html#hop-field-mac-computation
 // this method does not modify info or hf.
+// Modifying the provided buffer after calling this function may change the returned HopField MAC.
 // In contrast to MAC(), FullMAC returns all the 16 bytes instead of only 6 bytes of the MAC.
-func FullMAC(h hash.Hash, info *InfoField, hf *HopField, inputBuffer []byte) []byte {
-	if len(inputBuffer) < MACBufferSize {
-		inputBuffer = make([]byte, MACBufferSize)
+func FullMAC(h hash.Hash, info *InfoField, hf *HopField, buffer []byte) []byte {
+	if len(buffer) < MACBufferSize {
+		buffer = make([]byte, MACBufferSize)
 	}
 
 	h.Reset()
 	MACInput(info.SegID, info.Timestamp, hf.ExpTime,
-		hf.ConsIngress, hf.ConsEgress, inputBuffer)
+		hf.ConsIngress, hf.ConsEgress, buffer)
 	// Write must not return an error: https://godoc.org/hash#Hash
-	if _, err := h.Write(inputBuffer); err != nil {
+	if _, err := h.Write(buffer); err != nil {
 		panic(err)
 	}
-	return h.Sum(nil)[:16]
+	return h.Sum(buffer[:0])[:16]
 }
 
 // MACInput returns the MAC input data block with the following layout:

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -63,11 +63,7 @@ func NewOneHop(egress uint16, timestamp time.Time, expiration uint8, mac hash.Ha
 			ExpTime:    expiration,
 		},
 	}
-	ohp.FirstHop.Mac, err = path.MAC(mac, &ohp.Info, &ohp.FirstHop,
-		make([]byte, path.MACBufferSize))
-	if err != nil {
-		return Path{}, err
-	}
+	ohp.FirstHop.Mac = path.MAC(mac, &ohp.Info, &ohp.FirstHop, nil)
 
 	raw := make([]byte, onehop.PathLen)
 	if err := ohp.SerializeTo(raw); err != nil {

--- a/go/lib/spath/path.go
+++ b/go/lib/spath/path.go
@@ -63,7 +63,11 @@ func NewOneHop(egress uint16, timestamp time.Time, expiration uint8, mac hash.Ha
 			ExpTime:    expiration,
 		},
 	}
-	ohp.FirstHop.Mac = path.MAC(mac, &ohp.Info, &ohp.FirstHop)
+	ohp.FirstHop.Mac, err = path.MAC(mac, &ohp.Info, &ohp.FirstHop,
+		make([]byte, path.MACBufferSize))
+	if err != nil {
+		return Path{}, err
+	}
 
 	raw := make([]byte, onehop.PathLen)
 	if err := ohp.SerializeTo(raw); err != nil {

--- a/go/pkg/gateway/control/fake/config.go
+++ b/go/pkg/gateway/control/fake/config.go
@@ -261,7 +261,10 @@ func parsePath(rawPath rawPath, creationTime time.Time) (snet.Path, error) {
 		if err != nil {
 			return nil, err
 		}
-		hf.Mac = path.MAC(macGen(), sp.InfoFields[0], hf)
+		hf.Mac, err = path.MAC(macGen(), sp.InfoFields[0], hf, make([]byte, path.MACBufferSize))
+		if err != nil {
+			return nil, err
+		}
 		sp.InfoFields[0].UpdateSegID(hf.Mac)
 	}
 	sp.InfoFields[0].SegID = initialSegID

--- a/go/pkg/gateway/control/fake/config.go
+++ b/go/pkg/gateway/control/fake/config.go
@@ -261,10 +261,7 @@ func parsePath(rawPath rawPath, creationTime time.Time) (snet.Path, error) {
 		if err != nil {
 			return nil, err
 		}
-		hf.Mac, err = path.MAC(macGen(), sp.InfoFields[0], hf, make([]byte, path.MACBufferSize))
-		if err != nil {
-			return nil, err
-		}
+		hf.Mac = path.MAC(macGen(), sp.InfoFields[0], hf, nil)
 		sp.InfoFields[0].UpdateSegID(hf.Mac)
 	}
 	sp.InfoFields[0].SegID = initialSegID

--- a/go/pkg/router/dataplane.go
+++ b/go/pkg/router/dataplane.go
@@ -547,10 +547,10 @@ type processResult struct {
 
 func newPacketProcessor(d *DataPlane, ingressID uint16) *scionPacketProcessor {
 	return &scionPacketProcessor{
-		d:          d,
-		ingressID:  ingressID,
-		buffer:     gopacket.NewSerializeBuffer(),
-		mac:        d.macFactory(),
+		d:         d,
+		ingressID: ingressID,
+		buffer:    gopacket.NewSerializeBuffer(),
+		mac:       d.macFactory(),
 		macBuffers: macBuffers{
 			scionInput: make([]byte, path.MACBufferSize),
 			epicInput:  make([]byte, libepic.MACBufferSize),

--- a/go/pkg/router/dataplane.go
+++ b/go/pkg/router/dataplane.go
@@ -914,10 +914,7 @@ func (p *scionPacketProcessor) currentHopPointer() uint16 {
 }
 
 func (p *scionPacketProcessor) verifyCurrentMAC() (processResult, error) {
-	fullMac, err := path.FullMAC(p.mac, p.infoField, p.hopField, p.macBuffers.scionInput)
-	if err != nil {
-		return processResult{}, err
-	}
+	fullMac := path.FullMAC(p.mac, p.infoField, p.hopField, p.macBuffers.scionInput)
 	if subtle.ConstantTimeCompare(p.hopField.Mac[:path.MacLen], fullMac[:path.MacLen]) == 0 {
 		return p.packSCMP(
 			&slayers.SCMP{TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem,
@@ -1231,10 +1228,7 @@ func (p *scionPacketProcessor) processOHP() (processResult, error) {
 				"type", "ohp", "egress", ohp.FirstHop.ConsEgress,
 				"neighborIA", neighborIA, "dstIA", s.DstIA)
 		}
-		mac, err := path.MAC(p.mac, &ohp.Info, &ohp.FirstHop, p.macBuffers.scionInput)
-		if err != nil {
-			return processResult{}, err
-		}
+		mac := path.MAC(p.mac, &ohp.Info, &ohp.FirstHop, p.macBuffers.scionInput)
 		if subtle.ConstantTimeCompare(ohp.FirstHop.Mac[:path.MacLen], mac) == 0 {
 			// TODO parameter problem -> invalid MAC
 			return processResult{}, serrors.New("MAC", "expected", fmt.Sprintf("%x", mac),
@@ -1273,11 +1267,7 @@ func (p *scionPacketProcessor) processOHP() (processResult, error) {
 		ConsIngress: p.ingressID,
 		ExpTime:     ohp.FirstHop.ExpTime,
 	}
-	var err error
-	ohp.SecondHop.Mac, err = path.MAC(p.mac, &ohp.Info, &ohp.SecondHop, p.macBuffers.scionInput)
-	if err != nil {
-		return processResult{}, err
-	}
+	ohp.SecondHop.Mac = path.MAC(p.mac, &ohp.Info, &ohp.SecondHop, p.macBuffers.scionInput)
 
 	if err := updateSCIONLayer(p.rawPkt, s, p.buffer); err != nil {
 		return processResult{}, err
@@ -1380,12 +1370,7 @@ func (b *bfdSend) Send(bfd *layers.BFD) error {
 				ExpTime:    hopFieldDefaultExpTime,
 			},
 		}
-		var err error
-		ohp.FirstHop.Mac, err = path.MAC(b.mac, &ohp.Info, &ohp.FirstHop,
-			make([]byte, path.MACBufferSize))
-		if err != nil {
-			return err
-		}
+		ohp.FirstHop.Mac = path.MAC(b.mac, &ohp.Info, &ohp.FirstHop, nil)
 		scn.PathType = onehop.PathType
 		scn.Path = ohp
 	}

--- a/go/pkg/router/dataplane.go
+++ b/go/pkg/router/dataplane.go
@@ -551,10 +551,9 @@ func newPacketProcessor(d *DataPlane, ingressID uint16) *scionPacketProcessor {
 		ingressID:  ingressID,
 		buffer:     gopacket.NewSerializeBuffer(),
 		mac:        d.macFactory(),
-		macBuffers: &macBuffers{
+		macBuffers: macBuffers{
 			scionInput: make([]byte, path.MACBufferSize),
 			epicInput:  make([]byte, libepic.MACBufferSize),
-			epicOutput: make([]byte, libepic.MACBufferSize),
 		},
 	}
 }
@@ -707,7 +706,7 @@ func (p *scionPacketProcessor) processEPIC() (processResult, error) {
 			HVF = epicPath.LHVF
 		}
 		err = libepic.VerifyHVF(p.cachedMac, epicPath.PktID, &p.scionLayer, info.Timestamp, HVF,
-			p.macBuffers.epicInput, p.macBuffers.epicOutput)
+			p.macBuffers.epicInput)
 		if err != nil {
 			// TODO(mawyss): Send back SCMP packet
 			return processResult{}, err
@@ -753,14 +752,13 @@ type scionPacketProcessor struct {
 	// For a hop performing an Xover, it is the MAC corresponding to the down segment.
 	cachedMac []byte
 	// macBuffers avoid allocating memory during processing.
-	macBuffers *macBuffers
+	macBuffers macBuffers
 }
 
 // macBuffers are preallocated buffers for the in- and outputs of MAC functions.
 type macBuffers struct {
 	scionInput []byte
 	epicInput  []byte
-	epicOutput []byte
 }
 
 func (p *scionPacketProcessor) packSCMP(scmpH *slayers.SCMP, scmpP gopacket.SerializableLayer,

--- a/go/pkg/router/dataplane.go
+++ b/go/pkg/router/dataplane.go
@@ -706,7 +706,8 @@ func (p *scionPacketProcessor) processEPIC() (processResult, error) {
 		if isLast {
 			HVF = epicPath.LHVF
 		}
-		err = libepic.VerifyHVF(p.cachedMac, epicPath.PktID, &p.scionLayer, info.Timestamp, HVF)
+		err = libepic.VerifyHVF(p.cachedMac, epicPath.PktID, &p.scionLayer, info.Timestamp, HVF,
+			p.macBuffers.epicInput, p.macBuffers.epicOutput)
 		if err != nil {
 			// TODO(mawyss): Send back SCMP packet
 			return processResult{}, err

--- a/go/pkg/router/dataplane_test.go
+++ b/go/pkg/router/dataplane_test.go
@@ -1286,7 +1286,8 @@ func prepareEpicCrypto(t *testing.T, spkt *slayers.SCION,
 
 	// Calculate PHVF and LHVF
 	macLast, err := libepic.CalcMac(authLast, epicpath.PktID,
-		spkt, dpath.InfoFields[0].Timestamp)
+		spkt, dpath.InfoFields[0].Timestamp,
+		make([]byte, libepic.MACBufferSize), make([]byte, libepic.MACBufferSize))
 	require.NoError(t, err)
 	copy(epicpath.LHVF, macLast)
 }

--- a/go/pkg/router/dataplane_test.go
+++ b/go/pkg/router/dataplane_test.go
@@ -1286,8 +1286,7 @@ func prepareEpicCrypto(t *testing.T, spkt *slayers.SCION,
 
 	// Calculate PHVF and LHVF
 	macLast, err := libepic.CalcMac(authLast, epicpath.PktID,
-		spkt, dpath.InfoFields[0].Timestamp,
-		make([]byte, libepic.MACBufferSize), make([]byte, libepic.MACBufferSize))
+		spkt, dpath.InfoFields[0].Timestamp, nil, nil)
 	require.NoError(t, err)
 	copy(epicpath.LHVF, macLast)
 }
@@ -1307,17 +1306,13 @@ func toIP(t *testing.T, spkt *slayers.SCION, path path.Path, afterProcessing boo
 func computeMAC(t *testing.T, key []byte, info *path.InfoField, hf *path.HopField) []byte {
 	mac, err := scrypto.InitMac(key)
 	require.NoError(t, err)
-	output, err := path.MAC(mac, info, hf, make([]byte, path.MACBufferSize))
-	require.NoError(t, err)
-	return output
+	return path.MAC(mac, info, hf, nil)
 }
 
 func computeFullMAC(t *testing.T, key []byte, info *path.InfoField, hf *path.HopField) []byte {
 	mac, err := scrypto.InitMac(key)
 	require.NoError(t, err)
-	output, err := path.FullMAC(mac, info, hf, make([]byte, path.MACBufferSize))
-	require.NoError(t, err)
-	return output
+	return path.FullMAC(mac, info, hf, nil)
 }
 
 func bfd() control.BFD {

--- a/go/pkg/router/dataplane_test.go
+++ b/go/pkg/router/dataplane_test.go
@@ -1286,7 +1286,7 @@ func prepareEpicCrypto(t *testing.T, spkt *slayers.SCION,
 
 	// Calculate PHVF and LHVF
 	macLast, err := libepic.CalcMac(authLast, epicpath.PktID,
-		spkt, dpath.InfoFields[0].Timestamp, nil, nil)
+		spkt, dpath.InfoFields[0].Timestamp, nil)
 	require.NoError(t, err)
 	copy(epicpath.LHVF, macLast)
 }

--- a/go/pkg/router/dataplane_test.go
+++ b/go/pkg/router/dataplane_test.go
@@ -1306,13 +1306,17 @@ func toIP(t *testing.T, spkt *slayers.SCION, path path.Path, afterProcessing boo
 func computeMAC(t *testing.T, key []byte, info *path.InfoField, hf *path.HopField) []byte {
 	mac, err := scrypto.InitMac(key)
 	require.NoError(t, err)
-	return path.MAC(mac, info, hf)
+	output, err := path.MAC(mac, info, hf, make([]byte, path.MACBufferSize))
+	require.NoError(t, err)
+	return output
 }
 
 func computeFullMAC(t *testing.T, key []byte, info *path.InfoField, hf *path.HopField) []byte {
 	mac, err := scrypto.InitMac(key)
 	require.NoError(t, err)
-	return path.FullMAC(mac, info, hf)
+	output, err := path.FullMAC(mac, info, hf, make([]byte, path.MACBufferSize))
+	require.NoError(t, err)
+	return output
 }
 
 func bfd() control.BFD {


### PR DESCRIPTION
This PR extends https://github.com/scionproto/scion/pull/4030/ with the suggested preallocation of the
SCION MAC input buffer. For this, FullMAC is changed to accept
the input buffer as argument.
Also the EPIC MAC buffers are now preallocated (both input and
output buffers, and the zero initialization vector). Only the AES-
cipher is still allocated for each packet. This is however
inherent to EPIC, because every packet can potentially have
a different authenticator (= key for the AES cipher).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4053)
<!-- Reviewable:end -->
