### PR TITLE
doc: fix grammar in dependencies.rst

### DIFF
--- a/doc/dev/dependencies.rst
+++ b/doc/dev/dependencies.rst
@@ -28,27 +28,27 @@ To add/remove or update dependencies:
 5. ``make gazelle``, to update the build files that depend on the newly added dependency
 
 .. Warning::
-  The Go rules for Bazel (rules_go) declare some internally used dependencies.
+  The Go rules for Bazel (rules_go) declares some internally used dependencies.
   These may **silently shadow** the dependency versions declared in
   ``go_deps.bzl``.
 
   To explicitly override such a dependency version, the corresponding
   ``go_repository`` rule can be moved from ``go_deps.bzl`` to the
   ``WORKSPACE`` file, *before* the call to ``go_rules_dependencies``.
-  See the `go_rules documentation on overriding dependencies <https://github.com/bazelbuild/rules_go/blob/master/go/dependencies.rst#overriding-dependencies>`_.
+  Refer to the `go_rules documentation on overriding dependencies <https://github.com/bazelbuild/rules_go/blob/master/go/dependencies.rst#overriding-dependencies>`_.
 
 
 Python
 ^^^^^^
 
-The python dependencies are listed in ``requirements.txt`` files. They are generated with bazel from the
-adjoining ``requirements.in`` files.
+The Python dependencies are listed in ``requirements.txt`` files. They are generated with Bazel from the
+corresponding ``requirements.in`` files.
 
-The python dependencies are listed in `tools/env/pip3/requirements.txt
+The Python dependencies are listed in `tools/env/pip3/requirements.txt
 <https://github.com/scionproto/scion/blob/master/tools/env/pip3/requirements.txt>`__
 and `tools/lint/python/requirements.txt
 <https://github.com/scionproto/scion/blob/master/tools/lint/python/requirements.txt>`__.
-These files is generated from the adjoining ``requirements.in`` by bazel. Only
-direct dependencies have to be listed, the transitive dependencies are inferred.
+These files is generated from the corresponding ``requirements.in`` by Bazel. Only
+direct dependencies need to be listed; the transitive dependencies are inferred.
 The exact command to update ``requirements.txt`` is described in a comment in
-the header of the file.
+the file's header.


### PR DESCRIPTION
Found a couple grammar errors with past/present tense and capitalizing the nouns, very simple and minimal modifications.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4349)
<!-- Reviewable:end -->
