### PR TITLE
private/env: remove RunsInDocker during startup log

### DIFF
--- a/private/env/logging.go
+++ b/private/env/logging.go
@@ -17,6 +17,7 @@ package env
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/scionproto/scion/pkg/log"
 	"github.com/scionproto/scion/pkg/private/serrors"
@@ -31,10 +32,18 @@ var (
 // LogAppStarted should be called by applications as soon as logging is
 // initialized.
 func LogAppStarted(svcType, elemID string) error {
-	inDocker, err := RunsInDocker()
-	if err != nil {
-		return serrors.WrapStr("Unable to determine if running in docker", err)
+	// XXX(JordiSubira): Right now RunsInDocker() only is Linux-compatible.
+	// If we are going to run apps in docker also in macOS (and potentially in Windows)
+	// we should make the method compatible.
+	inDocker := false
+	if runtime.GOOS == "linux" {
+		var err error
+		inDocker, err = RunsInDocker()
+		if err != nil {
+			return serrors.WrapStr("Unable to determine if running in docker", err)
+		}
 	}
+
 	info := fmt.Sprintf("=====================> Service started %s %s\n"+
 		"%s  %s\n  %s\n  %s\n  %s\n",
 		svcType,

--- a/private/env/logging.go
+++ b/private/env/logging.go
@@ -17,10 +17,8 @@ package env
 import (
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/scionproto/scion/pkg/log"
-	"github.com/scionproto/scion/pkg/private/serrors"
 )
 
 // Startup* variables are set during link time.
@@ -32,24 +30,11 @@ var (
 // LogAppStarted should be called by applications as soon as logging is
 // initialized.
 func LogAppStarted(svcType, elemID string) error {
-	// XXX(JordiSubira): Right now RunsInDocker() only is Linux-compatible.
-	// If we are going to run apps in docker also in macOS (and potentially in Windows)
-	// we should make the method compatible.
-	inDocker := false
-	if runtime.GOOS == "linux" {
-		var err error
-		inDocker, err = RunsInDocker()
-		if err != nil {
-			return serrors.WrapStr("Unable to determine if running in docker", err)
-		}
-	}
-
 	info := fmt.Sprintf("=====================> Service started %s %s\n"+
-		"%s  %s\n  %s\n  %s\n  %s\n",
+		"%s\n  %s\n  %s\n  %s\n",
 		svcType,
 		elemID,
 		VersionInfo(),
-		fmt.Sprintf("In docker:     %v", inDocker),
 		fmt.Sprintf("pid:           %d", os.Getpid()),
 		fmt.Sprintf("euid/egid:     %d %d", os.Geteuid(), os.Getegid()),
 		fmt.Sprintf("cmd line:      %q", os.Args),


### PR DESCRIPTION
This PR tries to remove a Linux-only dependency for running SCION applications of other platforms. The `RunsUnDocker()` method is the Linux-only call, thus we check whether we are running in Docker only in Linux platform. I am in favor of even removing this log line, supporting @matzf comment on https://reviewable.io/reviews/scionproto/scion/4344#-Nt_IGRG4RbvC-PCVToV. 