### PR TITLE
launcher: ignore errors after SIGTERM

### DIFF
--- a/private/app/launcher/launcher.go
+++ b/private/app/launcher/launcher.go
@@ -143,7 +143,15 @@ func (a *Application) run() error {
 		cancel()
 	}()
 
-	return cmd.ExecuteContext(ctx)
+	err := cmd.ExecuteContext(ctx)
+	// If SIGTERM was already received, ignore the error and exit with error code 0.
+	select {
+	case <-sigtermCtx.Done():
+		log.Error("error occured after SIGTERM, ignoring", "err", err)
+		return nil
+	default:
+		return err
+	}
 }
 
 func (a *Application) getShortName(executable string) string {


### PR DESCRIPTION
This prevents acceptance tests failing in the teardown phase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4208)
<!-- Reviewable:end -->
