### PR TITLE
deps: change rules_antlr fork

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -125,9 +125,9 @@ rules_pkg_dependencies()
 # Antlr rules
 http_archive(
     name = "rules_antlr",
-    sha256 = "234c401cfabab78f2d7f5589239d98f16f04338768a72888f660831964948ab1",
+    sha256 = "8d7c457cc266965bdcf7e85aa349d2f851b772a55877354d9ae92ada7a62c857",
     strip_prefix = "rules_antlr-0.6.0",
-    urls = ["https://github.com/artisoft-io/rules_antlr/archive/0.6.0.tar.gz"],
+    urls = ["https://github.com/bacek/rules_antlr/archive/refs/tags/0.6.0.tar.gz"],
 )
 
 load("@rules_antlr//antlr:repositories.bzl", "rules_antlr_dependencies")


### PR DESCRIPTION
The fork of rules_antlr that we depend on has disappeared https://github.com/artisoft-io

We switch to another fork that contains the same changes that artisoft-io had.