### PR TITLE
cmd/scion: additional scion ping flag for package size

### DIFF
--- a/scion/cmd/scion/ping.go
+++ b/scion/cmd/scion/ping.go
@@ -53,6 +53,7 @@ func newPing(pather CommandPather) *cobra.Command {
 		healthyOnly bool
 		sequence    string
 		size        uint
+		pktSize     uint
 		timeout     time.Duration
 		tracer      string
 		epic        bool
@@ -180,6 +181,20 @@ On other errors, ping will exit with code 2.
 				Host: &net.UDPAddr{IP: localIP},
 			}
 			pldSize := int(flags.size)
+
+			if cmd.Flags().Changed("packet-size") {
+				overhead, err := ping.Size(local, remote, 0)
+				if err != nil {
+					return err
+				}
+
+				if overhead > int(flags.pktSize) {
+					return serrors.New("desired packet size smaller than header overhead")
+				}
+
+				pldSize = int(flags.pktSize - uint(overhead))
+
+			}
 			if flags.maxMTU {
 				mtu := int(path.Metadata().MTU)
 				pldSize, err = calcMaxPldSize(local, remote, mtu)
@@ -250,10 +265,15 @@ On other errors, ping will exit with code 2.
 the total size of the packet is still variable size due to the variable size of
 the SCION path.`,
 	)
+	cmd.Flags().UintVar(&flags.pktSize, "packet-size", 0,
+		`number of bytes to be sent including the SCION Header and SCMP echo header,
+the desired size must provide enough space for the required headers. This flag 
+overrides the 'payload_size' flag.`,
+	)
 	cmd.Flags().BoolVar(&flags.maxMTU, "max-mtu", false,
 		`choose the payload size such that the sent SCION packet including the SCION Header,
 SCMP echo header and payload are equal to the MTU of the path. This flag overrides the
-'payload_size' flag.`)
+'payload_size' and 'packet_size' flag.`)
 	cmd.Flags().StringVar(&flags.logLevel, "log.level", "", app.LogLevelUsage)
 	cmd.Flags().StringVar(&flags.tracer, "tracing.agent", "", "Tracing agent address")
 	cmd.Flags().BoolVar(&flags.epic, "epic", false, "Enable EPIC for path probing.")


### PR DESCRIPTION
cmd/scion: add a scion ping flag that allows specifying the final pkg size (independent of headers)

The new flag 'packet-size' allows specifying the size of the package, which takes the variable header size into account. The new flag overwrites the 'payload-size' flag similar to how the 'maxMTU' flag handles it, while the 'maxMTU' flag now overrides the 'payload-size' and the 'packet-size' flag.

Changes:
- additional check if the 'packet-size' is set
- if the desired size is smaller than the required overhead for headers, return an error
- 'packet-size' overwrites 'payload-size'
- 'maxMTU' overwrites both