### PR TITLE
doc: typos and comment on SCMP on legacy hosts

### DIFF
--- a/doc/dev/design/router-port-dispatch.rst
+++ b/doc/dev/design/router-port-dispatch.rst
@@ -179,7 +179,7 @@ With these mechanisms, the update procedure for an individual AS is:
 
    The recommended initial port range for the transition is ``31000-32767``.
    This range is just below the range of ephemeral ports that is assigned by the old dispatcher (32768-65535), ensuring that UDP traffic from legacy end hosts will be unaffected by the port dispatching in the router.
-   On legacy hosts, SCMP echo and error requests currently use random IDs, and thus have a low chance (~2.5%) to pick an ID in the range that is port dispatched by the router. As a preparatory change, the range of IDs can reduced, so that there is no intersection.
+   On legacy hosts, SCMP echo and traceroute requests currently use random ports, and thus have a low chance (~2.5%) to pick a port in the range that is dispatched by the router. As a preparatory change, the range of ephemeral ports of the operating system can be reduced, so that there is no intersection.
 
 2. Update devices, **in any order**, without requiring synchronisation:
 


### PR DESCRIPTION
Fix typos and clarify comment on SCMP on legacy hosts.