### PR TITLE
cs: persist TRCs to certs subdirectory

### DIFF
--- a/go/cs/main.go
+++ b/go/cs/main.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof"
+	"path/filepath"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -165,7 +166,7 @@ func realMain() error {
 	trustDB = truststoragefspersister.WrapDB(
 		trustDB,
 		truststoragefspersister.Config{
-			TRCDir: globalCfg.General.ConfigDir,
+			TRCDir: filepath.Join(globalCfg.General.ConfigDir, "certs"),
 			Metrics: truststoragefspersister.Metrics{
 				TRCFileWriteSuccesses: fileWrites.With(
 					prom.LabelResult,


### PR DESCRIPTION
The trustpersister configuration was such that TRCs were persisted to
the configuration directory root. Instead, they should be written
to the `certs/` subdirectory, where the loader will be looking for them.

According to @oncilla, the directory structure will eventually be changed
such that TRCs live in the `crypto/trcs/` subdirectory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4100)
<!-- Reviewable:end -->
