### PR TITLE
tools: await-connectivity to fix CI flakes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -85,8 +85,8 @@ steps:
       - make
       - echo "--- start topology"
       - ./scion.sh topology -c topology/default.topo
-      - ./scion.sh run && sleep 10
-      - echo "--- run tests"
+      - ./scion.sh run
+      - tools/await-connectivity
       - ./bin/scion_integration || ( echo "^^^ +++" && false )
       - ./bin/end2end_integration || ( echo "^^^ +++" && false )
     plugins:
@@ -111,8 +111,8 @@ steps:
       - make
       - echo "--- start topology"
       - ./scion.sh topology -c topology/default-no-peers.topo
-      - ./scion.sh run && sleep 10
-      - echo "--- run tests"
+      - ./scion.sh run
+      - tools/await-connectivity
       - ./bin/end2end_integration || ( echo "^^^ +++" && false )
       - ./integration/revocation_test.sh
     plugins:
@@ -138,8 +138,7 @@ steps:
       - echo "--- start topology"
       - ./scion.sh topology -d
       - ./scion.sh run
-      - docker-compose -f gen/scion-dc.yml -p scion up -d $(docker-compose -f gen/scion-dc.yml config --services | grep tester)
-      - sleep 10
+      - tools/await-connectivity
       - echo "--- run tests"
       - ./bin/end2end_integration -d || ( echo "^^^ +++" && false )
     plugins:

--- a/tools/await-connectivity
+++ b/tools/await-connectivity
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# This script waits for the beaconing process in a local topology (running
+# either with supervisor or docker-compose) to establish full connectivity.
+# Uses the control service's segments/ API to determine whether segments have
+# been registered.
+#
+# Returns success when full connectivity is established
+# or an error at timeout (default 20s).
+#
+# Remains quiet for a configurable time (default 10s). After that,
+# it reports the missing segments at 1s interval.
+# 
+# Usage: await-connectivity -q QUIET -t TIMEOUT
+
+set -euo pipefail
+
+QUIET=10
+TIMEOUT=20
+parse_opts() {
+  while getopts "q:t:" opt; do
+    case "$opt" in
+      q)
+        QUIET="$OPTARG"
+        ;;
+      t)
+        TIMEOUT="$OPTARG"
+        ;;
+    esac
+  done
+}
+
+# For a given ISD-AS, determine the gen/ directory
+as_dir() {
+  local isd_as=$1
+  local as=${isd_as#*-}
+  local as_file=${as//:/_}
+  echo "gen/AS$as_file"
+}
+
+# For a given ISD-AS, determine API address (extracted from the cs*.toml file)
+cs_api_addr() {
+  local isd_as=$1
+  grep -F "[api]" -A1 "$(as_dir "$isd_as")"/cs*.toml | sed -n 's/^\s*addr\s*=\s*"\([^"]*\)".*/\1/p'
+}
+
+# For a given ISD-AS, determine the CS segments-API URL
+cs_api_url_segments() {
+  local isd_as=$1
+  echo "$(cs_api_addr "$isd_as")/api/v1/segments"
+}
+
+# Check for connectivity between the given ASes, given as separate lists of
+# core and non-core ISD-ASes.
+check_connectivity() {
+  local cores="$1"
+  local noncores="$2"
+  local ret=0
+
+  # core ASes: wait for at least one (core-)segment to every other core-AS
+  for as in $cores; do
+    missing=$(comm -23 \
+      <(printf "%s\n" $cores | grep -v $as | sort) \
+      <(curl -sfS $(cs_api_url_segments "$as") | jq '.[].start_isd_as' -r | sort -u)
+    )
+    if [ -n "$missing" ]; then
+      echo "$as: waiting for" $missing
+      ret=1
+    fi
+  done
+
+  # non-core ASes: wait for at least one (up-)segment
+  for as in $noncores; do
+    curl -sfS $(cs_api_url_segments "$as") | jq -e 'length > 0' > /dev/null || { 
+      echo "$as waiting for up segment"
+      ret=1
+    }
+  done
+  return $ret
+}
+
+main() {
+  parse_opts "$@"
+
+  # poor bash-man's yaml parser
+  local cores=$(sed -n '1,/Non-core/{s/^- //p}' gen/as_list.yml)
+  local noncores=$(sed -n '/Non-core/,${s/^- //p}' gen/as_list.yml)
+
+  for i in $(seq 1 "$QUIET"); do
+    check_connectivity "$cores" "$noncores" > /dev/null && exit 0
+    sleep 1
+  done
+  for i in $(seq "$QUIET" $((TIMEOUT-1))); do
+    echo "Check after ${i}s"
+    check_connectivity "$cores" "$noncores" && exit 0
+    sleep 1
+  done
+  echo "Check after ${TIMEOUT}s"
+  check_connectivity "$cores" "$noncores" || { echo "Timeout, giving up"; exit 1; }
+}
+
+main "$@"


### PR DESCRIPTION
It has previously been observed that the integration tests are flaky
in the supervisord-based setup unless we keep the specific startup
sequence that starts dispatcher and routers before all other services
(see commit b94c06378c9d5f5571bcbfebe7d992a20cccaf07, or also #4164).
If the integration tests start before the control services have
established segments for full connectivity, i.e. offer a least one path
to every destination, the tests will fail.
When control services start before routers, it takes longer to reach
full connectivity. The first beacon origination can happen up to 5
seconds later, as the first attempt may result in a failed service
resolution attempt that needs to time out.
The CI pipeline would sleep for a fixed duration of 10 seconds which
is just enough to reach connectivity with the ideal startup sequence,
but if the processes randomly start in a bad order, it can fail.

In the docker-based topology setup this issue does not appear, simply
because the process startup (in particular for the servers of the e2e
tests) is so much slower that there is ample time to reach connectivity.

This change replaces the fixed sleep duration with a script, based on
the control service's segments API, that explicitly waits for full
connectivity, with a timeout.
Remove the hand-optimized startup sequence for supervisor tasks from
scion.sh -- a randomly bad startup sequence can and should be tolerated.

Also, more cleanup for scion.sh: don't set up ipv6 local addresses when
running docker setup. Always perform the corresponding cleanup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4168)
<!-- Reviewable:end -->
