### PR TITLE
scion-pki: print verification error

### DIFF
--- a/scion-pki/certs/renew.go
+++ b/scion-pki/certs/renew.go
@@ -468,7 +468,7 @@ The template is expressed in JSON. A valid example::
 				if verifyError := cppki.VerifyChain(chain, verifyOptions); verifyError != nil {
 					suffix := "." + addr.FormatIA(ca, addr.WithFileSeparator()) + ".unverified"
 
-					printErr("Verification failed: %s\n", err)
+					printErr("Verification failed: %s\n", verifyError)
 
 					// Write chain.
 					certFile := outCertFile + suffix


### PR DESCRIPTION
Print the verification error when certificate verification fails.
Before, there was a bug that would always print the nil error that was previously defined.