### PR TITLE
topogen: choose right address type when generating gateway topology

### DIFF
--- a/tools/topology/topo.py
+++ b/tools/topology/topo.py
@@ -333,7 +333,7 @@ class TopoGenerator(object):
         }
 
     def _gen_sig_entries(self, topo_id, as_conf):
-        addr_type = addr_type_from_underlay(DEFAULT_UNDERLAY)
+        addr_type = addr_type_from_underlay(as_conf.get('underlay', DEFAULT_UNDERLAY))
         elem_id = "sig" + topo_id.file_fmt()
         reg_id = "sig" + topo_id.file_fmt()
         port = 30256


### PR DESCRIPTION
There is a problem generating the local topology with the SIG configuration enabled.
When running e.g. `scion.sh topology --sig -d topology/tiny.topo`
the address type is set to IPv4 for the SIG of the 1-ff00:0:112 AS, which is wrong.

Fixes #4192

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4193)
<!-- Reviewable:end -->
