### PR TITLE
control: close connection in SVC resolver

### DIFF
--- a/private/svc/BUILD.bazel
+++ b/private/svc/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/addr:go_default_library",
+        "//pkg/log:go_default_library",
         "//pkg/private/common:go_default_library",
         "//pkg/private/serrors:go_default_library",
         "//pkg/proto/control_plane:go_default_library",

--- a/private/svc/internal/ctxconn/ctxconn_test.go
+++ b/private/svc/internal/ctxconn/ctxconn_test.go
@@ -34,7 +34,8 @@ func TestCloseConeOnDone(t *testing.T) {
 		closer := mock_ctxconn.NewMockDeadlineCloser(ctrl)
 		closer.EXPECT().Close()
 		cancelFunc := CloseConnOnDone(context.Background(), closer)
-		cancelFunc()
+		err := cancelFunc()
+		assert.NoError(t, err)
 	})
 	t.Run("close error is returned", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -54,7 +55,8 @@ func TestCloseConeOnDone(t *testing.T) {
 		closer := mock_ctxconn.NewMockDeadlineCloser(ctrl)
 		closer.EXPECT().Close()
 		cancelFunc := CloseConnOnDone(ctx, closer)
-		cancelFunc()
+		err := cancelFunc()
+		assert.NoError(t, err)
 	})
 
 	t.Run("if deadline expires, close is called once", func(t *testing.T) {
@@ -62,12 +64,13 @@ func TestCloseConeOnDone(t *testing.T) {
 		defer ctrl.Finish()
 		deadline := time.Now().Add(20 * time.Millisecond)
 		ctx, ctxCancelF := context.WithDeadline(context.Background(), deadline)
-		defer ctxCancelF()
+
 		closer := mock_ctxconn.NewMockDeadlineCloser(ctrl)
 		closer.EXPECT().Close()
 		closer.EXPECT().SetDeadline(deadline)
 		cancelFunc := CloseConnOnDone(ctx, closer)
-		<-ctx.Done() // Wait context canceled due to Deadline
-		cancelFunc()
+		ctxCancelF() // Pretend that we hit the deadline
+		err := cancelFunc()
+		assert.NoError(t, err)
 	})
 }

--- a/private/svc/internal/ctxconn/ctxconn_test.go
+++ b/private/svc/internal/ctxconn/ctxconn_test.go
@@ -16,6 +16,7 @@ package ctxconn
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -25,15 +26,25 @@ import (
 	"github.com/scionproto/scion/private/svc/internal/ctxconn/mock_ctxconn"
 )
 
-const baseUnit = time.Millisecond
-
 func TestCloseConeOnDone(t *testing.T) {
 
-	t.Run("if no deadline and no ctx canceled, close it not called", func(t *testing.T) {
+	t.Run("if no deadline and no ctx canceled, close is called once", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		cancelFunc := CloseConnOnDone(context.Background(), nil)
-		assert.NotPanics(t, func() { cancelFunc() })
+		closer := mock_ctxconn.NewMockDeadlineCloser(ctrl)
+		closer.EXPECT().Close()
+		cancelFunc := CloseConnOnDone(context.Background(), closer)
+		cancelFunc()
+	})
+	t.Run("close error is returned", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		closer := mock_ctxconn.NewMockDeadlineCloser(ctrl)
+		testErr := errors.New("test")
+		closer.EXPECT().Close().Return(testErr)
+		cancelFunc := CloseConnOnDone(context.Background(), closer)
+		err := cancelFunc()
+		assert.Equal(t, testErr, err)
 	})
 	t.Run("if no deadline and ctx canceled, close is called once", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -43,20 +54,20 @@ func TestCloseConeOnDone(t *testing.T) {
 		closer := mock_ctxconn.NewMockDeadlineCloser(ctrl)
 		closer.EXPECT().Close()
 		cancelFunc := CloseConnOnDone(ctx, closer)
-		time.Sleep(20 * baseUnit)
 		cancelFunc()
 	})
 
 	t.Run("if deadline expires, close is called once", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
-		deadline := time.Now().Add(0)
-		ctx, cancelF := context.WithDeadline(context.Background(), deadline)
-		defer cancelF()
+		deadline := time.Now().Add(20 * time.Millisecond)
+		ctx, ctxCancelF := context.WithDeadline(context.Background(), deadline)
+		defer ctxCancelF()
 		closer := mock_ctxconn.NewMockDeadlineCloser(ctrl)
 		closer.EXPECT().Close()
 		closer.EXPECT().SetDeadline(deadline)
-		CloseConnOnDone(ctx, closer)
-		time.Sleep(20 * baseUnit)
+		cancelFunc := CloseConnOnDone(ctx, closer)
+		<-ctx.Done() // Wait context canceled due to Deadline
+		cancelFunc()
 	})
 }

--- a/private/svc/resolver_test.go
+++ b/private/svc/resolver_test.go
@@ -68,6 +68,7 @@ func TestResolver(t *testing.T) {
 		mockPacketDispatcherService.EXPECT().Register(gomock.Any(), srcIA,
 			&net.UDPAddr{IP: net.IP{192, 0, 2, 1}},
 			addr.SvcNone).Return(mockConn, uint16(42), nil)
+		mockConn.EXPECT().Close()
 		mockRoundTripper := mock_svc.NewMockRoundTripper(ctrl)
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).Do(


### PR DESCRIPTION
When performing a service address resolution with `svc.Resolver.LookupSVC`, a new connection was opened but never closed.
One possible reason for this bug was that the unclear responsibility for closing the connection; the `svc.RoundTripper.RoundTrip` function closes the connection if the context ends, but not otherwise.

Fix this by always closing the conn in `CloseConnOnDone`.
The cancel function of `CloseConnOnDone` now also blocks until the connection is closed (relevant mostly for testing) and returns any errors from closing.
Also move the `CloseConnOnDone` to `LookupSVC`, so the responsibility for closing the connection is right next to where it's opened.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4314)
<!-- Reviewable:end -->
