### PR TITLE
router: drop packets with v4 mapped v6 src/dst or unspecified dst hosts

### DIFF
--- a/router/dataplane_internal_test.go
+++ b/router/dataplane_internal_test.go
@@ -725,7 +725,7 @@ func prepBaseMsgHop0Out(t *testing.T, payload []byte, flowId uint32) *slayers.SC
 			{ConsIngress: 31, ConsEgress: 30},
 		},
 	}
-	dpath.HopFields[2].Mac = computeMAC(t, testKey, dpath.InfoFields[0], dpath.HopFields[2])
+	dpath.HopFields[0].Mac = computeMAC(t, testKey, dpath.InfoFields[0], dpath.HopFields[0])
 	spkt.Path = dpath
 	return spkt
 }

--- a/router/dataplane_internal_test.go
+++ b/router/dataplane_internal_test.go
@@ -561,6 +561,29 @@ func TestSlowPathProcessing(t *testing.T) {
 			},
 			expectedLayerType: slayers.LayerTypeSCMPParameterProblem,
 		},
+		"invalid dest unspecified": {
+			prepareDP: func(ctrl *gomock.Controller) *DataPlane {
+				return NewDP(fakeExternalInterfaces,
+					nil, mock_router.NewMockBatchConn(ctrl),
+					fakeInternalNextHops,
+					fakeServices,
+					addr.MustParseIA("1-ff00:0:110"), nil, testKey)
+			},
+			mockMsg: func() []byte {
+				spkt := prepBaseMsg(t, payload, 0)
+				spkt.DstAddrType = slayers.T4Ip
+				spkt.RawDstAddr = []byte{0, 0, 0, 0}
+				ret := toMsg(t, spkt)
+				return ret
+			},
+			srcInterface: 1,
+			expectedSlowPathRequest: slowPathRequest{
+				typ:      slowPathSCMP,
+				scmpType: slayers.SCMPTypeParameterProblem,
+				code:     slayers.SCMPCodeInvalidDestinationAddress,
+			},
+			expectedLayerType: slayers.LayerTypeSCMPParameterProblem,
+		},
 		"invalid src v4mapped": {
 			prepareDP: func(ctrl *gomock.Controller) *DataPlane {
 				return NewDP(fakeExternalInterfaces,

--- a/router/dataplane_test.go
+++ b/router/dataplane_test.go
@@ -273,6 +273,7 @@ func TestDataPlaneRun(t *testing.T) {
 						for i := 0; i < totalCount; i++ {
 							spkt, dpath := prepBaseMsg(time.Now())
 							spkt.DstIA = local
+							spkt.RawDstAddr = []byte{192, 168, 1, 1}
 							dpath.HopFields = []path.HopField{
 								{ConsIngress: 41, ConsEgress: 40},
 								{ConsIngress: 31, ConsEgress: 30},


### PR DESCRIPTION
The check is done on the first hop for src and on the last hop for dst.

Fixes #4415
Fixes #4558 