### PR TITLE
pkt/spao: Fix computation of header length metadata item

### DIFF
--- a/pkg/spao/mac_test.go
+++ b/pkg/spao/mac_test.go
@@ -131,7 +131,7 @@ func TestComputeAuthMac(t *testing.T) {
 			pld: fooPayload,
 			rawMACInput: append([]byte{
 				// 1. Authenticator Option Metadata
-				0x24, 0xca, 0x0, 0xc, // HdrLen | Upper Layer | Upper-Layer Packet Length
+				0x9, 0xca, 0x0, 0xc, // HdrLen | Upper Layer | Upper-Layer Packet Length
 				0x0, 0x0, 0x3, 0xe8, // Algorithm  | Timestamp
 				0x0, 0x6, 0x5, 0x4, // RSV | Sequence Number
 				// 2. SCION Common Header
@@ -166,7 +166,7 @@ func TestComputeAuthMac(t *testing.T) {
 			pld: fooPayload,
 			rawMACInput: append([]byte{
 				// 1. Authenticator Option Metadata
-				0x70, 0xca, 0x0, 0xc, // HdrLen | Upper Layer | Upper-Layer Packet Length
+				0x1c, 0xca, 0x0, 0xc, // HdrLen | Upper Layer | Upper-Layer Packet Length
 				0x0, 0x0, 0x3, 0xe8, // Algorithm  | Timestamp
 				0x0, 0x6, 0x5, 0x4, // RSV | Sequence Number
 				// 2. SCION Common Header
@@ -206,7 +206,6 @@ func TestComputeAuthMac(t *testing.T) {
 				Auth:           make([]byte, 16),
 			},
 			scionL: slayers.SCION{
-				HdrLen:       255,
 				FlowID:       binary.BigEndian.Uint32([]byte{0x00, 0x00, 0x12, 0x34}),
 				TrafficClass: 0xff,
 				NextHdr:      slayers.End2EndClass,
@@ -243,7 +242,7 @@ func TestComputeAuthMac(t *testing.T) {
 			pld: fooPayload,
 			rawMACInput: append([]byte{
 				// 1. Authenticator Option Metadata
-				0x44, 0xca, 0x0, 0xc, // HdrLen | Upper Layer | Upper-Layer Packet Length
+				0x11, 0xca, 0x0, 0xc, // HdrLen | Upper Layer | Upper-Layer Packet Length
 				0x0, 0x0, 0x3, 0xe8, // Algorithm  | Timestamp
 				0x0, 0x6, 0x5, 0x4, // RSV | Sequence Number
 				// 2. SCION Common Header
@@ -272,7 +271,6 @@ func TestComputeAuthMac(t *testing.T) {
 				Auth:           make([]byte, 16),
 			},
 			scionL: slayers.SCION{
-				HdrLen:       255,
 				FlowID:       binary.BigEndian.Uint32([]byte{0x00, 0x00, 0x12, 0x34}),
 				TrafficClass: 0xff,
 				NextHdr:      slayers.End2EndClass,
@@ -300,7 +298,7 @@ func TestComputeAuthMac(t *testing.T) {
 			rawMACInput: append([]byte{
 
 				// 1. Authenticator Option Metadata
-				0x74, 0xca, 0x0, 0xc, // HdrLen | Upper Layer | Upper-Layer Packet Length
+				0x1d, 0xca, 0x0, 0xc, // HdrLen | Upper Layer | Upper-Layer Packet Length
 				0x0, 0x0, 0x3, 0xe8, // Algorithm  | Timestamp
 				0x0, 0x6, 0x5, 0x4, // RSV | Sequence Number
 				// 2. SCION Common Header


### PR DESCRIPTION
The length of the SCION header is part of the metadata flowing into the computation of the MAC value for SPAO [0]. The corresponding common header field value is stored in multiples of 4-bytes [1].

This PR makes sure that indeed multiples of 4-bytes are used instead of the actual length in bytes of the SCION header.

The problem did not appear in testing up till now, because all endpoints are based on the same implementation so far.

[0] https://docs.scion.org/en/latest/protocols/authenticator-option.html#authenticated-data

[1] https://docs.scion.org/en/latest/protocols/scion-header.html#common-header

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4318)
<!-- Reviewable:end -->
