### PR TITLE
grpc: remove roundrobin dependency from dialer.go

### DIFF
--- a/pkg/grpc/BUILD.bazel
+++ b/pkg/grpc/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "@com_github_opentracing_opentracing_go//:go_default_library",
         "@com_github_uber_jaeger_client_go//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//balancer/roundrobin:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
         "@org_golang_google_grpc//resolver:go_default_library",
         "@org_golang_google_grpc//resolver/manual:go_default_library",

--- a/pkg/grpc/dialer.go
+++ b/pkg/grpc/dialer.go
@@ -21,7 +21,6 @@ import (
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
@@ -106,7 +105,7 @@ func (t *TCPDialer) Dial(ctx context.Context, dst net.Addr) (*grpc.ClientConn, e
 		r := manual.NewBuilderWithScheme("svc")
 		r.InitialState(resolver.State{Addresses: targets})
 		return grpc.DialContext(ctx, r.Scheme()+":///"+v.BaseString(),
-			grpc.WithBalancerName(roundrobin.Name),
+			grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
 			grpc.WithInsecure(),
 			grpc.WithResolvers(r),
 			UnaryClientInterceptor(),


### PR DESCRIPTION
This PR removes the dependency to the `grpc/balancer/roundrobin` package.

The use of the `roundrobin` package is deprecated and is removed in a future version of the `grpc` package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4237)
<!-- Reviewable:end -->
