### PR TITLE
scion-pki: add --isd flag to trc verify command

### DIFF
--- a/scion-pki/testcrypto/testcrypto_test.go
+++ b/scion-pki/testcrypto/testcrypto_test.go
@@ -77,7 +77,7 @@ func TestCmd(t *testing.T) {
 func checkISD(t *testing.T, outDir string, isd addr.ISD) {
 	isdDir := filepath.Join(outDir, fmt.Sprintf("ISD%d", isd))
 	trcFile := filepath.Join(isdDir, "trcs", fmt.Sprintf("ISD%d-B1-S1.trc", isd))
-	assert.NoError(t, trcs.RunVerify([]string{trcFile}, trcFile))
+	assert.NoError(t, trcs.RunVerify([]string{trcFile}, trcFile, 0))
 }
 
 func checkAS(t *testing.T, outDir string, ia addr.IA) {

--- a/scion-pki/trcs/verify.go
+++ b/scion-pki/trcs/verify.go
@@ -84,7 +84,7 @@ func RunVerify(files []string, anchor string, isd addr.ISD) error {
 			return serrors.New("multiple ISDs", "isds", []addr.ISD{someISD, dec.TRC.ID.ISD})
 		}
 		if someBase != dec.TRC.ID.Base {
-			return serrors.New("multiple someBase versions", "bases", []scrypto.Version{
+			return serrors.New("multiple base versions", "bases", []scrypto.Version{
 				someBase, dec.TRC.ID.Base})
 		}
 	}

--- a/scion-pki/trcs/verify.go
+++ b/scion-pki/trcs/verify.go
@@ -49,6 +49,8 @@ The anchor can either be a collection of trusted certificates bundled in a PEM
 file, or a trusted TRC. TRC update chains that start with a base TRC can be
 verified with either type of anchor. TRC update chains that start with a
 non-base TRC must have a TRC as anchor.
+With the optional flag --isd, the ID of the ISD for which the TRC claims to be
+the root of trust can be matched against an expected value.
 `,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -139,7 +141,7 @@ func verifyInitial(trc cppki.SignedTRC, anchor string) error {
 func verifyTRCid(trc cppki.SignedTRC, isdID uint16) error {
 	includedTRCid := trc.TRC.ID.ISD
 	if includedTRCid != addr.ISD(isdID) {
-		return serrors.New("TRC identify does not match provided ISD ID",
+		return serrors.New("TRC identifiers does not match provided ISD ID",
 			"expected", isdID,
 			"actual", includedTRCid)
 	}

--- a/scion-pki/trcs/verify_test.go
+++ b/scion-pki/trcs/verify_test.go
@@ -92,30 +92,23 @@ func TestVerify(t *testing.T) {
 			ErrAssertion: require.NoError,
 		},
 		"base-verify-ISD": {
-			Files:  []string{"./testdata/admin/ISD1-B1-S1.trc"},
+			Files:  []string{filepath.Join(dir, "non-descript.trc")},
 			Anchor: filepath.Join(dir, "non-descript.trc"),
 			ISD:    1,
 			Prepare: func(*testing.T) {
-				src, err := os.Open("./testdata/admin/ISD1-B1-S1.trc")
-				defer src.Close()
-				require.NoError(t, err)
-				dst, err := os.Create(filepath.Join(dir, "non-descript.trc"))
-				defer dst.Close()
-				require.NoError(t, err)
-				_, err = io.Copy(dst, src)
-				require.NoError(t, err)
-				err = dst.Sync()
+				err := copyFile(filepath.Join(dir, "non-descript.trc"),
+					"./testdata/admin/ISD1-B1-S1.trc")
 				require.NoError(t, err)
 			},
 			ErrAssertion: require.NoError,
 		},
 		"base-ISD-mismatch": {
-			Files:  []string{filepath.Join(dir, "non-descript-linked.trc")},
+			Files:  []string{filepath.Join(dir, "non-descript-2dashes.trc")},
 			Anchor: filepath.Join(dir, "non-descript-linked.trc"),
 			ISD:    10,
 			Prepare: func(*testing.T) {
-				err := os.Symlink("./testdata/admin/ISD1-B1-S1.trc",
-					filepath.Join(dir, "non-descript-linked.trc"))
+				err := copyFile(filepath.Join(dir, "non-descript-2dashes.trc"),
+					"./testdata/admin/ISD1-B1-S1.trc")
 				require.NoError(t, err)
 			},
 			ErrAssertion: require.Error,
@@ -128,4 +121,23 @@ func TestVerify(t *testing.T) {
 			tc.ErrAssertion(t, err)
 		})
 	}
+}
+
+func copyFile(dst, src string) error {
+	sFile, err := os.Open(src)
+	defer sFile.Close()
+	if err != nil {
+		return err
+	}
+	dFile, err := os.Create(dst)
+	defer dFile.Close()
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(dFile, sFile)
+	if err != nil {
+		return err
+	}
+	err = dFile.Sync()
+	return err
 }

--- a/scion-pki/trcs/verify_test.go
+++ b/scion-pki/trcs/verify_test.go
@@ -15,6 +15,7 @@
 package trcs
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,18 +33,21 @@ func TestVerify(t *testing.T) {
 	testCases := map[string]struct {
 		Files        []string
 		Anchor       string
+		ISDid        uint16
 		Prepare      func(t *testing.T)
 		ErrAssertion require.ErrorAssertionFunc
 	}{
 		"base-trc-anchor": {
 			Files:        []string{"./testdata/admin/ISD1-B1-S1.trc"},
 			Anchor:       "./testdata/admin/ISD1-B1-S1.trc",
+			ISDid:        0,
 			Prepare:      func(*testing.T) {},
 			ErrAssertion: require.NoError,
 		},
 		"base-bundle-anchor": {
 			Files:  []string{"./testdata/admin/ISD1-B1-S1.trc"},
 			Anchor: filepath.Join(dir, "base.pem"),
+			ISDid:  0,
 			Prepare: func(*testing.T) {
 				out := filepath.Join(dir, "base.pem")
 				require.NoError(t, runExtractCertificates("./testdata/admin/ISD1-B1-S1.trc", out))
@@ -53,6 +57,7 @@ func TestVerify(t *testing.T) {
 		"base-bundle-missing": {
 			Files:  []string{"./testdata/admin/ISD1-B1-S1.trc"},
 			Anchor: filepath.Join(dir, "base-missing.pem"),
+			ISDid:  0,
 			Prepare: func(*testing.T) {
 				signed, err := DecodeFromFile("./testdata/admin/ISD1-B1-S1.trc")
 				require.NoError(t, err)
@@ -64,6 +69,7 @@ func TestVerify(t *testing.T) {
 		"base-invalid-signature": {
 			Files:  []string{filepath.Join(dir, "base-invalid-signature.der")},
 			Anchor: "./testdata/admin/ISD1-B1-S1.trc",
+			ISDid:  0,
 			Prepare: func(*testing.T) {
 				signed, err := DecodeFromFile("./testdata/admin/ISD1-B1-S1.trc")
 				require.NoError(t, err)
@@ -77,11 +83,43 @@ func TestVerify(t *testing.T) {
 			},
 			ErrAssertion: require.Error,
 		},
+		"base-ISDid-check": {
+			Files:        []string{"./testdata/admin/ISD1-B1-S1.trc"},
+			Anchor:       "./testdata/admin/ISD1-B1-S1.trc",
+			ISDid:        1,
+			Prepare:      func(*testing.T) {},
+			ErrAssertion: require.NoError,
+		},
+		"base-verify-ISDid": {
+			Files:  []string{"./testdata/admin/non-descript.trc"},
+			Anchor: "./testdata/admin/non-descript.trc",
+			ISDid:  1,
+			Prepare: func(*testing.T) {
+				src, err := os.Open("./testdata/admin/ISD1-B1-S1.trc")
+				defer src.Close()
+				require.NoError(t, err)
+				dst, err := os.Create("./testdata/admin/non-descript.trc")
+				defer dst.Close()
+				require.NoError(t, err)
+				_, err = io.Copy(dst, src)
+				require.NoError(t, err)
+				err = dst.Sync()
+				require.NoError(t, err)
+			},
+			ErrAssertion: require.NoError,
+		},
+		"base-ISDid-mismatch": {
+			Files:        []string{"./testdata/admin/ISD1-B1-S1.trc"},
+			Anchor:       "./testdata/admin/ISD1-B1-S1.trc",
+			ISDid:        10,
+			Prepare:      func(*testing.T) {},
+			ErrAssertion: require.Error,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			tc.Prepare(t)
-			err := RunVerify(tc.Files, tc.Anchor)
+			err := RunVerify(tc.Files, tc.Anchor, tc.ISDid)
 			tc.ErrAssertion(t, err)
 		})
 	}

--- a/scion-pki/trcs/verify_test.go
+++ b/scion-pki/trcs/verify_test.go
@@ -92,14 +92,14 @@ func TestVerify(t *testing.T) {
 			ErrAssertion: require.NoError,
 		},
 		"base-verify-ISD": {
-			Files:  []string{"./testdata/admin/non-descript.trc"},
-			Anchor: "./testdata/admin/non-descript.trc",
+			Files:  []string{"./testdata/admin/ISD1-B1-S1.trc"},
+			Anchor: filepath.Join(dir, "non-descript.trc"),
 			ISD:    1,
 			Prepare: func(*testing.T) {
 				src, err := os.Open("./testdata/admin/ISD1-B1-S1.trc")
 				defer src.Close()
 				require.NoError(t, err)
-				dst, err := os.Create("./testdata/admin/non-descript.trc")
+				dst, err := os.Create(filepath.Join(dir, "non-descript.trc"))
 				defer dst.Close()
 				require.NoError(t, err)
 				_, err = io.Copy(dst, src)

--- a/scion-pki/trcs/verify_test.go
+++ b/scion-pki/trcs/verify_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/private/xtest"
 )
 
@@ -33,21 +34,21 @@ func TestVerify(t *testing.T) {
 	testCases := map[string]struct {
 		Files        []string
 		Anchor       string
-		ISDid        uint16
+		ISD          addr.ISD
 		Prepare      func(t *testing.T)
 		ErrAssertion require.ErrorAssertionFunc
 	}{
 		"base-trc-anchor": {
 			Files:        []string{"./testdata/admin/ISD1-B1-S1.trc"},
 			Anchor:       "./testdata/admin/ISD1-B1-S1.trc",
-			ISDid:        0,
+			ISD:          0,
 			Prepare:      func(*testing.T) {},
 			ErrAssertion: require.NoError,
 		},
 		"base-bundle-anchor": {
 			Files:  []string{"./testdata/admin/ISD1-B1-S1.trc"},
 			Anchor: filepath.Join(dir, "base.pem"),
-			ISDid:  0,
+			ISD:    0,
 			Prepare: func(*testing.T) {
 				out := filepath.Join(dir, "base.pem")
 				require.NoError(t, runExtractCertificates("./testdata/admin/ISD1-B1-S1.trc", out))
@@ -57,7 +58,7 @@ func TestVerify(t *testing.T) {
 		"base-bundle-missing": {
 			Files:  []string{"./testdata/admin/ISD1-B1-S1.trc"},
 			Anchor: filepath.Join(dir, "base-missing.pem"),
-			ISDid:  0,
+			ISD:    0,
 			Prepare: func(*testing.T) {
 				signed, err := DecodeFromFile("./testdata/admin/ISD1-B1-S1.trc")
 				require.NoError(t, err)
@@ -69,7 +70,7 @@ func TestVerify(t *testing.T) {
 		"base-invalid-signature": {
 			Files:  []string{filepath.Join(dir, "base-invalid-signature.der")},
 			Anchor: "./testdata/admin/ISD1-B1-S1.trc",
-			ISDid:  0,
+			ISD:    0,
 			Prepare: func(*testing.T) {
 				signed, err := DecodeFromFile("./testdata/admin/ISD1-B1-S1.trc")
 				require.NoError(t, err)
@@ -83,17 +84,17 @@ func TestVerify(t *testing.T) {
 			},
 			ErrAssertion: require.Error,
 		},
-		"base-ISDid-check": {
+		"base-ISD-check": {
 			Files:        []string{"./testdata/admin/ISD1-B1-S1.trc"},
 			Anchor:       "./testdata/admin/ISD1-B1-S1.trc",
-			ISDid:        1,
+			ISD:          1,
 			Prepare:      func(*testing.T) {},
 			ErrAssertion: require.NoError,
 		},
-		"base-verify-ISDid": {
+		"base-verify-ISD": {
 			Files:  []string{"./testdata/admin/non-descript.trc"},
 			Anchor: "./testdata/admin/non-descript.trc",
-			ISDid:  1,
+			ISD:    1,
 			Prepare: func(*testing.T) {
 				src, err := os.Open("./testdata/admin/ISD1-B1-S1.trc")
 				defer src.Close()
@@ -108,10 +109,10 @@ func TestVerify(t *testing.T) {
 			},
 			ErrAssertion: require.NoError,
 		},
-		"base-ISDid-mismatch": {
+		"base-ISD-mismatch": {
 			Files:        []string{"./testdata/admin/ISD1-B1-S1.trc"},
 			Anchor:       "./testdata/admin/ISD1-B1-S1.trc",
-			ISDid:        10,
+			ISD:          10,
 			Prepare:      func(*testing.T) {},
 			ErrAssertion: require.Error,
 		},
@@ -119,7 +120,7 @@ func TestVerify(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			tc.Prepare(t)
-			err := RunVerify(tc.Files, tc.Anchor, tc.ISDid)
+			err := RunVerify(tc.Files, tc.Anchor, tc.ISD)
 			tc.ErrAssertion(t, err)
 		})
 	}

--- a/scion-pki/trcs/verify_test.go
+++ b/scion-pki/trcs/verify_test.go
@@ -110,10 +110,14 @@ func TestVerify(t *testing.T) {
 			ErrAssertion: require.NoError,
 		},
 		"base-ISD-mismatch": {
-			Files:        []string{"./testdata/admin/ISD1-B1-S1.trc"},
-			Anchor:       "./testdata/admin/ISD1-B1-S1.trc",
-			ISD:          10,
-			Prepare:      func(*testing.T) {},
+			Files:  []string{filepath.Join(dir, "non-descript-linked.trc")},
+			Anchor: filepath.Join(dir, "non-descript-linked.trc"),
+			ISD:    10,
+			Prepare: func(*testing.T) {
+				err := os.Symlink("./testdata/admin/ISD1-B1-S1.trc",
+					filepath.Join(dir, "non-descript-linked.trc"))
+				require.NoError(t, err)
+			},
 			ErrAssertion: require.Error,
 		},
 	}


### PR DESCRIPTION
Add a `--isd` flag to the `trc verify` command.

This optional flag enables checking the ISD number the TRC chain that is being verified.
The new flag simplifies CLI interactions for tools that want to validate that a TRC chain is for a specific ISD.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4171)
<!-- Reviewable:end -->
