### PR TITLE
scion-pki: add subjectIA flag to cert verify command

### DIFF
--- a/doc/cryptography/certificates.rst
+++ b/doc/cryptography/certificates.rst
@@ -241,10 +241,23 @@ attribute type is ``id-at-ia``, defined as:
 
     id-at-ia AttributeType ::= {id-ana id-cppki(1) id-at(2) 1}
 
-The attribute value for the *ISD-AS number* type is a ``UTF8String`` following
-the formatting defined in `ISD and AS numbering
-<https://github.com/scionproto/scion/wiki/ISD-and-AS-numbering>`_. For example,
-AS ``ff00:0:110`` in ISD ``1`` is formatted as ``1-ff00:0:110``.
+The type of the attribute value for the *ISD-AS number* is a ``UTF8String``.
+
+The string representation MUST follow the canonical formatting defined in `ISD
+and AS numbering
+<https://github.com/scionproto/scion/wiki/ISD-and-AS-numbering>`_.
+
+The canonical string representation of the *ISD-AS number* uses a `-`-separator
+between the ISD and AS numbers.
+
+The ISD numbers are formatted as decimal.
+
+The canonical string formatting of AS numbers in the BGP AS range (
+:math:`0 - 2^{32}-1`) is the decimal form.
+For larger AS numbers, it uses a 16-bit `:`-separated lower-case hex encoding
+with leading 0's omitted: 1:0:0 to ffff:ffff:ffff.
+
+For example, AS ``ff00:0:110`` in ISD ``1`` is formatted as ``1-ff00:0:110``.
 
 The *ISD-AS number* must be present exactly once in all SCION CP certificates.
 Implementations must not create nor successfully verify certificates that do not

--- a/pkg/scrypto/cppki/certs.go
+++ b/pkg/scrypto/cppki/certs.go
@@ -545,6 +545,9 @@ func findIA(dn pkix.Name) (*addr.IA, error) {
 		if ia.IsWildcard() {
 			return nil, serrors.New("wildcard ISD-AS not allowed", "isd_as", ia)
 		}
+		if ia.String() != rawIA {
+			return nil, serrors.New("ISD-AS not in canonical form", "isd_as", ia)
+		}
 		return &ia, nil
 	}
 	// not found

--- a/scion-pki/certs/verify.go
+++ b/scion-pki/certs/verify.go
@@ -1,4 +1,5 @@
 // Copyright 2020 Anapaya Systems
+// Copyright 2022 ETH Zurich
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +27,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/private/serrors"
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
 	"github.com/scionproto/scion/private/app/command"
@@ -33,8 +35,9 @@ import (
 
 func newVerifyCmd(pather command.Pather) *cobra.Command {
 	var flags struct {
-		trcFiles []string
-		unixTime int64
+		trcFiles  []string
+		unixTime  int64
+		subjectIA string
 	}
 
 	cmd := &cobra.Command{
@@ -44,6 +47,11 @@ func newVerifyCmd(pather command.Pather) *cobra.Command {
 
 The chain must be a PEM bundle with the AS certificate first, and the CA
 certificate second.
+
+The ISD-AS property of the subject identified by the certificate
+(or in the case of a certificate chain, the leaf certificate)
+can be validated by specifying the --subjectIA flag and
+the expected ISD-AS value.
 `,
 		Example: fmt.Sprintf(
 			`  %[1]s verify --trc ISD1-B1-S1.trc,ISD1-B1-S2.trc ISD1-ASff00_0_110.pem
@@ -54,7 +62,7 @@ certificate second.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			chain, err := cppki.ReadPEMCerts(args[0])
-			if err != nil {
+			if err != nil || len(chain) == 0 {
 				return serrors.WrapStr("reading chain", err, "file", args[0])
 			}
 			trcs, err := loadTRCs(flags.trcFiles)
@@ -71,6 +79,20 @@ certificate second.
 				opts.CurrentTime = time.Unix(flags.unixTime, 0)
 			}
 
+			if flags.subjectIA != "" {
+				expectedSubjectIA, err := addr.ParseIA(flags.subjectIA)
+				if err != nil {
+					return serrors.New("invalid ISD-AS provided for the ISD-AS property check",
+						"err", err)
+				}
+				certSubjectASID, err := cppki.ExtractIA(chain[0].Subject)
+				if certSubjectASID != expectedSubjectIA {
+					return serrors.New("ISD-AS property not matching the subject "+
+						"in the leaf certificate",
+						"expected", expectedSubjectIA,
+						"actual", certSubjectASID)
+				}
+			}
 			if err := cppki.VerifyChain(chain, opts); err != nil {
 				return serrors.WrapStr("verification failed", err)
 			}
@@ -87,6 +109,9 @@ certificate second.
 	)
 	cmd.Flags().Int64Var(&flags.unixTime, "currenttime", 0,
 		"Optional unix timestamp that sets the current time",
+	)
+	cmd.Flags().StringVar(&flags.subjectIA, "subjectIA", "",
+		"ISD-AS property of the subject of the certificate",
 	)
 	cmd.MarkFlagRequired("trc")
 

--- a/scion-pki/certs/verify.go
+++ b/scion-pki/certs/verify.go
@@ -50,7 +50,7 @@ certificate second.
 
 The ISD-AS property of the subject identified by the certificate
 (or in the case of a certificate chain, the leaf certificate)
-can be validated by specifying the --subjectIA flag and
+can be validated by specifying the --subject-isd-as flag and
 the expected ISD-AS value.
 `,
 		Example: fmt.Sprintf(
@@ -86,6 +86,10 @@ the expected ISD-AS value.
 						"err", err)
 				}
 				certSubjectASID, err := cppki.ExtractIA(chain[0].Subject)
+				if err != nil {
+					return serrors.New("failed to extract IA from leaf certificate",
+						"err", err)
+				}
 				if certSubjectASID != expectedSubjectIA {
 					return serrors.New("ISD-AS property not matching the subject "+
 						"in the leaf certificate",
@@ -110,7 +114,7 @@ the expected ISD-AS value.
 	cmd.Flags().Int64Var(&flags.unixTime, "currenttime", 0,
 		"Optional unix timestamp that sets the current time",
 	)
-	cmd.Flags().StringVar(&flags.subjectIA, "subjectIA", "",
+	cmd.Flags().StringVar(&flags.subjectIA, "subject-isd-as", "",
 		"ISD-AS property of the subject of the certificate",
 	)
 	cmd.MarkFlagRequired("trc")


### PR DESCRIPTION
Add an optional subjectIA flag to the certificate verify command.
This enables validating the IA property of the subject of the certificate against an expected value.

Invalid flag usage or a mismatching IA property of the certificate subject leads to a verification failure.

Adds a check to findIA to ensure that the ISD-AS property stored in the certificate is in the canonical string representation.
The canonical string representation of an ISD-AS is provided by the string formatting function. It is the decimal representation of the uint16 of the ISD, followed by a single dash -, followed by the string formatted representation of the AS id, which for AS ids in the BGP range is the decimal representation, and for larger AS ids consists of a colon separated hexadecimal representation of the value (see the fmtAS function in package addr).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4179)
<!-- Reviewable:end -->
