### PR TITLE
snet/metrics: use registry in snet metrics

### DIFF
--- a/pkg/snet/metrics/metrics.go
+++ b/pkg/snet/metrics/metrics.go
@@ -84,7 +84,7 @@ func NewSCIONPacketConnMetrics(opts ...Option) snet.SCIONPacketConnMetrics {
 		ParseErrors: metrics.NewPromCounter(auto.NewCounterVec(prometheus.CounterOpts{
 			Name: "lib_snet_parse_error_total",
 			Help: "Total number of parse errors"}, []string{})),
-		SCMPErrors: NewSCMPErrors(),
+		SCMPErrors: NewSCMPErrors(opts...),
 	}
 }
 


### PR DESCRIPTION
The options were not correctly passed in to `NewSCMPErrors` in `snet/metrics`. This commit fixes that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4423)
<!-- Reviewable:end -->
