### PR TITLE
dispatcher/snet: reduce packet buffer size

### DIFF
--- a/go/dispatcher/internal/respool/buffer.go
+++ b/go/dispatcher/internal/respool/buffer.go
@@ -26,7 +26,7 @@ import (
 
 var bufferPool = sync.Pool{
 	New: func() interface{} {
-		return make([]byte, common.MaxMTU)
+		return make([]byte, common.SupportedMTU)
 	},
 }
 
@@ -36,7 +36,7 @@ func GetBuffer() []byte {
 }
 
 func PutBuffer(b []byte) {
-	if cap(b) == common.MaxMTU {
+	if cap(b) == common.SupportedMTU {
 		bufferPool.Put(b)
 	}
 }

--- a/go/lib/common/defs.go
+++ b/go/lib/common/defs.go
@@ -23,11 +23,15 @@ import (
 
 const (
 	// LineLen is the number of bytes that all SCION headers are padded to a multiple of.
-	LineLen     = 8
-	MinMTU      = 1280
-	MaxMTU      = (1 << 16) - 1
-	TimeFmt     = "2006-01-02 15:04:05.000000-0700"
-	TimeFmtSecs = "2006-01-02 15:04:05-0700"
+	LineLen = 8
+	MinMTU  = 1280
+	MaxMTU  = (1 << 16) - 1
+	// SupportedMTU is the MTU supported by dispatcher/snet and router.
+	// Smaller than MaxMTU to avoid excessive overallocation for packet buffers.
+	// It's chosen as a common ethernet jumbo frame size minus IP/UDP headers.
+	SupportedMTU = 9216 - 20 - 8
+	TimeFmt      = "2006-01-02 15:04:05.000000-0700"
+	TimeFmtSecs  = "2006-01-02 15:04:05-0700"
 )
 
 const (

--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -24,8 +24,10 @@ import (
 )
 
 const (
-	// BufSize is the receive and send buffer sizes
-	BufSize = 1<<16 - 1
+	// defBufSize is the receive and send buffer sizes
+	// The theoretical maximum MTU is 64K, but we only support up to Ethernet
+	// jumbo frames (9K minus IP/UDP header) to avoid excessive overallocation.
+	defBufSize = 9000 - 20 - 8
 )
 
 type OpError struct {

--- a/go/lib/snet/conn.go
+++ b/go/lib/snet/conn.go
@@ -23,13 +23,6 @@ import (
 	"github.com/scionproto/scion/go/lib/slayers"
 )
 
-const (
-	// defBufSize is the receive and send buffer sizes
-	// The theoretical maximum MTU is 64K, but we only support up to Ethernet
-	// jumbo frames (9K minus IP/UDP header) to avoid excessive overallocation.
-	defBufSize = 9000 - 20 - 8
-)
-
 type OpError struct {
 	typeCode slayers.SCMPTypeCode
 	revInfo  *path_mgmt.RevInfo

--- a/go/lib/snet/reader.go
+++ b/go/lib/snet/reader.go
@@ -35,7 +35,7 @@ func newScionConnReader(base *scionConnBase, conn PacketConn) *scionConnReader {
 	return &scionConnReader{
 		base:   base,
 		conn:   conn,
-		buffer: make([]byte, common.MaxMTU),
+		buffer: make([]byte, common.SupportedMTU),
 	}
 }
 

--- a/go/lib/snet/writer.go
+++ b/go/lib/snet/writer.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/serrors"
 	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/lib/topology/underlay"
@@ -40,7 +41,7 @@ func newScionConnWriter(base *scionConnBase, conn PacketConn) *scionConnWriter {
 	return &scionConnWriter{
 		base:   base,
 		conn:   conn,
-		buffer: make([]byte, defBufSize),
+		buffer: make([]byte, common.SupportedMTU),
 	}
 }
 

--- a/go/lib/snet/writer.go
+++ b/go/lib/snet/writer.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/serrors"
 	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/lib/topology/underlay"
@@ -41,7 +40,7 @@ func newScionConnWriter(base *scionConnBase, conn PacketConn) *scionConnWriter {
 	return &scionConnWriter{
 		base:   base,
 		conn:   conn,
-		buffer: make([]byte, common.MaxMTU),
+		buffer: make([]byte, defBufSize),
 	}
 }
 

--- a/go/lib/sock/reliable/packetizer.go
+++ b/go/lib/sock/reliable/packetizer.go
@@ -19,6 +19,7 @@ import (
 	"net"
 
 	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/serrors"
 )
 
@@ -26,7 +27,7 @@ import (
 //
 // FIXME(scrye): This will be deleted when we move to SEQPACKET.
 type ReadPacketizer struct {
-	buffer    [1 << 16]byte
+	buffer    [common.SupportedMTU]byte
 	data      []byte
 	freeSpace []byte
 	conn      net.Conn

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -83,7 +83,10 @@ var (
 const (
 	// DefaultDispPath contains the system default for a dispatcher socket.
 	DefaultDispPath = "/run/shm/dispatcher/default.sock"
-	defBufSize      = 1 << 18
+	// defBufSize is the buffer size
+	// The theoretical maximum MTU is 64K, but we only support up to Ethernet
+	// jumbo frames (9K minus IP/UDP header) to avoid excessive overallocation.
+	defBufSize = 9000 - 20 - 8
 	// DefaultDispSocketFileMode allows read/write to the user and group only.
 	DefaultDispSocketFileMode = 0770
 )

--- a/go/lib/sock/reliable/reliable.go
+++ b/go/lib/sock/reliable/reliable.go
@@ -70,6 +70,7 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/prom"
 	"github.com/scionproto/scion/go/lib/serrors"
@@ -83,10 +84,6 @@ var (
 const (
 	// DefaultDispPath contains the system default for a dispatcher socket.
 	DefaultDispPath = "/run/shm/dispatcher/default.sock"
-	// defBufSize is the buffer size
-	// The theoretical maximum MTU is 64K, but we only support up to Ethernet
-	// jumbo frames (9K minus IP/UDP header) to avoid excessive overallocation.
-	defBufSize = 9000 - 20 - 8
 	// DefaultDispSocketFileMode allows read/write to the user and group only.
 	DefaultDispSocketFileMode = 0770
 )
@@ -139,9 +136,9 @@ func newConn(c net.Conn) *Conn {
 	conn := c.(*net.UnixConn)
 	return &Conn{
 		UnixConn:       c.(*net.UnixConn),
-		writeBuffer:    make([]byte, defBufSize),
+		writeBuffer:    make([]byte, common.SupportedMTU),
 		writeStreamer:  NewWriteStreamer(conn),
-		readBuffer:     make([]byte, defBufSize),
+		readBuffer:     make([]byte, common.SupportedMTU),
 		readPacketizer: NewReadPacketizer(conn),
 	}
 }

--- a/go/pkg/gateway/control/grpc/probeserver.go
+++ b/go/pkg/gateway/control/grpc/probeserver.go
@@ -38,7 +38,7 @@ func (d *ProbeDispatcher) Listen(ctx context.Context, conn net.PacketConn) error
 	d.logInfo("ProbeDispatcher: starting")
 	defer d.logInfo("ProbeDispatcher: stopped")
 
-	buf := make([]byte, common.MaxMTU)
+	buf := make([]byte, common.SupportedMTU)
 	for {
 		select {
 		case <-ctx.Done():

--- a/go/pkg/gateway/control/sessionmonitor.go
+++ b/go/pkg/gateway/control/sessionmonitor.go
@@ -257,7 +257,7 @@ func (m *SessionMonitor) handleExpiration() {
 }
 
 func (m *SessionMonitor) drainConn() {
-	buf := make([]byte, common.MaxMTU)
+	buf := make([]byte, common.SupportedMTU)
 	for {
 		n, _, err := m.ProbeConn.ReadFrom(buf)
 		// XXX(karampok): The .ReadFrom(buf) is a blocking action and when


### PR DESCRIPTION
Excessively large packet buffer sizes were allocated in the dispatcher
and snet; for each connection, for both reading and writing a 256KB buffer
was allocated in the dispatcher, and 64KB in snet.
With e.g. the control service creating a large number of different
connections, the very large buffer allocations create a signficant
memory pressure, taking up 1G to 2G in both the the control service
and the dispatcher in our setups.

The theoretical maximum MTU for SCION is 64KB, but only up to 9KB
ethernet jumbo frames make practical sense. In fact, the router only
supports 9KB packets.

Reduced the buffer size to 9216 - 20 - 8 (ethernet jumbo frame payload,
minus IPv4/UDP header size) in the dispatcher, snet and in the router.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4090)
<!-- Reviewable:end -->
