### PR TITLE
router: feature toggle for experimental SCMP authentication

### DIFF
--- a/acceptance/router_multi/conf/br.toml
+++ b/acceptance/router_multi/conf/br.toml
@@ -2,6 +2,9 @@
   id = "brA"
   config_dir = "/share/conf"
 
+[features]
+  experimental_scmp_authentication = true
+
 [log]
   [log.console]
     level = "debug"

--- a/doc/manuals/router.rst
+++ b/doc/manuals/router.rst
@@ -100,8 +100,7 @@ Environment Variables
 .. object:: SCION_TESTING_DRKEY_EPOCH_DURATION
 
    For **testing only**.
-   This option relates to :ref:`DRKey-based authentication of SCMPs <scmp-authentication>` in the
-   router, which is **experimental** and currently **incomplete**.
+   This option relates :option:`features.experimental_scmp_authentication <router-conf-toml features.experimental_scmp_authentication>`.
 
    Override the global duration for :doc:`/cryptography/drkey` epochs.
 
@@ -113,8 +112,7 @@ Environment Variables
 .. envvar:: SCION_TESTING_ACCEPTANCE_WINDOW
 
    For **testing only**.
-   This option relates to :ref:`DRKey-based authentication of SCMPs <scmp-authentication>` in the
-   router, which is **experimental** and currently **incomplete**.
+   This option relates :option:`features.experimental_scmp_authentication <router-conf-toml features.experimental_scmp_authentication>`.
 
    Defines the length of the window around the current time for which SCMP authentication timestamps
    are accepted. See :ref:`SPAO specification <spao-absTime>`.
@@ -157,6 +155,19 @@ considers the following options.
 
       If this is a relative path, it is interpreted as relative to the current working directory of the
       program (i.e. **not** relative to the location of this .toml configuration file).
+
+.. object:: features
+
+   Features is a container for generic, boolean feature flags (usually for experimental or
+   transitional features).
+
+   .. option:: features.experimental_scmp_authentication = <bool> (Default: false)
+
+      Enable the :ref:`DRKey-based authentication of SCMPs <scmp-authentication>` in the
+      router, which is **experimental** and currently **incomplete**.
+
+      When enabled, the router inserts the :ref:`authenticator-option` for SCMP messages.
+      For now, the MAC is computed based on a dummy key, and consequently is not practically useful.
 
 .. object:: router
 

--- a/private/env/features.go
+++ b/private/env/features.go
@@ -36,6 +36,15 @@ type Features struct {
 
 	// Example:
 	// DanceAtMidnight bool `toml:"dance_at_midnight,omitempty"`
+
+	// ExperimentalSCMPAuthentication enables experimental, DRKey-based
+	// authentication of SCMP messages.
+	//
+	// When enabled, the router inserts the SPAO authenticator for SCMP error messages,
+	// generated with a dummy key!
+	//
+	// Experimental: This field is experimental and will be subject to change.
+	ExperimentalSCMPAuthentication bool `toml:"experimental_scmp_authentication"`
 }
 
 func (cfg *Features) Sample(dst io.Writer, path config.Path, ctx config.CtxMap) {

--- a/router/cmd/router/main.go
+++ b/router/cmd/router/main.go
@@ -58,7 +58,8 @@ func realMain(ctx context.Context) error {
 	metrics := router.NewMetrics()
 	dp := &router.Connector{
 		DataPlane: router.DataPlane{
-			Metrics: metrics,
+			Metrics:                        metrics,
+			ExperimentalSCMPAuthentication: globalCfg.Features.ExperimentalSCMPAuthentication,
 		},
 		ReceiveBufferSize: globalCfg.Router.ReceiveBufferSize,
 		SendBufferSize:    globalCfg.Router.SendBufferSize,

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -112,6 +112,8 @@ type DataPlane struct {
 	Metrics           *Metrics
 	forwardingMetrics map[uint16]forwardingMetrics
 
+	ExperimentalSCMPAuthentication bool
+
 	// The pool that stores all the packet buffers as described in the design document. See
 	// https://github.com/scionproto/scion/blob/master/doc/dev/design/BorderRouter.rst
 	packetPool chan []byte
@@ -2153,14 +2155,17 @@ func (p *slowPathPacketProcessor) prepareSCMP(
 	scmpH := slayers.SCMP{TypeCode: typeCode}
 	scmpH.SetNetworkLayerForChecksum(&scionL)
 
-	// Error messages must be authenticated.
-	// Traceroute are OPTIONALLY authenticated ONLY IF the request
-	// was authenticated.
-	// TODO(JordiSubira): Reuse the key computed in p.hasValidAuth
-	// if SCMPTypeTracerouteReply to create the response.
-	needsAuth := cause != nil ||
-		(scmpH.TypeCode.Type() == slayers.SCMPTypeTracerouteReply &&
-			p.hasValidAuth(time.Now()))
+	needsAuth := false
+	if p.d.ExperimentalSCMPAuthentication {
+		// Error messages must be authenticated.
+		// Traceroute are OPTIONALLY authenticated ONLY IF the request
+		// was authenticated.
+		// TODO(JordiSubira): Reuse the key computed in p.hasValidAuth
+		// if SCMPTypeTracerouteReply to create the response.
+		needsAuth = cause != nil ||
+			(scmpH.TypeCode.Type() == slayers.SCMPTypeTracerouteReply &&
+				p.hasValidAuth(time.Now()))
+	}
 
 	var quote []byte
 	if cause != nil {


### PR DESCRIPTION
The experimental implementation of DRKey-based authentication for SCMP messages is incomplete and, in the current form, not practically useful. Add a feature flag to explicitly opt-in to the experimental SCMP authentication in the router.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4418)
<!-- Reviewable:end -->
