### PR TITLE
build: replace dummy build target with bazel info

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -63,16 +63,6 @@ config_setting(
     },
 )
 
-# This is a dummy target so Make can "blaze build --announce_rc <something>
-# Where something truly does nothing that we may care about.
-
-config_setting(
-    name = "dummy_setting",
-    define_values = {
-        "whatever": "whatever",
-    },
-)
-
 gazelle(
     name = "gazelle",
     build_tags = select({

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ lint-go-bazel:
 	$(info ==> $@)
 	@tools/quiet bazel test --config lint //...
 
-GO_BUILD_TAGS_ARG=$(shell bazel build --ui_event_filters=-stdout,-stderr --announce_rc --noshow_progress :dummy_setting 2>&1 | grep "'build' options" | sed -n "s/^.*--define gotags=\(\S*\).*/--build-tags \1/p" )
+GO_BUILD_TAGS_ARG=$(shell bazel info --ui_event_filters=-stdout,-stderr --announce_rc --noshow_progress 2>&1 | grep "'build' options" | sed -n "s/^.*--define gotags=\(\S*\).*/--build-tags \1/p" )
 
 lint-go-golangci:
 	$(info ==> $@)

--- a/tools/update_testdata.sh
+++ b/tools/update_testdata.sh
@@ -10,7 +10,7 @@ folders=$(grep \
             --exclude-dir=bazel-\* \
             "xtest.UpdateGoldenFiles()" . | xargs dirname  | sort  | uniq )
 
-GO_BUILD_TAGS_ARG=$(bazel build --ui_event_filters=-stdout,-stderr --announce_rc --noshow_progress :dummy_setting 2>&1 | grep "'build' options" | sed -n "s/^.*--define gotags=\(\S*\).*/-tags \1/p")
+GO_BUILD_TAGS_ARG=$(bazel info --ui_event_filters=-stdout,-stderr --announce_rc --noshow_progress 2>&1 | grep "'build' options" | sed -n "s/^.*--define gotags=\(\S*\).*/-tags \1/p")
 
 echo $folders -update | xargs go test ${GO_BUILD_TAGS_ARG}
 echo $folders -count=1 | xargs go test ${GO_BUILD_TAGS_ARG}


### PR DESCRIPTION
Just a tiny, random cleanup; I've noticed to obtain the effective go tags in the Makefile and scripts, instead of building a dummy target ":dummy_setting" we can also use the bazel info subcommand.