### PR TITLE
doc: clarify tutorial description

### DIFF
--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -1,7 +1,7 @@
 Tutorial: Freestanding SCION Network
 ====================================
 
-This document helps you set up a freestsnding SCION demo network, which consists of a stand-alone complete SCION environment distributed among five computers. The demo environment contains one SCION Isolation Domain (:term:`ISD`), with three core Autonomous Systems (:term:`AS`) and two non-core, leaf ASes.
+This document helps you set up a freestanding SCION demo network, which consists of a stand-alone complete SCION environment distributed among five computers. The demo environment contains one SCION Isolation Domain (:term:`ISD`), with three core Autonomous Systems (:term:`AS`) and two non-core, leaf ASes.
 
 - If you want to go deep and help develop SCION, use the development environment. See :ref:`setting-up-the-development-environment`.
 - If you want to experiment with SCION in a larger environment, use SCIONLab. For more information, see https://www.scionlab.org/.

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -1,10 +1,12 @@
-Tutorial: Freestanding Deployment
-=================================
+Tutorial: Freestanding SCION Network
+====================================
 
-This document helps you set up a SCION demo configuration, which consists of a stand-alone complete SCION environment distributed among five computers. The demo environment contains one SCION Isolation Domain (:term:`ISD`), with three core :term:`ASes <AS>` and two non-core, leaf ASes.
+This document helps you set up a freestsnding SCION demo network, which consists of a stand-alone complete SCION environment distributed among five computers. The demo environment contains one SCION Isolation Domain (:term:`ISD`), with three core Autonomous Systems (:term:`AS`) and two non-core, leaf ASes.
 
 - If you want to go deep and help develop SCION, use the development environment. See :ref:`setting-up-the-development-environment`.
 - If you want to experiment with SCION in a larger environment, use SCIONLab. For more information, see https://www.scionlab.org/.
+
+**Note**: This tutorial does **not** describe how to set up SCION endhosts. For endhosts please follow the instructions of your `SCION library or application <https://github.com/scionproto/awesome-scion>`_.
 
 Setup
 -----


### PR DESCRIPTION
We had another situation where users were confused about the difference of endhost vs AS. It seems that it was caused by this tutorial which could be clarified regarding it's intention and that the acronym AS used in SCION really refers to "Autonomous System" as used in inter-domain networking..