### PR TITLE
build: add support for cross-compiled rpms

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,6 +44,9 @@ steps:
             tar -chaf scion_${SCION_VERSION}_deb_armel.tar.gz *_${SCION_VERSION}_armel.deb
             tar -chaf scion_${SCION_VERSION}_openwrt_x86_64.tar.gz *_${SCION_VERSION}_x86_64.ipk
             tar -chaf scion_${SCION_VERSION}_rpm_x86_64.tar.gz *_${SCION_VERSION}_x86_64.rpm
+            tar -chaf scion_${SCION_VERSION}_rpm_arm64.tar.gz *_${SCION_VERSION}_x86_64.rpm
+            tar -chaf scion_${SCION_VERSION}_rpm_i386.tar.gz *_${SCION_VERSION}_x86_64.rpm
+            tar -chaf scion_${SCION_VERSION}_rpm_armel.tar.gz *_${SCION_VERSION}_x86_64.rpm
             popd
             ls installables
           post-artifact: |
@@ -57,6 +60,9 @@ steps:
             - <a href="artifact://installables/scion_${SCION_VERSION}_openwrt_x86_64.tar.gz">x86_64</a>
             #### Packages :rpm:
             - <a href="artifact://installables/scion_${SCION_VERSION}_rpm_x86_64.tar.gz">x86_64</a>
+            - <a href="artifact://installables/scion_${SCION_VERSION}_rpm_arm64.tar.gz">x86_64</a>
+            - <a href="artifact://installables/scion_${SCION_VERSION}_rpm_i386.tar.gz">x86_64</a>
+            - <a href="artifact://installables/scion_${SCION_VERSION}_rpm_armel.tar.gz">x86_64</a>
             EOF
     key: dist
     retry: *automatic-retry

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,9 +60,9 @@ steps:
             - <a href="artifact://installables/scion_${SCION_VERSION}_openwrt_x86_64.tar.gz">x86_64</a>
             #### Packages :rpm:
             - <a href="artifact://installables/scion_${SCION_VERSION}_rpm_x86_64.tar.gz">x86_64</a>
-            - <a href="artifact://installables/scion_${SCION_VERSION}_rpm_arm64.tar.gz">x86_64</a>
-            - <a href="artifact://installables/scion_${SCION_VERSION}_rpm_i386.tar.gz">x86_64</a>
-            - <a href="artifact://installables/scion_${SCION_VERSION}_rpm_armel.tar.gz">x86_64</a>
+            - <a href="artifact://installables/scion_${SCION_VERSION}_rpm_arm64.tar.gz">arm64</a>
+            - <a href="artifact://installables/scion_${SCION_VERSION}_rpm_i386.tar.gz">i386</a>
+            - <a href="artifact://installables/scion_${SCION_VERSION}_rpm_armel.tar.gz">armel</a>
             EOF
     key: dist
     retry: *automatic-retry

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,13 +122,12 @@ install_python_doc_deps()
 
 http_archive(
     name = "rules_pkg",
-    sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
+    urls = [
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.10.1/rules_pkg-0.10.1.tar.gz",
+    ],
+    sha256 = "d250924a2ecc5176808fc4c25d5cf5e9e79e6346d79d5ab1c493e289e722d1d0",
     patch_args = ["-p1"],
     patches = ["@//dist:rpm/rpm_rules.patch"],
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
-        "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
-    ],
 )
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,12 +122,12 @@ install_python_doc_deps()
 
 http_archive(
     name = "rules_pkg",
+    patch_args = ["-p1"],
+    patches = ["@//dist:rpm/rpm_rules.patch"],
+    sha256 = "d250924a2ecc5176808fc4c25d5cf5e9e79e6346d79d5ab1c493e289e722d1d0",
     urls = [
         "https://github.com/bazelbuild/rules_pkg/releases/download/0.10.1/rules_pkg-0.10.1.tar.gz",
     ],
-    sha256 = "d250924a2ecc5176808fc4c25d5cf5e9e79e6346d79d5ab1c493e289e722d1d0",
-    patch_args = ["-p1"],
-    patches = ["@//dist:rpm/rpm_rules.patch"],
 )
 
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -123,6 +123,8 @@ install_python_doc_deps()
 http_archive(
     name = "rules_pkg",
     sha256 = "8f9ee2dc10c1ae514ee599a8b42ed99fa262b757058f65ad3c384289ff70c4b8",
+    patch_args = ["-p1"],
+    patches = ["@//dist:rpm/rpm_rules.patch"],
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",
         "https://github.com/bazelbuild/rules_pkg/releases/download/0.9.1/rules_pkg-0.9.1.tar.gz",

--- a/dist/BUILD.bazel
+++ b/dist/BUILD.bazel
@@ -11,6 +11,9 @@ DEB_PLATFORMS = [
 
 RPM_PLATFORMS = [
     "@io_bazel_rules_go//go/toolchain:linux_amd64",
+    "@io_bazel_rules_go//go/toolchain:linux_arm64",
+    "@io_bazel_rules_go//go/toolchain:linux_386",
+    "@io_bazel_rules_go//go/toolchain:linux_arm",
 ]
 
 # TODO(jice@scion.org):

--- a/dist/package.bzl
+++ b/dist/package.bzl
@@ -132,6 +132,7 @@ def scion_pkg_rpm(name, package, executables = {}, systemds = [], configs = [], 
         package_name = package,
         release = "%autorelease",
         version_file = ":%s_version" % name,
+        defines = {"_smp_build_ncpus" : "1" }, 
         requires = deps,
         post_scriptlet_file = post,
         **kwargs

--- a/dist/package.bzl
+++ b/dist/package.bzl
@@ -113,6 +113,10 @@ def scion_pkg_rpm(name, package, executables = {}, systemds = [], configs = [], 
     else:
         deps = []
 
+    tarch =  kwargs.get("architecture")
+    if tarch:
+        kwargs.pop("architecture")
+
     post = kwargs.get("postinst")
     if post:
         kwargs.pop("postinst")
@@ -122,6 +126,7 @@ def scion_pkg_rpm(name, package, executables = {}, systemds = [], configs = [], 
         summary = kwargs["description"],
         srcs = ["%s_configs" % name, "%s_systemds" % name, "%s_execs" % name],
         target_compatible_with = ["@platforms//os:linux"],
+        target_architecture = tarch,
         package_file_name = "{package}_{file_name_version}_{architecture}.rpm",
         package_variables = ":package_file_naming_" + name,
         package_name = package,

--- a/dist/package.bzl
+++ b/dist/package.bzl
@@ -113,7 +113,7 @@ def scion_pkg_rpm(name, package, executables = {}, systemds = [], configs = [], 
     else:
         deps = []
 
-    tarch =  kwargs.get("architecture")
+    tarch = kwargs.get("architecture")
     if tarch:
         kwargs.pop("architecture")
 
@@ -132,7 +132,7 @@ def scion_pkg_rpm(name, package, executables = {}, systemds = [], configs = [], 
         package_name = package,
         release = "%autorelease",
         version_file = ":%s_version" % name,
-        defines = {"_smp_build_ncpus" : "1" }, 
+        defines = {"_smp_build_ncpus": "1"},
         requires = deps,
         post_scriptlet_file = post,
         **kwargs

--- a/dist/rpm/rpm_rules.patch
+++ b/dist/rpm/rpm_rules.patch
@@ -1,0 +1,139 @@
+The following patch comes from:
+https://github.com/bazelbuild/rules_pkg/pull/729
+Ownership as per the github project's provisions.
+
+I provide it here in advance of it being merged because it might take a while
+to happen.
+
+From 6c27a34cfe5a37901803ad8478f3b9ec668a3b69 Mon Sep 17 00:00:00 2001
+From: Alex Blago <ogalbxela@gmail.com>
+Date: Sun, 13 Aug 2023 00:33:00 -0700
+Subject: [PATCH] Support for cross-platform RPM package generation
+diff --git a/pkg/make_rpm.py b/pkg/make_rpm.py
+index e2ffca0a..76a2e51d 100644
+--- a/pkg/make_rpm.py
++++ b/pkg/make_rpm.py
+@@ -178,13 +178,14 @@ class RpmBuilder(object):
+   RPMS_DIR = 'RPMS'
+   DIRS = [SOURCE_DIR, BUILD_DIR, RPMS_DIR, TEMP_DIR]
+ 
+-  def __init__(self, name, version, release, arch, rpmbuild_path,
+-               source_date_epoch=None,
++  def __init__(self, name, version, release, arch, target_arch,
++               rpmbuild_path, source_date_epoch=None,
+                debug=False):
+     self.name = name
+     self.version = helpers.GetFlagValue(version)
+     self.release = helpers.GetFlagValue(release)
+     self.arch = arch
++    self.target_arch = target_arch
+     self.files = []
+     self.rpmbuild_path = FindRpmbuild(rpmbuild_path)
+     self.rpm_path = None
+@@ -354,6 +355,10 @@ def CallRpmBuild(self, dirname, rpmbuild_args):
+         '--buildroot=%s' % buildroot,
+     ]  # yapf: disable
+ 
++    # Target platform
++    if self.target_arch:
++      args += ['--target=%s' % self.target_arch]
++
+     # Macro-based RPM parameter substitution, if necessary inputs provided.
+     if self.preamble_file:
+       args += ['--define', 'build_rpm_options %s' % self.preamble_file]
+@@ -462,7 +467,10 @@ def main(argv):
+                       help='The release of the software being packaged.')
+   parser.add_argument(
+       '--arch',
+-      help='The CPU architecture of the software being packaged.')
++      help='The CPU architecture of the machine on which it is built. '
++           'If the package is not architecture dependent, set this to "noarch".')
++  parser.add_argument('--target_arch',
++      help='The CPU architecture of the target platform the software being packaged for.')
+   parser.add_argument('--spec_file', required=True,
+                       help='The file containing the RPM specification.')
+   parser.add_argument('--out_file', required=True,
+@@ -501,7 +509,7 @@ def main(argv):
+   try:
+     builder = RpmBuilder(options.name,
+                          options.version, options.release,
+-                         options.arch, options.rpmbuild,
++                         options.arch, options.target_arch, options.rpmbuild,
+                          source_date_epoch=options.source_date_epoch,
+                          debug=options.debug)
+     builder.AddFiles(options.files)
+diff --git a/pkg/rpm_pfg.bzl b/pkg/rpm_pfg.bzl
+index 1e3450c1..596dc26d 100644
+--- a/pkg/rpm_pfg.bzl
++++ b/pkg/rpm_pfg.bzl
+@@ -142,7 +142,7 @@ def _make_absolute_if_not_already_or_is_macro(path):
+     # this can be inlined easily.
+     return path if path.startswith(("/", "%")) else "/" + path
+ 
+-#### Input processing helper functons.
++#### Input processing helper functions.
+ 
+ # TODO(nacl, #459): These are redundant with functions and structures in
+ # pkg/private/pkg_files.bzl.  We should really use the infrastructure provided
+@@ -251,7 +251,7 @@ def _pkg_rpm_impl(ctx):
+             rpm_name,
+             ctx.attr.version,
+             ctx.attr.release,
+-            ctx.attr.architecture,
++            ctx.attr.architecture if ctx.attr.architecture else ctx.attr.target_architecture,
+         )
+ 
+     outputs, output_file, output_name = setup_output_files(
+@@ -432,6 +432,9 @@ def _pkg_rpm_impl(ctx):
+ 
+     args.append("--out_file=" + output_file.path)
+ 
++    if ctx.attr.target_architecture:
++        args.append("--target_arch=" + ctx.attr.target_architecture)
++
+     # Add data files.
+     if ctx.file.changelog:
+         files.append(ctx.file.changelog)
+@@ -666,7 +669,7 @@ def _pkg_rpm_impl(ctx):
+     output_groups = {
+         "out": [default_file],
+         "rpm": [output_file],
+-        "changes": changes
++        "changes": changes,
+     }
+     return [
+         OutputGroupInfo(**output_groups),
+@@ -791,20 +794,29 @@ pkg_rpm = rule(
+         # funny if it's not provided.  The contents of the RPM are believed to
+         # be set as expected, though.
+         "architecture": attr.string(
+-            doc = """Package architecture.
++            doc = """Host architecture.
+ 
+             This currently sets the `BuildArch` tag, which influences the output
+             architecture of the package.
+ 
+             Typically, `BuildArch` only needs to be set when the package is
+-            known to be cross-platform (e.g. written in an interpreted
+-            language), or, less common, when it is known that the application is
+-            only valid for specific architectures.
++            not architecture dependent (e.g. written in an interpreted
++            language).
+ 
+             When no attribute is provided, this will default to your host's
+             architecture.  This is usually what you want.
+ 
+             """,
+         ),
++        "target_architecture": attr.string(
++            doc = """Package architecture.
++
++            This currently sets the value for the "--target" argument to "rpmbuild" 
++            to specify platform package is built for.
++
++            When no attribute is provided, this will default to your host's
++            architecture.
++            """,
++        ),
+         "license": attr.string(
+             doc = """RPM "License" tag.

--- a/dist/rpm/rpm_rules.patch
+++ b/dist/rpm/rpm_rules.patch
@@ -66,15 +66,6 @@ diff --git a/pkg/rpm_pfg.bzl b/pkg/rpm_pfg.bzl
 index 1e3450c1..596dc26d 100644
 --- a/pkg/rpm_pfg.bzl
 +++ b/pkg/rpm_pfg.bzl
-@@ -142,7 +142,7 @@ def _make_absolute_if_not_already_or_is_macro(path):
-     # this can be inlined easily.
-     return path if path.startswith(("/", "%")) else "/" + path
- 
--#### Input processing helper functons.
-+#### Input processing helper functions.
- 
- # TODO(nacl, #459): These are redundant with functions and structures in
- # pkg/private/pkg_files.bzl.  We should really use the infrastructure provided
 @@ -251,7 +251,7 @@ def _pkg_rpm_impl(ctx):
              rpm_name,
              ctx.attr.version,
@@ -83,26 +74,16 @@ index 1e3450c1..596dc26d 100644
 +            ctx.attr.architecture if ctx.attr.architecture else ctx.attr.target_architecture,
          )
  
-     outputs, output_file, output_name = setup_output_files(
-@@ -432,6 +432,9 @@ def _pkg_rpm_impl(ctx):
+     _, output_file, _ = setup_output_files(
+@@ -454,5 +454,8 @@ def _pkg_rpm_impl(ctx):
  
      args.append("--out_file=" + output_file.path)
  
 +    if ctx.attr.target_architecture:
 +        args.append("--target_arch=" + ctx.attr.target_architecture)
 +
-     # Add data files.
-     if ctx.file.changelog:
-         files.append(ctx.file.changelog)
-@@ -666,7 +669,7 @@ def _pkg_rpm_impl(ctx):
-     output_groups = {
-         "out": [default_file],
-         "rpm": [output_file],
--        "changes": changes
-+        "changes": changes,
-     }
-     return [
-         OutputGroupInfo(**output_groups),
+     # Add data files
+     files += ctx.files.srcs
 @@ -791,20 +794,29 @@ pkg_rpm = rule(
          # funny if it's not provided.  The contents of the RPM are believed to
          # be set as expected, though.

--- a/licenses/data/platforms/LICENSE
+++ b/licenses/data/platforms/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
This is enabled by a pending PR to the rules_pkg project: https://github.com/bazelbuild/rules_pkg/pull/729

I just added the patch to our build while we wait for the PR to get merged.