### PR TITLE
pkg/snet: format UDPAddr to comply with net.SplitHostPort

### DIFF
--- a/pkg/snet/udpaddr.go
+++ b/pkg/snet/udpaddr.go
@@ -15,10 +15,10 @@
 package snet
 
 import (
-	"fmt"
 	"net"
 	"net/netip"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/scionproto/scion/pkg/addr"
@@ -117,7 +117,15 @@ func (a *UDPAddr) Network() string {
 
 // String implements net.Addr interface.
 func (a *UDPAddr) String() string {
-	return fmt.Sprintf("%v,%s", a.IA, a.Host.String())
+	host, port, suffix := "<nil>", "0", ""
+	if a.Host != nil {
+		host = a.Host.IP.String()
+		port = strconv.Itoa(a.Host.Port)
+		if a.Host.Zone != "" {
+			suffix = "%" + a.Host.Zone
+		}
+	}
+	return net.JoinHostPort(a.IA.String()+","+host+suffix, port)
 }
 
 // GetPath returns a path with attached metadata.

--- a/pkg/snet/udpaddr_test.go
+++ b/pkg/snet/udpaddr_test.go
@@ -37,32 +37,32 @@ func TestUDPAddrString(t *testing.T) {
 	}{
 		"empty": {
 			input: &snet.UDPAddr{},
-			want:  "0-0,<nil>",
+			want:  "0-0,<nil>:0",
 		},
 		"empty host": {
 			input: &snet.UDPAddr{Host: &net.UDPAddr{}},
-			want:  "0-0,:0",
+			want:  "0-0,<nil>:0",
 		},
 		"ipv4": {
 			input: &snet.UDPAddr{
 				IA:   addr.MustParseIA("1-ff00:0:320"),
 				Host: &net.UDPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 10000},
 			},
-			want: "1-ff00:0:320,1.2.3.4:10000",
+			want: "[1-ff00:0:320,1.2.3.4]:10000",
 		},
 		"ipv6": {
 			input: &snet.UDPAddr{
 				IA:   addr.MustParseIA("1-ff00:0:320"),
 				Host: &net.UDPAddr{IP: net.ParseIP("2001::1"), Port: 20000},
 			},
-			want: "1-ff00:0:320,[2001::1]:20000",
+			want: "[1-ff00:0:320,2001::1]:20000",
 		},
 		"ipv6-zone": {
 			input: &snet.UDPAddr{
 				IA:   addr.MustParseIA("1-ff00:0:320"),
 				Host: &net.UDPAddr{IP: net.ParseIP("2001::1"), Port: 20000, Zone: "some-zone"},
 			},
-			want: "1-ff00:0:320,[2001::1%some-zone]:20000",
+			want: "[1-ff00:0:320,2001::1%some-zone]:20000",
 		},
 	}
 	for n, tc := range tests {


### PR DESCRIPTION
Change the snet.UDPAddr.String() method to return the address in a format that is compatible with net.SplitHostPort. This will allow non SCION aware applications to extract the host and port part without the need to understand it is a SCION address.