### PR TITLE
Remove unused QUIC config field from CS

### DIFF
--- a/acceptance/topo_cs_reload/testdata/cs.toml
+++ b/acceptance/topo_cs_reload/testdata/cs.toml
@@ -16,6 +16,3 @@ connection = "cs1-ff00_0_110-1.beacon.db"
 
 [metrics]
 prometheus = "242.253.100.2:30453"
-
-[quic]
-address = "242.253.100.2:0"

--- a/control/config/config.go
+++ b/control/config/config.go
@@ -56,7 +56,6 @@ type Config struct {
 	Metrics     env.Metrics        `toml:"metrics,omitempty"`
 	API         api.Config         `toml:"api,omitempty"`
 	Tracing     env.Tracing        `toml:"tracing,omitempty"`
-	QUIC        env.QUIC           `toml:"quic,omitempty"`
 	BeaconDB    storage.DBConfig   `toml:"beacon_db,omitempty"`
 	TrustDB     storage.DBConfig   `toml:"trust_db,omitempty"`
 	PathDB      storage.DBConfig   `toml:"path_db,omitempty"`
@@ -115,7 +114,6 @@ func (cfg *Config) Sample(dst io.Writer, path config.Path, _ config.CtxMap) {
 		&cfg.Metrics,
 		&cfg.API,
 		&cfg.Tracing,
-		&cfg.QUIC,
 		config.OverrideName(
 			config.FormatData(
 				&cfg.BeaconDB,

--- a/private/env/env.go
+++ b/private/env/env.go
@@ -250,16 +250,3 @@ func (cfg *Tracing) NewTracer(id string) (opentracing.Tracer, io.Closer, error) 
 		jaegercfg.Extractor(opentracing.Binary, bp),
 		jaegercfg.Injector(opentracing.Binary, bp))
 }
-
-// QUIC contains configuration for control-plane speakers.
-type QUIC struct {
-	Address string `toml:"address,omitempty"`
-}
-
-func (cfg *QUIC) Sample(dst io.Writer, path config.Path, _ config.CtxMap) {
-	config.WriteString(dst, quicSample)
-}
-
-func (cfg *QUIC) ConfigName() string {
-	return "quic"
-}

--- a/private/env/sample.go
+++ b/private/env/sample.go
@@ -51,9 +51,3 @@ debug = false
 # (default: localhost:6831)
 agent = "localhost:6831"
 `
-
-const quicSample = `
-# The address to start a QUIC server on (ip:port). If not set, a QUIC server on
-# the public IP and a high port is started. (default "")
-address = ""
-`


### PR DESCRIPTION
And the type `env.QUIC`, as it's also unused.

Also relates to #2810 
Closes #2810 
