### PR TITLE
slayers: check CurrINF/HF in decoding SCION path

### DIFF
--- a/pkg/slayers/path/scion/base.go
+++ b/pkg/slayers/path/scion/base.go
@@ -66,6 +66,13 @@ func (s *Base) DecodeFromBytes(data []byte) error {
 		}
 		s.NumHops += int(s.PathMeta.SegLen[i])
 	}
+	if int(s.PathMeta.CurrINF) >= s.NumINF {
+		return serrors.New("CurrINF out of range", "value", s.PathMeta.CurrINF, "numInfo", s.NumINF)
+	}
+	if int(s.PathMeta.CurrHF) >= s.NumHops {
+		return serrors.New("CurrHF out of range", "value", s.PathMeta.CurrHF, "numHops", s.NumHops)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Check that the CurrINF and CurrHF fields are in the ranges defined by the number and lengths of segments.

Fixes #4133

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4270)
<!-- Reviewable:end -->
