### PR TITLE
snet: move SCMPHandler to cooked UDP Conn, don't propagate SCMP errors by default

### DIFF
--- a/gateway/pathhealth/pathwatcher.go
+++ b/gateway/pathhealth/pathwatcher.go
@@ -119,7 +119,7 @@ type pathWatcher struct {
 	// conn is the packet conn used to send probes on. The pathwatcher takes
 	// ownership and will close it on termination.
 	conn snet.PacketConn
-	// Handler for non-traceroute SCMP packets received on conn
+	// scmpHandler handles non-traceroute SCMP packets received on conn
 	scmpHandler snet.SCMPHandler
 	// id is used as SCMP traceroute ID. Since each pathwatcher should have it's
 	// own high port this value can be random.

--- a/gateway/pathhealth/scmp.go
+++ b/gateway/pathhealth/scmp.go
@@ -16,7 +16,6 @@ package pathhealth
 
 import (
 	"github.com/scionproto/scion/pkg/addr"
-	"github.com/scionproto/scion/pkg/private/serrors"
 	"github.com/scionproto/scion/pkg/snet"
 )
 
@@ -33,7 +32,7 @@ type scmpHandler struct {
 
 func (h scmpHandler) Handle(pkt *snet.Packet) error {
 	if pkt.Payload == nil {
-		return serrors.New("no payload found")
+		return nil
 	}
 	tr, ok := pkt.Payload.(snet.SCMPTracerouteReply)
 	if !ok {

--- a/gateway/pathhealth/scmp.go
+++ b/gateway/pathhealth/scmp.go
@@ -16,32 +16,10 @@ package pathhealth
 
 import (
 	"github.com/scionproto/scion/pkg/addr"
-	"github.com/scionproto/scion/pkg/snet"
 )
 
 type traceroutePkt struct {
 	Remote     addr.IA
 	Identifier uint16
 	Sequence   uint16
-}
-
-type scmpHandler struct {
-	wrappedHandler snet.SCMPHandler
-	pkts           chan<- traceroutePkt
-}
-
-func (h scmpHandler) Handle(pkt *snet.Packet) error {
-	if pkt.Payload == nil {
-		return nil
-	}
-	tr, ok := pkt.Payload.(snet.SCMPTracerouteReply)
-	if !ok {
-		return h.wrappedHandler.Handle(pkt)
-	}
-	h.pkts <- traceroutePkt{
-		Remote:     pkt.Source.IA,
-		Identifier: tr.Identifier,
-		Sequence:   tr.Sequence,
-	}
-	return nil
 }

--- a/pkg/snet/conn.go
+++ b/pkg/snet/conn.go
@@ -101,6 +101,16 @@ func (c *Conn) SyscallConn() (syscall.RawConn, error) {
 	return c.conn.SyscallConn()
 }
 
+func (c *Conn) SetReadBuffer(n int) error {
+	c.conn.SetReadBuffer(n)
+	return nil
+}
+
+func (c *Conn) SetWriteBuffer(n int) error {
+	c.conn.SetWriteBuffer(n)
+	return nil
+}
+
 func (c *Conn) SetDeadline(t time.Time) error {
 	if err := c.scionConnReader.SetReadDeadline(t); err != nil {
 		return err

--- a/pkg/snet/conn.go
+++ b/pkg/snet/conn.go
@@ -116,23 +116,21 @@ func (c *Conn) Close() error {
 }
 
 // ConnOption is a functional option type for configuring a Conn.
-type ConnOption func(o *options)
+type ConnOption func(o *connOptions)
 
 // WithReplyPather sets the reply pather for the connection.
 // The reply pather is responsible for determining the path to send replies to.
 // If this option is not provided, DefaultReplyPather is used.
 func WithReplyPather(replyPather ReplyPather) ConnOption {
-	return func(o *options) {
+	return func(o *connOptions) {
 		o.replyPather = replyPather
 	}
 }
 
 // WithSCMPHandler sets the SCMP handler for the connection.
 // The SCMP handler is a callback to react to SCMP messages, specifically to error messages.
-// If this option is not provided, no SCMP handler is used (equivalent to
-// DefaultSCMPHandler with an empty RevocationHandler).
 func WithSCMPHandler(scmpHandler SCMPHandler) ConnOption {
-	return func(o *options) {
+	return func(o *connOptions) {
 		o.scmpHandler = scmpHandler
 	}
 }
@@ -140,24 +138,24 @@ func WithSCMPHandler(scmpHandler SCMPHandler) ConnOption {
 // WithRemote sets the remote address for the connection.
 // This only applies to NewCookedConn, but not Dial/Listen.
 func WithRemote(addr *UDPAddr) ConnOption {
-	return func(o *options) {
+	return func(o *connOptions) {
 		o.remote = addr
 	}
 }
 
-type options struct {
+type connOptions struct {
 	replyPather ReplyPather
 	scmpHandler SCMPHandler
 	remote      *UDPAddr
 }
 
-func apply(opts []ConnOption) options {
-	o := options{
-		replyPather: DefaultReplyPather{},
-		scmpHandler: nil,
-	}
+func apply(opts []ConnOption) connOptions {
+	o := connOptions{}
 	for _, option := range opts {
 		option(&o)
+	}
+	if o.replyPather == nil {
+		o.replyPather = DefaultReplyPather{}
 	}
 	return o
 }

--- a/pkg/snet/conn.go
+++ b/pkg/snet/conn.go
@@ -18,29 +18,16 @@ package snet
 import (
 	"context"
 	"net"
+	"syscall"
 	"time"
 
 	"github.com/scionproto/scion/pkg/private/common"
-	"github.com/scionproto/scion/pkg/private/ctrl/path_mgmt"
 	"github.com/scionproto/scion/pkg/private/serrors"
-	"github.com/scionproto/scion/pkg/slayers"
 )
-
-type OpError struct {
-	typeCode slayers.SCMPTypeCode
-	revInfo  *path_mgmt.RevInfo
-}
-
-func (e *OpError) RevInfo() *path_mgmt.RevInfo {
-	return e.revInfo
-}
-
-func (e *OpError) Error() string {
-	return e.typeCode.String()
-}
 
 var _ net.Conn = (*Conn)(nil)
 var _ net.PacketConn = (*Conn)(nil)
+var _ syscall.Conn = (*Conn)(nil)
 
 type Conn struct {
 	conn PacketConn
@@ -96,6 +83,7 @@ func NewCookedConn(
 			conn:        pconn,
 			buffer:      make([]byte, common.SupportedMTU),
 			replyPather: o.replyPather,
+			scmpHandler: o.scmpHandler,
 			local:       local,
 		},
 	}, nil
@@ -107,6 +95,10 @@ func (c *Conn) LocalAddr() net.Addr {
 
 func (c *Conn) RemoteAddr() net.Addr {
 	return c.remote
+}
+
+func (c *Conn) SyscallConn() (syscall.RawConn, error) {
+	return c.conn.SyscallConn()
 }
 
 func (c *Conn) SetDeadline(t time.Time) error {
@@ -128,16 +120,25 @@ type ConnOption func(o *options)
 
 // WithReplyPather sets the reply pather for the connection.
 // The reply pather is responsible for determining the path to send replies to.
-// If the provided replyPather is not nil, it will be set as the reply pather for the connection.
+// If this option is not provided, DefaultReplyPather is used.
 func WithReplyPather(replyPather ReplyPather) ConnOption {
 	return func(o *options) {
-		if replyPather != nil {
-			o.replyPather = replyPather
-		}
+		o.replyPather = replyPather
+	}
+}
+
+// WithSCMPHandler sets the SCMP handler for the connection.
+// The SCMP handler is a callback to react to SCMP messages, specifically to error messages.
+// If this option is not provided, no SCMP handler is used (equivalent to
+// DefaultSCMPHandler with an empty RevocationHandler).
+func WithSCMPHandler(scmpHandler SCMPHandler) ConnOption {
+	return func(o *options) {
+		o.scmpHandler = scmpHandler
 	}
 }
 
 // WithRemote sets the remote address for the connection.
+// This only applies to NewCookedConn, but not Dial/Listen.
 func WithRemote(addr *UDPAddr) ConnOption {
 	return func(o *options) {
 		o.remote = addr
@@ -146,12 +147,14 @@ func WithRemote(addr *UDPAddr) ConnOption {
 
 type options struct {
 	replyPather ReplyPather
+	scmpHandler SCMPHandler
 	remote      *UDPAddr
 }
 
 func apply(opts []ConnOption) options {
 	o := options{
 		replyPather: DefaultReplyPather{},
+		scmpHandler: nil,
 	}
 	for _, option := range opts {
 		option(&o)

--- a/pkg/snet/interface.go
+++ b/pkg/snet/interface.go
@@ -22,6 +22,6 @@ import (
 
 type Network interface {
 	OpenRaw(ctx context.Context, addr *net.UDPAddr) (PacketConn, error)
-	Listen(ctx context.Context, network string, listen *net.UDPAddr) (*Conn, error)
-	Dial(ctx context.Context, network string, listen *net.UDPAddr, remote *UDPAddr) (*Conn, error)
+	Listen(ctx context.Context, network string, listen *net.UDPAddr, options ...ConnOption) (*Conn, error)
+	Dial(ctx context.Context, network string, listen *net.UDPAddr, remote *UDPAddr, options ...ConnOption) (*Conn, error)
 }

--- a/pkg/snet/packet_conn.go
+++ b/pkg/snet/packet_conn.go
@@ -40,6 +40,8 @@ type PacketConn interface {
 	SetWriteDeadline(t time.Time) error
 	SetDeadline(t time.Time) error
 	SyscallConn() (syscall.RawConn, error)
+	SetReadBuffer(int) error
+	SetWriteBuffer(int) error
 	LocalAddr() net.Addr
 	Close() error
 }
@@ -104,10 +106,6 @@ type SCIONPacketConn struct {
 	interfaceMap interfaceMap
 }
 
-func (c *SCIONPacketConn) SetReadBuffer(bytes int) error {
-	return c.Conn.SetReadBuffer(bytes)
-}
-
 func (c *SCIONPacketConn) SetDeadline(d time.Time) error {
 	return c.Conn.SetDeadline(d)
 }
@@ -151,6 +149,10 @@ func (c *SCIONPacketConn) ReadFrom(pkt *Packet, ov *net.UDPAddr) error {
 
 func (c *SCIONPacketConn) SyscallConn() (syscall.RawConn, error) {
 	return c.Conn.SyscallConn()
+}
+
+func (c *SCIONPacketConn) SetReadBuffer(n int) error {
+	return c.Conn.SetReadBuffer(n)
 }
 
 func (c *SCIONPacketConn) readFrom(pkt *Packet) (*net.UDPAddr, error) {

--- a/pkg/snet/reader.go
+++ b/pkg/snet/reader.go
@@ -32,9 +32,11 @@ type ReplyPather interface {
 }
 
 type scionConnReader struct {
+	conn  PacketConn
+	local *UDPAddr
+
 	replyPather ReplyPather
-	conn        PacketConn
-	local       *UDPAddr
+	scmpHandler SCMPHandler
 
 	mtx    sync.Mutex
 	buffer []byte
@@ -69,11 +71,12 @@ func (c *scionConnReader) read(b []byte) (int, *UDPAddr, error) {
 		Bytes: Bytes(c.buffer),
 	}
 	var lastHop net.UDPAddr
-	err := c.conn.ReadFrom(&pkt, &lastHop)
+	err := c.readPacketUDP(&pkt, &lastHop)
 	if err != nil {
 		return 0, nil, err
 	}
 
+	udp := pkt.Payload.(UDPPayload)
 	rpath, ok := pkt.Path.(RawPath)
 	if !ok {
 		return 0, nil, serrors.New("unexpected path", "type", common.TypeOf(pkt.Path))
@@ -81,11 +84,6 @@ func (c *scionConnReader) read(b []byte) (int, *UDPAddr, error) {
 	replyPath, err := c.replyPather.ReplyPath(rpath)
 	if err != nil {
 		return 0, nil, serrors.WrapStr("creating reply path", err)
-	}
-
-	udp, ok := pkt.Payload.(UDPPayload)
-	if !ok {
-		return 0, nil, serrors.New("unexpected payload", "type", common.TypeOf(pkt.Payload))
 	}
 
 	// XXX(JordiSubira): We explicitly forbid nil or unspecified address in the current constructor
@@ -117,6 +115,35 @@ func (c *scionConnReader) read(b []byte) (int, *UDPAddr, error) {
 	}
 	n := copy(b, udp.Payload)
 	return n, remote, nil
+}
+
+// readPacketUDP repeatedly reads a packet until a UDP datagram is found.
+// If an SCMP Handler is configured, it will be called on SCMP messages.
+func (c *scionConnReader) readPacketUDP(pkt *Packet, lastHop *net.UDPAddr) error {
+	for {
+		err := c.conn.ReadFrom(pkt, lastHop)
+		if err != nil {
+			return err
+		}
+
+		switch pkt.Payload.(type) {
+		case UDPPayload:
+			return nil
+		case SCMPPayload:
+			if c.scmpHandler == nil {
+				// TODO metrics
+				//	metrics.CounterInc(c.Metrics.SCMPErrors)
+				continue
+			}
+			err := c.scmpHandler.Handle(pkt)
+			if err != nil {
+				//	metrics.CounterInc(c.Metrics.SCMPErrors)
+			}
+			continue
+		default:
+			continue
+		}
+	}
 }
 
 func (c *scionConnReader) SetReadDeadline(t time.Time) error {

--- a/pkg/snet/reader.go
+++ b/pkg/snet/reader.go
@@ -71,8 +71,7 @@ func (c *scionConnReader) read(b []byte) (int, *UDPAddr, error) {
 		Bytes: Bytes(c.buffer),
 	}
 	var lastHop net.UDPAddr
-	err := c.readPacketUDP(&pkt, &lastHop)
-	if err != nil {
+	if err := c.readPacketUDP(&pkt, &lastHop); err != nil {
 		return 0, nil, err
 	}
 
@@ -117,12 +116,11 @@ func (c *scionConnReader) read(b []byte) (int, *UDPAddr, error) {
 	return n, remote, nil
 }
 
-// readPacketUDP repeatedly reads a packet until a UDP datagram is found.
+// readPacketUDP repeatedly reads a packet until a UDP datagram is found or an error occurs.
 // If an SCMP Handler is configured, it will be called on SCMP messages.
 func (c *scionConnReader) readPacketUDP(pkt *Packet, lastHop *net.UDPAddr) error {
 	for {
-		err := c.conn.ReadFrom(pkt, lastHop)
-		if err != nil {
+		if err := c.conn.ReadFrom(pkt, lastHop); err != nil {
 			return err
 		}
 
@@ -133,11 +131,9 @@ func (c *scionConnReader) readPacketUDP(pkt *Packet, lastHop *net.UDPAddr) error
 			if c.scmpHandler == nil {
 				continue
 			}
-			err := c.scmpHandler.Handle(pkt)
-			if err != nil {
+			if err := c.scmpHandler.Handle(pkt); err != nil {
 				return err
 			}
-			continue
 		default:
 			continue
 		}

--- a/pkg/snet/reader.go
+++ b/pkg/snet/reader.go
@@ -131,13 +131,11 @@ func (c *scionConnReader) readPacketUDP(pkt *Packet, lastHop *net.UDPAddr) error
 			return nil
 		case SCMPPayload:
 			if c.scmpHandler == nil {
-				// TODO metrics
-				//	metrics.CounterInc(c.Metrics.SCMPErrors)
 				continue
 			}
 			err := c.scmpHandler.Handle(pkt)
 			if err != nil {
-				//	metrics.CounterInc(c.Metrics.SCMPErrors)
+				return err
 			}
 			continue
 		default:

--- a/pkg/snet/snet.go
+++ b/pkg/snet/snet.go
@@ -28,12 +28,6 @@
 // used to send a message to a chosen destination.
 //
 // Multiple networking contexts can share the same SCIOND.
-//
-// Write calls never return SCMP errors directly. If a write call caused an
-// SCMP message to be received by the Conn, it can be inspected by calling
-// Read. In this case, the error value is non-nil and can be type asserted to
-// *OpError. Method SCMP() can be called on the error to extract the SCMP
-// header.
 package snet
 
 import (
@@ -41,6 +35,7 @@ import (
 	"errors"
 	"net"
 	"net/netip"
+	"slices"
 	"syscall"
 
 	"github.com/scionproto/scion/pkg/addr"
@@ -70,14 +65,10 @@ type SCIONNetwork struct {
 	// Topology provides local AS information, needed to handle sockets and
 	// traffic.
 	Topology Topology
-	// ReplyPather is used to create reply paths when reading packets on Conn
-	// (that implements net.Conn). If unset, the default reply pather is used,
-	// which parses the incoming path as a path.Path and reverses it.
-	ReplyPather ReplyPather
-	// Metrics holds the metrics emitted by the network.
-	Metrics SCIONNetworkMetrics
-	// SCMPHandler describes the network behaviour upon receiving SCMP traffic.
-	SCMPHandler       SCMPHandler
+
+	// XXX: SCMPHandler / Reverser
+
+	Metrics           SCIONNetworkMetrics
 	PacketConnMetrics SCIONPacketConnMetrics
 }
 
@@ -119,7 +110,6 @@ func (n *SCIONNetwork) OpenRaw(ctx context.Context, addr *net.UDPAddr) (PacketCo
 	}
 	return &SCIONPacketConn{
 		Conn:         pconn,
-		SCMPHandler:  n.SCMPHandler,
 		Metrics:      n.PacketConnMetrics,
 		interfaceMap: ifAddrs,
 	}, nil
@@ -133,8 +123,13 @@ func (n *SCIONNetwork) OpenRaw(ctx context.Context, addr *net.UDPAddr) (PacketCo
 //
 // The context is used for connection setup, it doesn't affect the returned
 // connection.
-func (n *SCIONNetwork) Dial(ctx context.Context, network string, listen *net.UDPAddr,
-	remote *UDPAddr) (*Conn, error) {
+func (n *SCIONNetwork) Dial(
+	ctx context.Context,
+	network string,
+	listen *net.UDPAddr,
+	remote *UDPAddr,
+	options ...ConnOption,
+) (*Conn, error) {
 	// XXX(JordiSubira): Currently Dial does not check that received packets are
 	// originated from the expected remote address. This should be adapted to
 	// check that the remote packets are originated from the expected remote address.
@@ -151,7 +146,8 @@ func (n *SCIONNetwork) Dial(ctx context.Context, network string, listen *net.UDP
 		return nil, err
 	}
 	log.FromCtx(ctx).Debug("UDP socket opened on", "addr", packetConn.LocalAddr(), "to", remote)
-	return NewCookedConn(packetConn, n.Topology, WithReplyPather(n.ReplyPather), WithRemote(remote))
+	options = append(slices.Clone(options), WithRemote(remote))
+	return NewCookedConn(packetConn, n.Topology, options...)
 }
 
 // Listen opens a Conn. The returned connection's ReadFrom and WriteTo methods
@@ -165,6 +161,7 @@ func (n *SCIONNetwork) Listen(
 	ctx context.Context,
 	network string,
 	listen *net.UDPAddr,
+	options ...ConnOption,
 ) (*Conn, error) {
 
 	metrics.CounterInc(n.Metrics.Listens)
@@ -176,7 +173,7 @@ func (n *SCIONNetwork) Listen(
 		return nil, err
 	}
 	log.FromCtx(ctx).Debug("UDP socket openned on", "addr", packetConn.LocalAddr())
-	return NewCookedConn(packetConn, n.Topology, WithReplyPather(n.ReplyPather))
+	return NewCookedConn(packetConn, n.Topology, options...)
 }
 
 func listenUDPRange(addr *net.UDPAddr, start, end uint16) (*net.UDPConn, error) {

--- a/scion-pki/certs/renew.go
+++ b/scion-pki/certs/renew.go
@@ -738,12 +738,12 @@ func (r *renewer) requestRemote(
 
 	sn := &snet.SCIONNetwork{
 		Topology: r.Daemon,
+		SCMPHandler: snet.DefaultSCMPHandler{
+			RevocationHandler: daemon.RevHandler{Connector: r.Daemon},
+		},
 	}
 
-	scmpHandler := snet.DefaultSCMPHandler{
-		RevocationHandler: daemon.RevHandler{Connector: r.Daemon},
-	}
-	conn, err := sn.Listen(ctx, "udp", local.Host, snet.WithSCMPHandler(scmpHandler))
+	conn, err := sn.Listen(ctx, "udp", local.Host)
 	if err != nil {
 		return nil, serrors.WrapStr("dialing", err)
 	}
@@ -758,7 +758,6 @@ func (r *renewer) requestRemote(
 			Resolver: &svc.Resolver{
 				LocalIA: local.IA,
 				Network: sn,
-				// XXX  scmp handler lost here
 				LocalIP: local.Host.IP,
 			},
 		},

--- a/scion-pki/certs/renew.go
+++ b/scion-pki/certs/renew.go
@@ -740,6 +740,7 @@ func (r *renewer) requestRemote(
 		Topology: r.Daemon,
 		SCMPHandler: snet.DefaultSCMPHandler{
 			RevocationHandler: daemon.RevHandler{Connector: r.Daemon},
+			Log:               log.FromCtx(ctx).Debug,
 		},
 	}
 

--- a/scion-pki/certs/renew.go
+++ b/scion-pki/certs/renew.go
@@ -738,15 +738,12 @@ func (r *renewer) requestRemote(
 
 	sn := &snet.SCIONNetwork{
 		Topology: r.Daemon,
-		SCMPHandler: snet.SCMPPropagationStopper{
-			Handler: snet.DefaultSCMPHandler{
-				RevocationHandler: daemon.RevHandler{Connector: r.Daemon},
-			},
-			Log: log.FromCtx(ctx).Debug,
-		},
 	}
 
-	conn, err := sn.Listen(ctx, "udp", local.Host)
+	scmpHandler := snet.DefaultSCMPHandler{
+		RevocationHandler: daemon.RevHandler{Connector: r.Daemon},
+	}
+	conn, err := sn.Listen(ctx, "udp", local.Host, snet.WithSCMPHandler(scmpHandler))
 	if err != nil {
 		return nil, serrors.WrapStr("dialing", err)
 	}
@@ -761,6 +758,7 @@ func (r *renewer) requestRemote(
 			Resolver: &svc.Resolver{
 				LocalIA: local.IA,
 				Network: sn,
+				// XXX  scmp handler lost here
 				LocalIP: local.Host.IP,
 			},
 		},


### PR DESCRIPTION
- snet.PacketConn is a "raw" socket. Having a special hook to handle SCMP packets, the SCMPHandler, seems unnecessary here, as any user of this raw socket can (and often wants to) just handle these packets explicitly.
  The SCMPHandler is thus moved from the "raw" PacketConn, to the "cooked" Conn and invoked only there. This makes use of the raw socket for things like sending and reacting to SCMPs much more straight forward.
- Options like the SCMPHandler and ReplyPather can be set in each Dial/Listen call, overriding the default set in the snet.SCIONNetwork.
- The `snet.DefaultSCMPHandler` no longer propagates any errors up. Path revocations are registered, but not directly reported back to the caller of Read/ReadFrom. That is, it's now equivalent to using the (removed) `snet.SCMPPropagationStopper`. See https://github.com/scionproto/scion/issues/4389
- Misc related snet API tweaks/cleanup; remove some unused structs, remove OpError, expose setting buffer sizes from snet.Conn (used by quic-go if available).

WIP: simply ignoring the SCMP errors seems undesirable in some places. The "end2end revocation test" relied on these errors and is no longer working. In the end2end test application itself, tighter timeouts for the ping/pong roundtrip might be sufficient to detect path failures quickly enough. However, I also noticed that path lookups themselves are not functioning well here and I suspect that in some place, the CS is also using SCMP errors for rapid detection of path failures. I need to investigate where this is, and what would be a good way to address this.

Perhaps this PR could be split into two parts; 1) moving the SCMPHandler from PacketConn to Conn, and 2) stopping the error propagation by default.