### PR TITLE
test: cleanup docker in scion-pki TestOpenSSLCompatible

### DIFF
--- a/scion-pki/trcs/sign_test.go
+++ b/scion-pki/trcs/sign_test.go
@@ -170,7 +170,7 @@ func TestOpensslCompatible(t *testing.T) {
 			require.NoError(t, err)
 
 			cmd := exec.Command(
-				"docker", "run", "-v", outDir+":"+outDir, "emberstack/openssl",
+				"docker", "run", "--rm", "-v", outDir+":"+outDir, "emberstack/openssl",
 				"openssl",
 				"cms",
 				"-verify",


### PR DESCRIPTION
Add `--rm` to docker run invocation, to remove the container after it finishes and so avoid littering the system with stopped containers.