### PR TITLE
doc: fixup certificate copying in deploy tutorial

### DIFF
--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -255,8 +255,8 @@ In practice, the private keys of ASes are of course never revealed to other enti
      cd /tmp/tutorial-scion-certs
      for i in {1..5}
      do
-        ssh scion0$i 'mkdir -p /etc/scion/{crypto,certs}'
-        scp ASS$i/* scion0$i:/etc/scion/crypto/
+        ssh scion0$i 'mkdir -p /etc/scion/{crypto/as,certs}'
+        scp AS$i/cp-as.{key,pem} scion0$i:/etc/scion/crypto/as/
         scp ISD42-B1-S1.trc scion0$i:/etc/scion/certs/
      done
 


### PR DESCRIPTION
Fix copying of certificates to individual hosts in the "freestanding deployment" tutorial.
Was suggesting to copy all certificates to `/etc/scion/crypto/`. Instead, it should copy the AS certificates to `/etc/scion/crypto/as/`.

Originally the instructions had been correct; the problem was introduced with the custom script to generate the crypto material. This script uses flatter paths (for brevity) than the originally used `scion-pki testcrypto` tool, and the copy instruction were not correctly updated (and not tested, duh).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scionproto/scion/4467)
<!-- Reviewable:end -->
