### PR TITLE
ci: fix build for openwrt package, enable setting version from env var

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -30,10 +30,12 @@ rm -f $HOME/.bazelrc
 # --nostamp is required for better caching (only on non-release jobs).
 if [ "$BUILDKITE_PIPELINE_SLUG" == "scion" ]; then
     echo "build --nostamp" > $HOME/.bazelrc
-    # Shorten the git version to omit commit information, improving cache reuse.
-    # The format of git-version is "<tag>-<number-of-commits-since-the-tag>-<commit-short-hash>"
-    # This will be shortened to "<tag>-modified-ci"
-    export GIT_VERSION=$(tools/git-version | sed 's/-.*/-modified-ci/')
+    if [ -z ${SCION_VERSION+x} ]; then
+        # Shorten the git version to omit commit information, improving cache reuse.
+        # The format of git-version is "<tag>-<number-of-commits-since-the-tag>-<commit-short-hash>"
+        # This will be shortened to "<tag>-modified-ci"
+        export SCION_VERSION=$(tools/git-version | sed 's/-.*/-modified-ci/')
+    fi
 else
     echo "build --stamp" > $HOME/.bazelrc
 fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,16 +24,16 @@ steps:
     timeout_in_minutes: 10
   - wait
   - label: "Package :debian: :openwrt:"
-    command:
-      - version=${SCION_VERSION:-$(tools/git-version)}
-      - make dist-deb BFLAGS="--file_name_version=${version}"
-      - make dist-openwrt BFLAGS="--file_name_version=${version}"
-      - cd installables;
-      - tar -chaf scion-deb-amd64.tar.gz *_${version}_amd64.deb
-      - tar -chaf scion-deb-arm64.tar.gz *_${version}_arm64.deb
-      - tar -chaf scion-deb-i386.tar.gz *_${version}_i386.deb
-      - tar -chaf scion-deb-armel.tar.gz *_${version}_armel.deb
-      - tar -chaf scion-openwrt-x86_64.tar.gz *_${version}_x86_64.ipk
+    command: |
+      version=${SCION_VERSION:-$(tools/git-version)}
+      make dist-deb BFLAGS="--file_name_version=$${version}"
+      make dist-openwrt BFLAGS="--file_name_version=$${version}"
+      cd installables;
+      tar -chaf scion-deb-amd64.tar.gz *_$${version}_amd64.deb
+      tar -chaf scion-deb-arm64.tar.gz *_$${version}_arm64.deb
+      tar -chaf scion-deb-i386.tar.gz *_$${version}_i386.deb
+      tar -chaf scion-deb-armel.tar.gz *_$${version}_armel.deb
+      tar -chaf scion-openwrt-x86_64.tar.gz *_$${version}_x86_64.ipk
     artifact_paths:
       - "installables/scion-*.tar.gz"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
   - wait
   - label: "Package :debian: :openwrt:"
     command:
-      - version="$(tools/git-version)"
+      - version=${SCION_VERSION:-$(tools/git-version)}
       - make dist-deb BFLAGS="--file_name_version=${version}"
       - make dist-openwrt BFLAGS="--file_name_version=${version}"
       - cd installables;

--- a/dist/openwrt/ipk.bzl
+++ b/dist/openwrt/ipk.bzl
@@ -92,10 +92,11 @@ def _ipk_impl(ctx):
             r"scripts/feeds install -a -p scion",
             r"make IB=1 defconfig",  # IB=1 bypasses various unnecessary prerequisites
             r"IFS='-' read tag count commit dirty < ${execroot_abspath}/$5",
+            r"pkgver=${tag}",
             r'pkgrel=${count}${dirty:+".dirty$(date +%s)"}',
             r"make package/feeds/scion/${2}/compile EXECROOT=${execroot_abspath}" +
-            ' PKG_VERSION="${tag}" PKG_RELEASE="${pkgrel}"',
-            r"cp bin/packages/${6}/scion/${2}_${tag}-${pkgrel}_${6}.ipk ${execroot_abspath}/${4}",
+            ' PKG_VERSION="${pkgver}" PKG_RELEASE="${pkgrel}"',
+            r"cp bin/packages/${6}/scion/${2}_${pkgver}${pkgrel:+-}${pkgrel}_${6}.ipk ${execroot_abspath}/${4}",
         ]),
     )
 

--- a/tools/bazel-build-env
+++ b/tools/bazel-build-env
@@ -4,8 +4,7 @@
 
 ROOTDIR=$(dirname "$0")/..
 
-# When building inside a docker container GIT_VERSION is set by the creator of the container.
-# When building locally, use the version reported by git.
-VERSION=${GIT_VERSION:-$($ROOTDIR/tools/git-version)}
+# Use the version reported by git, unless SCION_VERSION is set to override this.
+VERSION=${SCION_VERSION:-$($ROOTDIR/tools/git-version)}
 
 echo "STABLE_GIT_VERSION $VERSION"


### PR DESCRIPTION
Fix handling of release version (e.g. "0.11.0") in openwrt package build. Was only working for intermediate versions, like "0.10.0-32-asdlkjslka".

Fix variable interpolation issue for package builds; need to use `$${version}` to ensure interpolation of this variable at "runtime" with bash; otherwise buildkite attempts to interpolate with when creating the pipeline jobs. See https://buildkite.com/docs/pipelines/environment-variables#runtime-variable-interpolation.

Allow overwriting the version used for the builds consistently. Previously there was an envar GIT_VERSION that could do this partially. Renamed to SCION_VERSION and supported now also fully for the package builds. Setting this variable in buildkite pipelines should now allow, for example, building release builds before explicitly tagging the release.