### PR TITLE
path.Epic Reverse method error handling. 

### DIFF
--- a/pkg/slayers/path/epic/epic.go
+++ b/pkg/slayers/path/epic/epic.go
@@ -104,7 +104,7 @@ func (p *Path) Reverse() (path.Path, error) {
 	}
 	ScionPath, ok := revScion.(*scion.Raw)
 	if !ok {
-		return nil, err
+		return nil, serrors.New("reversed path of type scion.Raw must not change type")
 	}
 	p.ScionPath = ScionPath
 	return p, nil


### PR DESCRIPTION
Hello 👋 , currently one of the guaranteed post-conditions of the Path interface Reverse method is that "if the error return value is `nil`, then the returned Path is well-formed". This is a general pattern in Go when returning an error value, but especially in the context of the VerifiedSCION project.
In the case of the Epic path's Reverse function, if the type assertion fails, the returned `err` value would still be `nil` from the assignment on line 101, seen [here](https://github.com/scionproto/scion/blob/39b8fd4acbc2773e04e022bd66cf7cffae1f48a7/pkg/slayers/path/epic/epic.go#L101-L107).

I would say that this is invalid and propose that a new error should be returned. I simply threw in an error message there, however, I am unconvinced that it is the correct message. Better suggestions are welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4229)
<!-- Reviewable:end -->
