### PR TITLE
showpaths: handle empty path

### DIFF
--- a/go/pkg/showpaths/showpaths.go
+++ b/go/pkg/showpaths/showpaths.go
@@ -312,6 +312,9 @@ func Run(ctx context.Context, dst addr.IA, cfg Config) (*Result, error) {
 	if err != nil {
 		return nil, serrors.WrapStr("determining local ISD-AS", err)
 	}
+	if dst == localIA {
+		return nil, serrors.New("destination is the local AS", "dst", dst)
+	}
 
 	// TODO(lukedirtwalker): Replace this with snet.Router once we have the
 	// possibility to have the same functionality, i.e. refresh, fetch all paths.

--- a/go/pkg/showpaths/showpaths.go
+++ b/go/pkg/showpaths/showpaths.go
@@ -36,8 +36,9 @@ import (
 
 // Result contains all the discovered paths.
 type Result struct {
+	LocalIA     addr.IA `json:"local_isd_as"`
 	Destination addr.IA `json:"destination"`
-	Paths       []Path  `json:"paths"`
+	Paths       []Path  `json:"paths,omitempty"`
 }
 
 // Path holds information about the discovered path.
@@ -291,6 +292,11 @@ func (r Result) JSON(w io.Writer) error {
 	return enc.Encode(r)
 }
 
+// IsLocal returns true iff Source and Destination AS are identical
+func (r Result) IsLocal() bool {
+	return r.LocalIA == r.Destination
+}
+
 // Alive returns the number of alive paths.
 func (r Result) Alive() int {
 	var c int
@@ -313,7 +319,10 @@ func Run(ctx context.Context, dst addr.IA, cfg Config) (*Result, error) {
 		return nil, serrors.WrapStr("determining local ISD-AS", err)
 	}
 	if dst == localIA {
-		return nil, serrors.New("destination is the local AS", "dst", dst)
+		return &Result{
+			LocalIA:     localIA,
+			Destination: dst,
+		}, nil
 	}
 
 	// TODO(lukedirtwalker): Replace this with snet.Router once we have the
@@ -348,6 +357,7 @@ func Run(ctx context.Context, dst addr.IA, cfg Config) (*Result, error) {
 	}
 	path.Sort(paths)
 	res := &Result{
+		LocalIA:     localIA,
 		Destination: dst,
 		Paths:       []Path{},
 	}

--- a/go/scion/showpaths.go
+++ b/go/scion/showpaths.go
@@ -41,7 +41,6 @@ func newShowpaths(pather CommandPather) *cobra.Command {
 		logLevel string
 		noColor  bool
 		tracer   string
-		localIA  string
 	}
 
 	var cmd = &cobra.Command{

--- a/go/scion/showpaths.go
+++ b/go/scion/showpaths.go
@@ -110,6 +110,10 @@ On other errors, showpaths will exit with code 2.
 			if flags.json {
 				return res.JSON(os.Stdout)
 			}
+			if res.IsLocal() {
+				fmt.Fprintf(os.Stdout, "Empty path, destination is local AS %s\n", res.Destination)
+				return nil
+			}
 			fmt.Fprintln(os.Stdout, "Available paths to", res.Destination)
 			if len(res.Paths) == 0 {
 				return app.WithExitCode(serrors.New("no path found"), 1)


### PR DESCRIPTION
Previously, showpaths would show confusing results when the destination
is the local AS; it did list an empty path, but also showed the
error "no path alive" (because the empty path cannot be probed).
With the `-e` flag, it would also show a spurious expiration time.

If the destination is the local AS, this is now specifically handled
with a message explaining that this results in an empty path.

For the json output, the `paths` field is now an empty list in this case
and so omitted.
Additionally, a `local_isd_as` (following the naming pattern from the
existing `local_ip` field) is added to the json output, to allow
consumers to detect and handle this situation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4146)
<!-- Reviewable:end -->
