### PR TITLE
pkg/log: fix panic when using custom Logger

### DIFF
--- a/pkg/log/context.go
+++ b/pkg/log/context.go
@@ -65,8 +65,21 @@ func WithLabels(ctx context.Context, labels ...interface{}) (context.Context, Lo
 
 func attachSpan(ctx context.Context, l Logger) Logger {
 	if span := opentracing.SpanFromContext(ctx); span != nil {
+		if optioner, ok := l.(interface{ WithOptions(...zap.Option) Logger }); ok {
+			return Span{
+				Logger: optioner.WithOptions(zap.AddCallerSkip(1)),
+				Span:   span,
+			}
+		}
+		if il, ok := l.(*logger); ok {
+			return Span{
+				Logger: &logger{logger: il.logger.WithOptions(zap.AddCallerSkip(1))},
+				Span:   span,
+			}
+		}
+		// Pessimistic fallback, we don't have access to the underlying zap logger:
 		return Span{
-			Logger: &logger{logger: l.(*logger).logger.WithOptions(zap.AddCallerSkip(1))},
+			Logger: l,
 			Span:   span,
 		}
 	}


### PR DESCRIPTION
log.FromCtx could panic if a custom Logger was used and a span was present in the context. This commit allows the custom logger to implement the `WithOptions(...zap.Option) Logger` method so that the CallerSkip can still be applied. In case the logger can't be casted to anything the caller skip is not applied, but we also don't panic anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4452)
<!-- Reviewable:end -->
