### PR TITLE
ci: speed up go-module-proxy

### DIFF
--- a/.buildkite/hooks/go-module-proxy.yml
+++ b/.buildkite/hooks/go-module-proxy.yml
@@ -4,7 +4,8 @@ services:
   go-module-proxy:
     container_name: go-module-proxy
     network_mode: host
-    image: $REGISTRY/gomods/athens:v0.11.0
+    # gomods/athens:canary of 29.04.2022 -- using unstable version for the "ATHENS_NETWORK_MODE=offline" feature, see below
+    image: $REGISTRY/gomods/athens@sha256:319701a7541a3e70ff45f290b185364738cac62b845eeb13b25c258f6189af7f
     environment:
       ATHENS_PORT: 3200
       ATHENS_STORAGE_TYPE: "s3"
@@ -12,3 +13,8 @@ services:
       AWS_ACCESS_KEY_ID: $ATHENS_S3_ACCESS_KEY_ID
       AWS_SECRET_ACCESS_KEY: $ATHENS_S3_SECRET_ACCESS_KEY
       ATHENS_S3_BUCKET_NAME: $ATHENS_S3_BUCKET
+      # Optimisations for version listing (e.g. in go mod tidy), see https://github.com/gomods/athens/issues/1733#issuecomment-1063296486
+      # Use proxy.golang.org to accelerate fetching cache misses
+      ATHENS_GO_BINARY_ENV_VARS: "GOPROXY=https://proxy.golang.org|direct"
+      # disable accessing VCS for /list requests
+      ATHENS_NETWORK_MODE: offline

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -2,11 +2,14 @@
 
 
 if [ -f ".buildkite/hooks/bazel-remote.yml" -a -z "$PRE_COMMAND_SETUP" ]; then
-    echo "--- Uploading bazel-remote logs/metrics"
+    echo "--- Uploading bazel-remote and go-module-proxy logs/metrics"
     curl http://localhost:8080/metrics > bazel-remote-cache.metrics
-    docker stop bazel-remote-cache
     docker logs bazel-remote-cache &> bazel-remote-cache.log
-    buildkite-agent artifact upload "bazel-remote-cache.*"
+
+    curl http://localhost:3200/metrics > go-module-proxy.metrics
+    docker logs go-module-proxy &> go-module-proxy.log
+
+    buildkite-agent artifact upload "bazel-remote-cache.*;go-module-proxy.*"
 fi
 
 echo "--- Cleaning up the topology"
@@ -14,12 +17,7 @@ echo "--- Cleaning up the topology"
 ./scion.sh topo_clean
 
 echo "--- Cleaning up docker containers/networks/volumes"
-remote_cache=$(docker ps -q -f name=bazel-remote-cache)
-if [ -z ${remote_cache#+x} ]; then
-    cntrs="$(docker ps -aq)"
-else
-    cntrs="$(docker ps -aq | grep -v $remote_cache || true)"
-fi
+cntrs="$(docker ps -aq | grep -v -f <(docker ps -q --filter "name=go-module-proxy" --filter "name=bazel-remote-cache"))"
 [ -n "$cntrs" ] && { echo "Remove leftover containers..."; docker rm -f $cntrs; }
 
 echo "Remove leftover networks"

--- a/tools/update_testdata.sh
+++ b/tools/update_testdata.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-export PATH=$PATH:$(bazel info output_base)/external/go_sdk/bin
+export PATH=$(bazel info output_base)/external/go_sdk/bin:$PATH
 
 folders=$(grep \
             -lR \


### PR DESCRIPTION
Adapt configuration of go-module-proxy to improve performance, in
particular for `/list` queries, which occur for example during gazelle's
`update-repos` during `make go_deps.bzl`.

Upload go-module-proxy logs and metrics as artifacts.

Do not stop go-module-proxy or bazel-remote-cache on agent after exiting
between jobs to keep warmed up in-memory state. Any changes to the
docker configuration of these services between jobs are automatically
handled by docker-compose.

Aside; in tools/update_testdata.sh, put bazel's go_sdk first into the
path, so that the script picks up these binaries for running the
tests. This only makes a difference for local execution of the script,
the buildkite agents don't have go installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4211)
<!-- Reviewable:end -->
