### PR TITLE
scion.sh: block for child processes at shutdown

### DIFF
--- a/scion.sh
+++ b/scion.sh
@@ -113,7 +113,8 @@ stop_scion() {
     if is_docker_be; then
         ./tools/quiet ./tools/dc down
     else
-        ./tools/quiet tools/supervisor.sh shutdown
+        ./tools/quiet tools/supervisor.sh stop all # blocks until child processes are stopped
+        ./tools/quiet tools/supervisor.sh shutdown # shutdown does not block, but as children are already stopped, actual shutdown will be prompt too.
         run_teardown
     fi
 }


### PR DESCRIPTION
The `supervisorctl shutdown` command does not block for the supervisor or its child processes to terminate.
This can occasionally lead to situations where SCION processes were still running after the `scion.sh stop` command returned. In the CI system, which immediately proceeds to bundle up the log files, this led to `tar` reporting an error that the log file was still being written to (e.g. [here](https://buildkite.com/scionproto/scion-nightly/builds/1895#018bfa57-7ab1-4f15-9b7f-ed511ebb783d/2886-2888)).
Fixed by invoking `supervisorctl stop all`, which does block, to terminate all child processes before `shutdown`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4445)
<!-- Reviewable:end -->
