### PR TITLE
slayers: fix padding after TLV options

### DIFF
--- a/go/lib/slayers/extn.go
+++ b/go/lib/slayers/extn.go
@@ -144,8 +144,9 @@ func serializeTLVOptions(buf []byte, options []*tlvOption, fixLengths bool) int 
 		length += opt.length(fixLengths)
 	}
 	if fixLengths {
-		pad := length % LineLen
-		if pad != 0 {
+		p := length % LineLen
+		if p != 0 {
+			pad := LineLen - p
 			if !dryrun {
 				serializeTLVOptionPadding(buf[length-2:], pad)
 			}


### PR DESCRIPTION
Padding after the last TLV option is responsible for bringing the total length of the extension header to a multiple of the `LineLen`, i.e. to a multiple of 4 bytes.
The calculation for this padding was slightly wrong. It added `length % LineLen` instead of `LineLen - length % LineLen` padding bytes.
As a consequence, the total size of the extension was not padded to a multiple of 4 when a TLV option with odd length was used, triggering the corresponding error later during serialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4065)
<!-- Reviewable:end -->
