### PR TITLE
cmd/scion, snet: reduce range of IDs for SCMP requests

### DIFF
--- a/gateway/pathhealth/remotewatcher.go
+++ b/gateway/pathhealth/remotewatcher.go
@@ -17,7 +17,6 @@ package pathhealth
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"sync"
 	"time"
 
@@ -257,7 +256,7 @@ func (w *remoteWatcher) updatePaths(ctx context.Context) {
 
 func (w *remoteWatcher) selectID() (uint16, bool) {
 	for i := 0; i < 100; i++ {
-		id := uint16(rand.Uint32())
+		id := snet.RandomSCMPIdentifer()
 		if _, ok := w.pathWatchersByID[id]; !ok {
 			return id, true
 		}

--- a/pkg/snet/packet.go
+++ b/pkg/snet/packet.go
@@ -15,6 +15,8 @@
 package snet
 
 import (
+	"math/rand"
+
 	"github.com/google/gopacket"
 
 	"github.com/scionproto/scion/pkg/addr"
@@ -190,6 +192,30 @@ func (SCMPInternalConnectivityDown) Code() slayers.SCMPCode { return 0 }
 
 func (m SCMPInternalConnectivityDown) length() int {
 	return 28 + len(m.Payload)
+}
+
+const (
+	// SCMPIdentifierStart and SCMPIdentiferEnd define the range for Identifiers
+	// that should be used for SCMPEchoRequest and SCMPTracerouteRequest,
+	// in preparation for a dispatcher-less snet.
+	// This range corresponds to the port range used for SCION/UDP by the
+	// dispatcher. Using the same range for Identifiers in SCMP requests will
+	// allow a router to dispatch SCMP requests based on the Identifier,
+	// without risk of interfering with unaware endpoints.
+	//
+	// WARNING: transitional, this will be removed in the dispatcher-less snet.
+	SCMPIdentifierStart = 32768
+	SCMPIdentifierEnd   = 65535
+)
+
+// RandomSCMPIdentifier returns a random SCMP identifier in the range
+// [SCMPIdentifierStart, SCMPIdentifierEnd].
+//
+// WARNING: This is a transitional helper function, which will be removed
+// in the dispatcher-less snet; then, the underlay port must be used as identifier.
+func RandomSCMPIdentifer() uint16 {
+	id := SCMPIdentifierStart + rand.Int31n(SCMPIdentifierEnd-SCMPIdentifierStart+1)
+	return uint16(id)
 }
 
 // SCMPEchoRequest is the SCMP echo request payload.

--- a/private/app/path/path.go
+++ b/private/app/path/path.go
@@ -143,7 +143,7 @@ func filterUnhealthy(
 		DstIA:                  remote,
 		LocalIA:                cfg.LocalIA,
 		LocalIP:                cfg.LocalIP,
-		ID:                     uint16(rand.Uint32()),
+		ID:                     snet.RandomSCMPIdentifer(),
 		SCIONPacketConnMetrics: cfg.SCIONPacketConnMetrics,
 		Dispatcher:             cfg.Dispatcher,
 	}.GetStatuses(subCtx, nonEmptyPaths, pathprobe.WithEPIC(epic))

--- a/scion/showpaths/showpaths.go
+++ b/scion/showpaths/showpaths.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
 	"net/netip"
 	"strconv"
 	"strings"
@@ -356,7 +355,7 @@ func Run(ctx context.Context, dst addr.IA, cfg Config) (*Result, error) {
 			DstIA:      dst,
 			LocalIA:    localIA,
 			LocalIP:    cfg.Local,
-			ID:         uint16(rand.Uint32()),
+			ID:         snet.RandomSCMPIdentifer(),
 			Dispatcher: cfg.Dispatcher,
 		}.GetStatuses(ctx, p, pathprobe.WithEPIC(cfg.Epic))
 		if err != nil {

--- a/scion/traceroute/traceroute.go
+++ b/scion/traceroute/traceroute.go
@@ -17,7 +17,6 @@ package traceroute
 
 import (
 	"context"
-	"math/rand"
 	"net"
 	"net/netip"
 	"time"
@@ -100,7 +99,7 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 	if _, isEmpty := cfg.PathEntry.Dataplane().(path.Empty); isEmpty {
 		return Stats{}, serrors.New("empty path is not allowed for traceroute")
 	}
-	id := rand.Uint64()
+	id := snet.RandomSCMPIdentifer()
 	replies := make(chan reply, 10)
 	dispatcher := snet.DefaultPacketDispatcherService{
 		Dispatcher:  cfg.Dispatcher,
@@ -121,7 +120,7 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 		replies:       replies,
 		errHandler:    cfg.ErrHandler,
 		updateHandler: cfg.UpdateHandler,
-		id:            uint16(id),
+		id:            id,
 		path:          cfg.PathEntry,
 		epic:          cfg.EPIC,
 	}


### PR DESCRIPTION
Preparation for dispatcher-less endpoints. Reduce the range of IDs used for SCMP requests, to be forward-compatible with the default range for port-dispatching in the router.

In the dispatcher-less future, the router will forward SCMP reply messages to an application's underlay port determined based on the SCMP message ID. For this, the router will have a configurable range of ports for which it applies the dispatching, allowing dispatcher-ful and dispatcher-less endpoints to coexist. This port range will need to be disjoint from the port range currently used by the dispatcher and SCMP request identifiers.

For more details, see design document, #4280. 