### PR TITLE
router: simplify SCMP reply handling

### DIFF
--- a/go/integration/braccept/runner/run.go
+++ b/go/integration/braccept/runner/run.go
@@ -139,6 +139,11 @@ func (c *RunConfig) ExpectPacket(pkt ExpectedPacket, normalizeFn NormalizePacket
 				"pkt", i, "expected", pkt.DevName, "actual", c.deviceNames[idx], "packet", got))
 			continue
 		}
+		if err := got.ErrorLayer(); err != nil {
+			errors = append(errors, serrors.WrapStr("error decoding packet", err.Error(),
+				"pkt", i))
+			continue
+		}
 		if err := comparePkts(got, pkt.Pkt, normalizeFn); err != nil {
 			errors = append(errors, serrors.WrapStr("received mismatching packet", err,
 				"pkt", i))

--- a/go/pkg/router/dataplane.go
+++ b/go/pkg/router/dataplane.go
@@ -925,9 +925,6 @@ func (p *scionPacketProcessor) updateNonConsDirIngressSegID() error {
 		if err := p.path.SetInfoField(p.infoField, int(p.path.PathMeta.CurrINF)); err != nil {
 			return serrors.WrapStr("update info field", err)
 		}
-		if err := updateSCIONLayer(p.rawPkt, p.scionLayer, p.buffer); err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -995,9 +992,6 @@ func (p *scionPacketProcessor) processEgress() error {
 		// TODO parameter problem invalid path
 		return serrors.WrapStr("incrementing path", err)
 	}
-	if err := updateSCIONLayer(p.rawPkt, p.scionLayer, p.buffer); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -1014,9 +1008,6 @@ func (p *scionPacketProcessor) doXover() (processResult, error) {
 	}
 	if p.infoField, err = p.path.GetCurrentInfoField(); err != nil {
 		// TODO parameter problem invalid path
-		return processResult{}, err
-	}
-	if err := updateSCIONLayer(p.rawPkt, p.scionLayer, p.buffer); err != nil {
 		return processResult{}, err
 	}
 	if r, err := p.validateHopExpiry(); err != nil {
@@ -1330,6 +1321,9 @@ func addEndhostPort(dst *net.IPAddr) *net.UDPAddr {
 	return &net.UDPAddr{IP: dst.IP, Port: topology.EndhostPort}
 }
 
+// TODO(matzf) this function is now only used to update the OneHop-path.
+// This should be changed so that the OneHop-path can be updated in-place, like
+// the scion.Raw path.
 func updateSCIONLayer(rawPkt []byte, s slayers.SCION, buffer gopacket.SerializeBuffer) error {
 	if err := buffer.Clear(); err != nil {
 		return err

--- a/go/pkg/router/dataplane_test.go
+++ b/go/pkg/router/dataplane_test.go
@@ -901,12 +901,10 @@ func TestProcessPkt(t *testing.T) {
 						Timestamp: 0x100,
 					},
 					FirstHop: path.HopField{
-						IngressRouterAlert: true,
-						EgressRouterAlert:  true,
-						ExpTime:            63,
-						ConsIngress:        0,
-						ConsEgress:         21,
-						Mac:                []byte{1, 2, 3, 4, 5, 6},
+						ExpTime:     63,
+						ConsIngress: 0,
+						ConsEgress:  21,
+						Mac:         []byte{1, 2, 3, 4, 5, 6},
 					},
 				}
 				if !afterProcessing {
@@ -999,18 +997,14 @@ func TestProcessPkt(t *testing.T) {
 						Timestamp: util.TimeToSecs(time.Now()),
 					},
 					FirstHop: path.HopField{
-						IngressRouterAlert: true,
-						EgressRouterAlert:  true,
-						ExpTime:            63,
-						ConsIngress:        0,
-						ConsEgress:         21,
-						Mac:                []byte{1, 2, 3, 4, 5, 6},
+						ExpTime:     63,
+						ConsIngress: 0,
+						ConsEgress:  21,
+						Mac:         []byte{1, 2, 3, 4, 5, 6},
 					},
 					SecondHop: path.HopField{
-						IngressRouterAlert: true,
-						EgressRouterAlert:  true,
-						ExpTime:            63,
-						ConsIngress:        1,
+						ExpTime:     63,
+						ConsIngress: 1,
 					},
 				}
 				dpath.SecondHop.Mac = computeMAC(t, key, &dpath.Info, &dpath.SecondHop)
@@ -1061,11 +1055,9 @@ func TestProcessPkt(t *testing.T) {
 						Timestamp: 0x100,
 					},
 					FirstHop: path.HopField{
-						IngressRouterAlert: true,
-						EgressRouterAlert:  true,
-						ExpTime:            63,
-						ConsIngress:        0,
-						ConsEgress:         2,
+						ExpTime:     63,
+						ConsIngress: 0,
+						ConsEgress:  2,
 					},
 				}
 				dpath.FirstHop.Mac = computeMAC(t, key, &dpath.Info, &dpath.FirstHop)


### PR DESCRIPTION
* Simplify the SCMP error reply quote
  Previously, an explicit copy of the input packet was made, so that it could be used in the quote for an SCMP error reply. But the path header of this quote was updated to the current processing state of the packet. This somewhat surprising step was done in order to have identical behaviour to anapayas VPP router.
   Now, the input packet is used for the quote directly, with the modifications from processing directly written back to it. The result is identical (with exception of router alert flag clearing mentioned below).
 
*  Parse/skip SCION extension headers from the beginning, so that the actual L4 protocol type is available when SCMP replies need to be sent.  Previously, the full packet was parsed again to determine whether the input packet was an SCMP error message.
  Also, handling traceroute packets now checks that the input packet was even an SCMP message.

* Simplify clearing router alert flags
  This step where the quoted packet was updated to the current processing state, mentioned above, was also responsible for clearing the router alert in traceroute replies.
  This is now done explicitly during processing, with the consequence that router alerts are always cleared, as was probably intended, also for non-traceroute packets.

  Some test cases fail because router flag is now reset during processing.
  Removed setting router alert in these test cases. Alternatively, we could check for the expected alert flag clearing in the test, but I think this is not really the scope of these test cases.

* Remove unnecessary updateSCIONLayer calls
  Unnecessary because SetInfoField etc directly write back to the Raw path and thus the input packet.

* braccept: dont panic on decode error


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4057)
<!-- Reviewable:end -->
