### PR TITLE
ci: increase timeouts to avoid flaky failures

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,7 +26,7 @@ steps:
       automatic:
         - exit_status: -1 # Agent was lost
         - exit_status: 255 # Forced agent shutdown
-    timeout_in_minutes: 10
+    timeout_in_minutes: 20
   - label: "check generated"
     if: build.message !~ /\[doc\]/
     command:
@@ -50,7 +50,7 @@ steps:
       - make antlr
       - diff -ur /tmp/test-artifacts/antlr/ antlr/
       - ./tools/update_testdata.sh
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
     key: check_generated
     retry:
       automatic:
@@ -60,7 +60,7 @@ steps:
     if: build.message =~ /\[doc\]/
     command: make lint
     key: lint
-    timeout_in_minutes: 15
+    timeout_in_minutes: 20
     retry:
       automatic:
         - exit_status: -1 # Agent was lost
@@ -71,7 +71,7 @@ steps:
       - bazel test --config=integration_go
     artifact_paths:
       - "artifacts.out/**/*"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
     key: anapaya_integration_tests
     retry:
       automatic:


### PR DESCRIPTION
Occasionally, the adjusted steps take a bit longer to run when starting
and 10 minutes is not enough. This change sets the timeout higher.

GitOrigin-RevId: 9e994416580ac32a25e5e47c5c111cf9e6a68e7b

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4199)
<!-- Reviewable:end -->
