### PR TITLE
seg: fix AddASEntry with multiple PeerEntries

### DIFF
--- a/pkg/segment/seg.go
+++ b/pkg/segment/seg.go
@@ -276,6 +276,7 @@ func (ps *PathSegment) AddASEntry(ctx context.Context, asEntry ASEntry, signer S
 		Extensions:  extensionsToPB(asEntry.Extensions),
 	}
 	for _, peer := range asEntry.PeerEntries {
+		peer := peer
 		asEntryPB.PeerEntries = append(asEntryPB.PeerEntries,
 			&cppb.PeerEntry{
 				PeerIsdAs:     uint64(peer.Peer),

--- a/pkg/segment/seg_test.go
+++ b/pkg/segment/seg_test.go
@@ -39,6 +39,8 @@ var (
 	as111 = xtest.MustParseIA("1-ff00:0:111")
 	as112 = xtest.MustParseIA("1-ff00:0:112")
 	as113 = xtest.MustParseIA("1-ff00:0:113")
+	as211 = xtest.MustParseIA("2-ff00:0:211")
+	as311 = xtest.MustParseIA("3-ff00:0:311")
 )
 
 func TestPathSegmentAddASEntry(t *testing.T) {
@@ -84,6 +86,29 @@ func TestPathSegmentAddASEntry(t *testing.T) {
 				},
 				IngressMTU: 1442,
 			},
+			PeerEntries: []PeerEntry{
+				{
+					Peer:          as211,
+					PeerInterface: 2112,
+					PeerMTU:       1501,
+					HopField: HopField{
+						ConsIngress: 1221,
+						ConsEgress:  21,
+						ExpTime:     60,
+						MAC:         [path.MacLen]byte{0x44, 0x44, 0x44, 0x44, 0x44, 0x44},
+					},
+				}, {
+					Peer:          as311,
+					PeerInterface: 3112,
+					PeerMTU:       1502,
+					HopField: HopField{
+						ConsIngress: 1231,
+						ConsEgress:  21,
+						ExpTime:     59,
+						MAC:         [path.MacLen]byte{0x55, 0x55, 0x55, 0x55, 0x55, 0x55},
+					},
+				},
+			},
 		},
 	}
 	var keyPairs []keyPair
@@ -103,6 +128,7 @@ func TestPathSegmentAddASEntry(t *testing.T) {
 		newID, newFullID := ps.ID(), ps.FullID()
 		assert.NotEqual(t, id, newID)
 		assert.NotEqual(t, fullID, newFullID)
+
 	}
 
 	for i, kp := range keyPairs {
@@ -112,6 +138,7 @@ func TestPathSegmentAddASEntry(t *testing.T) {
 
 	c, err := BeaconFromPB(PathSegmentToPB(ps))
 	require.NoError(t, err)
+	assert.Equal(t, c, ps)
 	for i, kp := range keyPairs {
 		err := c.VerifyASEntry(context.Background(), kp, i)
 		require.NoErrorf(t, err, "index: %d", i)


### PR DESCRIPTION
During creating the signed protobuf body for an ASEntry in PathSegment.AddASentry, a reference to a member of the loop variable (`peer.HopField.MAC[:]`) was stored into newly created protobuf PeerEntries. As a result, all protobuf PeerEntries ended up with the same Mac buffer reference.
Fixed by the usual `peer := peer`.

Add tests for the case of multiple peers, both on the beacon extender and the path segment level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4315)
<!-- Reviewable:end -->
