### PR TITLE
drkey: Add SecretValue DB

### DIFF
--- a/pkg/drkey/db.go
+++ b/pkg/drkey/db.go
@@ -27,9 +27,9 @@ var ErrKeyNotFound = serrors.New("key not found")
 
 // SecretValueDB is the database for Secret Values.
 type SecretValueDB interface {
-	GetValue(ctx context.Context, meta SecretValueMeta) (SecretValue, error)
-	InsertValue(ctx context.Context, key SecretValue) error
-	DeleteExpiredValues(ctx context.Context, cutoff time.Time) (int64, error)
+	GetValue(ctx context.Context, meta SecretValueMeta, asSecret []byte) (SecretValue, error)
+	InsertValue(ctx context.Context, proto Protocol, epoch Epoch) error
+	DeleteExpiredValues(ctx context.Context, cutoff time.Time) (int, error)
 
 	io.Closer
 	db.LimitSetter
@@ -39,7 +39,7 @@ type SecretValueDB interface {
 type Level1DB interface {
 	GetLevel1Key(ctx context.Context, meta Level1Meta) (Level1Key, error)
 	InsertLevel1Key(ctx context.Context, key Level1Key) error
-	DeleteExpiredLevel1Keys(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteExpiredLevel1Keys(ctx context.Context, cutoff time.Time) (int, error)
 
 	io.Closer
 	db.LimitSetter
@@ -53,7 +53,7 @@ type Level2DB interface {
 	InsertASHostKey(ctx context.Context, key ASHostKey) error
 	InsertHostASKey(ctx context.Context, key HostASKey) error
 	InsertHostHostKey(ctx context.Context, key HostHostKey) error
-	DeleteExpiredLevel2Keys(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteExpiredLevel2Keys(ctx context.Context, cutoff time.Time) (int, error)
 
 	io.Closer
 	db.LimitSetter

--- a/private/storage/drkey/sv/dbtest/BUILD.bazel
+++ b/private/storage/drkey/sv/dbtest/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//tools/lint:go.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["dbtest.go"],
+    importpath = "github.com/scionproto/scion/private/storage/drkey/sv/dbtest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/drkey:go_default_library",
+        "//pkg/private/xtest:go_default_library",
+        "//pkg/scrypto/cppki:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
+)

--- a/private/storage/drkey/sv/dbtest/dbtest.go
+++ b/private/storage/drkey/sv/dbtest/dbtest.go
@@ -1,0 +1,92 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/pkg/drkey"
+	"github.com/scionproto/scion/pkg/private/xtest"
+	"github.com/scionproto/scion/pkg/scrypto/cppki"
+)
+
+const (
+	timeOffset = 10 * 60 // 10 minutes
+	timeout    = 3 * time.Second
+)
+
+var (
+	srcIA = xtest.MustParseIA("1-ff00:0:111")
+)
+
+type TestableDB interface {
+	drkey.SecretValueDB
+	Prepare(t *testing.T, ctx context.Context)
+}
+
+// TestDB should be used to test any implementation of the SecretValueDB interface. An
+// implementation of the SecretValueDB interface should at least have one test
+// method that calls this test-suite.
+func TestDB(t *testing.T, db TestableDB) {
+	prepareCtx, cancelF := context.WithTimeout(context.Background(), 2*timeout)
+	db.Prepare(t, prepareCtx)
+	cancelF()
+	defer db.Close()
+	testDB(t, db)
+}
+
+func testDB(t *testing.T, db drkey.SecretValueDB) {
+	ctx, cancelF := context.WithTimeout(context.Background(), timeout)
+	defer cancelF()
+
+	epoch := drkey.Epoch{
+		Validity: cppki.Validity{
+			NotBefore: time.Now(),
+			NotAfter:  time.Now().Add(timeOffset * time.Second),
+		},
+	}
+	asSecret := []byte{0, 1, 2, 3, 4, 5, 6, 7}
+	asSecret = append(asSecret, byte(srcIA))
+	sv, err := drkey.DeriveSV(drkey.Protocol(0), epoch, asSecret)
+	require.NoError(t, err)
+
+	err = db.InsertValue(ctx, sv.ProtoId, sv.Epoch)
+	require.NoError(t, err)
+	// same key again. It should be okay.
+	err = db.InsertValue(ctx, sv.ProtoId, sv.Epoch)
+	require.NoError(t, err)
+	newSecretValue, err := db.GetValue(ctx, drkey.SecretValueMeta{
+		ProtoId:  drkey.Protocol(0),
+		Validity: time.Now(),
+	},
+		asSecret,
+	)
+	require.NoError(t, err)
+	require.EqualValues(t, sv.Key, newSecretValue.Key)
+
+	rows, err := db.DeleteExpiredValues(ctx,
+		time.Now().Add(-timeOffset*time.Second))
+	require.NoError(t, err)
+	require.EqualValues(t, 0, rows)
+
+	rows, err = db.DeleteExpiredValues(ctx,
+		time.Now().Add(2*timeOffset*time.Second))
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+}

--- a/private/storage/drkey/sv/metrics/BUILD.bazel
+++ b/private/storage/drkey/sv/metrics/BUILD.bazel
@@ -1,0 +1,28 @@
+load("//tools/lint:go.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "github.com/scionproto/scion/private/storage/drkey/sv/metrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/drkey:go_default_library",
+        "//pkg/private/prom:go_default_library",
+        "//private/storage/db:go_default_library",
+        "//private/tracing:go_default_library",
+        "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["metrics_test.go"],
+    deps = [
+        ":go_default_library",
+        "//pkg/drkey:go_default_library",
+        "//private/storage/drkey/sv/dbtest:go_default_library",
+        "//private/storage/drkey/sv/sqlite:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
+)

--- a/private/storage/drkey/sv/metrics/metrics.go
+++ b/private/storage/drkey/sv/metrics/metrics.go
@@ -1,0 +1,145 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/scionproto/scion/pkg/drkey"
+	"github.com/scionproto/scion/pkg/private/prom"
+	dblib "github.com/scionproto/scion/private/storage/db"
+	"github.com/scionproto/scion/private/tracing"
+)
+
+const (
+	svNamespace = "secretValueDB"
+	promDBName  = "db"
+)
+
+type promOp string
+
+const (
+	promOpGetSV           promOp = "get_sv"
+	promOpInsertSV        promOp = "insert_sv"
+	promOpDeleteExpiredSV promOp = "delete_experied_sv"
+)
+
+var (
+	queriesSVTotal *prometheus.CounterVec
+	resultsSVTotal *prometheus.CounterVec
+
+	initMetricsSVOnce sync.Once
+)
+
+func initMetricsSecretValue() {
+	initMetricsSVOnce.Do(func() {
+		queriesSVTotal = prom.NewCounterVec(svNamespace, "", "queries_total",
+			"Total queries to the SecretValueDB.", []string{promDBName, prom.LabelOperation})
+		resultsSVTotal = prom.NewCounterVec(svNamespace, "", "results_total",
+			"The results of the SecretValueDB ops.",
+			[]string{promDBName, prom.LabelResult, prom.LabelOperation})
+	})
+}
+
+// SecretValueWithMetrics wraps the given SecretValueDB into one that also exports metrics.
+func SecretValueWithMetrics(dbName string, svdb drkey.SecretValueDB) drkey.SecretValueDB {
+	initMetricsSecretValue()
+	labels := prometheus.Labels{promDBName: dbName}
+	return &MetricsDB{
+		db: svdb,
+		metrics: &countersSV{
+			queriesSVTotal: queriesSVTotal.MustCurryWith(labels),
+			resultsSVTotal: resultsSVTotal.MustCurryWith(labels),
+		},
+	}
+}
+
+type countersSV struct {
+	queriesSVTotal *prometheus.CounterVec
+	resultsSVTotal *prometheus.CounterVec
+}
+
+func (c *countersSV) Observe(ctx context.Context, op promOp,
+	action func(ctx context.Context) error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, fmt.Sprintf("drkeySVDB.%s", string(op)))
+	defer span.Finish()
+	c.queriesSVTotal.WithLabelValues(string(op)).Inc()
+	err := action(ctx)
+
+	label := dblib.ErrToMetricLabel(err)
+	tracing.Error(span, err)
+	tracing.ResultLabel(span, label)
+
+	c.resultsSVTotal.WithLabelValues(label, string(op)).Inc()
+}
+
+var _ drkey.SecretValueDB = (*MetricsDB)(nil)
+
+// MetricsDB is a SecretValueDB wrapper that exports the counts of operations as
+// prometheus metrics
+type MetricsDB struct {
+	db      drkey.SecretValueDB
+	metrics *countersSV
+}
+
+func (db *MetricsDB) SetMaxOpenConns(maxOpenConns int) {
+	db.db.SetMaxOpenConns(maxOpenConns)
+}
+
+func (db *MetricsDB) SetMaxIdleConns(maxIdleConns int) {
+	db.db.SetMaxIdleConns(maxIdleConns)
+}
+
+func (db *MetricsDB) Close() error {
+	return db.db.Close()
+}
+
+func (db *MetricsDB) GetValue(ctx context.Context,
+	meta drkey.SecretValueMeta, asSecret []byte) (drkey.SecretValue, error) {
+	var ret drkey.SecretValue
+	var err error
+	db.metrics.Observe(ctx, promOpGetSV, func(ctx context.Context) error {
+		ret, err = db.db.GetValue(ctx, meta, asSecret)
+		return err
+	})
+	return ret, err
+}
+
+func (db *MetricsDB) InsertValue(ctx context.Context,
+	proto drkey.Protocol, epoch drkey.Epoch) error {
+	var err error
+	db.metrics.Observe(ctx, promOpInsertSV, func(ctx context.Context) error {
+		err = db.db.InsertValue(ctx, proto, epoch)
+		return err
+	})
+	return err
+}
+
+func (db *MetricsDB) DeleteExpiredValues(ctx context.Context,
+	cutoff time.Time) (int, error) {
+	var ret int
+	var err error
+	db.metrics.Observe(ctx, promOpDeleteExpiredSV, func(ctx context.Context) error {
+		ret, err = db.db.DeleteExpiredValues(ctx, cutoff)
+		return err
+	})
+	return ret, err
+}

--- a/private/storage/drkey/sv/metrics/metrics_test.go
+++ b/private/storage/drkey/sv/metrics/metrics_test.go
@@ -1,0 +1,56 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics_test
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/pkg/drkey"
+	"github.com/scionproto/scion/private/storage/drkey/sv/dbtest"
+	"github.com/scionproto/scion/private/storage/drkey/sv/metrics"
+	"github.com/scionproto/scion/private/storage/drkey/sv/sqlite"
+)
+
+var _ dbtest.TestableDB = (*TestBackend)(nil)
+
+type TestBackend struct {
+	drkey.SecretValueDB
+}
+
+func (b *TestBackend) Prepare(t *testing.T, _ context.Context) {
+	db := newSecretValueDatabase(t)
+	b.SecretValueDB = metrics.SecretValueWithMetrics("testdb", db)
+}
+
+func TestSecretValueDBSuite(t *testing.T) {
+	tdb := &TestBackend{}
+	dbtest.TestDB(t, tdb)
+}
+
+func newSecretValueDatabase(t *testing.T) *sqlite.Backend {
+	dir := t.TempDir()
+	file, err := ioutil.TempFile(dir, "db-test-")
+	require.NoError(t, err)
+	name := file.Name()
+	err = file.Close()
+	require.NoError(t, err)
+	db, err := sqlite.NewBackend(name)
+	require.NoError(t, err)
+	return db
+}

--- a/private/storage/drkey/sv/sqlite/BUILD.bazel
+++ b/private/storage/drkey/sv/sqlite/BUILD.bazel
@@ -1,0 +1,24 @@
+load("//tools/lint:go.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["db.go"],
+    importpath = "github.com/scionproto/scion/private/storage/drkey/sv/sqlite",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/drkey:go_default_library",
+        "//pkg/private/util:go_default_library",
+        "//private/storage/db:go_default_library",
+        "@com_github_mattn_go_sqlite3//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["db_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//private/storage/drkey/sv/dbtest:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
+)

--- a/private/storage/drkey/sv/sqlite/db.go
+++ b/private/storage/drkey/sv/sqlite/db.go
@@ -1,0 +1,158 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/scionproto/scion/pkg/drkey"
+	"github.com/scionproto/scion/pkg/private/util"
+	"github.com/scionproto/scion/private/storage/db"
+)
+
+const (
+	SVSchemaVersion = 1
+	SVSchema        = `
+	CREATE TABLE DRKeySV (
+		Protocol	INTEGER NOT NULL,
+		EpochBegin 	INTEGER NOT NULL,
+		EpochEnd 	INTEGER NOT NULL,
+		PRIMARY KEY (Protocol, EpochBegin)
+	);`
+)
+
+var _ drkey.SecretValueDB = (*Backend)(nil)
+
+// Backend implements a SV DB with sqlite.
+type Backend struct {
+	*executor
+	db *sql.DB
+}
+
+// NewBackend creates a database and prepares all statements.
+func NewBackend(path string) (*Backend, error) {
+	db, err := db.NewSqlite(path, SVSchema, SVSchemaVersion)
+	if err != nil {
+		return nil, err
+	}
+	b := &Backend{
+		executor: &executor{
+			db: db,
+		},
+		db: db,
+	}
+	return b, nil
+}
+
+// Close closes the database connection.
+func (b *Backend) Close() error {
+	return b.db.Close()
+}
+
+// SetMaxOpenConns sets the maximum number of open connections.
+func (b *Backend) SetMaxOpenConns(maxOpenConns int) {
+	b.db.SetMaxOpenConns(maxOpenConns)
+}
+
+// SetMaxIdleConns sets the maximum number of idle connections.
+func (b *Backend) SetMaxIdleConns(maxIdleConns int) {
+	b.db.SetMaxIdleConns(maxIdleConns)
+}
+
+type executor struct {
+	sync.RWMutex
+	db db.Sqler
+}
+
+const getSV = `
+SELECT EpochBegin, EpochEnd FROM DRKeySV
+WHERE Protocol=?
+AND EpochBegin<=? AND ?<EpochEnd
+`
+
+// GetValue takes the protocol and the time at which the SV must be
+// valid and return such a SV.
+func (e *executor) GetValue(ctx context.Context,
+	meta drkey.SecretValueMeta, asSecret []byte) (drkey.SecretValue, error) {
+	e.RLock()
+	defer e.RUnlock()
+	var epochBegin, epochEnd int
+
+	valSecs := util.TimeToSecs(meta.Validity)
+	err := e.db.QueryRowContext(ctx, getSV, meta.ProtoId, valSecs, valSecs).Scan(&epochBegin,
+		&epochEnd)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			return drkey.SecretValue{}, db.NewReadError("getting SV", err)
+		}
+		return drkey.SecretValue{}, drkey.ErrKeyNotFound
+	}
+	returningKey, err := drkey.DeriveSV(meta.ProtoId, drkey.NewEpoch(uint32(epochBegin),
+		uint32(epochEnd)), asSecret)
+	if err != nil {
+		return drkey.SecretValue{}, err
+	}
+	return returningKey, nil
+}
+
+const insertSVStmt = `
+INSERT OR IGNORE INTO DRKeySV (Protocol,EpochBegin, EpochEnd)
+VALUES (?, ?, ?)
+`
+
+// InsertValue inserts a SV.
+func (e *executor) InsertValue(ctx context.Context, proto drkey.Protocol,
+	epoch drkey.Epoch) error {
+	e.RLock()
+	defer e.RUnlock()
+
+	return db.DoInTx(ctx, e.db, func(ctx context.Context, tx *sql.Tx) error {
+		return insertSV(ctx, tx, proto, epoch)
+	})
+}
+
+func insertSV(ctx context.Context, tx *sql.Tx, proto drkey.Protocol, epoch drkey.Epoch) error {
+	_, err := tx.ExecContext(ctx, insertSVStmt, proto, uint32(epoch.NotBefore.Unix()),
+		uint32(epoch.NotAfter.Unix()))
+	if err != nil {
+		return db.NewWriteError("inserting SV", err)
+	}
+	return nil
+}
+
+// DeleteExpiredValues removes all expired SVs, i.e. all the keys
+// which expiration time is strictly smaller than the cutoff
+func (e *executor) DeleteExpiredValues(ctx context.Context, cutoff time.Time) (int, error) {
+	e.RLock()
+	defer e.RUnlock()
+
+	return db.DeleteInTx(ctx, e.db, func(tx *sql.Tx) (sql.Result, error) {
+		return deleteExpiredSV(ctx, tx, cutoff)
+	})
+}
+
+const deleteExpiredSVStmt = `
+DELETE FROM DRKeySV WHERE ? >= EpochEnd
+`
+
+func deleteExpiredSV(ctx context.Context, tx *sql.Tx, cutoff time.Time) (sql.Result, error) {
+	cutoffSecs := util.TimeToSecs(cutoff)
+	return tx.ExecContext(ctx, deleteExpiredSVStmt, cutoffSecs)
+}

--- a/private/storage/drkey/sv/sqlite/db_test.go
+++ b/private/storage/drkey/sv/sqlite/db_test.go
@@ -1,0 +1,53 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/private/storage/drkey/sv/dbtest"
+)
+
+var _ dbtest.TestableDB = (*TestBackend)(nil)
+
+type TestBackend struct {
+	*Backend
+}
+
+func (b *TestBackend) Prepare(t *testing.T, _ context.Context) {
+	db := newSecretValueDatabase(t)
+	b.Backend = db
+}
+
+func TestSecretValueDBSuite(t *testing.T) {
+	tdb := &TestBackend{}
+	dbtest.TestDB(t, tdb)
+}
+
+func newSecretValueDatabase(t *testing.T) *Backend {
+	dir := t.TempDir()
+	file, err := ioutil.TempFile(dir, "db-test-")
+	require.NoError(t, err)
+	name := file.Name()
+	err = file.Close()
+	require.NoError(t, err)
+	db, err := NewBackend(name)
+	require.NoError(t, err)
+	return db
+}


### PR DESCRIPTION
This PR is the 2/n started with #4217.

This PR contains:
- Sqlite implementation of the SecretValueDB interface
- Metrics support
- UTs