### PR TITLE
control/beaconing: include the beacon ID in the propagator

### DIFF
--- a/control/beaconing/propagator.go
+++ b/control/beaconing/propagator.go
@@ -294,12 +294,8 @@ func (p *propagator) Propagate(ctx context.Context) error {
 			if err := p.extender.Extend(ctx, b.Segment, b.InIfID, egress, p.peers); err != nil {
 				logger.Error("Unable to extend beacon",
 					"egress_interface", egress,
-<<<<<<< Updated upstream
-					"beacon.ingress_interface", b.InIfID,
-=======
 					"beacon.id", id,
-					"beacon.ingress_interface", b.InIfId,
->>>>>>> Stashed changes
+					"beacon.ingress_interface", b.InIfID,
 					"beacon.segment", hopsDescription(b.Segment.ASEntries),
 					"err", err,
 				)
@@ -311,12 +307,8 @@ func (p *propagator) Propagate(ctx context.Context) error {
 			if err := sender.Send(ctx, b.Segment); err != nil {
 				logger.Info("Unable to send beacon",
 					"egress_interface", egress,
-<<<<<<< Updated upstream
-					"beacon.ingress_interface", b.InIfID,
-=======
 					"beacon.id", id,
-					"beacon.ingress_interface", b.InIfId,
->>>>>>> Stashed changes
+					"beacon.ingress_interface", b.InIfID,
 					"beacon.segment", hopsDescription(b.Segment.ASEntries),
 					"waited_for", time.Since(sendStart).String(),
 					"err", err,

--- a/control/beaconing/propagator.go
+++ b/control/beaconing/propagator.go
@@ -287,18 +287,19 @@ func (p *propagator) Propagate(ctx context.Context) error {
 			defer log.HandlePanic()
 			defer wg.Done()
 
-			var id string
-			debugEnabled := logger.Enabled(log.DebugLevel)
-			if debugEnabled {
-				// Collect the ID before the segment is extended such that it
-				// matches the ID that was logged above in logCandidateBeacons.
-				id = b.Segment.GetLoggingID()
-			}
+			// Collect the ID before the segment is extended such that it
+			// matches the ID that was logged above in logCandidateBeacons.
+			id := b.Segment.GetLoggingID()
 
 			if err := p.extender.Extend(ctx, b.Segment, b.InIfID, egress, p.peers); err != nil {
 				logger.Error("Unable to extend beacon",
 					"egress_interface", egress,
+<<<<<<< Updated upstream
 					"beacon.ingress_interface", b.InIfID,
+=======
+					"beacon.id", id,
+					"beacon.ingress_interface", b.InIfId,
+>>>>>>> Stashed changes
 					"beacon.segment", hopsDescription(b.Segment.ASEntries),
 					"err", err,
 				)
@@ -310,7 +311,12 @@ func (p *propagator) Propagate(ctx context.Context) error {
 			if err := sender.Send(ctx, b.Segment); err != nil {
 				logger.Info("Unable to send beacon",
 					"egress_interface", egress,
+<<<<<<< Updated upstream
 					"beacon.ingress_interface", b.InIfID,
+=======
+					"beacon.id", id,
+					"beacon.ingress_interface", b.InIfId,
+>>>>>>> Stashed changes
 					"beacon.segment", hopsDescription(b.Segment.ASEntries),
 					"waited_for", time.Since(sendStart).String(),
 					"err", err,
@@ -323,7 +329,7 @@ func (p *propagator) Propagate(ctx context.Context) error {
 			p.incMetric(b.Segment.FirstIA(), b.InIfID, egress, prom.Success)
 			p.intf.Propagate(p.now)
 
-			if debugEnabled {
+			if logger.Enabled(log.DebugLevel) {
 				logger.Debug("Propagated beacon",
 					"egress_interface", egress,
 					"candidate_id", id,


### PR DESCRIPTION
Include the beacon ID in the propagator when logging errors. This helps the operator to easily track down the offending beacon and take appropriate action.