### PR TITLE
tools/build/doc: remove building from scion.sh topology

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -81,7 +81,9 @@ steps:
     if: build.message !~ /\[doc\]/
     parallelism: "${SCION_TESTING_FLAKE_PARALLELISM-1}"
     command:
-      - echo "--- start topology (including build)"
+      - echo "--- build"
+      - make
+      - echo "--- start topology"
       - ./scion.sh topology -c topology/default.topo
       - ./scion.sh run && sleep 10
       - echo "--- run tests"
@@ -105,7 +107,9 @@ steps:
     if: build.message !~ /\[doc\]/
     parallelism: "${SCION_TESTING_FLAKE_PARALLELISM-1}"
     command:
-      - echo "--- start topology (including build)"
+      - echo "--- build"
+      - make
+      - echo "--- start topology"
       - ./scion.sh topology -c topology/default-no-peers.topo
       - ./scion.sh run && sleep 10
       - echo "--- run tests"
@@ -129,7 +133,9 @@ steps:
     if: build.message !~ /\[doc\]/
     parallelism: "${SCION_TESTING_FLAKE_PARALLELISM-1}"
     command:
-      - echo "--- start topology (including build)"
+      - echo "--- build"
+      - make build docker-images
+      - echo "--- start topology"
       - ./scion.sh topology -d
       - ./scion.sh run
       - docker-compose -f gen/scion-dc.yml -p scion up -d $(docker-compose -f gen/scion-dc.yml config --services | grep tester)
@@ -154,8 +160,7 @@ steps:
     if: build.message !~ /\[doc\]/
     command:
       - echo "--- build"
-      - bazel build //:scion-topo >/dev/null 2>&1
-      - tar -xf bazel-bin/scion-topo.tar -C bin --overwrite
+      - make scion-topo
       - echo "--- run test"
       - mkdir -p /tmp/test-artifacts/trc-ceremony
       - export SAFEDIR="/tmp/test-artifacts/trc-ceremony"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
+.PHONY: all antlr bazel build clean docker-images gazelle golangci-lint licenses lint mocks protobuf scion-topo test
 
-.PHONY: all bazel clean gazelle licenses mocks protobuf antlr lint
 .NOTPARALLEL:
 
 GAZELLE_MODE?=fix
@@ -28,6 +28,16 @@ test:
 
 go_deps.bzl: go.mod
 	@tools/godeps.sh
+
+docker-images:
+	@echo "Build perapp images"
+	bazel run -c opt //docker:prod
+	@echo "Build scion tester"
+	bazel run //docker:test
+
+scion-topo:
+	bazel build //:scion-topo
+	tar --overwrite -xf bazel-bin/scion-topo.tar -C bin
 
 protobuf:
 	rm -rf bazel-bin/go/pkg/proto/*/go_default_library_/github.com/scionproto/scion/go/pkg/proto/*

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ antlr:
 	antlr/generate.sh $(GAZELLE_MODE)
 
 lint:
-	./scion.sh lint
+	tools/lint
 
 golangci-lint:
 	docker run --rm -v "${PWD}:/src" -w /src golangci/golangci-lint:v1.43.0 golangci-lint run --config=/src/.golangcilint.yml --timeout=3m go/...

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ go_deps.bzl: go.mod
 
 docker-images:
 	@echo "Build perapp images"
-	bazel run -c opt //docker:prod
+	bazel run //docker:prod
 	@echo "Build scion tester"
 	bazel run //docker:test
 

--- a/acceptance/common/scion.py
+++ b/acceptance/common/scion.py
@@ -46,7 +46,7 @@ class SCION(ABC):
     @LogExec(logger, 'running topology')
     def run(self):
         """ Run the scion infrastructure. """
-        self.scion_sh('run', 'nobuild')
+        self.scion_sh('run')
 
     @abstractmethod
     def execute(self, isd_as: ISD_AS, cmd: str, *args: str) -> str:

--- a/acceptance/reconnecting_acceptance/test
+++ b/acceptance/reconnecting_acceptance/test
@@ -11,8 +11,9 @@ TEST_TOPOLOGY="topology/tiny.topo"
 
 test_setup() {
     set -e
+    make scion-topo docker-images
     ./scion.sh topology -c $TEST_TOPOLOGY -d
-    ./scion.sh run nobuild
+    ./scion.sh run
     ./tools/dc start tester_1-ff00_0_112 tester_1-ff00_0_110
     docker_status
     sleep 10

--- a/acceptance/sigutil/common.sh
+++ b/acceptance/sigutil/common.sh
@@ -8,8 +8,9 @@ DST_IA=${DST_IA:-1-ff00:0:112}
 
 test_setup() {
     set -e
+    make scion-topo docker-images
     ./scion.sh topology -c $TEST_TOPOLOGY -d --sig -n 242.254.0.0/16
-    ./scion.sh run nobuild
+    ./scion.sh run
     ./tools/dc start 'tester*'
     sleep 20
     docker_status

--- a/python/topology/cert.py
+++ b/python/topology/cert.py
@@ -19,8 +19,9 @@
 import base64
 import collections
 import os
+import sys
 
-from plumbum import local
+from plumbum import local, CommandNotFound
 
 from python.topology import common
 from python.lib.util import write_file
@@ -39,7 +40,10 @@ class CertGenerator(object):
         self.args = args
         self.pki = local['./bin/scion-pki']
         if not local.path('./bin/scion-pki').exists():
-            self.pki = local[local.which('scion-pki')]
+            try:
+                self.pki = local[local.which('scion-pki')]
+            except CommandNotFound:
+                sys.exit("ERROR: scion-pki executable not found. Run `make` first.")
         self.core_count = collections.defaultdict(int)
 
     def generate(self, topo_dicts):

--- a/scion.sh
+++ b/scion.sh
@@ -38,14 +38,14 @@ cmd_topology() {
 }
 
 cmd_topodot() {
-		./tools/topodot.py "$@"
+    ./tools/topodot.py "$@"
 }
 
 cmd_run() {
     run_setup
     echo "Running the network..."
     if is_docker_be; then
-        docker-compose -f gen/scion-dc.yml -p scion up --build -d
+        docker-compose -f gen/scion-dc.yml -p scion up -d
         return 0
     fi
     ./tools/quiet ./supervisor/supervisor.sh start all

--- a/tools/lint
+++ b/tools/lint
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+set -o pipefail
+
+in_red() {
+    tput setaf 1
+    echo "$1"
+    tput sgr0
+}
+
+run_silently() {
+    tmpfile=$(mktemp /tmp/scion-silent.XXXXXX)
+    $@ >>$tmpfile 2>&1
+    if [ $? -ne 0 ]; then
+        cat $tmpfile
+        return 1
+    fi
+    return 0
+}
+
+go_lint() {
+    lint_header "go"
+    local TMPDIR=$(mktemp -d /tmp/scion-lint.XXXXXXX)
+    local LOCAL_DIRS="$(find go/* -maxdepth 0 -type d | grep -v vendor)"
+    # Find go files to lint, excluding generated code. For linelen and misspell.
+    find go acceptance -type f -iname '*.go' \
+      -a '!' -ipath '*.pb.go' \
+      -a '!' -ipath '*.gen.go' \
+      -a '!' -ipath 'go/scion-pki/certs/certinfo.go' \
+      -a '!' -ipath 'go/scion-pki/certs/certformat.go' \
+      -a '!' -ipath '*mock_*' > $TMPDIR/gofiles.list
+    lint_step "Building lint tools"
+
+    run_silently bazel build //:lint || return 1
+    tar -xf bazel-bin/lint.tar -C $TMPDIR || return 1
+    local ret=0
+    lint_step "gofmt"
+    # TODO(sustrik): At the moment there are no bazel rules for gofmt.
+    # See: https://github.com/bazelbuild/rules_go/issues/511
+    # Instead we'll just run the commands from Go SDK directly.
+    GOSDK=$(bazel info output_base 2>/dev/null)/external/go_sdk/bin
+    out=$($GOSDK/gofmt -d -s $LOCAL_DIRS ./acceptance);
+    if [ -n "$out" ]; then in_red "$out"; ret=1; fi
+    lint_step "linelen (lll)"
+    out=$($TMPDIR/lll -w 4 -l 100 --files -e '`comment:"|`ini:"|https?:|`sql:"|gorm:"|`json:"|`yaml:|nolint:lll' < $TMPDIR/gofiles.list)
+    if [ -n "$out" ]; then in_red "$out"; ret=1; fi
+    lint_step "misspell"
+    out=$(xargs -a $TMPDIR/gofiles.list $TMPDIR/misspell -error)
+    if [ -n "$out" ]; then in_red "$out"; ret=1; fi
+    lint_step "bazel"
+    run_silently make gazelle GAZELLE_MODE=diff || ret=1
+    bazel test --config lint || ret=1
+    # Clean up the binaries
+    rm -rf $TMPDIR
+    return $ret
+}
+
+protobuf_lint() {
+    lint_header "protobuf"
+    local TMPDIR=$(mktemp -d /tmp/scion-lint.XXXXXXX)
+    run_silently bazel build //:lint || return 1
+    tar -xf bazel-bin/lint.tar -C $TMPDIR || return 1
+    local ret=0
+    lint_step "check files"
+    $TMPDIR/buf check lint || return 1
+}
+
+bazel_lint() {
+    lint_header "bazel"
+    local ret=0
+    run_silently bazel run //:buildifier_check || ret=1
+    if [ $ret -ne 0 ]; then
+        printf "\nto fix run:\nbazel run //:buildifier\n"
+    fi
+    return $ret
+}
+
+md_lint() {
+    lint_header "markdown"
+    lint_step "mdlint"
+    ./tools/mdlint
+}
+
+semgrep_lint() {
+    lint_header "semgrep"
+    lint_step "custom rules"
+    docker run --rm -v "${PWD}:/src" returntocorp/semgrep@sha256:8b0735959a6eb737aa945f4d591b6db23b75344135d74c3021b7d427bd317a66 \
+        --config=/src/lint/semgrep
+}
+
+openapi_lint() {
+    lint_header "openapi"
+    lint_step "spectral"
+    make -C spec lint
+}
+
+lint_header() {
+    printf "\nlint $1\n==============\n"
+}
+
+lint_step() {
+    echo "======> $1"
+}
+
+ret=0
+go_lint || ret=1
+bazel_lint || ret=1
+protobuf_lint || ret=1
+md_lint || ret=1
+semgrep_lint || ret=1
+openapi_lint || ret=1
+exit $ret


### PR DESCRIPTION
The command `scion.sh topology` and `run` have automatically invoked a
build. The `scion.sh topology` command  has so featured in the setup
documentation as the one command to build everything. This has led to
various very confused questions from newcommers to the project.
At the same time, I have not found that building automatically in these
commands is helpful for my workflow.

tools/build:

Remove the build steps from `scion.sh topology` and `scion.sh run`.
At the same time, remove various broken/unnecessary/useless subcommands
from scion.sh.
Add make targets to build `scion-pki` and the docker images, for running
the docker-composed based local topology.
Move lint steps from `scion.sh` to a separate script `tools/lint`.
The idea is that scion.sh is responsible really only for the machinery
related to running a local topology. All the build related steps should
be in the Makefile -- we still  `bazel_remote` subcommand left which
doesn't fit the pattern, and this could also be cleaned up later.

ci:

Adapt a small number of CI pipeline steps to explicitly perform a build
before invoking `scion.sh topology`

doc:

Adapt the setup documentation to the changes above, i.e. split building
from running.

Split the information about running a local topology into a separate
subsection. Add a step describing how to use the `--sciond` parameter
for e.g. `scion showpaths` (another frequent question from newcommers).
To simplify the description and usage of this, a new subcommand
`sciond-addr` was added to `scion.sh`.

Add a subsection to describe building with go build. This fits in
relatively cleanly now, as the `scion.sh topology` script does not
overwrite everything by attempting to build with bazel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4141)
<!-- Reviewable:end -->
