### PR TITLE
scion.sh: fix IPv6 address bug in sciond-addr subcommand

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -55,7 +55,7 @@ cmd_sciond-addr() {
     jq -r 'to_entries |
            map(select(.key | match("'"$1"'";"i"))) |
            if length != 1 then error("No unique match for '"$1"'") else .[0] end |
-           "\(.value):30255"' gen/sciond_addresses.json
+           "[\(.value)]:30255"' gen/sciond_addresses.json
 }
 
 run_jaeger() {


### PR DESCRIPTION
Thanks to @matzf and its suggestions, I fixed a bug at line 58 of the scion.sh file. It was giving a "too much colons" error when finding an IPv6 address instead of IPv4, in the scion local topology. The problem was about trying to add a port number to an IPv6  address

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4341)
<!-- Reviewable:end -->
