### PR TITLE
doc: now published on docs.scion.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contribution Guide
 
 The Contribution Guide for the SCION project can be found
-[here](https://anapaya-scion.readthedocs-hosted.com/en/latest/contribute.html).
+[here](https://docs.scion.org/en/latest/contribute.html).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SCION
 
 [![Documentation](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/scionproto/scion)
-[![ReadTheDocs](https://img.shields.io/badge/doc-reference-blue?version=latest&style=flat&label=docs&logo=read-the-docs&logoColor=white)](https://anapaya-scion.readthedocs-hosted.com/en/latest)
+[![ReadTheDocs](https://img.shields.io/badge/doc-reference-blue?version=latest&style=flat&label=docs&logo=read-the-docs&logoColor=white)](https://docs.scion.org/en/latest)
 [![Build Status](https://badge.buildkite.com/e7ca347d947c23883ad7c3a4d091c2df5ae7feb52b238d29a1.svg?branch=master)](https://buildkite.com/scionproto/scion)
 [![Go Report Card](https://goreportcard.com/badge/github.com/scionproto/scion)](https://goreportcard.com/report/github.com/scionproto/scion)
 [![GitHub issues](https://img.shields.io/github/issues/scionproto/scion/help%20wanted.svg?label=help%20wanted&color=purple)](https://github.com/scionproto/scion/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
@@ -15,7 +15,7 @@ On next-generation Networks), a future Internet architecture. SCION is the first
 clean-slate Internet architecture designed to provide route control, failure
 isolation, and explicit trust information for end-to-end communication. To find
 out more about the project, please visit our [documentation
-site](https://anapaya-scion.readthedocs-hosted.com/en/latest/).
+site](https://docs.scion.org/en/latest/).
 
 ## Connecting to the SCION Test Network
 
@@ -27,13 +27,13 @@ packages](https://docs.scionlab.org/content/install/).
 ## Building
 
 To find out how to work with SCION, please visit our [documentation
-site](https://anapaya-scion.readthedocs-hosted.com/en/latest/contribute.html#setting-up-the-development-environment)
+site](https://docs.scion.org/en/latest/contribute.html#setting-up-the-development-environment)
 for instructions on how to install build dependencies, build and run SCION.
 
 ## Contributing
 
 Interested in contribution to the SCION project? Please visit us at
-[contribute.rst](https://anapaya-scion.readthedocs-hosted.com/en/latest/contribute.html)
+[contribute.rst](https://docs.scion.org/en/latest/contribute.html)
 for more information about how you can do so.
 
 ## License

--- a/demo/file_transfer/README.md
+++ b/demo/file_transfer/README.md
@@ -5,7 +5,7 @@ balancing the traffic among two non-overlapping paths.
 
 To run the demo:
 
-1. [set up the development environment](https://scion.docs.anapaya.net/en/latest/build/setup.html)
+1. [set up the development environment](https://docs.scion.org/en/latest/build/setup.html)
 1. `bazel run //demo/file_transfer`
 
 The topology consists of two ASes connected by two links, each thottled to 16 mbps of throughput:

--- a/doc/EPIC.md
+++ b/doc/EPIC.md
@@ -174,7 +174,8 @@ not apply any filtering for traffic from interface 2 to interface 1.
 
 There are two main applications for EPIC-HP:
 
-### <a id="HighlySecureHiddenPaths"></a> Highly Secure Hidden Paths
+<a id="HighlySecureHiddenPaths"></a>
+### Highly Secure Hidden Paths
 
 The last and penultimate ASes on the hidden path only allow EPIC-HP
 traffic on the interface pairs that affect the hidden path.
@@ -194,7 +195,8 @@ packets towards hosts in other ASes, but that those hosts can not
 send a response back if they do not have the necessary
 authenticators.
 
-### <a id="DOSSecureHiddenPaths"></a> DoS-Secure Hidden Paths
+<a id="DOSSecureHiddenPaths"></a>
+### DoS-Secure Hidden Paths
 
 The last and penultimate ASes on the hidden path allow EPIC-HP and
 other path types simultaneously, but prioritize traffic using the
@@ -220,7 +222,7 @@ Proceedings of the USENIX Security Symposium
 
 <a id="2">[2]</a>
 Design Document for the Hidden Path Infrastructure
-[[Link]](https://scion.docs.anapaya.net/en/latest/HiddenPaths.html)
+[[Link]](hidden-paths)
 
 <a id="3">[3]</a>
 T. Lee, C. Pappas, A. Perrig, V. Gligor, and Y. Hu. (2017) <br>

--- a/doc/protocols/bfd.rst
+++ b/doc/protocols/bfd.rst
@@ -49,8 +49,7 @@ SCION router, in particular, does bootstrapping in the following way.
 
 It creates one "external" BFD session for each SCION
 interface that it owns. Its BFD peer is the SCION router in the neighbouring
-AS. The associated BFD packets must use SCION `OneHopPath
-<https://scion.docs.anapaya.net/en/latest/protocols/scion-header.html#path-type-onehoppath>`__
+AS. The associated BFD packets must use SCION :ref:`OneHopPath <path-type-onehop>`
 type.
 
 This kind of BFD session in unambiguously identified by the ID of the SCION interface the
@@ -58,9 +57,7 @@ packet was received on.
 
 Furthermore, SCION router creates one "internal" BFD session for every
 other SCION router instance within the same AS. The associated BFD packets must use SCION
-`Empty
-<https://scion.docs.anapaya.net/en/latest/protocols/scion-header.html#path-type-empty>`__
-path type.
+:ref:`Empty <path-type-empty>` path type.
 
 These BFD sessions are uniquely identified by the source address and port, as it appears
 in the underlay UPD header.

--- a/pkg/slayers/path/infofield.go
+++ b/pkg/slayers/path/infofield.go
@@ -89,7 +89,7 @@ func (inf *InfoField) SerializeTo(b []byte) error {
 
 // UpdateSegID updates the SegID field by XORing the SegID field with the 2
 // first bytes of the MAC. It is the beta calculation according to
-// https://scion.docs.anapaya.net/en/latest/protocols/scion-header.html#hop-field-mac-computation
+// https://docs.scion.org/en/latest/protocols/scion-header.html#hop-field-mac-computation
 func (inf *InfoField) UpdateSegID(hfMac [MacLen]byte) {
 	inf.SegID = inf.SegID ^ binary.BigEndian.Uint16(hfMac[:2])
 }

--- a/pkg/slayers/path/mac.go
+++ b/pkg/slayers/path/mac.go
@@ -22,7 +22,7 @@ import (
 const MACBufferSize = 16
 
 // MAC calculates the HopField MAC according to
-// https://scion.docs.anapaya.net/en/latest/protocols/scion-header.html#hop-field-mac-computation
+// https://docs.scion.org/en/latest/protocols/scion-header.html#hop-field-mac-computation
 // this method does not modify info or hf.
 // Modifying the provided buffer after calling this function may change the returned HopField MAC.
 func MAC(h hash.Hash, info InfoField, hf HopField, buffer []byte) [MacLen]byte {
@@ -33,7 +33,7 @@ func MAC(h hash.Hash, info InfoField, hf HopField, buffer []byte) [MacLen]byte {
 }
 
 // FullMAC calculates the HopField MAC according to
-// https://scion.docs.anapaya.net/en/latest/protocols/scion-header.html#hop-field-mac-computation
+// https://docs.scion.org/en/latest/protocols/scion-header.html#hop-field-mac-computation
 // this method does not modify info or hf.
 // Modifying the provided buffer after calling this function may change the returned HopField MAC.
 // In contrast to MAC(), FullMAC returns all the 16 bytes instead of only 6 bytes of the MAC.


### PR DESCRIPTION
Point documentation links to docs.scion.org.
The corresponding readthedocs project is https://readthedocs.org/projects/scion/.

At the same time, fix a few problems with internal links and anchors in
EPIC and BFD docs.

[doc]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4191)
<!-- Reviewable:end -->
