### PR TITLE
cmd/scion: set payload size appropriately if --max-mtu is set

### DIFF
--- a/scion/cmd/scion/ping.go
+++ b/scion/cmd/scion/ping.go
@@ -206,7 +206,7 @@ On other errors, ping will exit with code 2.
 				Timeout:     flags.timeout,
 				Local:       local,
 				Remote:      remote,
-				PayloadSize: int(flags.size),
+				PayloadSize: pldSize,
 				ErrHandler: func(err error) {
 					fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 				},


### PR DESCRIPTION
Correct the behavior of the `--max-mtu` flag for `scion ping`.

Previously, there was a bug where the calculated payload size was ignored and the value from `--payload-size` was taken.
In most cases, this would be the default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4250)
<!-- Reviewable:end -->
