### PR TITLE
drkey: add RPC cs/daemon

### DIFF
--- a/daemon/internal/servers/grpc.go
+++ b/daemon/internal/servers/grpc.go
@@ -348,20 +348,26 @@ func (s *DaemonServer) notifyInterfaceDown(ctx context.Context,
 	return &sdpb.NotifyInterfaceDownResponse{}, nil
 }
 
-func (s *DaemonServer) DRKeyASHost(ctx context.Context,
-	req *pb_daemon.DRKeyASHostRequest) (*pb_daemon.DRKeyASHostResponse, error) {
+func (s *DaemonServer) DRKeyASHost(
+	ctx context.Context,
+	req *pb_daemon.DRKeyASHostRequest,
+) (*pb_daemon.DRKeyASHostResponse, error) {
 
 	panic("not implemented")
 }
 
-func (s *DaemonServer) DRKeyHostAS(ctx context.Context,
-	req *pb_daemon.DRKeyHostASRequest) (*pb_daemon.DRKeyHostASResponse, error) {
+func (s *DaemonServer) DRKeyHostAS(
+	ctx context.Context,
+	req *pb_daemon.DRKeyHostASRequest,
+) (*pb_daemon.DRKeyHostASResponse, error) {
 
 	panic("not implemented")
 }
 
-func (s *DaemonServer) DRKeyHostHost(ctx context.Context,
-	req *pb_daemon.DRKeyHostHostRequest) (*pb_daemon.DRKeyHostHostResponse, error) {
+func (s *DaemonServer) DRKeyHostHost(
+	ctx context.Context,
+	req *pb_daemon.DRKeyHostHostRequest,
+) (*pb_daemon.DRKeyHostHostResponse, error) {
 
 	panic("not implemented")
 }

--- a/daemon/internal/servers/grpc.go
+++ b/daemon/internal/servers/grpc.go
@@ -34,6 +34,7 @@ import (
 	"github.com/scionproto/scion/pkg/private/prom"
 	"github.com/scionproto/scion/pkg/private/serrors"
 	"github.com/scionproto/scion/pkg/private/util"
+	pb_daemon "github.com/scionproto/scion/pkg/proto/daemon"
 	sdpb "github.com/scionproto/scion/pkg/proto/daemon"
 	"github.com/scionproto/scion/pkg/snet"
 	snetpath "github.com/scionproto/scion/pkg/snet/path"
@@ -345,4 +346,22 @@ func (s *DaemonServer) notifyInterfaceDown(ctx context.Context,
 		}
 	}
 	return &sdpb.NotifyInterfaceDownResponse{}, nil
+}
+
+func (s *DaemonServer) DRKeyASHost(ctx context.Context,
+	req *pb_daemon.DRKeyASHostRequest) (*pb_daemon.DRKeyASHostResponse, error) {
+
+	panic("not implemented")
+}
+
+func (s *DaemonServer) DRKeyHostAS(ctx context.Context,
+	req *pb_daemon.DRKeyHostASRequest) (*pb_daemon.DRKeyHostASResponse, error) {
+
+	panic("not implemented")
+}
+
+func (s *DaemonServer) DRKeyHostHost(ctx context.Context,
+	req *pb_daemon.DRKeyHostHostRequest) (*pb_daemon.DRKeyHostHostResponse, error) {
+
+	panic("not implemented")
 }

--- a/pkg/proto/control_plane/drkey.pb.go
+++ b/pkg/proto/control_plane/drkey.pb.go
@@ -7,7 +7,11 @@
 package control_plane
 
 import (
+	context "context"
 	drkey "github.com/scionproto/scion/pkg/proto/drkey"
+	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
@@ -676,6 +680,156 @@ func (x *DRKeyASHostResponse) GetKey() []byte {
 	return nil
 }
 
+type DRKeyHostHostRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	ValTime    *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=val_time,json=valTime,proto3" json:"val_time,omitempty"`
+	ProtocolId drkey.Protocol         `protobuf:"varint,2,opt,name=protocol_id,json=protocolId,proto3,enum=proto.drkey.v1.Protocol" json:"protocol_id,omitempty"`
+	SrcIa      uint64                 `protobuf:"varint,3,opt,name=src_ia,json=srcIa,proto3" json:"src_ia,omitempty"`
+	DstIa      uint64                 `protobuf:"varint,4,opt,name=dst_ia,json=dstIa,proto3" json:"dst_ia,omitempty"`
+	SrcHost    string                 `protobuf:"bytes,5,opt,name=src_host,json=srcHost,proto3" json:"src_host,omitempty"`
+	DstHost    string                 `protobuf:"bytes,6,opt,name=dst_host,json=dstHost,proto3" json:"dst_host,omitempty"`
+}
+
+func (x *DRKeyHostHostRequest) Reset() {
+	*x = DRKeyHostHostRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_control_plane_v1_drkey_proto_msgTypes[10]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *DRKeyHostHostRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DRKeyHostHostRequest) ProtoMessage() {}
+
+func (x *DRKeyHostHostRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_control_plane_v1_drkey_proto_msgTypes[10]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DRKeyHostHostRequest.ProtoReflect.Descriptor instead.
+func (*DRKeyHostHostRequest) Descriptor() ([]byte, []int) {
+	return file_proto_control_plane_v1_drkey_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *DRKeyHostHostRequest) GetValTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ValTime
+	}
+	return nil
+}
+
+func (x *DRKeyHostHostRequest) GetProtocolId() drkey.Protocol {
+	if x != nil {
+		return x.ProtocolId
+	}
+	return drkey.Protocol(0)
+}
+
+func (x *DRKeyHostHostRequest) GetSrcIa() uint64 {
+	if x != nil {
+		return x.SrcIa
+	}
+	return 0
+}
+
+func (x *DRKeyHostHostRequest) GetDstIa() uint64 {
+	if x != nil {
+		return x.DstIa
+	}
+	return 0
+}
+
+func (x *DRKeyHostHostRequest) GetSrcHost() string {
+	if x != nil {
+		return x.SrcHost
+	}
+	return ""
+}
+
+func (x *DRKeyHostHostRequest) GetDstHost() string {
+	if x != nil {
+		return x.DstHost
+	}
+	return ""
+}
+
+type DRKeyHostHostResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	EpochBegin *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=epoch_begin,json=epochBegin,proto3" json:"epoch_begin,omitempty"`
+	EpochEnd   *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=epoch_end,json=epochEnd,proto3" json:"epoch_end,omitempty"`
+	Key        []byte                 `protobuf:"bytes,3,opt,name=key,proto3" json:"key,omitempty"`
+}
+
+func (x *DRKeyHostHostResponse) Reset() {
+	*x = DRKeyHostHostResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_control_plane_v1_drkey_proto_msgTypes[11]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *DRKeyHostHostResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DRKeyHostHostResponse) ProtoMessage() {}
+
+func (x *DRKeyHostHostResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_control_plane_v1_drkey_proto_msgTypes[11]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DRKeyHostHostResponse.ProtoReflect.Descriptor instead.
+func (*DRKeyHostHostResponse) Descriptor() ([]byte, []int) {
+	return file_proto_control_plane_v1_drkey_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *DRKeyHostHostResponse) GetEpochBegin() *timestamppb.Timestamp {
+	if x != nil {
+		return x.EpochBegin
+	}
+	return nil
+}
+
+func (x *DRKeyHostHostResponse) GetEpochEnd() *timestamppb.Timestamp {
+	if x != nil {
+		return x.EpochEnd
+	}
+	return nil
+}
+
+func (x *DRKeyHostHostResponse) GetKey() []byte {
+	if x != nil {
+		return x.Key
+	}
+	return nil
+}
+
 var File_proto_control_plane_v1_drkey_proto protoreflect.FileDescriptor
 
 var file_proto_control_plane_v1_drkey_proto_rawDesc = []byte{
@@ -792,11 +946,81 @@ var file_proto_control_plane_v1_drkey_proto_rawDesc = []byte{
 	0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74,
 	0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52, 0x08,
 	0x65, 0x70, 0x6f, 0x63, 0x68, 0x45, 0x6e, 0x64, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79, 0x18,
-	0x03, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x42, 0x35, 0x5a, 0x33, 0x67, 0x69,
-	0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73, 0x63, 0x69, 0x6f, 0x6e, 0x70, 0x72,
-	0x6f, 0x74, 0x6f, 0x2f, 0x73, 0x63, 0x69, 0x6f, 0x6e, 0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x70, 0x72,
-	0x6f, 0x74, 0x6f, 0x2f, 0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x5f, 0x70, 0x6c, 0x61, 0x6e,
-	0x65, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x03, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x22, 0xec, 0x01, 0x0a, 0x14, 0x44,
+	0x52, 0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73, 0x74, 0x48, 0x6f, 0x73, 0x74, 0x52, 0x65, 0x71, 0x75,
+	0x65, 0x73, 0x74, 0x12, 0x35, 0x0a, 0x08, 0x76, 0x61, 0x6c, 0x5f, 0x74, 0x69, 0x6d, 0x65, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70,
+	0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d,
+	0x70, 0x52, 0x07, 0x76, 0x61, 0x6c, 0x54, 0x69, 0x6d, 0x65, 0x12, 0x39, 0x0a, 0x0b, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x5f, 0x69, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0e, 0x32,
+	0x18, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x64, 0x72, 0x6b, 0x65, 0x79, 0x2e, 0x76, 0x31,
+	0x2e, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x52, 0x0a, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x63, 0x6f, 0x6c, 0x49, 0x64, 0x12, 0x15, 0x0a, 0x06, 0x73, 0x72, 0x63, 0x5f, 0x69, 0x61, 0x18,
+	0x03, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x73, 0x72, 0x63, 0x49, 0x61, 0x12, 0x15, 0x0a, 0x06,
+	0x64, 0x73, 0x74, 0x5f, 0x69, 0x61, 0x18, 0x04, 0x20, 0x01, 0x28, 0x04, 0x52, 0x05, 0x64, 0x73,
+	0x74, 0x49, 0x61, 0x12, 0x19, 0x0a, 0x08, 0x73, 0x72, 0x63, 0x5f, 0x68, 0x6f, 0x73, 0x74, 0x18,
+	0x05, 0x20, 0x01, 0x28, 0x09, 0x52, 0x07, 0x73, 0x72, 0x63, 0x48, 0x6f, 0x73, 0x74, 0x12, 0x19,
+	0x0a, 0x08, 0x64, 0x73, 0x74, 0x5f, 0x68, 0x6f, 0x73, 0x74, 0x18, 0x06, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x07, 0x64, 0x73, 0x74, 0x48, 0x6f, 0x73, 0x74, 0x22, 0x9f, 0x01, 0x0a, 0x15, 0x44, 0x52,
+	0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73, 0x74, 0x48, 0x6f, 0x73, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f,
+	0x6e, 0x73, 0x65, 0x12, 0x3b, 0x0a, 0x0b, 0x65, 0x70, 0x6f, 0x63, 0x68, 0x5f, 0x62, 0x65, 0x67,
+	0x69, 0x6e, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c,
+	0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73,
+	0x74, 0x61, 0x6d, 0x70, 0x52, 0x0a, 0x65, 0x70, 0x6f, 0x63, 0x68, 0x42, 0x65, 0x67, 0x69, 0x6e,
+	0x12, 0x37, 0x0a, 0x09, 0x65, 0x70, 0x6f, 0x63, 0x68, 0x5f, 0x65, 0x6e, 0x64, 0x18, 0x02, 0x20,
+	0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f,
+	0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52,
+	0x08, 0x65, 0x70, 0x6f, 0x63, 0x68, 0x45, 0x6e, 0x64, 0x12, 0x10, 0x0a, 0x03, 0x6b, 0x65, 0x79,
+	0x18, 0x03, 0x20, 0x01, 0x28, 0x0c, 0x52, 0x03, 0x6b, 0x65, 0x79, 0x32, 0x7d, 0x0a, 0x11, 0x44,
+	0x52, 0x4b, 0x65, 0x79, 0x49, 0x6e, 0x74, 0x65, 0x72, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+	0x12, 0x68, 0x0a, 0x0b, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x31, 0x12,
+	0x2a, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x5f,
+	0x70, 0x6c, 0x61, 0x6e, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x4c, 0x65,
+	0x76, 0x65, 0x6c, 0x31, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x2b, 0x2e, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x5f, 0x70, 0x6c, 0x61, 0x6e,
+	0x65, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x31,
+	0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x32, 0xc9, 0x04, 0x0a, 0x11, 0x44,
+	0x52, 0x4b, 0x65, 0x79, 0x49, 0x6e, 0x74, 0x72, 0x61, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65,
+	0x12, 0x77, 0x0a, 0x10, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x49, 0x6e, 0x74, 0x72, 0x61, 0x4c, 0x65,
+	0x76, 0x65, 0x6c, 0x31, 0x12, 0x2f, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f, 0x6e,
+	0x74, 0x72, 0x6f, 0x6c, 0x5f, 0x70, 0x6c, 0x61, 0x6e, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52,
+	0x4b, 0x65, 0x79, 0x49, 0x6e, 0x74, 0x72, 0x61, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x31, 0x52, 0x65,
+	0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x30, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f,
+	0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x5f, 0x70, 0x6c, 0x61, 0x6e, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x44,
+	0x52, 0x4b, 0x65, 0x79, 0x49, 0x6e, 0x74, 0x72, 0x61, 0x4c, 0x65, 0x76, 0x65, 0x6c, 0x31, 0x52,
+	0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x68, 0x0a, 0x0b, 0x44, 0x52, 0x4b,
+	0x65, 0x79, 0x41, 0x53, 0x48, 0x6f, 0x73, 0x74, 0x12, 0x2a, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x2e, 0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x5f, 0x70, 0x6c, 0x61, 0x6e, 0x65, 0x2e, 0x76,
+	0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x41, 0x53, 0x48, 0x6f, 0x73, 0x74, 0x52, 0x65, 0x71,
+	0x75, 0x65, 0x73, 0x74, 0x1a, 0x2b, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f, 0x6e,
+	0x74, 0x72, 0x6f, 0x6c, 0x5f, 0x70, 0x6c, 0x61, 0x6e, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52,
+	0x4b, 0x65, 0x79, 0x41, 0x53, 0x48, 0x6f, 0x73, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
+	0x65, 0x22, 0x00, 0x12, 0x68, 0x0a, 0x0b, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73, 0x74,
+	0x41, 0x53, 0x12, 0x2a, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f, 0x6e, 0x74, 0x72,
+	0x6f, 0x6c, 0x5f, 0x70, 0x6c, 0x61, 0x6e, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65,
+	0x79, 0x48, 0x6f, 0x73, 0x74, 0x41, 0x53, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x2b,
+	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x5f, 0x70,
+	0x6c, 0x61, 0x6e, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73,
+	0x74, 0x41, 0x53, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x6e, 0x0a,
+	0x0d, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73, 0x74, 0x48, 0x6f, 0x73, 0x74, 0x12, 0x2c,
+	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x5f, 0x70,
+	0x6c, 0x61, 0x6e, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73,
+	0x74, 0x48, 0x6f, 0x73, 0x74, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x2d, 0x2e, 0x70,
+	0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x5f, 0x70, 0x6c, 0x61,
+	0x6e, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73, 0x74, 0x48,
+	0x6f, 0x73, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x77, 0x0a,
+	0x10, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x56, 0x61, 0x6c, 0x75,
+	0x65, 0x12, 0x2f, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f,
+	0x6c, 0x5f, 0x70, 0x6c, 0x61, 0x6e, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65, 0x79,
+	0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65,
+	0x73, 0x74, 0x1a, 0x30, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x63, 0x6f, 0x6e, 0x74, 0x72,
+	0x6f, 0x6c, 0x5f, 0x70, 0x6c, 0x61, 0x6e, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65,
+	0x79, 0x53, 0x65, 0x63, 0x72, 0x65, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x65, 0x73, 0x70,
+	0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x35, 0x5a, 0x33, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62,
+	0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73, 0x63, 0x69, 0x6f, 0x6e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f,
+	0x73, 0x63, 0x69, 0x6f, 0x6e, 0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f,
+	0x63, 0x6f, 0x6e, 0x74, 0x72, 0x6f, 0x6c, 0x5f, 0x70, 0x6c, 0x61, 0x6e, 0x65, 0x62, 0x06, 0x70,
+	0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -811,7 +1035,7 @@ func file_proto_control_plane_v1_drkey_proto_rawDescGZIP() []byte {
 	return file_proto_control_plane_v1_drkey_proto_rawDescData
 }
 
-var file_proto_control_plane_v1_drkey_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_proto_control_plane_v1_drkey_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_proto_control_plane_v1_drkey_proto_goTypes = []interface{}{
 	(*DRKeySecretValueRequest)(nil),  // 0: proto.control_plane.v1.DRKeySecretValueRequest
 	(*DRKeySecretValueResponse)(nil), // 1: proto.control_plane.v1.DRKeySecretValueResponse
@@ -823,35 +1047,53 @@ var file_proto_control_plane_v1_drkey_proto_goTypes = []interface{}{
 	(*DRKeyHostASResponse)(nil),      // 7: proto.control_plane.v1.DRKeyHostASResponse
 	(*DRKeyASHostRequest)(nil),       // 8: proto.control_plane.v1.DRKeyASHostRequest
 	(*DRKeyASHostResponse)(nil),      // 9: proto.control_plane.v1.DRKeyASHostResponse
-	(*timestamppb.Timestamp)(nil),    // 10: google.protobuf.Timestamp
-	(drkey.Protocol)(0),              // 11: proto.drkey.v1.Protocol
+	(*DRKeyHostHostRequest)(nil),     // 10: proto.control_plane.v1.DRKeyHostHostRequest
+	(*DRKeyHostHostResponse)(nil),    // 11: proto.control_plane.v1.DRKeyHostHostResponse
+	(*timestamppb.Timestamp)(nil),    // 12: google.protobuf.Timestamp
+	(drkey.Protocol)(0),              // 13: proto.drkey.v1.Protocol
 }
 var file_proto_control_plane_v1_drkey_proto_depIdxs = []int32{
-	10, // 0: proto.control_plane.v1.DRKeySecretValueRequest.val_time:type_name -> google.protobuf.Timestamp
-	11, // 1: proto.control_plane.v1.DRKeySecretValueRequest.protocol_id:type_name -> proto.drkey.v1.Protocol
-	10, // 2: proto.control_plane.v1.DRKeySecretValueResponse.epoch_begin:type_name -> google.protobuf.Timestamp
-	10, // 3: proto.control_plane.v1.DRKeySecretValueResponse.epoch_end:type_name -> google.protobuf.Timestamp
-	10, // 4: proto.control_plane.v1.DRKeyLevel1Request.val_time:type_name -> google.protobuf.Timestamp
-	11, // 5: proto.control_plane.v1.DRKeyLevel1Request.protocol_id:type_name -> proto.drkey.v1.Protocol
-	10, // 6: proto.control_plane.v1.DRKeyLevel1Response.epoch_begin:type_name -> google.protobuf.Timestamp
-	10, // 7: proto.control_plane.v1.DRKeyLevel1Response.epoch_end:type_name -> google.protobuf.Timestamp
-	10, // 8: proto.control_plane.v1.DRKeyIntraLevel1Request.val_time:type_name -> google.protobuf.Timestamp
-	11, // 9: proto.control_plane.v1.DRKeyIntraLevel1Request.protocol_id:type_name -> proto.drkey.v1.Protocol
-	10, // 10: proto.control_plane.v1.DRKeyIntraLevel1Response.epoch_begin:type_name -> google.protobuf.Timestamp
-	10, // 11: proto.control_plane.v1.DRKeyIntraLevel1Response.epoch_end:type_name -> google.protobuf.Timestamp
-	10, // 12: proto.control_plane.v1.DRKeyHostASRequest.val_time:type_name -> google.protobuf.Timestamp
-	11, // 13: proto.control_plane.v1.DRKeyHostASRequest.protocol_id:type_name -> proto.drkey.v1.Protocol
-	10, // 14: proto.control_plane.v1.DRKeyHostASResponse.epoch_begin:type_name -> google.protobuf.Timestamp
-	10, // 15: proto.control_plane.v1.DRKeyHostASResponse.epoch_end:type_name -> google.protobuf.Timestamp
-	10, // 16: proto.control_plane.v1.DRKeyASHostRequest.val_time:type_name -> google.protobuf.Timestamp
-	11, // 17: proto.control_plane.v1.DRKeyASHostRequest.protocol_id:type_name -> proto.drkey.v1.Protocol
-	10, // 18: proto.control_plane.v1.DRKeyASHostResponse.epoch_begin:type_name -> google.protobuf.Timestamp
-	10, // 19: proto.control_plane.v1.DRKeyASHostResponse.epoch_end:type_name -> google.protobuf.Timestamp
-	20, // [20:20] is the sub-list for method output_type
-	20, // [20:20] is the sub-list for method input_type
-	20, // [20:20] is the sub-list for extension type_name
-	20, // [20:20] is the sub-list for extension extendee
-	0,  // [0:20] is the sub-list for field type_name
+	12, // 0: proto.control_plane.v1.DRKeySecretValueRequest.val_time:type_name -> google.protobuf.Timestamp
+	13, // 1: proto.control_plane.v1.DRKeySecretValueRequest.protocol_id:type_name -> proto.drkey.v1.Protocol
+	12, // 2: proto.control_plane.v1.DRKeySecretValueResponse.epoch_begin:type_name -> google.protobuf.Timestamp
+	12, // 3: proto.control_plane.v1.DRKeySecretValueResponse.epoch_end:type_name -> google.protobuf.Timestamp
+	12, // 4: proto.control_plane.v1.DRKeyLevel1Request.val_time:type_name -> google.protobuf.Timestamp
+	13, // 5: proto.control_plane.v1.DRKeyLevel1Request.protocol_id:type_name -> proto.drkey.v1.Protocol
+	12, // 6: proto.control_plane.v1.DRKeyLevel1Response.epoch_begin:type_name -> google.protobuf.Timestamp
+	12, // 7: proto.control_plane.v1.DRKeyLevel1Response.epoch_end:type_name -> google.protobuf.Timestamp
+	12, // 8: proto.control_plane.v1.DRKeyIntraLevel1Request.val_time:type_name -> google.protobuf.Timestamp
+	13, // 9: proto.control_plane.v1.DRKeyIntraLevel1Request.protocol_id:type_name -> proto.drkey.v1.Protocol
+	12, // 10: proto.control_plane.v1.DRKeyIntraLevel1Response.epoch_begin:type_name -> google.protobuf.Timestamp
+	12, // 11: proto.control_plane.v1.DRKeyIntraLevel1Response.epoch_end:type_name -> google.protobuf.Timestamp
+	12, // 12: proto.control_plane.v1.DRKeyHostASRequest.val_time:type_name -> google.protobuf.Timestamp
+	13, // 13: proto.control_plane.v1.DRKeyHostASRequest.protocol_id:type_name -> proto.drkey.v1.Protocol
+	12, // 14: proto.control_plane.v1.DRKeyHostASResponse.epoch_begin:type_name -> google.protobuf.Timestamp
+	12, // 15: proto.control_plane.v1.DRKeyHostASResponse.epoch_end:type_name -> google.protobuf.Timestamp
+	12, // 16: proto.control_plane.v1.DRKeyASHostRequest.val_time:type_name -> google.protobuf.Timestamp
+	13, // 17: proto.control_plane.v1.DRKeyASHostRequest.protocol_id:type_name -> proto.drkey.v1.Protocol
+	12, // 18: proto.control_plane.v1.DRKeyASHostResponse.epoch_begin:type_name -> google.protobuf.Timestamp
+	12, // 19: proto.control_plane.v1.DRKeyASHostResponse.epoch_end:type_name -> google.protobuf.Timestamp
+	12, // 20: proto.control_plane.v1.DRKeyHostHostRequest.val_time:type_name -> google.protobuf.Timestamp
+	13, // 21: proto.control_plane.v1.DRKeyHostHostRequest.protocol_id:type_name -> proto.drkey.v1.Protocol
+	12, // 22: proto.control_plane.v1.DRKeyHostHostResponse.epoch_begin:type_name -> google.protobuf.Timestamp
+	12, // 23: proto.control_plane.v1.DRKeyHostHostResponse.epoch_end:type_name -> google.protobuf.Timestamp
+	2,  // 24: proto.control_plane.v1.DRKeyInterService.DRKeyLevel1:input_type -> proto.control_plane.v1.DRKeyLevel1Request
+	4,  // 25: proto.control_plane.v1.DRKeyIntraService.DRKeyIntraLevel1:input_type -> proto.control_plane.v1.DRKeyIntraLevel1Request
+	8,  // 26: proto.control_plane.v1.DRKeyIntraService.DRKeyASHost:input_type -> proto.control_plane.v1.DRKeyASHostRequest
+	6,  // 27: proto.control_plane.v1.DRKeyIntraService.DRKeyHostAS:input_type -> proto.control_plane.v1.DRKeyHostASRequest
+	10, // 28: proto.control_plane.v1.DRKeyIntraService.DRKeyHostHost:input_type -> proto.control_plane.v1.DRKeyHostHostRequest
+	0,  // 29: proto.control_plane.v1.DRKeyIntraService.DRKeySecretValue:input_type -> proto.control_plane.v1.DRKeySecretValueRequest
+	3,  // 30: proto.control_plane.v1.DRKeyInterService.DRKeyLevel1:output_type -> proto.control_plane.v1.DRKeyLevel1Response
+	5,  // 31: proto.control_plane.v1.DRKeyIntraService.DRKeyIntraLevel1:output_type -> proto.control_plane.v1.DRKeyIntraLevel1Response
+	9,  // 32: proto.control_plane.v1.DRKeyIntraService.DRKeyASHost:output_type -> proto.control_plane.v1.DRKeyASHostResponse
+	7,  // 33: proto.control_plane.v1.DRKeyIntraService.DRKeyHostAS:output_type -> proto.control_plane.v1.DRKeyHostASResponse
+	11, // 34: proto.control_plane.v1.DRKeyIntraService.DRKeyHostHost:output_type -> proto.control_plane.v1.DRKeyHostHostResponse
+	1,  // 35: proto.control_plane.v1.DRKeyIntraService.DRKeySecretValue:output_type -> proto.control_plane.v1.DRKeySecretValueResponse
+	30, // [30:36] is the sub-list for method output_type
+	24, // [24:30] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_proto_control_plane_v1_drkey_proto_init() }
@@ -980,6 +1222,30 @@ func file_proto_control_plane_v1_drkey_proto_init() {
 				return nil
 			}
 		}
+		file_proto_control_plane_v1_drkey_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*DRKeyHostHostRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_proto_control_plane_v1_drkey_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*DRKeyHostHostResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -987,9 +1253,9 @@ func file_proto_control_plane_v1_drkey_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_proto_control_plane_v1_drkey_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   12,
 			NumExtensions: 0,
-			NumServices:   0,
+			NumServices:   2,
 		},
 		GoTypes:           file_proto_control_plane_v1_drkey_proto_goTypes,
 		DependencyIndexes: file_proto_control_plane_v1_drkey_proto_depIdxs,
@@ -999,4 +1265,300 @@ func file_proto_control_plane_v1_drkey_proto_init() {
 	file_proto_control_plane_v1_drkey_proto_rawDesc = nil
 	file_proto_control_plane_v1_drkey_proto_goTypes = nil
 	file_proto_control_plane_v1_drkey_proto_depIdxs = nil
+}
+
+// Reference imports to suppress errors if they are not otherwise used.
+var _ context.Context
+var _ grpc.ClientConnInterface
+
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the grpc package it is being compiled against.
+const _ = grpc.SupportPackageIsVersion6
+
+// DRKeyInterServiceClient is the client API for DRKeyInterService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+type DRKeyInterServiceClient interface {
+	DRKeyLevel1(ctx context.Context, in *DRKeyLevel1Request, opts ...grpc.CallOption) (*DRKeyLevel1Response, error)
+}
+
+type dRKeyInterServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewDRKeyInterServiceClient(cc grpc.ClientConnInterface) DRKeyInterServiceClient {
+	return &dRKeyInterServiceClient{cc}
+}
+
+func (c *dRKeyInterServiceClient) DRKeyLevel1(ctx context.Context, in *DRKeyLevel1Request, opts ...grpc.CallOption) (*DRKeyLevel1Response, error) {
+	out := new(DRKeyLevel1Response)
+	err := c.cc.Invoke(ctx, "/proto.control_plane.v1.DRKeyInterService/DRKeyLevel1", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// DRKeyInterServiceServer is the server API for DRKeyInterService service.
+type DRKeyInterServiceServer interface {
+	DRKeyLevel1(context.Context, *DRKeyLevel1Request) (*DRKeyLevel1Response, error)
+}
+
+// UnimplementedDRKeyInterServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedDRKeyInterServiceServer struct {
+}
+
+func (*UnimplementedDRKeyInterServiceServer) DRKeyLevel1(context.Context, *DRKeyLevel1Request) (*DRKeyLevel1Response, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DRKeyLevel1 not implemented")
+}
+
+func RegisterDRKeyInterServiceServer(s *grpc.Server, srv DRKeyInterServiceServer) {
+	s.RegisterService(&_DRKeyInterService_serviceDesc, srv)
+}
+
+func _DRKeyInterService_DRKeyLevel1_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DRKeyLevel1Request)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DRKeyInterServiceServer).DRKeyLevel1(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.control_plane.v1.DRKeyInterService/DRKeyLevel1",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DRKeyInterServiceServer).DRKeyLevel1(ctx, req.(*DRKeyLevel1Request))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+var _DRKeyInterService_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "proto.control_plane.v1.DRKeyInterService",
+	HandlerType: (*DRKeyInterServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "DRKeyLevel1",
+			Handler:    _DRKeyInterService_DRKeyLevel1_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "proto/control_plane/v1/drkey.proto",
+}
+
+// DRKeyIntraServiceClient is the client API for DRKeyIntraService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+type DRKeyIntraServiceClient interface {
+	DRKeyIntraLevel1(ctx context.Context, in *DRKeyIntraLevel1Request, opts ...grpc.CallOption) (*DRKeyIntraLevel1Response, error)
+	DRKeyASHost(ctx context.Context, in *DRKeyASHostRequest, opts ...grpc.CallOption) (*DRKeyASHostResponse, error)
+	DRKeyHostAS(ctx context.Context, in *DRKeyHostASRequest, opts ...grpc.CallOption) (*DRKeyHostASResponse, error)
+	DRKeyHostHost(ctx context.Context, in *DRKeyHostHostRequest, opts ...grpc.CallOption) (*DRKeyHostHostResponse, error)
+	DRKeySecretValue(ctx context.Context, in *DRKeySecretValueRequest, opts ...grpc.CallOption) (*DRKeySecretValueResponse, error)
+}
+
+type dRKeyIntraServiceClient struct {
+	cc grpc.ClientConnInterface
+}
+
+func NewDRKeyIntraServiceClient(cc grpc.ClientConnInterface) DRKeyIntraServiceClient {
+	return &dRKeyIntraServiceClient{cc}
+}
+
+func (c *dRKeyIntraServiceClient) DRKeyIntraLevel1(ctx context.Context, in *DRKeyIntraLevel1Request, opts ...grpc.CallOption) (*DRKeyIntraLevel1Response, error) {
+	out := new(DRKeyIntraLevel1Response)
+	err := c.cc.Invoke(ctx, "/proto.control_plane.v1.DRKeyIntraService/DRKeyIntraLevel1", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dRKeyIntraServiceClient) DRKeyASHost(ctx context.Context, in *DRKeyASHostRequest, opts ...grpc.CallOption) (*DRKeyASHostResponse, error) {
+	out := new(DRKeyASHostResponse)
+	err := c.cc.Invoke(ctx, "/proto.control_plane.v1.DRKeyIntraService/DRKeyASHost", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dRKeyIntraServiceClient) DRKeyHostAS(ctx context.Context, in *DRKeyHostASRequest, opts ...grpc.CallOption) (*DRKeyHostASResponse, error) {
+	out := new(DRKeyHostASResponse)
+	err := c.cc.Invoke(ctx, "/proto.control_plane.v1.DRKeyIntraService/DRKeyHostAS", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dRKeyIntraServiceClient) DRKeyHostHost(ctx context.Context, in *DRKeyHostHostRequest, opts ...grpc.CallOption) (*DRKeyHostHostResponse, error) {
+	out := new(DRKeyHostHostResponse)
+	err := c.cc.Invoke(ctx, "/proto.control_plane.v1.DRKeyIntraService/DRKeyHostHost", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dRKeyIntraServiceClient) DRKeySecretValue(ctx context.Context, in *DRKeySecretValueRequest, opts ...grpc.CallOption) (*DRKeySecretValueResponse, error) {
+	out := new(DRKeySecretValueResponse)
+	err := c.cc.Invoke(ctx, "/proto.control_plane.v1.DRKeyIntraService/DRKeySecretValue", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// DRKeyIntraServiceServer is the server API for DRKeyIntraService service.
+type DRKeyIntraServiceServer interface {
+	DRKeyIntraLevel1(context.Context, *DRKeyIntraLevel1Request) (*DRKeyIntraLevel1Response, error)
+	DRKeyASHost(context.Context, *DRKeyASHostRequest) (*DRKeyASHostResponse, error)
+	DRKeyHostAS(context.Context, *DRKeyHostASRequest) (*DRKeyHostASResponse, error)
+	DRKeyHostHost(context.Context, *DRKeyHostHostRequest) (*DRKeyHostHostResponse, error)
+	DRKeySecretValue(context.Context, *DRKeySecretValueRequest) (*DRKeySecretValueResponse, error)
+}
+
+// UnimplementedDRKeyIntraServiceServer can be embedded to have forward compatible implementations.
+type UnimplementedDRKeyIntraServiceServer struct {
+}
+
+func (*UnimplementedDRKeyIntraServiceServer) DRKeyIntraLevel1(context.Context, *DRKeyIntraLevel1Request) (*DRKeyIntraLevel1Response, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DRKeyIntraLevel1 not implemented")
+}
+func (*UnimplementedDRKeyIntraServiceServer) DRKeyASHost(context.Context, *DRKeyASHostRequest) (*DRKeyASHostResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DRKeyASHost not implemented")
+}
+func (*UnimplementedDRKeyIntraServiceServer) DRKeyHostAS(context.Context, *DRKeyHostASRequest) (*DRKeyHostASResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DRKeyHostAS not implemented")
+}
+func (*UnimplementedDRKeyIntraServiceServer) DRKeyHostHost(context.Context, *DRKeyHostHostRequest) (*DRKeyHostHostResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DRKeyHostHost not implemented")
+}
+func (*UnimplementedDRKeyIntraServiceServer) DRKeySecretValue(context.Context, *DRKeySecretValueRequest) (*DRKeySecretValueResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DRKeySecretValue not implemented")
+}
+
+func RegisterDRKeyIntraServiceServer(s *grpc.Server, srv DRKeyIntraServiceServer) {
+	s.RegisterService(&_DRKeyIntraService_serviceDesc, srv)
+}
+
+func _DRKeyIntraService_DRKeyIntraLevel1_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DRKeyIntraLevel1Request)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DRKeyIntraServiceServer).DRKeyIntraLevel1(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.control_plane.v1.DRKeyIntraService/DRKeyIntraLevel1",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DRKeyIntraServiceServer).DRKeyIntraLevel1(ctx, req.(*DRKeyIntraLevel1Request))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DRKeyIntraService_DRKeyASHost_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DRKeyASHostRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DRKeyIntraServiceServer).DRKeyASHost(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.control_plane.v1.DRKeyIntraService/DRKeyASHost",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DRKeyIntraServiceServer).DRKeyASHost(ctx, req.(*DRKeyASHostRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DRKeyIntraService_DRKeyHostAS_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DRKeyHostASRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DRKeyIntraServiceServer).DRKeyHostAS(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.control_plane.v1.DRKeyIntraService/DRKeyHostAS",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DRKeyIntraServiceServer).DRKeyHostAS(ctx, req.(*DRKeyHostASRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DRKeyIntraService_DRKeyHostHost_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DRKeyHostHostRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DRKeyIntraServiceServer).DRKeyHostHost(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.control_plane.v1.DRKeyIntraService/DRKeyHostHost",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DRKeyIntraServiceServer).DRKeyHostHost(ctx, req.(*DRKeyHostHostRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DRKeyIntraService_DRKeySecretValue_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DRKeySecretValueRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DRKeyIntraServiceServer).DRKeySecretValue(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.control_plane.v1.DRKeyIntraService/DRKeySecretValue",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DRKeyIntraServiceServer).DRKeySecretValue(ctx, req.(*DRKeySecretValueRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+var _DRKeyIntraService_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "proto.control_plane.v1.DRKeyIntraService",
+	HandlerType: (*DRKeyIntraServiceServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "DRKeyIntraLevel1",
+			Handler:    _DRKeyIntraService_DRKeyIntraLevel1_Handler,
+		},
+		{
+			MethodName: "DRKeyASHost",
+			Handler:    _DRKeyIntraService_DRKeyASHost_Handler,
+		},
+		{
+			MethodName: "DRKeyHostAS",
+			Handler:    _DRKeyIntraService_DRKeyHostAS_Handler,
+		},
+		{
+			MethodName: "DRKeyHostHost",
+			Handler:    _DRKeyIntraService_DRKeyHostHost_Handler,
+		},
+		{
+			MethodName: "DRKeySecretValue",
+			Handler:    _DRKeyIntraService_DRKeySecretValue_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "proto/control_plane/v1/drkey.proto",
 }

--- a/pkg/proto/daemon/daemon.pb.go
+++ b/pkg/proto/daemon/daemon.pb.go
@@ -1703,7 +1703,7 @@ var file_proto_daemon_v1_daemon_proto_rawDesc = []byte{
 	0x52, 0x45, 0x43, 0x54, 0x10, 0x01, 0x12, 0x17, 0x0a, 0x13, 0x4c, 0x49, 0x4e, 0x4b, 0x5f, 0x54,
 	0x59, 0x50, 0x45, 0x5f, 0x4d, 0x55, 0x4c, 0x54, 0x49, 0x5f, 0x48, 0x4f, 0x50, 0x10, 0x02, 0x12,
 	0x16, 0x0a, 0x12, 0x4c, 0x49, 0x4e, 0x4b, 0x5f, 0x54, 0x59, 0x50, 0x45, 0x5f, 0x4f, 0x50, 0x45,
-	0x4e, 0x5f, 0x4e, 0x45, 0x54, 0x10, 0x03, 0x32, 0xba, 0x03, 0x0a, 0x0d, 0x44, 0x61, 0x65, 0x6d,
+	0x4e, 0x5f, 0x4e, 0x45, 0x54, 0x10, 0x03, 0x32, 0xd4, 0x05, 0x0a, 0x0d, 0x44, 0x61, 0x65, 0x6d,
 	0x6f, 0x6e, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x48, 0x0a, 0x05, 0x50, 0x61, 0x74,
 	0x68, 0x73, 0x12, 0x1d, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x64, 0x61, 0x65, 0x6d, 0x6f,
 	0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x61, 0x74, 0x68, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
@@ -1731,10 +1731,28 @@ var file_proto_daemon_v1_daemon_proto_rawDesc = []byte{
 	0x75, 0x65, 0x73, 0x74, 0x1a, 0x2c, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x64, 0x61, 0x65,
 	0x6d, 0x6f, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x4e, 0x6f, 0x74, 0x69, 0x66, 0x79, 0x49, 0x6e, 0x74,
 	0x65, 0x72, 0x66, 0x61, 0x63, 0x65, 0x44, 0x6f, 0x77, 0x6e, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e,
-	0x73, 0x65, 0x22, 0x00, 0x42, 0x2e, 0x5a, 0x2c, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63,
-	0x6f, 0x6d, 0x2f, 0x73, 0x63, 0x69, 0x6f, 0x6e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x73, 0x63,
-	0x69, 0x6f, 0x6e, 0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x64, 0x61,
-	0x65, 0x6d, 0x6f, 0x6e, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x73, 0x65, 0x22, 0x00, 0x12, 0x5a, 0x0a, 0x0b, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x41, 0x53, 0x48,
+	0x6f, 0x73, 0x74, 0x12, 0x23, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x64, 0x61, 0x65, 0x6d,
+	0x6f, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x41, 0x53, 0x48, 0x6f, 0x73,
+	0x74, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x24, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x2e, 0x64, 0x61, 0x65, 0x6d, 0x6f, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65, 0x79,
+	0x41, 0x53, 0x48, 0x6f, 0x73, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00,
+	0x12, 0x5a, 0x0a, 0x0b, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73, 0x74, 0x41, 0x53, 0x12,
+	0x23, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x64, 0x61, 0x65, 0x6d, 0x6f, 0x6e, 0x2e, 0x76,
+	0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73, 0x74, 0x41, 0x53, 0x52, 0x65, 0x71,
+	0x75, 0x65, 0x73, 0x74, 0x1a, 0x24, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x64, 0x61, 0x65,
+	0x6d, 0x6f, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73, 0x74,
+	0x41, 0x53, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x60, 0x0a, 0x0d,
+	0x44, 0x52, 0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73, 0x74, 0x48, 0x6f, 0x73, 0x74, 0x12, 0x25, 0x2e,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x64, 0x61, 0x65, 0x6d, 0x6f, 0x6e, 0x2e, 0x76, 0x31, 0x2e,
+	0x44, 0x52, 0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73, 0x74, 0x48, 0x6f, 0x73, 0x74, 0x52, 0x65, 0x71,
+	0x75, 0x65, 0x73, 0x74, 0x1a, 0x26, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2e, 0x64, 0x61, 0x65,
+	0x6d, 0x6f, 0x6e, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x52, 0x4b, 0x65, 0x79, 0x48, 0x6f, 0x73, 0x74,
+	0x48, 0x6f, 0x73, 0x74, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x2e,
+	0x5a, 0x2c, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73, 0x63, 0x69,
+	0x6f, 0x6e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x73, 0x63, 0x69, 0x6f, 0x6e, 0x2f, 0x70, 0x6b,
+	0x67, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x64, 0x61, 0x65, 0x6d, 0x6f, 0x6e, 0x62, 0x06,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -1815,13 +1833,19 @@ var file_proto_daemon_v1_daemon_proto_depIdxs = []int32{
 	9,  // 28: proto.daemon.v1.DaemonService.Interfaces:input_type -> proto.daemon.v1.InterfacesRequest
 	12, // 29: proto.daemon.v1.DaemonService.Services:input_type -> proto.daemon.v1.ServicesRequest
 	17, // 30: proto.daemon.v1.DaemonService.NotifyInterfaceDown:input_type -> proto.daemon.v1.NotifyInterfaceDownRequest
-	2,  // 31: proto.daemon.v1.DaemonService.Paths:output_type -> proto.daemon.v1.PathsResponse
-	8,  // 32: proto.daemon.v1.DaemonService.AS:output_type -> proto.daemon.v1.ASResponse
-	10, // 33: proto.daemon.v1.DaemonService.Interfaces:output_type -> proto.daemon.v1.InterfacesResponse
-	13, // 34: proto.daemon.v1.DaemonService.Services:output_type -> proto.daemon.v1.ServicesResponse
-	18, // 35: proto.daemon.v1.DaemonService.NotifyInterfaceDown:output_type -> proto.daemon.v1.NotifyInterfaceDownResponse
-	31, // [31:36] is the sub-list for method output_type
-	26, // [26:31] is the sub-list for method input_type
+	21, // 31: proto.daemon.v1.DaemonService.DRKeyASHost:input_type -> proto.daemon.v1.DRKeyASHostRequest
+	19, // 32: proto.daemon.v1.DaemonService.DRKeyHostAS:input_type -> proto.daemon.v1.DRKeyHostASRequest
+	23, // 33: proto.daemon.v1.DaemonService.DRKeyHostHost:input_type -> proto.daemon.v1.DRKeyHostHostRequest
+	2,  // 34: proto.daemon.v1.DaemonService.Paths:output_type -> proto.daemon.v1.PathsResponse
+	8,  // 35: proto.daemon.v1.DaemonService.AS:output_type -> proto.daemon.v1.ASResponse
+	10, // 36: proto.daemon.v1.DaemonService.Interfaces:output_type -> proto.daemon.v1.InterfacesResponse
+	13, // 37: proto.daemon.v1.DaemonService.Services:output_type -> proto.daemon.v1.ServicesResponse
+	18, // 38: proto.daemon.v1.DaemonService.NotifyInterfaceDown:output_type -> proto.daemon.v1.NotifyInterfaceDownResponse
+	22, // 39: proto.daemon.v1.DaemonService.DRKeyASHost:output_type -> proto.daemon.v1.DRKeyASHostResponse
+	20, // 40: proto.daemon.v1.DaemonService.DRKeyHostAS:output_type -> proto.daemon.v1.DRKeyHostASResponse
+	24, // 41: proto.daemon.v1.DaemonService.DRKeyHostHost:output_type -> proto.daemon.v1.DRKeyHostHostResponse
+	34, // [34:42] is the sub-list for method output_type
+	26, // [26:34] is the sub-list for method input_type
 	26, // [26:26] is the sub-list for extension type_name
 	26, // [26:26] is the sub-list for extension extendee
 	0,  // [0:26] is the sub-list for field type_name
@@ -2160,6 +2184,9 @@ type DaemonServiceClient interface {
 	Interfaces(ctx context.Context, in *InterfacesRequest, opts ...grpc.CallOption) (*InterfacesResponse, error)
 	Services(ctx context.Context, in *ServicesRequest, opts ...grpc.CallOption) (*ServicesResponse, error)
 	NotifyInterfaceDown(ctx context.Context, in *NotifyInterfaceDownRequest, opts ...grpc.CallOption) (*NotifyInterfaceDownResponse, error)
+	DRKeyASHost(ctx context.Context, in *DRKeyASHostRequest, opts ...grpc.CallOption) (*DRKeyASHostResponse, error)
+	DRKeyHostAS(ctx context.Context, in *DRKeyHostASRequest, opts ...grpc.CallOption) (*DRKeyHostASResponse, error)
+	DRKeyHostHost(ctx context.Context, in *DRKeyHostHostRequest, opts ...grpc.CallOption) (*DRKeyHostHostResponse, error)
 }
 
 type daemonServiceClient struct {
@@ -2215,6 +2242,33 @@ func (c *daemonServiceClient) NotifyInterfaceDown(ctx context.Context, in *Notif
 	return out, nil
 }
 
+func (c *daemonServiceClient) DRKeyASHost(ctx context.Context, in *DRKeyASHostRequest, opts ...grpc.CallOption) (*DRKeyASHostResponse, error) {
+	out := new(DRKeyASHostResponse)
+	err := c.cc.Invoke(ctx, "/proto.daemon.v1.DaemonService/DRKeyASHost", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) DRKeyHostAS(ctx context.Context, in *DRKeyHostASRequest, opts ...grpc.CallOption) (*DRKeyHostASResponse, error) {
+	out := new(DRKeyHostASResponse)
+	err := c.cc.Invoke(ctx, "/proto.daemon.v1.DaemonService/DRKeyHostAS", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *daemonServiceClient) DRKeyHostHost(ctx context.Context, in *DRKeyHostHostRequest, opts ...grpc.CallOption) (*DRKeyHostHostResponse, error) {
+	out := new(DRKeyHostHostResponse)
+	err := c.cc.Invoke(ctx, "/proto.daemon.v1.DaemonService/DRKeyHostHost", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // DaemonServiceServer is the server API for DaemonService service.
 type DaemonServiceServer interface {
 	Paths(context.Context, *PathsRequest) (*PathsResponse, error)
@@ -2222,6 +2276,9 @@ type DaemonServiceServer interface {
 	Interfaces(context.Context, *InterfacesRequest) (*InterfacesResponse, error)
 	Services(context.Context, *ServicesRequest) (*ServicesResponse, error)
 	NotifyInterfaceDown(context.Context, *NotifyInterfaceDownRequest) (*NotifyInterfaceDownResponse, error)
+	DRKeyASHost(context.Context, *DRKeyASHostRequest) (*DRKeyASHostResponse, error)
+	DRKeyHostAS(context.Context, *DRKeyHostASRequest) (*DRKeyHostASResponse, error)
+	DRKeyHostHost(context.Context, *DRKeyHostHostRequest) (*DRKeyHostHostResponse, error)
 }
 
 // UnimplementedDaemonServiceServer can be embedded to have forward compatible implementations.
@@ -2242,6 +2299,15 @@ func (*UnimplementedDaemonServiceServer) Services(context.Context, *ServicesRequ
 }
 func (*UnimplementedDaemonServiceServer) NotifyInterfaceDown(context.Context, *NotifyInterfaceDownRequest) (*NotifyInterfaceDownResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method NotifyInterfaceDown not implemented")
+}
+func (*UnimplementedDaemonServiceServer) DRKeyASHost(context.Context, *DRKeyASHostRequest) (*DRKeyASHostResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DRKeyASHost not implemented")
+}
+func (*UnimplementedDaemonServiceServer) DRKeyHostAS(context.Context, *DRKeyHostASRequest) (*DRKeyHostASResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DRKeyHostAS not implemented")
+}
+func (*UnimplementedDaemonServiceServer) DRKeyHostHost(context.Context, *DRKeyHostHostRequest) (*DRKeyHostHostResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DRKeyHostHost not implemented")
 }
 
 func RegisterDaemonServiceServer(s *grpc.Server, srv DaemonServiceServer) {
@@ -2338,6 +2404,60 @@ func _DaemonService_NotifyInterfaceDown_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DaemonService_DRKeyASHost_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DRKeyASHostRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).DRKeyASHost(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.daemon.v1.DaemonService/DRKeyASHost",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).DRKeyASHost(ctx, req.(*DRKeyASHostRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_DRKeyHostAS_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DRKeyHostASRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).DRKeyHostAS(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.daemon.v1.DaemonService/DRKeyHostAS",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).DRKeyHostAS(ctx, req.(*DRKeyHostASRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DaemonService_DRKeyHostHost_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DRKeyHostHostRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DaemonServiceServer).DRKeyHostHost(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.daemon.v1.DaemonService/DRKeyHostHost",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DaemonServiceServer).DRKeyHostHost(ctx, req.(*DRKeyHostHostRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _DaemonService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "proto.daemon.v1.DaemonService",
 	HandlerType: (*DaemonServiceServer)(nil),
@@ -2361,6 +2481,18 @@ var _DaemonService_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "NotifyInterfaceDown",
 			Handler:    _DaemonService_NotifyInterfaceDown_Handler,
+		},
+		{
+			MethodName: "DRKeyASHost",
+			Handler:    _DaemonService_DRKeyASHost_Handler,
+		},
+		{
+			MethodName: "DRKeyHostAS",
+			Handler:    _DaemonService_DRKeyHostAS_Handler,
+		},
+		{
+			MethodName: "DRKeyHostHost",
+			Handler:    _DaemonService_DRKeyHostHost_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/private/proto/drkey/eq_definiton_test.go
+++ b/private/proto/drkey/eq_definiton_test.go
@@ -49,6 +49,18 @@ func TestEqualHostASResponse(t *testing.T) {
 	checkEquals(t, controlFields, daemonFields)
 }
 
+func TestEqualHostHostRequest(t *testing.T) {
+	controlFields := (&pb_cp.DRKeyHostHostRequest{}).ProtoReflect().Descriptor().Fields()
+	daemonFields := (&pb_daemon.DRKeyHostHostRequest{}).ProtoReflect().Descriptor().Fields()
+	checkEquals(t, controlFields, daemonFields)
+}
+
+func TestEqualHostHostResponse(t *testing.T) {
+	controlFields := (&pb_cp.DRKeyHostHostResponse{}).ProtoReflect().Descriptor().Fields()
+	daemonFields := (&pb_daemon.DRKeyHostHostResponse{}).ProtoReflect().Descriptor().Fields()
+	checkEquals(t, controlFields, daemonFields)
+}
+
 func checkEquals(t *testing.T, controlFields, daemonFields protoreflect.FieldDescriptors) {
 	require.Equal(t, controlFields.Len(), daemonFields.Len())
 	for i := 0; i < controlFields.Len(); i++ {

--- a/proto/control_plane/v1/drkey.proto
+++ b/proto/control_plane/v1/drkey.proto
@@ -21,6 +21,25 @@ package proto.control_plane.v1;
 import "proto/drkey/v1/drkey.proto";
 import "google/protobuf/timestamp.proto";
 
+service DRKeyInterService{
+    // Return the Level1Key that matches the request
+    rpc DRKeyLevel1(DRKeyLevel1Request) returns (DRKeyLevel1Response) {}
+}
+
+service DRKeyIntraService{
+    // Return the ASAS that matches the request
+    rpc DRKeyIntraLevel1(DRKeyIntraLevel1Request) returns (DRKeyIntraLevel1Response) {}
+    // Return the AS-Host that matches the request
+    rpc DRKeyASHost(DRKeyASHostRequest) returns (DRKeyASHostResponse) {}
+    // Return the Host-AS that matches the request
+    rpc DRKeyHostAS(DRKeyHostASRequest) returns (DRKeyHostASResponse) {}
+    // Return the Host-Host that matches the request
+    rpc DRKeyHostHost(DRKeyHostHostRequest) returns (DRKeyHostHostResponse) {}
+    // Return the SecretValue that matches the request
+    rpc DRKeySecretValue(DRKeySecretValueRequest) returns (DRKeySecretValueResponse) {}
+}
+
+
 message DRKeySecretValueRequest{
     // Point in time when the requested key is valid.
     google.protobuf.Timestamp val_time = 1;
@@ -121,3 +140,28 @@ message DRKeyASHostResponse{
     // Level2 key.
     bytes key = 3;
 }
+
+message DRKeyHostHostRequest{
+    // Point in time where requested key is valid.
+    google.protobuf.Timestamp val_time = 1;
+    // Protocol value.
+    proto.drkey.v1.Protocol protocol_id = 2;
+    // Src ISD-AS of the requested DRKey.
+    uint64 src_ia = 3;
+    // Dst ISD-AS of the requested DRKey.
+    uint64 dst_ia = 4;
+    // Src Host of the request DRKey.
+    string src_host = 5;
+    // Dst Host of the request DRKey.
+    string dst_host = 6;
+}
+
+message DRKeyHostHostResponse{
+    // Begin of validity period of DRKey.
+    google.protobuf.Timestamp epoch_begin = 1;
+    // End of validity period of DRKey.
+    google.protobuf.Timestamp epoch_end = 2;
+    // Level2 key.
+    bytes key = 3;
+}
+

--- a/proto/daemon/v1/daemon.proto
+++ b/proto/daemon/v1/daemon.proto
@@ -35,6 +35,12 @@ service DaemonService {
     rpc Services(ServicesRequest) returns (ServicesResponse) {}
     // Inform the SCION Daemon of a revocation.
     rpc NotifyInterfaceDown(NotifyInterfaceDownRequest) returns (NotifyInterfaceDownResponse) {}
+    // DRKeyASHost returns a key that matches the request.
+    rpc DRKeyASHost (DRKeyASHostRequest) returns (DRKeyASHostResponse) {}
+    // DRKeyHostAS returns a key that matches the request.
+    rpc DRKeyHostAS (DRKeyHostASRequest) returns (DRKeyHostASResponse) {}
+    // DRKeyHostHost returns a key that matches the request.
+    rpc DRKeyHostHost (DRKeyHostHostRequest) returns (DRKeyHostHostResponse) {}
 }
 
 message PathsRequest {


### PR DESCRIPTION
This PR is the 6th in a series of PRs that add support for DRKey started with https://github.com/scionproto/scion/pull/4217.

This PR contains:

- The protobuf drkey RPC call definitions for the CS and the daemon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4226)
<!-- Reviewable:end -->
