### PR TITLE
pkg/log: improve performance of log.Debug()

### DIFF
--- a/pkg/log/wrappers.go
+++ b/pkg/log/wrappers.go
@@ -22,7 +22,9 @@ import (
 
 // Debug logs at debug level.
 func Debug(msg string, ctx ...interface{}) {
-	zap.L().Debug(msg, convertCtx(ctx)...)
+	if zap.L().Core().Enabled(zapcore.DebugLevel) {
+		zap.L().Debug(msg, convertCtx(ctx)...)
+	}
 }
 
 // Info logs at info level.

--- a/pkg/log/wrappers.go
+++ b/pkg/log/wrappers.go
@@ -22,26 +22,26 @@ import (
 
 // Debug logs at debug level.
 func Debug(msg string, ctx ...interface{}) {
-	if Enabled(DebugLevel) {
+	if enabled(DebugLevel) {
 		zap.L().Debug(msg, convertCtx(ctx)...)
 	}
 }
 
 // Info logs at info level.
 func Info(msg string, ctx ...interface{}) {
-	if Enabled(InfoLevel) {
+	if enabled(InfoLevel) {
 		zap.L().Info(msg, convertCtx(ctx)...)
 	}
 }
 
 // Error logs at error level.
 func Error(msg string, ctx ...interface{}) {
-	if Enabled(ErrorLevel) {
+	if enabled(ErrorLevel) {
 		zap.L().Error(msg, convertCtx(ctx)...)
 	}
 }
 
-func Enabled(lvl Level) bool {
+func enabled(lvl Level) bool {
 	return zap.L().Core().Enabled(zapcore.Level(lvl))
 }
 

--- a/pkg/log/wrappers.go
+++ b/pkg/log/wrappers.go
@@ -22,19 +22,27 @@ import (
 
 // Debug logs at debug level.
 func Debug(msg string, ctx ...interface{}) {
-	if zap.L().Core().Enabled(zapcore.DebugLevel) {
+	if Enabled(DebugLevel) {
 		zap.L().Debug(msg, convertCtx(ctx)...)
 	}
 }
 
 // Info logs at info level.
 func Info(msg string, ctx ...interface{}) {
-	zap.L().Info(msg, convertCtx(ctx)...)
+	if Enabled(InfoLevel) {
+		zap.L().Info(msg, convertCtx(ctx)...)
+	}
 }
 
 // Error logs at error level.
 func Error(msg string, ctx ...interface{}) {
-	zap.L().Error(msg, convertCtx(ctx)...)
+	if Enabled(ErrorLevel) {
+		zap.L().Error(msg, convertCtx(ctx)...)
+	}
+}
+
+func Enabled(lvl Level) bool {
+	return zap.L().Core().Enabled(zapcore.Level(lvl))
 }
 
 // WithOptions returns the logger with the options applied.
@@ -74,15 +82,21 @@ func (l *logger) New(ctx ...interface{}) Logger {
 }
 
 func (l *logger) Debug(msg string, ctx ...interface{}) {
-	l.logger.Debug(msg, convertCtx(ctx)...)
+	if l.Enabled(DebugLevel) {
+		l.logger.Debug(msg, convertCtx(ctx)...)
+	}
 }
 
 func (l *logger) Info(msg string, ctx ...interface{}) {
-	l.logger.Info(msg, convertCtx(ctx)...)
+	if l.Enabled(InfoLevel) {
+		l.logger.Info(msg, convertCtx(ctx)...)
+	}
 }
 
 func (l *logger) Error(msg string, ctx ...interface{}) {
-	l.logger.Error(msg, convertCtx(ctx)...)
+	if l.Enabled(ErrorLevel) {
+		l.logger.Error(msg, convertCtx(ctx)...)
+	}
 }
 
 func (l *logger) Enabled(lvl Level) bool {


### PR DESCRIPTION
I saw that even if the log level is info a call to log.Debug(...) requires on my system 135ns because convertCtx() is executed before checking the log level. Therefore I added a check to the log.Debug(...) function. With the help of the following benchmark tests I was able to reduce the execution time from 135ns to 30ns.

func BenchmarkLog(b *testing.B) {
	err := log.Setup(log.Config{Console: log.ConsoleConfig{Level: "info"}})
	assert.NoError(b, err)
	for i := 0; i < b.N; i++ {
		log.Debug("hello world", "i", i)
	}
}

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4304)
<!-- Reviewable:end -->
