### PR TITLE
doc: fixup generated documentation files after removing dispatcher flags

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,7 +35,7 @@ test:unit_all --config=unit //...
 test:integration --test_tag_filters=integration,-lint
 test:integration_all --config=integration //...
 
-test:lint --test_tag_filters=lint --test_summary=terse --noshow_progress --experimental_convenience_symlinks=ignore
+test:lint --test_tag_filters=lint,write_src --test_summary=terse --noshow_progress --experimental_convenience_symlinks=ignore
 
 # run quietly, only display errors
 common:quiet --ui_event_filters=-warning,-info,-debug,-stdout,-stderr --noshow_progress

--- a/doc/command/scion-pki/scion-pki_certificate_renew.rst
+++ b/doc/command/scion-pki/scion-pki_certificate_renew.rst
@@ -120,7 +120,6 @@ Options
                                --ca is mutually exclusive with --remote
       --common-name string     The common name that replaces the common name in the subject template
       --curve string           The elliptic curve to use (P-256|P-384|P-521) (default "P-256")
-      --dispatcher string      Path to the dispatcher socket (default "/run/shm/dispatcher/default.sock")
       --expires-in string      Remaining time threshold for renewal
       --features strings       enable development features ()
       --force                  Force overwritting existing files

--- a/doc/command/scion/scion_address.rst
+++ b/doc/command/scion/scion_address.rst
@@ -35,12 +35,11 @@ Options
 
 ::
 
-      --dispatcher string   Path to the dispatcher socket (default "/run/shm/dispatcher/default.sock")
-  -h, --help                help for address
-      --isd-as isd-as       The local ISD-AS to use. (default 0-0)
-      --json                Write the output as machine readable json
-  -l, --local ip            Local IP address to listen on. (default invalid IP)
-      --sciond string       SCION Daemon address. (default "127.0.0.1:30255")
+  -h, --help            help for address
+      --isd-as isd-as   The local ISD-AS to use. (default 0-0)
+      --json            Write the output as machine readable json
+  -l, --local ip        Local IP address to listen on. (default invalid IP)
+      --sciond string   SCION Daemon address. (default "127.0.0.1:30255")
 
 SEE ALSO
 ~~~~~~~~

--- a/doc/command/scion/scion_ping.rst
+++ b/doc/command/scion/scion_ping.rst
@@ -87,7 +87,6 @@ Options
 ::
 
   -c, --count uint16           total number of packets to send
-      --dispatcher string      Path to the dispatcher socket (default "/run/shm/dispatcher/default.sock")
       --epic                   Enable EPIC for path probing.
       --format string          Specify the output format (human|json|yaml) (default "human")
       --healthy-only           only use healthy paths

--- a/doc/command/scion/scion_showpaths.rst
+++ b/doc/command/scion/scion_showpaths.rst
@@ -90,7 +90,6 @@ Options
 
 ::
 
-      --dispatcher string      Path to the dispatcher socket (default "/run/shm/dispatcher/default.sock")
       --epic                   Enable EPIC.
   -e, --extended               Show extended path meta data information
       --format string          Specify the output format (human|json|yaml) (default "human")

--- a/doc/command/scion/scion_traceroute.rst
+++ b/doc/command/scion/scion_traceroute.rst
@@ -79,7 +79,6 @@ Options
 
 ::
 
-      --dispatcher string      Path to the dispatcher socket (default "/run/shm/dispatcher/default.sock")
       --epic                   Enable EPIC.
       --format string          Specify the output format (human|json|yaml) (default "human")
   -h, --help                   help for traceroute


### PR DESCRIPTION
Run `bazel run //:write_all_source_files` to fix up generated documentation after removing the dispatcher flag from scion/scion-pki binaries.

This was missed during the PR because the existing check for this was not active in the CI. Extend the bazel configuration `test:lint` to enable running this in `make lint`.