### PR TITLE
segfetcher: log fetch error

### DIFF
--- a/private/segment/segfetcher/pather.go
+++ b/private/segment/segfetcher/pather.go
@@ -81,7 +81,7 @@ func (p *Pather) GetPaths(ctx context.Context, dst addr.IA,
 	segs, fetchErr := p.Fetcher.Fetch(ctx, reqs, refresh)
 	// Even if fetching failed, attempt to create paths.
 	if fetchErr != nil {
-		logger.Debug("Fetching failed, attempting to build paths anyway", "err", err)
+		logger.Debug("Fetching failed, attempting to build paths anyway", "err", fetchErr)
 	}
 	paths := p.buildAllPaths(src, dst, segs)
 	paths = p.filterRevoked(ctx, paths)


### PR DESCRIPTION
Include the error when debug logging that path segment fetching failed. Used to always log a nil error (wrong error variable).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4258)
<!-- Reviewable:end -->
