### PR TITLE
pkg/slayers: simplify Decoded.Reverse

### DIFF
--- a/pkg/slayers/path/scion/decoded.go
+++ b/pkg/slayers/path/scion/decoded.go
@@ -89,7 +89,7 @@ func (s *Decoded) Reverse() (path.Path, error) {
 		return nil, serrors.New("empty decoded path is invalid and cannot be reversed")
 	}
 	// Reverse order of InfoFields and SegLens
-	if 1 < s.NumINF {
+	if s.NumINF > 1 {
 		s.InfoFields[0], s.InfoFields[s.NumINF-1] = s.InfoFields[s.NumINF-1], s.InfoFields[0]
 		s.PathMeta.SegLen[0], s.PathMeta.SegLen[s.NumINF-1] = s.PathMeta.SegLen[s.NumINF-1], s.PathMeta.SegLen[0]
 	}

--- a/pkg/slayers/path/scion/decoded.go
+++ b/pkg/slayers/path/scion/decoded.go
@@ -90,9 +90,9 @@ func (s *Decoded) Reverse() (path.Path, error) {
 	}
 	// Reverse order of InfoFields and SegLens
 	if s.NumINF > 1 {
-		last := s.NumINF - 1
-		s.InfoFields[0], s.InfoFields[last] = s.InfoFields[last], s.InfoFields[0]
-		s.PathMeta.SegLen[0], s.PathMeta.SegLen[last] = s.PathMeta.SegLen[last], s.PathMeta.SegLen[0]
+		l := s.NumINF - 1
+		s.InfoFields[0], s.InfoFields[l] = s.InfoFields[l], s.InfoFields[0]
+		s.PathMeta.SegLen[0], s.PathMeta.SegLen[l] = s.PathMeta.SegLen[l], s.PathMeta.SegLen[0]
 	}
 	// Reverse cons dir flags
 	for i := 0; i < s.NumINF; i++ {

--- a/pkg/slayers/path/scion/decoded.go
+++ b/pkg/slayers/path/scion/decoded.go
@@ -90,8 +90,9 @@ func (s *Decoded) Reverse() (path.Path, error) {
 	}
 	// Reverse order of InfoFields and SegLens
 	if s.NumINF > 1 {
-		s.InfoFields[0], s.InfoFields[s.NumINF-1] = s.InfoFields[s.NumINF-1], s.InfoFields[0]
-		s.PathMeta.SegLen[0], s.PathMeta.SegLen[s.NumINF-1] = s.PathMeta.SegLen[s.NumINF-1], s.PathMeta.SegLen[0]
+		lastIdx := s.NumINF - 1
+		s.InfoFields[0], s.InfoFields[lastIdx] = s.InfoFields[lastIdx], s.InfoFields[0]
+		s.PathMeta.SegLen[0], s.PathMeta.SegLen[lastIdx] = s.PathMeta.SegLen[lastIdx], s.PathMeta.SegLen[0]
 	}
 	// Reverse cons dir flags
 	for i := 0; i < s.NumINF; i++ {

--- a/pkg/slayers/path/scion/decoded.go
+++ b/pkg/slayers/path/scion/decoded.go
@@ -89,9 +89,9 @@ func (s *Decoded) Reverse() (path.Path, error) {
 		return nil, serrors.New("empty decoded path is invalid and cannot be reversed")
 	}
 	// Reverse order of InfoFields and SegLens
-	for i, j := 0, s.NumINF-1; i < j; i, j = i+1, j-1 {
-		s.InfoFields[i], s.InfoFields[j] = s.InfoFields[j], s.InfoFields[i]
-		s.PathMeta.SegLen[i], s.PathMeta.SegLen[j] = s.PathMeta.SegLen[j], s.PathMeta.SegLen[i]
+	if 1 < s.NumINF {
+		s.InfoFields[0], s.InfoFields[s.NumINF-1] = s.InfoFields[s.NumINF-1], s.InfoFields[0]
+		s.PathMeta.SegLen[0], s.PathMeta.SegLen[s.NumINF-1] = s.PathMeta.SegLen[s.NumINF-1], s.PathMeta.SegLen[0]
 	}
 	// Reverse cons dir flags
 	for i := 0; i < s.NumINF; i++ {

--- a/pkg/slayers/path/scion/decoded.go
+++ b/pkg/slayers/path/scion/decoded.go
@@ -90,9 +90,9 @@ func (s *Decoded) Reverse() (path.Path, error) {
 	}
 	// Reverse order of InfoFields and SegLens
 	if s.NumINF > 1 {
-		lastIdx := s.NumINF - 1
-		s.InfoFields[0], s.InfoFields[lastIdx] = s.InfoFields[lastIdx], s.InfoFields[0]
-		s.PathMeta.SegLen[0], s.PathMeta.SegLen[lastIdx] = s.PathMeta.SegLen[lastIdx], s.PathMeta.SegLen[0]
+		last := s.NumINF - 1
+		s.InfoFields[0], s.InfoFields[last] = s.InfoFields[last], s.InfoFields[0]
+		s.PathMeta.SegLen[0], s.PathMeta.SegLen[last] = s.PathMeta.SegLen[last], s.PathMeta.SegLen[0]
 	}
 	// Reverse cons dir flags
 	for i := 0; i < s.NumINF; i++ {


### PR DESCRIPTION
`Decode.Reverse` seems to have a loop where one isn't needed. For the loop that I changed, there is at most one iteration (the original value of `i` is 0 and the original value of `j` is at most 2; after one iteration, the loop condition will always be broken). Besides being harder to read, it is also harder to reason about and this complicates our proofs and maintenance in the VerifiedSCION project.

To preserve the behaviour that stores on slices and arrays are only performed when `s.NumINF` is at least 2, I added an if statement. If you prefer, we can drop that as well.