### PR TITLE
pkg/addr: duplicate ISD-AS matcher

### DIFF
--- a/pkg/addr/BUILD.bazel
+++ b/pkg/addr/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "doc.go",
         "fmt.go",
         "host.go",
+        "ia.go",
         "isdas.go",
     ],
     importpath = "github.com/scionproto/scion/pkg/addr",
@@ -17,8 +18,12 @@ go_test(
     name = "go_default_test",
     srcs = [
         "host_test.go",
+        "ia_test.go",
         "isdas_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
+    deps = [
+        "//pkg/private/xtest:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
 )

--- a/pkg/addr/ia.go
+++ b/pkg/addr/ia.go
@@ -1,0 +1,31 @@
+// Copyright 2022 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addr
+
+// Match matches the input ISD-AS if both the ISD and the AS number are the same
+// as the one of the matcher. Zero values of ISD and AS in the matchers ISD-AS
+// are treated as wildcards and match everything.
+func (m IA) IAMatcher(ia IA) bool {
+	switch {
+	case m.IsZero():
+		return true
+	case m.ISD() == 0:
+		return m.AS() == ia.AS()
+	case m.AS() == 0:
+		return m.ISD() == ia.ISD()
+	default:
+		return m.Equal(ia)
+	}
+}

--- a/pkg/addr/ia_test.go
+++ b/pkg/addr/ia_test.go
@@ -1,0 +1,64 @@
+// Copyright 2020 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package addr_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/scionproto/scion/pkg/addr"
+	"github.com/scionproto/scion/pkg/private/xtest"
+)
+
+func TestIAMatcher(t *testing.T) {
+	testCases := map[string]struct {
+		IA         addr.IA
+		Matches    []string
+		NotMatches []string
+	}{
+		"match": {
+			IA:         xtest.MustParseIA("1-ff00:0:110"),
+			Matches:    []string{"1-ff00:0:110"},
+			NotMatches: []string{"1-ff00:0:111", "2-ff00:0:110"},
+		},
+		"match wildcard": {
+			IA:      xtest.MustParseIA("0-0"),
+			Matches: []string{"1-ff00:0:110"},
+		},
+		"match wildcard ISD": {
+			IA:         xtest.MustParseIA("0-ff00:0:110"),
+			Matches:    []string{"1-ff00:0:110", "2-ff00:0:110"},
+			NotMatches: []string{"1-ff00:0:111"},
+		},
+		"match wildcard AS": {
+			IA:         xtest.MustParseIA("1-0"),
+			Matches:    []string{"1-ff00:0:110", "1-ff00:0:110"},
+			NotMatches: []string{"2-ff00:0:110"},
+		},
+	}
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			for _, matches := range tc.Matches {
+				assert.True(t, tc.IA.IAMatcher(xtest.MustParseIA(matches)), matches)
+			}
+			for _, notMatches := range tc.NotMatches {
+				assert.False(t, tc.IA.IAMatcher(xtest.MustParseIA(notMatches)), notMatches)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Duplicate the ISD-AS matcher located in the gateway routing package to the `/scion/pkg/addr` package.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4256)
<!-- Reviewable:end -->
