### PR TITLE
scion-pki: enable kms support

### DIFF
--- a/doc/command/scion-pki/scion-pki.rst
+++ b/doc/command/scion-pki/scion-pki.rst
@@ -26,6 +26,7 @@ SEE ALSO
 * :ref:`scion-pki certificate <scion-pki_certificate>` 	 - Manage certificates for the SCION control plane PKI.
 * :ref:`scion-pki completion <scion-pki_completion>` 	 - Generate the autocompletion script for the specified shell
 * :ref:`scion-pki key <scion-pki_key>` 	 - Manage private and public keys
+* :ref:`scion-pki kms <scion-pki_kms>` 	 - Run the step-kms-plugin
 * :ref:`scion-pki trc <scion-pki_trc>` 	 - Manage TRCs for the SCION control plane PKI
 * :ref:`scion-pki version <scion-pki_version>` 	 - Show the scion-pki version information
 

--- a/doc/command/scion-pki/scion-pki_certificate_create.rst
+++ b/doc/command/scion-pki/scion-pki_certificate_create.rst
@@ -104,12 +104,14 @@ Options
       --bundle               Bundle the certificate with the issuer certificate as a certificate chain
       --ca string            The path to the issuer certificate
       --ca-key string        The path to the issuer private key used to sign the new certificate
+      --ca-kms string        The uri to configure a Cloud KMS or an HSM used for signing the certificate.
       --common-name string   The common name that replaces the common name in the subject template
       --csr                  Generate a certificate signign request instead of a certificate
       --curve string         The elliptic curve to use (P-256|P-384|P-521) (default "P-256")
       --force                Force overwritting existing files
   -h, --help                 help for create
       --key string           The path to the existing private key to use instead of creating a new one
+      --kms string           The uri to configure a Cloud KMS or an HSM.
       --not-after time       The NotAfter time of the certificate. Can either be a timestamp or an offset.
                              
                              If the value is a timestamp, it is expected to either be an RFC 3339 formatted

--- a/doc/command/scion-pki/scion-pki_certificate_match_private.rst
+++ b/doc/command/scion-pki/scion-pki_certificate_match_private.rst
@@ -36,6 +36,7 @@ Options
 ::
 
   -h, --help               help for private
+      --kms string         The uri to configure a Cloud KMS or an HSM.
       --separator string   The separator between file names (default "\n")
 
 SEE ALSO

--- a/doc/command/scion-pki/scion-pki_certificate_sign.rst
+++ b/doc/command/scion-pki/scion-pki_certificate_sign.rst
@@ -57,6 +57,7 @@ Options
       --bundle            Bundle the certificate with the issuer certificate as a certificate chain
       --ca string         The path to the issuer certificate
       --ca-key string     The path to the issuer private key used to sign the new certificate
+      --ca-kms string     The uri to configure a Cloud KMS or an HSM used for signing the certificate.
   -h, --help              help for sign
       --not-after time    The NotAfter time of the certificate. Can either be a timestamp or an offset.
                           

--- a/doc/command/scion-pki/scion-pki_key_match_certificate.rst
+++ b/doc/command/scion-pki/scion-pki_key_match_certificate.rst
@@ -36,6 +36,7 @@ Options
 ::
 
   -h, --help               help for certificate
+      --kms string         The uri to configure a Cloud KMS or an HSM.
       --separator string   The separator between file names (default "\n")
 
 SEE ALSO

--- a/doc/command/scion-pki/scion-pki_key_public.rst
+++ b/doc/command/scion-pki/scion-pki_key_public.rst
@@ -35,6 +35,7 @@ Options
 
       --force        Force overwritting existing public key
   -h, --help         help for public
+      --kms string   The uri to configure a Cloud KMS or an HSM.
       --out string   Path to write public key
 
 SEE ALSO

--- a/doc/command/scion-pki/scion-pki_kms.rst
+++ b/doc/command/scion-pki/scion-pki_kms.rst
@@ -1,0 +1,45 @@
+:orphan:
+
+.. _scion-pki_kms:
+
+scion-pki kms
+-------------
+
+Run the step-kms-plugin
+
+Synopsis
+~~~~~~~~
+
+
+This command leverages the step-kms-plugin to interact with cloud Key Management
+Systems (KMS) and Hardware Security Modules (HSM).
+
+The commands are passed directly to the step-kms-plugin. For more information on
+the available commands and their usage, please refer to the step-kms-plugin
+documentation at https://github.com/smallstep/step-kms-plugin. In order to enable
+KMS support, the step-kms-plugin must be installed and available in the PATH.
+
+Various commands of the scion-pki tool allow the use of KMS. In all cases, the
+private key needs to already exist in the KMS. To instruct the scion-pki tool to
+use the key in the KMS, the --kms flag must be set.
+
+For more information about supported KMSs and uri pattern, please consult
+https://smallstep.com/docs/step-ca/cryptographic-protection.
+
+
+::
+
+  scion-pki kms [command] [flags]
+
+Options
+~~~~~~~
+
+::
+
+  -h, --help   help for kms
+
+SEE ALSO
+~~~~~~~~
+
+* :ref:`scion-pki <scion-pki>` 	 - SCION Control Plane PKI Management Tool
+

--- a/doc/command/scion-pki/scion-pki_trc_sign.rst
+++ b/doc/command/scion-pki/scion-pki_trc_sign.rst
@@ -46,6 +46,7 @@ Options
 ::
 
   -h, --help             help for sign
+      --kms string       The uri to configure a Cloud KMS or an HSM.
   -o, --out string       Output file path. If --out is set, --out-dir is ignored.
       --out-dir string   Output directory. If --out is set, --out-dir is ignored. (default ".")
 

--- a/scion-pki/BUILD.bazel
+++ b/scion-pki/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//tools/lint:go.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "flags.go",
+        "plugin.go",
+    ],
+    importpath = "github.com/scionproto/scion/scion-pki",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_spf13_pflag//:go_default_library"],
+)

--- a/scion-pki/certs/BUILD.bazel
+++ b/scion-pki/certs/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//private/svc:go_default_library",
         "//private/tracing:go_default_library",
         "//private/trust:go_default_library",
+        "//scion-pki:go_default_library",
         "//scion-pki/encoding:go_default_library",
         "//scion-pki/file:go_default_library",
         "//scion-pki/key:go_default_library",

--- a/scion-pki/certs/create.go
+++ b/scion-pki/certs/create.go
@@ -35,6 +35,7 @@ import (
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
 	"github.com/scionproto/scion/private/app/command"
 	"github.com/scionproto/scion/private/app/flag"
+	scionpki "github.com/scionproto/scion/scion-pki"
 	"github.com/scionproto/scion/scion-pki/file"
 	"github.com/scionproto/scion/scion-pki/key"
 )
@@ -125,7 +126,9 @@ func newCreateCmd(pather command.Pather) *cobra.Command {
 		notAfter    flag.Time
 		ca          string
 		caKey       string
+		caKms       string
 		existingKey string
+		kms         string
 		curve       string
 		bundle      bool
 		force       bool
@@ -193,7 +196,7 @@ A valid example for a JSON formatted template::
 		Args: cobra.RangeArgs(2, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 2 && flags.existingKey == "" {
-				return serrors.New("positional key file is required")
+				return serrors.New("the positional key file is required")
 			}
 			ct, err := parseCertType(flags.profile)
 			if err != nil {
@@ -202,6 +205,9 @@ A valid example for a JSON formatted template::
 			subject, err := createSubject(args[0], flags.commonName)
 			if err != nil {
 				return serrors.Wrap("creating subject", err)
+			}
+			if flags.existingKey == "" && flags.kms != "" {
+				return serrors.New("the kms flag is only allowed with an existing key")
 			}
 
 			// Only check that the flags are set appropriately here.
@@ -220,10 +226,10 @@ A valid example for a JSON formatted template::
 
 			cmd.SilenceUsage = true
 
-			var privKey key.PrivateKey
+			var privKey crypto.Signer
 			var encodedKey []byte
 			if flags.existingKey != "" {
-				if privKey, err = key.LoadPrivateKey(flags.existingKey); err != nil {
+				if privKey, err = key.LoadPrivateKey(flags.kms, flags.existingKey); err != nil {
 					return serrors.Wrap("loading existing private key", err)
 				}
 			} else {
@@ -234,10 +240,15 @@ A valid example for a JSON formatted template::
 					return serrors.Wrap("encoding fresh private key", err)
 				}
 			}
+			if !key.IsX509Signer(privKey) {
+				return serrors.New("the private key cannot be used in X.509 certificates",
+					"type", fmt.Sprintf("%T", privKey),
+				)
+			}
 
 			var caCertRaw []byte
 			var caCert *x509.Certificate
-			var caKey key.PrivateKey
+			var caKey crypto.Signer
 			if loadCA {
 				if caCertRaw, err = os.ReadFile(flags.ca); err != nil {
 					return serrors.Wrap("read CA certificate", err)
@@ -245,7 +256,7 @@ A valid example for a JSON formatted template::
 				if caCert, err = parseCertificate(caCertRaw); err != nil {
 					return serrors.Wrap("parsing CA certificate", err)
 				}
-				if caKey, err = key.LoadPrivateKey(flags.caKey); err != nil {
+				if caKey, err = key.LoadPrivateKey(flags.caKms, flags.caKey); err != nil {
 					return serrors.Wrap("loading CA private key", err)
 				}
 			}
@@ -272,6 +283,12 @@ A valid example for a JSON formatted template::
 				}
 				fmt.Printf("CSR successfully written to %q\n", csrFile)
 			} else {
+				if !key.IsX509Signer(caKey) {
+					return serrors.New("the CA key cannot be used to create X.509 certificates",
+						"type", fmt.Sprintf("%T", caKey),
+					)
+				}
+
 				cert, err := CreateCertificate(CertParams{
 					Type:      ct,
 					Subject:   subject,
@@ -359,7 +376,8 @@ offset from the current time.`,
 	cmd.Flags().BoolVar(&flags.force, "force", false,
 		"Force overwritting existing files",
 	)
-
+	scionpki.BindFlagKmsCA(cmd.Flags(), &flags.caKms)
+	scionpki.BindFlagKms(cmd.Flags(), &flags.kms)
 	return cmd
 }
 

--- a/scion-pki/certs/create_test.go
+++ b/scion-pki/certs/create_test.go
@@ -610,7 +610,7 @@ func TestNewCreateCmdCSR(t *testing.T) {
 			Validate: func(t *testing.T, csr *x509.CertificateRequest) {
 				require.NoError(t, csr.CheckSignature())
 				require.Equal(t, "1-ff00:0:111 Certificate", csr.Subject.CommonName)
-				priv, err := key.LoadPrivateKey("testdata/create/private.key")
+				priv, err := key.LoadPrivateKey("", "testdata/create/private.key")
 				require.NoError(t, err)
 				require.Equal(t, priv.Public(), csr.PublicKey)
 			},

--- a/scion-pki/certs/match.go
+++ b/scion-pki/certs/match.go
@@ -26,6 +26,7 @@ import (
 	"github.com/scionproto/scion/pkg/private/serrors"
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
 	"github.com/scionproto/scion/private/app/command"
+	scionpki "github.com/scionproto/scion/scion-pki"
 	"github.com/scionproto/scion/scion-pki/key"
 )
 
@@ -45,6 +46,7 @@ func newMatchCmd(pather command.Pather) *cobra.Command {
 func newMatchPrivateKey(pather command.Pather) *cobra.Command {
 	var flags struct {
 		separator string
+		kms       string
 	}
 	cmd := &cobra.Command{
 		Use:   "private <certificate> <private-key> [<private-key> ...]",
@@ -74,7 +76,7 @@ The output contains all the private keys that are authenticated by the certifica
 
 			var keys []string
 			for _, file := range args[1:] {
-				key, err := loadPackedPublicFromPrivate(file)
+				key, err := loadPackedPublicFromPrivate(flags.kms, file)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "WARN: ignoring %q: %s\n", file, err)
 					continue
@@ -92,11 +94,12 @@ The output contains all the private keys that are authenticated by the certifica
 		},
 	}
 	cmd.Flags().StringVar(&flags.separator, "separator", "\n", "The separator between file names")
+	scionpki.BindFlagKms(cmd.Flags(), &flags.kms)
 	return cmd
 }
 
-func loadPackedPublicFromPrivate(file string) ([]byte, error) {
-	key, err := key.LoadPrivateKey(file)
+func loadPackedPublicFromPrivate(kms, name string) ([]byte, error) {
+	key, err := key.LoadPrivateKey(kms, name)
 	if err != nil {
 		return nil, err
 	}

--- a/scion-pki/certs/renew.go
+++ b/scion-pki/certs/renew.go
@@ -333,7 +333,11 @@ The template is expressed in JSON. A valid example::
 			span.SetTag("remote-options", remotes)
 
 			// Load private key.
-			privPrev, err := key.LoadPrivateKey(keyFile)
+			// XXX(roosd): The renewal process does currently not support KMS.
+			// This is a bit more involved, and requires some refactoring of the
+			// flags and the key loading/creation process. For now, KMS is also
+			// not a direct use-case for AS certificates.
+			privPrev, err := key.LoadPrivateKey("", keyFile)
 			if err != nil {
 				return serrors.Wrap("reading private key", err)
 			}

--- a/scion-pki/certs/renew_test.go
+++ b/scion-pki/certs/renew_test.go
@@ -107,7 +107,7 @@ func TestExtractChain(t *testing.T) {
 	chain := xtest.LoadChain(t, "testdata/renew/ISD1-ASff00_0_111.pem")
 
 	caChain := xtest.LoadChain(t, "testdata/renew/ISD1-ASff00_0_110.pem")
-	key, err := key.LoadPrivateKey("testdata/renew/cp-as-110.key")
+	key, err := key.LoadPrivateKey("", "testdata/renew/cp-as-110.key")
 	require.NoError(t, err)
 	caSigner := trust.Signer{
 		PrivateKey:   key,

--- a/scion-pki/certs/sign.go
+++ b/scion-pki/certs/sign.go
@@ -27,6 +27,7 @@ import (
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
 	"github.com/scionproto/scion/private/app/command"
 	"github.com/scionproto/scion/private/app/flag"
+	scionpki "github.com/scionproto/scion/scion-pki"
 	"github.com/scionproto/scion/scion-pki/key"
 )
 
@@ -39,6 +40,7 @@ func newSignCmd(pather command.Pather) *cobra.Command {
 		notAfter  flag.Time
 		ca        string
 		caKey     string
+		caKms     string
 		bundle    bool
 	}
 	flags.notBefore = flag.Time{
@@ -115,9 +117,14 @@ and not to \--not-before.
 			if err != nil {
 				return serrors.Wrap("parsing CA certificate", err)
 			}
-			caKey, err := key.LoadPrivateKey(flags.caKey)
+			caKey, err := key.LoadPrivateKey(flags.caKms, flags.caKey)
 			if err != nil {
 				return serrors.Wrap("loading CA private key", err)
+			}
+			if !key.IsX509Signer(caKey) {
+				return serrors.New("the CA key cannot be used to create X.509 certificates",
+					"type", fmt.Sprintf("%T", caKey),
+				)
 			}
 
 			subject := csr.Subject
@@ -190,6 +197,7 @@ offset from the current time.`,
 	cmd.Flags().BoolVar(&flags.bundle, "bundle", false,
 		"Bundle the certificate with the issuer certificate as a certificate chain",
 	)
+	scionpki.BindFlagKmsCA(cmd.Flags(), &flags.caKms)
 	cmd.MarkFlagRequired("ca")
 	cmd.MarkFlagRequired("ca-key")
 

--- a/scion-pki/cmd/scion-pki/BUILD.bazel
+++ b/scion-pki/cmd/scion-pki/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "gendocs.go",
+        "kms.go",
         "main.go",
         "version.go",
     ],
@@ -20,6 +21,7 @@ go_library(
         "//pkg/private/serrors:go_default_library",
         "//private/app:go_default_library",
         "//private/env:go_default_library",
+        "//scion-pki:go_default_library",
         "//scion-pki/certs:go_default_library",
         "//scion-pki/key:go_default_library",
         "//scion-pki/testcrypto:go_default_library",

--- a/scion-pki/cmd/scion-pki/kms.go
+++ b/scion-pki/cmd/scion-pki/kms.go
@@ -22,8 +22,9 @@ import (
 	"text/template"
 	"unicode"
 
-	scionpki "github.com/scionproto/scion/scion-pki"
 	"github.com/spf13/cobra"
+
+	scionpki "github.com/scionproto/scion/scion-pki"
 )
 
 func newKms(_ CommandPather) *cobra.Command {

--- a/scion-pki/cmd/scion-pki/kms.go
+++ b/scion-pki/cmd/scion-pki/kms.go
@@ -1,0 +1,112 @@
+// Copyright 2024 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"text/template"
+	"unicode"
+
+	scionpki "github.com/scionproto/scion/scion-pki"
+	"github.com/spf13/cobra"
+)
+
+func newKms(_ CommandPather) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "kms [command]",
+		Short: "Run the step-kms-plugin",
+		Long: `This command leverages the step-kms-plugin to interact with cloud Key Management
+Systems (KMS) and Hardware Security Modules (HSM).
+
+The commands are passed directly to the step-kms-plugin. For more information on
+the available commands and their usage, please refer to the step-kms-plugin
+documentation at https://github.com/smallstep/step-kms-plugin. In order to enable
+KMS support, the step-kms-plugin must be installed and available in the PATH.
+
+Various commands of the scion-pki tool allow the use of KMS. In all cases, the
+private key needs to already exist in the KMS. To instruct the scion-pki tool to
+use the key in the KMS, the --kms flag must be set.
+
+For more information about supported KMSs and uri pattern, please consult
+https://smallstep.com/docs/step-ca/cryptographic-protection.
+`,
+		RunE: func(c *cobra.Command, args []string) error {
+			file, err := scionpki.LookKms()
+			if err != nil {
+				return err
+			}
+			cmd := exec.Command(file, args...)
+			cmd.Stdin = c.InOrStdin()
+			cmd.Stdout = c.OutOrStdout()
+			cmd.Stderr = c.ErrOrStderr()
+			return cmd.Run()
+		},
+	}
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		if len(args) <= 2 {
+			err := tmpl(c.OutOrStdout(), `{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}`, c)
+			if err != nil {
+				c.PrintErrln(err)
+			}
+			fmt.Fprintf(c.OutOrStdout(), "\n\nstep-kms-plugin help output:\n\n")
+		}
+
+		file, err := scionpki.LookKms()
+		if err != nil {
+			c.PrintErrln(err)
+			return
+		}
+
+		cmd := exec.Command(file, args[1:]...)
+		cmd.Stdin = c.InOrStdin()
+		cmd.Stdout = c.OutOrStdout()
+		cmd.Stderr = c.ErrOrStderr()
+		if err := cmd.Run(); err != nil {
+			c.PrintErrln(err)
+		}
+	})
+
+	return cmd
+}
+
+// tmpl executes the given template text on data, writing the result to w.
+func tmpl(w io.Writer, text string, data interface{}) error {
+	t := template.New("top")
+	t.Funcs(templateFuncs)
+	template.Must(t.Parse(text))
+	return t.Execute(w, data)
+}
+
+var templateFuncs = template.FuncMap{
+	"trim":                    strings.TrimSpace,
+	"trimRightSpace":          trimRightSpace,
+	"trimTrailingWhitespaces": trimRightSpace,
+	"rpad":                    rpad,
+	"removeEscape":            removeEscape,
+}
+
+func trimRightSpace(s string) string {
+	return strings.TrimRightFunc(s, unicode.IsSpace)
+}
+
+// rpad adds padding to the right of a string.
+func rpad(s string, padding int) string {
+	return fmt.Sprintf("%-*s", padding, s)
+}

--- a/scion-pki/cmd/scion-pki/main.go
+++ b/scion-pki/cmd/scion-pki/main.go
@@ -57,15 +57,12 @@ func main() {
 		trcs.Cmd(cmd),
 		testcrypto.Cmd(cmd),
 		newGendocs(cmd),
+		newKms(cmd),
 	)
 	// This Templatefunc allows use some escape characters for the rst
 	// documentation conversion without compromising the readability of the help
 	// text in the CLI.
-	cobra.AddTemplateFunc("removeEscape", func(s string) string {
-		s = strings.ReplaceAll(s, "::", ":")
-		s = strings.ReplaceAll(s, "\\-", "-")
-		return s
-	})
+	cobra.AddTemplateFunc("removeEscape", removeEscape)
 
 	cmd.SetHelpTemplate(`{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces | removeEscape}}
 
@@ -79,4 +76,10 @@ func main() {
 		}
 		os.Exit(1)
 	}
+}
+
+func removeEscape(s string) string {
+	s = strings.ReplaceAll(s, "::", ":")
+	s = strings.ReplaceAll(s, "\\-", "-")
+	return s
 }

--- a/scion-pki/flags.go
+++ b/scion-pki/flags.go
@@ -1,0 +1,29 @@
+// Copyright 2024 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scionpki
+
+import "github.com/spf13/pflag"
+
+func BindFlagKms(flags *pflag.FlagSet, kms *string) {
+	flags.StringVar(kms, "kms", "",
+		"The uri to configure a Cloud KMS or an HSM.",
+	)
+}
+
+func BindFlagKmsCA(flags *pflag.FlagSet, kms *string) {
+	flags.StringVar(kms, "ca-kms", "",
+		"The uri to configure a Cloud KMS or an HSM used for signing the certificate.",
+	)
+}

--- a/scion-pki/key/BUILD.bazel
+++ b/scion-pki/key/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools/lint:go.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "cryptoutil.go",
         "fingerprint.go",
         "key.go",
         "match.go",
@@ -17,6 +18,7 @@ go_library(
         "//pkg/scrypto:go_default_library",
         "//pkg/scrypto/cppki:go_default_library",
         "//private/app/command:go_default_library",
+        "//scion-pki:go_default_library",
         "//scion-pki/encoding:go_default_library",
         "//scion-pki/file:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",

--- a/scion-pki/key/cryptoutil.go
+++ b/scion-pki/key/cryptoutil.go
@@ -1,0 +1,144 @@
+//  Copyright 2020 Smallstep Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is a copy of
+// https://github.com/smallstep/cli/blob/111bcb9cfbb101718f9c4a39f5ab439504b9c07f/internal/cryptoutil/cryptoutil.go
+// with the irrelevant parts stripped out and small adjustments to make it fit
+// our codebase.
+
+package key
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+
+	scionpki "github.com/scionproto/scion/scion-pki"
+)
+
+// IsX509Signer returns true if the given signer is supported by Go's
+// crypto/x509 package to sign X509 certificates. This methods returns true
+// for ECDSA, RSA and Ed25519 keys.
+func IsX509Signer(signer crypto.Signer) bool {
+	if signer == nil {
+		return false
+	}
+	pub := signer.Public()
+	switch pub.(type) {
+	case *ecdsa.PublicKey, *rsa.PublicKey, ed25519.PublicKey:
+		return true
+	default:
+		return false
+	}
+}
+
+type kmsSigner struct {
+	crypto.PublicKey
+	name     string
+	kms, key string
+}
+
+// exitError returns the error displayed on stderr after running the given
+// command.
+func exitError(cmd *exec.Cmd, err error) error {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return fmt.Errorf("command %q failed with:\n%s", cmd.String(), ee.Stderr)
+	}
+	return fmt.Errorf("command %q failed with: %w", cmd.String(), err)
+}
+
+// newKMSSigner creates a signer using `step-kms-plugin` as the signer.
+func newKMSSigner(kms, key string) (*kmsSigner, error) {
+	name, err := scionpki.LookKms()
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{"key"}
+	if kms != "" {
+		args = append(args, "--kms", kms)
+	}
+	args = append(args, key)
+
+	// Get public key
+	cmd := exec.Command(name, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, exitError(cmd, err)
+	}
+
+	pub, err := loadPublicKeyPem(out)
+	if err != nil {
+		return nil, err
+	}
+
+	return &kmsSigner{
+		PublicKey: pub,
+		name:      name,
+		kms:       kms,
+		key:       key,
+	}, nil
+}
+
+// Public implements crypto.Signer and returns the public key.
+func (s *kmsSigner) Public() crypto.PublicKey {
+	return s.PublicKey
+}
+
+// Sign implements crypto.Signer using the `step-kms-plugin`.
+func (s *kmsSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	args := []string{"sign", "--format", "base64"}
+	if s.kms != "" {
+		args = append(args, "--kms", s.kms)
+	}
+	if _, ok := s.PublicKey.(*rsa.PublicKey); ok {
+		if _, pss := opts.(*rsa.PSSOptions); pss {
+			args = append(args, "--pss")
+		}
+		switch opts.HashFunc() {
+		case crypto.SHA256:
+			args = append(args, "--alg", "SHA256")
+		case crypto.SHA384:
+			args = append(args, "--alg", "SHA384")
+		case crypto.SHA512:
+			args = append(args, "--alg", "SHA512")
+		default:
+			return nil, fmt.Errorf("unsupported hash function %q", opts.HashFunc().String())
+		}
+	}
+	args = append(args, s.key)
+
+	//nolint:gosec // arguments controlled by step.
+	cmd := exec.Command(s.name, args...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		defer stdin.Close()
+		stdin.Write(digest)
+	}()
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, exitError(cmd, err)
+	}
+	return base64.StdEncoding.DecodeString(string(out))
+}

--- a/scion-pki/key/cryptoutil.go
+++ b/scion-pki/key/cryptoutil.go
@@ -104,7 +104,7 @@ func (s *kmsSigner) Public() crypto.PublicKey {
 }
 
 // Sign implements crypto.Signer using the `step-kms-plugin`.
-func (s *kmsSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+func (s *kmsSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
 	args := []string{"sign", "--format", "base64"}
 	if s.kms != "" {
 		args = append(args, "--kms", s.kms)
@@ -134,7 +134,7 @@ func (s *kmsSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) (si
 	}
 	go func() {
 		defer stdin.Close()
-		stdin.Write(digest)
+		_, _ = stdin.Write(digest)
 	}()
 	out, err := cmd.Output()
 	if err != nil {

--- a/scion-pki/key/fingerprint.go
+++ b/scion-pki/key/fingerprint.go
@@ -106,6 +106,10 @@ func loadPublicKey(filename string) (crypto.PublicKey, error) {
 	if err != nil {
 		return nil, serrors.Wrap("reading input file", err)
 	}
+	return loadPublicKeyPem(raw)
+}
+
+func loadPublicKeyPem(raw []byte) (crypto.PublicKey, error) {
 	block, _ := pem.Decode(raw)
 	if block == nil {
 		return nil, serrors.New("parsing input failed")

--- a/scion-pki/key/match.go
+++ b/scion-pki/key/match.go
@@ -26,6 +26,7 @@ import (
 	"github.com/scionproto/scion/pkg/private/serrors"
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
 	"github.com/scionproto/scion/private/app/command"
+	scionpki "github.com/scionproto/scion/scion-pki"
 )
 
 func newMatchCmd(pather command.Pather) *cobra.Command {
@@ -44,6 +45,7 @@ func newMatchCmd(pather command.Pather) *cobra.Command {
 func newMatchCertificate(pather command.Pather) *cobra.Command {
 	var flags struct {
 		separator string
+		kms       string
 	}
 	cmd := &cobra.Command{
 		Use:   "certificate <private-key> <certificate> [<certificate> ...]",
@@ -62,7 +64,7 @@ The output contains all certificates that authenticate the key.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 
-			key, err := LoadPrivateKey(args[0])
+			key, err := LoadPrivateKey(flags.kms, args[0])
 			if err != nil {
 				return err
 			}
@@ -91,6 +93,7 @@ The output contains all certificates that authenticate the key.
 		},
 	}
 	cmd.Flags().StringVar(&flags.separator, "separator", "\n", "The separator between file names")
+	scionpki.BindFlagKms(cmd.Flags(), &flags.kms)
 	return cmd
 }
 

--- a/scion-pki/key/private.go
+++ b/scion-pki/key/private.go
@@ -84,7 +84,7 @@ The contents are the private key in PKCS #8 ASN.1 DER format.
 }
 
 // GeneratePrivateKey generates a new private key.
-func GeneratePrivateKey(curve string) (PrivateKey, error) {
+func GeneratePrivateKey(curve string) (crypto.Signer, error) {
 	switch strings.ToLower(curve) {
 	case "p-256", "p256":
 		return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/scion-pki/key/private_test.go
+++ b/scion-pki/key/private_test.go
@@ -91,7 +91,7 @@ func TestNewPrivateCmd(t *testing.T) {
 				return
 			}
 			filename := tc.Args[len(tc.Args)-1]
-			_, err = key.LoadPrivateKey(filename)
+			_, err = key.LoadPrivateKey("", filename)
 			require.NoError(t, err)
 
 			info, err := os.Stat(filename)

--- a/scion-pki/key/public.go
+++ b/scion-pki/key/public.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/scionproto/scion/pkg/private/serrors"
 	"github.com/scionproto/scion/private/app/command"
+	scionpki "github.com/scionproto/scion/scion-pki"
 	"github.com/scionproto/scion/scion-pki/file"
 )
 
@@ -35,6 +36,7 @@ func NewPublicCmd(pather command.Pather) *cobra.Command {
 	var flags struct {
 		out   string
 		force bool
+		kms   string
 	}
 	var cmd = &cobra.Command{
 		Use:   "public [flags] <private-key-file>",
@@ -50,7 +52,7 @@ By default, the public key is written to standard out.
 			cmd.SilenceUsage = true
 
 			filename := args[0]
-			priv, err := LoadPrivateKey(filename)
+			priv, err := LoadPrivateKey(flags.kms, filename)
 			if err != nil {
 				return err
 			}
@@ -89,36 +91,40 @@ By default, the public key is written to standard out.
 	cmd.Flags().BoolVar(&flags.force, "force", false,
 		"Force overwritting existing public key",
 	)
+	scionpki.BindFlagKms(cmd.Flags(), &flags.kms)
 	return cmd
 }
 
 // LoadPrivate key loads a private key from file.
-func LoadPrivateKey(filename string) (crypto.Signer, error) {
-	raw, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, serrors.Wrap("reading private key", err)
-	}
-	p, rest := pem.Decode(raw)
-	if p == nil {
-		return nil, serrors.New("parsing private key failed")
-	}
-	if len(rest) != 0 {
-		return nil, serrors.New("file must only contain private key")
-	}
-	if p.Type != "PRIVATE KEY" {
-		return nil, serrors.New("file does not contain a private key", "type", p.Type)
-	}
+func LoadPrivateKey(kms, name string) (crypto.Signer, error) {
+	if kms == "" {
+		raw, err := os.ReadFile(name)
+		if err != nil {
+			return nil, serrors.Wrap("reading private key", err)
+		}
+		p, rest := pem.Decode(raw)
+		if p == nil {
+			return nil, serrors.New("parsing private key failed")
+		}
+		if len(rest) != 0 {
+			return nil, serrors.New("file must only contain private key")
+		}
+		if p.Type != "PRIVATE KEY" {
+			return nil, serrors.New("file does not contain a private key", "type", p.Type)
+		}
 
-	key, err := x509.ParsePKCS8PrivateKey(p.Bytes)
-	if err != nil {
-		return nil, serrors.Wrap("parsing private key", err)
-	}
+		key, err := x509.ParsePKCS8PrivateKey(p.Bytes)
+		if err != nil {
+			return nil, serrors.Wrap("parsing private key", err)
+		}
 
-	priv, ok := key.(crypto.Signer)
-	if !ok {
-		return nil, serrors.New("cannot get public key from private key",
-			"type", fmt.Sprintf("%T", key),
-		)
+		priv, ok := key.(crypto.Signer)
+		if !ok {
+			return nil, serrors.New("cannot get public key from private key",
+				"type", fmt.Sprintf("%T", key),
+			)
+		}
+		return priv, nil
 	}
-	return priv, nil
+	return newKMSSigner(kms, name)
 }

--- a/scion-pki/plugin.go
+++ b/scion-pki/plugin.go
@@ -23,7 +23,9 @@ import (
 func LookKms() (string, error) {
 	path, err := exec.LookPath("step-kms-plugin")
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "step-kms-plugin not found in PATH\nInstall it from https://github.com/smallstep/step-kms-plugin")
+		fmt.Fprintln(os.Stderr, "step-kms-plugin not found in PATH\n"+
+			"Install it from https://github.com/smallstep/step-kms-plugin",
+		)
 		return "", err
 	}
 	return path, nil

--- a/scion-pki/plugin.go
+++ b/scion-pki/plugin.go
@@ -1,0 +1,30 @@
+// Copyright 2024 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scionpki
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func LookKms() (string, error) {
+	path, err := exec.LookPath("step-kms-plugin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "step-kms-plugin not found in PATH\nInstall it from https://github.com/smallstep/step-kms-plugin")
+		return "", err
+	}
+	return path, nil
+}

--- a/scion-pki/testcrypto/testcrypto.go
+++ b/scion-pki/testcrypto/testcrypto.go
@@ -366,12 +366,11 @@ func createTRCs(cfg config) error {
 }
 
 func loadVoterInfo(voter addr.IA, votingDir string) (*voterInfo, error) {
-	sensitiveKey, err := key.LoadPrivateKey(
-		filepath.Join(votingDir, "sensitive-voting.key"))
+	sensitiveKey, err := key.LoadPrivateKey("", filepath.Join(votingDir, "sensitive-voting.key"))
 	if err != nil {
 		return nil, serrors.Wrap("loading sensitive key", err)
 	}
-	regularKey, err := key.LoadPrivateKey(filepath.Join(votingDir, "regular-voting.key"))
+	regularKey, err := key.LoadPrivateKey("", filepath.Join(votingDir, "regular-voting.key"))
 	if err != nil {
 		return nil, serrors.Wrap("loading regular key", err)
 	}

--- a/scion-pki/trcs/BUILD.bazel
+++ b/scion-pki/trcs/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/scrypto/cms/protocol:go_default_library",
         "//pkg/scrypto/cppki:go_default_library",
         "//private/app/command:go_default_library",
+        "//scion-pki:go_default_library",
         "//scion-pki/conf:go_default_library",
         "//scion-pki/file:go_default_library",
         "//scion-pki/key:go_default_library",

--- a/scion-pki/trcs/sign_test.go
+++ b/scion-pki/trcs/sign_test.go
@@ -100,7 +100,7 @@ func TestSign(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			err := trcs.RunSign(tc.pld, tc.cert, tc.key, "", outDir)
+			err := trcs.RunSign(tc.pld, tc.cert, tc.key, "", "", outDir)
 			assert.NoError(t, err)
 			fn := filepath.Join(outDir, fmt.Sprintf("ISD1-B1-S2.1-1-%s.trc", tc.signType))
 
@@ -159,7 +159,7 @@ func TestOpensslCompatible(t *testing.T) {
 	for name, tc := range testCases {
 		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
-			err := trcs.RunSign(tc.pld, tc.cert, tc.key, "", outDir)
+			err := trcs.RunSign(tc.pld, tc.cert, tc.key, "", "", outDir)
 			assert.NoError(t, err)
 			fn := filepath.Join(outDir, fmt.Sprintf("ISD1-B1-S2.1-1-%s.trc", tc.signType))
 


### PR DESCRIPTION
Enable the scion-pki tool to interact with various cloud KMS and HSMs through the step-kms-plugin. The step-kms-plugin must be installed and available in the PATH.

For more information about step-kms-plugin, please refer to the documentation at https://github.com/smallstep/step-kms-plugin.

To see example usage of step-kms-plugin, please
refer to
https://smallstep.com/docs/step-ca/cryptographic-protection