### PR TITLE
scion-pki: support dummy TRC payload

### DIFF
--- a/doc/command/scion-pki/scion-pki_trc_payload.rst
+++ b/doc/command/scion-pki/scion-pki_trc_payload.rst
@@ -50,4 +50,5 @@ SEE ALSO
 ~~~~~~~~
 
 * :ref:`scion-pki trc <scion-pki_trc>` 	 - Manage TRCs for the SCION control plane PKI
+* :ref:`scion-pki trc payload dummy <scion-pki_trc_payload_dummy>` 	 - Generate dummy TRC payload
 

--- a/doc/command/scion-pki/scion-pki_trc_payload_dummy.rst
+++ b/doc/command/scion-pki/scion-pki_trc_payload_dummy.rst
@@ -1,0 +1,37 @@
+:orphan:
+
+.. _scion-pki_trc_payload_dummy:
+
+scion-pki trc payload dummy
+---------------------------
+
+Generate dummy TRC payload
+
+Synopsis
+~~~~~~~~
+
+
+'dummy' creates a dummy TRC payload.
+
+The output of this command can be used to test that you have access to the necessary
+cryptographic material. This is especially useful when preparing for a TRC signing
+ceremony.
+
+
+::
+
+  scion-pki trc payload dummy [flags]
+
+Options
+~~~~~~~
+
+::
+
+      --format string   Output format (der|pem) (default "pem")
+  -h, --help            help for dummy
+
+SEE ALSO
+~~~~~~~~
+
+* :ref:`scion-pki trc payload <scion-pki_trc_payload>` 	 - Generate new TRC payload
+

--- a/doc/command/scion-pki/scion-pki_trc_sign.rst
+++ b/doc/command/scion-pki/scion-pki_trc_sign.rst
@@ -23,6 +23,9 @@ naming pattern::
 
 An alternative name can be specified with the \--out flag.
 
+If 'dummy' is provided as the payload file, a dummy TRC payload is signed. This is useful for
+testing access to the necessary cryptographic material, especially in preparation for
+a TRC signing ceremony.
 
 
 ::

--- a/scion-pki/trcs/BUILD.bazel
+++ b/scion-pki/trcs/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "trcs.go",
         "verify.go",
     ],
+    embedsrcs = ["testdata/admin/ISD1-B1-S1.pld.der"],
     importpath = "github.com/scionproto/scion/scion-pki/trcs",
     visibility = ["//visibility:public"],
     deps = [
@@ -28,6 +29,7 @@ go_library(
         "//scion-pki/file:go_default_library",
         "//scion-pki/key:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_mattn_go_isatty//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
     ],

--- a/scion-pki/trcs/payload.go
+++ b/scion-pki/trcs/payload.go
@@ -16,11 +16,13 @@ package trcs
 
 import (
 	"crypto/x509"
+	_ "embed"
 	"encoding/pem"
 	"fmt"
 	"os"
 	"sort"
 
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
@@ -103,6 +105,49 @@ To inspect the created asn.1 file you can use the openssl tool::
 	cmd.MarkFlagRequired("template")
 	cmd.Flags().StringVarP(&flags.pred, "predecessor", "p", "", "Predecessor TRC")
 	cmd.Flags().StringVar(&flags.format, "format", "der", "Output format (der|pem)")
+
+	joined := command.Join(pather, cmd)
+	cmd.AddCommand(
+		newPayloadDummy(joined),
+	)
+
+	return cmd
+}
+
+//go:embed testdata/admin/ISD1-B1-S1.pld.der
+var dummyPayload []byte
+
+func newPayloadDummy(_ command.Pather) *cobra.Command {
+	var flags struct {
+		format string
+	}
+
+	cmd := &cobra.Command{
+		Use:   "dummy",
+		Short: "Generate dummy TRC payload",
+		Long: `'dummy' creates a dummy TRC payload.
+
+The output of this command can be used to test that you have access to the necessary
+cryptographic material. This is especially useful when preparing for a TRC signing
+ceremony.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if flags.format == "pem" {
+				raw := pem.EncodeToMemory(&pem.Block{
+					Type:  "TRC PAYLOAD",
+					Bytes: dummyPayload,
+				})
+				_, err := fmt.Fprint(cmd.OutOrStdout(), string(raw))
+				return err
+			}
+			if isatty.IsTerminal(os.Stdout.Fd()) {
+				return fmt.Errorf("refusing to write DER encoded bytes to tty")
+			}
+			_, err := fmt.Fprint(cmd.OutOrStdout(), string(dummyPayload))
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&flags.format, "format", "pem", "Output format (der|pem)")
 	return cmd
 }
 

--- a/tools/cryptoplayground/crypto_lib.sh
+++ b/tools/cryptoplayground/crypto_lib.sh
@@ -425,6 +425,19 @@ gen_sensitive() {
         -startdate $STARTDATE -enddate $ENDDATE -preserveDN \
         -notext -batch -utf8 -out sensitive-voting.crt
 # LITERALINCLUDE gen_sensitive END
+# LITERALINCLUDE gen_sensitive_dummy START
+    openssl cms -sign -in dummy.pld.der -inform der \
+        -signer $PUBDIR/sensitive-voting.crt \
+        -inkey $KEYDIR/sensitive-voting.key \
+        -nodetach -nocerts -nosmimecap -binary -outform der \
+        > $TRCID.sensitive.dummy.trc
+
+    openssl cms -verify -in $TRCID.sensitive.dummy.trc -inform der \
+        -certfile $PUBDIR/sensitive-voting.crt \
+        -CAfile $PUBDIR/sensitive-voting.crt \
+        -purpose any -no_check_time \
+        > /dev/null
+# LITERALINCLUDE gen_sensitive_dummy END
 }
 
 gen_sensitive_scion_pki() {
@@ -443,6 +456,11 @@ gen_sensitive_scion_pki() {
         sensitive-voting.crt \
         $KEYDIR/sensitive-voting.key
 # LITERALINCLUDE gen_sensitive_scion_pki END
+# LITERALINCLUDE gen_sensitive_scion_pki_dummy START
+    scion-pki trc sign dummy \
+        sensitive-voting.crt \
+        $KEYDIR/sensitive-voting.key
+# LITERALINCLUDE gen_sensitive_scion_pki_dummy START
 }
 
 
@@ -489,6 +507,19 @@ gen_regular() {
         -startdate $STARTDATE -enddate $ENDDATE -preserveDN \
         -notext -batch -utf8 -out regular-voting.crt
 # LITERALINCLUDE gen_regular END
+# LITERALINCLUDE gen_regular_dummy START
+    openssl cms -sign -in dummy.pld.der -inform der \
+        -signer $PUBDIR/regular-voting.crt \
+        -inkey $KEYDIR/regular-voting.key \
+        -nodetach -nocerts -nosmimecap -binary -outform der \
+        > $TRCID.regular.dummy.trc
+
+    openssl cms -verify -in $TRCID.regular.dummy.trc -inform der \
+        -certfile $PUBDIR/regular-voting.crt \
+        -CAfile $PUBDIR/regular-voting.crt \
+        -purpose any -no_check_time \
+        > /dev/null
+# LITERALINCLUDE gen_regular_dummy END
 }
 
 gen_regular_scion_pki() {
@@ -507,6 +538,11 @@ gen_regular_scion_pki() {
         regular-voting.crt \
         $KEYDIR/regular-voting.key
 # LITERALINCLUDE gen_regular_scion_pki END
+# LITERALINCLUDE gen_regular_scion_pki_dummy START
+    scion-pki trc sign dummy \
+        regular-voting.crt \
+        $KEYDIR/regular-voting.key
+# LITERALINCLUDE gen_regular_scion_pki_dummy START
 }
 
 check_regular() {
@@ -552,6 +588,19 @@ gen_root() {
         -startdate $STARTDATE -enddate $ENDDATE -preserveDN \
         -notext -batch -utf8 -out cp-root.crt
 # LITERALINCLUDE gen_root END
+# LITERALINCLUDE gen_root_dummy START
+    openssl cms -sign -in dummy.pld.der -inform der \
+        -signer $PUBDIR/cp-root.crt \
+        -inkey $KEYDIR/cp-root.key \
+        -nodetach -nocerts -nosmimecap -binary -outform der \
+        > $TRCID.root.dummy.trc
+
+    openssl cms -verify -in $TRCID.root.dummy.trc -inform der \
+        -certfile $PUBDIR/cp-root.crt \
+        -CAfile $PUBDIR/cp-root.crt \
+        -purpose any -no_check_time \
+        > /dev/null
+# LITERALINCLUDE gen_root_dummy END
 }
 
 
@@ -571,6 +620,11 @@ gen_root_scion_pki() {
         cp-root.crt \
         $KEYDIR/cp-root.key
 # LITERALINCLUDE gen_root_scion_pki END
+# LITERALINCLUDE gen_root_scion_pki_dummy START
+    scion-pki trc sign dummy \
+        cp-root.crt \
+        $KEYDIR/cp-root.key
+# LITERALINCLUDE gen_root_scion_pki_dummy START
 }
 
 check_root() {

--- a/tools/cryptoplayground/trc_ceremony.sh
+++ b/tools/cryptoplayground/trc_ceremony.sh
@@ -45,6 +45,7 @@ do
 
     if [ -z "$USE_SCION_PKI_SIGN" ]; then
         basic_conf && sensitive_conf && regular_conf && root_conf && ca_conf && as_conf
+        scion-pki trc payload dummy --format der > dummy.pld.der
         prepare_ca
         sed -i \
             -e 's/{{.Country}}/CH/g' \


### PR DESCRIPTION
The dummy TRC payload allows to create a TRC payload without much setup. This is useful for testing access to the necessary cryptographic material, especially in preparation of a TRC ceremony.