### PR TITLE
doc: update index.rst to include references to scion-application-docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,7 +44,7 @@ The ideas and concepts behind SCION.
   :doc:`Control Plane <control-plane>` |
   :doc:`Data Plane <data-plane>` |
   SCION End Hosts |
-  :doc:`Applications <https://docs.scion.org/projects/scion-applications/en/latest>` 
+  :doc:`Applications <https://docs.scion.org/projects/scion-applications/en/latest>`_
 
 
 Reference Manuals
@@ -94,7 +94,7 @@ implementation <https://github.com/scionproto/scion>`_.
    For this, the package documentation needs to be streamlined a bit...
 
 * **For users of SCION applications**:
-  :doc:`Applications <https://docs.scion.org/projects/scion-applications/en/latest>`
+  :doc:`Applications <https://docs.scion.org/projects/scion-applications/en/latest>`_
 
 
 Guides and Tutorials

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,7 +44,7 @@ The ideas and concepts behind SCION.
   :doc:`Control Plane <control-plane>` |
   :doc:`Data Plane <data-plane>` |
   SCION End Hosts |
-  :doc:`Applications <https://docs.scion.org/projects/scion-applications/en/latest>`_
+  `Applications <https://docs.scion.org/projects/scion-applications/en/latest>`_
 
 
 Reference Manuals
@@ -94,7 +94,7 @@ implementation <https://github.com/scionproto/scion>`_.
    For this, the package documentation needs to be streamlined a bit...
 
 * **For users of SCION applications**:
-  :doc:`Applications <https://docs.scion.org/projects/scion-applications/en/latest>`_
+  `Applications <https://docs.scion.org/projects/scion-applications/en/latest>`_
 
 
 Guides and Tutorials

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,7 +43,8 @@ The ideas and concepts behind SCION.
   :doc:`SCION <overview>` |
   :doc:`Control Plane <control-plane>` |
   :doc:`Data Plane <data-plane>` |
-  SCION End Hosts
+  SCION End Hosts |
+  :doc:`Applications <https://docs.scion.org/projects/scion-applications/en/latest>` 
 
 
 Reference Manuals
@@ -69,6 +70,7 @@ implementation <https://github.com/scionproto/scion>`_.
    command/scion-pki/scion-pki
 
    snet API <https://pkg.go.dev/github.com/scionproto/scion/pkg/snet>
+   Applications <https://docs.scion.org/projects/scion-applications/en/latest>
 
 * **For operators of SCION end hosts**:
   :doc:`manuals/install` |
@@ -90,6 +92,10 @@ implementation <https://github.com/scionproto/scion>`_.
 .. TODO
    snet documentation should be a good starting point for using SCION as an application library.
    For this, the package documentation needs to be streamlined a bit...
+
+* **For users of SCION applications**:
+  :doc:`Applications <https://docs.scion.org/projects/scion-applications/en/latest>`
+
 
 Guides and Tutorials
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
After an offline discussion from SCION contributors, we reached the conclusion that `docs.scion.org` is the best-suited candidate to host technical information about SCION applications (ideally already in a certain maturity level) since they can be run on different environments, i.e., production network, SCIONLab or local dev environment. It may also help to centralize a little bit the information and making the documentation environment a bit less hairy for the users/developers.

~~In this PR, I ported the `Applications` section in the [SCIERA docs](https://sciera.readthedocs.io/en/latest/index.html) , adding the file  `doc/applications/access.rst` as a preliminary documentation as how to connect the application host to the diverse SCION networks.~~

We can revisit, if some of documentation for the currently listed applications must be removed or updated.

---

We use [RTD subprojects](https://docs.readthedocs.io/en/stable/subprojects.html) and the project is located in https://github.com/scionproto-contrib/scion-applications-docs. 

This PR adds reference to the `SCION Applications` subproject.