### PR TITLE
control: formatted duration for config trustengine.cache.expiration

### DIFF
--- a/control/cmd/control/main.go
+++ b/control/cmd/control/main.go
@@ -271,7 +271,7 @@ func realMain(ctx context.Context) error {
 			DB: trustDB,
 		},
 		CacheHits:          cacheHits,
-		MaxCacheExpiration: globalCfg.TrustEngine.Cache.Expiration,
+		MaxCacheExpiration: globalCfg.TrustEngine.Cache.Expiration.Duration,
 		Cache:              trustengineCache,
 	}
 	provider := trust.FetchingProvider{
@@ -288,7 +288,7 @@ func realMain(ctx context.Context) error {
 		Verifier: trust.Verifier{
 			Engine:             provider,
 			CacheHits:          cacheHits,
-			MaxCacheExpiration: globalCfg.TrustEngine.Cache.Expiration,
+			MaxCacheExpiration: globalCfg.TrustEngine.Cache.Expiration.Duration,
 			Cache:              trustengineCache,
 		},
 	}

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -156,7 +156,7 @@ func realMain(ctx context.Context) error {
 		Inspector:          engine.Inspector,
 		Cache:              globalCfg.TrustEngine.Cache.New(),
 		CacheHits:          metrics.NewPromCounter(trustmetrics.CacheHitsTotal),
-		MaxCacheExpiration: globalCfg.TrustEngine.Cache.Expiration,
+		MaxCacheExpiration: globalCfg.TrustEngine.Cache.Expiration.Duration,
 	}
 	trcLoader := periodic.Start(periodic.Func{
 		Task: func(ctx context.Context) {
@@ -247,7 +247,7 @@ func realMain(ctx context.Context) error {
 			Engine:             engine,
 			Cache:              globalCfg.TrustEngine.Cache.New(),
 			CacheHits:          metrics.NewPromCounter(trustmetrics.CacheHitsTotal),
-			MaxCacheExpiration: globalCfg.TrustEngine.Cache.Expiration,
+			MaxCacheExpiration: globalCfg.TrustEngine.Cache.Expiration.Duration,
 		}}
 	}
 

--- a/doc/manuals/control.rst
+++ b/doc/manuals/control.rst
@@ -315,11 +315,9 @@ considers the following options.
 
       Disable caching entirely.
 
-   .. option:: trustengine.cache.expiration = <int> (Default: 60000000000)
+   .. option:: trustengine.cache.expiration = <duration> (Default: "1m")
 
-      Expiration of cached entries in nanoseconds.
-
-      **TODO:** this should be changed to accept values in :ref:`duration format <common-conf-duration>`.
+      Expiration time for cached entries.
 
 .. object:: drkey
 

--- a/private/trust/config/BUILD.bazel
+++ b/private/trust/config/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/scionproto/scion/private/trust/config",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/private/util:go_default_library",
         "//private/config:go_default_library",
         "@com_github_patrickmn_go_cache//:go_default_library",
     ],

--- a/private/trust/config/config.go
+++ b/private/trust/config/config.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/patrickmn/go-cache"
 
+	"github.com/scionproto/scion/pkg/private/util"
 	"github.com/scionproto/scion/private/config"
 )
 
@@ -47,20 +48,20 @@ func (cfg *Config) ConfigName() string {
 }
 
 type Cache struct {
-	Disable    bool          `toml:"disable,omitempty"`
-	Expiration time.Duration `toml:"expiration,omitempty"`
+	Disable    bool         `toml:"disable,omitempty"`
+	Expiration util.DurWrap `toml:"expiration,omitempty"`
 }
 
 func (cfg *Cache) New() *cache.Cache {
 	if cfg.Disable {
 		return nil
 	}
-	return cache.New(cfg.Expiration, time.Minute)
+	return cache.New(cfg.Expiration.Duration, time.Minute)
 }
 
 func (cfg *Cache) InitDefaults() {
-	if cfg.Expiration == 0 {
-		cfg.Expiration = defaultExpiration
+	if cfg.Expiration.Duration == 0 {
+		cfg.Expiration.Duration = defaultExpiration
 	}
 }
 


### PR DESCRIPTION
The `trustengine.cache.expiration` configuration option would accept durations as number of nanoseconds. Most likely, this was accidental, all other configuration options for durations accept formatted duration strings, with unit suffix.

Change `trustengine.cache.expiration` to accept (only) formatted duration strings.

This is a potentially compatibility breaking change for existing control service configuration files.
The `trustengine.cache` configuration block is marked as experimental and is likely not widely used, so no transition mechanism is added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4417)
<!-- Reviewable:end -->
