### PR TITLE
router/bfd: reduce allocations, prometheus metrics

### DIFF
--- a/go/pkg/router/BUILD.bazel
+++ b/go/pkg/router/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//go/lib/common:go_default_library",
         "//go/lib/epic:go_default_library",
         "//go/lib/log:go_default_library",
-        "//go/lib/metrics:go_default_library",
         "//go/lib/scrypto:go_default_library",
         "//go/lib/serrors:go_default_library",
         "//go/lib/slayers:go_default_library",

--- a/go/pkg/router/bfd/BUILD.bazel
+++ b/go/pkg/router/bfd/BUILD.bazel
@@ -14,9 +14,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//go/lib/log:go_default_library",
-        "//go/lib/metrics:go_default_library",
         "//go/lib/serrors:go_default_library",
         "@com_github_google_gopacket//layers:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
     ],
 )
 
@@ -35,10 +35,11 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/log/testlog:go_default_library",
-        "//go/lib/metrics:go_default_library",
         "//go/pkg/router/bfd/mock_bfd:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_google_gopacket//layers:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/testutil:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/go/pkg/router/bfd/jitter.go
+++ b/go/pkg/router/bfd/jitter.go
@@ -53,15 +53,17 @@ func computeInterval(transmitInterval time.Duration, detectMult uint,
 	if detectMult == 0 {
 		panic("detection multiplier must be > 0")
 	}
-	if gen == nil {
-		gen = defaultIntervalGenerator{}
-	}
 	jitter := minJitter
 	if detectMult == 1 {
 		jitter = minJitterDetectMult1
 	}
-	jitterPercent := time.Duration(gen.Generate(jitter, maxJitter))
-	return (transmitInterval * (100 - jitterPercent)) / 100
+	var jitterPercent int
+	if gen != nil {
+		jitterPercent = gen.Generate(jitter, maxJitter)
+	} else {
+		jitterPercent = defaultIntervalGenerator{}.Generate(jitter, maxJitter)
+	}
+	return (transmitInterval * time.Duration(100-jitterPercent)) / 100
 }
 
 // IntervalGenerator generates integers in [x, y). It panics if x < 0 or if y <= x.

--- a/go/pkg/router/bfd/metrics.go
+++ b/go/pkg/router/bfd/metrics.go
@@ -15,20 +15,20 @@
 package bfd
 
 import (
-	"github.com/scionproto/scion/go/lib/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Metrics is used by sessions to report information about internal operation.
 type Metrics struct {
 	// PacketsSent reports the total number of BFD packets sent out by the session.
-	PacketsSent metrics.Counter
+	PacketsSent prometheus.Counter
 	// PacketsReceived reports the total number of BFD packets received by the session.
-	PacketsReceived metrics.Counter
+	PacketsReceived prometheus.Counter
 	// Up reports 1 if the local session is in state Up, and 0 otherwise. Note that due to the
 	// bidirectional detection nature of BFD (the local session will transition to a non-Up state if
 	// it detects the remote is not Up), barring some network delays, if the local session is Up the
 	// remote session is also Up.
-	Up metrics.Gauge
+	Up prometheus.Gauge
 	// StateChanges reports the total number of state changes of the session.
-	StateChanges metrics.Counter
+	StateChanges prometheus.Counter
 }

--- a/go/pkg/router/bfd/metrics_test.go
+++ b/go/pkg/router/bfd/metrics_test.go
@@ -19,20 +19,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/go/lib/log/testlog"
-	"github.com/scionproto/scion/go/lib/metrics"
 	"github.com/scionproto/scion/go/pkg/router/bfd"
 )
 
 func TestMetrics(t *testing.T) {
 	// We only instrument session A
-	packetsSent := metrics.NewTestCounter()
-	packetsReceived := metrics.NewTestCounter()
-	up := metrics.NewTestGauge()
-	stateChanges := metrics.NewTestCounter()
+	packetsSent := prometheus.NewCounter(prometheus.CounterOpts{Name: "packets_sent"})
+	packetsReceived := prometheus.NewCounter(prometheus.CounterOpts{Name: "packets_received"})
+	up := prometheus.NewGauge(prometheus.GaugeOpts{Name: "up"})
+	stateChanges := prometheus.NewCounter(prometheus.CounterOpts{Name: "state_changes"})
 
 	sessionA := &bfd.Session{
 		DetectMult:            1,
@@ -88,18 +89,18 @@ func TestMetrics(t *testing.T) {
 	// Negotiation of send interval should yield 50 millis, with jitter adjusment that can be as
 	// fast as 37.5 millis, so that gives an upper bound of approximately 27 packets and lower bound
 	// of 10. For flakyness, we expect between 5 and 27.
-	betweenOrEqual(t, 5.0, 27.0, metrics.CounterValue(packetsSent))
-	betweenOrEqual(t, 5.0, 27.0, metrics.CounterValue(packetsReceived))
-	assert.Equal(t, 1.0, metrics.GaugeValue(up))
-	assert.Greater(t, metrics.CounterValue(stateChanges), 0.0)
+	betweenOrEqual(t, 5.0, 27.0, promtest.ToFloat64(packetsSent))
+	betweenOrEqual(t, 5.0, 27.0, promtest.ToFloat64(packetsReceived))
+	assert.Equal(t, 1.0, promtest.ToFloat64(up))
+	assert.Greater(t, promtest.ToFloat64(stateChanges), 0.0)
 
-	changes := metrics.CounterValue(stateChanges)
+	changes := promtest.ToFloat64(stateChanges)
 	linkAToB.Sending(false)
 	linkBToA.Sending(false)
 	time.Sleep(2 * time.Second)
 
-	assert.Equal(t, 0.0, metrics.GaugeValue(up))
-	assert.Greater(t, metrics.CounterValue(stateChanges), changes)
+	assert.Equal(t, 0.0, promtest.ToFloat64(up))
+	assert.Greater(t, promtest.ToFloat64(stateChanges), changes)
 
 	linkAToB.Close()
 	linkBToA.Close()

--- a/go/pkg/router/bfd/session.go
+++ b/go/pkg/router/bfd/session.go
@@ -196,6 +196,8 @@ func (s *Session) Run() error {
 
 	s.desiredMinTXInterval = defaultTransmissionInterval
 	sendTimer := time.NewTimer(s.desiredMinTXInterval)
+
+	pkt := &layers.BFD{}
 MainLoop:
 	for {
 		select {
@@ -260,7 +262,7 @@ MainLoop:
 			desiredMinTxInterval, _ := durationToBFDInterval(s.desiredMinTXInterval)
 			requiredMinRxInterval, _ := durationToBFDInterval(s.RequiredMinRxInterval)
 
-			pkt := layers.BFD{
+			*pkt = layers.BFD{
 				Version:               1,
 				State:                 layers.BFDState(s.getLocalState()),
 				DetectMultiplier:      s.DetectMult,
@@ -270,7 +272,7 @@ MainLoop:
 				RequiredMinRxInterval: requiredMinRxInterval,
 			}
 
-			if err := s.Sender.Send(&pkt); err != nil {
+			if err := s.Sender.Send(pkt); err != nil {
 				s.debug("error sending message", "err", err)
 				continue
 			}

--- a/go/pkg/router/dataplane.go
+++ b/go/pkg/router/dataplane.go
@@ -37,7 +37,6 @@ import (
 	"github.com/scionproto/scion/go/lib/common"
 	libepic "github.com/scionproto/scion/go/lib/epic"
 	"github.com/scionproto/scion/go/lib/log"
-	"github.com/scionproto/scion/go/lib/metrics"
 	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/serrors"
 	"github.com/scionproto/scion/go/lib/slayers"
@@ -265,31 +264,19 @@ func (d *DataPlane) AddExternalInterfaceBFD(ifID uint16, conn BatchConn,
 	}
 	var m bfd.Metrics
 	if d.Metrics != nil {
-		labels := []string{
-			"interface", fmt.Sprint(ifID),
-			"isd_as", d.localIA.String(),
-			"neighbor_isd_as", dst.IA.String(),
+		labels := prometheus.Labels{
+			"interface":       fmt.Sprint(ifID),
+			"isd_as":          d.localIA.String(),
+			"neighbor_isd_as": dst.IA.String(),
 		}
 		m = bfd.Metrics{
-			Up: metrics.NewPromGauge(d.Metrics.InterfaceUp).
-				With(labels...),
-			StateChanges: metrics.NewPromCounter(d.Metrics.BFDInterfaceStateChanges).
-				With(labels...),
-			PacketsSent: metrics.NewPromCounter(d.Metrics.BFDPacketsSent).
-				With(labels...),
-			PacketsReceived: metrics.NewPromCounter(d.Metrics.BFDPacketsReceived).
-				With(labels...),
+			Up:              d.Metrics.InterfaceUp.With(labels),
+			StateChanges:    d.Metrics.BFDInterfaceStateChanges.With(labels),
+			PacketsSent:     d.Metrics.BFDPacketsSent.With(labels),
+			PacketsReceived: d.Metrics.BFDPacketsReceived.With(labels),
 		}
 	}
-	s := &bfdSend{
-		conn:    conn,
-		srcAddr: src.Addr,
-		dstAddr: dst.Addr,
-		srcIA:   src.IA,
-		dstIA:   dst.IA,
-		ifID:    ifID,
-		mac:     d.macFactory(),
-	}
+	s := newBFDSend(conn, src.IA, dst.IA, src.Addr, dst.Addr, ifID, d.macFactory())
 	return d.addBFDController(ifID, s, cfg, m)
 }
 
@@ -421,27 +408,16 @@ func (d *DataPlane) AddNextHopBFD(ifID uint16, src, dst *net.UDPAddr, cfg contro
 	}
 	var m bfd.Metrics
 	if d.Metrics != nil {
-		labels := []string{"isd_as", d.localIA.String(), "sibling", sibling}
+		labels := prometheus.Labels{"isd_as": d.localIA.String(), "sibling": sibling}
 		m = bfd.Metrics{
-			Up: metrics.NewPromGauge(d.Metrics.SiblingReachable).
-				With(labels...),
-			StateChanges: metrics.NewPromCounter(d.Metrics.SiblingBFDStateChanges).
-				With(labels...),
-			PacketsSent: metrics.NewPromCounter(d.Metrics.SiblingBFDPacketsSent).
-				With(labels...),
-			PacketsReceived: metrics.NewPromCounter(d.Metrics.SiblingBFDPacketsReceived).
-				With(labels...),
+			Up:              d.Metrics.SiblingReachable.With(labels),
+			StateChanges:    d.Metrics.SiblingBFDStateChanges.With(labels),
+			PacketsSent:     d.Metrics.SiblingBFDPacketsSent.With(labels),
+			PacketsReceived: d.Metrics.SiblingBFDPacketsReceived.With(labels),
 		}
 	}
-	s := &bfdSend{
-		conn:    d.internal,
-		srcAddr: src,
-		dstAddr: dst,
-		srcIA:   d.localIA,
-		dstIA:   d.localIA,
-		ifID:    0,
-		mac:     d.macFactory(),
-	}
+
+	s := newBFDSend(d.internal, d.localIA, d.localIA, src, dst, 0, d.macFactory())
 	return d.addBFDController(ifID, s, cfg, m)
 }
 
@@ -1359,9 +1335,62 @@ func updateSCIONLayer(rawPkt []byte, s slayers.SCION, buffer gopacket.SerializeB
 type bfdSend struct {
 	conn             BatchConn
 	srcAddr, dstAddr *net.UDPAddr
-	srcIA, dstIA     addr.IA
+	scn              *slayers.SCION
+	ohp              *onehop.Path
 	mac              hash.Hash
-	ifID             uint16
+	macBuffer        []byte
+	buffer           gopacket.SerializeBuffer
+}
+
+// newBFDSend creates and initializes a BFD Sender
+func newBFDSend(conn BatchConn, srcIA, dstIA addr.IA, srcAddr, dstAddr *net.UDPAddr,
+	ifID uint16, mac hash.Hash) *bfdSend {
+
+	scn := &slayers.SCION{
+		Version:      0,
+		TrafficClass: 0xb8,
+		FlowID:       0xdead,
+		NextHdr:      common.L4BFD,
+		SrcIA:        srcIA,
+		DstIA:        dstIA,
+	}
+
+	if err := scn.SetSrcAddr(&net.IPAddr{IP: srcAddr.IP}); err != nil {
+		panic(err) // Must work unless IPAddr is not supported
+	}
+	if err := scn.SetDstAddr(&net.IPAddr{IP: dstAddr.IP}); err != nil {
+		panic(err) // Must work unless IPAddr is not supported
+	}
+
+	var ohp *onehop.Path
+	if ifID == 0 {
+		scn.PathType = empty.PathType
+		scn.Path = &empty.Path{}
+	} else {
+		ohp = &onehop.Path{
+			Info: path.InfoField{
+				ConsDir: true,
+				// Timestamp set in Send
+			},
+			FirstHop: path.HopField{
+				ConsEgress: ifID,
+				ExpTime:    hopFieldDefaultExpTime,
+			},
+		}
+		scn.PathType = onehop.PathType
+		scn.Path = ohp
+	}
+
+	return &bfdSend{
+		conn:      conn,
+		srcAddr:   srcAddr,
+		dstAddr:   dstAddr,
+		scn:       scn,
+		ohp:       ohp,
+		mac:       mac,
+		macBuffer: make([]byte, path.MACBufferSize),
+		buffer:    gopacket.NewSerializeBuffer(),
+	}
 }
 
 func (b *bfdSend) String() string {
@@ -1372,49 +1401,19 @@ func (b *bfdSend) String() string {
 // Due to the internal state of the MAC computation, this is not goroutine
 // safe.
 func (b *bfdSend) Send(bfd *layers.BFD) error {
-	scn := &slayers.SCION{
-		Version:      0,
-		TrafficClass: 0xb8,
-		FlowID:       0xdead,
-		NextHdr:      common.L4BFD,
-		SrcIA:        b.srcIA,
-		DstIA:        b.dstIA,
+	if b.ohp != nil {
+		// Subtract 10 seconds to deal with possible clock drift.
+		ohp := b.ohp
+		ohp.Info.Timestamp = uint32(time.Now().Unix() - 10)
+		ohp.FirstHop.Mac = path.MAC(b.mac, ohp.Info, ohp.FirstHop, b.macBuffer)
 	}
 
-	if err := scn.SetSrcAddr(&net.IPAddr{IP: b.srcAddr.IP}); err != nil {
-		return err
-	}
-	if err := scn.SetDstAddr(&net.IPAddr{IP: b.dstAddr.IP}); err != nil {
-		return err
-	}
-
-	if b.ifID == 0 {
-		scn.PathType = empty.PathType
-		scn.Path = &empty.Path{}
-	} else {
-		ohp := &onehop.Path{
-			Info: path.InfoField{
-				ConsDir: true,
-				// Subtract 10 seconds to deal with possible clock drift.
-				Timestamp: uint32(time.Now().Unix() - 10),
-			},
-			FirstHop: path.HopField{
-				ConsEgress: b.ifID,
-				ExpTime:    hopFieldDefaultExpTime,
-			},
-		}
-		ohp.FirstHop.Mac = path.MAC(b.mac, ohp.Info, ohp.FirstHop, nil)
-		scn.PathType = onehop.PathType
-		scn.Path = ohp
-	}
-
-	buffer := gopacket.NewSerializeBuffer()
-	err := gopacket.SerializeLayers(buffer, gopacket.SerializeOptions{FixLengths: true},
-		scn, bfd)
+	err := gopacket.SerializeLayers(b.buffer, gopacket.SerializeOptions{FixLengths: true},
+		b.scn, bfd)
 	if err != nil {
 		return err
 	}
-	_, err = b.conn.WriteTo(buffer.Bytes(), b.dstAddr)
+	_, err = b.conn.WriteTo(b.buffer.Bytes(), b.dstAddr)
 	return err
 }
 


### PR DESCRIPTION
Use prometheus metrics directly, bypassing the metrics library.
This avoids a large amount of allocations caused by usage patterns in
the metrics library. While this does not help making progress towards a
consistent way to handle metrics, it also does not appear to make
matters worse.

Avoid various other allocations in the BFD session and sender code,
by reusing the relevant objects and avoiding temporaries to escape to
the heap.
As the BFD messages are comparably infrequent, the allocations triggered
here were usually not critical. However, for setups with a large number
of interfaces, the wasteful allocations were indeed somewhat significant
compared to the allocations from the forwarding part of the router
dataplane (which are much harder to optimize away).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4142)
<!-- Reviewable:end -->
