### PR TITLE
doc: fix bazel bin path in setup instructions

### DIFF
--- a/doc/dev/setup.rst
+++ b/doc/dev/setup.rst
@@ -51,7 +51,7 @@ Setup
 
       ./tools/install_bazel
 
-   and make sure that ``~/bin`` is on your ``PATH``.
+   and make sure that ``~/.local/bin`` is on your ``PATH``.
 
    You can also manually install ``bazelisk`` and create an alias so that
    ``bazel`` will resolve to the ``bazelisk`` command.


### PR DESCRIPTION
Setup documentation contained wrong path of bazel binary.