### PR TITLE
drkey: add config for control

### DIFF
--- a/control/config/BUILD.bazel
+++ b/control/config/BUILD.bazel
@@ -5,11 +5,14 @@ go_library(
     srcs = [
         "bs_sample.go",
         "config.go",
+        "drkey.go",
         "sample.go",
     ],
     importpath = "github.com/scionproto/scion/control/config",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/addr:go_default_library",
+        "//pkg/drkey:go_default_library",
         "//pkg/log:go_default_library",
         "//pkg/private/serrors:go_default_library",
         "//pkg/private/util:go_default_library",
@@ -19,20 +22,28 @@ go_library(
         "//private/mgmtapi/jwtauth:go_default_library",
         "//private/storage:go_default_library",
         "//private/trust/config:go_default_library",
+        "@af_inet_netaddr//:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["config_test.go"],
+    srcs = [
+        "config_test.go",
+        "drkey_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/drkey:go_default_library",
         "//pkg/log/logtest:go_default_library",
         "//private/env/envtest:go_default_library",
         "//private/mgmtapi/jwtauth:go_default_library",
         "//private/mgmtapi/mgmtapitest:go_default_library",
+        "//private/storage:go_default_library",
         "//private/storage/test:go_default_library",
+        "@af_inet_netaddr//:go_default_library",
         "@com_github_pelletier_go_toml//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/control/config/drkey.go
+++ b/control/config/drkey.go
@@ -1,0 +1,167 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"io"
+	"strings"
+	"time"
+
+	"inet.af/netaddr"
+
+	"github.com/scionproto/scion/pkg/addr"
+	"github.com/scionproto/scion/pkg/drkey"
+	"github.com/scionproto/scion/pkg/private/serrors"
+	"github.com/scionproto/scion/private/config"
+	"github.com/scionproto/scion/private/storage"
+)
+
+const (
+	// DefaultEpochDuration is the default duration for the drkey SecretValue and derived keys
+	DefaultEpochDuration   = 24 * time.Hour
+	DefaultPrefetchEntries = 10000
+	EnvVarEpochDuration    = "SCION_TESTING_DRKEY_EPOCH_DURATION"
+)
+
+var _ (config.Config) = (*DRKeyConfig)(nil)
+
+// DRKeyConfig is the configuration for the connection to the trust database.
+type DRKeyConfig struct {
+	Level1DB        storage.DBConfig    `toml:"level1_db,omitempty"`
+	SecretValueDB   storage.DBConfig    `toml:"secret_value_db,omitempty"`
+	Delegation      SecretValueHostList `toml:"delegation,omitempty"`
+	PrefetchEntries int                 `toml:"prefetch_entries,omitempty"`
+}
+
+// InitDefaults initializes values of unset keys and determines if the configuration enables DRKey.
+func (cfg *DRKeyConfig) InitDefaults() {
+	if cfg.PrefetchEntries == 0 {
+		cfg.PrefetchEntries = DefaultPrefetchEntries
+	}
+	config.InitAll(
+		cfg.Level1DB.WithDefault(""),
+		cfg.SecretValueDB.WithDefault(""),
+		&cfg.Delegation,
+	)
+}
+
+// Enabled returns true if DRKey is configured. False otherwise.
+func (cfg *DRKeyConfig) Enabled() bool {
+	return cfg.Level1DB.Connection != ""
+}
+
+// Validate validates that all values are parsable.
+func (cfg *DRKeyConfig) Validate() error {
+	return config.ValidateAll(&cfg.Level1DB, &cfg.SecretValueDB, &cfg.Delegation)
+}
+
+// Sample writes a config sample to the writer.
+func (cfg *DRKeyConfig) Sample(dst io.Writer, path config.Path, ctx config.CtxMap) {
+	config.WriteString(dst, drkeySample)
+	config.WriteSample(dst, path,
+		config.CtxMap{config.ID: idSample},
+		config.OverrideName(
+			config.FormatData(
+				&cfg.Level1DB,
+				storage.SetID(storage.SampleDRKeyLevel1DB, idSample).Connection,
+			),
+			"level1_db",
+		),
+		config.OverrideName(
+			config.FormatData(
+				&cfg.SecretValueDB,
+				storage.SetID(storage.SampleDRKeySecretValueDB, idSample).Connection,
+			),
+			"secret_value_db",
+		),
+		&cfg.Delegation,
+	)
+}
+
+// ConfigName is the key in the toml file.
+func (cfg *DRKeyConfig) ConfigName() string {
+	return "drkey"
+}
+
+// SecretValueHostList configures which endhosts can get delegation secrets, per protocol.
+type SecretValueHostList map[string][]string
+
+var _ (config.Config) = (*SecretValueHostList)(nil)
+
+// InitDefaults will not add or modify any entry in the config.
+func (cfg *SecretValueHostList) InitDefaults() {
+	if *cfg == nil {
+		*cfg = make(SecretValueHostList)
+	}
+}
+
+// Validate validates that the protocols exist, and their addresses are parsable.
+func (cfg *SecretValueHostList) Validate() error {
+	for proto, list := range *cfg {
+		protoString := "PROTOCOL_" + strings.ToUpper(proto)
+		protoID, ok := drkey.ProtocolStringToId(protoString)
+		if !ok {
+			return serrors.New("Configured protocol not found", "protocol", proto)
+		}
+		if protoID == drkey.Generic {
+			return serrors.New("GENERIC protocol is not allowed")
+		}
+		for _, ip := range list {
+			if h := addr.HostFromIPStr(ip); h == nil {
+				return serrors.New("Syntax error: not a valid address", "ip", ip)
+			}
+		}
+	}
+	return nil
+}
+
+// Sample writes a config sample to the writer.
+func (cfg *SecretValueHostList) Sample(dst io.Writer, path config.Path, ctx config.CtxMap) {
+	config.WriteString(dst, drkeySecretValueHostListSample)
+}
+
+// ConfigName is the key in the toml file.
+func (cfg *SecretValueHostList) ConfigName() string {
+	return "delegation"
+}
+
+type HostProto struct {
+	Host  netaddr.IP
+	Proto drkey.Protocol
+}
+
+// ToAllowedSet will return map where there is a set of supported (Host,Protocol).
+func (cfg *SecretValueHostList) ToAllowedSet() map[HostProto]struct{} {
+	m := make(map[HostProto]struct{})
+	for proto, ipList := range *cfg {
+		for _, ip := range ipList {
+			host, err := netaddr.ParseIP(ip)
+			if err != nil {
+				continue
+			}
+			protoString := "PROTOCOL_" + strings.ToUpper(proto)
+			protoID, ok := drkey.ProtocolStringToId(protoString)
+			if !ok {
+				continue
+			}
+			hostProto := HostProto{
+				Host:  host,
+				Proto: protoID,
+			}
+			m[hostProto] = struct{}{}
+		}
+	}
+	return m
+}

--- a/control/config/drkey_test.go
+++ b/control/config/drkey_test.go
@@ -1,0 +1,163 @@
+// Copyright 2022 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	toml "github.com/pelletier/go-toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"inet.af/netaddr"
+
+	"github.com/scionproto/scion/pkg/drkey"
+	"github.com/scionproto/scion/private/storage"
+)
+
+func TestInitDefaults(t *testing.T) {
+	var cfg DRKeyConfig
+	cfg.InitDefaults()
+	assert.EqualValues(t, DefaultPrefetchEntries, cfg.PrefetchEntries)
+	assert.NotNil(t, cfg.Delegation)
+}
+
+func TestSample(t *testing.T) {
+	var sample bytes.Buffer
+	var cfg DRKeyConfig
+	cfg.Sample(&sample, nil, nil)
+	err := toml.NewDecoder(bytes.NewReader(sample.Bytes())).Strict(true).Decode(&cfg)
+	require.NoError(t, err)
+	err = cfg.Validate()
+	assert.NoError(t, err)
+}
+
+func TestDisable(t *testing.T) {
+	cases := []struct {
+		name          string
+		prepareCfg    func(cfg *DRKeyConfig)
+		expectEnabled bool
+	}{
+		{
+			name:          "default",
+			expectEnabled: false,
+		},
+		{
+			name: "with CacheEntries",
+			prepareCfg: func(cfg *DRKeyConfig) {
+				cfg.PrefetchEntries = 100
+			},
+			expectEnabled: false,
+		},
+		{
+			name: "with Level1DB",
+			prepareCfg: func(cfg *DRKeyConfig) {
+				cfg.Level1DB.Connection = "test"
+			},
+			expectEnabled: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cfg := &DRKeyConfig{}
+			cfg.InitDefaults()
+			if c.prepareCfg != nil {
+				c.prepareCfg(cfg)
+			}
+			assert.NoError(t, cfg.Validate())
+			assert.Equal(t, c.expectEnabled, cfg.Enabled())
+		})
+	}
+}
+
+func TestSecretValueHostListDefaults(t *testing.T) {
+	var cfg SecretValueHostList
+	cfg.InitDefaults()
+	assert.NotNil(t, cfg)
+	assert.Empty(t, cfg)
+}
+
+func TestSecretValueHostListSyntax(t *testing.T) {
+	var cfg SecretValueHostList
+	var err error
+	sample1 := `scmp = ["1.1.1.1"]`
+	err = toml.NewDecoder(bytes.NewReader([]byte(sample1))).Strict(true).Decode(&cfg)
+	require.NoError(t, err)
+	assert.NoError(t, cfg.Validate())
+
+	sample2 := `scmp = ["not an address"]`
+	err = toml.NewDecoder(bytes.NewReader([]byte(sample2))).Strict(true).Decode(&cfg)
+	require.NoError(t, err)
+	assert.Error(t, cfg.Validate())
+}
+
+func TestToMapPerHost(t *testing.T) {
+	var cfg SecretValueHostList
+	sample := `scmp = ["1.1.1.1", "2.2.2.2"]`
+	ip1111, err := netaddr.ParseIP("1.1.1.1")
+	require.NoError(t, err)
+	ip2222, err := netaddr.ParseIP("2.2.2.2")
+	require.NoError(t, err)
+	err = toml.NewDecoder(bytes.NewReader([]byte(sample))).Strict(true).Decode(&cfg)
+	require.NoError(t, err)
+	assert.NoError(t, cfg.Validate())
+	m := cfg.ToAllowedSet()
+
+	assert.Len(t, m, 2)
+	assert.Contains(t, m, HostProto{
+		Host:  ip1111,
+		Proto: drkey.SCMP,
+	})
+	assert.Contains(t, m, HostProto{
+		Host:  ip2222,
+		Proto: drkey.SCMP,
+	})
+}
+
+func TestNewLevel1DB(t *testing.T) {
+	cfg := DRKeyConfig{}
+	cfg.InitDefaults()
+	cfg.Level1DB.Connection = tempFile(t)
+	db, err := storage.NewDRKeyLevel1Storage(cfg.Level1DB)
+	defer func() {
+		db.Close()
+		os.Remove(cfg.Level1DB.Connection)
+	}()
+	assert.NoError(t, err)
+	assert.NotNil(t, db)
+}
+
+func TestNewSecretValueDB(t *testing.T) {
+	cfg := DRKeyConfig{}
+	cfg.InitDefaults()
+	cfg.SecretValueDB.Connection = tempFile(t)
+	db, err := storage.NewDRKeySecretValueStorage(cfg.SecretValueDB)
+	defer func() {
+		db.Close()
+		os.Remove(cfg.Level1DB.Connection)
+	}()
+	assert.NoError(t, err)
+	assert.NotNil(t, db)
+}
+
+func tempFile(t *testing.T) string {
+	file, err := os.CreateTemp("", "db-test-")
+	require.NoError(t, err)
+	name := file.Name()
+	err = file.Close()
+	require.NoError(t, err)
+	return name
+}

--- a/control/config/sample.go
+++ b/control/config/sample.go
@@ -63,3 +63,12 @@ lifetime = "10m"
 # authorization tokens. If not set, the SCION ID is used instead.
 client_id = ""
 `
+
+const drkeySample = `
+# Number of distinct Level1Keys to be prefetched.
+prefetch_entries = 10000
+`
+const drkeySecretValueHostListSample = `
+# The list of hosts authorized to get a SV per protocol.
+scmp = [ "127.0.0.1", "127.0.0.2"]
+`

--- a/private/storage/BUILD.bazel
+++ b/private/storage/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//control/beacon:go_default_library",
         "//pkg/addr:go_default_library",
+        "//pkg/drkey:go_default_library",
         "//pkg/log:go_default_library",
         "//private/config:go_default_library",
         "//private/pathdb:go_default_library",
@@ -21,6 +22,9 @@ go_library(
         "//private/storage/beacon/sqlite:go_default_library",
         "//private/storage/cleaner:go_default_library",
         "//private/storage/db:go_default_library",
+        "//private/storage/drkey/level1/sqlite:go_default_library",
+        "//private/storage/drkey/level2/sqlite:go_default_library",
+        "//private/storage/drkey/secret/sqlite:go_default_library",
         "//private/storage/path/sqlite:go_default_library",
         "//private/storage/trust:go_default_library",
         "//private/storage/trust/sqlite:go_default_library",


### PR DESCRIPTION
This PR is the 7th in a series of PRs that add support for DRKey started with https://github.com/scionproto/scion/pull/4217.

This PR contains:

- The drkey configuration for the CS.
- Adding initiators for DB backends + defaults.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4227)
<!-- Reviewable:end -->
