### PR TITLE
doc: update deploy tutorial to release v0.11.0

### DIFF
--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -106,8 +106,8 @@ Execute the following commands on each VM:
 .. code-block:: sh
 
    cd /tmp/
-   wget https://github.com/scionproto/scion/releases/download/v0.10.0/scion_v0.10.0_deb_amd64.tar.gz
-   tar xfz scion_v0.10.0_deb_amd64.tar.gz
+   wget https://github.com/scionproto/scion/releases/download/v0.11.0/scion_v0.11.0_deb_amd64.tar.gz
+   tar xfz scion_v0.11.0_deb_amd64.tar.gz
 
    sudo apt install ./scion*.deb
 
@@ -142,19 +142,8 @@ On scion01, download the topology1.json file. On scion02, download topology2.jso
 
    wget LINK_TO_TOPOLOGY.JSON_FILE -O /etc/scion/topology.json
 
-
-The downloaded AS topology file is configured with generic IP address (10.0.0.1-5) as placeholder for the hosts scion01-05. These IP addresses will need to be changed to the VM IP specific addresses.
-
-.. code-block:: sh
-
-   sed -i 's/10.0.0.1/YOUR_SCION01_IP/g' /etc/scion/topology.json
-   sed -i 's/10.0.0.2/YOUR_SCION02_IP/g' /etc/scion/topology.json
-   sed -i 's/10.0.0.3/YOUR_SCION03_IP/g' /etc/scion/topology.json
-   sed -i 's/10.0.0.4/YOUR_SCION04_IP/g' /etc/scion/topology.json
-   sed -i 's/10.0.0.5/YOUR_SCION05_IP/g' /etc/scion/topology.json
-
-Replace ``YOUR_SCIONXX_IP`` with the VM specific IP address and apply on each scion host.
-
+The AS topology files reference the hosts scion01-05 by host name.
+Ensure that you have set up the ``/etc/hosts`` file (:ref:`see above <step0>`) or replace the hostnames with IP addresses.
 
 Step 2 - Generate the Required Certificates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/tutorials/deploy/topology1.json
+++ b/doc/tutorials/deploy/topology1.json
@@ -20,8 +20,8 @@
       "interfaces": {
         "1": {
           "underlay": {
-            "public": "10.0.0.1:50014",
-            "remote": "10.0.0.4:50014"
+            "local": ":50014",
+            "remote": "scion04:50014"
           },
           "isd_as": "42-ffaa:1:4",
           "link_to": "child",
@@ -29,8 +29,8 @@
         },
         "2": {
           "underlay": {
-            "public": "10.0.0.1:50012",
-            "remote": "10.0.0.2:50012"
+            "local": ":50012",
+            "remote": "scion02:50012"
           },
           "isd_as": "42-ffaa:1:2",
           "link_to": "core",
@@ -38,8 +38,8 @@
         },
         "3": {
           "underlay": {
-            "public": "10.0.0.1:50013",
-            "remote": "10.0.0.3:50013"
+            "local": ":50013",
+            "remote": "scion03:50013"
           },
           "isd_as": "42-ffaa:1:3",
           "link_to": "core",

--- a/doc/tutorials/deploy/topology2.json
+++ b/doc/tutorials/deploy/topology2.json
@@ -20,8 +20,8 @@
       "interfaces": {
         "1": {
           "underlay": {
-            "public": "10.0.0.2:50012",
-            "remote": "10.0.0.1:50012"
+            "local": ":50012",
+            "remote": "scion01:50012"
           },
           "isd_as": "42-ffaa:1:1",
           "link_to": "core",
@@ -29,8 +29,8 @@
         },
         "2": {
           "underlay": {
-            "public": "10.0.0.2:50023",
-            "remote": "10.0.0.3:50023"
+            "local": ":50023",
+            "remote": "scion03:50023"
           },
           "isd_as": "42-ffaa:1:3",
           "link_to": "core",
@@ -38,8 +38,8 @@
         },
         "3": {
           "underlay": {
-            "public": "10.0.0.2:50025",
-            "remote": "10.0.0.5:50025"
+            "local": ":50025",
+            "remote": "scion05:50025"
           },
           "isd_as": "42-ffaa:1:5",
           "link_to": "child",

--- a/doc/tutorials/deploy/topology3.json
+++ b/doc/tutorials/deploy/topology3.json
@@ -20,8 +20,8 @@
       "interfaces": {
         "1": {
           "underlay": {
-            "public": "10.0.0.3:50013",
-            "remote": "10.0.0.1:50013"
+            "local": ":50013",
+            "remote": "scion01:50013"
           },
           "isd_as": "42-ffaa:1:1",
           "link_to": "core",
@@ -29,8 +29,8 @@
         },
         "2": {
           "underlay": {
-            "public": "10.0.0.3:50023",
-            "remote": "10.0.0.2:50023"
+            "local": ":50023",
+            "remote": "scion02:50023"
           },
           "isd_as": "42-ffaa:1:2",
           "link_to": "core",
@@ -38,8 +38,8 @@
         },
         "3": {
           "underlay": {
-            "public": "10.0.0.3:50034",
-            "remote": "10.0.0.4:50034"
+            "local": ":50034",
+            "remote": "scion04:50034"
           },
           "isd_as": "42-ffaa:1:4",
           "link_to": "child",
@@ -47,8 +47,8 @@
         },
         "4": {
           "underlay": {
-            "public": "10.0.0.3:50035",
-            "remote": "10.0.0.5:50035"
+            "local": ":50035",
+            "remote": "scion05:50035"
           },
           "isd_as": "42-ffaa:1:5",
           "link_to": "child",

--- a/doc/tutorials/deploy/topology4.json
+++ b/doc/tutorials/deploy/topology4.json
@@ -18,8 +18,8 @@
       "interfaces": {
         "1": {
           "underlay": {
-            "public": "10.0.0.4:50014",
-            "remote": "10.0.0.1:50014"
+            "local": ":50014",
+            "remote": "scion01:50014"
           },
           "isd_as": "42-ffaa:1:1",
           "link_to": "parent",
@@ -27,8 +27,8 @@
         },
         "2": {
           "underlay": {
-            "public": "10.0.0.4:50034",
-            "remote": "10.0.0.3:50034"
+            "local": ":50034",
+            "remote": "scion03:50034"
           },
           "isd_as": "42-ffaa:1:3",
           "link_to": "parent",

--- a/doc/tutorials/deploy/topology5.json
+++ b/doc/tutorials/deploy/topology5.json
@@ -18,8 +18,8 @@
       "interfaces": {
         "1": {
           "underlay": {
-            "public": "10.0.0.5:50025",
-            "remote": "10.0.0.2:50025"
+            "local": ":50025",
+            "remote": "scion02:50025"
           },
           "isd_as": "42-ffaa:1:2",
           "link_to": "parent",
@@ -27,8 +27,8 @@
         },
         "2": {
           "underlay": {
-            "public": "10.0.0.5:50035",
-            "remote": "10.0.0.3:50035"
+            "local": ":50035",
+            "remote": "scion03:50035"
           },
           "isd_as": "42-ffaa:1:3",
           "link_to": "parent",


### PR DESCRIPTION
Update link to download v0.11.0 packages.
Update topology.json files:
- Use simpler "local" address configuration without explicitly binding to a specific local IP.
- Use hostnames for remote hosts to avoid having to explicitly patch the placeholder IP addresses in the topology files.