### PR TITLE
cs: remove noisy debug log message on beacon loop

### DIFF
--- a/go/cs/beaconing/propagator.go
+++ b/go/cs/beaconing/propagator.go
@@ -270,8 +270,6 @@ func (p *propagator) extendAndSend(
 // interface because it creates a loop.
 func (p *propagator) shouldIgnore(bseg beacon.Beacon, intf *ifstate.Interface) bool {
 	if err := beacon.FilterLoop(bseg, intf.TopoInfo().IA, p.AllowIsdLoop); err != nil {
-		p.logger.Debug("Ignoring beacon on loop", "egress_interface",
-			intf.TopoInfo().ID, "err", err)
 		return true
 	}
 	return false


### PR DESCRIPTION
Every single beacon loop detected with FilterLoop was logged from the
propagator. In setups with large number of candidate beacons, this is
extremely noisy, making the debug log quite unusable.
The loop filter appears to be simple and clear enough, so that having
this information in the log would rarely ever seem helpful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4092)
<!-- Reviewable:end -->
