### PR TITLE
tracing: wrap existing logger instead of creating a new one

### DIFF
--- a/private/tracing/context.go
+++ b/private/tracing/context.go
@@ -32,9 +32,11 @@ func CtxWith(parentCtx context.Context, operationName string,
 	span, ctx := opentracing.StartSpanFromContext(parentCtx, operationName, opts...)
 	if spanCtx, ok := span.Context().(jaeger.SpanContext); ok {
 		id := spanCtx.TraceID()
-		return span, log.CtxWith(ctx, log.New("debug_id", id.String()[:8], "trace_id", id))
+		ctx, _ = log.WithLabels(ctx, "debug_id", id.String()[:8], "trace_id", id)
+		return span, ctx
 	}
-	return span, log.CtxWith(ctx, log.New("debug_id", log.NewDebugID()))
+	ctx, _ = log.WithLabels(ctx, "debug_id", log.NewDebugID())
+	return span, ctx
 }
 
 // LoggerWith attaches the trace ID if the context contains a span.


### PR DESCRIPTION
When starting a span from Context add the debug_id and tracing_id to the logger on the context (if it exists) instead of creating a new one.

This preserves the logger that is attached to the parentCtx.