### PR TITLE
processmetrics: explicit type conversion to support arm64

### DIFF
--- a/pkg/private/processmetrics/processmetrics_linux.go
+++ b/pkg/private/processmetrics/processmetrics_linux.go
@@ -123,7 +123,8 @@ func (c *procStatCollector) updateStat() error {
 	if err != nil {
 		return err
 	}
-	newCount := taskStat.Nlink - 2
+	//nolint:unconvert // this is required for arm64 support
+	newCount := uint64(taskStat.Nlink - 2)
 	if newCount != c.lastTaskCount {
 		c.taskListUpdates++
 		c.myProcs, err = procfs.AllThreads(c.myPid)


### PR DESCRIPTION
When building SCION in a VM on my MacBook, I got an error about mismatched types:
```
pkg/private/processmetrics/processmetrics_linux.go:127:17: invalid operation: newCount != c.lastTaskCount (mismatched types uint32 and uint64)
pkg/private/processmetrics/processmetrics_linux.go:133:21: cannot use newCount (variable of type uint32) as uint64 value in assignment
```

This modification doesn't change the behavior on amd64 but makes SCION compile also for arm64.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4446)
<!-- Reviewable:end -->
