### PR TITLE
pkg/private/serrors: do not use reflect encoder for all context

### DIFF
--- a/pkg/private/serrors/errors.go
+++ b/pkg/private/serrors/errors.go
@@ -30,6 +30,7 @@ import (
 	"sort"
 	"strings"
 
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -98,9 +99,7 @@ func (e basicError) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		}
 	}
 	for k, v := range e.fields {
-		if err := enc.AddReflected(k, v); err != nil {
-			return err
-		}
+		zap.Any(k, v).AddTo(enc)
 	}
 	return nil
 }


### PR DESCRIPTION
Previously, the context was always encoded using the reflect encoder (which is just json marshaling). This has the bad side effect that the usual marshaling methods are not respected. E.g., error context that would in theory implement the fmt.Stringer method were just JSON encoded.

With this change, we leave it up to zap to decide how the values are encoded based on their type.