### PR TITLE
support BGP ASNs in local topologies

### DIFF
--- a/tools/topology/config.py
+++ b/tools/topology/config.py
@@ -95,6 +95,7 @@ class ConfigGenerator(object):
         Generate all needed files.
         """
         self._ensure_uniq_ases()
+        self._canonicalize_isd_asns()
         topo_dicts, self.all_networks = self._generate_topology()
         self.networks = remove_v4_nets(self.all_networks)
         self._generate_with_topo(topo_dicts)
@@ -109,6 +110,12 @@ class ConfigGenerator(object):
                 logging.critical("Non-unique AS Id '%s'", ia.as_str())
                 sys.exit(1)
             seen.add(ia.as_str())
+
+    def _canonicalize_isd_asns(self):
+        canonicalized = {}
+        for asStr, value in self.topo_config["ASes"].items():
+            canonicalized[str(ISD_AS(asStr))] = value
+        self.topo_config["ASes"] = canonicalized
 
     def _generate_with_topo(self, topo_dicts):
         self._generate_go(topo_dicts)


### PR DESCRIPTION
Local topologies (created using the scion.sh topology command) do not support ASN < 2^32. If such ASNs are written in decimal notation, validation of the ISD-ASN fails. Writing the ASN in hexadecimal also fails, because the crytographic material is generated in the wrong directory.

All that seems to be missing to support BGP ASNs is allowing the decimal format and making sure that all ASNs < 2^32 are converted to decimal format as expected by the scion-pki tool.