### PR TITLE
lint: detect captured loop var in go/defer statement

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,1 @@
+# Empty .semgrepignore; the default one skips all _test.go.

--- a/gateway/control/remotemonitor.go
+++ b/gateway/control/remotemonitor.go
@@ -119,7 +119,8 @@ func (rm *RemoteMonitor) process(ctx context.Context, ias []addr.IA) {
 	defer rm.stateMtx.Unlock()
 	logger := log.FromCtx(ctx)
 	newWatchers := make(map[addr.IA]watcherEntry)
-	for _, ia := range ias {
+	for i := range ias {
+		ia := ias[i]
 		we, ok := rm.currentWatchers[ia]
 		if ok {
 			// Watcher for the remote IA exists. Move it to the new map of

--- a/gateway/control/remotemonitor.go
+++ b/gateway/control/remotemonitor.go
@@ -119,8 +119,8 @@ func (rm *RemoteMonitor) process(ctx context.Context, ias []addr.IA) {
 	defer rm.stateMtx.Unlock()
 	logger := log.FromCtx(ctx)
 	newWatchers := make(map[addr.IA]watcherEntry)
-	for i := range ias {
-		ia := ias[i]
+	for _, ia := range ias {
+		ia := ia
 		we, ok := rm.currentWatchers[ia]
 		if ok {
 			// Watcher for the remote IA exists. Move it to the new map of

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -89,8 +89,8 @@ md_lint() {
 semgrep_lint() {
     lint_header "semgrep"
     lint_step "custom rules"
-    docker run --rm -v "${PWD}:/src" returntocorp/semgrep@sha256:8b0735959a6eb737aa945f4d591b6db23b75344135d74c3021b7d427bd317a66 \
-        --config=/src/tools/lint/semgrep --error
+    docker run --rm -v "${PWD}:/src" returntocorp/semgrep@sha256:3bef9d533a44e6448c43ac38159d61fad89b4b57f63e565a8a55ca265273f5ba \
+       semgrep --config=/src/tools/lint/semgrep --error
 }
 
 openapi_lint() {

--- a/tools/lint/semgrep/loopvar_capture.yml
+++ b/tools/lint/semgrep/loopvar_capture.yml
@@ -1,24 +1,44 @@
 rules:
   - id: loopvar_capture
-    pattern-either:
-      - pattern: |
-          for $X := ...; ...; <... $X ...> { ...; go func(...){ ...; <... $X ...>; ... }(...); ... }
-      - pattern: |
-          for $X := ...; ...; <... $X ...> { ...; defer func(...){ ...; <... $X ...>; ... }(...); ... }
-      - pattern: |
-          for $X := range $SLICE { ...; defer func(...){ ...; <... $X ...>; ... }(...); ... }
-      - pattern: |
-          for $X := range $SLICE { ...; go func(...){ ...; <... $X ...>; ... }(...); ... }
-      - pattern: |
-          for $X := range $SLICE { ...; defer func(...){ ...; <... $X ...>; ... }(...); ... }
-      - pattern: |
-          for $X, ... := range $SLICE { ...; go func(...){ ...; <... $X ...>; ... }(...); ... }
-      - pattern: |
-          for $X, ... := range $SLICE { ...; defer func(...){ ...; <... $X ...>; ... }(...); ... }
-      - pattern: |
-          for ..., $X := range $SLICE { ...; go func(...){ ...; <... $X ...>; ... }(...); ... }
-      - pattern: |
-          for ..., $X := range $SLICE { ...; defer func(...){ ...; <... $X ...>; ... }(...); ... }
+    patterns:
+      - pattern-either:
+        - pattern-inside: |
+            for $X := ...; ...; <... $X ...> { ... }
+        - pattern-inside: |
+            for $X := range $SLICE { ... }
+        - pattern-inside: |
+            for $X, ... := range $SLICE { ... }
+        - pattern-inside: |
+            for ..., $X := range $SLICE { ... }
+      - pattern-either:
+        - pattern: |
+            go func(...){ ...; <... $X ...>; ... }(...)
+        - pattern: |
+            defer func(...){ ...; <... $X ...>; ... }(...)
+        - pattern: |
+            $ERRGROUP.Go(func() error { ...; <... $X ...>; ...})
+
+      # These additional patterns are a workaround to exclude certain false
+      # positives, which appear to be caused by semgrep not fully handling
+      # multi-variable assignment.
+      # These two patterns exclude this case:
+      #   for i, x := range values {
+      #      i, x := i, x
+      #      go func() { fmt.Println(i,x) }()
+      #   }
+      - pattern-not-inside: |
+            for ... { $X, ... :=  $X, ...;  ... }
+      - pattern-not-inside: |
+            for ... { ..., $X :=  ..., $X; ... }
+      # This pattern excludes odd matches of the _ variable,
+      # for example
+      #   for _, x := range values {
+      #      go func() { v, _ := foo() }()
+      #   }
+      - metavariable-pattern:
+          metavariable: $X
+          patterns:
+            - pattern-not: _
     message: |
       Captured loop variable `$X` in go or defer statement
     severity: WARNING

--- a/tools/lint/semgrep/loopvar_capture.yml
+++ b/tools/lint/semgrep/loopvar_capture.yml
@@ -1,0 +1,26 @@
+rules:
+  - id: loopvar_capture
+    pattern-either:
+      - pattern: |
+          for $X := ...; ...; <... $X ...> { ...; go func(...){ ...; <... $X ...>; ... }(...); ... }
+      - pattern: |
+          for $X := ...; ...; <... $X ...> { ...; defer func(...){ ...; <... $X ...>; ... }(...); ... }
+      - pattern: |
+          for $X := range $SLICE { ...; defer func(...){ ...; <... $X ...>; ... }(...); ... }
+      - pattern: |
+          for $X := range $SLICE { ...; go func(...){ ...; <... $X ...>; ... }(...); ... }
+      - pattern: |
+          for $X := range $SLICE { ...; defer func(...){ ...; <... $X ...>; ... }(...); ... }
+      - pattern: |
+          for $X, ... := range $SLICE { ...; go func(...){ ...; <... $X ...>; ... }(...); ... }
+      - pattern: |
+          for $X, ... := range $SLICE { ...; defer func(...){ ...; <... $X ...>; ... }(...); ... }
+      - pattern: |
+          for ..., $X := range $SLICE { ...; go func(...){ ...; <... $X ...>; ... }(...); ... }
+      - pattern: |
+          for ..., $X := range $SLICE { ...; defer func(...){ ...; <... $X ...>; ... }(...); ... }
+    message: |
+      Captured loop variable `$X` in go or defer statement
+    severity: WARNING
+    languages:
+      - go


### PR DESCRIPTION
Detect loop variable captured by function in go or defer statement.
The loop variable is reassigned when stepping in the loop, and so
by the time the go routine is run, the value may have changed.

Fix the single occurrence of the pattern.

Update semgrep, as the rules did not appear to work as expected with the
older version.
With this newer version, we now need an (empty) .semgrepignore file, as
by default semgrep ignores all _test.go files, which seems undesirable.
The docker command for semgrep is also changed to explicitly invoke
`semgrep`, as directed by a deprecation warning.

Closes #2164.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4202)
<!-- Reviewable:end -->
