### PR TITLE
slayers: fix decoding and serializing wide DT/ST

### DIFF
--- a/pkg/drkey/generic/generic.go
+++ b/pkg/drkey/generic/generic.go
@@ -94,7 +94,7 @@ func (d Deriver) serializeLevel2Input(
 	_ = input[inputLength-1]
 	input[0] = uint8(derType)
 	binary.BigEndian.PutUint16(input[1:], uint16(proto))
-	input[3] = uint8(host.AddrType & 0x7)
+	input[3] = uint8(host.AddrType & 0xF)
 	copy(input[4:], hostAddr)
 	copy(input[4+l:inputLength], drkey.ZeroBlock[:])
 

--- a/pkg/drkey/protocol.go
+++ b/pkg/drkey/protocol.go
@@ -102,7 +102,7 @@ func SerializeHostHostInput(input []byte, host HostAddr) int {
 
 	_ = input[inputLength-1]
 	input[0] = uint8(HostHost)
-	input[1] = uint8(host.AddrType & 0x7)
+	input[1] = uint8(host.AddrType & 0xF)
 	copy(input[2:], hostAddr)
 	copy(input[2+l:inputLength], ZeroBlock[:])
 

--- a/pkg/drkey/specific/specific.go
+++ b/pkg/drkey/specific/specific.go
@@ -96,7 +96,7 @@ func (d Deriver) serializeLevel2Input(
 
 	_ = input[inputLength-1]
 	input[0] = uint8(derType)
-	input[1] = uint8(host.AddrType & 0x7)
+	input[1] = uint8(host.AddrType & 0xF)
 	copy(input[2:], hostAddr)
 	copy(input[2+l:inputLength], drkey.ZeroBlock[:])
 

--- a/pkg/slayers/scion.go
+++ b/pkg/slayers/scion.go
@@ -183,7 +183,7 @@ func (s *SCION) SerializeTo(b gopacket.SerializeBuffer, opts gopacket.SerializeO
 	buf[5] = s.HdrLen
 	binary.BigEndian.PutUint16(buf[6:8], s.PayloadLen)
 	buf[8] = uint8(s.PathType)
-	buf[9] = uint8(s.DstAddrType&0x7)<<4 | uint8(s.SrcAddrType&0x7)
+	buf[9] = uint8(s.DstAddrType&0xF)<<4 | uint8(s.SrcAddrType&0xF)
 	binary.BigEndian.PutUint16(buf[10:12], 0)
 
 	// Serialize address header.
@@ -215,8 +215,8 @@ func (s *SCION) DecodeFromBytes(data []byte, df gopacket.DecodeFeedback) error {
 	s.HdrLen = data[5]
 	s.PayloadLen = binary.BigEndian.Uint16(data[6:8])
 	s.PathType = path.Type(data[8])
-	s.DstAddrType = AddrType(data[9] >> 4 & 0x7)
-	s.SrcAddrType = AddrType(data[9] & 0x7)
+	s.DstAddrType = AddrType(data[9] >> 4 & 0xF)
+	s.SrcAddrType = AddrType(data[9] & 0xF)
 
 	// Decode address header.
 	if err := s.DecodeAddrHdr(data[CmnHdrLen:]); err != nil {

--- a/pkg/spao/mac.go
+++ b/pkg/spao/mac.go
@@ -137,7 +137,7 @@ func serializeAuthenticatedData(
 	firstHdrLine := uint32(s.Version&0xF)<<28 | uint32(s.TrafficClass&0x3f)<<20 | s.FlowID&0xFFFFF
 	binary.BigEndian.PutUint32(buf[12:], firstHdrLine)
 	buf[16] = byte(s.PathType)
-	buf[17] = byte(s.DstAddrType&0x7)<<4 | byte(s.SrcAddrType&0x7)
+	buf[17] = byte(s.DstAddrType&0xF)<<4 | byte(s.SrcAddrType&0xF)
 	binary.BigEndian.PutUint16(buf[18:], 0)
 	offset := fixAuthDataInputLen
 


### PR DESCRIPTION
Both decoding and serializing of the address type fields (DstAddrType and SrcAddrType) was truncating the most significant bit. This has not caused any issues so far as no address type with type greater than 1 is defined and used.

This bug was introduced in #4160, by consistently using the wrong (!) value 0x7, instead of 0xF, to mask the lowest four bits. Fixed the same mistake in copies of the serialization logic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4352)
<!-- Reviewable:end -->
