### PR TITLE
build: prevent go from linking libresolv dynamically.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,7 +17,7 @@ build --incompatible_default_to_explicit_init_py
 
 # include one of "--define gotags=sqlite_mattn" or "--define gotags=sqlite_modernc"
 # cannot be in common, because query chokes on it.
-build --define gotags=sqlite_modernc
+build --define gotags=sqlite_modernc,no_libresolv
 
 ### options for test
 test --build_tests_only --print_relative_test_log_paths --test_output=errors


### PR DESCRIPTION
This is default (https://pkg.go.dev/net@go1.21.1#hdr-Name_Resolution). It creates an indirect dependency on a fresh version of glibc. As a result, it prevents our binaries from running on not-so-fesh docker images.