### PR TITLE
tools: fix wireshark dissector TLV options without data

### DIFF
--- a/tools/wireshark/scion.lua
+++ b/tools/wireshark/scion.lua
@@ -558,7 +558,9 @@ function scion_extn_tlv_option_dissect(tvbuf, pktinfo, root)
     else
         -- no specific dissector
         ret_len = data_len
-        tree:add(scion_extn_tlv_option_value, tlv.data)
+        if tlv.data ~= nil then
+            tree:add(scion_extn_tlv_option_value, tlv.data)
+        end
     end
 
     local type_str = scion_extn_tlv_option_types[tlv.type:uint()]


### PR DESCRIPTION
Dissecting TLV options crashes the wireshark plugin, if the `data` field is empty. This happens always for Pad1 options and for PadN options if `data_len` is 0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4458)
<!-- Reviewable:end -->
