### PR TITLE
pkt/spao: support empty path value as input for SPAO MAC computation

### DIFF
--- a/pkg/spao/BUILD.bazel
+++ b/pkg/spao/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/private/util:go_default_library",
         "//pkg/slayers:go_default_library",
         "//pkg/slayers/path:go_default_library",
+        "//pkg/slayers/path/empty:go_default_library",
         "//pkg/slayers/path/epic:go_default_library",
         "//pkg/slayers/path/onehop:go_default_library",
         "//pkg/slayers/path/scion:go_default_library",

--- a/pkg/spao/BUILD.bazel
+++ b/pkg/spao/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "//pkg/private/xtest:go_default_library",
         "//pkg/slayers:go_default_library",
         "//pkg/slayers/path:go_default_library",
+        "//pkg/slayers/path/empty:go_default_library",
         "//pkg/slayers/path/epic:go_default_library",
         "//pkg/slayers/path/onehop:go_default_library",
         "//pkg/slayers/path/scion:go_default_library",

--- a/pkg/spao/mac.go
+++ b/pkg/spao/mac.go
@@ -160,7 +160,7 @@ func zeroOutMutablePath(orig path.Path, buf []byte) error {
 		return serrors.WrapStr("serializing path for resetting fields", err)
 	}
 	switch p := orig.(type) {
-	case *empty.Path:
+	case empty.Path:
 		return nil
 	case *scion.Raw:
 		zeroOutWithBase(p.Base, buf)

--- a/pkg/spao/mac.go
+++ b/pkg/spao/mac.go
@@ -25,6 +25,7 @@ import (
 	"github.com/scionproto/scion/pkg/private/serrors"
 	"github.com/scionproto/scion/pkg/slayers"
 	"github.com/scionproto/scion/pkg/slayers/path"
+	"github.com/scionproto/scion/pkg/slayers/path/empty"
 	"github.com/scionproto/scion/pkg/slayers/path/epic"
 	"github.com/scionproto/scion/pkg/slayers/path/onehop"
 	"github.com/scionproto/scion/pkg/slayers/path/scion"
@@ -159,6 +160,8 @@ func zeroOutMutablePath(orig path.Path, buf []byte) error {
 		return serrors.WrapStr("serializing path for resetting fields", err)
 	}
 	switch p := orig.(type) {
+	case *empty.Path:
+		return nil
 	case *scion.Raw:
 		zeroOutWithBase(p.Base, buf)
 		return nil

--- a/pkg/spao/mac_test.go
+++ b/pkg/spao/mac_test.go
@@ -122,7 +122,7 @@ func TestComputeAuthMac(t *testing.T) {
 				SrcIA:        dstIA,
 				DstIA:        dstIA,
 				SrcAddrType:  slayers.T4Ip,
-				RawSrcAddr:   net.IPv4(10, 1, 1, 12).To4(),
+				RawSrcAddr:   net.IPv4(10, 1, 1, 11).To4(),
 				DstAddrType:  slayers.T4Ip,
 				RawDstAddr:   net.IPv4(10, 1, 1, 12).To4(),
 				Path:         empty.Path{},
@@ -138,7 +138,7 @@ func TestComputeAuthMac(t *testing.T) {
 				0x3, 0xf0, 0x12, 0x34, // Version | QoS | FlowID
 				0x0, 0x0, 0x0, 0x0, // PathType |DT |DL |ST |SL | RSV
 				// 3.  SCION Address Header
-				0xa, 0x1, 0x1, 0xc,
+				0xa, 0x1, 0x1, 0xb,
 			}, fooPayload...),
 			assertErr: assert.NoError,
 		},

--- a/pkg/spao/mac_test.go
+++ b/pkg/spao/mac_test.go
@@ -125,7 +125,7 @@ func TestComputeAuthMac(t *testing.T) {
 				RawSrcAddr:   net.IPv4(10, 1, 1, 12).To4(),
 				DstAddrType:  slayers.T4Ip,
 				RawDstAddr:   net.IPv4(10, 1, 1, 12).To4(),
-				Path:         &empty.Path{},
+				Path:         empty.Path{},
 				PathType:     empty.PathType,
 			},
 			pld: fooPayload,


### PR DESCRIPTION
PR #4300 will enable the use of SPAO also for AS internal communication. This PR then implements support for empty path values as inputs for the SPAO MAC computation.

The additional type switch case contains the struct type instead of the pointer type because the snet path method Empty.SetPath sets an empty path struct value as the path of the provided SCION layer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4317)
<!-- Reviewable:end -->
