### PR TITLE
github: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# Order is important. The last matching pattern has the most precedence.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# Human summary:
+# - The entire core team should be involved for changes that affect the wire
+#   format(s) and the main public libraries (snet).
+# - Dominik (oncilla) should be involed in changes that affect cppki.
+# - Either Dominik (oncilla) or Lukas (lukedirtwalker) should be involved for
+#   changes that could impact the compatibility between this implementation and
+#   their proprietary system.
+# - Matthias (matzf) would like to be involved for changes to the router
+antlr/** @oncilla @lukedirtwalker
+control/trust/** @oncilla
+gateway/dataplane/encoder.go @oncilla @lukedirtwalker
+pkg/scrypto/** @oncilla
+pkg/segment/** @oncilla @lukedirtwalker
+pkg/slayers/** @scionproto/scion-core-team
+pkg/snet/** @scionproto/scion-core-team
+private/trust/** @oncilla
+proto/** @oncilla @lukedirtwalker
+router/dataplane.go @matzf
+scion-pki/** @oncilla
+tools/braccept/cases/** @scionproto/scion-core-team


### PR DESCRIPTION
Add CODEOWNERS file. For details about the file format, see https://help.github.com/articles/about-codeowners/

The overall owner over the implementation is the SCION Association's Technical Committee Implementation, represented as @scionproto/scion-core-team. Note that the CODEOWNERS file does not contain a '*' pattern to specify this, as this would notify the entire core team by default. Instead, we only define owners for specific modules that require particular attention.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4306)
<!-- Reviewable:end -->
