### PR TITLE
tools: fix wireshark dissector SPAO MAC offset

### DIFF
--- a/tools/wireshark/scion.lua
+++ b/tools/wireshark/scion.lua
@@ -727,7 +727,7 @@ function scion_packet_authenticator_option_dissect(buffer, pktinfo, tree)
             return -1
         end
         authenticator_tree:add(scion_packet_authenticator_option_authenticator, buffer(12,20)):append_text(" (SHA1)")
-        authenticator_tree:add(scion_packet_authenticator_option_authenticator, buffer(31,16)):append_text(" (AES-CBC MAC)")
+        authenticator_tree:add(scion_packet_authenticator_option_authenticator, buffer(32,16)):append_text(" (AES-CBC MAC)")
     else
         authenticator_tree:add(scion_packet_authenticator_option_authenticator, buffer(12,authenticator_length))
     end


### PR DESCRIPTION
The MAC for the SHA1-AES-CBC algorithm starts at an offset of 32 bytes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4289)
<!-- Reviewable:end -->
