### PR TITLE
build: remove call to py_repositories() in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,10 +85,6 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_python/archive/0.2.0.tar.gz",
 )
 
-load("@rules_python//python:repositories.bzl", "py_repositories")
-
-py_repositories()
-
 load("@rules_python//python:pip.bzl", "pip_install")
 
 pip_install(


### PR DESCRIPTION
When building, `bazel` issues a message like:
```
DEBUG: /home/user/.cache/bazel/_bazel_user/cfce495ce828f2c59125c60e2bcbff5f/external/rules_python/python/repositories.bzl:8:10: py_repositories is a no-op and is deprecated. You can remove this from your WORKSPACE file
```
Calling `py_repositories` is deprecated.
Removing it seems to cause no harm and disables the message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4075)
<!-- Reviewable:end -->
