### PR TITLE
addr: add bounds-check when parsing HostTypeSVC

### DIFF
--- a/go/lib/addr/BUILD.bazel
+++ b/go/lib/addr/BUILD.bazel
@@ -14,7 +14,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["isdas_test.go"],
+    srcs = [
+        "host_test.go",
+        "isdas_test.go",
+    ],
     embed = [":go_default_library"],
     deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/go/lib/addr/host.go
+++ b/go/lib/addr/host.go
@@ -310,6 +310,9 @@ func HostFromRaw(b []byte, htype HostAddrType) (HostAddr, error) {
 		}
 		return HostIPv6(b[:HostLenIPv6]), nil
 	case HostTypeSVC:
+		if len(b) < HostLenSVC {
+			return nil, serrors.WithCtx(ErrMalformedHostAddrType, "type", htype)
+		}
 		return HostSVC(binary.BigEndian.Uint16(b)), nil
 	default:
 		return nil, serrors.WithCtx(ErrBadHostAddrType, "type", htype)

--- a/go/lib/addr/host_test.go
+++ b/go/lib/addr/host_test.go
@@ -18,8 +18,9 @@ import (
 	"net"
 	"testing"
 
-	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/scionproto/scion/go/lib/addr"
 )
 
 func TestHostFromRaw(t *testing.T) {

--- a/go/lib/addr/host_test.go
+++ b/go/lib/addr/host_test.go
@@ -1,0 +1,43 @@
+// Copyright 2016 ETH Zurich
+// Copyright 2020 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostFromRaw(t *testing.T) {
+	var testSlice = []byte{}
+	var hostAddrTypes = []struct {
+		name     string
+		addrType HostAddrType
+	}{
+		{"HostTypeIPv4", HostTypeIPv4},
+		{"HostTypeIPv6", HostTypeIPv6},
+		{"HostTypeSVC", HostTypeSVC},
+	}
+
+	t.Log("HostFromRaw should return a non-nil error when the length of the slice argument is less than expected")
+
+	for _, addrType := range hostAddrTypes {
+		t.Run(addrType.name, func(t *testing.T) {
+			_, err := HostFromRaw(testSlice, addrType.addrType)
+			assert.Error(t, err, "Must return non-nil error")
+		})
+	}
+}


### PR DESCRIPTION
Add a bounds-check when parsing a `HostTypeSVC` address.

Fixes #4080

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4081)
<!-- Reviewable:end -->
