### PR TITLE
prometheus: fix copying of metrics labels

### DIFF
--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -91,7 +91,9 @@ func (lvs labelValuesSlice) With(labelValues ...string) labelValuesSlice {
 	if len(labelValues)%2 != 0 {
 		labelValues = append(labelValues, "unknown")
 	}
-	return append(lvs, labelValues...)
+	result := make(labelValuesSlice, len(lvs))
+	copy(result, lvs)
+	return append(result, labelValues...)
 }
 
 // gauge implements Gauge, via a Prometheus GaugeVec.


### PR DESCRIPTION
When copying metric labels we assumed that `append` will always create a copy of the label array. This is not necessarily the case. In such case two metrics may end up with the same underlaying array of labels and change to one of them also overwrites the labels in the other one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4450)
<!-- Reviewable:end -->
