### PR TITLE
doc, slayers: correct maximum for HdrLen

### DIFF
--- a/doc/protocols/scion-header.rst
+++ b/doc/protocols/scion-header.rst
@@ -51,7 +51,7 @@ HdrLen
     common header, the address header, and the path header). All SCION header
     fields are aligned to a multiple of 4 bytes. The SCION header length is
     computed as ``HdrLen * 4 bytes``. The 8 bits of the ``HdrLen`` field limit
-    the SCION header to a maximum of 1024 bytes.
+    the SCION header to a maximum of ``255 * 4 == 1020`` bytes.
 PayloadLen
     Length of the payload in bytes. The payload includes extension headers and
     the L4 payload. This field is 16 bits long, supporting a maximum payload


### PR DESCRIPTION
The maximum for the representable value for HdrLen was incorrectly documented as 1024 bytes, but it is 255*4 == 1020 bytes.

Add sanity checks for the header length (which in essence are checks for the path length) when serializing the SCION header, to avoid silently creating malformed packets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4259)
<!-- Reviewable:end -->
