### PR TITLE
pkg/snet: add URI scion address encoding

### DIFF
--- a/pkg/snet/udpaddr.go
+++ b/pkg/snet/udpaddr.go
@@ -26,8 +26,8 @@ import (
 	"github.com/scionproto/scion/pkg/private/serrors"
 )
 
-var addrRegexp = regexp.MustCompile(`^(?P<ia>\d+-[\d:A-Fa-f]+),(?P<host>.+)$`)
-var rfcAddrRegexp = regexp.MustCompile(`^[\[](?P<ia>\d+-[\d:A-Fa-f]+),(?P<host>.+)[\]]:(?P<port>.+)$`)
+var addrRegexpLegacy = regexp.MustCompile(`^(?P<ia>\d+-[\d:A-Fa-f]+),(?P<host>.+)$`)
+var addrRegexp = regexp.MustCompile(`^[\[](?P<ia>\d+-[\d:A-Fa-f]+),(?P<host>.+)[\]]:(?P<port>.+)$`)
 
 // UDPAddr to be used when UDP host.
 type UDPAddr struct {
@@ -165,7 +165,7 @@ func CopyUDPAddr(a *net.UDPAddr) *net.UDPAddr {
 }
 
 func parseAddr(s string) (string, string, error) {
-	match := addrRegexp.FindStringSubmatch(s)
+	match := addrRegexpLegacy.FindStringSubmatch(s)
 	if len(match) != 3 {
 		return "", "", serrors.New("invalid address: regex match failed", "addr", s)
 	}
@@ -180,7 +180,7 @@ func parseAddr(s string) (string, string, error) {
 }
 
 func parseScionAddr(s string) (string, string, error) {
-	match := rfcAddrRegexp.FindStringSubmatch(s)
+	match := addrRegexp.FindStringSubmatch(s)
 	if len(match) != 4 {
 		return "", "", serrors.New("invalid address: regex match failed", "addr", s)
 	}

--- a/pkg/snet/udpaddr_test.go
+++ b/pkg/snet/udpaddr_test.go
@@ -157,6 +157,9 @@ func TestParseUDPAddr(t *testing.T) {
 		{address: "1-ff00:0:300,[1.2.3.4]:70000", isError: true},
 		{address: "1-ff00:0:300,[1.2.3.4]]", isError: true},
 		{address: "1-ff00:0:300,::1:60000", isError: true},
+		{address: "[1-ff00:0:110,192.0.2.1]:70000", isError: true},
+		{address: "[1-ff00:0:110,192.0.2.290]:80", isError: true},
+		{address: "[1-,127.0.0.1]:80", isError: true},
 		{address: "", isError: true},
 		{address: "1-ff00:0:300,[1.2.3.4]:80",
 			ia:   "1-ff00:0:300",
@@ -235,6 +238,11 @@ func TestParseUDPAddr(t *testing.T) {
 			ia:   "1-64496",
 			host: "2001:DB8::1",
 			port: 80,
+		},
+		{address: "[1-64496,2001:DB8::1]:60000",
+			ia:   "1-64496",
+			host: "2001:DB8::1",
+			port: 60000,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/snet/udpaddr_test.go
+++ b/pkg/snet/udpaddr_test.go
@@ -221,6 +221,21 @@ func TestParseUDPAddr(t *testing.T) {
 			port: 0,
 			zone: "some-zone",
 		},
+		{address: "[1-ff00:0:110,192.0.2.1]:80",
+			ia:   "1-ff00:0:110",
+			host: "192.0.2.1",
+			port: 80,
+		},
+		{address: "[1-ff00:0:110,2001:DB8::1]:80",
+			ia:   "1-ff00:0:110",
+			host: "2001:DB8::1",
+			port: 80,
+		},
+		{address: "[1-64496,2001:DB8::1]:80",
+			ia:   "1-64496",
+			host: "2001:DB8::1",
+			port: 80,
+		},
 	}
 	for _, test := range tests {
 		t.Log(fmt.Sprintf("given address %q", test.address))


### PR DESCRIPTION
pkg/snet: add URI scion address encoding

When converting an address string to a SCION address, the URI scion address encoding is now tried first, while the old parser is still supported for backward compatibility.