### PR TITLE
control: pluggable segment signer

### DIFF
--- a/control/beaconing/BUILD.bazel
+++ b/control/beaconing/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/private/prom:go_default_library",
         "//pkg/private/serrors:go_default_library",
         "//pkg/private/util:go_default_library",
+        "//pkg/proto/crypto:go_default_library",
         "//pkg/segment:go_default_library",
         "//pkg/segment/extensions/digest:go_default_library",
         "//pkg/segment/extensions/epic:go_default_library",
@@ -37,7 +38,6 @@ go_library(
         "//private/segment/verifier:go_default_library",
         "//private/topology:go_default_library",
         "//private/tracing:go_default_library",
-        "//private/trust:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
     ],
 )

--- a/control/beaconing/writer_test.go
+++ b/control/beaconing/writer_test.go
@@ -349,7 +349,7 @@ type testSignerGen struct {
 	Signer trust.Signer
 }
 
-func (s testSignerGen) Generate(ctx context.Context) (trust.Signer, error) {
+func (s testSignerGen) Generate(ctx context.Context) (beaconing.Signer, error) {
 	return s.Signer, nil
 }
 

--- a/control/cmd/control/main.go
+++ b/control/cmd/control/main.go
@@ -780,13 +780,15 @@ func realMain(ctx context.Context) error {
 		},
 		SegmentRegister: beaconinggrpc.Registrar{Dialer: dialer},
 		BeaconStore:     beaconStore,
-		SignerGen:       signer.SignerGen,
-		Inspector:       inspector,
-		Metrics:         metrics,
-		DRKeyEngine:     drkeyEngine,
-		MACGen:          macGen,
-		NextHopper:      topo,
-		StaticInfo:      func() *beaconing.StaticInfoCfg { return staticInfo },
+		SignerGen: beaconing.SignerGenFunc(func(ctx context.Context) (beaconing.Signer, error) {
+			return signer.SignerGen.Generate(ctx)
+		}),
+		Inspector:   inspector,
+		Metrics:     metrics,
+		DRKeyEngine: drkeyEngine,
+		MACGen:      macGen,
+		NextHopper:  topo,
+		StaticInfo:  func() *beaconing.StaticInfoCfg { return staticInfo },
 
 		OriginationInterval:       globalCfg.BS.OriginationInterval.Duration,
 		PropagationInterval:       globalCfg.BS.PropagationInterval.Duration,

--- a/pkg/experimental/hiddenpath/beaconwriter_test.go
+++ b/pkg/experimental/hiddenpath/beaconwriter_test.go
@@ -356,7 +356,7 @@ type testSignerGen struct {
 	Signer trust.Signer
 }
 
-func (s testSignerGen) Generate(ctx context.Context) (trust.Signer, error) {
+func (s testSignerGen) Generate(ctx context.Context) (beaconing.Signer, error) {
 	return s.Signer, nil
 }
 

--- a/private/trust/signer.go
+++ b/private/trust/signer.go
@@ -135,6 +135,10 @@ func (s Signer) validate(ctx context.Context, now time.Time) error {
 	return nil
 }
 
+func (s Signer) GetExpiration() time.Time {
+	return s.Expiration
+}
+
 func (s Signer) Equal(o Signer) bool {
 	return s.IA.Equal(o.IA) &&
 		bytes.Equal(s.SubjectKeyID, o.SubjectKeyID) &&


### PR DESCRIPTION
Make the segment signer pluggable. This decouples the beacon extender from the trust signer implementation and allows plugging in different implementations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4460)
<!-- Reviewable:end -->
