### PR TITLE
serrors: append to existing context in WithCtx

### DIFF
--- a/pkg/private/serrors/errors.go
+++ b/pkg/private/serrors/errors.go
@@ -164,6 +164,15 @@ func IsTemporary(err error) bool {
 // The returned error implements Is and Is(err) returns true.
 // Deprecated: use WrapStr or New instead.
 func WithCtx(err error, errCtx ...interface{}) error {
+	if top, ok := err.(basicError); ok {
+		return basicError{
+			msg:    top.msg,
+			fields: combineFields(top.fields, errCtxToFields(errCtx)),
+			cause:  top.cause,
+			stack:  top.stack,
+		}
+	}
+
 	return basicError{
 		msg:    errOrMsg{err: err},
 		fields: errCtxToFields(errCtx),
@@ -261,6 +270,17 @@ func errCtxToFields(errCtx []interface{}) map[string]interface{} {
 	fields := make(map[string]interface{}, len(errCtx)/2)
 	for i := 0; i < len(errCtx)-1; i += 2 {
 		fields[fmt.Sprint(errCtx[i])] = errCtx[i+1]
+	}
+	return fields
+}
+
+func combineFields(a, b map[string]interface{}) map[string]interface{} {
+	fields := make(map[string]interface{}, len(a)+len(b))
+	for k, v := range a {
+		fields[k] = v
+	}
+	for k, v := range b {
+		fields[k] = v
 	}
 	return fields
 }

--- a/private/mgmtapi/segments/api/testdata/segments-malformed-query.json
+++ b/private/mgmtapi/segments/api/testdata/segments-malformed-query.json
@@ -1,5 +1,5 @@
 {
-    "detail": "[ parsing AS part {index=0; value=ff001:0:110}: strconv.ParseUint: parsing \"ff001\": value out of range {parameter=start_isd_as}; parsing AS part {index=0; value=ff000:0:112}: strconv.ParseUint: parsing \"ff000\": value out of range {parameter=end_isd_as} ]",
+    "detail": "[ parsing AS part {index=0; parameter=start_isd_as; value=ff001:0:110}: strconv.ParseUint: parsing \"ff001\": value out of range; parsing AS part {index=0; parameter=end_isd_as; value=ff000:0:112}: strconv.ParseUint: parsing \"ff000\": value out of range ]",
     "status": 400,
     "title": "malformed query parameters",
     "type": "/problems/bad-request"


### PR DESCRIPTION
When calling `WithCtx` on an existing wrapped `serrors.basicError`,
append the new context to the existing context `fields`.

To illustrate, the following two blocks below create the same error:
```go
cause := serrors.New("base error")
err := serrors.WrapStr("wrapped", cause, "ctx1", 1, "ctx2", 2)
fmt.Println(err)
// -> wrapped {ctx1=1; ctx2=2}: base error

err = serrors.WrapStr("wrapped", cause, "ctx1", 1)
err = serrors.WithCtx(err, "ctx2", 2)
fmt.Println(err)
// -> wrapped {ctx1=1; ctx2=2}: base error
```

This tidies up the string representation of the error; previously
the second block would have returned the somewhat confusing
```
wrapped {ctx1=1}: base error {ctx2=2}
```

Fixes #3364

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4207)
<!-- Reviewable:end -->
