### PR TITLE
build: allow building without scion-ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@ bazel:
 	tar -kxf bazel-bin/scion.tar -C bin
 	tar -kxf bazel-bin/scion-ci.tar -C bin
 
+bazel-no-ci:
+	rm -f bin/*
+	bazel build //:scion
+	tar -kxf bazel-bin/scion.tar -C bin
+
 test:
 	bazel test --config=unit_all
 


### PR DESCRIPTION
My motivation for this is an error on ARM64 machines when building `scion-ci`:
```
(13:40:17) ERROR: /home/ubuntu/.cache/bazel/_bazel_ubuntu/d590279010957ac1dca373a0e19d0c3c/external/io_bazel_rules_go/BUILD.bazel:86:17: While resolving toolchains for target @io_bazel_rules_go//:cgo_context_data: No matching toolchains found for types @bazel_tools//tools/cpp:toolchain_type.
```

However, it may be interesting irrespective of this to just build the main binaries without the CI tools.

Maybe the naming could be improved, let me know what you think.