### PR TITLE
doc: add apple silicon mac dev env setup manual

### DIFF
--- a/doc/dev/setup.rst
+++ b/doc/dev/setup.rst
@@ -176,6 +176,12 @@ Setup
       make test
       make test-integration
 
+   .. Warning::
+
+      Integration tests will fail to execute on ARM64 due to OpenWRT.
+      The current workaround is to remove the ``"integration"`` tag from
+      ``"openwrt_test"`` in ``dist/test/BUILD.bazel``.
+
 #. (Optional) If you already have some code you wish to contribute upstream, you can also run the
    linters locally with:
 


### PR DESCRIPTION
I went through the hoops of setting up the development environment on my M4 Macbook and found [Lima](https://github.com/lima-vm/lima) to be the most convenient way:

- Licensed under [Apache-2.0 license](https://github.com/lima-vm/lima?tab=Apache-2.0-1-ov-file#readme)
- Actively maintained and [stable](https://github.com/lima-vm/lima/releases)