### PR TITLE
topology: deprecate unused attributes

### DIFF
--- a/acceptance/topo_common/topology.json
+++ b/acceptance/topo_common/topology.json
@@ -2,10 +2,7 @@
   "isd_as": "1-ff00:0:110",
   "mtu": 1400,
   "attributes": [
-    "authoritative",
-    "core",
-    "issuing",
-    "voting"
+    "core"
   ],
   "border_routers": {
     "br1-ff00_0_110-1": {

--- a/acceptance/topo_cs_reload/testdata/topology_reload.json
+++ b/acceptance/topo_cs_reload/testdata/topology_reload.json
@@ -2,10 +2,7 @@
   "isd_as": "1-ff00:0:110",
   "mtu": 1400,
   "attributes": [
-    "authoritative",
-    "core",
-    "issuing",
-    "voting"
+    "core"
   ],
   "border_routers": {
     "br1-ff00_0_110-1": {

--- a/acceptance/topo_daemon_reload/testdata/topology_reload.json
+++ b/acceptance/topo_daemon_reload/testdata/topology_reload.json
@@ -2,10 +2,7 @@
   "isd_as": "1-ff00:0:110",
   "mtu": 1400,
   "attributes": [
-    "authoritative",
-    "core",
-    "issuing",
-    "voting"
+    "core"
   ],
   "border_routers": {
     "br1-ff00_0_110-1": {

--- a/control/beaconing/testdata/topology-core.json
+++ b/control/beaconing/testdata/topology-core.json
@@ -2,10 +2,7 @@
   "isd_as": "1-ff00:0:110",
   "mtu": 1472,
   "attributes": [
-    "authoritative",
-    "core",
-    "issuing",
-    "voting"
+      "core"
   ],
   "border_routers": {
     "br1-ff00_0_110-1": {

--- a/private/topology/interface.go
+++ b/private/topology/interface.go
@@ -39,8 +39,6 @@ type Topology interface {
 	MTU() uint16
 	// Core returns whether the local AS is core.
 	Core() bool
-	// CA returns whether the local AS is a CA.
-	CA() bool
 	// InterfaceIDs returns all interface IDS from the local AS.
 	InterfaceIDs() []common.IFIDType
 
@@ -184,15 +182,6 @@ func (t *topologyS) MakeHostInfos(st ServiceType) ([]*net.UDPAddr, error) {
 func (t *topologyS) Core() bool {
 	for _, attr := range t.Topology.Attributes {
 		if attr == jsontopo.AttrCore {
-			return true
-		}
-	}
-	return false
-}
-
-func (t *topologyS) CA() bool {
-	for _, attr := range t.Topology.Attributes {
-		if attr == jsontopo.Issuing {
 			return true
 		}
 	}

--- a/private/topology/interface.go
+++ b/private/topology/interface.go
@@ -24,7 +24,6 @@ import (
 	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/private/common"
 	"github.com/scionproto/scion/pkg/private/serrors"
-	jsontopo "github.com/scionproto/scion/private/topology/json"
 )
 
 // Topology is the topology type for applications and libraries that only need read access to AS
@@ -180,12 +179,7 @@ func (t *topologyS) MakeHostInfos(st ServiceType) ([]*net.UDPAddr, error) {
 }
 
 func (t *topologyS) Core() bool {
-	for _, attr := range t.Topology.Attributes {
-		if attr == jsontopo.AttrCore {
-			return true
-		}
-	}
-	return false
+	return t.Topology.IsCore
 }
 
 func (t *topologyS) Gateways() ([]GatewayInfo, error) {

--- a/private/topology/json/BUILD.bazel
+++ b/private/topology/json/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/scionproto/scion/private/topology/json",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/log:go_default_library",
         "//pkg/private/common:go_default_library",
         "//pkg/private/serrors:go_default_library",
         "//pkg/private/util:go_default_library",

--- a/private/topology/json/json_test.go
+++ b/private/topology/json/json_test.go
@@ -41,8 +41,7 @@ func TestLoadRawFromFile(t *testing.T) {
 		TimestampHuman: "May  6 00:00:00 CET 1975",
 		IA:             "6-ff00:0:362",
 		MTU:            1472,
-		Attributes: []jsontopo.Attribute{jsontopo.Authoritative, jsontopo.AttrCore,
-			jsontopo.Issuing, jsontopo.Voting},
+		Attributes:     []jsontopo.Attribute{jsontopo.AttrCore},
 		BorderRouters: map[string]*jsontopo.BRInfo{
 			"borderrouter6-f00:0:362-1": {
 				InternalAddr: "10.1.0.1:0",
@@ -105,4 +104,12 @@ func TestLoadRawFromFile(t *testing.T) {
 			strings.TrimSpace(string(topologyBytes)),
 		)
 	})
+}
+
+func TestLoadIgnoreDeprecatedAttributes(t *testing.T) {
+	reference, err := jsontopo.LoadFromFile("testdata/topology.json")
+	require.NoError(t, err)
+	legacyFiltered, err := jsontopo.LoadFromFile("testdata/topology-deprecated-attrs.json")
+	assert.NoError(t, err)
+	assert.Equal(t, reference, legacyFiltered)
 }

--- a/private/topology/json/testdata/topology-deprecated-attrs.json
+++ b/private/topology/json/testdata/topology-deprecated-attrs.json
@@ -1,0 +1,49 @@
+{
+  "timestamp": 168562800,
+  "timestamp_human": "May  6 00:00:00 CET 1975",
+  "isd_as": "6-ff00:0:362",
+  "mtu": 1472,
+  "attributes": [
+    "authoritative",
+    "core",
+    "issuing",
+    "voting"
+  ],
+  "border_routers": {
+    "borderrouter6-f00:0:362-1": {
+      "internal_addr": "10.1.0.1:0",
+      "interfaces": {
+        "91": {
+          "underlay": {
+            "public": "192.0.2.1:4997",
+            "remote": "192.0.2.2:4998",
+            "bind": "10.0.0.1"
+          },
+          "isd_as": "6-ff00:0:363",
+          "link_to": "CORE",
+          "mtu": 1472,
+          "bfd": {
+            "detect_mult": 3,
+            "desired_min_tx_interval": "25ms",
+            "required_min_rx_interval": "25ms"
+          }
+        }
+      }
+    },
+    "borderrouter6-f00:0:362-9": {
+      "internal_addr": "[2001:db8:a0b:12f0::2]:0",
+      "interfaces": {
+        "32": {
+          "underlay": {
+            "public": "[2001:db8:a0b:12f0::1]:4997",
+            "remote": "[2001:db8:a0b:12f0::2]:4998",
+            "bind": "2001:db8:a0b:12f0::8"
+          },
+          "isd_as": "6-ff00:0:364",
+          "link_to": "CHILD",
+          "mtu": 4430
+        }
+      }
+    }
+  }
+}

--- a/private/topology/json/testdata/topology.json
+++ b/private/topology/json/testdata/topology.json
@@ -4,10 +4,7 @@
   "isd_as": "6-ff00:0:362",
   "mtu": 1472,
   "attributes": [
-    "authoritative",
-    "core",
-    "issuing",
-    "voting"
+    "core"
   ],
   "border_routers": {
     "borderrouter6-f00:0:362-1": {

--- a/private/topology/mock_topology/mock.go
+++ b/private/topology/mock_topology/mock.go
@@ -81,20 +81,6 @@ func (mr *MockTopologyMockRecorder) BRNames() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BRNames", reflect.TypeOf((*MockTopology)(nil).BRNames))
 }
 
-// CA mocks base method.
-func (m *MockTopology) CA() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CA")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// CA indicates an expected call of CA.
-func (mr *MockTopologyMockRecorder) CA() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CA", reflect.TypeOf((*MockTopology)(nil).CA))
-}
-
 // Core mocks base method.
 func (m *MockTopology) Core() bool {
 	m.ctrl.T.Helper()

--- a/private/topology/reload.go
+++ b/private/topology/reload.go
@@ -129,13 +129,6 @@ func (l *Loader) Core() bool {
 	return l.topo.Core()
 }
 
-func (l *Loader) CA() bool {
-	l.mtx.Lock()
-	defer l.mtx.Unlock()
-
-	return l.topo.CA()
-}
-
 func (l *Loader) UnderlayNextHop(ifID uint16) *net.UDPAddr {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()

--- a/private/topology/testdata/core.json
+++ b/private/topology/testdata/core.json
@@ -4,10 +4,7 @@
   "isd_as": "6-ff00:0:362",
   "mtu": 1472,
   "attributes": [
-    "authoritative",
-    "core",
-    "issuing",
-    "voting"
+      "core"
   ],
   "border_routers": {
     "borderrouter6-ff00:0:362-1": {

--- a/private/topology/topology_test.go
+++ b/private/topology/topology_test.go
@@ -35,7 +35,7 @@ func TestMeta(t *testing.T) {
 	assert.Equal(t, time.Unix(168570123, 0), c.Timestamp, "Field 'Timestamp'")
 	assert.Equal(t, addr.MustIAFrom(1, 0xff0000000311), c.IA, "Field 'ISD_AS'")
 	assert.Equal(t, 1472, c.MTU, "Field 'MTU'")
-	assert.Empty(t, c.Attributes, "Field 'Attributes'")
+	assert.False(t, c.IsCore, "Field 'Attributes'")
 }
 
 func TestActive(t *testing.T) {

--- a/private/topology/validator.go
+++ b/private/topology/validator.go
@@ -122,9 +122,9 @@ func (v *generalValidator) Immutable(new, old *RWTopology) error {
 		return serrors.New("IA is immutable",
 			"expected", old.IA, "actual", new.IA)
 	}
-	if !attributesEqual(new.Attributes, old.Attributes) {
-		return serrors.New("Attributes are immutable",
-			"expected", old.Attributes, "actual", new.Attributes)
+	if new.IsCore != old.IsCore {
+		return serrors.New("IsCore is immutable",
+			"expected", old.IsCore, "actual", new.IsCore)
 	}
 	if new.MTU != old.MTU {
 		return serrors.New("MTU is immutable",

--- a/private/topology/validator.go
+++ b/private/topology/validator.go
@@ -19,7 +19,6 @@ import (
 	"sync"
 
 	"github.com/scionproto/scion/pkg/private/serrors"
-	jsontopo "github.com/scionproto/scion/private/topology/json"
 )
 
 // DefaultValidator is the default topology update validator.
@@ -200,16 +199,4 @@ func (v *routerValidator) Immutable(new, old *RWTopology) error {
 			old.BR[v.id].InternalAddr, "actual", new.BR[v.id].InternalAddr)
 	}
 	return nil
-}
-
-func attributesEqual(a, b []jsontopo.Attribute) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/private/topology/validator_test.go
+++ b/private/topology/validator_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/private/topology"
-	jsontopo "github.com/scionproto/scion/private/topology/json"
 )
 
 func TestDefaultValidatorValidate(t *testing.T) {
@@ -54,9 +53,8 @@ func TestDefaultValidatorValidate(t *testing.T) {
 			assertErr: assert.Error,
 		},
 		"attributes immutable": {
-			loadOld: defaultTopo,
-			loadNew: topoWithModification(t,
-				setAttributes([]jsontopo.Attribute{jsontopo.AttrCore})),
+			loadOld:   defaultTopo,
+			loadNew:   topoWithModification(t, setIsCore(true)),
 			assertErr: assert.Error,
 		},
 		"valid update": {
@@ -114,9 +112,8 @@ func TestControlValidatorValidate(t *testing.T) {
 			assertErr: assert.Error,
 		},
 		"attributes immutable": {
-			loadOld: defaultTopo,
-			loadNew: topoWithModification(t,
-				setAttributes([]jsontopo.Attribute{jsontopo.AttrCore})),
+			loadOld:   defaultTopo,
+			loadNew:   topoWithModification(t, setIsCore(true)),
 			assertErr: assert.Error,
 		},
 		"valid update": {
@@ -192,9 +189,8 @@ func TestRouterValidatorValidate(t *testing.T) {
 			assertErr: assert.Error,
 		},
 		"attributes immutable": {
-			loadOld: defaultTopo,
-			loadNew: topoWithModification(t,
-				setAttributes([]jsontopo.Attribute{jsontopo.AttrCore})),
+			loadOld:   defaultTopo,
+			loadNew:   topoWithModification(t, setIsCore(true)),
 			assertErr: assert.Error,
 		},
 		"valid update": {
@@ -259,9 +255,9 @@ func setMTU(mtu int) func(topo *topology.RWTopology) {
 	}
 }
 
-func setAttributes(attrs []jsontopo.Attribute) func(topo *topology.RWTopology) {
+func setIsCore(isCore bool) func(topo *topology.RWTopology) {
 	return func(topo *topology.RWTopology) {
-		topo.Attributes = attrs
+		topo.IsCore = isCore
 	}
 }
 

--- a/router/control/testdata/topology.json
+++ b/router/control/testdata/topology.json
@@ -2,10 +2,7 @@
   "isd_as": "1-ff00:0:110",
   "mtu": 1472,
   "attributes": [
-    "authoritative",
-    "core",
-    "issuing",
-    "voting"
+      "core"
   ],
   "border_routers": {
     "br1-ff00_0_110-1": {

--- a/tools/topology/config.py
+++ b/tools/topology/config.py
@@ -134,7 +134,7 @@ class ConfigGenerator(object):
         go_gen.generate_disp()
 
     def _go_args(self, topo_dicts):
-        return GoGenArgs(self.args, topo_dicts, self.networks)
+        return GoGenArgs(self.args, self.topo_config, topo_dicts, self.networks)
 
     def _generate_jaeger(self, topo_dicts):
         args = JaegerGenArgs(self.args, topo_dicts)

--- a/tools/topology/go.py
+++ b/tools/topology/go.py
@@ -25,7 +25,7 @@ from typing import Mapping
 # SCION
 from topology.util import write_file
 from topology.common import (
-    ArgsTopoDicts,
+    ArgsBase,
     DISP_CONFIG_NAME,
     docker_host,
     prom_addr,
@@ -51,9 +51,17 @@ from topology.prometheus import (
 DEFAULT_COLIBRI_TOTAL_BW = 1000
 
 
-class GoGenArgs(ArgsTopoDicts):
-    def __init__(self, args, topo_dicts, networks: Mapping[IPNetwork, NetworkDescription]):
-        super().__init__(args, topo_dicts)
+class GoGenArgs(ArgsBase):
+    def __init__(self, args, topo_config, topo_dicts,
+                 networks: Mapping[IPNetwork, NetworkDescription]):
+        """
+        :param object args: Contains the passed command line arguments as named attributes.
+        :param dict topo_config: The parsed topology config.
+        :param dict topo_dicts: The generated topo dicts from TopoGenerator.
+        """
+        super().__init__(args)
+        self.config = topo_config
+        self.topo_dicts = topo_dicts
         self.networks = networks
 
 
@@ -95,7 +103,7 @@ class GoGenerator(object):
 
     def generate_control_service(self):
         for topo_id, topo in self.args.topo_dicts.items():
-            ca = 'issuing' in topo.get("attributes", [])
+            ca = self.args.config["ASes"][str(topo_id)].get("issuing", False)
             for elem_id, elem in topo.get("control_service", {}).items():
                 # only a single Go-BS per AS is currently supported
                 if elem_id.endswith("-1"):

--- a/tools/topology/topo.py
+++ b/tools/topology/topo.py
@@ -238,7 +238,7 @@ class TopoGenerator(object):
         mtu = as_conf.get('mtu', self.args.default_mtu)
         assert mtu >= SCION_MIN_MTU, mtu
         attributes = []
-        for attr in ['authoritative', 'core', 'issuing', 'voting']:
+        for attr in ['core']:
             if as_conf.get(attr, False):
                 attributes.append(attr)
         self.topo_dicts[topo_id] = {


### PR DESCRIPTION
Deprecate unused attributes `authoritative`, `voting` and `issuing` from the topology.json configuration. These are no longer considered by any service or tool and the functionality has been moved into the cs.toml (containing a `[ca]` section for "issuing" ASes) or into the TRC and the configuration of the corresponding tooling.
Only the `core` attribute option remains. In the long run, this should either disappear entirely from the topology configuration or be changed to a boolean flag.

In the internal `private/topology`, remove the unused `CA() bool` from the interface, and simplify the representation of the state from a list of attributes to a simpler `IsCore`.

The goal here is mainly to avoid confusion caused by the unused attributes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4333)
<!-- Reviewable:end -->
