### PR TITLE
disp: add correct SCION next header for SCMP response

### DIFF
--- a/go/dispatcher/dispatcher/underlay.go
+++ b/go/dispatcher/dispatcher/underlay.go
@@ -304,6 +304,7 @@ func (h SCMPHandler) reverse(pkt *respool.Packet) ([]byte, error) {
 	if err := h.reverseSCION(pkt); err != nil {
 		return nil, err
 	}
+	pkt.SCION.NextHdr = common.L4SCMP
 	// FIXME(roosd): Consider moving this to a resource pool.
 	buf := gopacket.NewSerializeBuffer()
 	if err := pkt.SCMP.SetNetworkLayerForChecksum(&pkt.SCION); err != nil {

--- a/go/dispatcher/dispatcher/underlay.go
+++ b/go/dispatcher/dispatcher/underlay.go
@@ -304,6 +304,8 @@ func (h SCMPHandler) reverse(pkt *respool.Packet) ([]byte, error) {
 	if err := h.reverseSCION(pkt); err != nil {
 		return nil, err
 	}
+	// XXX(roosd): This does not take HBH and E2E extensions into consideration.
+	// See: https://github.com/scionproto/scion/issues/4128
 	pkt.SCION.NextHdr = common.L4SCMP
 	// FIXME(roosd): Consider moving this to a resource pool.
 	buf := gopacket.NewSerializeBuffer()


### PR DESCRIPTION
While the SCION dispatcher correctly parses SCMP packets that include extensions (e.g., SCION / HBH / SCMP), it sends back invalid responses, i.e., SCION / SCMP with the SCION next header field still set to the value corresponding to the extension header.
This PR explicitly sets the SCION next header field to the value corresponding to SCMP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4125)
<!-- Reviewable:end -->
