### PR TITLE
drkey: Add Level1 DB

### DIFF
--- a/private/storage/drkey/BUILD.bazel
+++ b/private/storage/drkey/BUILD.bazel
@@ -1,0 +1,8 @@
+load("//tools/lint:go.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "github.com/scionproto/scion/private/storage/drkey",
+    visibility = ["//visibility:public"],
+)

--- a/private/storage/drkey/level1/BUILD.bazel
+++ b/private/storage/drkey/level1/BUILD.bazel
@@ -1,0 +1,28 @@
+load("//tools/lint:go.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["db.go"],
+    importpath = "github.com/scionproto/scion/private/storage/drkey/level1",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/drkey:go_default_library",
+        "//pkg/metrics:go_default_library",
+        "//private/storage/db:go_default_library",
+        "//private/tracing:go_default_library",
+        "@com_github_opentracing_opentracing_go//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["db_test.go"],
+    deps = [
+        ":go_default_library",
+        "//pkg/drkey:go_default_library",
+        "//pkg/metrics:go_default_library",
+        "//private/storage/drkey/level1/dbtest:go_default_library",
+        "//private/storage/drkey/level1/sqlite:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
+)

--- a/private/storage/drkey/level1/BUILD.bazel
+++ b/private/storage/drkey/level1/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/drkey:go_default_library",
         "//pkg/metrics:go_default_library",
         "//private/storage/db:go_default_library",
+        "//private/storage/drkey:go_default_library",
         "//private/tracing:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
     ],

--- a/private/storage/drkey/level1/db.go
+++ b/private/storage/drkey/level1/db.go
@@ -1,0 +1,108 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package level1
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/scionproto/scion/pkg/drkey"
+	"github.com/scionproto/scion/pkg/metrics"
+	dblib "github.com/scionproto/scion/private/storage/db"
+	"github.com/scionproto/scion/private/tracing"
+)
+
+const (
+	promOpGetKey            = "get_lvl1_key"
+	promOpInsertKey         = "insert_lvl1_key"
+	promOpDeleteExpiredKeys = "delete_expired_lvl1_keys"
+)
+
+type Metrics struct {
+	QueriesTotal metrics.Counter
+	ResultsTotal metrics.Counter
+}
+
+func (m *Metrics) Observe(ctx context.Context, op string, action func(context.Context) error) {
+	if m == nil {
+		_ = action(ctx)
+		return
+	}
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, fmt.Sprintf("drkeyLevel1DB.%s", op))
+	defer span.Finish()
+
+	metrics.CounterInc(metrics.CounterWith(m.QueriesTotal, "operation", op))
+	err := action(ctx)
+
+	label := dblib.ErrToMetricLabel(err)
+	tracing.Error(span, err)
+	tracing.ResultLabel(span, label)
+
+	metrics.CounterInc(metrics.CounterWith(m.ResultsTotal, "operation", op))
+}
+
+type Database struct {
+	Backend drkey.Level1DB
+	Metrics *Metrics
+}
+
+func (db *Database) SetMaxOpenConns(maxOpenConns int) {
+	db.Backend.SetMaxOpenConns(maxOpenConns)
+}
+
+func (db *Database) SetMaxIdleConns(maxIdleConns int) {
+	db.Backend.SetMaxIdleConns(maxIdleConns)
+}
+
+func (db *Database) Close() error {
+	return db.Backend.Close()
+}
+
+func (db *Database) GetLevel1Key(
+	ctx context.Context,
+	meta drkey.Level1Meta,
+) (drkey.Level1Key, error) {
+	var ret drkey.Level1Key
+	var err error
+	db.Metrics.Observe(ctx, promOpGetKey, func(ctx context.Context) error {
+		ret, err = db.Backend.GetLevel1Key(ctx, meta)
+		return err
+	})
+	return ret, err
+}
+
+func (db *Database) InsertLevel1Key(ctx context.Context, key drkey.Level1Key) error {
+	var err error
+	db.Metrics.Observe(ctx, promOpInsertKey, func(ctx context.Context) error {
+		err = db.Backend.InsertLevel1Key(ctx, key)
+		return err
+	})
+	return err
+}
+
+func (db *Database) DeleteExpiredLevel1Keys(ctx context.Context,
+	cutoff time.Time) (int, error) {
+	var ret int
+	var err error
+	db.Metrics.Observe(ctx, promOpDeleteExpiredKeys, func(ctx context.Context) error {
+		ret, err = db.Backend.DeleteExpiredLevel1Keys(ctx, cutoff)
+		return err
+	})
+	return ret, err
+}

--- a/private/storage/drkey/level1/db.go
+++ b/private/storage/drkey/level1/db.go
@@ -24,13 +24,8 @@ import (
 	"github.com/scionproto/scion/pkg/drkey"
 	"github.com/scionproto/scion/pkg/metrics"
 	dblib "github.com/scionproto/scion/private/storage/db"
+	st_drkey "github.com/scionproto/scion/private/storage/drkey"
 	"github.com/scionproto/scion/private/tracing"
-)
-
-const (
-	promOpGetKey            = "get_lvl1_key"
-	promOpInsertKey         = "insert_lvl1_key"
-	promOpDeleteExpiredKeys = "delete_expired_lvl1_keys"
 )
 
 type Metrics struct {
@@ -78,9 +73,10 @@ func (db *Database) GetLevel1Key(
 	ctx context.Context,
 	meta drkey.Level1Meta,
 ) (drkey.Level1Key, error) {
+
 	var ret drkey.Level1Key
 	var err error
-	db.Metrics.Observe(ctx, promOpGetKey, func(ctx context.Context) error {
+	db.Metrics.Observe(ctx, st_drkey.PromOpGetKey, func(ctx context.Context) error {
 		ret, err = db.Backend.GetLevel1Key(ctx, meta)
 		return err
 	})
@@ -89,7 +85,7 @@ func (db *Database) GetLevel1Key(
 
 func (db *Database) InsertLevel1Key(ctx context.Context, key drkey.Level1Key) error {
 	var err error
-	db.Metrics.Observe(ctx, promOpInsertKey, func(ctx context.Context) error {
+	db.Metrics.Observe(ctx, st_drkey.PromOpInsertKey, func(ctx context.Context) error {
 		err = db.Backend.InsertLevel1Key(ctx, key)
 		return err
 	})
@@ -100,7 +96,7 @@ func (db *Database) DeleteExpiredLevel1Keys(ctx context.Context,
 	cutoff time.Time) (int, error) {
 	var ret int
 	var err error
-	db.Metrics.Observe(ctx, promOpDeleteExpiredKeys, func(ctx context.Context) error {
+	db.Metrics.Observe(ctx, st_drkey.PromOpDeleteExpiredKeys, func(ctx context.Context) error {
 		ret, err = db.Backend.DeleteExpiredLevel1Keys(ctx, cutoff)
 		return err
 	})

--- a/private/storage/drkey/level1/db_test.go
+++ b/private/storage/drkey/level1/db_test.go
@@ -1,0 +1,62 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package level1_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/pkg/drkey"
+	"github.com/scionproto/scion/pkg/metrics"
+	"github.com/scionproto/scion/private/storage/drkey/level1"
+	"github.com/scionproto/scion/private/storage/drkey/level1/dbtest"
+	"github.com/scionproto/scion/private/storage/drkey/level1/sqlite"
+)
+
+var _ dbtest.TestableDB = (*TestBackend)(nil)
+
+type TestBackend struct {
+	drkey.Level1DB
+}
+
+func (b *TestBackend) Prepare(t *testing.T, _ context.Context) {
+	b.Level1DB = &level1.Database{
+		Backend: newDatabase(t),
+		Metrics: &level1.Metrics{
+			QueriesTotal: metrics.NewTestCounter(),
+			ResultsTotal: metrics.NewTestCounter(),
+		},
+	}
+}
+
+func TestDBSuite(t *testing.T) {
+	tdb := &TestBackend{}
+	dbtest.TestDB(t, tdb)
+}
+
+func newDatabase(t *testing.T) *sqlite.Backend {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "db-test-")
+	require.NoError(t, err)
+	name := file.Name()
+	err = file.Close()
+	require.NoError(t, err)
+	db, err := sqlite.NewBackend(name)
+	require.NoError(t, err)
+	return db
+}

--- a/private/storage/drkey/level1/dbtest/BUILD.bazel
+++ b/private/storage/drkey/level1/dbtest/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//tools/lint:go.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["dbtest.go"],
+    importpath = "github.com/scionproto/scion/private/storage/drkey/level1/dbtest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/drkey:go_default_library",
+        "//pkg/private/xtest:go_default_library",
+        "//pkg/scrypto/cppki:go_default_library",
+        "//private/drkey/drkeytest:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
+)

--- a/private/storage/drkey/level1/dbtest/dbtest.go
+++ b/private/storage/drkey/level1/dbtest/dbtest.go
@@ -1,0 +1,96 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dbtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/scionproto/scion/pkg/drkey"
+	"github.com/scionproto/scion/pkg/private/xtest"
+	"github.com/scionproto/scion/pkg/scrypto/cppki"
+	"github.com/scionproto/scion/private/drkey/drkeytest"
+)
+
+const (
+	timeOffset = 10 * 60 * time.Second // 10 minutes
+	timeout    = 3 * time.Second
+)
+
+var (
+	srcIA = xtest.MustParseIA("1-ff00:0:111")
+	dstIA = xtest.MustParseIA("1-ff00:0:112")
+)
+
+type TestableDB interface {
+	drkey.Level1DB
+	Prepare(t *testing.T, ctx context.Context)
+}
+
+// Test should be used to test any implementation of the Level1DB interface. An
+// implementation of the Level1DB interface should at least have one test
+// method that calls this test-suite.
+func TestDB(t *testing.T, db TestableDB) {
+	prepareCtx, cancelF := context.WithTimeout(context.Background(), 2*timeout)
+	db.Prepare(t, prepareCtx)
+	cancelF()
+	defer db.Close()
+	testDRKeyLevel1(t, db)
+}
+
+func testDRKeyLevel1(t *testing.T, db drkey.Level1DB) {
+	ctx, cancelF := context.WithTimeout(context.Background(), timeout)
+	defer cancelF()
+
+	epoch := drkey.Epoch{
+		Validity: cppki.Validity{
+			NotBefore: time.Now(),
+			NotAfter:  time.Now().Add(timeOffset),
+		},
+	}
+	protoId := drkey.Protocol(0)
+	drkeyLevel1 := drkeytest.GetLevel1(t, protoId, epoch, srcIA, dstIA)
+
+	lvl1Meta := drkey.Level1Meta{
+		Validity: time.Now(),
+		ProtoId:  protoId,
+		SrcIA:    srcIA,
+		DstIA:    dstIA,
+	}
+
+	err := db.InsertLevel1Key(ctx, drkeyLevel1)
+	assert.NoError(t, err)
+	// same key again. It should be okay.
+	err = db.InsertLevel1Key(ctx, drkeyLevel1)
+	assert.NoError(t, err)
+
+	newKey, err := db.GetLevel1Key(ctx, lvl1Meta)
+	assert.NoError(t, err)
+	assert.Equal(t, drkeyLevel1.Key, newKey.Key)
+
+	rows, err := db.DeleteExpiredLevel1Keys(ctx,
+		time.Now().Add(-timeOffset))
+	assert.NoError(t, err)
+	assert.EqualValues(t, 0, rows)
+
+	rows, err = db.DeleteExpiredLevel1Keys(ctx,
+		time.Now().Add(2*timeOffset))
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, rows)
+
+}

--- a/private/storage/drkey/level1/sqlite/BUILD.bazel
+++ b/private/storage/drkey/level1/sqlite/BUILD.bazel
@@ -1,0 +1,24 @@
+load("//tools/lint:go.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["db.go"],
+    importpath = "github.com/scionproto/scion/private/storage/drkey/level1/sqlite",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/drkey:go_default_library",
+        "//pkg/private/util:go_default_library",
+        "//private/storage/db:go_default_library",
+        "@com_github_mattn_go_sqlite3//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["db_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//private/storage/drkey/level1/dbtest:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
+)

--- a/private/storage/drkey/level1/sqlite/db.go
+++ b/private/storage/drkey/level1/sqlite/db.go
@@ -1,0 +1,178 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/scionproto/scion/pkg/drkey"
+	"github.com/scionproto/scion/pkg/private/util"
+	"github.com/scionproto/scion/private/storage/db"
+)
+
+const (
+	// Level1SchemaVersion is the version of the SQLite schema understood by this backend.
+	// Whenever changes to the schema are made, this version number should be increased
+	// to prevent data corruption between incompatible database schemas.
+	Level1SchemaVersion = 1
+	// Level1Schema is the SQLite database layout.
+	Level1Schema = `
+	CREATE TABLE DRKeyLevel1 (
+		SrcIsdID 	INTEGER NOT NULL,
+		SrcAsID 	INTEGER NOT NULL,
+		DstIsdID 	INTEGER NOT NULL,
+		DstAsID 	INTEGER NOT NULL,
+		Protocol	INTEGER NOT NULL,
+		EpochBegin 	INTEGER NOT NULL,
+		EpochEnd 	INTEGER NOT NULL,
+		Key 		BLOB NOT NULL,
+		PRIMARY KEY (SrcIsdID, SrcAsID, DstIsdID, DstAsID, Protocol, EpochBegin)
+	);`
+)
+
+var _ drkey.Level1DB = (*Backend)(nil)
+
+// Level1Backend implements a level 1 drkey DB with sqlite.
+type Backend struct {
+	*executor
+	db *sql.DB
+}
+
+// NewLevel1Backend creates a database and prepares all statements.
+func NewBackend(path string) (*Backend, error) {
+	db, err := db.NewSqlite(path, Level1Schema, Level1SchemaVersion)
+	if err != nil {
+		return nil, err
+	}
+	b := &Backend{
+		executor: &executor{
+			db: db,
+		},
+		db: db,
+	}
+	return b, nil
+}
+
+// Close closes the database connection.
+func (b *Backend) Close() error {
+	return b.db.Close()
+}
+
+// SetMaxOpenConns sets the maximum number of open connections.
+func (b *Backend) SetMaxOpenConns(maxOpenConns int) {
+	b.db.SetMaxOpenConns(maxOpenConns)
+}
+
+// SetMaxIdleConns sets the maximum number of idle connections.
+func (b *Backend) SetMaxIdleConns(maxIdleConns int) {
+	b.db.SetMaxIdleConns(maxIdleConns)
+}
+
+type executor struct {
+	sync.RWMutex
+	db db.Sqler
+}
+
+const getLevel1KeyStmt = `
+SELECT EpochBegin, EpochEnd, Key FROM DRKeyLevel1
+WHERE SrcIsdID=? AND SrcAsID=? AND DstIsdID=? AND DstAsID=?
+AND Protocol=?
+AND EpochBegin<=? AND ?<EpochEnd
+`
+
+// GetLevel1Key takes metadata information for the Level1 key and a timestamp at which it should be
+// valid and returns the corresponding Level1Key.
+func (e *executor) GetLevel1Key(
+	ctx context.Context,
+	meta drkey.Level1Meta,
+) (drkey.Level1Key, error) {
+
+	e.RLock()
+	defer e.RUnlock()
+	var epochBegin, epochEnd int
+	var bytes []byte
+	valSecs := util.TimeToSecs(meta.Validity)
+
+	err := e.db.QueryRowContext(ctx, getLevel1KeyStmt, meta.SrcIA.ISD(), meta.SrcIA.AS(),
+		meta.DstIA.ISD(), meta.DstIA.AS(), meta.ProtoId, valSecs,
+		valSecs).Scan(&epochBegin, &epochEnd, &bytes)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			return drkey.Level1Key{}, db.NewReadError("getting Level1 key", err)
+		}
+		return drkey.Level1Key{}, drkey.ErrKeyNotFound
+	}
+	returningKey := drkey.Level1Key{
+		ProtoId: meta.ProtoId,
+		Epoch:   drkey.NewEpoch(uint32(epochBegin), uint32(epochEnd)),
+		SrcIA:   meta.SrcIA,
+		DstIA:   meta.DstIA,
+	}
+	copy(returningKey.Key[:], bytes)
+	return returningKey, nil
+}
+
+const insertLevel1KeyStmt = `
+INSERT OR IGNORE INTO DRKeyLevel1 (SrcIsdID, SrcAsID, DstIsdID, DstAsID,
+	Protocol ,EpochBegin, EpochEnd, Key)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`
+
+// InsertLevel1Key inserts a Level1 key.
+func (e *executor) InsertLevel1Key(ctx context.Context, key drkey.Level1Key) error {
+
+	e.RLock()
+	defer e.RUnlock()
+
+	return db.DoInTx(ctx, e.db, func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(
+			ctx,
+			insertLevel1KeyStmt,
+			key.SrcIA.ISD(),
+			key.SrcIA.AS(),
+			key.DstIA.ISD(),
+			key.DstIA.AS(),
+			key.ProtoId,
+			uint32(key.Epoch.NotBefore.Unix()),
+			uint32(key.Epoch.NotAfter.Unix()),
+			key.Key[:],
+		)
+		if err != nil {
+			return db.NewWriteError("inserting level1 key", err)
+		}
+		return nil
+	})
+}
+
+const deleteExpiredLevel1KeysStmt = `
+DELETE FROM DRKeyLevel1 WHERE ? >= EpochEnd
+`
+
+// DeleteExpiredLevel1Keys removes all expired Level1 key, i.e. all the keys
+// which expiration time is strictly smaller than the cutoff
+func (e *executor) DeleteExpiredLevel1Keys(ctx context.Context, cutoff time.Time) (int, error) {
+	e.RLock()
+	defer e.RUnlock()
+
+	return db.DeleteInTx(ctx, e.db, func(tx *sql.Tx) (sql.Result, error) {
+		cutoffSecs := util.TimeToSecs(cutoff)
+		return tx.ExecContext(ctx, deleteExpiredLevel1KeysStmt, cutoffSecs)
+	})
+}

--- a/private/storage/drkey/level1/sqlite/db_test.go
+++ b/private/storage/drkey/level1/sqlite/db_test.go
@@ -1,0 +1,51 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/scionproto/scion/private/storage/drkey/level1/dbtest"
+)
+
+type TestLevel1Backend struct {
+	*Backend
+}
+
+func (b *TestLevel1Backend) Prepare(t *testing.T, _ context.Context) {
+	db := newLevel1Database(t)
+	b.Backend = db
+}
+
+func TestLevel1DBSuite(t *testing.T) {
+	tdb := &TestLevel1Backend{}
+	dbtest.TestDB(t, tdb)
+}
+
+func newLevel1Database(t *testing.T) *Backend {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "db-test-")
+	require.NoError(t, err)
+	name := file.Name()
+	err = file.Close()
+	require.NoError(t, err)
+	db, err := NewBackend(name)
+	require.NoError(t, err)
+	return db
+}

--- a/private/storage/drkey/metrics.go
+++ b/private/storage/drkey/metrics.go
@@ -1,0 +1,21 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkey
+
+const (
+	PromOpGetKey            = "get"
+	PromOpInsertKey         = "insert"
+	PromOpDeleteExpiredKeys = "delete"
+)

--- a/private/storage/drkey/secret/BUILD.bazel
+++ b/private/storage/drkey/secret/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/drkey:go_default_library",
         "//pkg/metrics:go_default_library",
         "//private/storage/db:go_default_library",
+        "//private/storage/drkey:go_default_library",
         "//private/tracing:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
     ],

--- a/private/storage/drkey/secret/db.go
+++ b/private/storage/drkey/secret/db.go
@@ -24,13 +24,8 @@ import (
 	"github.com/scionproto/scion/pkg/drkey"
 	"github.com/scionproto/scion/pkg/metrics"
 	dblib "github.com/scionproto/scion/private/storage/db"
+	st_drkey "github.com/scionproto/scion/private/storage/drkey"
 	"github.com/scionproto/scion/private/tracing"
-)
-
-const (
-	promOpGetSV           = "get_sv"
-	promOpInsertSV        = "insert_sv"
-	promOpDeleteExpiredSV = "delete_expired_sv"
 )
 
 type Metrics struct {
@@ -78,7 +73,7 @@ func (db *Database) GetValue(ctx context.Context,
 	meta drkey.SecretValueMeta, asSecret []byte) (drkey.SecretValue, error) {
 	var ret drkey.SecretValue
 	var err error
-	db.Metrics.Observe(ctx, promOpGetSV, func(ctx context.Context) error {
+	db.Metrics.Observe(ctx, st_drkey.PromOpGetKey, func(ctx context.Context) error {
 		ret, err = db.Backend.GetValue(ctx, meta, asSecret)
 		return err
 	})
@@ -88,7 +83,7 @@ func (db *Database) GetValue(ctx context.Context,
 func (db *Database) InsertValue(ctx context.Context,
 	proto drkey.Protocol, epoch drkey.Epoch) error {
 	var err error
-	db.Metrics.Observe(ctx, promOpInsertSV, func(ctx context.Context) error {
+	db.Metrics.Observe(ctx, st_drkey.PromOpInsertKey, func(ctx context.Context) error {
 		err = db.Backend.InsertValue(ctx, proto, epoch)
 		return err
 	})
@@ -98,7 +93,7 @@ func (db *Database) InsertValue(ctx context.Context,
 func (db *Database) DeleteExpiredValues(ctx context.Context, cutoff time.Time) (int, error) {
 	var ret int
 	var err error
-	db.Metrics.Observe(ctx, promOpDeleteExpiredSV, func(ctx context.Context) error {
+	db.Metrics.Observe(ctx, st_drkey.PromOpDeleteExpiredKeys, func(ctx context.Context) error {
 		ret, err = db.Backend.DeleteExpiredValues(ctx, cutoff)
 		return err
 	})


### PR DESCRIPTION
This PR is the third in a series of PRs that add support for DRKey.

This PR contains:

- Sqlite implementation of the Level1 DB interface
- Metrics support
- UTs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4221)
<!-- Reviewable:end -->
