### PR TITLE
ci: fixes for updated buildkite elastic stack version 

### DIFF
--- a/acceptance/router_multi/test.py
+++ b/acceptance/router_multi/test.py
@@ -118,6 +118,10 @@ class RouterTest(base.TestBase):
         sudo("chown -R %s %s" % (cmd.whoami(), self.artifacts))
 
     def create_veths(self, ns: str):
+        # Set default TTL for outgoing packets to the common value 64, so that packets sent
+        # from router will match the expected value.
+        sudo("ip netns exec %s sysctl -w net.ipv4.ip_default_ttl=64" % ns)
+
         create_veth("veth_int_host", "veth_int", "192.168.0.11/24", "f0:0d:ca:fe:00:01", ns,
                     ["192.168.0.12", "192.168.0.13", "192.168.0.14", "192.168.0.51", "192.168.0.61",
                         "192.168.0.71"])

--- a/demo/file_transfer/tc_setup.sh
+++ b/demo/file_transfer/tc_setup.sh
@@ -4,7 +4,7 @@ set -ex
 NETWORK=$1
 RATE=$2
 
-veths=$(brctl show $NETWORK | awk 'NR>1''{print $NF}')
+veths=$(bridge link show | awk "/$NETWORK/{print \$2}")
 for veth in $veths
 do
     echo $veth

--- a/doc/dev/testing/buildkite.rst
+++ b/doc/dev/testing/buildkite.rst
@@ -44,12 +44,13 @@ Agents
 Machine Image
 -------------
 
-We use the default machine image of the *Elastic CI Stack for AWS*. `What's on each machine <https://buildkite.com/docs/agent/v3/elastic-ci-aws#whats-on-each-machine>`_:
+We use the default machine image of the *Elastic CI Stack for AWS* release `v6.7.1 <https://github.com/buildkite/elastic-ci-stack-for-aws/releases/tag/v6.7.1>`.
+`What's on each machine <https://buildkite.com/docs/agent/v3/elastic-ci-aws#before-you-start-whats-on-each-machine>`_:
 
-- Amazon Linux 2
-- Buildkite Agent v3.39.1
-- Docker v20.10.7
-- Docker Compose v1.29.2
+- Amazon Linux 2023
+- Buildkite Agent v3.50.2
+- Docker v20.10.25
+- Docker Compose v2.20.3
 - AWS CLI
 - jq
 

--- a/tools/env/rhel/pkgs.txt
+++ b/tools/env/rhel/pkgs.txt
@@ -1,10 +1,8 @@
-bridge-utils
-moreutils
+ethtool
 gcc
 g++
 python3-pip
 python3-setuptools
 python3-wheel
 jq
-sqlite3
 openssl


### PR DESCRIPTION
Fixes for update of buildkite elastic stack to v6.7.1.

Update package "rhel" dependency list for Amazon Linux 2023:
- `bridge-utils`: no longer available. Replace deprecated `brctl` with iproute2's `bridge`
- `moreutils`: no longer available, not used
- `sqlite3`: no longer available, not used
- `ethtool`: required for router_multi test, seems to have previously been installed by default.

For the router_multi test, set the default TTL to 64, so that the packets sent back by the router match the expected value. This is the default value on many other systems, so we did not previously need to worry about this.
The value is only set in a net-namespace, so we don't need to worry about resetting it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4397)
<!-- Reviewable:end -->
