### PR TITLE
pkg/daemon: use grpc.NewClient instead of Dial

### DIFF
--- a/pkg/daemon/BUILD.bazel
+++ b/pkg/daemon/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/snet/path:go_default_library",
         "//private/topology:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials/insecure:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
         "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],


### PR DESCRIPTION
Dial and DialContext is deprecated in newer version of gRPC. (See https://pkg.go.dev/google.golang.org/grpc#Dial)