### PR TITLE
doc: dispatched_ports syntax

### DIFF
--- a/doc/dev/design/router-port-dispatch.rst
+++ b/doc/dev/design/router-port-dispatch.rst
@@ -160,9 +160,7 @@ For this, we add two mechanisms:
 
     .. code-block:: yaml
 
-       "underlay": {
-         "dispatched_ports": "<min>-<max>"
-       }
+       "dispatched_ports": "<min>-<max>"
 
   The ``min``, ``max`` values define the range of ports ``[min, max]`` (inclusive).
   The value ``"-"`` explicitly represents an empty range.


### PR DESCRIPTION
The current implementation does not use the "underlay" element.
I propose to adapt the docment to reflect the current implementation