### PR TITLE
doc: fix link to EPIC-HP design doc

### DIFF
--- a/doc/dev/design/EPIC.md
+++ b/doc/dev/design/EPIC.md
@@ -3,7 +3,7 @@
 - Author: Marc Wyss, Markus Legner
 - Last updated: 2020-10-14
 - Status: **implemented**
-- Discussion at: [#3884](https://github.com/scionproto/scion/issues/3653)
+- Discussion at: [#3884](https://github.com/scionproto/scion/issues/3884)
 - Implemented in: [#3951](https://github.com/scionproto/scion/issues/3951),
                   [#3954](https://github.com/scionproto/scion/issues/3954),
                   [#4079](https://github.com/scionproto/scion/issues/4079)


### PR DESCRIPTION
Hi there,
just a small fix cause I am getting annoyed over having to fix the link manually all the time.
Current Link goes to a PR for a COLIBRI design document instead of EPIC.

Best Regards

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4358)
<!-- Reviewable:end -->
