### PR TITLE
slayers: predefine LayerClass objects

### DIFF
--- a/go/lib/slayers/extn.go
+++ b/go/lib/slayers/extn.go
@@ -222,7 +222,7 @@ func (h *HopByHopExtn) LayerType() gopacket.LayerType {
 }
 
 func (h *HopByHopExtn) CanDecode() gopacket.LayerClass {
-	return LayerTypeHopByHopExtn
+	return LayerClassHopByHopExtn
 }
 
 func (h *HopByHopExtn) NextLayerType() gopacket.LayerType {
@@ -302,7 +302,7 @@ func (e *EndToEndExtn) LayerType() gopacket.LayerType {
 }
 
 func (e *EndToEndExtn) CanDecode() gopacket.LayerClass {
-	return LayerTypeEndToEndExtn
+	return LayerClassEndToEndExtn
 }
 
 func (e *EndToEndExtn) NextLayerType() gopacket.LayerType {
@@ -407,7 +407,7 @@ func (e *HopByHopExtnSkipper) LayerType() gopacket.LayerType {
 }
 
 func (s *HopByHopExtnSkipper) CanDecode() gopacket.LayerClass {
-	return LayerTypeHopByHopExtn
+	return LayerClassHopByHopExtn
 }
 
 func (h *HopByHopExtnSkipper) NextLayerType() gopacket.LayerType {
@@ -440,7 +440,7 @@ func (e *EndToEndExtnSkipper) LayerType() gopacket.LayerType {
 }
 
 func (s *EndToEndExtnSkipper) CanDecode() gopacket.LayerClass {
-	return LayerTypeEndToEndExtn
+	return LayerClassEndToEndExtn
 }
 
 func (e *EndToEndExtnSkipper) NextLayerType() gopacket.LayerType {

--- a/go/lib/slayers/layertypes.go
+++ b/go/lib/slayers/layertypes.go
@@ -29,6 +29,8 @@ var (
 			Decoder: gopacket.DecodeFunc(decodeSCION),
 		},
 	)
+	LayerClassSCION gopacket.LayerClass = LayerTypeSCION
+
 	LayerTypeSCIONUDP = gopacket.RegisterLayerType(
 		1001,
 		gopacket.LayerTypeMetadata{
@@ -36,6 +38,8 @@ var (
 			Decoder: gopacket.DecodeFunc(decodeSCIONUDP),
 		},
 	)
+	LayerClassSCIONUDP gopacket.LayerClass = LayerTypeSCIONUDP
+
 	LayerTypeSCMP = gopacket.RegisterLayerType(
 		1002,
 		gopacket.LayerTypeMetadata{
@@ -43,13 +47,7 @@ var (
 			Decoder: gopacket.DecodeFunc(decodeSCMP),
 		},
 	)
-	LayerTypeSCMPDummy = gopacket.RegisterLayerType(
-		2002,
-		gopacket.LayerTypeMetadata{
-			Name:    "SCMPDummy",
-			Decoder: gopacket.DecodeFunc(decodeSCMP),
-		},
-	)
+	LayerClassSCMP gopacket.LayerClass = LayerTypeSCMP
 
 	LayerTypeHopByHopExtn = gopacket.RegisterLayerType(
 		1003,
@@ -58,6 +56,8 @@ var (
 			Decoder: gopacket.DecodeFunc(decodeHopByHopExtn),
 		},
 	)
+	LayerClassHopByHopExtn gopacket.LayerClass = LayerTypeHopByHopExtn
+
 	LayerTypeEndToEndExtn = gopacket.RegisterLayerType(
 		1004,
 		gopacket.LayerTypeMetadata{
@@ -65,6 +65,8 @@ var (
 			Decoder: gopacket.DecodeFunc(decodeEndToEndExtn),
 		},
 	)
+	LayerClassEndToEndExtn gopacket.LayerClass = LayerTypeEndToEndExtn
+
 	LayerTypeSCMPExternalInterfaceDown = gopacket.RegisterLayerType(
 		1005,
 		gopacket.LayerTypeMetadata{

--- a/go/lib/slayers/scion.go
+++ b/go/lib/slayers/scion.go
@@ -153,7 +153,7 @@ func (s *SCION) LayerType() gopacket.LayerType {
 }
 
 func (s *SCION) CanDecode() gopacket.LayerClass {
-	return LayerTypeSCION
+	return LayerClassSCION
 }
 
 func (s *SCION) NextLayerType() gopacket.LayerType {

--- a/go/lib/slayers/scmp.go
+++ b/go/lib/slayers/scmp.go
@@ -70,7 +70,7 @@ func (s *SCMP) LayerType() gopacket.LayerType {
 
 // CanDecode returns the set of layer types that this DecodingLayer can decode.
 func (s *SCMP) CanDecode() gopacket.LayerClass {
-	return LayerTypeSCMP
+	return LayerClassSCMP
 }
 
 // NextLayerType use the typecode to select the right next decoder.

--- a/go/lib/slayers/udp.go
+++ b/go/lib/slayers/udp.go
@@ -42,7 +42,7 @@ func (u *UDP) LayerType() gopacket.LayerType {
 }
 
 func (u *UDP) CanDecode() gopacket.LayerClass {
-	return LayerTypeSCIONUDP
+	return LayerClassSCIONUDP
 }
 
 func (u *UDP) NextLayerType() gopacket.LayerType {


### PR DESCRIPTION
In the router dataplane, we call CanDecode on multiple gopacket
layers to skip extension headers. 
Returning a LayerType from CanDecode implicitly wraps this in a
LayerClass interface, which allocates on each call.
Predefine these LayerClass objects to avoid these allocations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4144)
<!-- Reviewable:end -->
