### PR TITLE
paths: Add check for hopfield count <= 64 when deserializing a scion path

### DIFF
--- a/pkg/slayers/path/scion/BUILD.bazel
+++ b/pkg/slayers/path/scion/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
     ],
     deps = [
         ":go_default_library",
+        "//pkg/private/serrors:go_default_library",
         "//pkg/slayers/path:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",

--- a/pkg/slayers/path/scion/base.go
+++ b/pkg/slayers/path/scion/base.go
@@ -66,13 +66,6 @@ func (s *Base) DecodeFromBytes(data []byte) error {
 		}
 		s.NumHops += int(s.PathMeta.SegLen[i])
 	}
-	// We must check the validity of NumHops. It is possible to fit more than 64 hops in
-	// the length of a scion header. Yet a path of more than 64 hops cannot be followed to
-	// the end because CurrHF is only 6 bits long.
-	if s.NumHops > 64 {
-		return serrors.New(
-			fmt.Sprintf("NumHops > 64"))
-	}
 	return nil
 }
 

--- a/pkg/slayers/path/scion/base.go
+++ b/pkg/slayers/path/scion/base.go
@@ -22,10 +22,17 @@ import (
 	"github.com/scionproto/scion/pkg/slayers/path"
 )
 
-// MetaLen is the length of the PathMetaHeader.
-const MetaLen = 4
+const (
+	// MaxINFs is the maximum number of info fields in a SCION path.
+	MaxINFs = 3
+	// MaxHops is the maximum number of hop fields in a SCION path.
+	MaxHops = 64
 
-const PathType path.Type = 1
+	// MetaLen is the length of the PathMetaHeader.
+	MetaLen = 4
+
+	PathType path.Type = 1
+)
 
 func RegisterPath() {
 	path.RegisterPath(path.Metadata{
@@ -66,6 +73,14 @@ func (s *Base) DecodeFromBytes(data []byte) error {
 		}
 		s.NumHops += int(s.PathMeta.SegLen[i])
 	}
+
+	// We must check the validity of NumHops. It is possible to fit more than 64 hops in
+	// the length of a scion header. Yet a path of more than 64 hops cannot be followed to
+	// the end because CurrHF is only 6 bits long.
+	if s.NumHops > MaxHops {
+		return serrors.New("NumHops too large", "NumHops", s.NumHops, "Maximum", MaxHops)
+	}
+
 	return nil
 }
 

--- a/pkg/slayers/path/scion/base.go
+++ b/pkg/slayers/path/scion/base.go
@@ -66,6 +66,13 @@ func (s *Base) DecodeFromBytes(data []byte) error {
 		}
 		s.NumHops += int(s.PathMeta.SegLen[i])
 	}
+	// We must check the validity of NumHops. It is possible to fit more than 64 hops in
+	// the length of a scion header. Yet a path of more than 64 hops cannot be followed to
+	// the end because CurrHF is only 6 bits long.
+	if s.NumHops > 64 {
+		return serrors.New(
+			fmt.Sprintf("NumHops > 64"))
+	}
 	return nil
 }
 
@@ -113,7 +120,9 @@ func (s *Base) infIndexForHF(hf uint8) uint8 {
 	}
 }
 
-// Len returns the length of the path in bytes.
+// Len returns the length of the path in bytes. That is, the number of byte required to
+// store it, based on the metadata. The actual number of bytes available to contain it
+// can be inferred from the common header field HdrLen. It may or may not be consistent.
 func (s *Base) Len() int {
 	return MetaLen + s.NumINF*path.InfoLen + s.NumHops*path.HopLen
 }

--- a/pkg/slayers/path/scion/decoded.go
+++ b/pkg/slayers/path/scion/decoded.go
@@ -49,8 +49,8 @@ func (s *Decoded) DecodeFromBytes(data []byte) error {
 	// We must check the validity of NumHops. It is possible to fit more than 64 hops in
 	// the length of a scion header. Yet a path of more than 64 hops cannot be followed to
 	// the end because CurrHF is only 6 bits long.
-	if s.NumHops > 64 {
-		return serrors.New("NumHops > 64")
+	if s.NumHops > MaxHops {
+		return serrors.New("NumHops too large", "NumHops", s.NumHops, "Maximum", MaxHops)
 	}
 
 	offset := MetaLen

--- a/pkg/slayers/path/scion/decoded.go
+++ b/pkg/slayers/path/scion/decoded.go
@@ -46,6 +46,13 @@ func (s *Decoded) DecodeFromBytes(data []byte) error {
 		return serrors.New("DecodedPath raw too short", "expected", minLen, "actual", len(data))
 	}
 
+	// We must check the validity of NumHops. It is possible to fit more than 64 hops in
+	// the length of a scion header. Yet a path of more than 64 hops cannot be followed to
+	// the end because CurrHF is only 6 bits long.
+	if s.NumHops > 64 {
+		return serrors.New("NumHops > 64")
+	}
+
 	offset := MetaLen
 	s.InfoFields = make([]path.InfoField, s.NumINF)
 	for i := 0; i < s.NumINF; i++ {

--- a/pkg/slayers/path/scion/decoded.go
+++ b/pkg/slayers/path/scion/decoded.go
@@ -19,13 +19,6 @@ import (
 	"github.com/scionproto/scion/pkg/slayers/path"
 )
 
-const (
-	// MaxINFs is the maximum number of info fields in a SCION path.
-	MaxINFs = 3
-	// MaxHops is the maximum number of hop fields in a SCION path.
-	MaxHops = 64
-)
-
 // Decoded implements the SCION (data-plane) path type. Decoded is intended to be used in
 // non-performance critical code paths, where the convenience of having a fully parsed path trumps
 // the loss of performance.
@@ -44,13 +37,6 @@ func (s *Decoded) DecodeFromBytes(data []byte) error {
 	}
 	if minLen := s.Len(); len(data) < minLen {
 		return serrors.New("DecodedPath raw too short", "expected", minLen, "actual", len(data))
-	}
-
-	// We must check the validity of NumHops. It is possible to fit more than 64 hops in
-	// the length of a scion header. Yet a path of more than 64 hops cannot be followed to
-	// the end because CurrHF is only 6 bits long.
-	if s.NumHops > MaxHops {
-		return serrors.New("NumHops too large", "NumHops", s.NumHops, "Maximum", MaxHops)
 	}
 
 	offset := MetaLen

--- a/pkg/slayers/path/scion/decoded_test.go
+++ b/pkg/slayers/path/scion/decoded_test.go
@@ -87,6 +87,18 @@ var emptyDecodedTestPath = &scion.Decoded{
 	HopFields:  []path.HopField{},
 }
 
+var overlongPath = &scion.Decoded{
+	Base: scion.Base{
+		PathMeta: scion.MetaHdr{
+			CurrINF: 0,
+			CurrHF:  0,
+			SegLen:  [3]uint8{24, 24, 17},
+		},
+		NumINF:  3,
+		NumHops: 65,
+	},
+}
+
 var rawPath = []byte("\x00\x00\x20\x80\x00\x00\x01\x11\x00\x00\x01\x00\x01\x00\x02\x22\x00\x00" +
 	"\x01\x00\x00\x3f\x00\x01\x00\x00\x01\x02\x03\x04\x05\x06\x00\x3f\x00\x03\x00\x02\x01\x02\x03" +
 	"\x04\x05\x06\x00\x3f\x00\x00\x00\x02\x01\x02\x03\x04\x05\x06\x00\x3f\x00\x01\x00\x00\x01\x02" +
@@ -165,6 +177,13 @@ func TestDecodedSerializeDecode(t *testing.T) {
 	s := &scion.Decoded{}
 	assert.NoError(t, s.DecodeFromBytes(b))
 	assert.Equal(t, decodedTestPath, s)
+}
+
+func TestOverlongSerliazeDecode(t *testing.T) {
+	b := make([]byte, overlongPath.Len())
+	assert.NoError(t, overlongPath.SerializeTo(b)) // permitted, if only to enable this test.
+	s := &scion.Decoded{}
+	assert.Error(t, s.DecodeFromBytes(b)) // invalid raw packet.
 }
 
 func TestDecodedReverse(t *testing.T) {

--- a/pkg/slayers/path/scion/decoded_test.go
+++ b/pkg/slayers/path/scion/decoded_test.go
@@ -87,18 +87,6 @@ var emptyDecodedTestPath = &scion.Decoded{
 	HopFields:  []path.HopField{},
 }
 
-var overlongPath = &scion.Decoded{
-	Base: scion.Base{
-		PathMeta: scion.MetaHdr{
-			CurrINF: 0,
-			CurrHF:  0,
-			SegLen:  [3]uint8{24, 24, 17},
-		},
-		NumINF:  3,
-		NumHops: 65,
-	},
-}
-
 var rawPath = []byte("\x00\x00\x20\x80\x00\x00\x01\x11\x00\x00\x01\x00\x01\x00\x02\x22\x00\x00" +
 	"\x01\x00\x00\x3f\x00\x01\x00\x00\x01\x02\x03\x04\x05\x06\x00\x3f\x00\x03\x00\x02\x01\x02\x03" +
 	"\x04\x05\x06\x00\x3f\x00\x00\x00\x02\x01\x02\x03\x04\x05\x06\x00\x3f\x00\x01\x00\x00\x01\x02" +
@@ -177,13 +165,6 @@ func TestDecodedSerializeDecode(t *testing.T) {
 	s := &scion.Decoded{}
 	assert.NoError(t, s.DecodeFromBytes(b))
 	assert.Equal(t, decodedTestPath, s)
-}
-
-func TestOverlongSerliazeDecode(t *testing.T) {
-	b := make([]byte, overlongPath.Len())
-	assert.NoError(t, overlongPath.SerializeTo(b)) // permitted, if only to enable this test.
-	s := &scion.Decoded{}
-	assert.Error(t, s.DecodeFromBytes(b)) // invalid raw packet.
 }
 
 func TestDecodedReverse(t *testing.T) {

--- a/pkg/slayers/path/scion/raw_test.go
+++ b/pkg/slayers/path/scion/raw_test.go
@@ -51,19 +51,6 @@ var emptyRawTestPath = &scion.Raw{
 	Raw: make([]byte, scion.MetaLen),
 }
 
-var overlongPath = &scion.Raw{
-	Base: scion.Base{
-		PathMeta: scion.MetaHdr{
-			CurrINF: 0,
-			CurrHF:  0,
-			SegLen:  [3]uint8{24, 24, 17},
-		},
-		NumINF:  3,
-		NumHops: 65,
-	},
-	Raw: rawPath,
-}
-
 func TestRawSerialize(t *testing.T) {
 	b := make([]byte, rawTestPath.Len())
 	assert.NoError(t, rawTestPath.SerializeTo(b))
@@ -82,13 +69,6 @@ func TestRawSerliazeDecode(t *testing.T) {
 	s := &scion.Raw{}
 	assert.NoError(t, s.DecodeFromBytes(b))
 	assert.Equal(t, rawTestPath, s)
-}
-
-func TestOverlongSerliazeDecode(t *testing.T) {
-	b := make([]byte, overlongPath.Len())
-	assert.NoError(t, overlongPath.SerializeTo(b)) // permitted, if only to enable this test.
-	s := &scion.Raw{}
-	assert.Error(t, s.DecodeFromBytes(b)) // invalid raw packet.
 }
 
 func TestRawReverse(t *testing.T) {

--- a/pkg/slayers/path/scion/raw_test.go
+++ b/pkg/slayers/path/scion/raw_test.go
@@ -51,6 +51,19 @@ var emptyRawTestPath = &scion.Raw{
 	Raw: make([]byte, scion.MetaLen),
 }
 
+var overlongPath = &scion.Raw{
+	Base: scion.Base{
+		PathMeta: scion.MetaHdr{
+			CurrINF: 0,
+			CurrHF:  0,
+			SegLen:  [3]uint8{24, 24, 17},
+		},
+		NumINF:  3,
+		NumHops: 65,
+	},
+	Raw: rawPath,
+}
+
 func TestRawSerialize(t *testing.T) {
 	b := make([]byte, rawTestPath.Len())
 	assert.NoError(t, rawTestPath.SerializeTo(b))
@@ -63,12 +76,19 @@ func TestRawDecodeFromBytes(t *testing.T) {
 	assert.Equal(t, rawTestPath, s)
 }
 
-func TestRawSerliazeDecode(t *testing.T) {
+func TestRawSerializeDecode(t *testing.T) {
 	b := make([]byte, rawTestPath.Len())
 	assert.NoError(t, rawTestPath.SerializeTo(b))
 	s := &scion.Raw{}
 	assert.NoError(t, s.DecodeFromBytes(b))
 	assert.Equal(t, rawTestPath, s)
+}
+
+func TestOverlongSerializeDecode(t *testing.T) {
+	b := make([]byte, overlongPath.Len())
+	assert.NoError(t, overlongPath.SerializeTo(b)) // permitted, if only to enable this test.
+	s := &scion.Raw{}
+	assert.Error(t, s.DecodeFromBytes(b)) // invalid raw packet.
 }
 
 func TestRawReverse(t *testing.T) {

--- a/pkg/slayers/path/scion/raw_test.go
+++ b/pkg/slayers/path/scion/raw_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/scionproto/scion/pkg/private/serrors"
 	"github.com/scionproto/scion/pkg/slayers/path"
 	"github.com/scionproto/scion/pkg/slayers/path/scion"
 )
@@ -88,7 +89,9 @@ func TestOverlongSerializeDecode(t *testing.T) {
 	b := make([]byte, overlongPath.Len())
 	assert.NoError(t, overlongPath.SerializeTo(b)) // permitted, if only to enable this test.
 	s := &scion.Raw{}
-	assert.Error(t, s.DecodeFromBytes(b)) // invalid raw packet.
+	expected := serrors.New("NumHops too large", "NumHops", 65, "Maximum", scion.MaxHops)
+	err := s.DecodeFromBytes(b)
+	assert.Equal(t, expected.Error(), err.Error())
 }
 
 func TestRawReverse(t *testing.T) {

--- a/pkg/slayers/path/scion/raw_test.go
+++ b/pkg/slayers/path/scion/raw_test.go
@@ -51,6 +51,19 @@ var emptyRawTestPath = &scion.Raw{
 	Raw: make([]byte, scion.MetaLen),
 }
 
+var overlongPath = &scion.Raw{
+	Base: scion.Base{
+		PathMeta: scion.MetaHdr{
+			CurrINF: 0,
+			CurrHF:  0,
+			SegLen:  [3]uint8{24, 24, 17},
+		},
+		NumINF:  3,
+		NumHops: 65,
+	},
+	Raw: rawPath,
+}
+
 func TestRawSerialize(t *testing.T) {
 	b := make([]byte, rawTestPath.Len())
 	assert.NoError(t, rawTestPath.SerializeTo(b))
@@ -69,6 +82,13 @@ func TestRawSerliazeDecode(t *testing.T) {
 	s := &scion.Raw{}
 	assert.NoError(t, s.DecodeFromBytes(b))
 	assert.Equal(t, rawTestPath, s)
+}
+
+func TestOverlongSerliazeDecode(t *testing.T) {
+	b := make([]byte, overlongPath.Len())
+	assert.NoError(t, overlongPath.SerializeTo(b)) // permitted, if only to enable this test.
+	s := &scion.Raw{}
+	assert.Error(t, s.DecodeFromBytes(b)) // invalid raw packet.
 }
 
 func TestRawReverse(t *testing.T) {

--- a/router/dataplane_test.go
+++ b/router/dataplane_test.go
@@ -667,10 +667,7 @@ func TestProcessPkt(t *testing.T) {
 				}
 				expected := serrors.New("NumHops too large",
 					"NumHops", 65, "Maximum", scion.MaxHops).Error()
-				if !assert.Equal(t, expected, err.Error()) {
-					return false
-				}
-				return true
+				return assert.Equal(t, expected, err.Error())
 			},
 		},
 		"outbound": {

--- a/router/dataplane_test.go
+++ b/router/dataplane_test.go
@@ -666,8 +666,8 @@ func TestProcessPkt(t *testing.T) {
 					return false
 				}
 				expected := serrors.New("NumHops too large",
-					"NumHops", 65, "Maximum", scion.MaxHops).Error()
-				return assert.Equal(t, expected, err.Error())
+					"NumHops", 65, "Maximum", scion.MaxHops)
+				return assert.Equal(t, expected.Error(), err.Error())
 			},
 		},
 		"outbound": {


### PR DESCRIPTION
Added unit test for deserialization and unit test for router ingress.

Fixes #4482 