### PR TITLE
router: add checks for intra-segment forwarding

### DIFF
--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -778,8 +778,12 @@ type macBuffers struct {
 	epicInput  []byte
 }
 
-func (p *scionPacketProcessor) packSCMP(scmpH *slayers.SCMP, scmpP gopacket.SerializableLayer,
-	cause error) (processResult, error) {
+func (p *scionPacketProcessor) packSCMP(
+	typ slayers.SCMPType,
+	code slayers.SCMPCode,
+	scmpP gopacket.SerializableLayer,
+	cause error,
+) (processResult, error) {
 
 	// check invoking packet was an SCMP error:
 	if p.lastLayer.NextLayerType() == slayers.LayerTypeSCMP {
@@ -793,11 +797,7 @@ func (p *scionPacketProcessor) packSCMP(scmpH *slayers.SCMP, scmpP gopacket.Seri
 		}
 	}
 
-	rawSCMP, err := p.prepareSCMP(
-		scmpH,
-		scmpP,
-		cause,
-	)
+	rawSCMP, err := p.prepareSCMP(typ, code, scmpP, cause)
 	return processResult{OutPkt: rawSCMP}, err
 }
 
@@ -824,9 +824,8 @@ func (p *scionPacketProcessor) validateHopExpiry() (processResult, error) {
 		return processResult{}, nil
 	}
 	return p.packSCMP(
-		&slayers.SCMP{TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem,
-			slayers.SCMPCodePathExpired),
-		},
+		slayers.SCMPTypeParameterProblem,
+		slayers.SCMPCodePathExpired,
 		&slayers.SCMPParameterProblem{Pointer: p.currentHopPointer()},
 		serrors.New("expired hop", "cons_dir", p.infoField.ConsDir, "if_id", p.ingressID,
 			"curr_inf", p.path.PathMeta.CurrINF, "curr_hf", p.path.PathMeta.CurrHF),
@@ -842,9 +841,8 @@ func (p *scionPacketProcessor) validateIngressID() (processResult, error) {
 	}
 	if p.ingressID != 0 && p.ingressID != pktIngressID {
 		return p.packSCMP(
-			&slayers.SCMP{
-				TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem, errCode),
-			},
+			slayers.SCMPTypeParameterProblem,
+			errCode,
 			&slayers.SCMPParameterProblem{Pointer: p.currentHopPointer()},
 			serrors.New("ingress interface invalid",
 				"pkt_ingress", pktIngressID, "router_ingress", p.ingressID),
@@ -882,10 +880,8 @@ func (p *scionPacketProcessor) validateSrcDstIA() (processResult, error) {
 // invalidSrcIA is a helper to return an SCMP error for an invalid SrcIA.
 func (p *scionPacketProcessor) invalidSrcIA() (processResult, error) {
 	return p.packSCMP(
-		&slayers.SCMP{
-			TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem,
-				slayers.SCMPCodeInvalidSourceAddress),
-		},
+		slayers.SCMPTypeParameterProblem,
+		slayers.SCMPCodeInvalidSourceAddress,
 		&slayers.SCMPParameterProblem{Pointer: uint16(slayers.CmnHdrLen + addr.IABytes)},
 		invalidSrcIA,
 	)
@@ -894,10 +890,8 @@ func (p *scionPacketProcessor) invalidSrcIA() (processResult, error) {
 // invalidDstIA is a helper to return an SCMP error for an invalid DstIA.
 func (p *scionPacketProcessor) invalidDstIA() (processResult, error) {
 	return p.packSCMP(
-		&slayers.SCMP{
-			TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem,
-				slayers.SCMPCodeInvalidDestinationAddress),
-		},
+		slayers.SCMPTypeParameterProblem,
+		slayers.SCMPCodeInvalidDestinationAddress,
 		&slayers.SCMPParameterProblem{Pointer: uint16(slayers.CmnHdrLen)},
 		invalidDstIA,
 	)
@@ -932,20 +926,37 @@ func (p *scionPacketProcessor) validateEgressID() (processResult, error) {
 			errCode = slayers.SCMPCodeUnknownHopFieldIngress
 		}
 		return p.packSCMP(
-			&slayers.SCMP{
-				TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem, errCode),
-			},
+			slayers.SCMPTypeParameterProblem,
+			errCode,
 			&slayers.SCMPParameterProblem{Pointer: p.currentHopPointer()},
 			cannotRoute,
 		)
 	}
 
+	ingress, egress := p.d.linkTypes[p.ingressID], p.d.linkTypes[pktEgressID]
 	if !p.segmentChange {
-		return processResult{}, nil
+		// Check that the interface pair is valid within a single segment.
+		// No check required if the packet is received from an internal interface.
+		switch {
+		case p.ingressID == 0:
+			return processResult{}, nil
+		case ingress == topology.Core && egress == topology.Core:
+			return processResult{}, nil
+		case ingress == topology.Child && egress == topology.Parent:
+			return processResult{}, nil
+		case ingress == topology.Parent && egress == topology.Child:
+			return processResult{}, nil
+		default: // malicious
+			return p.packSCMP(
+				slayers.SCMPTypeParameterProblem,
+				slayers.SCMPCodeInvalidPath, // XXX(matzf) new code InvalidHop?
+				&slayers.SCMPParameterProblem{Pointer: p.currentHopPointer()},
+				serrors.WithCtx(cannotRoute, "ingress_id", p.ingressID, "ingress_type", ingress,
+					"egress_id", pktEgressID, "egress_type", egress))
+		}
 	}
 	// Check that the interface pair is valid on a segment switch.
 	// Having a segment change received from the internal interface is never valid.
-	ingress, egress := p.d.linkTypes[p.ingressID], p.d.linkTypes[pktEgressID]
 	switch {
 	case ingress == topology.Core && egress == topology.Child:
 		return processResult{}, nil
@@ -955,12 +966,8 @@ func (p *scionPacketProcessor) validateEgressID() (processResult, error) {
 		return processResult{}, nil
 	default:
 		return p.packSCMP(
-			&slayers.SCMP{
-				TypeCode: slayers.CreateSCMPTypeCode(
-					slayers.SCMPTypeParameterProblem,
-					slayers.SCMPCodeInvalidSegmentChange,
-				),
-			},
+			slayers.SCMPTypeParameterProblem,
+			slayers.SCMPCodeInvalidSegmentChange,
 			&slayers.SCMPParameterProblem{Pointer: p.currentInfoPointer()},
 			serrors.WithCtx(cannotRoute, "ingress_id", p.ingressID, "ingress_type", ingress,
 				"egress_id", pktEgressID, "egress_type", egress))
@@ -995,9 +1002,8 @@ func (p *scionPacketProcessor) verifyCurrentMAC() (processResult, error) {
 	fullMac := path.FullMAC(p.mac, p.infoField, p.hopField, p.macBuffers.scionInput)
 	if subtle.ConstantTimeCompare(p.hopField.Mac[:path.MacLen], fullMac[:path.MacLen]) == 0 {
 		return p.packSCMP(
-			&slayers.SCMP{TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem,
-				slayers.SCMPCodeInvalidHopFieldMAC),
-			},
+			slayers.SCMPTypeParameterProblem,
+			slayers.SCMPCodeInvalidHopFieldMAC,
 			&slayers.SCMPParameterProblem{Pointer: p.currentHopPointer()},
 			serrors.New("MAC verification failed", "expected", fmt.Sprintf(
 				"%x", fullMac[:path.MacLen]),
@@ -1019,10 +1025,8 @@ func (p *scionPacketProcessor) resolveInbound() (*net.UDPAddr, processResult, er
 	switch {
 	case errors.Is(err, noSVCBackend):
 		r, err := p.packSCMP(
-			&slayers.SCMP{
-				TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeDestinationUnreachable,
-					slayers.SCMPCodeNoRoute),
-			},
+			slayers.SCMPTypeDestinationUnreachable,
+			slayers.SCMPCodeNoRoute,
 			&slayers.SCMPDestinationUnreachable{}, err)
 		return nil, r, err
 	default:
@@ -1096,23 +1100,20 @@ func (p *scionPacketProcessor) validateEgressUp() (processResult, error) {
 	egressID := p.egressInterface()
 	if v, ok := p.d.bfdSessions[egressID]; ok {
 		if !v.IsUp() {
-			scmpH := &slayers.SCMP{
-				TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeExternalInterfaceDown, 0),
-			}
+			typ := slayers.SCMPTypeExternalInterfaceDown
 			var scmpP gopacket.SerializableLayer = &slayers.SCMPExternalInterfaceDown{
 				IA:   p.d.localIA,
 				IfID: uint64(egressID),
 			}
 			if _, external := p.d.external[egressID]; !external {
-				scmpH.TypeCode =
-					slayers.CreateSCMPTypeCode(slayers.SCMPTypeInternalConnectivityDown, 0)
+				typ = slayers.SCMPTypeInternalConnectivityDown
 				scmpP = &slayers.SCMPInternalConnectivityDown{
 					IA:      p.d.localIA,
 					Ingress: uint64(p.ingressID),
 					Egress:  uint64(egressID),
 				}
 			}
-			return p.packSCMP(scmpH, scmpP, serrors.New("bfd session down"))
+			return p.packSCMP(typ, 0, scmpP, serrors.New("bfd session down"))
 		}
 	}
 	return processResult{}, nil
@@ -1186,16 +1187,13 @@ func (p *scionPacketProcessor) handleSCMPTraceRouteRequest(
 		log.Debug("Parsing SCMPTraceroute", "err", err)
 		return processResult{}, nil
 	}
-	scmpH = slayers.SCMP{
-		TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeTracerouteReply, 0),
-	}
 	scmpP = slayers.SCMPTraceroute{
 		Identifier: scmpP.Identifier,
 		Sequence:   scmpP.Sequence,
 		IA:         p.d.localIA,
 		Interface:  uint64(interfaceID),
 	}
-	return p.packSCMP(&scmpH, &scmpP, nil)
+	return p.packSCMP(slayers.SCMPTypeTracerouteReply, 0, &scmpP, nil)
 }
 
 func (p *scionPacketProcessor) validatePktLen() (processResult, error) {
@@ -1203,10 +1201,8 @@ func (p *scionPacketProcessor) validatePktLen() (processResult, error) {
 		return processResult{}, nil
 	}
 	return p.packSCMP(
-		&slayers.SCMP{
-			TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem,
-				slayers.SCMPCodeInvalidPacketSize),
-		},
+		slayers.SCMPTypeParameterProblem,
+		slayers.SCMPCodeInvalidPacketSize,
 		&slayers.SCMPParameterProblem{Pointer: 0},
 		serrors.New("bad packet size",
 			"header", p.scionLayer.PayloadLen, "actual", len(p.scionLayer.Payload)),
@@ -1297,9 +1293,8 @@ func (p *scionPacketProcessor) process() (processResult, error) {
 		errCode = slayers.SCMPCodeUnknownHopFieldIngress
 	}
 	return p.packSCMP(
-		&slayers.SCMP{
-			TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem, errCode),
-		},
+		slayers.SCMPTypeParameterProblem,
+		errCode,
 		&slayers.SCMPParameterProblem{Pointer: p.currentHopPointer()},
 		cannotRoute,
 	)
@@ -1521,8 +1516,12 @@ func (b *bfdSend) Send(bfd *layers.BFD) error {
 	return err
 }
 
-func (p *scionPacketProcessor) prepareSCMP(scmpH *slayers.SCMP, scmpP gopacket.SerializableLayer,
-	cause error) ([]byte, error) {
+func (p *scionPacketProcessor) prepareSCMP(
+	typ slayers.SCMPType,
+	code slayers.SCMPCode,
+	scmpP gopacket.SerializableLayer,
+	cause error,
+) ([]byte, error) {
 
 	// *copy* and reverse path -- the original path should not be modified as this writes directly
 	// back to rawPkt (quote).
@@ -1597,6 +1596,8 @@ func (p *scionPacketProcessor) prepareSCMP(scmpH *slayers.SCMP, scmpP gopacket.S
 	}
 	scionL.NextHdr = slayers.L4SCMP
 
+	typeCode := slayers.CreateSCMPTypeCode(typ, code)
+	scmpH := slayers.SCMP{TypeCode: typeCode}
 	scmpH.SetNetworkLayerForChecksum(&scionL)
 
 	if err := p.buffer.Clear(); err != nil {
@@ -1607,7 +1608,7 @@ func (p *scionPacketProcessor) prepareSCMP(scmpH *slayers.SCMP, scmpP gopacket.S
 		ComputeChecksums: true,
 		FixLengths:       true,
 	}
-	scmpLayers := []gopacket.SerializableLayer{&scionL, scmpH, scmpP}
+	scmpLayers := []gopacket.SerializableLayer{&scionL, &scmpH, scmpP}
 	if cause != nil {
 		// add quote for errors.
 		hdrLen := slayers.CmnHdrLen + scionL.AddrHdrLen() + scionL.Path.Len()
@@ -1631,7 +1632,7 @@ func (p *scionPacketProcessor) prepareSCMP(scmpH *slayers.SCMP, scmpP gopacket.S
 	if err != nil {
 		return nil, serrors.Wrap(cannotRoute, err, "details", "serializing SCMP message")
 	}
-	return p.buffer.Bytes(), scmpError{TypeCode: scmpH.TypeCode, Cause: cause}
+	return p.buffer.Bytes(), scmpError{TypeCode: typeCode, Cause: cause}
 }
 
 // decodeLayers implements roughly the functionality of

--- a/tools/braccept/cases/BUILD.bazel
+++ b/tools/braccept/cases/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "parent_to_internal.go",
         "scmp_dest_unreachable.go",
         "scmp_expired_hop.go",
+        "scmp_invalid_hop.go",
         "scmp_invalid_ia.go",
         "scmp_invalid_mac.go",
         "scmp_invalid_pkt.go",

--- a/tools/braccept/cases/scmp_invalid_hop.go
+++ b/tools/braccept/cases/scmp_invalid_hop.go
@@ -1,0 +1,348 @@
+// Copyright 2022 SCION Association
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cases
+
+import (
+	"hash"
+	"net"
+	"path/filepath"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+
+	"github.com/scionproto/scion/pkg/private/util"
+	"github.com/scionproto/scion/pkg/private/xtest"
+	"github.com/scionproto/scion/pkg/slayers"
+	"github.com/scionproto/scion/pkg/slayers/path"
+	"github.com/scionproto/scion/pkg/slayers/path/scion"
+	"github.com/scionproto/scion/tools/braccept/runner"
+)
+
+// SCMPInvalidHopParentToParent tests a packet that attempts a hop from a parent to
+// a parent interface, with a valid hopfield MAC. This can only occur if the
+// hop key has been compromised.
+func SCMPInvalidHopParentToParent(artifactsDir string, mac hash.Hash) runner.Case {
+	options := gopacket.SerializeOptions{
+		FixLengths:       true,
+		ComputeChecksums: true,
+	}
+
+	ethernet := &layers.Ethernet{
+		SrcMAC:       net.HardwareAddr{0xf0, 0x0d, 0xca, 0xfe, 0xbe, 0xef},
+		DstMAC:       net.HardwareAddr{0xf0, 0x0d, 0xca, 0xfe, 0x00, 0x13},
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+
+	ip := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		SrcIP:    net.IP{192, 168, 13, 3},
+		DstIP:    net.IP{192, 168, 13, 2},
+		Protocol: layers.IPProtocolUDP,
+		Flags:    layers.IPv4DontFragment,
+	}
+
+	udp := &layers.UDP{
+		SrcPort: layers.UDPPort(40000),
+		DstPort: layers.UDPPort(50000),
+	}
+	_ = udp.SetNetworkLayerForChecksum(ip)
+
+	sp := &scion.Decoded{
+		Base: scion.Base{
+			PathMeta: scion.MetaHdr{
+				CurrHF:  1,
+				CurrINF: 0,
+				SegLen:  [3]uint8{3, 0, 0},
+			},
+			NumINF:  1,
+			NumHops: 3,
+		},
+		InfoFields: []path.InfoField{
+			{
+				SegID:     0x111,
+				ConsDir:   true,
+				Timestamp: util.TimeToSecs(time.Now()),
+			},
+		},
+		HopFields: []path.HopField{
+			{ConsIngress: 0, ConsEgress: 311},
+			{ConsIngress: 131, ConsEgress: 191},
+			{ConsIngress: 911, ConsEgress: 0},
+		},
+	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
+
+	scionL := &slayers.SCION{
+		Version:      0,
+		TrafficClass: 0xb8,
+		FlowID:       0xdead,
+		NextHdr:      slayers.L4UDP,
+		PathType:     scion.PathType,
+		SrcIA:        xtest.MustParseIA("1-ff00:0:3"),
+		DstIA:        xtest.MustParseIA("1-ff00:0:9"),
+		Path:         sp,
+	}
+	srcA := &net.IPAddr{IP: net.ParseIP("172.16.5.1")}
+	if err := scionL.SetSrcAddr(srcA); err != nil {
+		panic(err)
+	}
+	if err := scionL.SetDstAddr(&net.IPAddr{IP: net.ParseIP("174.16.4.1")}); err != nil {
+		panic(err)
+	}
+
+	scionudp := &slayers.UDP{}
+	scionudp.SrcPort = 40111
+	scionudp.DstPort = 40222
+	_ = scionudp.SetNetworkLayerForChecksum(scionL)
+
+	payload := []byte("actualpayloadbytes")
+
+	// Prepare input packet
+	input := gopacket.NewSerializeBuffer()
+	if err := gopacket.SerializeLayers(input, options,
+		ethernet, ip, udp, scionL, scionudp, gopacket.Payload(payload),
+	); err != nil {
+		panic(err)
+	}
+
+	// Pointer to current hop field
+	pointer := slayers.CmnHdrLen + scionL.AddrHdrLen() +
+		scion.MetaLen + path.InfoLen*sp.NumINF + path.HopLen*int(sp.PathMeta.CurrHF)
+
+	// Prepare quoted packet that is part of the SCMP error message.
+	quoted := gopacket.NewSerializeBuffer()
+	if err := gopacket.SerializeLayers(quoted, options,
+		scionL, scionudp, gopacket.Payload(payload),
+	); err != nil {
+		panic(err)
+	}
+	quote := quoted.Bytes()
+
+	// Prepare want packet
+	want := gopacket.NewSerializeBuffer()
+	ethernet.SrcMAC = net.HardwareAddr{0xf0, 0x0d, 0xca, 0xfe, 0x00, 0x13}
+	ethernet.DstMAC = net.HardwareAddr{0xf0, 0x0d, 0xca, 0xfe, 0xbe, 0xef}
+	ip.SrcIP = net.IP{192, 168, 13, 2}
+	ip.DstIP = net.IP{192, 168, 13, 3}
+	udp.SrcPort, udp.DstPort = udp.DstPort, udp.SrcPort
+
+	scionL.DstIA = scionL.SrcIA
+	scionL.SrcIA = xtest.MustParseIA("1-ff00:0:1")
+	if err := scionL.SetDstAddr(srcA); err != nil {
+		panic(err)
+	}
+	intlA := &net.IPAddr{IP: net.IP{192, 168, 0, 11}}
+	if err := scionL.SetSrcAddr(intlA); err != nil {
+		panic(err)
+	}
+
+	p, err := sp.Reverse()
+	if err != nil {
+		panic(err)
+	}
+	sp = p.(*scion.Decoded)
+	if err := sp.IncPath(); err != nil {
+		panic(err)
+	}
+
+	scionL.NextHdr = slayers.L4SCMP
+	scmpH := &slayers.SCMP{
+		TypeCode: slayers.CreateSCMPTypeCode(
+			slayers.SCMPTypeParameterProblem,
+			slayers.SCMPCodeInvalidPath,
+		),
+	}
+	_ = scmpH.SetNetworkLayerForChecksum(scionL)
+
+	scmpP := &slayers.SCMPParameterProblem{
+		Pointer: uint16(pointer),
+	}
+
+	if err := gopacket.SerializeLayers(want, options,
+		ethernet, ip, udp, scionL, scmpH, scmpP, gopacket.Payload(quote),
+	); err != nil {
+		panic(err)
+	}
+
+	return runner.Case{
+		Name:     "SCMPInvalidHopParentToParent",
+		WriteTo:  "veth_131_host",
+		ReadFrom: "veth_131_host",
+		Input:    input.Bytes(),
+		Want:     want.Bytes(),
+		StoreDir: filepath.Join(artifactsDir, "SCMPInvalidHopParentToParent"),
+	}
+}
+
+// SCMPInvalidHopChildToChild tests a packet that attempts a hop from a child to
+// a child interface, with a valid hopfield MAC. This can only occur if the
+// hop key has been compromised.
+func SCMPInvalidHopChildToChild(artifactsDir string, mac hash.Hash) runner.Case {
+	options := gopacket.SerializeOptions{
+		FixLengths:       true,
+		ComputeChecksums: true,
+	}
+
+	ethernet := &layers.Ethernet{
+		SrcMAC:       net.HardwareAddr{0xf0, 0x0d, 0xca, 0xfe, 0xbe, 0xef},
+		DstMAC:       net.HardwareAddr{0xf0, 0x0d, 0xca, 0xfe, 0x00, 0x14},
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+
+	ip := &layers.IPv4{
+		Version:  4,
+		IHL:      5,
+		TTL:      64,
+		SrcIP:    net.IP{192, 168, 14, 3},
+		DstIP:    net.IP{192, 168, 14, 2},
+		Protocol: layers.IPProtocolUDP,
+		Flags:    layers.IPv4DontFragment,
+	}
+
+	udp := &layers.UDP{
+		SrcPort: layers.UDPPort(40000),
+		DstPort: layers.UDPPort(50000),
+	}
+	_ = udp.SetNetworkLayerForChecksum(ip)
+
+	sp := &scion.Decoded{
+		Base: scion.Base{
+			PathMeta: scion.MetaHdr{
+				CurrHF:  1,
+				CurrINF: 0,
+				SegLen:  [3]uint8{3, 0, 0},
+			},
+			NumINF:  1,
+			NumHops: 3,
+		},
+		InfoFields: []path.InfoField{
+			{
+				SegID:     0x111,
+				ConsDir:   true,
+				Timestamp: util.TimeToSecs(time.Now()),
+			},
+		},
+		HopFields: []path.HopField{
+			{ConsIngress: 0, ConsEgress: 411},
+			{ConsIngress: 141, ConsEgress: 151},
+			{ConsIngress: 511, ConsEgress: 0},
+		},
+	}
+	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
+
+	scionL := &slayers.SCION{
+		Version:      0,
+		TrafficClass: 0xb8,
+		FlowID:       0xdead,
+		NextHdr:      slayers.L4UDP,
+		PathType:     scion.PathType,
+		SrcIA:        xtest.MustParseIA("1-ff00:0:4"),
+		DstIA:        xtest.MustParseIA("1-ff00:0:5"),
+		Path:         sp,
+	}
+	srcA := &net.IPAddr{IP: net.ParseIP("172.16.5.1")}
+	if err := scionL.SetSrcAddr(srcA); err != nil {
+		panic(err)
+	}
+	if err := scionL.SetDstAddr(&net.IPAddr{IP: net.ParseIP("174.16.4.1")}); err != nil {
+		panic(err)
+	}
+
+	scionudp := &slayers.UDP{}
+	scionudp.SrcPort = 40111
+	scionudp.DstPort = 40222
+	_ = scionudp.SetNetworkLayerForChecksum(scionL)
+
+	payload := []byte("actualpayloadbytes")
+
+	// Prepare input packet
+	input := gopacket.NewSerializeBuffer()
+	if err := gopacket.SerializeLayers(input, options,
+		ethernet, ip, udp, scionL, scionudp, gopacket.Payload(payload),
+	); err != nil {
+		panic(err)
+	}
+
+	// Pointer to current hop field
+	pointer := slayers.CmnHdrLen + scionL.AddrHdrLen() +
+		scion.MetaLen + path.InfoLen*sp.NumINF + path.HopLen*int(sp.PathMeta.CurrHF)
+
+	// Prepare quoted packet that is part of the SCMP error message.
+	quoted := gopacket.NewSerializeBuffer()
+	if err := gopacket.SerializeLayers(quoted, options,
+		scionL, scionudp, gopacket.Payload(payload),
+	); err != nil {
+		panic(err)
+	}
+	quote := quoted.Bytes()
+
+	// Prepare want packet
+	want := gopacket.NewSerializeBuffer()
+	ethernet.SrcMAC = net.HardwareAddr{0xf0, 0x0d, 0xca, 0xfe, 0x00, 0x14}
+	ethernet.DstMAC = net.HardwareAddr{0xf0, 0x0d, 0xca, 0xfe, 0xbe, 0xef}
+	ip.SrcIP = net.IP{192, 168, 14, 2}
+	ip.DstIP = net.IP{192, 168, 14, 3}
+	udp.SrcPort, udp.DstPort = udp.DstPort, udp.SrcPort
+
+	scionL.DstIA = scionL.SrcIA
+	scionL.SrcIA = xtest.MustParseIA("1-ff00:0:1")
+	if err := scionL.SetDstAddr(srcA); err != nil {
+		panic(err)
+	}
+	intlA := &net.IPAddr{IP: net.IP{192, 168, 0, 11}}
+	if err := scionL.SetSrcAddr(intlA); err != nil {
+		panic(err)
+	}
+
+	p, err := sp.Reverse()
+	if err != nil {
+		panic(err)
+	}
+	sp = p.(*scion.Decoded)
+	if err := sp.IncPath(); err != nil {
+		panic(err)
+	}
+
+	scionL.NextHdr = slayers.L4SCMP
+	scmpH := &slayers.SCMP{
+		TypeCode: slayers.CreateSCMPTypeCode(
+			slayers.SCMPTypeParameterProblem,
+			slayers.SCMPCodeInvalidPath,
+		),
+	}
+	_ = scmpH.SetNetworkLayerForChecksum(scionL)
+
+	scmpP := &slayers.SCMPParameterProblem{
+		Pointer: uint16(pointer),
+	}
+
+	if err := gopacket.SerializeLayers(want, options,
+		ethernet, ip, udp, scionL, scmpH, scmpP, gopacket.Payload(quote),
+	); err != nil {
+		panic(err)
+	}
+
+	return runner.Case{
+		Name:     "SCMPInvalidHopChildToChild",
+		WriteTo:  "veth_141_host",
+		ReadFrom: "veth_141_host",
+		Input:    input.Bytes(),
+		Want:     want.Bytes(),
+		StoreDir: filepath.Join(artifactsDir, "SCMPInvalidHopChildToChild"),
+	}
+}

--- a/tools/braccept/cases/scmp_traceroute.go
+++ b/tools/braccept/cases/scmp_traceroute.go
@@ -362,8 +362,8 @@ func SCMPTracerouteEgress(artifactsDir string, mac hash.Hash) runner.Case {
 		},
 		HopFields: []path.HopField{
 			{ConsIngress: 411, ConsEgress: 0},
-			{ConsIngress: 121, ConsEgress: 141, IngressRouterAlert: true},
-			{ConsIngress: 0, ConsEgress: 211},
+			{ConsIngress: 131, ConsEgress: 141, IngressRouterAlert: true},
+			{ConsIngress: 0, ConsEgress: 311},
 		},
 	}
 	sp.HopFields[1].Mac = path.MAC(mac, sp.InfoFields[0], sp.HopFields[1], nil)
@@ -376,7 +376,7 @@ func SCMPTracerouteEgress(artifactsDir string, mac hash.Hash) runner.Case {
 		NextHdr:      slayers.L4SCMP,
 		PathType:     scion.PathType,
 		SrcIA:        xtest.MustParseIA("1-ff00:0:4"),
-		DstIA:        xtest.MustParseIA("1-ff00:0:2"),
+		DstIA:        xtest.MustParseIA("1-ff00:0:3"),
 		Path:         sp,
 	}
 	srcA := &net.IPAddr{IP: net.ParseIP("172.16.4.1").To4()}
@@ -438,7 +438,7 @@ func SCMPTracerouteEgress(artifactsDir string, mac hash.Hash) runner.Case {
 		Identifier: scmpP.Identifier,
 		Sequence:   scmpP.Sequence,
 		IA:         scionL.SrcIA,
-		Interface:  121,
+		Interface:  131,
 	}
 
 	// Skip Ethernet + IPv4 + UDP

--- a/tools/braccept/main.go
+++ b/tools/braccept/main.go
@@ -107,6 +107,8 @@ func realMain() int {
 		cases.SCMPInternalXover(artifactsDir, hfMAC),
 		cases.SCMPUnknownHop(artifactsDir, hfMAC),
 		cases.SCMPUnknownHopEgress(artifactsDir, hfMAC),
+		cases.SCMPInvalidHopParentToParent(artifactsDir, hfMAC),
+		cases.SCMPInvalidHopChildToChild(artifactsDir, hfMAC),
 		cases.SCMPTracerouteIngress(artifactsDir, hfMAC),
 		cases.SCMPTracerouteIngressConsDir(artifactsDir, hfMAC),
 		cases.SCMPTracerouteEgress(artifactsDir, hfMAC),


### PR DESCRIPTION
Similar to the existing checks for segment switching, add checks for the
case in which the router forwards a packet along a single segment. This
check only allows child-to-parent, parent-to-child, and core-to-core
combinations, as well as packets coming from an internal interface
(peering links are not yet considered).
This explicit check ensures valley-free forwarding, even if an attacker
knows all AS hop keys.
Invalid hops result in an SCMP Error message with type `Parameter
Problem` and code `Invalid Path`.

Add new braccept cases for the invalid hops child-to-child and
parent-to-parent. Additional cases would be child-to-core and
core-to-child, but these cannot be checked in the current braccept
framework.
Adapt existing braccept case SCMPTracerouteEgress, where a child-to-peer
hop was used, which is currently not considered valid (peering links are
not supported). It appears that this test case did not specifically
intend to use a peering link (as the path only consists of a single
segment).

Aside: restructure parameters for packSCMP in router to make calls more
compact and increase readability.

~~Based on #4157~~ 
Resolves #4148.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4294)
<!-- Reviewable:end -->
