### PR TITLE
daemon: fix docstring for latencies in protobuf file

### DIFF
--- a/proto/daemon/v1/daemon.proto
+++ b/proto/daemon/v1/daemon.proto
@@ -74,7 +74,8 @@ message Path {
     // Latency lists the latencies between any two consecutive interfaces.
     // Entry i describes the latency between interface i and i+1.
     // Consequently, there are N-1 entries for N interfaces.
-    // A 0-value indicates that the AS did not announce a latency for this hop.
+    // A negative value indicates that the AS did not announce a latency for
+    // this hop.
     repeated google.protobuf.Duration latency = 6;
     // Bandwidth lists the bandwidth between any two consecutive interfaces, in
     // Kbit/s.


### PR DESCRIPTION
This was probably an oversight in #4005.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4443)
<!-- Reviewable:end -->
