### PR TITLE
router: make the benchmark and the router more adaptive to core count

### DIFF
--- a/.buildkite/pipeline_lib.sh
+++ b/.buildkite/pipeline_lib.sh
@@ -56,5 +56,7 @@ gen_bazel_test_steps() {
         echo "          automatic:"
         echo "            - exit_status: -1 # Agent was lost"
         echo "            - exit_status: 255 # Forced agent shutdown"
+	echo "            - exit_status: 1 # Test may be flaky or it just didn't pass"
+	echo "              limit: 2
     done
 }

--- a/.buildkite/pipeline_lib.sh
+++ b/.buildkite/pipeline_lib.sh
@@ -57,6 +57,6 @@ gen_bazel_test_steps() {
         echo "            - exit_status: -1 # Agent was lost"
         echo "            - exit_status: 255 # Forced agent shutdown"
 	echo "            - exit_status: 1 # Test may be flaky or it just didn't pass"
-	echo "              limit: 2
+	echo "              limit: 2"
     done
 }

--- a/.buildkite/pipeline_lib.sh
+++ b/.buildkite/pipeline_lib.sh
@@ -56,7 +56,7 @@ gen_bazel_test_steps() {
         echo "          automatic:"
         echo "            - exit_status: -1 # Agent was lost"
         echo "            - exit_status: 255 # Forced agent shutdown"
-	echo "            - exit_status: 1 # Test may be flaky or it just didn't pass"
+	echo "            - exit_status: 3 # Test may be flaky or it just didn't pass"
 	echo "              limit: 2"
     done
 }

--- a/.buildkite/pipeline_lib.sh
+++ b/.buildkite/pipeline_lib.sh
@@ -53,12 +53,12 @@ gen_bazel_test_steps() {
         echo "          - \"bazel-testlogs.tar.gz\""
         echo "        timeout_in_minutes: 20"
         echo "        retry:"
-	echo "          manual:"
-	echo "            permit_on_passed: true"
+        echo "          manual:"
+        echo "            permit_on_passed: true"
         echo "          automatic:"
         echo "            - exit_status: -1 # Agent was lost"
         echo "            - exit_status: 255 # Forced agent shutdown"
-	echo "            - exit_status: 3 # Test may be flaky or it just didn't pass"
-	echo "              limit: 2"
+        echo "            - exit_status: 3 # Test may be flaky or it just didn't pass"
+        echo "              limit: 2"
     done
 }

--- a/.buildkite/pipeline_lib.sh
+++ b/.buildkite/pipeline_lib.sh
@@ -53,6 +53,8 @@ gen_bazel_test_steps() {
         echo "          - \"bazel-testlogs.tar.gz\""
         echo "        timeout_in_minutes: 20"
         echo "        retry:"
+	echo "          manual:"
+	echo "            permit_on_passed: true"
         echo "          automatic:"
         echo "            - exit_status: -1 # Agent was lost"
         echo "            - exit_status: 255 # Forced agent shutdown"

--- a/acceptance/router_benchmark/test.py
+++ b/acceptance/router_benchmark/test.py
@@ -34,11 +34,11 @@ logger = logging.getLogger(__name__)
 
 # Those values are valid expectations only when running in the CI environment.
 TEST_CASES = {
-    'in': 270000,
-    'out': 240000,
-    'in_transit': 270000,
-    'out_transit': 240000,
-    'br_transit': 260000,
+    'in': 310000,
+    'out': 290000,
+    'in_transit': 320000,
+    'out_transit': 310000,
+    'br_transit': 330000,
 }
 
 

--- a/acceptance/router_benchmark/test.py
+++ b/acceptance/router_benchmark/test.py
@@ -34,11 +34,11 @@ logger = logging.getLogger(__name__)
 
 # Those values are valid expectations only when running in the CI environment.
 TEST_CASES = {
-    'in': 310000,
+    'in': 290000,
     'out': 290000,
-    'in_transit': 320000,
-    'out_transit': 310000,
-    'br_transit': 330000,
+    'in_transit': 250000,
+    'out_transit': 250000,
+    'br_transit': 290000,
 }
 
 

--- a/acceptance/router_benchmark/test.py
+++ b/acceptance/router_benchmark/test.py
@@ -20,7 +20,7 @@ import time
 
 from collections import namedtuple
 from plumbum import cli
-from plumbum.cmd import docker, whoami
+from plumbum.cmd import docker, whoami, cat
 from plumbum import cmd
 
 from acceptance.common import base
@@ -58,6 +58,12 @@ Intf = namedtuple("Intf", "name, mac, peerMac")
 def mac_for_ip(ip: str) -> str:
     ipBytes = ip.split(".")
     return 'f0:0d:ca:fe:{:02x}:{:02x}'.format(int(ipBytes[2]), int(ipBytes[3]))
+
+
+# Dump the cpu info into the log just to inform our thoughts on performance variability.
+def log_cpu_info():
+    cpu_info = cat('/proc/cpuinfo')
+    logger.info(f"CPU INFO BEGINS\n{cpu_info}\nCPU_INFO ENDS")
 
 
 class RouterBMTest(base.TestBase):
@@ -147,6 +153,9 @@ class RouterBMTest(base.TestBase):
 
     def setup_prepare(self):
         super().setup_prepare()
+
+        # As the name inplies.
+        log_cpu_info()
 
         # get the config where the router can find it.
         shutil.copytree("acceptance/router_benchmark/conf/", self.artifacts / "conf")

--- a/router/config/config.go
+++ b/router/config/config.go
@@ -74,11 +74,24 @@ func (cfg *RouterConfig) Validate() error {
 func (cfg *RouterConfig) InitDefaults() {
 
 	// NumProcessors is the number of goroutines used to handle the processing queue.
-	// By default, there are as many as cores allowed by Go and other goroutines displace
-	// the packet processors sporadically. It may be either good or bad to create more
-	// processors (plus the other goroutines) than there are cores... experience will tell.
+	// It has been observed that allowing the packet processors starve the other tasks was
+	// counterproductive. We get much better results by setting two cores aside for other go
+	// routines (such as for input and output). It remains to be seen if even more cores need to be
+	// set aside on large core-count systems.
+
 	if cfg.NumProcessors == 0 {
-		cfg.NumProcessors = runtime.GOMAXPROCS(0)
+		// Do what we think is best, so in most cases there's no need for an explicit config.
+		maxProcs := runtime.GOMAXPROCS(0)
+		if maxProcs > 3 {
+			// Two for I/Os, two or more for processing.
+			cfg.NumProcessors = maxProcs - 2
+		} else if maxProcs > 1 {
+			// I/Os <= processing.
+			cfg.NumProcessors = maxProcs - 1
+		} else {
+			// No choice.
+			cfg.NumProcessors = maxProcs
+		}
 	}
 
 	if cfg.NumSlowPathProcessors == 0 {


### PR DESCRIPTION
In the router. Compute a better default for the number of processors based on multiple observations: given enough streams to occupy all processors, performance is degraded if there are as many processors as cores. Best performance is obtained by setting aside two cores for other tasks. Making this the default simplifies the benchmarking process by not having to configure an override for each type of target machine being tested.

In the benchmark. Run the test with many streams. It reflects reality and allows a very parallel router to perform at its best without distorting the performance of a less-parallel one. Make sure that the number of streams is likely to be a multiple of the number of cores so the cores are loaded evenly in spite of there being typically fewer streams than in real life. (TBD, learn the router's internal processors count and just use that).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4456)
<!-- Reviewable:end -->
