### PR TITLE
slayers: recycle path when decoding

### DIFF
--- a/go/lib/slayers/scion.go
+++ b/go/lib/slayers/scion.go
@@ -245,9 +245,12 @@ func (s *SCION) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 		return serrors.New("provided buffer is too small", "expected", minLen, "actual", len(data))
 	}
 
-	s.Path, err = path.NewPath(s.PathType)
-	if err != nil {
-		return err
+	if s.Path == nil || s.Path.Type() != s.PathType {
+		path, err := path.NewPath(s.PathType)
+		if err != nil {
+			return err
+		}
+		s.Path = path
 	}
 
 	err = s.Path.DecodeFromBytes(data[offset : offset+pathLen])

--- a/go/pkg/router/dataplane.go
+++ b/go/pkg/router/dataplane.go
@@ -578,7 +578,7 @@ type processResult struct {
 }
 
 func newPacketProcessor(d *DataPlane, ingressID uint16) *scionPacketProcessor {
-	return &scionPacketProcessor{
+	p := &scionPacketProcessor{
 		d:         d,
 		ingressID: ingressID,
 		buffer:    gopacket.NewSerializeBuffer(),
@@ -588,6 +588,8 @@ func newPacketProcessor(d *DataPlane, ingressID uint16) *scionPacketProcessor {
 			epicInput:  make([]byte, libepic.MACBufferSize),
 		},
 	}
+	p.scionLayer.RecyclePaths()
+	return p
 }
 
 func (p *scionPacketProcessor) reset() error {


### PR DESCRIPTION
In `slayers.SCION.DecodeFromBytes`, we allocate a new path for the
correct path type on every invocation. This negates the advantages of
recycling the layer object.

Introduce a "recycling bin" for paths that can be reused in the SCION
layer's DecodeFromBytes.
This is only used when explicitly enabled, as it only makes sense if the
layer is really reused for parsing. This opt-in also avoids issues with
tests that deep-compare the SCION layer with an expected value where
this recycling bin is empty..

----

I'm not particularly fond of this approach, but I don't know a really good alternative either.

A somewhat simpler approach (implemented in the first commit in this PR) that does not need additional fields, would be to
only recycle the last path as long as the type matches. This would reduce allocations in typical situations, but has an obvious performance degradation if the path type switches back and forth (path type is attacker controlled, so possibly exploitable).

One variation on the current proposal could be to add a method like `slayers/SCION.SetPathsForDecoding(paths ...Path)` instead of the current `RecylePaths`. The caller would allocate an instance for each supported path type on startup. This would feel vaguely similar to passing layers to  the `gopacket.DecodingLayerParser`, except that it's passed to a layer.
I don't find this strictly better or worse than the current proposal, so just mentioning this as a possible alternative.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4147)
<!-- Reviewable:end -->
