### PR TITLE
crypto: do not load already loaded TRC files

### DIFF
--- a/control/trust.go
+++ b/control/trust.go
@@ -103,7 +103,7 @@ func newCachingSignerGen(
 
 	gen := trust.SignerGen{
 		IA: ia,
-		DB: cstrust.CryptoLoader{
+		DB: &cstrust.CryptoLoader{
 			Dir:     filepath.Join(cfgDir, "crypto/as"),
 			TRCDirs: []string{filepath.Join(cfgDir, "certs")},
 			DB:      db,

--- a/private/trust/store.go
+++ b/private/trust/store.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/scionproto/scion/pkg/private/serrors"
@@ -112,9 +113,22 @@ func LoadChains(ctx context.Context, dir string, db DB) (LoadResult, error) {
 }
 
 // LoadTRCs loads all *.trc located in a directory in the database. This
-// function exits on the first encountered error. TRCs with a not before time
-// in the future are ignored.
+// function exits on the first encountered error. TRCs with a not before time in
+// the future are ignored.
+//
+// This function is not recommended for repeated use as it will read all TRC
+// files in a directory on every invocation. Consider using a TRCLoader if you
+// want to monitor a directory for new TRCs.
 func LoadTRCs(ctx context.Context, dir string, db DB) (LoadResult, error) {
+	return loadTRCs(ctx, dir, db, nil)
+}
+
+func loadTRCs(
+	ctx context.Context,
+	dir string,
+	db DB,
+	ignoreFiles map[string]struct{},
+) (LoadResult, error) {
 	if _, err := os.Stat(dir); err != nil {
 		return LoadResult{}, serrors.WrapNoStack("stating directory", err, "dir", dir)
 	}
@@ -127,6 +141,10 @@ func LoadTRCs(ctx context.Context, dir string, db DB) (LoadResult, error) {
 	res := LoadResult{Ignored: map[string]error{}}
 	// TODO(roosd): should probably be a transaction.
 	for _, f := range files {
+		// ignore as per request of the caller
+		if _, ok := ignoreFiles[f]; ok {
+			continue
+		}
 		raw, err := os.ReadFile(f)
 		if err != nil {
 			return res, serrors.WrapNoStack("reading TRC", err, "file", f)
@@ -148,10 +166,41 @@ func LoadTRCs(ctx context.Context, dir string, db DB) (LoadResult, error) {
 			return res, serrors.WrapNoStack("adding TRC to DB", err, "file", f)
 		}
 		if !inserted {
-			res.Ignored[f] = serrors.JoinNoStack(ErrAlreadyExists, err)
+			res.Ignored[f] = ErrAlreadyExists
 			continue
 		}
 		res.Loaded = append(res.Loaded, f)
 	}
 	return res, nil
+}
+
+// TRCLoader loads TRCs from a directory and stores them in the database. It
+// tracks files that it has already loaded and does not load them again.
+type TRCLoader struct {
+	Dir string
+	DB  DB
+
+	seen map[string]struct{}
+	mtx  sync.Mutex
+}
+
+// Load loads all TRCs from the directory into database. Files that have been
+// loaded by a previous Load invocation are silently ignored.
+func (l *TRCLoader) Load(ctx context.Context) (LoadResult, error) {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	if l.seen == nil {
+		l.seen = make(map[string]struct{})
+	}
+
+	result, err := loadTRCs(ctx, l.Dir, l.DB, l.seen)
+	for _, f := range result.Loaded {
+		l.seen[f] = struct{}{}
+	}
+	for f, err := range result.Ignored {
+		if errors.Is(err, ErrAlreadyExists) {
+			l.seen[f] = struct{}{}
+		}
+	}
+	return result, err
 }


### PR DESCRIPTION
This commit introduces a TRC loader that keeps track of what TRC files have already been read. By doing so we can omit duplicate work of parsing TRC files and storing them in the DB.

This applies to the control service and the daemon.