### PR TITLE
fix spelling of Daemon

### DIFF
--- a/private/app/flag/env.go
+++ b/private/app/flag/env.go
@@ -106,7 +106,7 @@ func (e *SCIONEnvironment) Register(flagSet *pflag.FlagSet) {
 	sciond := defaultDaemon
 	dispatcher := defaultDispatcher
 	e.sciondFlag = flagSet.VarPF((*stringVal)(&sciond), "sciond", "",
-		"SCION Deamon address.")
+		"SCION Daemon address.")
 	e.iaFlag = flagSet.VarPF((*iaVal)(&e.ia), "isd-as", "",
 		"The local ISD-AS to use.")
 	e.dispFlag = flagSet.VarPF((*stringVal)(&dispatcher), "dispatcher", "",

--- a/scion/cmd/scion/showpaths.go
+++ b/scion/cmd/scion/showpaths.go
@@ -61,7 +61,7 @@ func newShowpaths(pather CommandPather) *cobra.Command {
 		Long: fmt.Sprintf(`'showpaths' lists available paths between the local and the specified
 SCION ASe a.
 
-By default, the paths are probed. Paths served from the SCION Deamon's might not
+By default, the paths are probed. Paths served from the SCION Daemon's might not
 forward traffic successfully (e.g. if a network link went down, or there is a black
 hole on the path). To disable path probing, set the appropriate flag.
 
@@ -155,7 +155,7 @@ On other errors, showpaths will exit with code 2.
 	cmd.Flags().BoolVarP(&flags.extended, "extended", "e", false,
 		"Show extended path meta data information")
 	cmd.Flags().BoolVarP(&flags.cfg.Refresh, "refresh", "r", false,
-		"Set refresh flag for SCION Deamon path request")
+		"Set refresh flag for SCION Daemon path request")
 	cmd.Flags().BoolVar(&flags.cfg.NoProbe, "no-probe", false,
 		"Do not probe the paths and print the health status")
 	cmd.Flags().BoolVarP(&flags.json, "json", "j", false,

--- a/scion/showpaths/config.go
+++ b/scion/showpaths/config.go
@@ -26,7 +26,7 @@ type Config struct {
 	// Local configures the local IP address to use. If this option is not provided,
 	// a local IP that can reach SCION hosts is selected with the help of the kernel.
 	Local net.IP
-	// Daemon configures a specific SCION Deamon address.
+	// Daemon configures a specific SCION Daemon address.
 	Daemon string
 	// MaxPaths configures the maximum number of displayed paths. If this option is
 	// not provided, the DefaultMaxPaths is used.


### PR DESCRIPTION
The Daemon was called Deamon in some places. This commit fixes that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4354)
<!-- Reviewable:end -->
