### PR TITLE
lint: fix flake8 bazel integration after update

### DIFF
--- a/tools/lint/python/BUILD.bazel
+++ b/tools/lint/python/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_binary")
-load("@com_github_scionproto_scion_python_lint_deps//:requirements.bzl", "requirement")
+load("@com_github_scionproto_scion_python_lint_deps//:requirements.bzl", "entry_point", "requirement")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 
 compile_pip_requirements(
@@ -8,10 +8,8 @@ compile_pip_requirements(
     requirements_txt = ":requirements.txt",
 )
 
-py_binary(
+alias(
     name = "flake8",
-    srcs = ["flakelint.py"],
-    main = "flakelint.py",
+    actual = entry_point("flake8"),
     visibility = ["//visibility:public"],
-    deps = [requirement("flake8")],
 )

--- a/tools/lint/python/flakelint.py
+++ b/tools/lint/python/flakelint.py
@@ -1,4 +1,0 @@
-from flake8.main import cli
-
-
-cli.main()


### PR DESCRIPTION
Fix flake8 bazel integration after updating from version 3.8.4 to 7.0.0. While the linter was running and working, it always returned a zero exit code, making bazel think everything is ok.

This problem was caused by our wrapper script, flakelint.py, and a change in the internal API. `cli.main` no longer sets/raises the exit code, this is done by the caller now.
See https://github.com/PyCQA/flake8/commit/81a4110338496714c0bf2bb0e8dd929461d9d492

To fix this, and avoid similar issues in the future, replace the wrapper script with an "entry_point" declaration. This serves the same purpose of creating a runnable bazel target for flake8. I assume that this was not already done when creating this flake8 integration, because either this entry_point mechanism did not yet exist or it was just too obscure.