### PR TITLE
lint: enable black formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,9 @@ __pycache__
 
 # VSCode folder
 #########################
-.vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 
 # build files
 #########################

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    //////////////////////
+    // Python
+    //////////////////////
+    "python.languageServer": "Pylance",
+    "python.analysis.exclude": [
+        "**/.bazel-*/**",
+        "**/.idea/**",
+        "**/.git/objects/**",
+        "**/.git/subtree-cache/**",
+        "**/.venvs/**",
+        "**/bazel-*/**"
+    ],
+    "python.envFile": "${workspaceFolder}/.vscode/.env",
+    "python.formatting.provider": "black"
+}

--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,14 @@ licenses:
 antlr:
 	antlr/generate.sh $(GAZELLE_MODE)
 
-.PHONY: lint lint-bazel lint-bazel-buildifier lint-doc lint-doc-mdlint lint-go lint-go-bazel lint-go-gazelle lint-go-golangci lint-go-semgrep lint-openapi lint-openapi-spectral lint-protobuf lint-protobuf-buf
+.PHONY: lint lint-bazel lint-bazel-buildifier lint-doc lint-doc-mdlint lint-go lint-go-bazel lint-go-gazelle lint-go-golangci lint-go-semgrep lint-py lint-py-black lint-openapi lint-openapi-spectral lint-protobuf lint-protobuf-buf
 
 # Enable --keep-going if all goals specified on the command line match the pattern "lint%"
 ifeq ($(filter-out lint%, $(MAKECMDGOALS)), )
 MAKEFLAGS+=--keep-going
 endif
 
-lint: lint-go lint-bazel lint-protobuf lint-openapi lint-doc
+lint: lint-go lint-py lint-bazel lint-protobuf lint-openapi lint-doc
 
 lint-go: lint-go-gazelle lint-go-bazel lint-go-golangci lint-go-semgrep
 
@@ -94,6 +94,12 @@ lint-go-semgrep:
 	$(info ==> $@)
 	@if [ -t 1 ]; then tty=true; else tty=false; fi; \
 		tools/quiet docker run --tty=$$tty --rm -v "${PWD}:/src" returntocorp/semgrep@sha256:3bef9d533a44e6448c43ac38159d61fad89b4b57f63e565a8a55ca265273f5ba semgrep --config=/src/tools/lint/semgrep --error
+
+lint-py: lint-py-black
+
+lint-py-black:
+	$(info ==> $@)
+	docker run --rm --volume ${PWD}:/src --workdir /src pyfound/black:23.1.0 black --check .
 
 lint-bazel: lint-bazel-buildifier
 

--- a/acceptance/common/base.py
+++ b/acceptance/common/base.py
@@ -68,27 +68,37 @@ class TestBase(ABC):
     during setup.
     """
 
-    @cli.switch("executable", NameExecutable, list=True,
-                help="Paths for executables, format name:path")
+    @cli.switch(
+        "executable",
+        NameExecutable,
+        list=True,
+        help="Paths for executables, format name:path",
+    )
     def _set_executables(self, executables):
         self.executables = {name: executable for (name, executable) in executables}
 
-    container_loaders = cli.SwitchAttr("container-loader", ContainerLoader, list=True,
-                                       help="Container loader, format tag#path")
+    container_loaders = cli.SwitchAttr(
+        "container-loader",
+        ContainerLoader,
+        list=True,
+        help="Container loader, format tag#path",
+    )
 
-    artifacts = cli.SwitchAttr("artifacts-dir",
-                               LocalPath,
-                               envname="TEST_UNDECLARED_OUTPUTS_DIR",
-                               default=LocalPath("/tmp/artifacts-scion"),
-                               help="Directory for test artifacts. " +
-                                    "Environment variable TEST_UNDECLARED_OUTPUTS_DIR")
+    artifacts = cli.SwitchAttr(
+        "artifacts-dir",
+        LocalPath,
+        envname="TEST_UNDECLARED_OUTPUTS_DIR",
+        default=LocalPath("/tmp/artifacts-scion"),
+        help="Directory for test artifacts. "
+        + "Environment variable TEST_UNDECLARED_OUTPUTS_DIR",
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._setup_prepare_failed = False
 
     def init(self):
-        """ init is called first. The Test object can be initialized here.
+        """init is called first. The Test object can be initialized here.
         The cli parameters have already been parsed when this is called (contrasting to __init__).
         """
         pass
@@ -113,15 +123,22 @@ class TestBase(ABC):
         pass
 
     def setup_prepare(self):
-        """Unpacks loads local docker images and generates the topology.
-        """
+        """Unpacks loads local docker images and generates the topology."""
         docker.assert_no_networks()
         self._setup_artifacts()
         self._setup_container_loaders()
         # Define where coredumps will be stored.
         print(
-            cmd.docker("run", "--rm", "--privileged", "alpine", "sysctl", "-w",
-                       "kernel.core_pattern=/share/coredump"))
+            cmd.docker(
+                "run",
+                "--rm",
+                "--privileged",
+                "alpine",
+                "sysctl",
+                "-w",
+                "kernel.core_pattern=/share/coredump",
+            )
+        )
 
     def setup_start(self):
         pass
@@ -139,7 +156,7 @@ class TestBase(ABC):
             if idx < 0:
                 logger.error("extracting tag from loader script %s" % tag)
                 continue
-            bazel_tag = o[idx+len("as "):].strip()
+            bazel_tag = o[idx + len("as ") :].strip()
             logger.info("docker tag %s %s" % (bazel_tag, tag))
             cmd.docker("tag", bazel_tag, tag)
 
@@ -153,9 +170,12 @@ class TestBase(ABC):
 
 
 class TestTopogen(TestBase):
-    topo = cli.SwitchAttr("topo", cli.ExistingFile, help="Config file for topogen, .topo")
-    setup_params = cli.SwitchAttr("setup-params", str, list=True,
-                                  help="Additional parameters for topogen")
+    topo = cli.SwitchAttr(
+        "topo", cli.ExistingFile, help="Config file for topogen, .topo"
+    )
+    setup_params = cli.SwitchAttr(
+        "setup-params", str, list=True, help="Additional parameters for topogen"
+    )
 
     def init(self):
         super().init()
@@ -167,6 +187,7 @@ class TestTopogen(TestBase):
 
     def _setup_generate(self):
         """Generate the topology"""
+
         def copy_file(src, dst):
             cmd.mkdir("-p", os.path.dirname(dst))
             cmd.cp("-L", src, dst)
@@ -190,12 +211,10 @@ class TestTopogen(TestBase):
                 *self.setup_params,
             )
         for support_dir in ["logs", "gen-cache", "gen-data", "traces"]:
-            os.makedirs(self.artifacts / support_dir,
-                        exist_ok=True)
+            os.makedirs(self.artifacts / support_dir, exist_ok=True)
 
     def setup_start(self):
-        """Starts the docker containers in the topology.
-        """
+        """Starts the docker containers in the topology."""
         print(self.dc("up", "-d"))
         ps = self.dc("ps")
         print(ps)

--- a/acceptance/common/docker.py
+++ b/acceptance/common/docker.py
@@ -36,13 +36,11 @@ from plumbum import cmd
 
 SCION_DC_FILE = "gen/scion-dc.yml"
 DC_PROJECT = "scion"
-SCION_TESTING_DOCKER_ASSERTIONS_OFF = 'SCION_TESTING_DOCKER_ASSERTIONS_OFF'
+SCION_TESTING_DOCKER_ASSERTIONS_OFF = "SCION_TESTING_DOCKER_ASSERTIONS_OFF"
 
 
 class Compose(object):
-    def __init__(self,
-                 project: str = DC_PROJECT,
-                 compose_file: str = SCION_DC_FILE):
+    def __init__(self, project: str = DC_PROJECT, compose_file: str = SCION_DC_FILE):
         self.project = project
         self.compose_file = compose_file
 
@@ -52,7 +50,11 @@ class Compose(object):
         try:
             res = subprocess.run(
                 ["docker-compose", "-f", self.compose_file, "-p", self.project, *args],
-                check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8")
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                encoding="utf-8",
+            )
         except subprocess.CalledProcessError as e:
             raise _CalledProcessErrorWithOutput(e) from None
         return res.stdout
@@ -65,18 +67,22 @@ class Compose(object):
             # Collect logs.
             dst_f = out_p / "%s.log" % svc
             with open(dst_f, "w") as log_file:
-                cmd.docker.run(args=("logs", svc), stdout=log_file,
-                               stderr=subprocess.STDOUT, retcode=None)
+                cmd.docker.run(
+                    args=("logs", svc),
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    retcode=None,
+                )
             # Collect coredupms.
             coredump_f = out_p / "%s.coredump" % svc
             try:
-                cmd.docker.run(args=("cp", svc+":/share/coredump", coredump_f))
+                cmd.docker.run(args=("cp", svc + ":/share/coredump", coredump_f))
             except Exception:
                 # If the coredump does not exist, do nothing.
                 pass
             # Collect tshark traces.
             try:
-                cmd.docker.run(args=("cp", svc+":/share/tshark", out_p))
+                cmd.docker.run(args=("cp", svc + ":/share/tshark", out_p))
                 cmd.mv(out_p / "tshark" // "*", out_p)
                 cmd.rmdir(out_p / "tshark")
             except Exception:
@@ -146,8 +152,9 @@ class Compose(object):
             The output of the command.
         """
         user = kwargs.get("user", "{}:{}".format(os.getuid(), os.getgid()))
-        return self("exec", "-T", "--user", user, container,
-                    "timeout", "1m", *args, **kwargs)
+        return self(
+            "exec", "-T", "--user", user, container, "timeout", "1m", *args, **kwargs
+        )
 
     def execute_as_user(self, container, user, *args, **kwargs):
         """Executes an arbitrary command in the specified container.
@@ -161,8 +168,7 @@ class Compose(object):
         Returns:
             The output of the command.
         """
-        return self("exec", "-T", "--user", user, container,
-                    "timeout", "1m", *args)
+        return self("exec", "-T", "--user", user, container, "timeout", "1m", *args)
 
 
 class _Network(NamedTuple):
@@ -195,17 +201,17 @@ def assert_no_networks(writer=None):
         plumbum.commands.processes.ProcessExecutionError: One of the docker
             commands returned a non-zero exit code.
     """
-    if os.environ.get(SCION_TESTING_DOCKER_ASSERTIONS_OFF) == '1':
+    if os.environ.get(SCION_TESTING_DOCKER_ASSERTIONS_OFF) == "1":
         if writer:
             writer.write("Docker networking assertions are OFF\n")
         return
 
-    allowed_nets = ['bridge', 'host', 'none']
+    allowed_nets = ["bridge", "host", "none"]
     unexpected_nets = []
     for net in _get_networks():
         if net.name not in allowed_nets:
             if writer:
-                writer.write(f'{net.name} {net.driver} {net.containers}\n')
+                writer.write(f"{net.name} {net.driver} {net.containers}\n")
             unexpected_nets.append(net.name)
     if unexpected_nets:
         raise UnexpectedNetworkError(str(unexpected_nets))
@@ -224,20 +230,20 @@ def _get_networks() -> List[_Network]:
     """
 
     nets = []
-    net_json = cmd.docker('network', 'ls', '-q', '--format={{json .}}')
+    net_json = cmd.docker("network", "ls", "-q", "--format={{json .}}")
     for net_json in net_json.splitlines():
         net = json.loads(net_json)
-        net_inspect_json = cmd.docker('network', 'inspect',
-                                      '--format={{json .}}', net['ID'])
+        net_inspect_json = cmd.docker(
+            "network", "inspect", "--format={{json .}}", net["ID"]
+        )
         net_inspect = json.loads(net_inspect_json)
 
         containers = []
-        for container_id, prop in net_inspect['Containers'].items():
-            ipv4 = prop.get('IPv4Address', '')
-            ipv6 = prop.get('IPv6Address', '')
-            containers.append('%s: %s %s' % (prop['Name'], ipv4, ipv6))
-        nets.append(_Network(net_inspect['Name'], net_inspect['Driver'],
-                             containers))
+        for container_id, prop in net_inspect["Containers"].items():
+            ipv4 = prop.get("IPv4Address", "")
+            ipv6 = prop.get("IPv6Address", "")
+            containers.append("%s: %s %s" % (prop["Name"], ipv4, ipv6))
+        nets.append(_Network(net_inspect["Name"], net_inspect["Driver"], containers))
     return nets
 
 
@@ -246,4 +252,8 @@ class _CalledProcessErrorWithOutput(Exception):
         self.base = base
 
     def __str__(self):
-        return "%s\nSTDOUT:\n%s\nSTDERR:%s\n" % (str(self.base), self.base.stdout, self.base.stderr)
+        return "%s\nSTDOUT:\n%s\nSTDERR:%s\n" % (
+            str(self.base),
+            self.base.stdout,
+            self.base.stderr,
+        )

--- a/acceptance/common/log.py
+++ b/acceptance/common/log.py
@@ -16,5 +16,5 @@ import logging
 
 
 def init_log():
-    fmt = '%(asctime)-15s [%(levelname)-8s] %(message)s'
-    logging.basicConfig(format=fmt, level='INFO')
+    fmt = "%(asctime)-15s [%(levelname)-8s] %(message)s"
+    logging.basicConfig(format=fmt, level="INFO")

--- a/acceptance/common/scion.py
+++ b/acceptance/common/scion.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 def update_toml(change_dict: Dict[str, Any], files: LocalPath):
-    """ Overwrite or set the values in the TOML files with the specified changes.
+    """Overwrite or set the values in the TOML files with the specified changes.
 
     Args:
         change_dict: Change dictionary containing a dot separated path
@@ -50,7 +50,7 @@ def update_toml(change_dict: Dict[str, Any], files: LocalPath):
 
 
 def update_json(change_dict: Dict[str, Any], files: LocalPath):
-    """ Overwrite or set the values in the JSON files with the specified changes.
+    """Overwrite or set the values in the JSON files with the specified changes.
 
     Args:
         change_dict: Change dictionary containing a dot separated path
@@ -101,9 +101,9 @@ def sciond_addr(isd_as: ISD_AS, port: bool = True, gen_dir: str = "gen"):
         ip = addrs[str(isd_as)]
         if not port:
             return ip
-        if ':' in ip:
-            return '[%s]:30255' % ip
-        return '%s:30255' % ip
+        if ":" in ip:
+            return "[%s]:30255" % ip
+        return "%s:30255" % ip
 
 
 def path_to_dict(path: str, val: Any) -> Dict:
@@ -112,7 +112,7 @@ def path_to_dict(path: str, val: Any) -> Dict:
     {'a': {'b': {'c': val}}}
     """
     d = val
-    for k in reversed(path.split('.')):
+    for k in reversed(path.split(".")):
         d = {k: d}
     return d
 

--- a/acceptance/common/scion_test.py
+++ b/acceptance/common/scion_test.py
@@ -22,43 +22,41 @@ from acceptance.common.scion import (
 
 
 class MergeDictTestCase(unittest.TestCase):
-
     def test_add_entry(self):
         actual = self._orig()
-        merge_dict({'trustdb': 'insert'}, actual)
+        merge_dict({"trustdb": "insert"}, actual)
         expected = self._orig()
-        expected['trustdb'] = 'insert'
+        expected["trustdb"] = "insert"
         self.assertEqual(actual, expected, "trustdb not inserted")
 
     def test_replace_leaf_entry(self):
         actual = self._orig()
-        merge_dict(path_to_dict('log.file.level', 'error'), actual)
+        merge_dict(path_to_dict("log.file.level", "error"), actual)
         expected = self._orig()
-        expected['log']['file']['level'] = 'error'
+        expected["log"]["file"]["level"] = "error"
         self.assertEqual(actual, expected, "level not overwritten")
 
     def test_replace_dict(self):
         actual = self._orig()
-        merge_dict(path_to_dict('log.file', 'disable'), actual)
+        merge_dict(path_to_dict("log.file", "disable"), actual)
         expected = self._orig()
-        expected['log']['file'] = 'disable'
+        expected["log"]["file"] = "disable"
         self.assertEqual(actual, expected, "file dict not overwritten")
 
     @staticmethod
     def _orig() -> Dict[str, Any]:
         return {
-            'log': {
-                'file': {
-                    'path': '/var/log/scion/bs.log',
-                    'level': 'info',
+            "log": {
+                "file": {
+                    "path": "/var/log/scion/bs.log",
+                    "level": "info",
                 },
-                'console': False,
+                "console": False,
             }
         }
 
 
 class PathToDictTestCase(unittest.TestCase):
-
     def test_path_to_dict(self):
-        d = path_to_dict('a.b.c', 'd')
-        self.assertEqual(d, {'a': {'b': {'c': 'd'}}}, 'wrong dictionary')
+        d = path_to_dict("a.b.c", "d")
+        self.assertEqual(d, {"a": {"b": {"c": "d"}}}, "wrong dictionary")

--- a/acceptance/hidden_paths/test.py
+++ b/acceptance/hidden_paths/test.py
@@ -83,15 +83,23 @@ class Test(base.TestTopogen):
         # the computed configuration URL
         for as_number in as_numbers:
             hp_config_url = "http://%s:%d/acceptance/hidden_paths/testdata/%s" % (
-                server_ips[as_number], self.http_server_port, hp_configs[as_number])
+                server_ips[as_number],
+                self.http_server_port,
+                hp_configs[as_number],
+            )
 
-            daemon_path = self.artifacts / "gen" / ("ASff00_0_%s" % as_number) \
-                / "sd.toml"
+            daemon_path = (
+                self.artifacts / "gen" / ("ASff00_0_%s" % as_number) / "sd.toml"
+            )
             scion.update_toml({"sd.hidden_path_groups": hp_config_url}, [daemon_path])
 
             control_id = "cs1-ff00_0_%s-1" % as_number
-            control_path = self.artifacts / "gen" / ("ASff00_0_%s" % as_number) \
+            control_path = (
+                self.artifacts
+                / "gen"
+                / ("ASff00_0_%s" % as_number)
                 / ("%s.toml" % control_id)
+            )
             scion.update_toml({"path.hidden_paths_cfg": hp_config_url}, [control_path])
 
             # For simplicity, expose the services in all hidden paths ASes,
@@ -99,17 +107,18 @@ class Test(base.TestTopogen):
             as_dir_path = self.artifacts / "gen" / ("ASff00_0_%s" % as_number)
 
             topology_update = {
-                "hidden_segment_lookup_service.%s.addr" % control_id:
-                    control_addresses[as_number],
-                "hidden_segment_registration_service.%s.addr" % control_id:
-                    control_addresses[as_number],
+                "hidden_segment_lookup_service.%s.addr"
+                % control_id: control_addresses[as_number],
+                "hidden_segment_registration_service.%s.addr"
+                % control_id: control_addresses[as_number],
             }
             topology_file = as_dir_path / "topology.json"
             scion.update_json(topology_update, [topology_file])
 
     def setup_start(self):
         server = http.server.HTTPServer(
-                ("0.0.0.0", self.http_server_port), http.server.SimpleHTTPRequestHandler)
+            ("0.0.0.0", self.http_server_port), http.server.SimpleHTTPRequestHandler
+        )
         server_thread = threading.Thread(target=configuration_server, args=[server])
         server_thread.start()
 
@@ -149,10 +158,19 @@ class Test(base.TestTopogen):
         self._showpaths_run(destination, source, retcode)
 
     def _showpaths_run(self, source_as: str, destination_as: str, retcode: int):
-        print(cmd.docker("exec", "-t", self._testers[source_as], "scion",
-                         "sp", self._ases[destination_as],
-                         "--timeout", "2s",
-                         retcode=retcode))
+        print(
+            cmd.docker(
+                "exec",
+                "-t",
+                self._testers[source_as],
+                "scion",
+                "sp",
+                self._ases[destination_as],
+                "--timeout",
+                "2s",
+                retcode=retcode,
+            )
+        )
 
 
 def configuration_server(server):

--- a/demo/file_transfer/file_transfer.py
+++ b/demo/file_transfer/file_transfer.py
@@ -25,14 +25,33 @@ from acceptance.common import base
 
 
 class Test(base.TestTopogen):
-
     def _refresh_paths(self):
         self.dc("exec", "-T", "tester_1-ff00_0_110", "ping", "-c", "2", "172.20.0.39")
         self.dc("exec", "-T", "tester_1-ff00_0_111", "ping", "-c", "2", "172.20.0.23")
-        self.dc("exec", "-T", "tester_1-ff00_0_110", "scion", "sp", "1-ff00:0:111",
-                "--timeout", "5s", "--refresh", "--no-probe")
-        self.dc("exec", "-T", "tester_1-ff00_0_111", "scion", "sp", "1-ff00:0:110",
-                "--timeout", "5s", "--refresh", "--no-probe")
+        self.dc(
+            "exec",
+            "-T",
+            "tester_1-ff00_0_110",
+            "scion",
+            "sp",
+            "1-ff00:0:111",
+            "--timeout",
+            "5s",
+            "--refresh",
+            "--no-probe",
+        )
+        self.dc(
+            "exec",
+            "-T",
+            "tester_1-ff00_0_111",
+            "scion",
+            "sp",
+            "1-ff00:0:110",
+            "--timeout",
+            "5s",
+            "--refresh",
+            "--no-probe",
+        )
 
     def _set_path_count(self, path_count):
         # Change the gateway config.
@@ -52,8 +71,20 @@ class Test(base.TestTopogen):
         # Send 20M random data, using 20 parallel TCP streams:
         start_time = time.time()
         print(
-            self.dc("exec", "-T", "tester_1-ff00_0_111",
-                    "iperf3", "-c", "172.20.0.23", "-n", "20M", "-P", "20", "--interval", "0")
+            self.dc(
+                "exec",
+                "-T",
+                "tester_1-ff00_0_111",
+                "iperf3",
+                "-c",
+                "172.20.0.23",
+                "-n",
+                "20M",
+                "-P",
+                "20",
+                "--interval",
+                "0",
+            )
         )
         elapsed = time.time() - start_time
         throughput = float(size * 1024 * 1024 * 8) / 1000000 / elapsed
@@ -63,11 +94,13 @@ class Test(base.TestTopogen):
 
     def _get_br_traffic(self, endpoint):
         conn = client.HTTPConnection(endpoint)
-        conn.request('GET', '/metrics')
+        conn.request("GET", "/metrics")
         resp = conn.getresponse()
-        metrics = resp.read().decode('utf-8')
+        metrics = resp.read().decode("utf-8")
         for line in metrics.splitlines():
-            m = re.search(r"""^router_input_bytes_total{interface="internal".*\s(.*)$""", line)
+            m = re.search(
+                r"""^router_input_bytes_total{interface="internal".*\s(.*)$""", line
+            )
             if m is not None:
                 return float(m.group(1)) / 1024 / 1024
         return None
@@ -85,14 +118,19 @@ class Test(base.TestTopogen):
             "container_name": "tc_setup",
             "image": "tester:latest",
             "cap_add": ["NET_ADMIN"],
-            "volumes": [{
-                "type": "bind",
-                "source": os.path.realpath("demo/file_transfer/tc_setup.sh"),
-                "target": "/share/tc_setup.sh",
-            }],
-            "entrypoint": ["/bin/sh", "-exc",
-                           "ls -l /share; /share/tc_setup.sh scn_000 16.0mbit ;"
-                           " /share/tc_setup.sh scn_001 16.0mbit"],
+            "volumes": [
+                {
+                    "type": "bind",
+                    "source": os.path.realpath("demo/file_transfer/tc_setup.sh"),
+                    "target": "/share/tc_setup.sh",
+                }
+            ],
+            "entrypoint": [
+                "/bin/sh",
+                "-exc",
+                "ls -l /share; /share/tc_setup.sh scn_000 16.0mbit ;"
+                " /share/tc_setup.sh scn_001 16.0mbit",
+            ],
             "depends_on": ["scion_br1-ff00_0_111-1", "scion_br1-ff00_0_111-2"],
             "network_mode": "host",
         }
@@ -122,17 +160,29 @@ class Test(base.TestTopogen):
         self._set_path_count(1)
         self._transfer("foo1.txt", 20)
         traffic1 = self._get_br_traffic("172.20.0.34:30442") - traffic1
-        print("traffic on path 1: %f MB (includes SCION and encapsulation overhead)" % traffic1)
+        print(
+            "traffic on path 1: %f MB (includes SCION and encapsulation overhead)"
+            % traffic1
+        )
         traffic2 = self._get_br_traffic("172.20.0.35:30442") - traffic2
-        print("traffic on path 2: %f MB (includes SCION and encapsulation overhead)" % traffic2)
+        print(
+            "traffic on path 2: %f MB (includes SCION and encapsulation overhead)"
+            % traffic2
+        )
         print("--------------------")
         print("using two paths")
         self._set_path_count(2)
         self._transfer("foo2.txt", 20)
         traffic1 = self._get_br_traffic("172.20.0.34:30442") - traffic1
-        print("traffic on path 1: %f MB (includes SCION and encapsulation overhead)" % traffic1)
+        print(
+            "traffic on path 1: %f MB (includes SCION and encapsulation overhead)"
+            % traffic1
+        )
         traffic2 = self._get_br_traffic("172.20.0.35:30442") - traffic2
-        print("traffic on path 2: %f MB (includes SCION and encapsulation overhead)" % traffic2)
+        print(
+            "traffic on path 2: %f MB (includes SCION and encapsulation overhead)"
+            % traffic2
+        )
 
 
 if __name__ == "__main__":

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,9 +18,9 @@ import sphinx_rtd_theme  # noqa
 
 # -- Project information -----------------------------------------------------
 
-project = 'SCION'
-copyright = '2023, Anapaya Systems, ETH Zurich, SCION Association'
-author = 'Anapaya Systems, ETH Zurich, SCION Association'
+project = "SCION"
+copyright = "2023, Anapaya Systems, ETH Zurich, SCION Association"
+author = "Anapaya Systems, ETH Zurich, SCION Association"
 
 
 # -- General configuration ---------------------------------------------------
@@ -29,32 +29,42 @@ author = 'Anapaya Systems, ETH Zurich, SCION Association'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'recommonmark',
-    'sphinx_rtd_theme',
+    "sphinx_rtd_theme",
+    "myst_parser",
+]
+
+myst_enable_extensions = [
+    "colon_fence",
+    "dollarmath",
+    "tasklist",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
-    'venv', 'requirements.in', 'requirements.txt',
-    '_build', 'Thumbs.db', '.DS_Store',
-    'manuals/*/*',  # manuals/<x>.rst uses "include" directive to compose files from subdirectories
+    "venv",
+    "requirements.in",
+    "requirements.txt",
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    "manuals/*/*",  # manuals/<x>.rst uses "include" directive to compose files from subdirectories
 ]
 
-master_doc = 'index'
+master_doc = "index"
 
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['']
+html_static_path = [""]

--- a/tools/gomocks.py
+++ b/tools/gomocks.py
@@ -21,13 +21,15 @@ def rule_to_file(rule: str) -> Tuple[str, str]:
     if ":" not in rule:
         raise ValueError("invalid rule name: '%s', must contain :" % rule)
     package = rule.split(":")[0][2:]
-    return (os.path.join('bazel-bin', package, "mock.go"),
-            os.path.join(package, "mock.go"))
+    return (
+        os.path.join("bazel-bin", package, "mock.go"),
+        os.path.join(package, "mock.go"),
+    )
 
 
 def mock_rules() -> List[str]:
-    bazel = plumbum.local['bazel']
-    raw_rules = bazel("query", "filter(\"go_default_mock$\", kind(gomock, //...))")
+    bazel = plumbum.local["bazel"]
+    raw_rules = bazel("query", 'filter("go_default_mock$", kind(gomock, //...))')
     return raw_rules.splitlines()
 
 
@@ -44,7 +46,7 @@ class GoMocks(cli.Application):
 
     def update_files(self):
         rules = mock_rules()
-        bazel = plumbum.local['bazel']
+        bazel = plumbum.local["bazel"]
         print("building mock files...")
         bazel("build", rules)
         for rule in rules:
@@ -59,9 +61,10 @@ class Diff(GoMocks):
     """
     Checks the difference between generated files and the files in the worktree.
     """
+
     def main(self):
         rules = mock_rules()
-        bazel = plumbum.local['bazel']
+        bazel = plumbum.local["bazel"]
         bazel("build", rules)
         for rule in rules:
             bf, wf = rule_to_file(rule)
@@ -76,10 +79,18 @@ class Add(GoMocks):
     rule, all interfaces need to be specified.
     """
 
-    package = cli.SwitchAttr("--package", str, mandatory=True,
-                             help="The package directory, relatively to the SCION root dir")
-    interfaces = cli.SwitchAttr("--interfaces", str, mandatory=True,
-                                help="The interfaces to mock, separated by comma")
+    package = cli.SwitchAttr(
+        "--package",
+        str,
+        mandatory=True,
+        help="The package directory, relatively to the SCION root dir",
+    )
+    interfaces = cli.SwitchAttr(
+        "--interfaces",
+        str,
+        mandatory=True,
+        help="The interfaces to mock, separated by comma",
+    )
 
     def main(self):
         self.package = self.package.rstrip("/")
@@ -96,11 +107,17 @@ gomock(
     library = "//%s:go_default_library",
     package = "mock_%s",
 )
-""" % (self.interfaces.split(","), self.package, name)
+""" % (
+            self.interfaces.split(","),
+            self.package,
+            name,
+        )
         pathlib.Path(mock_path).mkdir(parents=True, exist_ok=True)
         pathlib.Path(mock_path / "BUILD.bazel").write_text(buildscript)
-        mock_rule = "//%s:go_default_mock" % os.path.join(self.package, "mock_%s" % name)
-        bazel = plumbum.local['bazel']
+        mock_rule = "//%s:go_default_mock" % os.path.join(
+            self.package, "mock_%s" % name
+        )
+        bazel = plumbum.local["bazel"]
         bazel("build", mock_rule)
         bf, wf = rule_to_file(mock_rule)
         cmd.cp(bf, wf)

--- a/tools/licensechecker.py
+++ b/tools/licensechecker.py
@@ -4,8 +4,7 @@ import sys
 import subprocess
 
 license_texts = {
-    "#":
-    """
+    "#": """
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -18,8 +17,7 @@ license_texts = {
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """,
-    "//":
-    """
+    "//": """
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -55,9 +53,9 @@ def main():
     for f in sys.argv[1:]:
         if is_ignored(f):
             continue
-        header = subprocess.check_output("head -15 %s" % f,
-                                         stderr=subprocess.STDOUT,
-                                         shell=True)
+        header = subprocess.check_output(
+            "head -15 %s" % f, stderr=subprocess.STDOUT, shell=True
+        )
         lines = header.splitlines()
         if len(lines) < 1:
             not_ok[f] = "empty file"
@@ -70,8 +68,7 @@ def main():
         if not first_line.startswith(comment_marker):
             comment_marker = "#"
             if not first_line.startswith(comment_marker):
-                not_ok[
-                    f] = "no comment / unknown comment marker: %s" % first_line
+                not_ok[f] = "no comment / unknown comment marker: %s" % first_line
                 continue
         if license_texts[comment_marker] not in header.decode("utf-8"):
             not_ok[f] = "missing licence"

--- a/tools/set_ipv6_addr.py
+++ b/tools/set_ipv6_addr.py
@@ -37,12 +37,12 @@ def ip_missing(addr):  # Can only safely detect the _absences_ of addr
 
 def ip_add(addr, mask):
     if ip_missing(addr):
-        os.system('sudo ip addr replace %s%s dev lo' % (addr, mask))
+        os.system("sudo ip addr replace %s%s dev lo" % (addr, mask))
 
 
 def net_clear(net):
     if not ip_missing(net):
-        os.system('sudo ip addr flush dev lo to %s' % (net))
+        os.system("sudo ip addr flush dev lo to %s" % (net))
 
 
 def set_interfaces():
@@ -50,10 +50,10 @@ def set_interfaces():
     if not os.path.exists(path):
         # no network configuration file, nothing to do
         return
-    with open(path, 'r') as f:
+    with open(path, "r") as f:
         for l in f.readlines():
             split = l.split("= ")
-            if (len(split) < 2):
+            if len(split) < 2:
                 continue
             address = split[1]
             try:
@@ -67,10 +67,18 @@ def set_interfaces():
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-a', '--add', action='store_true',
-                        help='Add IPv6 local host addresses to loopback')
-    parser.add_argument('-d', '--delete', action='store_true',
-                        help='Delete IPv6 local host addresses from loopback')
+    parser.add_argument(
+        "-a",
+        "--add",
+        action="store_true",
+        help="Add IPv6 local host addresses to loopback",
+    )
+    parser.add_argument(
+        "-d",
+        "--delete",
+        action="store_true",
+        help="Delete IPv6 local host addresses from loopback",
+    )
     args = parser.parse_args()
     if args.add:
         ip_add(DEFAULT6_CLIENT, DEFAULT6_MASK)

--- a/tools/topodot.py
+++ b/tools/topodot.py
@@ -55,18 +55,17 @@ core_fmt = """\t\tsubgraph cluster_{isd}_core {{
 class TopoDot(cli.Application):
     show = cli.Flag(
         ["-s", "--show"],
-        help="Run dot and show the graph, " +
-        "instead of only outputting the dot file.",
+        help="Run dot and show the graph, "
+        + "instead of only outputting the dot file.",
     )
 
     def main(self, topofile):
         if self.show:
-            prefix = pathlib.PurePath(topofile).stem + '-'
-            with tempfile.NamedTemporaryFile(prefix=prefix,
-                                             suffix='.png') as tmp:
-                dot = local['dot']
-                xdg_open = local['xdg-open']
-                p = dot.popen(('-Tpng', '-o', tmp.name), encoding='utf-8')
+            prefix = pathlib.PurePath(topofile).stem + "-"
+            with tempfile.NamedTemporaryFile(prefix=prefix, suffix=".png") as tmp:
+                dot = local["dot"]
+                xdg_open = local["xdg-open"]
+                p = dot.popen(("-Tpng", "-o", tmp.name), encoding="utf-8")
                 p.stdin.write(topodot(topofile))
                 p.communicate()
                 xdg_open(tmp.name)
@@ -81,20 +80,21 @@ class Link(NamedTuple):
 
 
 def topodot(topofile) -> str:
-    with open(topofile, 'r') as f:
+    with open(topofile, "r") as f:
         topo_config = yaml.safe_load(f)
 
     links = topo_links(topo_config)
     clusters = topo_clusters(topo_config)
 
     def format_nodes(indent, ases):
-        fmt = '\t' * indent + '"%s"'
-        return '\n'.join(fmt % isd_as for isd_as in ases)
+        fmt = "\t" * indent + '"%s"'
+        return "\n".join(fmt % isd_as for isd_as in ases)
 
     def format_links(indent, links):
-        fmt = '\t' * indent + '"%s" -> "%s"%s'
-        return '\n'.join(fmt % (link.a, link.b, fmt_attrs(link_attrs(link)))
-                         for link in links)
+        fmt = "\t" * indent + '"%s" -> "%s"%s'
+        return "\n".join(
+            fmt % (link.a, link.b, fmt_attrs(link_attrs(link))) for link in links
+        )
 
     formatted_clusters = []
     for isd in sorted(clusters.keys()):
@@ -103,45 +103,46 @@ def topodot(topofile) -> str:
             core=format_nodes(3, clusters[isd]["core"]),
         )
         rest = format_nodes(2, clusters[isd]["noncore"])
-        formatted_clusters.append(isd_fmt.format(isd=isd, core=core,
-                                                 rest=rest))
+        formatted_clusters.append(isd_fmt.format(isd=isd, core=core, rest=rest))
     rest = format_links(1, links)
-    return graph_fmt.format('\n'.join(c for c in formatted_clusters + [rest]))
+    return graph_fmt.format("\n".join(c for c in formatted_clusters + [rest]))
 
 
 def fmt_attrs(attrs: Dict[str, str]) -> str:
     if attrs:
-        return '[' + ';'.join('%s=%s' % (k, v) for k, v in attrs.items()) + ']'
+        return "[" + ";".join("%s=%s" % (k, v) for k, v in attrs.items()) + "]"
     else:
-        return ''
+        return ""
 
 
 def link_attrs(link: Link) -> Dict[str, str]:
     attrs = {
-        'taillabel': link.a.ifid,
-        'headlabel': link.b.ifid,
+        "taillabel": link.a.ifid,
+        "headlabel": link.b.ifid,
     }
     if link.type == LinkType.CORE:
-        attrs['dir'] = 'none'
+        attrs["dir"] = "none"
     if link.type == LinkType.PEER:
-        attrs['constraint'] = 'false'
-        attrs['dir'] = 'none'
-        attrs['style'] = 'dotted'
+        attrs["constraint"] = "false"
+        attrs["dir"] = "none"
+        attrs["style"] = "dotted"
     return attrs
 
 
 def topo_links(topo_config) -> List[Link]:
     return [
-        Link(a=LinkEP(link['a']),
-             b=LinkEP(link['b']),
-             type=LinkType[link['linkAtoB'].upper()])
-        for link in topo_config['links']
+        Link(
+            a=LinkEP(link["a"]),
+            b=LinkEP(link["b"]),
+            type=LinkType[link["linkAtoB"].upper()],
+        )
+        for link in topo_config["links"]
     ]
 
 
 def topo_clusters(topo_config) -> Dict[str, Dict[str, List[str]]]:
     clusters = defaultdict(lambda: defaultdict(list))
-    for raw_isd_as, config in topo_config['ASes'].items():
+    for raw_isd_as, config in topo_config["ASes"].items():
         isd_as = TopoID(raw_isd_as)
         if config.get("core"):
             clusters[isd_as.ISD()]["core"].append(str(isd_as))

--- a/tools/topogen.py
+++ b/tools/topogen.py
@@ -32,37 +32,52 @@ from topology.config import (
 
 
 def add_arguments(parser):
-    parser.add_argument('-c', '--topo-config', default=DEFAULT_TOPOLOGY_FILE,
-                        help='Path policy file')
-    parser.add_argument('-d', '--docker', action='store_true',
-                        help='Create a docker-compose configuration')
-    parser.add_argument('-n', '--network',
-                        help='Network to create subnets in (E.g. "127.0.0.0/8"')
-    parser.add_argument('-o', '--output-dir', default=GEN_PATH,
-                        help='Output directory')
-    parser.add_argument('--random-ifids', action='store_true',
-                        help='Generate random IFIDs')
-    parser.add_argument('--docker-registry', help='Specify docker registry to pull images from')
-    parser.add_argument('--image-tag', help='Docker image tag')
-    parser.add_argument('--sig', action='store_true',
-                        help='Generate a SIG per AS (only available with -d, the SIG image needs\
-                        to be built manually e.g. when running acceptance tests)')
-    parser.add_argument('-qos', '--colibri', action='store_true',
-                        help='Generate COLIBRI service')
-    parser.add_argument('--features', help='Feature flags to enable, a comma separated list\
-                        e.g. foo,bar enables foo and bar feature.')
+    parser.add_argument(
+        "-c", "--topo-config", default=DEFAULT_TOPOLOGY_FILE, help="Path policy file"
+    )
+    parser.add_argument(
+        "-d",
+        "--docker",
+        action="store_true",
+        help="Create a docker-compose configuration",
+    )
+    parser.add_argument(
+        "-n", "--network", help='Network to create subnets in (E.g. "127.0.0.0/8"'
+    )
+    parser.add_argument("-o", "--output-dir", default=GEN_PATH, help="Output directory")
+    parser.add_argument(
+        "--random-ifids", action="store_true", help="Generate random IFIDs"
+    )
+    parser.add_argument(
+        "--docker-registry", help="Specify docker registry to pull images from"
+    )
+    parser.add_argument("--image-tag", help="Docker image tag")
+    parser.add_argument(
+        "--sig",
+        action="store_true",
+        help="Generate a SIG per AS (only available with -d, the SIG image needs\
+                        to be built manually e.g. when running acceptance tests)",
+    )
+    parser.add_argument(
+        "-qos", "--colibri", action="store_true", help="Generate COLIBRI service"
+    )
+    parser.add_argument(
+        "--features",
+        help="Feature flags to enable, a comma separated list\
+                        e.g. foo,bar enables foo and bar feature.",
+    )
     return parser
 
 
 def init_features(raw_args):
-    features = getattr(raw_args, 'features')
+    features = getattr(raw_args, "features")
     if features is None:
-        features = ''
+        features = ""
     feature_dict = {}
-    for f in features.split(','):
-        if f != '':
+    for f in features.split(","):
+        if f != "":
             feature_dict[f] = True
-    setattr(raw_args, 'features', feature_dict)
+    setattr(raw_args, "features", feature_dict)
 
 
 def main():

--- a/tools/topology/cert.py
+++ b/tools/topology/cert.py
@@ -38,33 +38,37 @@ class CertGenerator(object):
         arguments and the parsed topo config.
         """
         self.args = args
-        self.pki = local['./bin/scion-pki']
-        if not local.path('./bin/scion-pki').exists():
+        self.pki = local["./bin/scion-pki"]
+        if not local.path("./bin/scion-pki").exists():
             try:
-                self.pki = local[local.which('scion-pki')]
+                self.pki = local[local.which("scion-pki")]
             except CommandNotFound:
                 sys.exit("ERROR: scion-pki executable not found. Run `make` first.")
         self.core_count = collections.defaultdict(int)
 
     def generate(self, topo_dicts):
-        self.pki('testcrypto', '-t', self.args.topo_config, '-o', self.args.output_dir)
+        self.pki("testcrypto", "-t", self.args.topo_config, "-o", self.args.output_dir)
         self._master_keys(topo_dicts)
         self._copy_files(topo_dicts)
 
     def _master_keys(self, topo_dicts):
         for topo_id in topo_dicts:
             base = topo_id.base_dir(self.args.output_dir)
-            write_file(os.path.join(base, 'keys', 'master0.key'),
-                       base64.b64encode(os.urandom(16)).decode())
-            write_file(os.path.join(base, 'keys', 'master1.key'),
-                       base64.b64encode(os.urandom(16)).decode())
+            write_file(
+                os.path.join(base, "keys", "master0.key"),
+                base64.b64encode(os.urandom(16)).decode(),
+            )
+            write_file(
+                os.path.join(base, "keys", "master1.key"),
+                base64.b64encode(os.urandom(16)).decode(),
+            )
 
     def _copy_files(self, topo_dicts):
-        cp = local['cp']
-        mkdir = local['mkdir']
+        cp = local["cp"]
+        mkdir = local["mkdir"]
         # Copy the certs and key dir for all elements.
         for topo_id, as_topo in topo_dicts.items():
             base = local.path(self.args.output_dir)
             as_dir = local.path(topo_id.base_dir(self.args.output_dir))
-            mkdir('-p', as_dir / 'certs')
-            cp(base // '*/trcs/*.trc', as_dir / 'certs/')
+            mkdir("-p", as_dir / "certs")
+            cp(base // "*/trcs/*.trc", as_dir / "certs/")

--- a/tools/topology/common.py
+++ b/tools/topology/common.py
@@ -24,7 +24,7 @@ import subprocess
 from topology.scion_addr import ISD_AS
 from topology.net import AddressProxy, NetworkDescription, IPNetwork
 
-COMMON_DIR = 'endhost'
+COMMON_DIR = "endhost"
 
 SCION_SERVICE_NAMES = (
     "control_service",
@@ -33,14 +33,14 @@ SCION_SERVICE_NAMES = (
     "colibri_service",
 )
 
-BR_CONFIG_NAME = 'br.toml'
-BS_CONFIG_NAME = 'bs.toml'
-CS_CONFIG_NAME = 'cs.toml'
-PS_CONFIG_NAME = 'ps.toml'
-CO_CONFIG_NAME = 'co.toml'
-SD_CONFIG_NAME = 'sd.toml'
-DISP_CONFIG_NAME = 'disp.toml'
-SIG_CONFIG_NAME = 'sig.toml'
+BR_CONFIG_NAME = "br.toml"
+BS_CONFIG_NAME = "bs.toml"
+CS_CONFIG_NAME = "cs.toml"
+PS_CONFIG_NAME = "ps.toml"
+CO_CONFIG_NAME = "co.toml"
+SD_CONFIG_NAME = "sd.toml"
+DISP_CONFIG_NAME = "disp.toml"
+SIG_CONFIG_NAME = "sig.toml"
 
 SD_API_PORT = 30255
 
@@ -71,7 +71,7 @@ class ArgsTopoDicts(ArgsBase):
         self.topo_dicts = topo_dicts
 
 
-LinkType = Enum('LinkType', ['CHILD', 'PARENT', 'PEER', 'CORE'])
+LinkType = Enum("LinkType", ["CHILD", "PARENT", "PEER", "CORE"])
 
 
 class TopoID(ISD_AS):
@@ -103,54 +103,52 @@ def prom_addr(addr: str, port: int) -> str:
 
 
 def split_host_port(addr: str) -> Tuple[str, int]:
-    parts = urlsplit('//' + addr)
+    parts = urlsplit("//" + addr)
     if parts.port is None:
         raise ValueError("missing port in addr: {}".format(addr))
     # first remove the port, and strip ipv6 brackets:
-    ip = parts.netloc.rsplit(sep=':{}'.format(parts.port),
-                             maxsplit=1)[0].strip('[]')
+    ip = parts.netloc.rsplit(sep=":{}".format(parts.port), maxsplit=1)[0].strip("[]")
     return (ip, parts.port)
 
 
 def join_host_port(host: str, port: int) -> str:
     ip = ip_address(host)
     if ip.version == 4:
-        return '{}:{}'.format(host, port)
-    return '[{}]:{}'.format(host, port)
+        return "{}:{}".format(host, port)
+    return "[{}]:{}".format(host, port)
 
 
-def sciond_ip(docker, topo_id, networks: Mapping[IPNetwork,
-                                                 NetworkDescription]):
+def sciond_ip(docker, topo_id, networks: Mapping[IPNetwork, NetworkDescription]):
     for net_desc in networks.values():
         for prog, ip_net in net_desc.ip_net.items():
-            if prog == 'sd%s' % topo_id.file_fmt():
+            if prog == "sd%s" % topo_id.file_fmt():
                 return ip_net.ip
     return None
 
 
-def prom_addr_dispatcher(docker, topo_id,
-                         networks: Mapping[IPNetwork,
-                                           NetworkDescription], port, name):
+def prom_addr_dispatcher(
+    docker, topo_id, networks: Mapping[IPNetwork, NetworkDescription], port, name
+):
     if not docker:
         return "[127.0.0.1]:%s" % port
-    target_name = ''
-    if name.startswith('disp_br'):
-        target_name = 'br%s%s_internal' % (topo_id.file_fmt(), name[-2:])
-    elif name.startswith('disp_sig'):
-        target_name = 'sig%s' % topo_id.file_fmt()
+    target_name = ""
+    if name.startswith("disp_br"):
+        target_name = "br%s%s_internal" % (topo_id.file_fmt(), name[-2:])
+    elif name.startswith("disp_sig"):
+        target_name = "sig%s" % topo_id.file_fmt()
     else:
-        target_name = 'disp%s' % topo_id.file_fmt()
+        target_name = "disp%s" % topo_id.file_fmt()
     for net_desc in networks.values():
         if target_name in net_desc.ip_net:
-            return '[%s]:%s' % (net_desc.ip_net[target_name].ip, port)
+            return "[%s]:%s" % (net_desc.ip_net[target_name].ip, port)
     return None
 
 
 def docker_image(args, image):
     if args.docker_registry:
-        image = '%s/%s' % (args.docker_registry, image)
+        image = "%s/%s" % (args.docker_registry, image)
     if args.image_tag:
-        image = '%s:%s' % (image, args.image_tag)
+        image = "%s:%s" % (image, args.image_tag)
     return image
 
 
@@ -163,7 +161,7 @@ def docker_host(docker, addr=None):
 
 
 def docker_ip():
-    return subprocess.check_output(['tools/docker-ip']).decode("utf-8").strip()
+    return subprocess.check_output(["tools/docker-ip"]).decode("utf-8").strip()
 
 
 def remote_nets(networks, topo_id):
@@ -175,17 +173,17 @@ def remote_nets(networks, topo_id):
     """
     rem_nets = []
     for key in networks:
-        if 'sig' in key and topo_id.file_fmt() not in key:
-            rem_nets.append(str(networks[key][0]['net']))
-    return ','.join(rem_nets)
+        if "sig" in key and topo_id.file_fmt() not in key:
+            rem_nets.append(str(networks[key][0]["net"]))
+    return ",".join(rem_nets)
 
 
 def sciond_name(topo_id):
-    return 'sd%s' % topo_id.file_fmt()
+    return "sd%s" % topo_id.file_fmt()
 
 
 def sciond_svc_name(topo_id):
-    return 'scion_%s' % sciond_name(topo_id)
+    return "scion_%s" % sciond_name(topo_id)
 
 
 def json_default(o):

--- a/tools/topology/config.py
+++ b/tools/topology/config.py
@@ -146,8 +146,13 @@ class ConfigGenerator(object):
         return topo_gen.generate()
 
     def _topo_args(self):
-        return TopoGenArgs(self.args, self.topo_config, self.subnet_gen4,
-                           self.subnet_gen6, self.default_mtu)
+        return TopoGenArgs(
+            self.args,
+            self.topo_config,
+            self.subnet_gen4,
+            self.subnet_gen6,
+            self.default_mtu,
+        )
 
     def _generate_supervisor(self, topo_dicts):
         args = self._supervisor_args(topo_dicts)
@@ -182,9 +187,9 @@ class ConfigGenerator(object):
             for path, value in ca_files[int(isd)].items():
                 write_file(os.path.join(base, path), value.decode())
 
-    def _write_networks_conf(self,
-                             networks: Mapping[IPNetwork, NetworkDescription],
-                             out_file: str):
+    def _write_networks_conf(
+        self, networks: Mapping[IPNetwork, NetworkDescription], out_file: str
+    ):
         config = configparser.ConfigParser(interpolation=None)
         for net, net_desc in networks.items():
             sub_conf = {}
@@ -195,7 +200,9 @@ class ConfigGenerator(object):
         config.write(text)
         write_file(os.path.join(self.args.output_dir, out_file), text.getvalue())
 
-    def _write_sciond_conf(self, networks: Mapping[IPNetwork, NetworkDescription], out_file: str):
+    def _write_sciond_conf(
+        self, networks: Mapping[IPNetwork, NetworkDescription], out_file: str
+    ):
         d = dict()
         for net_desc in networks.values():
             for prog, ip_net in net_desc.ip_net.items():
@@ -206,11 +213,12 @@ class ConfigGenerator(object):
             json.dump(d, f, sort_keys=True, indent=4)
 
 
-def remove_v4_nets(nets: Mapping[IPNetwork, NetworkDescription]
-                   ) -> Mapping[IPNetwork, NetworkDescription]:
+def remove_v4_nets(
+    nets: Mapping[IPNetwork, NetworkDescription]
+) -> Mapping[IPNetwork, NetworkDescription]:
     res = {}
     for net, net_desc in nets.items():
-        if net_desc.name.endswith('_v4'):
+        if net_desc.name.endswith("_v4"):
             continue
         res[net] = net_desc
     return res

--- a/tools/topology/defines.py
+++ b/tools/topology/defines.py
@@ -18,7 +18,7 @@ Contains constant definitions used throughout the codebase.
 """
 
 #: Generated files directory
-GEN_PATH = 'gen'
+GEN_PATH = "gen"
 #: Topology configuration
 TOPO_FILE = "topology.json"
 #: Networks config

--- a/tools/topology/docker.py
+++ b/tools/topology/docker.py
@@ -16,8 +16,10 @@
 import copy
 import os
 from typing import Mapping
+
 # External packages
 import yaml
+
 # SCION
 from topology.defines import DOCKER_COMPOSE_CONFIG_VERSION
 from topology.util import write_file
@@ -31,12 +33,13 @@ from topology.docker_utils import DockerUtilsGenArgs, DockerUtilsGenerator
 from topology.net import NetworkDescription, IPNetwork
 from topology.sig import SIGGenArgs, SIGGenerator
 
-DOCKER_CONF = 'scion-dc.yml'
+DOCKER_CONF = "scion-dc.yml"
 
 
 class DockerGenArgs(ArgsTopoDicts):
-    def __init__(self, args, topo_dicts,
-                 networks: Mapping[IPNetwork, NetworkDescription]):
+    def __init__(
+        self, args, topo_dicts, networks: Mapping[IPNetwork, NetworkDescription]
+    ):
         """
         :param object args: Contains the passed command line arguments as named attributes.
         :param dict topo_dicts: The generated topo dicts from TopoGenerator.
@@ -53,38 +56,41 @@ class DockerGenerator(object):
         """
         self.args = args
         self.dc_conf = {
-            'version': DOCKER_COMPOSE_CONFIG_VERSION,
-            'services': {},
-            'networks': {},
-            'volumes': {}
+            "version": DOCKER_COMPOSE_CONFIG_VERSION,
+            "services": {},
+            "networks": {},
+            "volumes": {},
         }
         self.elem_networks = {}
         self.bridges = {}
-        self.output_base = os.environ.get('SCION_OUTPUT_BASE', os.getcwd())
-        self.user = '%d:%d' % (os.getuid(), os.getgid())
-        self.prefix = 'scion_'
+        self.output_base = os.environ.get("SCION_OUTPUT_BASE", os.getcwd())
+        self.user = "%d:%d" % (os.getuid(), os.getgid())
+        self.prefix = "scion_"
 
     def generate(self):
         self._create_networks()
         for topo_id, topo in self.args.topo_dicts.items():
-            base = os.path.join(self.output_base,
-                                topo_id.base_dir(self.args.output_dir))
+            base = os.path.join(
+                self.output_base, topo_id.base_dir(self.args.output_dir)
+            )
             self._gen_topo(topo_id, topo, base)
         if self.args.sig:
             self._gen_sig()
         docker_utils_gen = DockerUtilsGenerator(self._docker_utils_args())
         self.dc_conf = docker_utils_gen.generate()
 
-        write_file(os.path.join(self.args.output_dir, DOCKER_CONF),
-                   yaml.dump(self.dc_conf, default_flow_style=False))
+        write_file(
+            os.path.join(self.args.output_dir, DOCKER_CONF),
+            yaml.dump(self.dc_conf, default_flow_style=False),
+        )
 
     def _docker_utils_args(self):
-        return DockerUtilsGenArgs(self.args, self.dc_conf, self.bridges,
-                                  self.elem_networks)
+        return DockerUtilsGenArgs(
+            self.args, self.dc_conf, self.bridges, self.elem_networks
+        )
 
     def _sig_args(self):
-        return SIGGenArgs(self.args, self.dc_conf, self.bridges,
-                          self.elem_networks)
+        return SIGGenArgs(self.args, self.dc_conf, self.bridges, self.elem_networks)
 
     def _gen_topo(self, topo_id, topo, base):
         self._dispatcher_conf(topo_id, topo, base)
@@ -103,7 +109,7 @@ class DockerGenerator(object):
         for network, net_desc in self.args.networks.items():
             if network.version == 6:
                 continue
-            if net_desc.name.endswith('_v4'):
+            if net_desc.name.endswith("_v4"):
                 v4nets[net_desc.name[:-3]] = network
                 ignore_nets.append(network)
 
@@ -113,163 +119,137 @@ class DockerGenerator(object):
             for elem in net_desc.ip_net:
                 if elem not in self.elem_networks:
                     self.elem_networks[elem] = []
-                ipv = 'ipv4'
+                ipv = "ipv4"
                 ip = net_desc.ip_net[elem].ip
                 if ip.version == 6:
-                    ipv = 'ipv6'
-                self.elem_networks[elem].append({'net': str(network), ipv: ip})
+                    ipv = "ipv6"
+                self.elem_networks[elem].append({"net": str(network), ipv: ip})
             # Create docker networks
-            prefix = 'scn_'
+            prefix = "scn_"
             net_name = "%s%03d" % (prefix, len(self.bridges))
             self.bridges[str(network)] = net_name
-            self.dc_conf['networks'][net_name] = {
-                'ipam': {
-                    'config': [{
-                        'subnet': str(network)
-                    }]
-                },
-                'driver': 'bridge',
-                'driver_opts': {
-                    'com.docker.network.bridge.name': net_name
-                }
+            self.dc_conf["networks"][net_name] = {
+                "ipam": {"config": [{"subnet": str(network)}]},
+                "driver": "bridge",
+                "driver_opts": {"com.docker.network.bridge.name": net_name},
             }
             if net_desc.name in v4nets:
                 v4_net = v4nets[net_desc.name]
-                self.dc_conf['networks'][net_name]['ipam']['config'].append(
-                    {'subnet': str(v4_net)})
+                self.dc_conf["networks"][net_name]["ipam"]["config"].append(
+                    {"subnet": str(v4_net)}
+                )
             if network.version == 6:
-                self.dc_conf['networks'][net_name]['enable_ipv6'] = True
+                self.dc_conf["networks"][net_name]["enable_ipv6"] = True
 
     def _br_conf(self, topo_id, topo, base):
         for k, _ in topo.get("border_routers", {}).items():
-            image = docker_image(self.args, 'posix-router')
+            image = docker_image(self.args, "posix-router")
             entry = {
-                'image': image,
-                'container_name': self.prefix + k,
-                'networks': {},
-                'user': self.user,
-                'volumes':
-                ['%s:/share/conf:ro' % base],
-                'environment': {
-                    'SCION_EXPERIMENTAL_BFD_DETECT_MULT':
-                    '${SCION_EXPERIMENTAL_BFD_DETECT_MULT}',
-                    'SCION_EXPERIMENTAL_BFD_DESIRED_MIN_TX':
-                    '${SCION_EXPERIMENTAL_BFD_DESIRED_MIN_TX}',
-                    'SCION_EXPERIMENTAL_BFD_REQUIRED_MIN_RX':
-                    '${SCION_EXPERIMENTAL_BFD_REQUIRED_MIN_RX}',
+                "image": image,
+                "container_name": self.prefix + k,
+                "networks": {},
+                "user": self.user,
+                "volumes": ["%s:/share/conf:ro" % base],
+                "environment": {
+                    "SCION_EXPERIMENTAL_BFD_DETECT_MULT": "${SCION_EXPERIMENTAL_BFD_DETECT_MULT}",
+                    "SCION_EXPERIMENTAL_BFD_DESIRED_MIN_TX": "${SCION_EXPERIMENTAL_BFD_DESIRED_MIN_TX}",
+                    "SCION_EXPERIMENTAL_BFD_REQUIRED_MIN_RX": "${SCION_EXPERIMENTAL_BFD_REQUIRED_MIN_RX}",
                 },
-                'command': ['--config', '/share/conf/%s.toml' % k]
+                "command": ["--config", "/share/conf/%s.toml" % k],
             }
             # add data networks:
-            net_keys = [k, k + '_internal']
+            net_keys = [k, k + "_internal"]
             for net_key in net_keys:
                 for net in self.elem_networks[net_key]:
-                    ipv = 'ipv4'
+                    ipv = "ipv4"
                     if ipv not in net:
-                        ipv = 'ipv6'
-                    entry['networks'][self.bridges[net['net']]] = {
-                        '%s_address' % ipv: str(net[ipv])
+                        ipv = "ipv6"
+                    entry["networks"][self.bridges[net["net"]]] = {
+                        "%s_address" % ipv: str(net[ipv])
                     }
-            self.dc_conf['services']['scion_%s' % k] = entry
+            self.dc_conf["services"]["scion_%s" % k] = entry
 
     def _control_service_conf(self, topo_id, topo, base):
         for k in topo.get("control_service", {}).keys():
             entry = {
-                'image':
-                docker_image(self.args, 'control'),
-                'container_name':
-                self.prefix + k,
-                'depends_on': ['scion_disp_%s' % k],
-                'network_mode':
-                'service:scion_disp_%s' % k,
-                'user':
-                self.user,
-                'volumes': [
+                "image": docker_image(self.args, "control"),
+                "container_name": self.prefix + k,
+                "depends_on": ["scion_disp_%s" % k],
+                "network_mode": "service:scion_disp_%s" % k,
+                "user": self.user,
+                "volumes": [
                     self._cache_vol(),
                     self._certs_vol(),
-                    '%s:/share/conf:ro' % base,
+                    "%s:/share/conf:ro" % base,
                     self._disp_vol(k),
                 ],
-                'command': ['--config', '/share/conf/%s.toml' % k]
+                "command": ["--config", "/share/conf/%s.toml" % k],
             }
-            self.dc_conf['services']['scion_%s' % k] = entry
+            self.dc_conf["services"]["scion_%s" % k] = entry
 
     def _dispatcher_conf(self, topo_id, topo, base):
-        image = 'dispatcher'
+        image = "dispatcher"
         base_entry = {
-            'extra_hosts': ['jaeger:%s' % docker_host(self.args.docker)],
-            'image': docker_image(self.args, image),
-            'networks': {},
-            'user': self.user,
-            'volumes': [],
-            'depends_on': {
-                'utils_chowner': {
-                    'condition': 'service_started'
-                },
+            "extra_hosts": ["jaeger:%s" % docker_host(self.args.docker)],
+            "image": docker_image(self.args, image),
+            "networks": {},
+            "user": self.user,
+            "volumes": [],
+            "depends_on": {
+                "utils_chowner": {"condition": "service_started"},
             },
         }
-        keys = (list(topo.get("control_service", {})) +
-                ["tester_%s" % topo_id.file_fmt()])
+        keys = list(topo.get("control_service", {})) + [
+            "tester_%s" % topo_id.file_fmt()
+        ]
         for disp_id in keys:
             entry = copy.deepcopy(base_entry)
             net_key = disp_id
             net = self.elem_networks[net_key][0]
-            ipv = 'ipv4'
+            ipv = "ipv4"
             if ipv not in net:
-                ipv = 'ipv6'
+                ipv = "ipv6"
             ip = str(net[ipv])
-            entry['networks'][self.bridges[net['net']]] = {
-                '%s_address' % ipv: ip
-            }
-            entry['container_name'] = '%sdisp_%s' % (self.prefix, disp_id)
-            entry['volumes'].append(self._disp_vol(disp_id))
-            conf = '%s:/share/conf:rw' % base
-            entry['volumes'].append(conf)
-            entry['command'] = [
-                '--config', '/share/conf/disp_%s.toml' % disp_id
-            ]
+            entry["networks"][self.bridges[net["net"]]] = {"%s_address" % ipv: ip}
+            entry["container_name"] = "%sdisp_%s" % (self.prefix, disp_id)
+            entry["volumes"].append(self._disp_vol(disp_id))
+            conf = "%s:/share/conf:rw" % base
+            entry["volumes"].append(conf)
+            entry["command"] = ["--config", "/share/conf/disp_%s.toml" % disp_id]
 
-            self.dc_conf['services']['scion_disp_%s' % disp_id] = entry
-            self.dc_conf['volumes'][self._disp_vol(disp_id).split(':')
-                                    [0]] = None
+            self.dc_conf["services"]["scion_disp_%s" % disp_id] = entry
+            self.dc_conf["volumes"][self._disp_vol(disp_id).split(":")[0]] = None
 
     def _sciond_conf(self, topo_id, base):
         name = sciond_svc_name(topo_id)
         net = self.elem_networks["sd" + topo_id.file_fmt()][0]
-        ipv = 'ipv4'
+        ipv = "ipv4"
         if ipv not in net:
-            ipv = 'ipv6'
+            ipv = "ipv6"
         ip = str(net[ipv])
-        disp_id = 'cs%s-1' % topo_id.file_fmt()
+        disp_id = "cs%s-1" % topo_id.file_fmt()
         entry = {
-            'extra_hosts': ['jaeger:%s' % docker_host(self.args.docker)],
-            'image':
-            docker_image(self.args, 'daemon'),
-            'container_name':
-            '%ssd%s' % (self.prefix, topo_id.file_fmt()),
-            'depends_on': ['scion_disp_%s' % disp_id],
-            'user':
-            self.user,
-            'volumes': [
+            "extra_hosts": ["jaeger:%s" % docker_host(self.args.docker)],
+            "image": docker_image(self.args, "daemon"),
+            "container_name": "%ssd%s" % (self.prefix, topo_id.file_fmt()),
+            "depends_on": ["scion_disp_%s" % disp_id],
+            "user": self.user,
+            "volumes": [
                 self._disp_vol(disp_id),
                 self._cache_vol(),
                 self._certs_vol(),
-                '%s:/share/conf:ro' % base
+                "%s:/share/conf:ro" % base,
             ],
-            'networks': {
-                self.bridges[net['net']]: {
-                    '%s_address' % ipv: ip
-                }
-            },
-            'command': ['--config', '/share/conf/sd.toml'],
+            "networks": {self.bridges[net["net"]]: {"%s_address" % ipv: ip}},
+            "command": ["--config", "/share/conf/sd.toml"],
         }
-        self.dc_conf['services'][name] = entry
+        self.dc_conf["services"][name] = entry
 
     def _disp_vol(self, disp_id):
-        return 'vol_%sdisp_%s:/run/shm/dispatcher:rw' % (self.prefix, disp_id)
+        return "vol_%sdisp_%s:/run/shm/dispatcher:rw" % (self.prefix, disp_id)
 
     def _cache_vol(self):
-        return self.output_base + '/gen-cache:/share/cache:rw'
+        return self.output_base + "/gen-cache:/share/cache:rw"
 
     def _certs_vol(self):
-        return self.output_base + '/gen-certs:/share/crypto:rw'
+        return self.output_base + "/gen-certs:/share/crypto:rw"

--- a/tools/topology/docker_utils.py
+++ b/tools/topology/docker_utils.py
@@ -16,6 +16,7 @@
 # Stdlib
 import os
 import pathlib
+
 # SCION
 from topology.common import (
     ArgsBase,
@@ -45,8 +46,8 @@ class DockerUtilsGenerator(object):
         """
         self.args = args
         self.dc_conf = args.dc_conf
-        self.user = '%d:%d' % (os.getuid(), os.getgid())
-        self.output_base = os.environ.get('SCION_OUTPUT_BASE', os.getcwd())
+        self.user = "%d:%d" % (os.getuid(), os.getgid())
+        self.output_base = os.environ.get("SCION_OUTPUT_BASE", os.getcwd())
 
     def generate(self):
         self._utils_conf()
@@ -58,64 +59,63 @@ class DockerUtilsGenerator(object):
 
     def _utils_conf(self):
         entry_chown = {
-            'image': 'busybox',
-            'network_mode': 'none',
-            'volumes': [
-                '/etc/passwd:/etc/passwd:ro',
-                '/etc/group:/etc/group:ro'
-            ],
-            'command': 'chown -R ' + self.user + ' /mnt/volumes'
+            "image": "busybox",
+            "network_mode": "none",
+            "volumes": ["/etc/passwd:/etc/passwd:ro", "/etc/group:/etc/group:ro"],
+            "command": "chown -R " + self.user + " /mnt/volumes",
         }
-        for volume in self.dc_conf['volumes']:
-            entry_chown['volumes'].append('%s:/mnt/volumes/%s' % (volume, volume))
-        self.dc_conf['services']['utils_chowner'] = entry_chown
+        for volume in self.dc_conf["volumes"]:
+            entry_chown["volumes"].append("%s:/mnt/volumes/%s" % (volume, volume))
+        self.dc_conf["services"]["utils_chowner"] = entry_chown
 
     def _test_conf(self, topo_id):
-        cntr_base = '/share'
-        name = 'tester_%s' % topo_id.file_fmt()
+        cntr_base = "/share"
+        name = "tester_%s" % topo_id.file_fmt()
         entry = {
-            'image': docker_image(self.args, 'tester'),
-            'container_name': 'tester_%s' % topo_id.file_fmt(),
-            'depends_on': ['scion_disp_%s' % name],
-            'privileged': True,
-            'entrypoint': 'sh tester.sh',
-            'environment': {},
+            "image": docker_image(self.args, "tester"),
+            "container_name": "tester_%s" % topo_id.file_fmt(),
+            "depends_on": ["scion_disp_%s" % name],
+            "privileged": True,
+            "entrypoint": "sh tester.sh",
+            "environment": {},
             # 'user': self.user,
-            'volumes': [
-                'vol_scion_disp_%s:/run/shm/dispatcher:rw' % name,
-                self.output_base + '/logs:' + cntr_base + '/logs:rw',
-                self.output_base + '/gen:' + cntr_base + '/gen:rw',
-                self.output_base + '/gen-certs:' + cntr_base + '/gen-certs:rw'
+            "volumes": [
+                "vol_scion_disp_%s:/run/shm/dispatcher:rw" % name,
+                self.output_base + "/logs:" + cntr_base + "/logs:rw",
+                self.output_base + "/gen:" + cntr_base + "/gen:rw",
+                self.output_base + "/gen-certs:" + cntr_base + "/gen-certs:rw",
             ],
-            'network_mode': 'service:scion_disp_%s' % name,
+            "network_mode": "service:scion_disp_%s" % name,
         }
         net = self.args.networks[name][0]
-        ipv = 'ipv4'
+        ipv = "ipv4"
         if ipv not in net:
-            ipv = 'ipv6'
+            ipv = "ipv6"
         disp_net = self.args.networks[name][0]
-        entry['environment']['SCION_LOCAL_ADDR'] = str(disp_net[ipv])
-        sciond_net = self.args.networks['sd%s' % topo_id.file_fmt()][0]
-        if ipv == 'ipv4':
-            entry['environment']['SCION_DAEMON'] = '%s:30255' % sciond_net[ipv]
+        entry["environment"]["SCION_LOCAL_ADDR"] = str(disp_net[ipv])
+        sciond_net = self.args.networks["sd%s" % topo_id.file_fmt()][0]
+        if ipv == "ipv4":
+            entry["environment"]["SCION_DAEMON"] = "%s:30255" % sciond_net[ipv]
         else:
-            entry['environment']['SCION_DAEMON'] = '[%s]:30255' % sciond_net[ipv]
+            entry["environment"]["SCION_DAEMON"] = "[%s]:30255" % sciond_net[ipv]
         if self.args.sig:
             # If the tester container needs to communicate to the SIG, it needs the SIG_IP and
             # REMOTE_NETS which are the remote subnets that need to be routed through the SIG.
             # net information for the connected SIG
-            sig_net = self.args.networks['sig%s' % topo_id.file_fmt()][0]
-            entry['environment']['SIG_IP'] = str(sig_net[ipv])
-            entry['environment']['REMOTE_NETS'] = remote_nets(self.args.networks, topo_id)
-        self.dc_conf['services'][name] = entry
+            sig_net = self.args.networks["sig%s" % topo_id.file_fmt()][0]
+            entry["environment"]["SIG_IP"] = str(sig_net[ipv])
+            entry["environment"]["REMOTE_NETS"] = remote_nets(
+                self.args.networks, topo_id
+            )
+        self.dc_conf["services"][name] = entry
 
     def _sig_testing_conf(self):
-        text = ''
+        text = ""
         for topo_id in self.args.topo_dicts:
-            net = self.args.networks['tester_%s' % topo_id.file_fmt()][0]
-            ipv = 'ipv4'
+            net = self.args.networks["tester_%s" % topo_id.file_fmt()][0]
+            ipv = "ipv4"
             if ipv not in net:
-                ipv = 'ipv6'
+                ipv = "ipv6"
             ip = net[ipv]
-            text += str(topo_id) + ' ' + str(ip) + '\n'
-            pathlib.Path(self.args.output_dir, 'sig-testing.conf').write_text(text)
+            text += str(topo_id) + " " + str(ip) + "\n"
+            pathlib.Path(self.args.output_dir, "sig-testing.conf").write_text(text)

--- a/tools/topology/go.py
+++ b/tools/topology/go.py
@@ -52,7 +52,9 @@ DEFAULT_COLIBRI_TOTAL_BW = 1000
 
 
 class GoGenArgs(ArgsTopoDicts):
-    def __init__(self, args, topo_dicts, networks: Mapping[IPNetwork, NetworkDescription]):
+    def __init__(
+        self, args, topo_dicts, networks: Mapping[IPNetwork, NetworkDescription]
+    ):
         super().__init__(args, topo_dicts)
         self.networks = networks
 
@@ -63,10 +65,10 @@ class GoGenerator(object):
         :param GoGenArgs args: Contains the passed command line arguments and topo dicts.
         """
         self.args = args
-        self.log_dir = '/share/logs' if args.docker else 'logs'
-        self.db_dir = '/share/cache' if args.docker else 'gen-cache'
-        self.certs_dir = '/share/crypto' if args.docker else 'gen-certs'
-        self.log_level = 'debug'
+        self.log_dir = "/share/logs" if args.docker else "logs"
+        self.db_dir = "/share/cache" if args.docker else "gen-cache"
+        self.certs_dir = "/share/crypto" if args.docker else "gen-certs"
+        self.log_level = "debug"
 
     def generate_br(self):
         for topo_id, topo in self.args.topo_dicts.items():
@@ -76,60 +78,60 @@ class GoGenerator(object):
                 write_file(os.path.join(base, "%s.toml" % k), toml.dumps(br_conf))
 
     def _build_br_conf(self, topo_id, ia, base, name, v):
-        config_dir = '/share/conf' if self.args.docker else base
+        config_dir = "/share/conf" if self.args.docker else base
         raw_entry = {
-            'general': {
-                'id': name,
-                'config_dir': config_dir,
+            "general": {
+                "id": name,
+                "config_dir": config_dir,
             },
-            'log': self._log_entry(name),
-            'metrics': {
-                'prometheus': prom_addr(v['internal_addr'], DEFAULT_BR_PROM_PORT),
+            "log": self._log_entry(name),
+            "metrics": {
+                "prometheus": prom_addr(v["internal_addr"], DEFAULT_BR_PROM_PORT),
             },
-            'features': translate_features(self.args.features),
-            'api': {
-                'addr': prom_addr(v['internal_addr'], DEFAULT_BR_PROM_PORT+700)
-            }
+            "features": translate_features(self.args.features),
+            "api": {"addr": prom_addr(v["internal_addr"], DEFAULT_BR_PROM_PORT + 700)},
         }
         return raw_entry
 
     def generate_control_service(self):
         for topo_id, topo in self.args.topo_dicts.items():
-            ca = 'issuing' in topo.get("attributes", [])
+            ca = "issuing" in topo.get("attributes", [])
             for elem_id, elem in topo.get("control_service", {}).items():
                 # only a single Go-BS per AS is currently supported
                 if elem_id.endswith("-1"):
                     base = topo_id.base_dir(self.args.output_dir)
                     bs_conf = self._build_control_service_conf(
-                        topo_id, topo["isd_as"], base, elem_id, elem, ca)
-                    write_file(os.path.join(base, "%s.toml" % elem_id),
-                               toml.dumps(bs_conf))
+                        topo_id, topo["isd_as"], base, elem_id, elem, ca
+                    )
+                    write_file(
+                        os.path.join(base, "%s.toml" % elem_id), toml.dumps(bs_conf)
+                    )
 
     def _build_control_service_conf(self, topo_id, ia, base, name, infra_elem, ca):
-        config_dir = '/share/conf' if self.args.docker else base
+        config_dir = "/share/conf" if self.args.docker else base
         raw_entry = {
-            'general': {
-                'id': name,
-                'config_dir': config_dir,
-                'reconnect_to_dispatcher': True,
+            "general": {
+                "id": name,
+                "config_dir": config_dir,
+                "reconnect_to_dispatcher": True,
             },
-            'log': self._log_entry(name),
-            'trust_db': {
-                'connection': os.path.join(self.db_dir, '%s.trust.db' % name),
+            "log": self._log_entry(name),
+            "trust_db": {
+                "connection": os.path.join(self.db_dir, "%s.trust.db" % name),
             },
-            'beacon_db':     {
-                'connection': os.path.join(self.db_dir, '%s.beacon.db' % name),
+            "beacon_db": {
+                "connection": os.path.join(self.db_dir, "%s.beacon.db" % name),
             },
-            'path_db': {
-                'connection': os.path.join(self.db_dir, '%s.path.db' % name),
+            "path_db": {
+                "connection": os.path.join(self.db_dir, "%s.path.db" % name),
             },
-            'tracing': self._tracing_entry(),
-            'metrics': self._metrics_entry(infra_elem, CS_PROM_PORT),
-            'api': self._api_entry(infra_elem, CS_PROM_PORT+700),
-            'features': translate_features(self.args.features),
+            "tracing": self._tracing_entry(),
+            "metrics": self._metrics_entry(infra_elem, CS_PROM_PORT),
+            "api": self._api_entry(infra_elem, CS_PROM_PORT + 700),
+            "features": translate_features(self.args.features),
         }
         if ca:
-            raw_entry['ca'] = {'mode': 'in-process'}
+            raw_entry["ca"] = {"mode": "in-process"}
         return raw_entry
 
     def generate_co(self):
@@ -140,30 +142,38 @@ class GoGenerator(object):
                 # only a single Go-CO per AS is currently supported
                 if elem_id.endswith("-1"):
                     base = topo_id.base_dir(self.args.output_dir)
-                    co_conf = self._build_co_conf(topo_id, topo["isd_as"], base, elem_id, elem)
-                    write_file(os.path.join(base, elem_id, CO_CONFIG_NAME), toml.dumps(co_conf))
+                    co_conf = self._build_co_conf(
+                        topo_id, topo["isd_as"], base, elem_id, elem
+                    )
+                    write_file(
+                        os.path.join(base, elem_id, CO_CONFIG_NAME), toml.dumps(co_conf)
+                    )
                     traffic_matrix = self._build_co_traffic_matrix(topo_id)
-                    write_file(os.path.join(base, elem_id, 'matrix.yml'),
-                               yaml.dump(traffic_matrix, default_flow_style=False))
+                    write_file(
+                        os.path.join(base, elem_id, "matrix.yml"),
+                        yaml.dump(traffic_matrix, default_flow_style=False),
+                    )
                     rsvps = self._build_co_reservations(topo_id)
-                    write_file(os.path.join(base, elem_id, 'reservations.yml'),
-                               yaml.dump(rsvps, default_flow_style=False))
+                    write_file(
+                        os.path.join(base, elem_id, "reservations.yml"),
+                        yaml.dump(rsvps, default_flow_style=False),
+                    )
 
     def _build_co_conf(self, topo_id, ia, base, name, infra_elem):
-        config_dir = '/share/conf' if self.args.docker else base
+        config_dir = "/share/conf" if self.args.docker else base
         raw_entry = {
-            'general': {
-                'ID': name,
-                'ConfigDir': config_dir,
-                'ReconnectToDispatcher': True,
+            "general": {
+                "ID": name,
+                "ConfigDir": config_dir,
+                "ReconnectToDispatcher": True,
             },
-            'log': self._log_entry(name),
-            'trust_db': {
-                'connection': os.path.join(self.db_dir, '%s.trust.db' % name),
+            "log": self._log_entry(name),
+            "trust_db": {
+                "connection": os.path.join(self.db_dir, "%s.trust.db" % name),
             },
-            'tracing': self._tracing_entry(),
-            'metrics': self._metrics_entry(infra_elem, CO_PROM_PORT),
-            'features': translate_features(self.args.features),
+            "tracing": self._tracing_entry(),
+            "metrics": self._metrics_entry(infra_elem, CO_PROM_PORT),
+            "features": translate_features(self.args.features),
         }
         return raw_entry
 
@@ -172,7 +182,11 @@ class GoGenerator(object):
         Creates a NxN traffic matrix for colibri with N = len(interfaces)
         """
         topo = self.args.topo_dicts[ia]
-        if_ids = {iface for br in topo['border_routers'].values() for iface in br['interfaces']}
+        if_ids = {
+            iface
+            for br in topo["border_routers"].values()
+            for iface in br["interfaces"]
+        }
         if_ids.add(0)
         bw = int(DEFAULT_COLIBRI_TOTAL_BW / (len(if_ids) - 1))
         traffic_matrix = {}
@@ -189,37 +203,38 @@ class GoGenerator(object):
         """
         rsvps = {}
         this_as = self.args.topo_dicts[ia]
-        if this_as['Core']:
+        if this_as["Core"]:
             for dst_ia, topo in self.args.topo_dicts.items():
-                if dst_ia != ia and topo['Core']:
-                    rsvps['Core-%s' % dst_ia] = self._build_co_reservation(dst_ia, 'Core')
+                if dst_ia != ia and topo["Core"]:
+                    rsvps["Core-%s" % dst_ia] = self._build_co_reservation(
+                        dst_ia, "Core"
+                    )
         else:
             for dst_ia, topo in self.args.topo_dicts.items():
-                if dst_ia != ia and dst_ia._isd == ia._isd and topo['Core']:
+                if dst_ia != ia and dst_ia._isd == ia._isd and topo["Core"]:
                     # reach this core AS in the same ISD
-                    rsvps['Up-%s' % dst_ia] = self._build_co_reservation(dst_ia, 'Up')
-                    rsvps['Down-%s' % dst_ia] = self._build_co_reservation(dst_ia, 'Down')
+                    rsvps["Up-%s" % dst_ia] = self._build_co_reservation(dst_ia, "Up")
+                    rsvps["Down-%s" % dst_ia] = self._build_co_reservation(
+                        dst_ia, "Down"
+                    )
         return rsvps
 
     def _build_co_reservation(self, dst_ia, path_type):
-        start_props = {'L', 'T'}
-        end_props = {'L', 'T'}
-        if path_type == 'Up':
-            start_props.remove('T')
-        elif path_type == 'Down':
-            end_props.remove('T')
+        start_props = {"L", "T"}
+        end_props = {"L", "T"}
+        if path_type == "Up":
+            start_props.remove("T")
+        elif path_type == "Down":
+            end_props.remove("T")
         return {
-            'desired_size': 27,
-            'ia': str(dst_ia),
-            'max_size': 30,
-            'min_size': 1,
-            'path_predicate': '%s#0' % dst_ia,
-            'path_type': path_type,
-            'split_cls': 8,
-            'end_props': {
-                'start': list(start_props),
-                'end': list(end_props)
-            }
+            "desired_size": 27,
+            "ia": str(dst_ia),
+            "max_size": 30,
+            "min_size": 1,
+            "path_predicate": "%s#0" % dst_ia,
+            "path_type": path_type,
+            "split_cls": 8,
+            "end_props": {"start": list(start_props), "end": list(end_props)},
         }
 
     def generate_sciond(self):
@@ -230,32 +245,30 @@ class GoGenerator(object):
 
     def _build_sciond_conf(self, topo_id, ia, base):
         name = sciond_name(topo_id)
-        config_dir = '/share/conf' if self.args.docker else base
+        config_dir = "/share/conf" if self.args.docker else base
         ip = sciond_ip(self.args.docker, topo_id, self.args.networks)
         raw_entry = {
-            'general': {
-                'id': name,
-                'config_dir': config_dir,
-                'reconnect_to_dispatcher': True,
+            "general": {
+                "id": name,
+                "config_dir": config_dir,
+                "reconnect_to_dispatcher": True,
             },
-            'log': self._log_entry(name),
-            'trust_db': {
-                'connection': os.path.join(self.db_dir, '%s.trust.db' % name),
+            "log": self._log_entry(name),
+            "trust_db": {
+                "connection": os.path.join(self.db_dir, "%s.trust.db" % name),
             },
-            'path_db': {
-                'connection': os.path.join(self.db_dir, '%s.path.db' % name),
+            "path_db": {
+                "connection": os.path.join(self.db_dir, "%s.path.db" % name),
             },
-            'sd': {
-                'address': socket_address_str(ip, SD_API_PORT),
+            "sd": {
+                "address": socket_address_str(ip, SD_API_PORT),
             },
-            'tracing': self._tracing_entry(),
-            'metrics': {
-                'prometheus': socket_address_str(ip, SCIOND_PROM_PORT)
+            "tracing": self._tracing_entry(),
+            "metrics": {"prometheus": socket_address_str(ip, SCIOND_PROM_PORT)},
+            "features": translate_features(self.args.features),
+            "api": {
+                "addr": socket_address_str(ip, SD_API_PORT + 700),
             },
-            'features': translate_features(self.args.features),
-            'api': {
-                'addr': socket_address_str(ip, SD_API_PORT+700),
-            }
         }
         return raw_entry
 
@@ -265,63 +278,67 @@ class GoGenerator(object):
         else:
             elem_dir = os.path.join(self.args.output_dir, "dispatcher")
             config_file_path = os.path.join(elem_dir, DISP_CONFIG_NAME)
-            write_file(config_file_path, toml.dumps(self._build_disp_conf("dispatcher")))
+            write_file(
+                config_file_path, toml.dumps(self._build_disp_conf("dispatcher"))
+            )
 
     def _gen_disp_docker(self):
         for topo_id, topo in self.args.topo_dicts.items():
             base = topo_id.base_dir(self.args.output_dir)
-            elem_ids = ['sig_%s' % topo_id.file_fmt()] + \
-                list(topo.get("border_routers", {})) + \
-                list(topo.get("control_service", {})) + \
-                ['tester_%s' % topo_id.file_fmt()]
+            elem_ids = (
+                ["sig_%s" % topo_id.file_fmt()]
+                + list(topo.get("border_routers", {}))
+                + list(topo.get("control_service", {}))
+                + ["tester_%s" % topo_id.file_fmt()]
+            )
             for k in elem_ids:
-                disp_id = 'disp_%s' % k
+                disp_id = "disp_%s" % k
                 disp_conf = self._build_disp_conf(disp_id, topo_id)
-                write_file(os.path.join(base, '%s.toml' % disp_id), toml.dumps(disp_conf))
+                write_file(
+                    os.path.join(base, "%s.toml" % disp_id), toml.dumps(disp_conf)
+                )
 
     def _build_disp_conf(self, name, topo_id=None):
-        prometheus_addr = prom_addr_dispatcher(self.args.docker, topo_id,
-                                               self.args.networks, DISP_PROM_PORT, name)
-        api_addr = prom_addr_dispatcher(self.args.docker, topo_id,
-                                        self.args.networks, DISP_PROM_PORT+700, name)
+        prometheus_addr = prom_addr_dispatcher(
+            self.args.docker, topo_id, self.args.networks, DISP_PROM_PORT, name
+        )
+        api_addr = prom_addr_dispatcher(
+            self.args.docker, topo_id, self.args.networks, DISP_PROM_PORT + 700, name
+        )
         return {
-            'dispatcher': {
-                'id': name,
+            "dispatcher": {
+                "id": name,
             },
-            'log': self._log_entry(name),
-            'metrics': {
-                'prometheus': prometheus_addr,
+            "log": self._log_entry(name),
+            "metrics": {
+                "prometheus": prometheus_addr,
             },
-            'features': translate_features(self.args.features),
-            'api': {
-                'addr': api_addr,
+            "features": translate_features(self.args.features),
+            "api": {
+                "addr": api_addr,
             },
         }
 
     def _tracing_entry(self):
         docker_ip = docker_host(self.args.docker)
-        entry = {
-            'enabled': True,
-            'debug': True,
-            'agent': '%s:6831' % docker_ip
-        }
+        entry = {"enabled": True, "debug": True, "agent": "%s:6831" % docker_ip}
         return entry
 
     def _log_entry(self, name):
         return {
-            'console': {
-                'level': self.log_level,
+            "console": {
+                "level": self.log_level,
             },
         }
 
     def _metrics_entry(self, infra_elem, base_port):
-        a = prom_addr(infra_elem['addr'], base_port)
+        a = prom_addr(infra_elem["addr"], base_port)
         return {
-            'prometheus': a,
+            "prometheus": a,
         }
 
     def _api_entry(self, infra_elem, base_port):
-        a = prom_addr(infra_elem['addr'], base_port)
+        a = prom_addr(infra_elem["addr"], base_port)
         return {
-            'addr': a,
+            "addr": a,
         }

--- a/tools/topology/jaeger.py
+++ b/tools/topology/jaeger.py
@@ -20,7 +20,7 @@ from topology.common import (
     ArgsTopoDicts,
 )
 
-JAEGER_DC = 'jaeger-dc.yml'
+JAEGER_DC = "jaeger-dc.yml"
 
 
 class JaegerGenArgs(ArgsTopoDicts):
@@ -28,43 +28,41 @@ class JaegerGenArgs(ArgsTopoDicts):
 
 
 class JaegerGenerator(object):
-
     def __init__(self, args):
         self.args = args
-        output_base = os.environ.get('SCION_OUTPUT_BASE', os.getcwd())
-        self.local_jaeger_dir = os.path.join('traces')
+        output_base = os.environ.get("SCION_OUTPUT_BASE", os.getcwd())
+        self.local_jaeger_dir = os.path.join("traces")
         self.docker_jaeger_dir = os.path.join(output_base, self.local_jaeger_dir)
 
     def generate(self):
         dc_conf = self._generate_dc()
-        os.makedirs(os.path.join(self.local_jaeger_dir, 'data'), exist_ok=True)
-        os.makedirs(os.path.join(self.local_jaeger_dir, 'key'), exist_ok=True)
-        write_file(os.path.join(self.args.output_dir, JAEGER_DC),
-                   yaml.dump(dc_conf, default_flow_style=False))
+        os.makedirs(os.path.join(self.local_jaeger_dir, "data"), exist_ok=True)
+        os.makedirs(os.path.join(self.local_jaeger_dir, "key"), exist_ok=True)
+        write_file(
+            os.path.join(self.args.output_dir, JAEGER_DC),
+            yaml.dump(dc_conf, default_flow_style=False),
+        )
 
     def _generate_dc(self):
-        name = 'jaeger'
+        name = "jaeger"
         entry = {
-            'version': '2',
-            'services': {
-                'jaeger': {
-                    'image': 'jaegertracing/all-in-one:1.22.0',
-                    'container_name': name,
-                    'user': '%s:%s' % (str(os.getuid()), str(os.getgid())),
-                    'ports': [
-                        '6831:6831/udp',
-                        '16686:16686'
+            "version": "2",
+            "services": {
+                "jaeger": {
+                    "image": "jaegertracing/all-in-one:1.22.0",
+                    "container_name": name,
+                    "user": "%s:%s" % (str(os.getuid()), str(os.getgid())),
+                    "ports": ["6831:6831/udp", "16686:16686"],
+                    "environment": [
+                        "SPAN_STORAGE_TYPE=badger",
+                        "BADGER_EPHEMERAL=false",
+                        "BADGER_DIRECTORY_VALUE=/badger/data",
+                        "BADGER_DIRECTORY_KEY=/badger/key",
                     ],
-                    'environment': [
-                        'SPAN_STORAGE_TYPE=badger',
-                        'BADGER_EPHEMERAL=false',
-                        'BADGER_DIRECTORY_VALUE=/badger/data',
-                        'BADGER_DIRECTORY_KEY=/badger/key',
-                    ],
-                    'volumes': [
-                        '%s:/badger:rw' % self.docker_jaeger_dir,
+                    "volumes": [
+                        "%s:/badger:rw" % self.docker_jaeger_dir,
                     ],
                 }
-            }
+            },
         }
         return entry

--- a/tools/topology/net.py
+++ b/tools/topology/net.py
@@ -70,7 +70,7 @@ class AddressProxy(yaml.YAMLObject):
 
     @classmethod
     def to_yaml(cls, dumper, inst):
-        return dumper.represent_scalar('tag:yaml.org,2002:str', str(inst.ip))
+        return dumper.represent_scalar("tag:yaml.org,2002:str", str(inst.ip))
 
 
 class AddressGenerator(object):
@@ -103,15 +103,15 @@ class SubnetGenerator(object):
         if self.docker and network == DEFAULT_NETWORK:
             network = DEFAULT_SCN_DC_NETWORK
         if "/" not in network:
-            logging.critical("No prefix length specified for network '%s'",
-                             network)
+            logging.critical("No prefix length specified for network '%s'", network)
         try:
             self._net = ip_network(network)
         except ValueError:
             logging.critical("Invalid network '%s'", network)
             sys.exit(1)
-        self._subnets = defaultdict(lambda: AddressGenerator(self.docker)) \
-            # type: Mapping[str, AddressGenerator]
+        self._subnets = defaultdict(
+            lambda: AddressGenerator(self.docker)
+        )  # type: Mapping[str, AddressGenerator]
         self._allocations = defaultdict(list)
         # Initialise the allocations with the supplied network, making sure to
         # exclude 127.0.0.0/30 (for v4) and DEFAULT6_NETWORK_ADDR/126 (for v6)
@@ -159,9 +159,13 @@ class SubnetGenerator(object):
                 # Carve out subnet of the required size
                 new_net = next(alloc.subnets(new_prefix=req_prefix))
                 new_net = _workaround_ip_network_hosts_py35(new_net)
-                logging.debug("Allocating %s from %s for subnet size %d" %
-                              (new_net, alloc, len(subnet)))
-                networks[new_net] = NetworkDescription(topo, subnet.alloc_addrs(new_net))
+                logging.debug(
+                    "Allocating %s from %s for subnet size %d"
+                    % (new_net, alloc, len(subnet))
+                )
+                networks[new_net] = NetworkDescription(
+                    topo, subnet.alloc_addrs(new_net)
+                )
                 # Repopulate the allocations list with the left-over space
                 self._exclude_net(alloc, new_net)
                 break
@@ -183,7 +187,7 @@ class PortGenerator(object):
     def register(self, id_: str) -> int:
         p = self._ports[id_]
         # reserve a quic port
-        self._ports[id_+"quic"]
+        self._ports[id_ + "quic"]
         return p
 
 
@@ -202,4 +206,4 @@ def _workaround_ip_network_hosts_py35(net: IPNetwork) -> IPNetwork:
     This regression is fixed in python 3.6.6 / 3.7.0.
     See https://bugs.python.org/issue27683
     """
-    return ip_network('%s/%i' % (net.network_address, net.prefixlen))
+    return ip_network("%s/%i" % (net.network_address, net.prefixlen))

--- a/tools/topology/prometheus.py
+++ b/tools/topology/prometheus.py
@@ -49,7 +49,9 @@ PROM_DC_FILE = "prom-dc.yml"
 
 
 class PrometheusGenArgs(ArgsTopoDicts):
-    def __init__(self, args, topo_dicts, networks: Mapping[IPNetwork, NetworkDescription]):
+    def __init__(
+        self, args, topo_dicts, networks: Mapping[IPNetwork, NetworkDescription]
+    ):
         super().__init__(args, topo_dicts)
         self.networks = networks
 
@@ -74,7 +76,7 @@ class PrometheusGenerator(object):
         :param PrometheusGenArgs args: Contains the passed command line arguments and topo dicts.
         """
         self.args = args
-        self.output_base = os.environ.get('SCION_OUTPUT_BASE', os.getcwd())
+        self.output_base = os.environ.get("SCION_OUTPUT_BASE", os.getcwd())
 
     def generate(self):
         config_dict = {}
@@ -87,13 +89,17 @@ class PrometheusGenerator(object):
                 a = prom_addr(elem["addr"], CS_PROM_PORT)
                 ele_dict["ControlService"].append(a)
             if self.args.docker:
-                host_dispatcher = prom_addr_dispatcher(self.args.docker, topo_id,
-                                                       self.args.networks, DISP_PROM_PORT, "")
-                br_dispatcher = prom_addr_dispatcher(self.args.docker, topo_id,
-                                                     self.args.networks, DISP_PROM_PORT, "br")
+                host_dispatcher = prom_addr_dispatcher(
+                    self.args.docker, topo_id, self.args.networks, DISP_PROM_PORT, ""
+                )
+                br_dispatcher = prom_addr_dispatcher(
+                    self.args.docker, topo_id, self.args.networks, DISP_PROM_PORT, "br"
+                )
                 ele_dict["Dispatcher"] = [host_dispatcher, br_dispatcher]
-            sd_prom_addr = '[%s]:%d' % (sciond_ip(self.args.docker, topo_id, self.args.networks),
-                                        SCIOND_PROM_PORT)
+            sd_prom_addr = "[%s]:%d" % (
+                sciond_ip(self.args.docker, topo_id, self.args.networks),
+                SCIOND_PROM_PORT,
+            )
             ele_dict["Sciond"].append(sd_prom_addr)
             config_dict[topo_id] = ele_dict
         self._write_config_files(config_dict)
@@ -107,63 +113,73 @@ class PrometheusGenerator(object):
             as_local_targets_path = {}
             for ele_type, target_list in ele_dict.items():
                 local_path = os.path.join(self.PROM_DIR, self.TARGET_FILES[ele_type])
-                targets_path = os.path.join(topo_id.base_dir(''), local_path)
+                targets_path = os.path.join(topo_id.base_dir(""), local_path)
                 targets_paths[self.JOB_NAMES[ele_type]].append(targets_path)
                 as_local_targets_path[self.JOB_NAMES[ele_type]] = [local_path]
                 self._write_target_file(base, target_list, ele_type)
-            self._write_config_file(os.path.join(base, PROM_FILE), as_local_targets_path)
+            self._write_config_file(
+                os.path.join(base, PROM_FILE), as_local_targets_path
+            )
         if not self.args.docker:
-            targets_paths["dispatcher"] = [os.path.join("dispatcher", "prometheus", "disp.yml")]
-        self._write_config_file(os.path.join(self.args.output_dir, PROM_FILE), targets_paths)
+            targets_paths["dispatcher"] = [
+                os.path.join("dispatcher", "prometheus", "disp.yml")
+            ]
+        self._write_config_file(
+            os.path.join(self.args.output_dir, PROM_FILE), targets_paths
+        )
 
     def _write_config_file(self, config_path, job_dict):
         scrape_configs = []
         for job_name, file_paths in job_dict.items():
-            scrape_configs.append({
-                'job_name': job_name,
-                'file_sd_configs': [{'files': file_paths}],
-            })
-        config = {
-            'global': {
-                'scrape_interval': '1s',
-                'evaluation_interval': '1s',
-                'external_labels': {
-                    'monitor': 'scion-monitor'
+            scrape_configs.append(
+                {
+                    "job_name": job_name,
+                    "file_sd_configs": [{"files": file_paths}],
                 }
+            )
+        config = {
+            "global": {
+                "scrape_interval": "1s",
+                "evaluation_interval": "1s",
+                "external_labels": {"monitor": "scion-monitor"},
             },
-            'scrape_configs': scrape_configs,
+            "scrape_configs": scrape_configs,
         }
         write_file(config_path, yaml.dump(config, default_flow_style=False))
 
     def _write_target_file(self, base_path, target_addrs, ele_type):
-        targets_path = os.path.join(base_path, self.PROM_DIR, self.TARGET_FILES[ele_type])
-        target_config = [{'targets': target_addrs}]
+        targets_path = os.path.join(
+            base_path, self.PROM_DIR, self.TARGET_FILES[ele_type]
+        )
+        target_config = [{"targets": target_addrs}]
         write_file(targets_path, yaml.dump(target_config, default_flow_style=False))
 
     def _write_disp_file(self):
         if self.args.docker:
             return
-        targets_path = os.path.join(self.args.output_dir, "dispatcher",
-                                    PrometheusGenerator.PROM_DIR, "disp.yml")
-        target_config = [{'targets': [prom_addr_dispatcher(False, None, None,
-                                                           DISP_PROM_PORT, None)]}]
+        targets_path = os.path.join(
+            self.args.output_dir, "dispatcher", PrometheusGenerator.PROM_DIR, "disp.yml"
+        )
+        target_config = [
+            {"targets": [prom_addr_dispatcher(False, None, None, DISP_PROM_PORT, None)]}
+        ]
         write_file(targets_path, yaml.dump(target_config, default_flow_style=False))
 
     def _write_dc_file(self):
-        name = 'prometheus'
+        name = "prometheus"
         prom_dc = {
-            'version': DOCKER_COMPOSE_CONFIG_VERSION,
-            'services': {
+            "version": DOCKER_COMPOSE_CONFIG_VERSION,
+            "services": {
                 name: {
-                    'image': 'prom/prometheus:v2.6.0',
-                    'container_name': name,
-                    'network_mode': 'host',
-                    'volumes': [
-                        self.output_base + '/gen:/prom-config:ro'
-                    ],
-                    'command': ['--config.file', '/prom-config/prometheus.yml'],
+                    "image": "prom/prometheus:v2.6.0",
+                    "container_name": name,
+                    "network_mode": "host",
+                    "volumes": [self.output_base + "/gen:/prom-config:ro"],
+                    "command": ["--config.file", "/prom-config/prometheus.yml"],
                 }
-            }
+            },
         }
-        write_file(os.path.join(self.args.output_dir, PROM_DC_FILE),
-                   yaml.dump(prom_dc, default_flow_style=False))
+        write_file(
+            os.path.join(self.args.output_dir, PROM_DC_FILE),
+            yaml.dump(prom_dc, default_flow_style=False),
+        )

--- a/tools/topology/scion_addr.py
+++ b/tools/topology/scion_addr.py
@@ -74,10 +74,10 @@ def _clean_isd_as(isd_as_str):
     """
     m = _RE_ISD_AS.match(isd_as_str)
     if not m:
-        raise ValueError('Invalid ISD-AS', isd_as_str)
+        raise ValueError("Invalid ISD-AS", isd_as_str)
     isd = int(m.group(1), 10)
     if isd >= 2**16:
-        raise ValueError('Invalid ISD-AS, ISD out of range', isd_as_str)
+        raise ValueError("Invalid ISD-AS, ISD out of range", isd_as_str)
     hig = int(m.group(2), 16)
     mid = int(m.group(3), 16)
     low = int(m.group(4), 16)

--- a/tools/topology/sig.py
+++ b/tools/topology/sig.py
@@ -16,8 +16,10 @@
 # Stdlib
 import json
 import os
+
 # External packages
 import toml
+
 # SCION
 from topology.util import write_file
 from topology.common import (
@@ -53,14 +55,15 @@ class SIGGenerator(object):
         """
         self.args = args
         self.dc_conf = args.dc_conf
-        self.user = '%d:%d' % (os.getuid(), os.getgid())
-        self.output_base = os.environ.get('SCION_OUTPUT_BASE', os.getcwd())
-        self.prefix = ''
+        self.user = "%d:%d" % (os.getuid(), os.getgid())
+        self.output_base = os.environ.get("SCION_OUTPUT_BASE", os.getcwd())
+        self.prefix = ""
 
     def generate(self):
         for topo_id, topo in self.args.topo_dicts.items():
-            base = os.path.join(self.output_base,
-                                topo_id.base_dir(self.args.output_dir))
+            base = os.path.join(
+                self.output_base, topo_id.base_dir(self.args.output_dir)
+            )
             self._dispatcher_conf(topo_id, base)
             self._sig_dc_conf(topo_id, base)
             self._sig_toml(topo_id, topo)
@@ -70,76 +73,67 @@ class SIGGenerator(object):
     def _dispatcher_conf(self, topo_id, base):
         # Create dispatcher config
         entry = {
-            'image':
-            'dispatcher',
-            'container_name':
-            'scion_%sdisp_sig_%s' % (self.prefix, topo_id.file_fmt()),
-            'depends_on': {
-                'utils_chowner': {
-                    'condition': 'service_started'
-                },
+            "image": "dispatcher",
+            "container_name": "scion_%sdisp_sig_%s" % (self.prefix, topo_id.file_fmt()),
+            "depends_on": {
+                "utils_chowner": {"condition": "service_started"},
             },
-            'user':
-            self.user,
-            'networks': {},
-            'volumes': [
+            "user": self.user,
+            "networks": {},
+            "volumes": [
                 self._disp_vol(topo_id),
-                '%s:/share/conf:rw' % base,
+                "%s:/share/conf:rw" % base,
             ],
-            'command':
-            ['--config',
-             '/share/conf/disp_sig_%s.toml' % topo_id.file_fmt()],
+            "command": [
+                "--config",
+                "/share/conf/disp_sig_%s.toml" % topo_id.file_fmt(),
+            ],
         }
 
-        net = self.args.networks['sig%s' % topo_id.file_fmt()][0]
-        ipv = 'ipv4'
+        net = self.args.networks["sig%s" % topo_id.file_fmt()][0]
+        ipv = "ipv4"
         if ipv not in net:
-            ipv = 'ipv6'
-        entry['networks'][self.args.bridges[net['net']]] = {
-            '%s_address' % ipv: str(net[ipv])
+            ipv = "ipv6"
+        entry["networks"][self.args.bridges[net["net"]]] = {
+            "%s_address" % ipv: str(net[ipv])
         }
-        self.dc_conf['services']['scion_disp_sig_%s' %
-                                 topo_id.file_fmt()] = entry
-        vol_name = 'vol_scion_%sdisp_sig_%s' % (self.prefix,
-                                                topo_id.file_fmt())
-        self.dc_conf['volumes'][vol_name] = None
+        self.dc_conf["services"]["scion_disp_sig_%s" % topo_id.file_fmt()] = entry
+        vol_name = "vol_scion_%sdisp_sig_%s" % (self.prefix, topo_id.file_fmt())
+        self.dc_conf["volumes"][vol_name] = None
 
     def _sig_dc_conf(self, topo_id, base):
-        setup_name = 'scion_sig_setup_%s' % topo_id.file_fmt()
-        disp_id = 'scion_disp_sig_%s' % topo_id.file_fmt()
-        self.dc_conf['services'][setup_name] = {
-            'image': 'tester:latest',
-            'depends_on': [disp_id],
-            'entrypoint': './sig_setup.sh',
-            'privileged': True,
-            'network_mode': 'service:%s' % disp_id,
+        setup_name = "scion_sig_setup_%s" % topo_id.file_fmt()
+        disp_id = "scion_disp_sig_%s" % topo_id.file_fmt()
+        self.dc_conf["services"][setup_name] = {
+            "image": "tester:latest",
+            "depends_on": [disp_id],
+            "entrypoint": "./sig_setup.sh",
+            "privileged": True,
+            "network_mode": "service:%s" % disp_id,
         }
-        self.dc_conf['services']['scion_sig_%s' % topo_id.file_fmt()] = {
-            'image':
-            'posix-gateway:latest',
-            'container_name':
-            'scion_%ssig_%s' % (self.prefix, topo_id.file_fmt()),
-            'depends_on': [
+        self.dc_conf["services"]["scion_sig_%s" % topo_id.file_fmt()] = {
+            "image": "posix-gateway:latest",
+            "container_name": "scion_%ssig_%s" % (self.prefix, topo_id.file_fmt()),
+            "depends_on": [
                 disp_id,
                 sciond_svc_name(topo_id),
                 setup_name,
             ],
-            'environment': {
-                'SCION_EXPERIMENTAL_GATEWAY_PATH_UPDATE_INTERVAL': '1s',
+            "environment": {
+                "SCION_EXPERIMENTAL_GATEWAY_PATH_UPDATE_INTERVAL": "1s",
             },
-            'cap_add': ['NET_ADMIN'],
+            "cap_add": ["NET_ADMIN"],
             # XXX(matzf): running as root; it _should_ work running as unprivileged user. The
             # gateway is a setcap binary and that should suffice. It does work on Ubuntu,
             # but on the RHEL machines in in CI it simply doesn't. Needs to be investigated & fixed.
             #  'user': self.user,
-            'volumes': [
+            "volumes": [
                 self._disp_vol(topo_id),
-                '/dev/net/tun:/dev/net/tun',
-                '%s:/share/conf' % base,
+                "/dev/net/tun:/dev/net/tun",
+                "%s:/share/conf" % base,
             ],
-            'network_mode':
-            'service:%s' % disp_id,
-            'command': ['--config', '/share/conf/sig.toml'],
+            "network_mode": "service:%s" % disp_id,
+            "command": ["--config", "/share/conf/sig.toml"],
         }
 
     def _sig_json(self, topo_id):
@@ -147,54 +141,51 @@ class SIGGenerator(object):
         for t_id, topo in self.args.topo_dicts.items():
             if topo_id == t_id:
                 continue
-            sig_cfg['ASes'][str(t_id)] = {"Nets": []}
-            net = self.args.networks['sig%s' % t_id.file_fmt()][0]
-            sig_cfg['ASes'][str(t_id)]['Nets'].append(net['net'])
+            sig_cfg["ASes"][str(t_id)] = {"Nets": []}
+            net = self.args.networks["sig%s" % t_id.file_fmt()][0]
+            sig_cfg["ASes"][str(t_id)]["Nets"].append(net["net"])
 
         cfg = os.path.join(topo_id.base_dir(self.args.output_dir), "sig.json")
         contents_json = json.dumps(sig_cfg, default=json_default, indent=2)
-        write_file(cfg, contents_json + '\n')
+        write_file(cfg, contents_json + "\n")
 
     def _sig_toml(self, topo_id, topo):
-        name = 'sig%s' % topo_id.file_fmt()
+        name = "sig%s" % topo_id.file_fmt()
         net = self.args.networks[name][0]
-        log_level = 'debug'
-        ipv = 'ipv4'
+        log_level = "debug"
+        ipv = "ipv4"
         if ipv not in net:
-            ipv = 'ipv6'
+            ipv = "ipv6"
 
         sciond_net = self.args.networks["sd" + topo_id.file_fmt()][0]
-        ipv = 'ipv4'
+        ipv = "ipv4"
         if ipv not in sciond_net:
-            ipv = 'ipv6'
+            ipv = "ipv6"
         sciond_ip = sciond_net[ipv]
 
         sig_conf = {
-            'gateway': {
-                'id': name,
-                'traffic_policy_file': 'conf/sig.json',
-                'ctrl_addr': str(net[ipv]),
+            "gateway": {
+                "id": name,
+                "traffic_policy_file": "conf/sig.json",
+                "ctrl_addr": str(net[ipv]),
             },
-            'sciond_connection': {
-                'address': socket_address_str(sciond_ip, SD_API_PORT),
+            "sciond_connection": {
+                "address": socket_address_str(sciond_ip, SD_API_PORT),
             },
-            'log': {
-                'console': {
-                    'level': log_level,
+            "log": {
+                "console": {
+                    "level": log_level,
                 }
             },
-            'metrics': {
-                'prometheus': '0.0.0.0:%s' % SIG_PROM_PORT
-            },
-            'api': {
-                'addr': '0.0.0.0:%s' % (SIG_PROM_PORT+700)
-            },
-            'features': translate_features(self.args.features),
+            "metrics": {"prometheus": "0.0.0.0:%s" % SIG_PROM_PORT},
+            "api": {"addr": "0.0.0.0:%s" % (SIG_PROM_PORT + 700)},
+            "features": translate_features(self.args.features),
         }
-        path = os.path.join(topo_id.base_dir(self.args.output_dir),
-                            SIG_CONFIG_NAME)
+        path = os.path.join(topo_id.base_dir(self.args.output_dir), SIG_CONFIG_NAME)
         write_file(path, toml.dumps(sig_conf))
 
     def _disp_vol(self, topo_id):
-        return 'vol_scion_%sdisp_sig_%s:/run/shm/dispatcher:rw' % (
-            self.prefix, topo_id.file_fmt())
+        return "vol_scion_%sdisp_sig_%s:/run/shm/dispatcher:rw" % (
+            self.prefix,
+            topo_id.file_fmt(),
+        )

--- a/tools/topology/supervisor.py
+++ b/tools/topology/supervisor.py
@@ -30,7 +30,7 @@ from topology.common import (
     SD_CONFIG_NAME,
 )
 
-SUPERVISOR_CONF = 'supervisord.conf'
+SUPERVISOR_CONF = "supervisord.conf"
 
 
 class SupervisorGenArgs(ArgsTopoDicts):
@@ -51,8 +51,7 @@ class SupervisorGenerator(object):
             self._add_as_config(config, topo_id, topo)
         self._add_dispatcher(config)
 
-        self._write_config(config,
-                           os.path.join(self.args.output_dir, SUPERVISOR_CONF))
+        self._write_config(config, os.path.join(self.args.output_dir, SUPERVISOR_CONF))
 
     def _add_as_config(self, config, topo_id, topo):
         entries = self._as_entries(topo_id, topo)
@@ -75,7 +74,7 @@ class SupervisorGenerator(object):
         for k, v in topo.get("border_routers", {}).items():
             conf = os.path.join(base, "%s.toml" % k)
             prog = self._common_entry(k, [cmd, "--config", conf])
-            prog['environment'] += ',GODEBUG="cgocheck=0"'
+            prog["environment"] += ',GODEBUG="cgocheck=0"'
             entries.append((k, prog))
         return entries
 
@@ -91,10 +90,7 @@ class SupervisorGenerator(object):
 
     def _sciond_entry(self, topo_id, conf_dir):
         sd_name = "sd%s" % topo_id.file_fmt()
-        cmd_args = [
-            "bin/daemon", "--config",
-            os.path.join(conf_dir, SD_CONFIG_NAME)
-        ]
+        cmd_args = ["bin/daemon", "--config", os.path.join(conf_dir, SD_CONFIG_NAME)]
         return (sd_name, self._common_entry(sd_name, cmd_args))
 
     def _add_dispatcher(self, config):
@@ -105,8 +101,9 @@ class SupervisorGenerator(object):
         name = "dispatcher"
         conf_dir = os.path.join(self.args.output_dir, name)
         cmd_args = [
-            "bin/dispatcher", "--config",
-            os.path.join(conf_dir, DISP_CONFIG_NAME)
+            "bin/dispatcher",
+            "--config",
+            os.path.join(conf_dir, DISP_CONFIG_NAME),
         ]
         return (name, self._common_entry(name, cmd_args))
 
@@ -115,19 +112,19 @@ class SupervisorGenerator(object):
 
     def _common_entry(self, name, cmd_args):
         entry = {
-            'autostart': 'false',
-            'autorestart': 'false',
-            'environment': 'TZ=UTC',
-            'stdout_logfile': "logs/%s.log" % name,
-            'redirect_stderr': True,
-            'startretries': 0,
-            'startsecs': 5,
-            'priority': 100,
-            'command': ' '.join(shlex.quote(a) for a in cmd_args),
+            "autostart": "false",
+            "autorestart": "false",
+            "environment": "TZ=UTC",
+            "stdout_logfile": "logs/%s.log" % name,
+            "redirect_stderr": True,
+            "startretries": 0,
+            "startsecs": 5,
+            "priority": 100,
+            "command": " ".join(shlex.quote(a) for a in cmd_args),
         }
         if name == "dispatcher":
-            entry['startsecs'] = 1
-            entry['priority'] = 50
+            entry["startsecs"] = 1
+            entry["priority"] = 50
         return entry
 
     def _write_config(self, config, path):


### PR DESCRIPTION
Enable the [black formatter](https://github.com/psf/black) for python files.

This will give us consistent python formatting similar to gofmt.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4330)
<!-- Reviewable:end -->
