### PR TITLE
daemon/combinator: memoize calculated fingerprints (IDs)

### DIFF
--- a/private/path/combinator/combinator_test.go
+++ b/private/path/combinator/combinator_test.go
@@ -598,6 +598,7 @@ func TestFilterDuplicates(t *testing.T) {
 				Interfaces: interfaces,
 				Expiry:     expiry,
 			},
+			Fingerprint: combinator.Fingerprint(interfaces, combinator.NewHashState()),
 		}
 	}
 

--- a/private/path/combinator/export_test.go
+++ b/private/path/combinator/export_test.go
@@ -16,4 +16,6 @@ package combinator
 
 var (
 	FilterDuplicates = filterDuplicates
+	Fingerprint      = fingerprint
+	NewHashState     = newHashState
 )

--- a/private/revcache/util.go
+++ b/private/revcache/util.go
@@ -44,9 +44,6 @@ func NoRevokedHopIntf(ctx context.Context, revCache RevCache,
 			if err != nil || rev != nil {
 				return false, err
 			}
-			if rev != nil {
-				return false, nil
-			}
 		}
 	}
 	return true, nil


### PR DESCRIPTION
A profile shows that ID calculation is a big part of the CPU time of the daemon:
![image](https://github.com/user-attachments/assets/613eedfe-c969-41ef-aa78-bee1488f9afc)

Therefore this change memoizes IDs where possible.
Also re-use buffer for fingerprint calculation.
Use slices package for sorting in the combinator.