### PR TITLE
pktgen: truncate output file

### DIFF
--- a/go/pkg/pktgen/pcap.go
+++ b/go/pkg/pktgen/pcap.go
@@ -26,7 +26,7 @@ import (
 
 // StorePcap stores a Pcap file with the given raw packet and file name.
 func StorePcap(file string, pkt []byte) error {
-	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return serrors.WrapStr("creating file", err, "file", file)
 	}


### PR DESCRIPTION
Truncate the output file before writing to it. Without truncating, an
existing file may be only partially overwritten, leading to broken and
confusing capture files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4067)
<!-- Reviewable:end -->
