### PR TITLE
deps: bump google.golang.org/grpc, set MaxConcurrentStreams

### DIFF
--- a/control/cmd/control/main.go
+++ b/control/cmd/control/main.go
@@ -315,8 +315,12 @@ func realMain(ctx context.Context) error {
 	quicServer := grpc.NewServer(
 		grpc.Creds(libgrpc.PassThroughCredentials{}),
 		libgrpc.UnaryServerInterceptor(),
+		libgrpc.DefaultMaxConcurrentStreams(),
 	)
-	tcpServer := grpc.NewServer(libgrpc.UnaryServerInterceptor())
+	tcpServer := grpc.NewServer(
+		libgrpc.UnaryServerInterceptor(),
+		libgrpc.DefaultMaxConcurrentStreams(),
+	)
 
 	// Register trust material related handlers.
 	trustServer := &cstrustgrpc.MaterialServer{

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -251,7 +251,10 @@ func realMain(ctx context.Context) error {
 		}}
 	}
 
-	server := grpc.NewServer(libgrpc.UnaryServerInterceptor())
+	server := grpc.NewServer(
+		libgrpc.UnaryServerInterceptor(),
+		libgrpc.DefaultMaxConcurrentStreams(),
+	)
 	sdpb.RegisterDaemonServiceServer(server, daemon.NewServer(
 		daemon.ServerConfig{
 			IA:       topo.IA(),

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -584,7 +584,10 @@ func (g *Gateway) Run(ctx context.Context) error {
 	if g.Metrics != nil {
 		paMetric = metrics.NewPromGauge(g.Metrics.PrefixesAdvertised)
 	}
-	discoveryServer := grpc.NewServer(libgrpc.UnaryServerInterceptor())
+	discoveryServer := grpc.NewServer(
+		libgrpc.UnaryServerInterceptor(),
+		libgrpc.DefaultMaxConcurrentStreams(),
+	)
 	gatewaypb.RegisterIPPrefixesServiceServer(
 		discoveryServer,
 		controlgrpc.IPPrefixServer{

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	golang.org/x/net v0.10.0
 	golang.org/x/sync v0.2.0
 	golang.org/x/tools v0.9.1
-	google.golang.org/grpc v1.57.0
+	google.golang.org/grpc v1.57.2
 	google.golang.org/grpc/examples v0.0.0-20230222033013-5353eaa44095
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -772,8 +772,8 @@ google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.57.0 h1:kfzNeI/klCGD2YPMUlaGNT3pxvYfga7smW3Vth8Zsiw=
-google.golang.org/grpc v1.57.0/go.mod h1:Sd+9RMTACXwmub0zcNY2c4arhtrbBYD1AUHI/dt16Mo=
+google.golang.org/grpc v1.57.2 h1:uw37EN34aMFFXB2QPW7Tq6tdTbind1GpRxw5aOX3a5k=
+google.golang.org/grpc v1.57.2/go.mod h1:Sd+9RMTACXwmub0zcNY2c4arhtrbBYD1AUHI/dt16Mo=
 google.golang.org/grpc/examples v0.0.0-20230222033013-5353eaa44095 h1:ijVKWXLMbG/RK63KfOQ1lEVpEApj174fkw073gxZf3w=
 google.golang.org/grpc/examples v0.0.0-20230222033013-5353eaa44095/go.mod h1:Nr5H8+MlGWr5+xX/STzdoEqJrO+YteqFbMyCsrb6mH0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/go_deps.bzl
+++ b/go_deps.bzl
@@ -1410,8 +1410,8 @@ def go_deps():
             "gazelle:resolve go google.golang.org/genproto/googleapis/rpc/status @org_golang_google_genproto_googleapis_rpc//status",
         ],
         importpath = "google.golang.org/grpc",
-        sum = "h1:kfzNeI/klCGD2YPMUlaGNT3pxvYfga7smW3Vth8Zsiw=",
-        version = "v1.57.0",
+        sum = "h1:uw37EN34aMFFXB2QPW7Tq6tdTbind1GpRxw5aOX3a5k=",
+        version = "v1.57.2",
     )
     go_repository(
         name = "org_golang_google_grpc_examples",

--- a/pkg/grpc/interceptor.go
+++ b/pkg/grpc/interceptor.go
@@ -165,8 +165,8 @@ func StreamClientInterceptor() grpc.DialOption {
 // grpc-go prohibits more than MaxConcurrentStreams handlers from running at once, and setting this
 // option so prevents easy resource exhaustion attacks from malicious clients.
 func DefaultMaxConcurrentStreams() grpc.ServerOption {
-	// FIXME this number is pulled out of thin air.
-	return grpc.MaxConcurrentStreams(16)
+	// A very generic default value; this is the default that nginx appears to use.
+	return grpc.MaxConcurrentStreams(128)
 }
 
 // UnaryServerInterceptor constructs the default unary RPC server-side interceptor for

--- a/pkg/grpc/interceptor.go
+++ b/pkg/grpc/interceptor.go
@@ -161,6 +161,14 @@ func StreamClientInterceptor() grpc.DialOption {
 	)
 }
 
+// DefaultMaxConcurrentStreams constructs the default grpc.MaxConcurrentStreams Server Option.
+// grpc-go prohibits more than MaxConcurrentStreams handlers from running at once, and setting this
+// option so prevents easy resource exhaustion attacks from malicious clients.
+func DefaultMaxConcurrentStreams() grpc.ServerOption {
+	// FIXME this number is pulled out of thin air.
+	return grpc.MaxConcurrentStreams(16)
+}
+
 // UnaryServerInterceptor constructs the default unary RPC server-side interceptor for
 // SCION control-plane applications.
 func UnaryServerInterceptor() grpc.ServerOption {


### PR DESCRIPTION
Bump google.golang.org/grpc from 1.57.0 to 1.57.2 due to a security patch.
Skipping 1.57.1, because that contained a bug.

From vulnerability alert "gRPC-Go HTTP/2 Rapid Reset vulnerability":

> Impact
>
> In affected releases of gRPC-Go, it is possible for an attacker to send
> HTTP/2 requests, cancel them, and send subsequent requests, which is
> valid by the HTTP/2 protocol, but would cause the gRPC-Go server to
> launch more concurrent method handlers than the configured maximum
> stream limit. Patches
>
> This vulnerability was addressed by #6703 and has been included in patch
> releases: 1.56.3, 1.57.1, 1.58.3. It is also included in the latest
> release, 1.59.0.
>
> Along with applying the patch, users should also ensure they are using
> the grpc.MaxConcurrentStreams server option to apply a limit to the
> server's resources used for any single connection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4424)
<!-- Reviewable:end -->
