### PR TITLE
slayers: type-safe SetNetworkLayerForChecksum

### DIFF
--- a/.golangcilint.yml
+++ b/.golangcilint.yml
@@ -91,8 +91,6 @@ issues:
              ^dispatcher/cmd/dispatcher/main.go$|\
              ^dispatcher/dispatcher.go$|\
              ^dispatcher/internal/registration/bench_test.go$|\
-             ^dispatcher/internal/respool/packet_test.go$|\
-             ^dispatcher/underlay_test.go$|\
              ^gateway/control/aggregator.go$|\
              ^gateway/control/engine.go$|\
              ^gateway/control/engine_test.go$|\
@@ -108,7 +106,6 @@ issues:
              ^gateway/dataplane/routingtable.go$|\
              ^gateway/dataplane/session_test.go$|\
              ^gateway/gateway.go$|\
-             ^gateway/pktcls/cond_test.go$|\
              ^gateway/routing/file.go$|\
              ^gateway/xnet/xnet.go$|\
              ^pkg/experimental/colibri/reservation/types.go$|\
@@ -125,7 +122,6 @@ issues:
              ^pkg/segment/segs_test.go$|\
              ^pkg/slayers/extn_test.go$|\
              ^pkg/slayers/scion_test.go$|\
-             ^pkg/snet/packet.go$|\
              ^pkg/snet/packet_test.go$|\
              ^pkg/snet/path.go$|\
              ^pkg/snet/squic/net.go$|\
@@ -151,34 +147,14 @@ issues:
              ^private/trust/verifier.go$|\
              ^private/trust/verifier_bench_test.go$|\
              ^private/worker/worker_test.go$|\
-             ^router/dataplane.go$|\
              ^router/dataplane_test.go$|\
              ^router/export_test.go$|\
              ^router/mgmtapi/api.go$|\
              ^scion-pki/trcs/combine_test.go$|\
-             ^tools/braccept/cases/bfd.go$|\
-             ^tools/braccept/cases/child_to_child_xover.go$|\
-             ^tools/braccept/cases/child_to_internal.go$|\
-             ^tools/braccept/cases/child_to_parent.go$|\
-             ^tools/braccept/cases/internal_to_child.go$|\
-             ^tools/braccept/cases/jumbo.go$|\
-             ^tools/braccept/cases/onehop.go$|\
-             ^tools/braccept/cases/parent_to_child.go$|\
-             ^tools/braccept/cases/parent_to_internal.go$|\
-             ^tools/braccept/cases/scmp_dest_unreachable.go$|\
-             ^tools/braccept/cases/scmp_expired_hop.go$|\
-             ^tools/braccept/cases/scmp_invalid_mac.go$|\
-             ^tools/braccept/cases/scmp_invalid_pkt.go$|\
-             ^tools/braccept/cases/scmp_invalid_segment_change.go$|\
-             ^tools/braccept/cases/scmp_invalid_segment_change_local.go$|\
-             ^tools/braccept/cases/scmp_traceroute.go$|\
-             ^tools/braccept/cases/scmp_unknown_hop.go$|\
-             ^tools/braccept/cases/svc.go$|\
              ^tools/end2end/main.go$|\
              ^tools/end2end_integration/main.go$|\
              ^tools/integration/binary.go$|\
              ^tools/integration/done.go$|\
              ^tools/integration/integration.go$|\
-             ^tools/integration/progress/progress.go$|\
-             ^tools/pktgen/cmd/pktgen/main.go$"
+             ^tools/integration/progress/progress.go$"
       linters: [errcheck]

--- a/dispatcher/underlay.go
+++ b/dispatcher/underlay.go
@@ -311,9 +311,7 @@ func (h SCMPHandler) reverse(pkt *respool.Packet) ([]byte, error) {
 	pkt.SCION.NextHdr = slayers.L4SCMP
 	// FIXME(roosd): Consider moving this to a resource pool.
 	buf := gopacket.NewSerializeBuffer()
-	if err := pkt.SCMP.SetNetworkLayerForChecksum(&pkt.SCION); err != nil {
-		return nil, err
-	}
+	pkt.SCMP.SetNetworkLayerForChecksum(&pkt.SCION)
 	err = gopacket.SerializeLayers(
 		buf,
 		gopacket.SerializeOptions{

--- a/gateway/pktcls/cond_test.go
+++ b/gateway/pktcls/cond_test.go
@@ -221,7 +221,7 @@ func createUDPPacket(src, dst uint16) gopacket.Layer {
 		SrcPort: layers.UDPPort(src),
 		DstPort: layers.UDPPort(dst),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 	payload := []byte("payload")
 	input := gopacket.NewSerializeBuffer()
 	options := gopacket.SerializeOptions{
@@ -233,7 +233,9 @@ func createUDPPacket(src, dst uint16) gopacket.Layer {
 		panic(err)
 	}
 	pkt := &layers.IPv4{}
-	pkt.DecodeFromBytes(input.Bytes(), gopacket.NilDecodeFeedback)
+	if err := pkt.DecodeFromBytes(input.Bytes(), gopacket.NilDecodeFeedback); err != nil {
+		panic(err)
+	}
 	return pkt
 }
 

--- a/pkg/slayers/scmp.go
+++ b/pkg/slayers/scmp.go
@@ -137,16 +137,8 @@ func (s *SCMP) String() string {
 
 // SetNetworkLayerForChecksum tells this layer which network layer is wrapping it.
 // This is needed for computing the checksum when serializing,
-func (s *SCMP) SetNetworkLayerForChecksum(l gopacket.NetworkLayer) error {
-	if l == nil {
-		return serrors.New("cannot use nil layer type for scmp checksum network layer")
-	}
-	if l.LayerType() != LayerTypeSCION {
-		return serrors.New("cannot use layer type for scmp checksum network layer",
-			"type", l.LayerType())
-	}
-	s.scn = l.(*SCION)
-	return nil
+func (s *SCMP) SetNetworkLayerForChecksum(scn *SCION) {
+	s.scn = scn
 }
 
 func decodeSCMP(data []byte, pb gopacket.PacketBuilder) error {

--- a/pkg/slayers/scmp_test.go
+++ b/pkg/slayers/scmp_test.go
@@ -122,7 +122,7 @@ func TestSCMPSerializeTo(t *testing.T) {
 			tc.decoded.Contents = tc.raw[:4]
 			tc.decoded.Payload = tc.raw[4:]
 			buffer := gopacket.NewSerializeBuffer()
-			require.NoError(t, tc.decoded.SetNetworkLayerForChecksum(scnL))
+			tc.decoded.SetNetworkLayerForChecksum(scnL)
 			err := tc.decoded.SerializeTo(buffer, tc.opts)
 			tc.assertFunc(t, err)
 			if err != nil {
@@ -523,7 +523,7 @@ func TestSCMP(t *testing.T) {
 				for _, l := range tc.decodedLayers {
 					switch v := l.(type) {
 					case *slayers.SCMP:
-						require.NoError(t, v.SetNetworkLayerForChecksum(scnL))
+						v.SetNetworkLayerForChecksum(scnL)
 					}
 				}
 

--- a/pkg/slayers/slayers_test.go
+++ b/pkg/slayers/slayers_test.go
@@ -208,7 +208,7 @@ func TestPaths(t *testing.T) {
 					Length:   1032,
 					Checksum: 0xb8e4,
 				}
-				require.NoError(t, u.SetNetworkLayerForChecksum(s))
+				u.SetNetworkLayerForChecksum(s)
 				return []gopacket.SerializableLayer{s, u, gopacket.Payload(mkPayload(1024))}
 			},
 		},
@@ -238,7 +238,7 @@ func TestPaths(t *testing.T) {
 					Length:   1032,
 					Checksum: 0xb7d2,
 				}
-				require.NoError(t, u.SetNetworkLayerForChecksum(s))
+				u.SetNetworkLayerForChecksum(s)
 				return []gopacket.SerializableLayer{s, u, gopacket.Payload(mkPayload(1024))}
 			},
 		},
@@ -341,7 +341,7 @@ func TestSerializeSCIONUPDExtn(t *testing.T) {
 	u := &slayers.UDP{}
 	u.SrcPort = 1280
 	u.DstPort = 80
-	require.NoError(t, u.SetNetworkLayerForChecksum(s))
+	u.SetNetworkLayerForChecksum(s)
 	hbh := &slayers.HopByHopExtn{}
 	hbh.NextHdr = slayers.End2EndClass
 	hbh.Options = []*slayers.HopByHopOption{

--- a/pkg/slayers/udp.go
+++ b/pkg/slayers/udp.go
@@ -117,12 +117,8 @@ func (u *UDP) fixLengths(length int) {
 	u.Length = uint16(length)
 }
 
-func (u *UDP) SetNetworkLayerForChecksum(l gopacket.NetworkLayer) error {
-	if l.LayerType() == LayerTypeSCION {
-		u.scn = l.(*SCION)
-		return nil
-	}
-	return fmt.Errorf("cannot use layer type %v for UDP checksum network layer", l.LayerType())
+func (u *UDP) SetNetworkLayerForChecksum(scn *SCION) {
+	u.scn = scn
 }
 
 func (u *UDP) String() string {

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -587,7 +587,9 @@ func (p *scionPacketProcessor) reset() error {
 func (p *scionPacketProcessor) processPkt(rawPkt []byte,
 	srcAddr *net.UDPAddr) (processResult, error) {
 
-	p.reset()
+	if err := p.reset(); err != nil {
+		return processResult{}, err
+	}
 	p.rawPkt = rawPkt
 	p.srcAddr = srcAddr
 

--- a/tools/braccept/cases/bfd.go
+++ b/tools/braccept/cases/bfd.go
@@ -77,7 +77,7 @@ func ExternalBFD(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 	localIA, _ := addr.ParseIA("1-ff00:0:1")
 	remoteIA, _ := addr.ParseIA("1-ff00:0:3")
 	ohp := &onehop.Path{
@@ -186,7 +186,7 @@ func InternalBFD(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(30003),
 		DstPort: layers.UDPPort(30001),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 	localIA, _ := addr.ParseIA("1-ff00:0:1")
 	scionL := &slayers.SCION{
 		Version:      0,

--- a/tools/braccept/cases/child_to_child_xover.go
+++ b/tools/braccept/cases/child_to_child_xover.go
@@ -59,7 +59,7 @@ func ChildToChildXover(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -136,8 +136,12 @@ func ChildToChildXover(artifactsDir string, mac hash.Hash) runner.Case {
 	ip.SrcIP = net.IP{192, 168, 14, 2}
 	ip.DstIP = net.IP{192, 168, 14, 3}
 	udp.SrcPort, udp.DstPort = udp.DstPort, udp.SrcPort
-	sp.IncPath()
-	sp.IncPath()
+	if err := sp.IncPath(); err != nil {
+		panic(err)
+	}
+	if err := sp.IncPath(); err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 	sp.InfoFields[1].UpdateSegID(sp.HopFields[2].Mac)
 

--- a/tools/braccept/cases/child_to_internal.go
+++ b/tools/braccept/cases/child_to_internal.go
@@ -58,7 +58,7 @@ func ChildToInternalHost(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
 	// 		ADDR: SrcIA=1-ff00:0:4 Src=172.16.4.1 DstIA=1-ff00:0:1 Dst=192.168.0.51
@@ -171,7 +171,7 @@ func ChildToInternalHostShortcut(artifactsDir string, mac hash.Hash) runner.Case
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -281,7 +281,7 @@ func ChildToInternalParent(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
 	// 		ADDR: SrcIA=1-ff00:0:4 Src=174.16.4.1 DstIA=1-ff00:0:9 Dst=172.16.9.1

--- a/tools/braccept/cases/child_to_parent.go
+++ b/tools/braccept/cases/child_to_parent.go
@@ -59,7 +59,7 @@ func ChildToParent(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// pkt0.ParsePacket(`
 	// 	SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
@@ -137,7 +137,9 @@ func ChildToParent(artifactsDir string, mac hash.Hash) runner.Case {
 	// 	UDP: Src=50000 Dst=40000
 	udp.SrcPort, udp.DstPort = udp.DstPort, udp.SrcPort
 	// 	SCION: CurrHopF=7
-	sp.IncPath()
+	if err := sp.IncPath(); err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	if err := gopacket.SerializeLayers(want, options,

--- a/tools/braccept/cases/internal_to_child.go
+++ b/tools/braccept/cases/internal_to_child.go
@@ -59,7 +59,7 @@ func InternalHostToChild(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(30041),
 		DstPort: layers.UDPPort(30001),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// 	SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=5 SrcType=IPv4 DstType=IPv4
 	// 		ADDR: SrcIA=1-ff00:0:1 Src=192.168.0.51 DstIA=1-ff00:0:4 Dst=172.16.4.1
@@ -133,7 +133,9 @@ func InternalHostToChild(artifactsDir string, mac hash.Hash) runner.Case {
 	// 	UDP: Src=50000 Dst=40000
 	udp.SrcPort, udp.DstPort = 50000, 40000
 	// 	SCION: CurrHopF=7
-	sp.IncPath()
+	if err := sp.IncPath(); err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[0].Mac)
 
 	if err := gopacket.SerializeLayers(want, options,
@@ -181,7 +183,7 @@ func InternalParentToChild(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(30004),
 		DstPort: layers.UDPPort(30001),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// 	SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
 	// 		ADDR: SrcIA=1-ff00:0:9 Src=174.16.9.1 DstIA=1-ff00:0:4 Dst=174.16.4.1
@@ -257,7 +259,9 @@ func InternalParentToChild(artifactsDir string, mac hash.Hash) runner.Case {
 	// 	UDP: Src=50000 Dst=40000
 	udp.SrcPort, udp.DstPort = 50000, 40000
 	// 	SCION: CurrHopF=7
-	sp.IncPath()
+	if err := sp.IncPath(); err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	if err := gopacket.SerializeLayers(want, options,
@@ -306,7 +310,7 @@ func InvalidSrcInternalParentToChild(artifactsDir string, mac hash.Hash) runner.
 		SrcPort: layers.UDPPort(30004),
 		DstPort: layers.UDPPort(30001),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// 	SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
 	// 		ADDR: SrcIA=1-ff00:0:9 Src=174.16.9.1 DstIA=1-ff00:0:4 Dst=174.16.4.1

--- a/tools/braccept/cases/jumbo.go
+++ b/tools/braccept/cases/jumbo.go
@@ -59,7 +59,7 @@ func JumboPacket(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// pkt0.ParsePacket(`
 	//	SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
@@ -141,7 +141,9 @@ func JumboPacket(artifactsDir string, mac hash.Hash) runner.Case {
 	// 	UDP: Src=50000 Dst=40000
 	udp.SrcPort, udp.DstPort = udp.DstPort, udp.SrcPort
 	// 	SCION: CurrHopF=7
-	sp.IncPath()
+	if err := sp.IncPath(); err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	if err := gopacket.SerializeLayers(want, options,

--- a/tools/braccept/cases/onehop.go
+++ b/tools/braccept/cases/onehop.go
@@ -56,7 +56,7 @@ func IncomingOneHop(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 	ohp := &onehop.Path{
 		Info: path.InfoField{
 			ConsDir:   true,
@@ -151,7 +151,7 @@ func OutgoingOneHop(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(30041),
 		DstPort: layers.UDPPort(30001),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 	ohp := &onehop.Path{
 		Info: path.InfoField{
 			ConsDir:   true,

--- a/tools/braccept/cases/parent_to_child.go
+++ b/tools/braccept/cases/parent_to_child.go
@@ -59,7 +59,7 @@ func ParentToChild(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// pkt0.ParsePacket(`
 	//	SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
@@ -137,7 +137,9 @@ func ParentToChild(artifactsDir string, mac hash.Hash) runner.Case {
 	// 	UDP: Src=50000 Dst=40000
 	udp.SrcPort, udp.DstPort = udp.DstPort, udp.SrcPort
 	// 	SCION: CurrHopF=7
-	sp.IncPath()
+	if err := sp.IncPath(); err != nil {
+		panic(err)
+	}
 	sp.InfoFields[0].UpdateSegID(sp.HopFields[1].Mac)
 
 	if err := gopacket.SerializeLayers(want, options,

--- a/tools/braccept/cases/parent_to_internal.go
+++ b/tools/braccept/cases/parent_to_internal.go
@@ -56,7 +56,7 @@ func ParentToInternalHost(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -163,7 +163,7 @@ func ParentToInternalHostMultiSegment(artifactsDir string, mac hash.Hash) runner
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{

--- a/tools/braccept/cases/scmp_dest_unreachable.go
+++ b/tools/braccept/cases/scmp_dest_unreachable.go
@@ -60,7 +60,7 @@ func SCMPDestinationUnreachable(artifactsDir string, mac hash.Hash) runner.Case 
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{

--- a/tools/braccept/cases/scmp_expired_hop.go
+++ b/tools/braccept/cases/scmp_expired_hop.go
@@ -59,7 +59,7 @@ func SCMPExpiredHop(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// pkt0.ParsePacket(`
 	//	SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
@@ -216,7 +216,7 @@ func SCMPExpiredHopAfterXover(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -391,7 +391,7 @@ func SCMPExpiredHopAfterXoverConsDir(artifactsDir string, mac hash.Hash) runner.
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -564,7 +564,7 @@ func SCMPExpiredHopAfterXoverInternal(artifactsDir string, mac hash.Hash) runner
 		SrcPort: layers.UDPPort(30003),
 		DstPort: layers.UDPPort(30001),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -730,7 +730,7 @@ func SCMPExpiredHopAfterXoverInternalConsDir(artifactsDir string, mac hash.Hash)
 		SrcPort: layers.UDPPort(30003),
 		DstPort: layers.UDPPort(30001),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{

--- a/tools/braccept/cases/scmp_invalid_hop.go
+++ b/tools/braccept/cases/scmp_invalid_hop.go
@@ -108,7 +108,7 @@ func SCMPInvalidHopParentToParent(artifactsDir string, mac hash.Hash) runner.Cas
 	scionudp := &slayers.UDP{}
 	scionudp.SrcPort = 40111
 	scionudp.DstPort = 40222
-	_ = scionudp.SetNetworkLayerForChecksum(scionL)
+	scionudp.SetNetworkLayerForChecksum(scionL)
 
 	payload := []byte("actualpayloadbytes")
 
@@ -167,7 +167,7 @@ func SCMPInvalidHopParentToParent(artifactsDir string, mac hash.Hash) runner.Cas
 			slayers.SCMPCodeInvalidPath,
 		),
 	}
-	_ = scmpH.SetNetworkLayerForChecksum(scionL)
+	scmpH.SetNetworkLayerForChecksum(scionL)
 
 	scmpP := &slayers.SCMPParameterProblem{
 		Pointer: uint16(pointer),
@@ -266,7 +266,7 @@ func SCMPInvalidHopChildToChild(artifactsDir string, mac hash.Hash) runner.Case 
 	scionudp := &slayers.UDP{}
 	scionudp.SrcPort = 40111
 	scionudp.DstPort = 40222
-	_ = scionudp.SetNetworkLayerForChecksum(scionL)
+	scionudp.SetNetworkLayerForChecksum(scionL)
 
 	payload := []byte("actualpayloadbytes")
 
@@ -325,7 +325,7 @@ func SCMPInvalidHopChildToChild(artifactsDir string, mac hash.Hash) runner.Case 
 			slayers.SCMPCodeInvalidPath,
 		),
 	}
-	_ = scmpH.SetNetworkLayerForChecksum(scionL)
+	scmpH.SetNetworkLayerForChecksum(scionL)
 
 	scmpP := &slayers.SCMPParameterProblem{
 		Pointer: uint16(pointer),

--- a/tools/braccept/cases/scmp_invalid_ia.go
+++ b/tools/braccept/cases/scmp_invalid_ia.go
@@ -110,7 +110,7 @@ func SCMPInvalidSrcIAInternalHostToChild(artifactsDir string, mac hash.Hash) run
 	scionudp := &slayers.UDP{}
 	scionudp.SrcPort = 40111
 	scionudp.DstPort = 40222
-	_ = scionudp.SetNetworkLayerForChecksum(scionL)
+	scionudp.SetNetworkLayerForChecksum(scionL)
 
 	payload := []byte("actualpayloadbytes")
 
@@ -150,7 +150,7 @@ func SCMPInvalidSrcIAInternalHostToChild(artifactsDir string, mac hash.Hash) run
 		TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem,
 			slayers.SCMPCodeInvalidSourceAddress),
 	}
-	_ = scmpH.SetNetworkLayerForChecksum(scionL)
+	scmpH.SetNetworkLayerForChecksum(scionL)
 	scmpP := &slayers.SCMPParameterProblem{
 		Pointer: uint16(slayers.CmnHdrLen + 8),
 	}
@@ -253,7 +253,7 @@ func SCMPInvalidDstIAInternalHostToChild(artifactsDir string, mac hash.Hash) run
 	scionudp := &slayers.UDP{}
 	scionudp.SrcPort = 40111
 	scionudp.DstPort = 40222
-	_ = scionudp.SetNetworkLayerForChecksum(scionL)
+	scionudp.SetNetworkLayerForChecksum(scionL)
 
 	payload := []byte("actualpayloadbytes")
 
@@ -293,7 +293,7 @@ func SCMPInvalidDstIAInternalHostToChild(artifactsDir string, mac hash.Hash) run
 		TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem,
 			slayers.SCMPCodeInvalidDestinationAddress),
 	}
-	_ = scmpH.SetNetworkLayerForChecksum(scionL)
+	scmpH.SetNetworkLayerForChecksum(scionL)
 	scmpP := &slayers.SCMPParameterProblem{
 		Pointer: uint16(slayers.CmnHdrLen + 0),
 	}
@@ -400,7 +400,7 @@ func SCMPInvalidSrcIAChildToParent(artifactsDir string, mac hash.Hash) runner.Ca
 	scionudp := &slayers.UDP{}
 	scionudp.SrcPort = 40111
 	scionudp.DstPort = 40222
-	_ = scionudp.SetNetworkLayerForChecksum(scionL)
+	scionudp.SetNetworkLayerForChecksum(scionL)
 
 	payload := []byte("actualpayloadbytes")
 
@@ -446,7 +446,7 @@ func SCMPInvalidSrcIAChildToParent(artifactsDir string, mac hash.Hash) runner.Ca
 		TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem,
 			slayers.SCMPCodeInvalidSourceAddress),
 	}
-	_ = scmpH.SetNetworkLayerForChecksum(scionL)
+	scmpH.SetNetworkLayerForChecksum(scionL)
 	scmpP := &slayers.SCMPParameterProblem{
 		Pointer: uint16(slayers.CmnHdrLen + 8),
 	}
@@ -553,7 +553,7 @@ func SCMPInvalidDstIAChildToParent(artifactsDir string, mac hash.Hash) runner.Ca
 	scionudp := &slayers.UDP{}
 	scionudp.SrcPort = 40111
 	scionudp.DstPort = 40222
-	_ = scionudp.SetNetworkLayerForChecksum(scionL)
+	scionudp.SetNetworkLayerForChecksum(scionL)
 
 	payload := []byte("actualpayloadbytes")
 
@@ -599,7 +599,7 @@ func SCMPInvalidDstIAChildToParent(artifactsDir string, mac hash.Hash) runner.Ca
 		TypeCode: slayers.CreateSCMPTypeCode(slayers.SCMPTypeParameterProblem,
 			slayers.SCMPCodeInvalidDestinationAddress),
 	}
-	_ = scmpH.SetNetworkLayerForChecksum(scionL)
+	scmpH.SetNetworkLayerForChecksum(scionL)
 	scmpP := &slayers.SCMPParameterProblem{
 		Pointer: uint16(slayers.CmnHdrLen + 0),
 	}

--- a/tools/braccept/cases/scmp_invalid_mac.go
+++ b/tools/braccept/cases/scmp_invalid_mac.go
@@ -59,7 +59,7 @@ func SCMPBadMAC(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// pkt0.ParsePacket(`
 	//	SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
@@ -214,7 +214,7 @@ func SCMPBadMACInternal(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(30004),
 		DstPort: layers.UDPPort(30001),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// 	SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
 	// 		ADDR: SrcIA=1-ff00:0:9 Src=174.16.3.1 DstIA=1-ff00:0:4 Dst=174.16.4.1

--- a/tools/braccept/cases/scmp_invalid_pkt.go
+++ b/tools/braccept/cases/scmp_invalid_pkt.go
@@ -56,7 +56,7 @@ func SCMPBadPktLen(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -207,7 +207,7 @@ func SCMPQuoteCut(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -364,7 +364,7 @@ func NoSCMPReplyForSCMPError(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{

--- a/tools/braccept/cases/scmp_invalid_segment_change.go
+++ b/tools/braccept/cases/scmp_invalid_segment_change.go
@@ -60,7 +60,7 @@ func SCMPParentToParentXover(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -232,7 +232,7 @@ func SCMPParentToChildXover(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -405,7 +405,7 @@ func SCMPChildToParentXover(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -579,7 +579,7 @@ func SCMPInternalXover(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(30003),
 		DstPort: layers.UDPPort(30001),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{

--- a/tools/braccept/cases/scmp_invalid_segment_change_local.go
+++ b/tools/braccept/cases/scmp_invalid_segment_change_local.go
@@ -60,7 +60,7 @@ func SCMPParentToParentLocalXover(artifactsDir string, mac hash.Hash) runner.Cas
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -232,7 +232,7 @@ func SCMPParentToChildLocalXover(artifactsDir string, mac hash.Hash) runner.Case
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -405,7 +405,7 @@ func SCMPChildToParentLocalXover(artifactsDir string, mac hash.Hash) runner.Case
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{

--- a/tools/braccept/cases/scmp_traceroute.go
+++ b/tools/braccept/cases/scmp_traceroute.go
@@ -56,7 +56,7 @@ func SCMPTracerouteIngress(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -197,7 +197,7 @@ func SCMPTracerouteIngressConsDir(artifactsDir string, mac hash.Hash) runner.Cas
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -342,7 +342,7 @@ func SCMPTracerouteEgress(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -483,7 +483,7 @@ func SCMPTracerouteEgressConsDir(artifactsDir string, mac hash.Hash) runner.Case
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -632,7 +632,7 @@ func SCMPTracerouteEgressAfterXover(artifactsDir string, mac hash.Hash) runner.C
 		SrcPort: layers.UDPPort(30003),
 		DstPort: layers.UDPPort(30001),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{
@@ -786,7 +786,7 @@ func SCMPTracerouteInternal(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(30041),
 		DstPort: layers.UDPPort(30001),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	sp := &scion.Decoded{
 		Base: scion.Base{

--- a/tools/braccept/cases/scmp_unknown_hop.go
+++ b/tools/braccept/cases/scmp_unknown_hop.go
@@ -59,7 +59,7 @@ func SCMPUnknownHop(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// pkt0.ParsePacket(`
 	//	SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
@@ -216,7 +216,7 @@ func SCMPUnknownHopEgress(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 
 	// SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
 	// 		ADDR: SrcIA=1-ff00:0:3 Src=172.16.3.1 DstIA=1-ff00:0:f1 Dst=172.16.16.1

--- a/tools/braccept/cases/svc.go
+++ b/tools/braccept/cases/svc.go
@@ -59,7 +59,7 @@ func SVC(artifactsDir string, mac hash.Hash) runner.Case {
 		SrcPort: layers.UDPPort(40000),
 		DstPort: layers.UDPPort(50000),
 	}
-	udp.SetNetworkLayerForChecksum(ip)
+	_ = udp.SetNetworkLayerForChecksum(ip)
 	// SCION: NextHdr=UDP CurrInfoF=4 CurrHopF=6 SrcType=IPv4 DstType=IPv4
 	// 		ADDR: SrcIA=1-ff00:0:4 Src=172.16.4.1 DstIA=1-ff00:0:1 Dst=SVC_CS
 	// 		IF_1: ISD=1 Hops=2

--- a/tools/pktgen/cmd/pktgen/main.go
+++ b/tools/pktgen/cmd/pktgen/main.go
@@ -96,7 +96,9 @@ func main() {
 
 func run(cfg flags, dst *snet.UDPAddr) error {
 	defer log.Flush()
-	log.Setup(log.Config{Console: log.ConsoleConfig{Level: cfg.logLevel}})
+	if err := log.Setup(log.Config{Console: log.ConsoleConfig{Level: cfg.logLevel}}); err != nil {
+		return serrors.WrapStr("setting up log", err)
+	}
 
 	raw, err := os.ReadFile(cfg.config)
 	if err != nil {
@@ -112,7 +114,7 @@ func run(cfg flags, dst *snet.UDPAddr) error {
 	}
 	ipv4Layer := parseIPv4(&layersCfg)
 	udpLayer := parseUDP(&layersCfg)
-	udpLayer.SetNetworkLayerForChecksum(ipv4Layer)
+	_ = udpLayer.SetNetworkLayerForChecksum(ipv4Layer)
 	scionLayer := parseSCION(&layersCfg)
 
 	ctx := app.WithSignal(context.Background(), os.Kill)


### PR DESCRIPTION
Change parameter for slayers.UDP/SCMP.SetNetworkLayerForChecksum to *slayers.SCION, from previously gopacket.Layer. Remove error from signature, as explicit type check is no longer needed.

Note that in the gopacket/layer.UDP and TCP layers, SetNetworkLayerForChecksum takes a generic gopacket.Layer for because it accepts either IPv4 or IPv6.
There is no reason to keep this for the slayers layers, there is no common interface covering this functionality.

Cleanup exceptions for errcheck in golangci-lint: removed all files that use SetNetworkLayerForChecksum from exception list, assuming that not checking the return code of this function was the errcheck violation.
Fix various small other errcheck issues in these files; in particular, one frequent case was to explicitly ignore the error from calling gopacket/layers.UDP.SetNetworkLayerForChecksum in the braccept cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4305)
<!-- Reviewable:end -->
