### PR TITLE
underlay: support SockOptInt on all platforms incl Windows

### DIFF
--- a/private/underlay/sockctrl/BUILD.bazel
+++ b/private/underlay/sockctrl/BUILD.bazel
@@ -4,9 +4,55 @@ go_library(
     name = "go_default_library",
     srcs = [
         "sockctrl.go",
+        "sockctrl_windows.go",
         "sockopt.go",
+        "sockopt_windows.go",
     ],
     importpath = "github.com/scionproto/scion/private/underlay/sockctrl",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/private/serrors:go_default_library"],
+    deps = select({
+        "@io_bazel_rules_go//go/platform:aix": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:android": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:illumos": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:js": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:windows": [
+            "//pkg/private/serrors:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/private/underlay/sockctrl/sockctrl.go
+++ b/private/underlay/sockctrl/sockctrl.go
@@ -14,7 +14,6 @@
 
 // In Windows, SetSockOptInt and GetSockOptInt require syscall.Handle instead of int.
 //go:build !windows
-// +build !windows
 
 package sockctrl
 

--- a/private/underlay/sockctrl/sockctrl_windows.go
+++ b/private/underlay/sockctrl/sockctrl_windows.go
@@ -13,25 +13,26 @@
 // limitations under the License.
 
 // In Windows, SetSockOptInt and GetSockOptInt require syscall.Handle instead of int.
-//go:build !windows
-// +build !windows
+//go:build windows
+// +build windows
 
 package sockctrl
 
 import (
 	"net"
+	"syscall"
 
 	"github.com/scionproto/scion/pkg/private/serrors"
 )
 
-func SockControl(c *net.UDPConn, f func(int) error) error {
+func SockControl(c *net.UDPConn, f func(syscall.Handle) error) error {
 	rawConn, err := c.SyscallConn()
 	if err != nil {
 		return serrors.Wrap("sockctrl: error accessing raw connection", err)
 	}
 	var ctrlErr error
 	err = rawConn.Control(func(fd uintptr) {
-		ctrlErr = f(int(fd))
+		ctrlErr = f(syscall.Handle(fd))
 	})
 	if err != nil {
 		return serrors.Wrap("sockctrl: RawConn.Control error", err)

--- a/private/underlay/sockctrl/sockctrl_windows.go
+++ b/private/underlay/sockctrl/sockctrl_windows.go
@@ -14,7 +14,6 @@
 
 // In Windows, SetSockOptInt and GetSockOptInt require syscall.Handle instead of int.
 //go:build windows
-// +build windows
 
 package sockctrl
 

--- a/private/underlay/sockctrl/sockctrl_windows.go
+++ b/private/underlay/sockctrl/sockctrl_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2017 ETH Zurich
+// Copyright 2024 ETH Zurich
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/private/underlay/sockctrl/sockopt.go
+++ b/private/underlay/sockctrl/sockopt.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// In Windows, SetSockOptInt and GetSockOptInt require syscall.Handle instead of int.
+//go:build !windows
+// +build !windows
+
 package sockctrl
 
 import (

--- a/private/underlay/sockctrl/sockopt.go
+++ b/private/underlay/sockctrl/sockopt.go
@@ -14,7 +14,6 @@
 
 // In Windows, SetSockOptInt and GetSockOptInt require syscall.Handle instead of int.
 //go:build !windows
-// +build !windows
 
 package sockctrl
 

--- a/private/underlay/sockctrl/sockopt_windows.go
+++ b/private/underlay/sockctrl/sockopt_windows.go
@@ -14,7 +14,6 @@
 
 // In Windows, SetSockOptInt and GetSockOptInt require syscall.Handle instead of int.
 //go:build windows
-// +build windows
 
 package sockctrl
 

--- a/private/underlay/sockctrl/sockopt_windows.go
+++ b/private/underlay/sockctrl/sockopt_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2017 ETH Zurich
+// Copyright 2024 ETH Zurich
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Hey all,

I  tried to build all the major SCION binaries for windows to see if it's possible to run an AS also on this platform. However, there is an issue that `syscall.GetsockoptInt` and `syscall.SetsockoptInt` have different signatures on windows than on all other platforms. One fix is to have extra windows code to support this, but I'm not sure what you prefer, so let me know if this fits or if I can do some other changes. In the end it would be great to have Windows support for all SCION services, too.

PS: The issue popped up when building the router, not sure if it affects other services.

Cheers,
Marten