### PR TITLE
Update git-version

### DIFF
--- a/tools/git-version
+++ b/tools/git-version
@@ -2,4 +2,4 @@
 
 # Small script to determine the git version.
 
-exec git describe --tags --dirty
+exec git describe --tags --dirty --always


### PR DESCRIPTION
--always, will substitute a CL number if there's no tag in sight. Better than failing with a cryptic message.