### PR TITLE
ci: doc pipeline for doc-only PRs

### DIFF
--- a/.buildkite/pipeline-doc.yml
+++ b/.buildkite/pipeline-doc.yml
@@ -1,0 +1,10 @@
+steps:
+  - label: "Lint doc :bash:"
+    key: lint_doc
+    command:
+      - make lint-doc
+    retry:
+      automatic:
+        - exit_status: -1 # Agent was lost
+        - exit_status: 255 # Forced agent shutdown
+    timeout_in_minutes: 10

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -2,6 +2,14 @@
 
 set -eou pipefail
 
+if [ -n "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" ]; then
+  if git diff --quiet "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" ':!doc/' ':!**.md'; then
+    # No diff other than doc/ and *.md
+    cat .buildkite/pipeline-doc.yml
+    exit 0
+  fi
+fi
+
 # Following values are useful when debugging the CI.
 # Modify this value to run only a single test in the CI.
 export SINGLE_TEST=

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -2,6 +2,10 @@
 
 set -eou pipefail
 
+# XXX(matzf): simply test pipeline-doc. Only as check for scionproto/scion#4302.
+cat .buildkite/pipeline-doc.yml
+exit 0
+
 if [ -n "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" ]; then
   if git diff --quiet "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" ':!doc/' ':!**.md'; then
     # No diff other than doc/ and *.md

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -2,10 +2,6 @@
 
 set -eou pipefail
 
-# XXX(matzf): simply test pipeline-doc. Only as check for scionproto/scion#4302.
-cat .buildkite/pipeline-doc.yml
-exit 0
-
 if [ -n "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" ]; then
   if git diff --quiet "${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-}" ':!doc/' ':!**.md'; then
     # No diff other than doc/ and *.md

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,6 @@ env:
   GOPROXY: "http://localhost:3200|https://proxy.golang.org|direct"
 steps:
   - label: "Build :bazel:"
-    if: build.message !~ /\[doc\]/
     command:
       - bazel build --verbose_failures --announce_rc //:all
       - bazel run --verbose_failures //docker:prod //docker:test
@@ -14,7 +13,6 @@ steps:
     timeout_in_minutes: 10
   - wait
   - label: "Unit Tests :bazel:"
-    if: build.message !~ /\[doc\]/
     command:
       - bazel test --config=race --config=unit_all
     key: unit_tests
@@ -29,7 +27,6 @@ steps:
     retry: *automatic-retry
     timeout_in_minutes: 20
   - label: "Check Generated :bash:"
-    if: build.message !~ /\[doc\]/
     command:
       - echo "--- go_deps.bzl"
       - mkdir -p /tmp/test-artifacts
@@ -61,7 +58,6 @@ steps:
     retry: *automatic-retry
   - group: "End to End"
     key: e2e
-    if: build.message !~ /\[doc\]/
     steps:
     - label: "E2E: default :man_in_business_suit_levitating: (scion, ping)"
       command:

--- a/.buildkite/pipeline_lib.sh
+++ b/.buildkite/pipeline_lib.sh
@@ -5,7 +5,6 @@ gen_bazel_test_steps() {
     parallel="${PARALLELISM:-1}"
     echo "  - group: \"Integration Tests :bazel:\""
     echo "    key: integration-tests"
-    echo "    if: build.message !~ /\[doc\]/"
     echo "    steps:"
 
     targets="$(bazel query "attr(tags, integration, tests(//...)) except attr(tags, \"lint|manual\", tests(//...))" 2>/dev/null)"


### PR DESCRIPTION
Run short pipeline with only documentation linting for PRs that only touch documentation.
Replaces previous manual mechanism based on a `[doc]` tag in the commit comment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4302)
<!-- Reviewable:end -->
