### PR TITLE
sig: retry when connecting to sciond

### DIFF
--- a/gateway/cmd/gateway/main.go
+++ b/gateway/cmd/gateway/main.go
@@ -54,6 +54,9 @@ func main() {
 }
 
 func realMain(ctx context.Context) error {
+
+	const retryDelay = 2
+
 	daemonService := &daemon.Service{
 		Address: globalCfg.Daemon.Address,
 	}
@@ -65,8 +68,8 @@ func realMain(ctx context.Context) error {
 	localIA, err := daemon.LocalIA(ctx)
 	if err != nil {
 		// May be we were too early. Wait and retry the whole shebang.
-		log.Info("Retying daemon connection")
-		time.Sleep(2 * time.Second)
+		log.Info("Retying daemon connection", "retryDelay", retryDelay)
+		time.Sleep(retryDelay * time.Second)
 		daemon.Close()
 		daemon, err = daemonService.Connect(ctx)
 		if err != nil {
@@ -77,7 +80,7 @@ func realMain(ctx context.Context) error {
 		if err != nil {
 			return serrors.Wrap("retrieving local ISD-AS", err)
 		}
-		log.Info("This time it worked")
+		log.Info("Connected to daemon")
 	}
 	controlAddress, err := net.ResolveUDPAddr("udp", globalCfg.Gateway.CtrlAddr)
 	if err != nil {

--- a/gateway/cmd/gateway/main.go
+++ b/gateway/cmd/gateway/main.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"net/netip"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
@@ -63,9 +64,21 @@ func realMain(ctx context.Context) error {
 	defer daemon.Close()
 	localIA, err := daemon.LocalIA(ctx)
 	if err != nil {
-		return serrors.Wrap("retrieving local ISD-AS", err)
-	}
+		// May be we were too early. Wait and retry the whole shebang.
+		log.Info("Retying daemon connection")
+		time.Sleep(2 * time.Second)
+		daemon.Close()
+		daemon, err = daemonService.Connect(ctx)
+		if err != nil {
+			return serrors.Wrap("connecting to daemon", err)
+		}
 
+		localIA, err = daemon.LocalIA(ctx)
+		if err != nil {
+			return serrors.Wrap("retrieving local ISD-AS", err)
+		}
+		log.Info("This time it worked")
+	}
 	controlAddress, err := net.ResolveUDPAddr("udp", globalCfg.Gateway.CtrlAddr)
 	if err != nil {
 		return serrors.Wrap("parsing control address", err)


### PR DESCRIPTION
Some tests start sig in the same time as sciond and have become flaky (presumably due to ordering or timing changes in docker). This resolves it.