### PR TITLE
trust: extend TLSCryptoManager with support for verifying correctness of extKeyUsage extensions

### DIFF
--- a/private/trust/mock_trust/mock.go
+++ b/private/trust/mock_trust/mock.go
@@ -425,17 +425,32 @@ func (m *MockX509KeyPairLoader) EXPECT() *MockX509KeyPairLoaderMockRecorder {
 	return m.recorder
 }
 
-// LoadX509KeyPair mocks base method.
-func (m *MockX509KeyPairLoader) LoadX509KeyPair(arg0 context.Context, arg1 x509.ExtKeyUsage) (*tls.Certificate, error) {
+// LoadClientKeyPair mocks base method.
+func (m *MockX509KeyPairLoader) LoadClientKeyPair(arg0 context.Context) (*tls.Certificate, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadX509KeyPair", arg0, arg1)
+	ret := m.ctrl.Call(m, "LoadClientKeyPair", arg0)
 	ret0, _ := ret[0].(*tls.Certificate)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// LoadX509KeyPair indicates an expected call of LoadX509KeyPair.
-func (mr *MockX509KeyPairLoaderMockRecorder) LoadX509KeyPair(arg0, arg1 interface{}) *gomock.Call {
+// LoadClientKeyPair indicates an expected call of LoadClientKeyPair.
+func (mr *MockX509KeyPairLoaderMockRecorder) LoadClientKeyPair(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadX509KeyPair", reflect.TypeOf((*MockX509KeyPairLoader)(nil).LoadX509KeyPair), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadClientKeyPair", reflect.TypeOf((*MockX509KeyPairLoader)(nil).LoadClientKeyPair), arg0)
+}
+
+// LoadServerKeyPair mocks base method.
+func (m *MockX509KeyPairLoader) LoadServerKeyPair(arg0 context.Context) (*tls.Certificate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadServerKeyPair", arg0)
+	ret0, _ := ret[0].(*tls.Certificate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LoadServerKeyPair indicates an expected call of LoadServerKeyPair.
+func (mr *MockX509KeyPairLoaderMockRecorder) LoadServerKeyPair(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadServerKeyPair", reflect.TypeOf((*MockX509KeyPairLoader)(nil).LoadServerKeyPair), arg0)
 }

--- a/private/trust/mock_trust/mock.go
+++ b/private/trust/mock_trust/mock.go
@@ -426,16 +426,16 @@ func (m *MockX509KeyPairLoader) EXPECT() *MockX509KeyPairLoaderMockRecorder {
 }
 
 // LoadX509KeyPair mocks base method.
-func (m *MockX509KeyPairLoader) LoadX509KeyPair() (*tls.Certificate, error) {
+func (m *MockX509KeyPairLoader) LoadX509KeyPair(arg0 context.Context, arg1 x509.ExtKeyUsage) (*tls.Certificate, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadX509KeyPair")
+	ret := m.ctrl.Call(m, "LoadX509KeyPair", arg0, arg1)
 	ret0, _ := ret[0].(*tls.Certificate)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LoadX509KeyPair indicates an expected call of LoadX509KeyPair.
-func (mr *MockX509KeyPairLoaderMockRecorder) LoadX509KeyPair() *gomock.Call {
+func (mr *MockX509KeyPairLoaderMockRecorder) LoadX509KeyPair(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadX509KeyPair", reflect.TypeOf((*MockX509KeyPairLoader)(nil).LoadX509KeyPair))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadX509KeyPair", reflect.TypeOf((*MockX509KeyPairLoader)(nil).LoadX509KeyPair), arg0, arg1)
 }

--- a/private/trust/tls_handshake.go
+++ b/private/trust/tls_handshake.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"strings"
 	"time"
 
+	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/private/serrors"
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
 )
@@ -28,7 +30,7 @@ const defaultTimeout = 5 * time.Second
 
 // X509KeyPairLoader provides a certificate to be presented during TLS handshake.
 type X509KeyPairLoader interface {
-	LoadX509KeyPair() (*tls.Certificate, error)
+	LoadX509KeyPair(ctx context.Context, extKeyUsage x509.ExtKeyUsage) (*tls.Certificate, error)
 }
 
 // TLSCryptoManager implements callbacks which will be called during TLS handshake.
@@ -48,8 +50,8 @@ func NewTLSCryptoManager(loader X509KeyPairLoader, db DB) *TLSCryptoManager {
 }
 
 // GetCertificate retrieves a certificate to be presented during TLS handshake.
-func (m *TLSCryptoManager) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	c, err := m.Loader.LoadX509KeyPair()
+func (m *TLSCryptoManager) GetCertificate(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	c, err := m.Loader.LoadX509KeyPair(hello.Context(), x509.ExtKeyUsageServerAuth)
 	if err != nil {
 		return nil, serrors.WrapStr("loading server key pair", err)
 	}
@@ -57,19 +59,53 @@ func (m *TLSCryptoManager) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certific
 }
 
 // GetClientCertificate retrieves a client certificate to be presented during TLS handshake.
-func (m *TLSCryptoManager) GetClientCertificate(_ *tls.CertificateRequestInfo) (*tls.Certificate,
-	error) {
-	c, err := m.Loader.LoadX509KeyPair()
+func (m *TLSCryptoManager) GetClientCertificate(
+	reqInfo *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	c, err := m.Loader.LoadX509KeyPair(reqInfo.Context(), x509.ExtKeyUsageClientAuth)
 	if err != nil {
 		return nil, serrors.WrapStr("loading client key pair", err)
 	}
 	return c, nil
 }
 
-// VerifyPeerCertificate verifies the certificate presented by the peer during TLS handshake,
-// based on the TRC.
-func (m *TLSCryptoManager) VerifyPeerCertificate(rawCerts [][]byte,
+// VerifyServerCertificate verifies the certificate presented by the server
+// using the CP-PKI.
+func (m *TLSCryptoManager) VerifyServerCertificate(rawCerts [][]byte,
 	_ [][]*x509.Certificate) error {
+	return m.verifyPeerCertificate(rawCerts, x509.ExtKeyUsageServerAuth)
+}
+
+// VerifyClientCertificate verifies the certificate presented by the client
+// using the CP-PKI.
+func (m *TLSCryptoManager) VerifyClientCertificate(rawCerts [][]byte,
+	_ [][]*x509.Certificate) error {
+	return m.verifyPeerCertificate(rawCerts, x509.ExtKeyUsageClientAuth)
+}
+
+// VerifyConnection callback is intended to be used by the client to verify
+// that the certificate presented by the server matches the server name
+// the client is trying to connect to.
+func (m *TLSCryptoManager) VerifyConnection(cs tls.ConnectionState) error {
+	serverNameIA := strings.Split(cs.ServerName, ",")[0]
+	serverIA, err := addr.ParseIA(serverNameIA)
+	if err != nil {
+		return serrors.WrapStr("extracting IA from server name", err)
+	}
+	certIA, err := cppki.ExtractIA(cs.PeerCertificates[0].Subject)
+	if err != nil {
+		return serrors.WrapStr("extracting IA from peer cert", err)
+	}
+	if !serverIA.Equal(certIA) {
+		return serrors.New("extracted IA from cert and server IA do not match",
+			"peer IA", certIA, "server IA", serverIA)
+	}
+	return nil
+}
+
+// verifyPeerCertificate verifies the certificate presented by the peer during TLS handshake,
+// based on the TRC.
+func (m *TLSCryptoManager) verifyPeerCertificate(rawCerts [][]byte,
+	extKeyUsage x509.ExtKeyUsage) error {
 	chain := make([]*x509.Certificate, len(rawCerts))
 	for i, asn1Data := range rawCerts {
 		cert, err := x509.ParseCertificate(asn1Data)
@@ -77,6 +113,9 @@ func (m *TLSCryptoManager) VerifyPeerCertificate(rawCerts [][]byte,
 			return serrors.WrapStr("parsing peer certificate", err)
 		}
 		chain[i] = cert
+	}
+	if err := verifyExtendedKeyUsage(chain[0], extKeyUsage); err != nil {
+		return err
 	}
 	ia, err := cppki.ExtractIA(chain[0].Subject)
 	if err != nil {
@@ -105,4 +144,15 @@ func verifyChain(chain []*x509.Certificate, trcs []cppki.SignedTRC) error {
 		return nil
 	}
 	return errs.ToError()
+}
+
+// verifyExtendedKeyUsage return an error if the certifcate extended key usages do not
+// include any requested extended key usage.
+func verifyExtendedKeyUsage(cert *x509.Certificate, expectedKeyUsage x509.ExtKeyUsage) error {
+	for _, certExtKeyUsage := range cert.ExtKeyUsage {
+		if expectedKeyUsage == certExtKeyUsage {
+			return nil
+		}
+	}
+	return serrors.New("Invalid certificate key usages")
 }

--- a/private/trust/tls_handshake_test.go
+++ b/private/trust/tls_handshake_test.go
@@ -131,7 +131,8 @@ func TestHandshake(t *testing.T) {
 	db := mock_trust.NewMockDB(ctrl)
 	db.EXPECT().SignedTRC(gomock.Any(), gomock.Any()).MaxTimes(2).Return(trc, nil)
 	loader := mock_trust.NewMockX509KeyPairLoader(ctrl)
-	loader.EXPECT().LoadX509KeyPair(gomock.Any(), gomock.Any()).MaxTimes(2).Return(&tlsCert, nil)
+	loader.EXPECT().LoadServerKeyPair(gomock.Any()).Return(&tlsCert, nil)
+	loader.EXPECT().LoadClientKeyPair(gomock.Any()).Return(&tlsCert, nil)
 
 	mgr := trust.NewTLSCryptoManager(loader, db)
 	clientConn, serverConn := net.Pipe()

--- a/private/trust/tls_handshake_test.go
+++ b/private/trust/tls_handshake_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/scionproto/scion/private/trust/mock_trust"
 )
 
-func TestTLSCryptoManagerVerifyPeerCertificate(t *testing.T) {
+func TestTLSCryptoManagerVerifyServerCertificate(t *testing.T) {
 	dir := genCrypto(t)
 
 	trc := xtest.LoadTRC(t, filepath.Join(dir, "trcs/ISD1-B1-S1.trc"))
@@ -66,31 +66,72 @@ func TestTLSCryptoManagerVerifyPeerCertificate(t *testing.T) {
 				Timeout: 5 * time.Second,
 			}
 			rawChain := loadRawChain(t, crt111File)
-			err := mgr.VerifyPeerCertificate(rawChain, nil)
+			err := mgr.VerifyServerCertificate(rawChain, nil)
+			tc.assertErr(t, err)
+		})
+	}
+}
+
+func TestTLSCryptoManagerVerifyClientCertificate(t *testing.T) {
+	dir := genCrypto(t)
+
+	trc := xtest.LoadTRC(t, filepath.Join(dir, "trcs/ISD1-B1-S1.trc"))
+	crt111File := filepath.Join(dir, "certs/ISD1-ASff00_0_111.pem")
+
+	out, _ := exec.Command("tree", dir).CombinedOutput()
+	t.Log(string(out))
+
+	testCases := map[string]struct {
+		db        func(ctrl *gomock.Controller) trust.DB
+		assertErr assert.ErrorAssertionFunc
+	}{
+		"valid": {
+			db: func(ctrl *gomock.Controller) trust.DB {
+				db := mock_trust.NewMockDB(ctrl)
+				db.EXPECT().SignedTRC(gomock.Any(), gomock.Any()).Return(trc, nil)
+				return db
+			},
+			assertErr: assert.NoError,
+		},
+	}
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			db := tc.db(ctrl)
+			mgr := trust.TLSCryptoManager{
+				DB:      db,
+				Timeout: 5 * time.Second,
+			}
+			rawChain := loadRawChain(t, crt111File)
+			err := mgr.VerifyClientCertificate(rawChain, nil)
 			tc.assertErr(t, err)
 		})
 	}
 }
 
 func TestHandshake(t *testing.T) {
+	dir := genCrypto(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-
-	dir := genCrypto(t)
 
 	trc := xtest.LoadTRC(t, filepath.Join(dir, "trcs/ISD1-B1-S1.trc"))
 	crt111File := filepath.Join(dir, "certs/ISD1-ASff00_0_111.pem")
 	key111File := filepath.Join(dir, "ISD1/ASff00_0_111/crypto/as/cp-as.key")
-
 	tlsCert, err := tls.LoadX509KeyPair(crt111File, key111File)
 	require.NoError(t, err)
 	chain, err := cppki.ReadPEMCerts(crt111File)
 	require.NoError(t, err)
 
+	out, _ := exec.Command("tree", dir).CombinedOutput()
+	t.Log(string(out))
+
 	db := mock_trust.NewMockDB(ctrl)
 	db.EXPECT().SignedTRC(gomock.Any(), gomock.Any()).MaxTimes(2).Return(trc, nil)
 	loader := mock_trust.NewMockX509KeyPairLoader(ctrl)
-	loader.EXPECT().LoadX509KeyPair().MaxTimes(2).Return(&tlsCert, nil)
+	loader.EXPECT().LoadX509KeyPair(gomock.Any(), gomock.Any()).MaxTimes(2).Return(&tlsCert, nil)
 
 	mgr := trust.NewTLSCryptoManager(loader, db)
 	clientConn, serverConn := net.Pipe()
@@ -100,12 +141,12 @@ func TestHandshake(t *testing.T) {
 	client := tls.Client(clientConn, &tls.Config{
 		InsecureSkipVerify:    true,
 		GetClientCertificate:  mgr.GetClientCertificate,
-		VerifyPeerCertificate: mgr.VerifyPeerCertificate,
+		VerifyPeerCertificate: mgr.VerifyServerCertificate,
 	})
 	server := tls.Server(serverConn, &tls.Config{
 		InsecureSkipVerify:    true,
 		GetCertificate:        mgr.GetCertificate,
-		VerifyPeerCertificate: mgr.VerifyPeerCertificate,
+		VerifyPeerCertificate: mgr.VerifyClientCertificate,
 		ClientAuth:            tls.RequireAnyClientCert,
 	})
 


### PR DESCRIPTION
This PR includes the following changes:
- Adds extKeyUsage verification for TLS HS [1] [2].
- Replaces `VerifyPeerCertificate` with `VerifyClientCertificate` and `VerifyServerCertificate`.
- Extends `X509KeyPairLoader` with two separate functions to load a client and a server certificate.
- Adds `VerifyConnection` callback implementation, available as of Go1.16.

[1] https://scion.docs.anapaya.net/en/latest/cryptography/certificates.html?highlight=extKeyUsage#extended-key-usage-extension
[2] https://scion.docs.anapaya.net/en/latest/cryptography/certificates.html#id34.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4222)
<!-- Reviewable:end -->
