### PR TITLE
chore: replace interface{} with any

### DIFF
--- a/control/beaconing/propagator_test.go
+++ b/control/beaconing/propagator_test.go
@@ -83,7 +83,7 @@ func TestPropagatorRunNonCore(t *testing.T) {
 	}
 	g := graph.NewDefaultGraph(mctrl)
 	provider.EXPECT().BeaconsToPropagate(gomock.Any()).Times(1).DoAndReturn(
-		func(_ interface{}) ([]beacon.Beacon, error) {
+		func(_ any) ([]beacon.Beacon, error) {
 			res := make([]beacon.Beacon, 0, len(beacons))
 			for _, desc := range beacons {
 				res = append(res, testBeacon(g, desc))
@@ -157,7 +157,7 @@ func TestPropagatorRunCore(t *testing.T) {
 	}
 	g := graph.NewDefaultGraph(mctrl)
 	provider.EXPECT().BeaconsToPropagate(gomock.Any()).Times(2).DoAndReturn(
-		func(_ interface{}) ([]beacon.Beacon, error) {
+		func(_ any) ([]beacon.Beacon, error) {
 			res := make([]beacon.Beacon, 0, len(beacons))
 			for _, desc := range beacons {
 				res = append(res, testBeacon(g, desc))
@@ -248,7 +248,7 @@ func TestPropagatorFastRecovery(t *testing.T) {
 	// We call run 4 times in this test, since the interface to 1-ff00:0:120
 	// will never be beaconed on, because the beacons are filtered for loops.
 	provider.EXPECT().BeaconsToPropagate(gomock.Any()).Times(4).DoAndReturn(
-		func(_ interface{}) ([]beacon.Beacon, error) {
+		func(_ any) ([]beacon.Beacon, error) {
 			return []beacon.Beacon{testBeacon(g, beacons[0])}, nil
 		},
 	)

--- a/control/beaconing/util.go
+++ b/control/beaconing/util.go
@@ -122,9 +122,9 @@ type silentLogger struct {
 	log.Logger
 }
 
-func (s silentLogger) Info(msg string, ctx ...interface{}) {
+func (s silentLogger) Info(msg string, ctx ...any) {
 	s.Logger.Debug(msg, ctx...)
 }
-func (s silentLogger) Error(msg string, ctx ...interface{}) {
+func (s silentLogger) Error(msg string, ctx ...any) {
 	s.Logger.Debug(msg, ctx...)
 }

--- a/control/beaconing/writer_test.go
+++ b/control/beaconing/writer_test.go
@@ -119,7 +119,7 @@ func TestRegistrarRun(t *testing.T) {
 
 			g := graph.NewDefaultGraph(mctrl)
 			segProvider.EXPECT().SegmentsToRegister(gomock.Any(), test.segType).DoAndReturn(
-				func(_, _ interface{}) ([]beacon.Beacon, error) {
+				func(_, _ any) ([]beacon.Beacon, error) {
 					res := make([]beacon.Beacon, 0, len(test.beacons))
 					for _, desc := range test.beacons {
 						res = append(res, testBeacon(g, desc))
@@ -210,7 +210,7 @@ func TestRegistrarRun(t *testing.T) {
 
 			g := graph.NewDefaultGraph(mctrl)
 			segProvider.EXPECT().SegmentsToRegister(gomock.Any(), test.segType).DoAndReturn(
-				func(_, _ interface{}) ([]beacon.Beacon, error) {
+				func(_, _ any) ([]beacon.Beacon, error) {
 					res := make([]beacon.Beacon, len(test.beacons))
 					for _, desc := range test.beacons {
 						res = append(res, testBeacon(g, desc))
@@ -313,7 +313,7 @@ func TestRegistrarRun(t *testing.T) {
 		require.NoError(t, err)
 		segProvider.EXPECT().SegmentsToRegister(gomock.Any(),
 			seg.TypeDown).DoAndReturn(
-			func(_, _ interface{}) (<-chan beacon.Beacon, error) {
+			func(_, _ any) (<-chan beacon.Beacon, error) {
 				res := make(chan beacon.Beacon, 1)
 				b := testBeacon(g, []uint16{graph.If_120_X_111_B})
 				b.InIfID = 10

--- a/daemon/internal/servers/grpc.go
+++ b/daemon/internal/servers/grpc.go
@@ -117,7 +117,7 @@ func (s *DaemonServer) fetchPaths(
 ) ([]snet.Path, error) {
 
 	r, err, _ := group.Do(fmt.Sprintf("%s%s%t", src, dst, refresh),
-		func() (interface{}, error) {
+		func() (any, error) {
 			return s.Fetcher.GetPaths(ctx, src, dst, refresh)
 		},
 	)

--- a/gateway/control/sessionmonitor_test.go
+++ b/gateway/control/sessionmonitor_test.go
@@ -45,7 +45,7 @@ type pktMatcher struct {
 }
 
 // Matches returns whether x is a match.
-func (m pktMatcher) Matches(x interface{}) bool {
+func (m pktMatcher) Matches(x any) bool {
 	other, ok := x.([]byte)
 	if !ok {
 		return false
@@ -69,7 +69,7 @@ type udpAddrMatcher struct {
 }
 
 // Matches returns whether x is a match.
-func (m udpAddrMatcher) Matches(x interface{}) bool {
+func (m udpAddrMatcher) Matches(x any) bool {
 	other, ok := x.(*snet.UDPAddr)
 	if !ok {
 		return false

--- a/gateway/control/watcher_test.go
+++ b/gateway/control/watcher_test.go
@@ -49,14 +49,14 @@ func TestGatewayWatcherRun(t *testing.T) {
 	fetcher.EXPECT().Close().AnyTimes().Return(nil)
 
 	discoverer.EXPECT().Gateways(gomock.Any()).DoAndReturn(
-		func(interface{}) ([]control.Gateway, error) {
+		func(any) ([]control.Gateway, error) {
 			discoveryCounts.Add(1)
 			return []control.Gateway{gateway1, gateway2}, nil
 		},
 	)
 
 	fetcher.EXPECT().Prefixes(gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
-		func(_ interface{}, g *net.UDPAddr) ([]*net.IPNet, error) {
+		func(_ any, g *net.UDPAddr) ([]*net.IPNet, error) {
 			fetcherCounts.With("gateway", g.String()).Add(1)
 			return nil, serrors.New("error")
 		},
@@ -105,7 +105,7 @@ func TestGatewayWatcherRun(t *testing.T) {
 
 	// now let's reset and remove one gateway, this time we only return gateway1
 	discoverer.EXPECT().Gateways(gomock.Any()).DoAndReturn(
-		func(interface{}) ([]control.Gateway, error) {
+		func(any) ([]control.Gateway, error) {
 			discoveryCounts.Add(1)
 			return []control.Gateway{gateway1}, nil
 		},
@@ -144,26 +144,26 @@ func TestPrefixWatcherRun(t *testing.T) {
 	// called with the up to date list.
 	first := []*net.IPNet{cidr(t, "127.0.0.0/24"), cidr(t, "127.0.1.0/24"), cidr(t, "::/64")}
 	fetcher.EXPECT().Prefixes(gomock.Any(), gateway.Control).DoAndReturn(
-		func(_, _ interface{}) ([]*net.IPNet, error) {
+		func(_, _ any) ([]*net.IPNet, error) {
 			fetcherCounts.Add(1)
 			return first, nil
 		},
 	)
 	consumer.EXPECT().Prefixes(gomock.Any(), gateway, first).Do(
-		func(_, _, _ interface{}) {
+		func(_, _, _ any) {
 			consumerCounts.Add(1)
 		},
 	)
 
 	afterwards := []*net.IPNet{cidr(t, "127.0.0.0/24"), cidr(t, "::/64")}
 	fetcher.EXPECT().Prefixes(gomock.Any(), gateway.Control).AnyTimes().DoAndReturn(
-		func(_, _ interface{}) ([]*net.IPNet, error) {
+		func(_, _ any) ([]*net.IPNet, error) {
 			fetcherCounts.Add(1)
 			return afterwards, nil
 		},
 	)
 	consumer.EXPECT().Prefixes(gomock.Any(), gateway, afterwards).AnyTimes().Do(
-		func(_, _, _ interface{}) {
+		func(_, _, _ any) {
 			consumerCounts.Add(1)
 		},
 	)

--- a/gateway/dataplane/framebuf.go
+++ b/gateway/dataplane/framebuf.go
@@ -181,7 +181,7 @@ func (fb *frameBuf) String() string {
 }
 
 func initFreeFrames() {
-	freeFrames = ringbuf.New(freeFramesCap, func() interface{} {
+	freeFrames = ringbuf.New(freeFramesCap, func() any {
 		return newFrameBuf()
 	}, "ingress_free")
 }

--- a/gateway/dataplane/ipforwarder_test.go
+++ b/gateway/dataplane/ipforwarder_test.go
@@ -259,7 +259,7 @@ type packetMatcher struct {
 	packet gopacket.Packet
 }
 
-func (pm *packetMatcher) Matches(x interface{}) bool {
+func (pm *packetMatcher) Matches(x any) bool {
 	packet := x.(gopacket.Packet)
 	return bytes.Equal(packet.Data(), pm.packet.Data())
 }

--- a/gateway/dataplane/routingtable_test.go
+++ b/gateway/dataplane/routingtable_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestRoutingTable(t *testing.T) {
 	rt := &dataplane.RoutingTable{}
-	_, ok := interface{}(rt).(control.RoutingTable)
+	_, ok := any(rt).(control.RoutingTable)
 	if ok != true {
 		assert.Fail(t, "should implement the client interface")
 	}

--- a/gateway/dataplane/sender_test.go
+++ b/gateway/dataplane/sender_test.go
@@ -31,7 +31,7 @@ import (
 
 func expectFrames(conn *mock_net.MockPacketConn) *gomock.Call {
 	return conn.EXPECT().WriteTo(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(f []byte, _ interface{}) (int, error) {
+		func(f []byte, _ any) (int, error) {
 			// Slow down the sending to induce packet batching.
 			time.Sleep(10 * time.Millisecond)
 			return 0, nil

--- a/gateway/dataplane/session_test.go
+++ b/gateway/dataplane/session_test.go
@@ -128,7 +128,7 @@ func createSession(t *testing.T, ctrl *gomock.Controller, frameChan chan []byte)
 		&snet.UDPAddr{Host: &net.UDPAddr{IP: net.IP{192, 168, 1, 1}}},
 	).AnyTimes()
 	conn.EXPECT().WriteTo(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(f []byte, _ interface{}) (int, error) {
+		func(f []byte, _ any) (int, error) {
 			frameChan <- f
 			return 0, nil
 		}).AnyTimes()

--- a/gateway/pktcls/class.go
+++ b/gateway/pktcls/class.go
@@ -78,11 +78,11 @@ func (cm *ClassMap) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (cm ClassMap) MarshalYAML() (interface{}, error) {
+func (cm ClassMap) MarshalYAML() (any, error) {
 	return (map[string]*Class)(cm), nil
 }
 
-func (cm *ClassMap) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (cm *ClassMap) UnmarshalYAML(unmarshal func(any) error) error {
 	err := unmarshal(cm)
 	if err != nil {
 		return err

--- a/gateway/pktcls/error_listener.go
+++ b/gateway/pktcls/error_listener.go
@@ -28,7 +28,7 @@ type ErrorListener struct {
 	errorType string
 }
 
-func (l *ErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line,
+func (l *ErrorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol any, line,
 	column int, msg string, e antlr.RecognitionException) {
 	l.msg = msg
 	log.Debug(fmt.Sprintf("%s Error", l.errorType), "err", msg)

--- a/gateway/pktcls/json.go
+++ b/gateway/pktcls/json.go
@@ -57,7 +57,7 @@ const (
 )
 
 // generic container for marshaling custom data
-type jsonContainer map[string]interface{}
+type jsonContainer map[string]any
 
 func marshalInterface(t Typer) ([]byte, error) {
 	return json.Marshal(jsonContainer{t.Type(): t})

--- a/pkg/experimental/hiddenpath/beaconwriter_test.go
+++ b/pkg/experimental/hiddenpath/beaconwriter_test.go
@@ -299,7 +299,7 @@ type addrMatcher struct {
 	udp *snet.UDPAddr
 }
 
-func (m addrMatcher) Matches(other interface{}) bool {
+func (m addrMatcher) Matches(other any) bool {
 	if m.svc != nil {
 		svc, ok := other.(*snet.SVCAddr)
 		if !ok {

--- a/pkg/experimental/hiddenpath/group.go
+++ b/pkg/experimental/hiddenpath/group.go
@@ -152,7 +152,7 @@ func (g Groups) Validate() error {
 }
 
 // UnmarshalYAML implements the yaml unmarshaller for the Groups type.
-func (g Groups) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (g Groups) UnmarshalYAML(unmarshal func(any) error) error {
 	yg := &registrationPolicyInfo{}
 	if err := unmarshal(&yg); err != nil {
 		return serrors.Wrap("unmarshaling YAML", err)
@@ -171,7 +171,7 @@ func (g Groups) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // MarshalYAML implements yaml marshalling.
-func (g Groups) MarshalYAML() (interface{}, error) {
+func (g Groups) MarshalYAML() (any, error) {
 	return &registrationPolicyInfo{
 		Groups: marshalGroups(g),
 	}, nil

--- a/pkg/experimental/hiddenpath/registrationpolicy.go
+++ b/pkg/experimental/hiddenpath/registrationpolicy.go
@@ -48,7 +48,7 @@ func (p RegistrationPolicy) Validate() error {
 }
 
 // MarshalYAML implements the yaml marshaller interface.
-func (p RegistrationPolicy) MarshalYAML() (interface{}, error) {
+func (p RegistrationPolicy) MarshalYAML() (any, error) {
 	collectedGroups := make(Groups)
 	policies := make(map[uint64][]string, len(p))
 	for ifID, ip := range p {
@@ -68,7 +68,7 @@ func (p RegistrationPolicy) MarshalYAML() (interface{}, error) {
 }
 
 // UnmarshalYAML implements YAML unmarshaling for the registration policy type.
-func (p RegistrationPolicy) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p RegistrationPolicy) UnmarshalYAML(unmarshal func(any) error) error {
 	rawPolicy := &registrationPolicyInfo{}
 	if err := unmarshal(&rawPolicy); err != nil {
 		return serrors.Wrap("parsing yaml", err)

--- a/pkg/grpc/interceptor.go
+++ b/pkg/grpc/interceptor.go
@@ -31,7 +31,7 @@ func LogIDClientInterceptor() grpc.UnaryClientInterceptor {
 	return func(
 		ctx context.Context,
 		method string,
-		req, resp interface{},
+		req, resp any,
 		cc *grpc.ClientConn,
 		invoker grpc.UnaryInvoker,
 		opts ...grpc.CallOption,
@@ -65,10 +65,10 @@ func LogIDClientStreamInterceptor() grpc.StreamClientInterceptor {
 func LogIDServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
-		req interface{},
+		req any,
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
-	) (interface{}, error) {
+	) (any, error) {
 
 		logger := loggerFromSpan(opentracing.SpanFromContext(ctx))
 		logger.Debug("Serving RPC", "method", info.FullMethod)
@@ -79,7 +79,7 @@ func LogIDServerInterceptor() grpc.UnaryServerInterceptor {
 
 func LogIDServerStreamInterceptor() grpc.StreamServerInterceptor {
 	return func(
-		srv interface{},
+		srv any,
 		ss grpc.ServerStream,
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
@@ -116,7 +116,7 @@ func openTracingInterceptorWithTarget() grpc.UnaryClientInterceptor {
 	return func(
 		ctx context.Context,
 		method string,
-		req, reply interface{},
+		req, reply any,
 		cc *grpc.ClientConn,
 		invoker grpc.UnaryInvoker,
 		opts ...grpc.CallOption,
@@ -125,7 +125,7 @@ func openTracingInterceptorWithTarget() grpc.UnaryClientInterceptor {
 		spanDecorator := func(
 			span opentracing.Span,
 			method string,
-			req, resp interface{},
+			req, resp any,
 			grpcError error,
 		) {
 			if span != nil {

--- a/pkg/log/context.go
+++ b/pkg/log/context.go
@@ -57,7 +57,7 @@ func FromCtx(ctx context.Context) Logger {
 
 // WithLabels returns context with additional labels added to the logger.
 // For convenience it also returns the logger itself.
-func WithLabels(ctx context.Context, labels ...interface{}) (context.Context, Logger) {
+func WithLabels(ctx context.Context, labels ...any) (context.Context, Logger) {
 	logger := FromCtx(ctx).New(labels...)
 	ctx = CtxWith(ctx, logger)
 	return ctx, logger

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -221,7 +221,7 @@ func (l httpLevel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // SafeNewLogger creates a new logger as a child of l only if l is not nil. If l is nil, then
 // nil is returned.
-func SafeNewLogger(l Logger, fields ...interface{}) Logger {
+func SafeNewLogger(l Logger, fields ...any) Logger {
 	if l != nil {
 		return l.New(fields...)
 	}
@@ -229,7 +229,7 @@ func SafeNewLogger(l Logger, fields ...interface{}) Logger {
 }
 
 // SafeDebug logs to l only if l is not nil.
-func SafeDebug(l Logger, msg string, fields ...interface{}) {
+func SafeDebug(l Logger, msg string, fields ...any) {
 	if l != nil {
 		if ll, ok := l.(*logger); ok {
 			ll.logger.Debug(msg, convertCtx(fields)...)
@@ -240,7 +240,7 @@ func SafeDebug(l Logger, msg string, fields ...interface{}) {
 }
 
 // SafeInfo logs to l only if l is not nil.
-func SafeInfo(l Logger, msg string, fields ...interface{}) {
+func SafeInfo(l Logger, msg string, fields ...any) {
 	if l != nil {
 		if ll, ok := l.(*logger); ok {
 			ll.logger.Info(msg, convertCtx(fields)...)
@@ -251,7 +251,7 @@ func SafeInfo(l Logger, msg string, fields ...interface{}) {
 }
 
 // SafeError logs to l only if l is not nil.
-func SafeError(l Logger, msg string, fields ...interface{}) {
+func SafeError(l Logger, msg string, fields ...any) {
 	if l != nil {
 		if ll, ok := l.(*logger); ok {
 			ll.logger.Error(msg, convertCtx(fields)...)

--- a/pkg/log/span.go
+++ b/pkg/log/span.go
@@ -25,19 +25,19 @@ type Span struct {
 }
 
 // Debug logs to the logger and span.
-func (s Span) Debug(msg string, ctx ...interface{}) {
+func (s Span) Debug(msg string, ctx ...any) {
 	s.Logger.Debug(msg, ctx...)
 	s.spanLog("debug", msg, ctx...)
 }
 
 // Info logs to the logger and span.
-func (s Span) Info(msg string, ctx ...interface{}) {
+func (s Span) Info(msg string, ctx ...any) {
 	s.Logger.Info(msg, ctx...)
 	s.spanLog("info", msg, ctx...)
 }
 
 // Error logs to the logger and span.
-func (s Span) Error(msg string, ctx ...interface{}) {
+func (s Span) Error(msg string, ctx ...any) {
 	s.Logger.Error(msg, ctx...)
 	s.spanLog("error", msg, ctx...)
 }
@@ -47,16 +47,16 @@ func (s Span) Enabled(lvl Level) bool {
 }
 
 // New creates a new logger with the context attached.
-func (s Span) New(ctx ...interface{}) Logger {
+func (s Span) New(ctx ...any) Logger {
 	return Span{
 		Logger: s.Logger.New(ctx...),
 		Span:   s.Span,
 	}
 }
 
-func (s Span) spanLog(lvl, msg string, ctx ...interface{}) {
+func (s Span) spanLog(lvl, msg string, ctx ...any) {
 	if s.Span == nil {
 		return
 	}
-	s.Span.LogKV(append([]interface{}{"level", lvl, "event", msg}, ctx...)...)
+	s.Span.LogKV(append([]any{"level", lvl, "event", msg}, ctx...)...)
 }

--- a/pkg/log/testlog/log.go
+++ b/pkg/log/testlog/log.go
@@ -36,23 +36,23 @@ type logger struct {
 }
 
 // New creates a logger with the given context.
-func New(ctx ...interface{}) log.Logger {
+func New(ctx ...any) log.Logger {
 	return &logger{logger: zap.L().With(convertCtx(ctx)...)}
 }
 
-func (l *logger) New(ctx ...interface{}) log.Logger {
+func (l *logger) New(ctx ...any) log.Logger {
 	return &logger{logger: l.logger.With(convertCtx(ctx)...)}
 }
 
-func (l *logger) Debug(msg string, ctx ...interface{}) {
+func (l *logger) Debug(msg string, ctx ...any) {
 	l.logger.Debug(msg, convertCtx(ctx)...)
 }
 
-func (l *logger) Info(msg string, ctx ...interface{}) {
+func (l *logger) Info(msg string, ctx ...any) {
 	l.logger.Info(msg, convertCtx(ctx)...)
 }
 
-func (l *logger) Error(msg string, ctx ...interface{}) {
+func (l *logger) Error(msg string, ctx ...any) {
 	l.logger.Error(msg, convertCtx(ctx)...)
 }
 
@@ -60,7 +60,7 @@ func (l *logger) Enabled(lvl log.Level) bool {
 	return l.logger.Core().Enabled(zapcore.Level(lvl))
 }
 
-func convertCtx(ctx []interface{}) []zap.Field {
+func convertCtx(ctx []any) []zap.Field {
 	fields := make([]zap.Field, 0, len(ctx)/2)
 	for i := 0; i+1 < len(ctx); i += 2 {
 		fields = append(fields, zap.Any(ctx[i].(string), ctx[i+1]))

--- a/pkg/log/wrappers.go
+++ b/pkg/log/wrappers.go
@@ -21,21 +21,21 @@ import (
 )
 
 // Debug logs at debug level.
-func Debug(msg string, ctx ...interface{}) {
+func Debug(msg string, ctx ...any) {
 	if enabled(DebugLevel) {
 		zap.L().Debug(msg, convertCtx(ctx)...)
 	}
 }
 
 // Info logs at info level.
-func Info(msg string, ctx ...interface{}) {
+func Info(msg string, ctx ...any) {
 	if enabled(InfoLevel) {
 		zap.L().Info(msg, convertCtx(ctx)...)
 	}
 }
 
 // Error logs at error level.
-func Error(msg string, ctx ...interface{}) {
+func Error(msg string, ctx ...any) {
 	if enabled(ErrorLevel) {
 		zap.L().Error(msg, convertCtx(ctx)...)
 	}
@@ -61,10 +61,10 @@ const (
 
 // Logger describes the logger interface.
 type Logger interface {
-	New(ctx ...interface{}) Logger
-	Debug(msg string, ctx ...interface{})
-	Info(msg string, ctx ...interface{})
-	Error(msg string, ctx ...interface{})
+	New(ctx ...any) Logger
+	Debug(msg string, ctx ...any)
+	Info(msg string, ctx ...any)
+	Error(msg string, ctx ...any)
 	Enabled(lvl Level) bool
 }
 
@@ -73,27 +73,27 @@ type logger struct {
 }
 
 // New creates a logger with the given context.
-func New(ctx ...interface{}) Logger {
+func New(ctx ...any) Logger {
 	return &logger{logger: zap.L().With(convertCtx(ctx)...)}
 }
 
-func (l *logger) New(ctx ...interface{}) Logger {
+func (l *logger) New(ctx ...any) Logger {
 	return &logger{logger: l.logger.With(convertCtx(ctx)...)}
 }
 
-func (l *logger) Debug(msg string, ctx ...interface{}) {
+func (l *logger) Debug(msg string, ctx ...any) {
 	if l.Enabled(DebugLevel) {
 		l.logger.Debug(msg, convertCtx(ctx)...)
 	}
 }
 
-func (l *logger) Info(msg string, ctx ...interface{}) {
+func (l *logger) Info(msg string, ctx ...any) {
 	if l.Enabled(InfoLevel) {
 		l.logger.Info(msg, convertCtx(ctx)...)
 	}
 }
 
-func (l *logger) Error(msg string, ctx ...interface{}) {
+func (l *logger) Error(msg string, ctx ...any) {
 	if l.Enabled(ErrorLevel) {
 		l.logger.Error(msg, convertCtx(ctx)...)
 	}
@@ -121,13 +121,13 @@ func Discard() {
 // To see how to use this, see the example.
 type DiscardLogger struct{}
 
-func (d DiscardLogger) New(ctx ...interface{}) Logger      { return d }
-func (DiscardLogger) Debug(msg string, ctx ...interface{}) {}
-func (DiscardLogger) Info(msg string, ctx ...interface{})  {}
-func (DiscardLogger) Error(msg string, ctx ...interface{}) {}
-func (DiscardLogger) Enabled(lvl Level) bool               { return false }
+func (d DiscardLogger) New(ctx ...any) Logger      { return d }
+func (DiscardLogger) Debug(msg string, ctx ...any) {}
+func (DiscardLogger) Info(msg string, ctx ...any)  {}
+func (DiscardLogger) Error(msg string, ctx ...any) {}
+func (DiscardLogger) Enabled(lvl Level) bool       { return false }
 
-func convertCtx(ctx []interface{}) []zap.Field {
+func convertCtx(ctx []any) []zap.Field {
 	fields := make([]zap.Field, 0, len(ctx)/2)
 	for i := 0; i+1 < len(ctx); i += 2 {
 		fields = append(fields, zap.Any(ctx[i].(string), ctx[i+1]))

--- a/pkg/private/common/defs.go
+++ b/pkg/private/common/defs.go
@@ -28,7 +28,7 @@ const (
 	TimeFmtSecs  = "2006-01-02 15:04:05-0700"
 )
 
-func TypeOf(v interface{}) string {
+func TypeOf(v any) string {
 	t := reflect.TypeOf(v)
 	if t != nil {
 		return t.String()

--- a/pkg/private/common/defs_test.go
+++ b/pkg/private/common/defs_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestTypeOf(t *testing.T) {
 	type A struct{}
-	tests := map[string]interface{}{
+	tests := map[string]any{
 		"nil":       nil,
 		"typed nil": (*A)(nil),
 		"ptr":       &A{},

--- a/pkg/private/prom/promtest/promtest.go
+++ b/pkg/private/prom/promtest/promtest.go
@@ -27,7 +27,7 @@ import (
 
 // CheckLabelsStruct checks that labels has a Values and Labels method. It also
 // checks that labels.Labels() returns the struct field names.
-func CheckLabelsStruct(t *testing.T, xLabels interface{}) {
+func CheckLabelsStruct(t *testing.T, xLabels any) {
 	v, ok := xLabels.(prom.Labels)
 	if !ok {
 		assert.Fail(t, "should implement labels interface")

--- a/pkg/private/serrors/errors.go
+++ b/pkg/private/serrors/errors.go
@@ -37,7 +37,7 @@ import (
 // ctxPair is one item of context info.
 type ctxPair struct {
 	Key   string
-	Value interface{}
+	Value any
 }
 
 // errorInfo is a base class for two implementations of error: basicError and joinedError.
@@ -102,7 +102,7 @@ func IsTemporary(err error) bool {
 	return errors.As(err, &t) && t.Temporary()
 }
 
-func mkErrorInfo(cause error, addStack bool, errCtx ...interface{}) errorInfo {
+func mkErrorInfo(cause error, addStack bool, errCtx ...any) errorInfo {
 	np := len(errCtx) / 2
 	ctx := make([]ctxPair, np)
 	for i := 0; i < np; i++ {
@@ -191,7 +191,7 @@ func (e basicError) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 //
 // Wrap may be useful to enrich sentinel errors if the main message needs to be different than
 // that supplied by the sentinel error.
-func Wrap(msg string, cause error, errCtx ...interface{}) error {
+func Wrap(msg string, cause error, errCtx ...any) error {
 	return basicError{
 		errorInfo: mkErrorInfo(cause, true, errCtx...),
 		msg:       msg,
@@ -200,7 +200,7 @@ func Wrap(msg string, cause error, errCtx ...interface{}) error {
 
 // WrapNoStack behaves like [Wrap], except that no stack dump is added, regardless of cause's
 // underlying type.
-func WrapNoStack(msg string, cause error, errCtx ...interface{}) error {
+func WrapNoStack(msg string, cause error, errCtx ...any) error {
 	return basicError{
 		errorInfo: mkErrorInfo(cause, false, errCtx...),
 		msg:       msg,
@@ -212,7 +212,7 @@ func WrapNoStack(msg string, cause error, errCtx ...interface{}) error {
 // Avoid using this in performance-critical code: it is the most expensive variant. If used to
 // construct other errors, such as with Join, the embedded stack trace and context serve no
 // purpose. Therefore, to make sentinel errors, errors.New() should be preferred.
-func New(msg string, errCtx ...interface{}) error {
+func New(msg string, errCtx ...any) error {
 	return &basicError{
 		errorInfo: mkErrorInfo(nil, true, errCtx...),
 		msg:       msg,
@@ -260,7 +260,7 @@ func (e joinedError) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // case the result is a sentinel error enriched with context. For such a purpose this is better than
 // [Wrap], since [Wrap] would retain any irrelevant context possibly attached to the sentinel error
 // and store a redundant message string.
-func Join(err, cause error, errCtx ...interface{}) error {
+func Join(err, cause error, errCtx ...any) error {
 	if err == nil && cause == nil {
 		// Pointless. Will not. Also, maintaining backward compatibility with
 		// a previous Join function.
@@ -274,7 +274,7 @@ func Join(err, cause error, errCtx ...interface{}) error {
 
 // JoinNoStack behaves like [Join] except that no stack dump is added regardless of cause's
 // underlying type.
-func JoinNoStack(err, cause error, errCtx ...interface{}) error {
+func JoinNoStack(err, cause error, errCtx ...any) error {
 	if err == nil && cause == nil {
 		// Pointless. Will not.
 		return nil

--- a/pkg/private/serrors/errors_test.go
+++ b/pkg/private/serrors/errors_test.go
@@ -255,7 +255,7 @@ func TestEncoding(t *testing.T) {
 			logOut := sanitizeLog(b.Bytes())
 			// Parse the log output and marshal it again to sort it.
 			// The zap encoder is not deterministic for nested maps.
-			var parsed map[string]interface{}
+			var parsed map[string]any
 			require.NoError(t, json.Unmarshal(logOut, &parsed), string(logOut))
 			sorted, err := json.Marshal(parsed)
 			require.NoError(t, err)

--- a/pkg/private/xtest/helpers.go
+++ b/pkg/private/xtest/helpers.go
@@ -139,7 +139,7 @@ func CopyFile(t testing.TB, src, dst string) {
 // MustMarshalJSONToFile marshals v and writes the result to file
 // testdata/baseName. If the file exists, it is truncated; if it doesn't exist,
 // it is created. On errors, t.Fatal() is called.
-func MustMarshalJSONToFile(t testing.TB, v interface{}, baseName string) {
+func MustMarshalJSONToFile(t testing.TB, v any, baseName string) {
 	t.Helper()
 
 	enc, err := json.MarshalIndent(v, "", "    ")

--- a/pkg/private/xtest/matchers/matchers.go
+++ b/pkg/private/xtest/matchers/matchers.go
@@ -40,7 +40,7 @@ func IsSnetSVCAddrWithIA(ia addr.IA) gomock.Matcher {
 	return &addrIAMatcher{ia: ia}
 }
 
-func (m *addrIAMatcher) Matches(x interface{}) bool {
+func (m *addrIAMatcher) Matches(x any) bool {
 	sAddr, ok := x.(*snet.SVCAddr)
 	if !ok {
 		return false
@@ -64,7 +64,7 @@ type QueryParams struct {
 
 // Matches returns whether x matches the defined query parameter ignoring the
 // order of the slices.
-func (m *QueryParams) Matches(x interface{}) bool {
+func (m *QueryParams) Matches(x any) bool {
 	query, ok := x.(*query.Params)
 	if !ok {
 		return false
@@ -108,7 +108,7 @@ type QueryHPGroupIDs struct {
 
 // Matches returns whether x matches the defined HPGroupIDs ignoring the
 // order of the slice elements.
-func (m *QueryHPGroupIDs) Matches(x interface{}) bool {
+func (m *QueryHPGroupIDs) Matches(x any) bool {
 	ids, ok := x.([]uint64)
 	if !ok {
 		return false
@@ -128,10 +128,10 @@ func (m *QueryHPGroupIDs) String() string {
 // value are ignored. Passing a target which is not a struct or a pointer to a
 // struct is invalid and will result in a matcher that matches nothing.
 type PartialStruct struct {
-	Target interface{}
+	Target any
 }
 
-func (m PartialStruct) Matches(x interface{}) bool {
+func (m PartialStruct) Matches(x any) bool {
 	expect := reflect.ValueOf(m.Target)
 	unpack := func(v reflect.Value) reflect.Value { return v }
 	if expect.Kind() == reflect.Ptr {

--- a/pkg/private/xtest/matchers/matchers_test.go
+++ b/pkg/private/xtest/matchers/matchers_test.go
@@ -38,7 +38,7 @@ type testPartial2 struct {
 func TestPartialStructMatches(t *testing.T) {
 	testCases := map[string]struct {
 		Matcher     gomock.Matcher
-		Input       interface{}
+		Input       any
 		ExpectMatch bool
 	}{
 		"exact match": {

--- a/pkg/private/xtest/mocking.go
+++ b/pkg/private/xtest/mocking.go
@@ -30,6 +30,6 @@ type PanickingReporter struct {
 	*testing.T
 }
 
-func (reporter *PanickingReporter) Fatalf(format string, args ...interface{}) {
+func (reporter *PanickingReporter) Fatalf(format string, args ...any) {
 	panic(fmt.Sprintf(format, args...))
 }

--- a/pkg/scrypto/cms/protocol/protocol.go
+++ b/pkg/scrypto/cms/protocol/protocol.go
@@ -209,7 +209,7 @@ type Attribute struct {
 }
 
 // NewAttribute creates a single-value Attribute.
-func NewAttribute(typ asn1.ObjectIdentifier, val interface{}) (Attribute, error) {
+func NewAttribute(typ asn1.ObjectIdentifier, val any) (Attribute, error) {
 	der, err := asn1.Marshal(val)
 	if err != nil {
 		return Attribute{}, err

--- a/pkg/snet/svcaddr_test.go
+++ b/pkg/snet/svcaddr_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestSVCAddrInterface(t *testing.T) {
-	var x interface{} = &snet.SVCAddr{}
+	var x any = &snet.SVCAddr{}
 	_, ok := x.(net.Addr)
 	assert.True(t, ok, "should implement net interface")
 }

--- a/pkg/snet/udpaddr_test.go
+++ b/pkg/snet/udpaddr_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestUDPAddrInterface(t *testing.T) {
-	var x interface{} = &snet.UDPAddr{}
+	var x any = &snet.UDPAddr{}
 	_, ok := x.(net.Addr)
 	assert.True(t, ok, "should implement net interface")
 }

--- a/private/app/feature/feature.go
+++ b/private/app/feature/feature.go
@@ -30,7 +30,7 @@ import (
 // Parse parses the features from the input into the feature set. The provided
 // feature set should be a pointer to a struct. All boolean fields on that
 // struct are discovered as feature flags. Non-boolean fields are ignored.
-func Parse(input []string, featureSet interface{}) error {
+func Parse(input []string, featureSet any) error {
 	val := reflect.ValueOf(featureSet)
 	if !val.IsValid() || val.IsZero() {
 		return serrors.New("feature set must not be nil")
@@ -59,7 +59,7 @@ func ParseDefault(input []string) (Default, error) {
 }
 
 // Features lists the supported features.
-func Features(featureSet interface{}) []string {
+func Features(featureSet any) []string {
 	m := featureMap(featureSet)
 	var s []string
 	for k := range m {
@@ -70,11 +70,11 @@ func Features(featureSet interface{}) []string {
 }
 
 // String returns the features as a sorted list separated by the provided separator.
-func String(featureSet interface{}, sep string) string {
+func String(featureSet any, sep string) string {
 	return strings.Join(Features(featureSet), sep)
 }
 
-func featureMap(featureSet interface{}) map[string]int {
+func featureMap(featureSet any) map[string]int {
 	m := map[string]int{}
 	val := reflect.ValueOf(featureSet)
 	if !val.IsValid() {

--- a/private/app/feature/feature_test.go
+++ b/private/app/feature/feature_test.go
@@ -30,9 +30,9 @@ func TestParse(t *testing.T) {
 
 	testCases := map[string]struct {
 		Input          []string
-		FeatureSet     interface{}
+		FeatureSet     any
 		ErrorAssertion assert.ErrorAssertionFunc
-		Expected       interface{}
+		Expected       any
 	}{
 		"default": {
 			Input:          []string{"header_legacy"},
@@ -132,7 +132,7 @@ func TestString(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		FeatureSet interface{}
+		FeatureSet any
 		Expected   string
 	}{
 		"default": {

--- a/private/ca/config/pemsymmetrickey.go
+++ b/private/ca/config/pemsymmetrickey.go
@@ -56,6 +56,6 @@ func NewPEMSymmetricKey(path string) *PEMSymmetricKey {
 	}
 }
 
-func parsePEMSymmetricKey(b []byte) (interface{}, error) {
+func parsePEMSymmetricKey(b []byte) (any, error) {
 	return scrypto.ParsePEMSymmetricKey(b)
 }

--- a/private/ca/renewal/main_test.go
+++ b/private/ca/renewal/main_test.go
@@ -109,7 +109,7 @@ func genCrypto(t *testing.T) string {
 	return dir
 }
 
-func writeKey(t *testing.T, file string, key interface{}) {
+func writeKey(t *testing.T, file string, key any) {
 	t.Helper()
 	raw, err := x509.MarshalPKCS8PrivateKey(key)
 	require.NoError(t, err)

--- a/private/config/config.go
+++ b/private/config/config.go
@@ -161,12 +161,12 @@ func InitAll(defaulters ...Defaulter) {
 }
 
 // Decode decodes a raw config.
-func Decode(raw []byte, cfg interface{}) error {
+func Decode(raw []byte, cfg any) error {
 	return toml.NewDecoder(bytes.NewReader(raw)).DisallowUnknownFields().Decode(cfg)
 }
 
 // LoadFile loads the config from file.
-func LoadFile(file string, cfg interface{}) error {
+func LoadFile(file string, cfg any) error {
 	raw, err := os.ReadFile(file)
 	if err != nil {
 		return err
@@ -194,7 +194,7 @@ func OverrideName(s Sampler, name string) Sampler {
 
 type formatDataSampler struct {
 	Sampler
-	data []interface{}
+	data []any
 }
 
 func (s formatDataSampler) Sample(dst io.Writer, path Path, ctx CtxMap) {
@@ -205,7 +205,7 @@ func (s formatDataSampler) Sample(dst io.Writer, path Path, ctx CtxMap) {
 
 // FormatData creates a sampler that will call fmt.Sprintf on the string returned
 // by s.Sample using the supplied argument information.
-func FormatData(s Sampler, a ...interface{}) Sampler {
+func FormatData(s Sampler, a ...any) Sampler {
 	return formatDataSampler{
 		Sampler: s,
 		data:    a,

--- a/private/file/periodicview.go
+++ b/private/file/periodicview.go
@@ -46,24 +46,24 @@ type PeriodicView struct {
 	taskRunner *periodic.Runner
 	running    bool
 	closed     bool
-	obj        interface{}
+	obj        any
 	err        error
 }
 
 // Parser converts a slice of bytes into an object.
 type Parser interface {
-	Parse(b []byte) (interface{}, error)
+	Parse(b []byte) (any, error)
 }
 
 // ParserFunc is a convenience type for using typical Go parsers as the Parser
 // type in this package.
-type ParserFunc func(b []byte) (interface{}, error)
+type ParserFunc func(b []byte) (any, error)
 
-func (f ParserFunc) Parse(b []byte) (interface{}, error) {
+func (f ParserFunc) Parse(b []byte) (any, error) {
 	return f(b)
 }
 
-func (v *PeriodicView) Get() (interface{}, error) {
+func (v *PeriodicView) Get() (any, error) {
 	v.mu.Lock()
 	defer v.mu.Unlock()
 
@@ -97,7 +97,7 @@ func (v *PeriodicView) Get() (interface{}, error) {
 	return v.obj, v.err
 }
 
-func (v *PeriodicView) invokeParserLocked(b []byte) (interface{}, error) {
+func (v *PeriodicView) invokeParserLocked(b []byte) (any, error) {
 	if v.Parser == nil {
 		return b, nil
 	}

--- a/private/file/periodicview_test.go
+++ b/private/file/periodicview_test.go
@@ -164,7 +164,7 @@ type syncFileView struct {
 	Path string
 }
 
-func (v *syncFileView) Get() (interface{}, error) {
+func (v *syncFileView) Get() (any, error) {
 	b, err := os.ReadFile(v.Path)
 	if err != nil {
 		return nil, err
@@ -191,7 +191,7 @@ type cachedFileView struct {
 	view *file.PeriodicView
 }
 
-func (v *cachedFileView) Get() (interface{}, error) {
+func (v *cachedFileView) Get() (any, error) {
 	b, err := v.view.Get()
 	if err != nil {
 		return nil, err
@@ -219,7 +219,7 @@ func benchmarkView(b *testing.B, view file.View) {
 	}
 }
 
-func pemKeyParse(b []byte) (interface{}, error) {
+func pemKeyParse(b []byte) (any, error) {
 	// Change the return type from []byte to interface{}
 	return scrypto.ParsePEMSymmetricKey(b)
 }

--- a/private/file/view.go
+++ b/private/file/view.go
@@ -27,5 +27,5 @@ type View interface {
 	// However, Get implementations are free to return different objects or
 	// return references to the same object, so callers should not assume
 	// they see the same object across different calls.
-	Get() (interface{}, error)
+	Get() (any, error)
 }

--- a/private/mgmtapi/segments/api/api_test.go
+++ b/private/mgmtapi/segments/api/api_test.go
@@ -174,7 +174,7 @@ func TestAPI(t *testing.T) {
 					gomock.Any(),
 					gomock.Any(),
 					gomock.Any()).AnyTimes().DoAndReturn(
-					func(_ interface{},
+					func(_ any,
 						msg []byte,
 						associatedData ...[]byte) (*cryptopb.SignedMessage, error) {
 						inputHdr := &cryptopb.Header{

--- a/private/path/pathpol/acl.go
+++ b/private/path/pathpol/acl.go
@@ -69,11 +69,11 @@ func (a *ACL) UnmarshalJSON(b []byte) error {
 	return validateACL(a.Entries)
 }
 
-func (a *ACL) MarshalYAML() (interface{}, error) {
+func (a *ACL) MarshalYAML() (any, error) {
 	return a.Entries, nil
 }
 
-func (a *ACL) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (a *ACL) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal(&a.Entries); err != nil {
 		return err
 	}
@@ -168,11 +168,11 @@ func (ae *ACLEntry) UnmarshalJSON(b []byte) error {
 	return ae.LoadFromString(str)
 }
 
-func (ae *ACLEntry) MarshalYAML() (interface{}, error) {
+func (ae *ACLEntry) MarshalYAML() (any, error) {
 	return ae.String(), nil
 }
 
-func (ae *ACLEntry) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (ae *ACLEntry) UnmarshalYAML(unmarshal func(any) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {

--- a/private/path/pathpol/sequence.go
+++ b/private/path/pathpol/sequence.go
@@ -122,11 +122,11 @@ func (s *Sequence) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (s *Sequence) MarshalYAML() (interface{}, error) {
+func (s *Sequence) MarshalYAML() (any, error) {
 	return s.srcstr, nil
 }
 
-func (s *Sequence) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *Sequence) UnmarshalYAML(unmarshal func(any) error) error {
 	var str string
 	err := unmarshal(&str)
 	if err != nil {
@@ -145,7 +145,7 @@ type errorListener struct {
 	msg string
 }
 
-func (l *errorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol interface{}, line,
+func (l *errorListener) SyntaxError(recognizer antlr.Recognizer, offendingSymbol any, line,
 	column int, msg string, e antlr.RecognitionException) {
 
 	//fmt.Printf("Error: %s\n", msg)

--- a/private/ringbuf/ringbuf.go
+++ b/private/ringbuf/ringbuf.go
@@ -20,9 +20,9 @@ import (
 	"github.com/scionproto/scion/private/ringbuf/internal/metrics"
 )
 
-type Entry interface{}
+type Entry any
 type EntryList []Entry
-type NewEntryF func() interface{}
+type NewEntryF func() any
 
 // Ring is a classic generic ring buffer on top of a fixed-sized slice. It is thread-safe.
 type Ring struct {

--- a/private/service/statuspages.go
+++ b/private/service/statuspages.go
@@ -125,7 +125,7 @@ func (s StatusPages) Register(serveMux *http.ServeMux, elemId string) error {
 }
 
 // NewConfigStatusPage returns a page with the specified TOML config.
-func NewConfigStatusPage(config interface{}) StatusPage {
+func NewConfigStatusPage(config any) StatusPage {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		var buf bytes.Buffer
 		err := toml.NewEncoder(&buf).Encode(config)

--- a/private/storage/beacon/sqlite/db.go
+++ b/private/storage/beacon/sqlite/db.go
@@ -249,8 +249,8 @@ func (e *executor) DeleteBeacon(ctx context.Context, partialID string) error {
 	return err
 }
 
-func (e *executor) buildQuery(params *storagebeacon.QueryParams) (string, []interface{}) {
-	var args []interface{}
+func (e *executor) buildQuery(params *storagebeacon.QueryParams) (string, []any) {
+	var args []any
 	query := "SELECT DISTINCT RowID, LastUpdated, Usage, Beacon, InIntfID FROM Beacons"
 	if params == nil {
 		return query, args

--- a/private/storage/db/errors.go
+++ b/private/storage/db/errors.go
@@ -32,27 +32,27 @@ var (
 	ErrTx = serrors.New("db: transaction error")
 )
 
-func NewTxError(msg common.ErrMsg, err error, logCtx ...interface{}) error {
+func NewTxError(msg common.ErrMsg, err error, logCtx ...any) error {
 	return serrors.JoinNoStack(ErrTx, err,
-		append([]interface{}{"detailMsg", msg}, logCtx...)...)
+		append([]any{"detailMsg", msg}, logCtx...)...)
 }
 
-func NewInputDataError(msg common.ErrMsg, err error, logCtx ...interface{}) error {
+func NewInputDataError(msg common.ErrMsg, err error, logCtx ...any) error {
 	return serrors.JoinNoStack(ErrInvalidInputData, err,
-		append([]interface{}{"detailMsg", msg}, logCtx...)...)
+		append([]any{"detailMsg", msg}, logCtx...)...)
 }
 
-func NewDataError(msg common.ErrMsg, err error, logCtx ...interface{}) error {
+func NewDataError(msg common.ErrMsg, err error, logCtx ...any) error {
 	return serrors.JoinNoStack(ErrDataInvalid, err,
-		append([]interface{}{"detailMsg", msg}, logCtx...)...)
+		append([]any{"detailMsg", msg}, logCtx...)...)
 }
 
-func NewReadError(msg common.ErrMsg, err error, logCtx ...interface{}) error {
+func NewReadError(msg common.ErrMsg, err error, logCtx ...any) error {
 	return serrors.JoinNoStack(ErrReadFailed, err,
-		append([]interface{}{"detailMsg", msg}, logCtx...)...)
+		append([]any{"detailMsg", msg}, logCtx...)...)
 }
 
-func NewWriteError(msg common.ErrMsg, err error, logCtx ...interface{}) error {
+func NewWriteError(msg common.ErrMsg, err error, logCtx ...any) error {
 	return serrors.JoinNoStack(ErrWriteFailed, err,
-		append([]interface{}{"detailMsg", msg}, logCtx...)...)
+		append([]any{"detailMsg", msg}, logCtx...)...)
 }

--- a/private/storage/db/sqler.go
+++ b/private/storage/db/sqler.go
@@ -26,9 +26,9 @@ var _ Sqler = (*sql.Tx)(nil)
 
 // Sqler contains the common functions of *sql.DB and *sql.Tx.
 type Sqler interface {
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
-	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 // DoInTx executes the given action in a transaction. If db is already a transaction the action is

--- a/private/storage/path/path.go
+++ b/private/storage/path/path.go
@@ -23,7 +23,7 @@ import (
 
 type GroupIDs []uint64
 
-func (g *GroupIDs) Scan(src interface{}) error {
+func (g *GroupIDs) Scan(src any) error {
 	var group string
 	switch src := src.(type) {
 	case string:
@@ -46,7 +46,7 @@ func (g *GroupIDs) Scan(src interface{}) error {
 
 type SegTypes []seg.Type
 
-func (t *SegTypes) Scan(src interface{}) error {
+func (t *SegTypes) Scan(src any) error {
 	var group string
 	switch src := src.(type) {
 	case string:

--- a/private/storage/path/sqlite/sqlite.go
+++ b/private/storage/path/sqlite/sqlite.go
@@ -439,8 +439,8 @@ func (e *executor) Get(ctx context.Context, params *query.Params) (query.Results
 	return res, nil
 }
 
-func (e *executor) buildQuery(params *query.Params) (string, []interface{}) {
-	var args []interface{}
+func (e *executor) buildQuery(params *query.Params) (string, []any) {
+	var args []any
 	query := []string{
 		"SELECT DISTINCT s.RowID, s.Segment, s.LastUpdated, group_concat(DISTINCT t.Type), " +
 			"group_concat(DISTINCT h.GroupID) FROM Segments s",

--- a/private/storage/trust/sqlite/db.go
+++ b/private/storage/trust/sqlite/db.go
@@ -88,7 +88,7 @@ func (e *executor) SignedTRC(ctx context.Context, id cppki.TRCID) (cppki.SignedT
 	sqlQuery := `SELECT trc FROM trcs WHERE isd_id=$1
 				ORDER BY base DESC, serial DESC
 				LIMIT 1`
-	args := []interface{}{id.ISD}
+	args := []any{id.ISD}
 	if !id.Base.IsLatest() {
 		sqlQuery = `SELECT trc FROM trcs WHERE isd_id=$1 AND base=$2 AND serial=$3`
 		args = append(args, id.Base, id.Serial)
@@ -150,7 +150,7 @@ func (e *executor) Chains(ctx context.Context,
 	defer e.RUnlock()
 
 	sqlQuery := []string{"SELECT as_cert, ca_cert FROM chains"}
-	var args []interface{}
+	var args []any
 	var filters []string
 
 	if len(query.SubjectKeyID) != 0 {
@@ -274,7 +274,7 @@ func (e *executor) SignedTRCs(ctx context.Context,
 	defer e.RUnlock()
 
 	var filter string
-	var args []interface{}
+	var args []any
 	if len(query.ISD) > 0 {
 		subQ := make([]string, 0, len(query.ISD))
 		for _, ISD := range query.ISD {

--- a/private/svc/resolver_test.go
+++ b/private/svc/resolver_test.go
@@ -73,7 +73,7 @@ func TestResolver(t *testing.T) {
 		mockRoundTripper := mock_svc.NewMockRoundTripper(ctrl)
 		mockRoundTripper.EXPECT().RoundTrip(gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any()).Do(
-			func(_, _ interface{}, pkt *snet.Packet, _ interface{}) {
+			func(_, _ any, pkt *snet.Packet, _ any) {
 				pld := pkt.Payload.(snet.UDPPayload)
 				require.NoError(t, proto.Unmarshal(pld.Payload, &cppb.ServiceResolutionRequest{}))
 			})

--- a/private/topology/interface.go
+++ b/private/topology/interface.go
@@ -365,7 +365,7 @@ func (t *topologyS) Writable() *RWTopology {
 	return t.Topology
 }
 
-func Digest(t interface{}) ([]byte, error) {
+func Digest(t any) ([]byte, error) {
 	h := sha256.New()
 	enc := json.NewEncoder(h)
 	if err := enc.Encode(t); err != nil {

--- a/private/trust/db_inspector.go
+++ b/private/trust/db_inspector.go
@@ -167,7 +167,7 @@ func (i CachingInspector) HasAttributes(ctx context.Context, ia addr.IA,
 	return hasAttributes, nil
 }
 
-func (i CachingInspector) cacheGet(key string, reqType string) (interface{}, bool) {
+func (i CachingInspector) cacheGet(key string, reqType string) (any, bool) {
 	if i.Cache == nil {
 		return nil, false
 	}
@@ -185,7 +185,7 @@ func (i CachingInspector) cacheGet(key string, reqType string) (interface{}, boo
 	return result, ok
 }
 
-func (i CachingInspector) cacheAdd(key string, value interface{}, d time.Duration) {
+func (i CachingInspector) cacheAdd(key string, value any, d time.Duration) {
 	if i.Cache == nil {
 		return
 	}

--- a/private/trust/main_test.go
+++ b/private/trust/main_test.go
@@ -75,7 +75,7 @@ type chainQueryMatcher struct {
 	skid []byte
 }
 
-func (m chainQueryMatcher) Matches(x interface{}) bool {
+func (m chainQueryMatcher) Matches(x any) bool {
 	v, ok := x.(trust.ChainQuery)
 	if !ok {
 		return false
@@ -89,7 +89,7 @@ func (m chainQueryMatcher) String() string {
 
 type ctxMatcher struct{}
 
-func (m ctxMatcher) Matches(x interface{}) bool {
+func (m ctxMatcher) Matches(x any) bool {
 	_, ok := x.(context.Context)
 	return ok
 }

--- a/private/trust/options_test.go
+++ b/private/trust/options_test.go
@@ -27,7 +27,7 @@ type OptionsMatcher struct {
 	Server        net.Addr
 }
 
-func (m OptionsMatcher) Matches(x interface{}) bool {
+func (m OptionsMatcher) Matches(x any) bool {
 	var o options
 
 	if opts, ok := x.([]Option); ok {

--- a/private/trust/verifier.go
+++ b/private/trust/verifier.go
@@ -161,7 +161,7 @@ func (v *Verifier) getChains(ctx context.Context, q ChainQuery) ([][]*x509.Certi
 	return chains, nil
 }
 
-func (v *Verifier) cacheGet(key string, reqType string) (interface{}, bool) {
+func (v *Verifier) cacheGet(key string, reqType string) (any, bool) {
 	if v.Cache == nil {
 		return nil, false
 	}
@@ -179,7 +179,7 @@ func (v *Verifier) cacheGet(key string, reqType string) (interface{}, bool) {
 	return result, ok
 }
 
-func (v *Verifier) cacheAdd(key string, value interface{}, d time.Duration) {
+func (v *Verifier) cacheAdd(key string, value any, d time.Duration) {
 	if v.Cache == nil {
 		return
 	}

--- a/scion-pki/certs/certformat.go
+++ b/scion-pki/certs/certformat.go
@@ -44,7 +44,7 @@ type formatBuffer struct {
 }
 
 // Writef writes a string formated using fmt.Sprintf.
-func (b *formatBuffer) Writef(format string, args ...interface{}) (int, error) {
+func (b *formatBuffer) Writef(format string, args ...any) (int, error) {
 	return b.Buffer.WriteString(fmt.Sprintf(format, args...))
 }
 
@@ -202,7 +202,7 @@ func getProvisioner(cert *x509.Certificate) *provisioner {
 	return nil
 }
 
-func getPublicKeyAlgorithm(algorithm x509.PublicKeyAlgorithm, key interface{}) string {
+func getPublicKeyAlgorithm(algorithm x509.PublicKeyAlgorithm, key any) string {
 	var params string
 	switch pk := key.(type) {
 	case *ecdsa.PublicKey:

--- a/scion-pki/certs/certinfo.go
+++ b/scion-pki/certs/certinfo.go
@@ -195,7 +195,7 @@ func printVersion(version int, buf *bytes.Buffer) {
 	buf.WriteString(fmt.Sprintf("%8sVersion: %d (%#x)\n", "", version, hexVersion))
 }
 
-func printSubjectInformation(subj *pkix.Name, pkAlgo x509.PublicKeyAlgorithm, pk interface{}, buf *bytes.Buffer) error {
+func printSubjectInformation(subj *pkix.Name, pkAlgo x509.PublicKeyAlgorithm, pk any, buf *bytes.Buffer) error {
 	buf.WriteString(fmt.Sprintf("%8sSubject:", ""))
 	if len(subj.Names) > 0 {
 		buf.WriteString(" ")

--- a/scion-pki/certs/renew.go
+++ b/scion-pki/certs/renew.go
@@ -203,10 +203,10 @@ The template is expressed in JSON. A valid example::
 		RunE: func(cmd *cobra.Command, args []string) error {
 			certFile := args[0]
 			keyFile := args[1]
-			printErr := func(f string, ctx ...interface{}) {
+			printErr := func(f string, ctx ...any) {
 				fmt.Fprintf(cmd.ErrOrStderr(), f, ctx...)
 			}
-			printf := func(f string, ctx ...interface{}) {
+			printf := func(f string, ctx ...any) {
 				fmt.Fprintf(cmd.OutOrStdout(), f, ctx...)
 			}
 

--- a/scion-pki/cmd/scion-pki/kms.go
+++ b/scion-pki/cmd/scion-pki/kms.go
@@ -88,7 +88,7 @@ https://smallstep.com/docs/step-ca/cryptographic-protection.
 }
 
 // tmpl executes the given template text on data, writing the result to w.
-func tmpl(w io.Writer, text string, data interface{}) error {
+func tmpl(w io.Writer, text string, data any) error {
 	t := template.New("top")
 	t.Funcs(templateFuncs)
 	template.Must(t.Parse(text))

--- a/scion-pki/trcs/inspect.go
+++ b/scion-pki/trcs/inspect.go
@@ -99,7 +99,7 @@ return an error if parts of a TRC fail to decode, enable the strict mode.
 	return cmd
 }
 
-func getEncoder(w io.Writer, format string) (interface{ Encode(v interface{}) error }, error) {
+func getEncoder(w io.Writer, format string) (interface{ Encode(v any) error }, error) {
 	switch format {
 	case "yaml", "yml":
 		return yaml.NewEncoder(w), nil

--- a/scion/cmd/scion/common.go
+++ b/scion/cmd/scion/common.go
@@ -63,14 +63,14 @@ func getHops(path snet.Path) []Hop {
 
 // getPrintf returns a printf function for the "human" formatting flag and an empty one for machine
 // readable format flags
-func getPrintf(output string, writer io.Writer) (func(format string, ctx ...interface{}), error) {
+func getPrintf(output string, writer io.Writer) (func(format string, ctx ...any), error) {
 	switch output {
 	case "human":
-		return func(format string, ctx ...interface{}) {
+		return func(format string, ctx ...any) {
 			fmt.Fprintf(writer, format, ctx...)
 		}, nil
 	case "yaml", "json":
-		return func(format string, ctx ...interface{}) {}, nil
+		return func(format string, ctx ...any) {}, nil
 	default:
 		return nil, serrors.New("format not supported", "format", output)
 	}
@@ -86,7 +86,7 @@ func (d durationMillis) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.MillisRounded())
 }
 
-func (d durationMillis) MarshalYAML() (interface{}, error) {
+func (d durationMillis) MarshalYAML() (any, error) {
 	return d.MillisRounded(), nil
 }
 

--- a/tools/buildkite/buildkite.go
+++ b/tools/buildkite/buildkite.go
@@ -158,13 +158,13 @@ func (d *Downloader) downloadArtifact(artifact buildkite.Artifact, file string) 
 
 }
 
-func (d *Downloader) info(format string, ctx ...interface{}) {
+func (d *Downloader) info(format string, ctx ...any) {
 	if d.StdOut != nil {
 		fmt.Fprintf(d.StdOut, format, ctx...)
 	}
 }
 
-func (d *Downloader) error(format string, ctx ...interface{}) {
+func (d *Downloader) error(format string, ctx ...any) {
 	if d.StdErr != nil {
 		fmt.Fprintf(d.StdErr, format, ctx...)
 	}

--- a/tools/integration/integrationlib/common.go
+++ b/tools/integration/integrationlib/common.go
@@ -185,7 +185,7 @@ func Done(src, dst addr.IA) {
 }
 
 // LogFatal logs a critical error and exits with 1
-func LogFatal(msg string, a ...interface{}) {
+func LogFatal(msg string, a ...any) {
 	log.Error(msg, a...)
 	os.Exit(1)
 }

--- a/tools/lint/lint.go
+++ b/tools/lint/lint.go
@@ -59,7 +59,7 @@ func RenderList(fset *token.FileSet, list []ast.Expr) string {
 }
 
 // Render renders the the expression.
-func Render(fset *token.FileSet, x interface{}) string {
+func Render(fset *token.FileSet, x any) string {
 	var buf bytes.Buffer
 	if err := printer.Fprint(&buf, fset, x); err != nil {
 		panic(err)

--- a/tools/lint/log/log.go
+++ b/tools/lint/log/log.go
@@ -36,7 +36,7 @@ var goCallFilter = []ast.Node{
 	(*ast.GoStmt)(nil),
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
 	inspect.Preorder(goCallFilter, func(n ast.Node) {
 		goStmt := n.(*ast.GoStmt)

--- a/tools/lint/logctxcheck/analyzer.go
+++ b/tools/lint/logctxcheck/analyzer.go
@@ -35,7 +35,7 @@ var Analyzer = &analysis.Analyzer{
 	RunDespiteErrors: true,
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	for _, file := range pass.Files {
 		if _, ok := lint.FindPackageNames(file)[importPath]; !ok {
 			continue

--- a/tools/lint/maincheck/maincheck.go
+++ b/tools/lint/maincheck/maincheck.go
@@ -36,7 +36,7 @@ var Analyzer = &analysis.Analyzer{
 	RunDespiteErrors: true,
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	for _, file := range pass.Files {
 		// If this is not a main package, we can exit early.
 		if file.Name.Name != "main" {

--- a/tools/lint/serrorscheck/analyzer.go
+++ b/tools/lint/serrorscheck/analyzer.go
@@ -35,7 +35,7 @@ var Analyzer = &analysis.Analyzer{
 	RunDespiteErrors: true,
 }
 
-func run(pass *analysis.Pass) (interface{}, error) {
+func run(pass *analysis.Pass) (any, error) {
 	for _, file := range pass.Files {
 		_, ok := lint.FindPackageNames(file)[importPath]
 		if !ok {


### PR DESCRIPTION
This is the result of running:

```sh
find . -name "*.go" ! -exec grep -q "// Code generated" {} \; -exec gofmt -w -r 'interface{} -> any' {} +
```

It safely replaces all usage of `interface{}` with `any`, excluding generated files and is hence a purely **cosmetic change**.

Also see https://github.com/golang/go/issues/49884