### PR TITLE
addr: add bounds-check when parsing HostTypeSVC

### DIFF
--- a/go/lib/addr/BUILD.bazel
+++ b/go/lib/addr/BUILD.bazel
@@ -14,7 +14,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["isdas_test.go"],
+    srcs = [
+        "host_test.go",
+        "isdas_test.go",
+    ],
     embed = [":go_default_library"],
     deps = ["@com_github_stretchr_testify//assert:go_default_library"],
 )

--- a/go/lib/addr/host.go
+++ b/go/lib/addr/host.go
@@ -310,6 +310,9 @@ func HostFromRaw(b []byte, htype HostAddrType) (HostAddr, error) {
 		}
 		return HostIPv6(b[:HostLenIPv6]), nil
 	case HostTypeSVC:
+		if len(b) < HostLenSVC {
+			return nil, serrors.WithCtx(ErrMalformedHostAddrType, "type", htype)
+		}
 		return HostSVC(binary.BigEndian.Uint16(b)), nil
 	default:
 		return nil, serrors.WithCtx(ErrBadHostAddrType, "type", htype)

--- a/go/lib/addr/host_test.go
+++ b/go/lib/addr/host_test.go
@@ -1,0 +1,86 @@
+// Copyright 2021 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addr_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/scionproto/scion/go/lib/addr"
+)
+
+func TestHostFromRaw(t *testing.T) {
+	testCases := map[string]struct {
+		input        []byte
+		addrType     addr.HostAddrType
+		expected     addr.HostAddr
+		errAssertion assert.ErrorAssertionFunc
+	}{
+		"nil IPv4": {
+			addrType:     addr.HostTypeIPv4,
+			errAssertion: assert.Error,
+		},
+		"short IPv4": {
+			input:        make([]byte, 3),
+			addrType:     addr.HostTypeIPv4,
+			errAssertion: assert.Error,
+		},
+		"valid IPv4": {
+			input:        []byte{127, 0, 0, 1},
+			addrType:     addr.HostTypeIPv4,
+			expected:     addr.HostFromIP(net.IPv4(127, 0, 0, 1)),
+			errAssertion: assert.NoError,
+		},
+		"nil IPv6": {
+			addrType:     addr.HostTypeIPv6,
+			errAssertion: assert.Error,
+		},
+		"short IPv6": {
+			input:        make([]byte, 14),
+			addrType:     addr.HostTypeIPv6,
+			errAssertion: assert.Error,
+		},
+		"valid IPv6": {
+			input:        net.ParseIP("dead::beef"),
+			addrType:     addr.HostTypeIPv6,
+			expected:     addr.HostFromIP(net.ParseIP("dead::beef")),
+			errAssertion: assert.NoError,
+		},
+		"nil SVC": {
+			addrType:     addr.HostTypeSVC,
+			errAssertion: assert.Error,
+		},
+		"short SVC": {
+			input:        make([]byte, 1),
+			addrType:     addr.HostTypeSVC,
+			errAssertion: assert.Error,
+		},
+		"valid SVC": {
+			input:        addr.SvcDS.Pack(),
+			addrType:     addr.HostTypeSVC,
+			expected:     addr.SvcDS,
+			errAssertion: assert.NoError,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := addr.HostFromRaw(tc.input, tc.addrType)
+			tc.errAssertion(t, err)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
Add a bounds-check when parsing a `HostTypeSVC` address.

Fixes #4080
Closes #4081

GitOrigin-RevId: eb035aef1d31b14d3aa1a3de8b5f4e88ba884f91

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4086)
<!-- Reviewable:end -->
