### PR TITLE
router: forbid bouncing packets internally

### DIFF
--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1440,7 +1440,10 @@ func (p *scionPacketProcessor) validateEgressID() (processResult, error) {
 	pktEgressID := p.egressInterface()
 	_, ih := p.d.internalNextHops[pktEgressID]
 	_, eh := p.d.external[pktEgressID]
-	if !ih && !eh {
+	// egress interface must be a known interface
+	// packet coming from internal interface, must go to an external interface
+	// packet coming from external interface can go to either internal or external interface
+	if !ih && !eh || (p.ingressID == 0) && !eh {
 		errCode := slayers.SCMPCodeUnknownHopFieldEgress
 		if !p.infoField.ConsDir {
 			errCode = slayers.SCMPCodeUnknownHopFieldIngress

--- a/tools/braccept/main.go
+++ b/tools/braccept/main.go
@@ -107,6 +107,7 @@ func realMain() int {
 		cases.SCMPInternalXover(artifactsDir, hfMAC),
 		cases.SCMPUnknownHop(artifactsDir, hfMAC),
 		cases.SCMPUnknownHopEgress(artifactsDir, hfMAC),
+		cases.SCMPUnknownHopWrongRouter(artifactsDir, hfMAC),
 		cases.SCMPInvalidHopParentToParent(artifactsDir, hfMAC),
 		cases.SCMPInvalidHopChildToChild(artifactsDir, hfMAC),
 		cases.SCMPTracerouteIngress(artifactsDir, hfMAC),


### PR DESCRIPTION
A packet received on the internal interface would previously be "bounced" to the responsible egress router.
This is forbidden in the SCION design and was an accidental mis-feature of the processing logic.

Fixes #4497