### PR TITLE
tools: topogen: Fix network argument. Added IPv6 network argument.

### DIFF
--- a/tools/topogen.py
+++ b/tools/topogen.py
@@ -37,7 +37,9 @@ def add_arguments(parser):
     parser.add_argument('-d', '--docker', action='store_true',
                         help='Create a docker compose configuration')
     parser.add_argument('-n', '--network',
-                        help='Network to create subnets in (E.g. "127.0.0.0/8"')
+                        help='IPv4 network to create subnets in (E.g. "127.0.0.0/8"')
+    parser.add_argument('-n6', '--network-v6',
+                        help='IPv6 network to create subnets in (E.g. "fd00:f00d:cafe::7f00:0000/104"')
     parser.add_argument('-o', '--output-dir', default=GEN_PATH,
                         help='Output directory')
     parser.add_argument('--random-ifids', action='store_true',

--- a/tools/topology/config.py
+++ b/tools/topology/config.py
@@ -76,15 +76,17 @@ class ConfigGenerator(object):
             logging.critical("Cannot use sig without docker!")
             sys.exit(1)
         self.default_mtu = None
-        self._read_defaults(self.args.network)
+        self._read_defaults()
 
-    def _read_defaults(self, network):
+    def _read_defaults(self):
         """
         Configure default network.
         """
         defaults = self.topo_config.get("defaults", {})
-        self.subnet_gen4 = SubnetGenerator(DEFAULT_NETWORK, self.args.docker)
-        self.subnet_gen6 = SubnetGenerator(DEFAULT6_NETWORK, self.args.docker)
+        self.subnet_gen4 = SubnetGenerator(self.args.network, self.args.docker) \
+            if self.args.network else SubnetGenerator(DEFAULT_NETWORK, self.args.docker)
+        self.subnet_gen6 = SubnetGenerator(self.args.network_v6, self.args.docker) \
+            if self.args.network_v6 else SubnetGenerator(DEFAULT6_NETWORK, self.args.docker)
         self.default_mtu = defaults.get("mtu", DEFAULT_MTU)
         self.dispatched_ports = defaults.get("dispatched_ports", DEFAULT_DISPATCHED_PORTS)
 

--- a/tools/topology/defines.py
+++ b/tools/topology/defines.py
@@ -40,6 +40,11 @@ DEFAULT_MTU = 1500 - 20 - 8
 #: IPv6 min value
 SCION_MIN_MTU = 1280
 
+# Default IPv4 network
+DEFAULT_NETWORK = "127.0.0.0/8"
+DEFAULT_PRIV_NETWORK = "192.168.0.0/16"
+DEFAULT_SCN_DC_NETWORK = "172.20.0.0/20"
+
 # Default IPv6 network, our equivalent to 127.0.0.0/8
 # https://en.wikipedia.org/wiki/Unique_local_address#Definition
 DEFAULT6_MASK = "/104"

--- a/tools/topology/net.py
+++ b/tools/topology/net.py
@@ -37,11 +37,7 @@ from typing import Mapping, Union
 import yaml
 
 # SCION
-from topology.defines import DEFAULT6_NETWORK_ADDR
-
-DEFAULT_NETWORK = "127.0.0.0/8"
-DEFAULT_PRIV_NETWORK = "192.168.0.0/16"
-DEFAULT_SCN_DC_NETWORK = "172.20.0.0/20"
+from topology.defines import DEFAULT_NETWORK, DEFAULT_SCN_DC_NETWORK, DEFAULT6_NETWORK_ADDR
 
 IPAddress = Union[IPv4Address, IPv6Address]
 IPNetwork = Union[IPv4Network, IPv6Network]


### PR DESCRIPTION
The argument `-n` or `--network` in [topogen.py](https://github.com/scionproto/scion/blob/9d52e2f8d2211427707dfe5b4028158759ebddeb/tools/topogen.py) is ignored when generating a topology, the default network is always used.

There exists no argument for the user to specify a different IPv6 network with respect to the default one.
I have added the argument `-n6` or `--network-v6` which is the IPv6 version of the `--network` argument.

I moved for consistency the variables like `DEFAULT_NETWORK` from [net.py](https://github.com/scionproto/scion/blob/9d52e2f8d2211427707dfe5b4028158759ebddeb/tools/topology/net.py) to [defines.py](https://github.com/scionproto/scion/blob/9d52e2f8d2211427707dfe5b4028158759ebddeb/tools/topology/defines.py) where the IPv6 network defines are already present.