### PR TITLE
drkey: daemon grpc RPC methods implementation

### DIFF
--- a/daemon/internal/servers/BUILD.bazel
+++ b/daemon/internal/servers/BUILD.bazel
@@ -9,8 +9,10 @@ go_library(
     importpath = "github.com/scionproto/scion/daemon/internal/servers",
     visibility = ["//daemon:__subpackages__"],
     deps = [
+        "//daemon/drkey:go_default_library",
         "//daemon/fetcher:go_default_library",
         "//pkg/addr:go_default_library",
+        "//pkg/drkey:go_default_library",
         "//pkg/log:go_default_library",
         "//pkg/metrics:go_default_library",
         "//pkg/private/common:go_default_library",

--- a/daemon/internal/servers/grpc.go
+++ b/daemon/internal/servers/grpc.go
@@ -25,8 +25,10 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"golang.org/x/sync/singleflight"
 
+	drkey_daemon "github.com/scionproto/scion/daemon/drkey"
 	"github.com/scionproto/scion/daemon/fetcher"
 	"github.com/scionproto/scion/pkg/addr"
+	"github.com/scionproto/scion/pkg/drkey"
 	"github.com/scionproto/scion/pkg/log"
 	"github.com/scionproto/scion/pkg/private/common"
 	"github.com/scionproto/scion/pkg/private/ctrl/path_mgmt"
@@ -57,6 +59,7 @@ type DaemonServer struct {
 	Fetcher     fetcher.Fetcher
 	RevCache    revcache.RevCache
 	ASInspector trust.Inspector
+	DRKeyClient drkey_daemon.ClientEngine
 
 	Metrics Metrics
 
@@ -353,7 +356,21 @@ func (s *DaemonServer) DRKeyASHost(
 	req *pb_daemon.DRKeyASHostRequest,
 ) (*pb_daemon.DRKeyASHostResponse, error) {
 
-	panic("not implemented")
+	meta, err := requestToASHostMeta(req)
+	if err != nil {
+		return nil, serrors.WrapStr("parsing protobuf ASHostReq", err)
+	}
+
+	lvl2Key, err := s.DRKeyClient.GetASHostKey(ctx, meta)
+	if err != nil {
+		return nil, serrors.WrapStr("getting AS-Host from client store", err)
+	}
+
+	return &sdpb.DRKeyASHostResponse{
+		EpochBegin: &timestamppb.Timestamp{Seconds: lvl2Key.Epoch.NotBefore.Unix()},
+		EpochEnd:   &timestamppb.Timestamp{Seconds: lvl2Key.Epoch.NotAfter.Unix()},
+		Key:        lvl2Key.Key[:],
+	}, nil
 }
 
 func (s *DaemonServer) DRKeyHostAS(
@@ -361,7 +378,21 @@ func (s *DaemonServer) DRKeyHostAS(
 	req *pb_daemon.DRKeyHostASRequest,
 ) (*pb_daemon.DRKeyHostASResponse, error) {
 
-	panic("not implemented")
+	meta, err := requestToHostASMeta(req)
+	if err != nil {
+		return nil, serrors.WrapStr("parsing protobuf HostASReq", err)
+	}
+
+	lvl2Key, err := s.DRKeyClient.GetHostASKey(ctx, meta)
+	if err != nil {
+		return nil, serrors.WrapStr("getting Host-AS from client store", err)
+	}
+
+	return &sdpb.DRKeyHostASResponse{
+		EpochBegin: &timestamppb.Timestamp{Seconds: lvl2Key.Epoch.NotBefore.Unix()},
+		EpochEnd:   &timestamppb.Timestamp{Seconds: lvl2Key.Epoch.NotAfter.Unix()},
+		Key:        lvl2Key.Key[:],
+	}, nil
 }
 
 func (s *DaemonServer) DRKeyHostHost(
@@ -369,5 +400,62 @@ func (s *DaemonServer) DRKeyHostHost(
 	req *pb_daemon.DRKeyHostHostRequest,
 ) (*pb_daemon.DRKeyHostHostResponse, error) {
 
-	panic("not implemented")
+	meta, err := requestToHostHostMeta(req)
+	if err != nil {
+		return nil, serrors.WrapStr("parsing protobuf HostHostReq", err)
+	}
+
+	lvl2Key, err := s.DRKeyClient.GetHostHostKey(ctx, meta)
+	if err != nil {
+		return nil, serrors.WrapStr("getting Host-Host from client store", err)
+	}
+
+	return &sdpb.DRKeyHostHostResponse{
+		EpochBegin: &timestamppb.Timestamp{Seconds: lvl2Key.Epoch.NotBefore.Unix()},
+		EpochEnd:   &timestamppb.Timestamp{Seconds: lvl2Key.Epoch.NotAfter.Unix()},
+		Key:        lvl2Key.Key[:],
+	}, nil
+}
+
+func requestToASHostMeta(req *sdpb.DRKeyASHostRequest) (drkey.ASHostMeta, error) {
+	err := req.ValTime.CheckValid()
+	if err != nil {
+		return drkey.ASHostMeta{}, serrors.WrapStr("invalid valTime from pb request", err)
+	}
+	return drkey.ASHostMeta{
+		ProtoId:  drkey.Protocol(req.ProtocolId),
+		Validity: req.ValTime.AsTime(),
+		SrcIA:    addr.IA(req.SrcIa),
+		DstIA:    addr.IA(req.DstIa),
+		DstHost:  req.DstHost,
+	}, nil
+}
+
+func requestToHostASMeta(req *sdpb.DRKeyHostASRequest) (drkey.HostASMeta, error) {
+	err := req.ValTime.CheckValid()
+	if err != nil {
+		return drkey.HostASMeta{}, serrors.WrapStr("invalid valTime from pb request", err)
+	}
+	return drkey.HostASMeta{
+		ProtoId:  drkey.Protocol(req.ProtocolId),
+		Validity: req.ValTime.AsTime(),
+		SrcIA:    addr.IA(req.SrcIa),
+		DstIA:    addr.IA(req.DstIa),
+		SrcHost:  req.SrcHost,
+	}, nil
+}
+
+func requestToHostHostMeta(req *sdpb.DRKeyHostHostRequest) (drkey.HostHostMeta, error) {
+	err := req.ValTime.CheckValid()
+	if err != nil {
+		return drkey.HostHostMeta{}, serrors.WrapStr("invalid valTime from pb request", err)
+	}
+	return drkey.HostHostMeta{
+		ProtoId:  drkey.Protocol(req.ProtocolId),
+		Validity: req.ValTime.AsTime(),
+		SrcIA:    addr.IA(req.SrcIa),
+		DstIA:    addr.IA(req.DstIa),
+		SrcHost:  req.SrcHost,
+		DstHost:  req.DstHost,
+	}, nil
 }


### PR DESCRIPTION
This PR is the 12th in a series of PRs that add support for DRKey started with https://github.com/scionproto/scion/pull/4217.

This PR contains:

- implementation for DRKey gRPC methods in the daemon service

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4234)
<!-- Reviewable:end -->
