### PR TITLE
deps: add libssl-dev dependency

### DIFF
--- a/tools/env/debian/pkgs.txt
+++ b/tools/env/debian/pkgs.txt
@@ -6,6 +6,7 @@ g++
 gcc
 git
 jq
+libssl-dev
 make
 moreutils
 net-tools


### PR DESCRIPTION
Otherwise the `openssl/md5.h` header can be missing in some systems.
E.g. by running `scion start` with a locally generated topology (with docker):
```
...
bbcp_MD5_openssl.h:47:10: fatal error: openssl/md5.h: No such file or directory
 #include "openssl/md5.h"
          ^~~~~~~~~~~~~~~
compilation terminated.
make[3]: *** [../obj/amd64_linux/bbcp_ChkSum.o] Error 1
make[2]: *** [makeLinuxx86_64] Error 2
make[1]: *** [Linux] Error 2
make: *** [all] Error 2
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4194)
<!-- Reviewable:end -->
