### PR TITLE
drkey: add daemon api + daemon config

### DIFF
--- a/daemon/BUILD.bazel
+++ b/daemon/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/scionproto/scion/daemon",
     visibility = ["//visibility:public"],
     deps = [
+        "//daemon/drkey:go_default_library",
         "//daemon/fetcher:go_default_library",
         "//daemon/internal/servers:go_default_library",
         "//pkg/addr:go_default_library",

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -38,16 +38,17 @@ var (
 var _ config.Config = (*Config)(nil)
 
 type Config struct {
-	General     env.General        `toml:"general,omitempty"`
-	Features    env.Features       `toml:"features,omitempty"`
-	Logging     log.Config         `toml:"log,omitempty"`
-	Metrics     env.Metrics        `toml:"metrics,omitempty"`
-	API         api.Config         `toml:"api,omitempty"`
-	Tracing     env.Tracing        `toml:"tracing,omitempty"`
-	TrustDB     storage.DBConfig   `toml:"trust_db,omitempty"`
-	PathDB      storage.DBConfig   `toml:"path_db,omitempty"`
-	SD          SDConfig           `toml:"sd,omitempty"`
-	TrustEngine trustengine.Config `toml:"trustengine,omitempty"`
+	General       env.General        `toml:"general,omitempty"`
+	Features      env.Features       `toml:"features,omitempty"`
+	Logging       log.Config         `toml:"log,omitempty"`
+	Metrics       env.Metrics        `toml:"metrics,omitempty"`
+	API           api.Config         `toml:"api,omitempty"`
+	Tracing       env.Tracing        `toml:"tracing,omitempty"`
+	TrustDB       storage.DBConfig   `toml:"trust_db,omitempty"`
+	PathDB        storage.DBConfig   `toml:"path_db,omitempty"`
+	SD            SDConfig           `toml:"sd,omitempty"`
+	TrustEngine   trustengine.Config `toml:"trustengine,omitempty"`
+	DRKeyLevel2DB storage.DBConfig   `toml:"drkey_level2_db,omitempty"`
 }
 
 func (cfg *Config) InitDefaults() {
@@ -62,6 +63,7 @@ func (cfg *Config) InitDefaults() {
 		cfg.PathDB.WithDefault(fmt.Sprintf(storage.DefaultPathDBPath, "sd")),
 		&cfg.SD,
 		&cfg.TrustEngine,
+		&cfg.DRKeyLevel2DB,
 	)
 }
 
@@ -76,6 +78,7 @@ func (cfg *Config) Validate() error {
 		&cfg.PathDB,
 		&cfg.SD,
 		&cfg.TrustEngine,
+		&cfg.DRKeyLevel2DB,
 	)
 }
 
@@ -103,6 +106,13 @@ func (cfg *Config) Sample(dst io.Writer, path config.Path, _ config.CtxMap) {
 		),
 		&cfg.SD,
 		&cfg.TrustEngine,
+		config.OverrideName(
+			config.FormatData(
+				&cfg.DRKeyLevel2DB,
+				fmt.Sprintf(storage.DefaultDRKeyLevel2DBPath, "sd"),
+			),
+			"drkey_level2_db",
+		),
 	)
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/scionproto/scion/daemon/drkey"
 	"github.com/scionproto/scion/daemon/fetcher"
 	"github.com/scionproto/scion/daemon/internal/servers"
 	"github.com/scionproto/scion/pkg/addr"
@@ -106,12 +107,13 @@ func TrustEngine(
 
 // ServerConfig is the configuration for the daemon API server.
 type ServerConfig struct {
-	IA       addr.IA
-	MTU      uint16
-	Fetcher  fetcher.Fetcher
-	RevCache revcache.RevCache
-	Engine   trust.Engine
-	Topology servers.Topology
+	IA          addr.IA
+	MTU         uint16
+	Fetcher     fetcher.Fetcher
+	RevCache    revcache.RevCache
+	Engine      trust.Engine
+	Topology    servers.Topology
+	DRKeyClient drkey.ClientEngine
 }
 
 // NewServer constructs a daemon API server.
@@ -123,6 +125,7 @@ func NewServer(cfg ServerConfig) *servers.DaemonServer {
 		Fetcher:     cfg.Fetcher,
 		ASInspector: cfg.Engine.Inspector,
 		RevCache:    cfg.RevCache,
+		DRKeyClient: cfg.DRKeyClient,
 		Metrics: servers.Metrics{
 			PathsRequests: servers.RequestMetrics{
 				Requests: metrics.NewPromCounterFrom(prometheus.CounterOpts{

--- a/pkg/daemon/BUILD.bazel
+++ b/pkg/daemon/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/addr:go_default_library",
         "//pkg/daemon/internal/metrics:go_default_library",
+        "//pkg/drkey:go_default_library",
         "//pkg/grpc:go_default_library",
         "//pkg/metrics:go_default_library",
         "//pkg/private/common:go_default_library",
@@ -20,9 +21,12 @@ go_library(
         "//pkg/private/prom:go_default_library",
         "//pkg/private/serrors:go_default_library",
         "//pkg/proto/daemon:go_default_library",
+        "//pkg/proto/drkey:go_default_library",
+        "//pkg/scrypto/cppki:go_default_library",
         "//pkg/snet:go_default_library",
         "//pkg/snet/path:go_default_library",
         "//private/topology:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
 )

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/daemon/internal/metrics"
+	"github.com/scionproto/scion/pkg/drkey"
 	libmetrics "github.com/scionproto/scion/pkg/metrics"
 	"github.com/scionproto/scion/pkg/private/common"
 	"github.com/scionproto/scion/pkg/private/ctrl/path_mgmt"
@@ -80,6 +81,12 @@ type Connector interface {
 	SVCInfo(ctx context.Context, svcTypes []addr.HostSVC) (map[addr.HostSVC][]string, error)
 	// RevNotification sends a RevocationInfo message to the daemon.
 	RevNotification(ctx context.Context, revInfo *path_mgmt.RevInfo) error
+	// DRKeyGetASHostKey requests a AS-Host Key from the daemon.
+	DRKeyGetASHostKey(ctx context.Context, meta drkey.ASHostMeta) (drkey.ASHostKey, error)
+	// DRKeyGetHostASKey requests a Host-AS Key from the daemon.
+	DRKeyGetHostASKey(ctx context.Context, meta drkey.HostASMeta) (drkey.HostASKey, error)
+	// DRKeyGetHostHostKey requests a Host-Host Key from the daemon.
+	DRKeyGetHostHostKey(ctx context.Context, meta drkey.HostHostMeta) (drkey.HostHostKey, error)
 	// Close shuts down the connection to the daemon.
 	Close() error
 }

--- a/pkg/daemon/mock_daemon/BUILD.bazel
+++ b/pkg/daemon/mock_daemon/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     deps = [
         "//pkg/addr:go_default_library",
         "//pkg/daemon:go_default_library",
+        "//pkg/drkey:go_default_library",
         "//pkg/private/common:go_default_library",
         "//pkg/private/ctrl/path_mgmt:go_default_library",
         "//pkg/snet:go_default_library",

--- a/pkg/daemon/mock_daemon/mock.go
+++ b/pkg/daemon/mock_daemon/mock.go
@@ -12,6 +12,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	addr "github.com/scionproto/scion/pkg/addr"
 	daemon "github.com/scionproto/scion/pkg/daemon"
+	drkey "github.com/scionproto/scion/pkg/drkey"
 	common "github.com/scionproto/scion/pkg/private/common"
 	path_mgmt "github.com/scionproto/scion/pkg/private/ctrl/path_mgmt"
 	snet "github.com/scionproto/scion/pkg/snet"
@@ -67,6 +68,51 @@ func (m *MockConnector) Close() error {
 func (mr *MockConnectorMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockConnector)(nil).Close))
+}
+
+// DRKeyGetASHostKey mocks base method.
+func (m *MockConnector) DRKeyGetASHostKey(arg0 context.Context, arg1 drkey.ASHostMeta) (drkey.ASHostKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DRKeyGetASHostKey", arg0, arg1)
+	ret0, _ := ret[0].(drkey.ASHostKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DRKeyGetASHostKey indicates an expected call of DRKeyGetASHostKey.
+func (mr *MockConnectorMockRecorder) DRKeyGetASHostKey(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DRKeyGetASHostKey", reflect.TypeOf((*MockConnector)(nil).DRKeyGetASHostKey), arg0, arg1)
+}
+
+// DRKeyGetHostASKey mocks base method.
+func (m *MockConnector) DRKeyGetHostASKey(arg0 context.Context, arg1 drkey.HostASMeta) (drkey.HostASKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DRKeyGetHostASKey", arg0, arg1)
+	ret0, _ := ret[0].(drkey.HostASKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DRKeyGetHostASKey indicates an expected call of DRKeyGetHostASKey.
+func (mr *MockConnectorMockRecorder) DRKeyGetHostASKey(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DRKeyGetHostASKey", reflect.TypeOf((*MockConnector)(nil).DRKeyGetHostASKey), arg0, arg1)
+}
+
+// DRKeyGetHostHostKey mocks base method.
+func (m *MockConnector) DRKeyGetHostHostKey(arg0 context.Context, arg1 drkey.HostHostMeta) (drkey.HostHostKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DRKeyGetHostHostKey", arg0, arg1)
+	ret0, _ := ret[0].(drkey.HostHostKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DRKeyGetHostHostKey indicates an expected call of DRKeyGetHostHostKey.
+func (mr *MockConnectorMockRecorder) DRKeyGetHostHostKey(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DRKeyGetHostHostKey", reflect.TypeOf((*MockConnector)(nil).DRKeyGetHostHostKey), arg0, arg1)
 }
 
 // IFInfo mocks base method.


### PR DESCRIPTION
This PR is the 14th in a series of PRs that add support for DRKey started with https://github.com/scionproto/scion/pull/4217.

This PR contains:

- Daemon API calls
- Config for daemon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4238)
<!-- Reviewable:end -->
