### PR TITLE
refactor: replace deprecated grpc packages

### DIFF
--- a/control/trust/grpc/BUILD.bazel
+++ b/control/trust/grpc/BUILD.bazel
@@ -36,8 +36,8 @@ go_test(
         "//pkg/addr:go_default_library",
         "//pkg/proto/control_plane:go_default_library",
         "//pkg/scrypto/cppki:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
 )

--- a/control/trust/grpc/proto_test.go
+++ b/control/trust/grpc/proto_test.go
@@ -19,9 +19,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	trustgrpc "github.com/scionproto/scion/control/trust/grpc"
 	"github.com/scionproto/scion/pkg/addr"
@@ -31,10 +31,8 @@ import (
 
 func TestReqToChainQuery(t *testing.T) {
 	now := time.Now().UTC()
-	validUntil, err := ptypes.TimestampProto(now)
-	require.NoError(t, err)
-	validSince, err := ptypes.TimestampProto(now.Add(-time.Hour))
-	require.NoError(t, err)
+	validUntil := timestamppb.New(now)
+	validSince := timestamppb.New(now.Add(-time.Hour))
 
 	req := &cppb.ChainsRequest{
 		IsdAs:             uint64(addr.MustParseIA("1-ff00:0:110")),

--- a/daemon/drkey/grpc/BUILD.bazel
+++ b/daemon/drkey/grpc/BUILD.bazel
@@ -32,7 +32,7 @@ go_test(
         "//pkg/proto/control_plane:go_default_library",
         "//pkg/proto/control_plane/mock_control_plane:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_stretchr_testify//require:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
 )

--- a/daemon/drkey/grpc/fetching_test.go
+++ b/daemon/drkey/grpc/fetching_test.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	sd_drkey "github.com/scionproto/scion/daemon/drkey"
 	sd_grpc "github.com/scionproto/scion/daemon/drkey/grpc"
@@ -38,10 +38,8 @@ func TestGetHostHost(t *testing.T) {
 	defer ctrl.Finish()
 
 	now := time.Now().UTC()
-	epochBegin, err := ptypes.TimestampProto(now)
-	require.NoError(t, err)
-	epochEnd, err := ptypes.TimestampProto(now.Add(24 * time.Hour))
-	require.NoError(t, err)
+	epochBegin := timestamppb.New(now)
+	epochEnd := timestamppb.New(now.Add(24 * time.Hour))
 
 	resp := &cppb.DRKeyHostHostResponse{
 		Key:        xtest.MustParseHexString("c584cad32613547c64823c756651b6f5"),
@@ -65,6 +63,6 @@ func TestGetHostHost(t *testing.T) {
 	}
 
 	meta := drkey.HostHostMeta{}
-	_, err = fetcher.HostHostKey(context.Background(), meta)
+	_, err := fetcher.HostHostKey(context.Background(), meta)
 	require.NoError(t, err)
 }

--- a/daemon/internal/servers/BUILD.bazel
+++ b/daemon/internal/servers/BUILD.bazel
@@ -27,10 +27,10 @@ go_library(
         "//private/revcache:go_default_library",
         "//private/topology:go_default_library",
         "//private/trust:go_default_library",
-        "@com_github_golang_protobuf//ptypes/duration",
-        "@com_github_golang_protobuf//ptypes/timestamp",
         "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
         "@org_golang_x_sync//singleflight:go_default_library",
     ],
 )

--- a/daemon/internal/servers/grpc.go
+++ b/daemon/internal/servers/grpc.go
@@ -178,7 +178,7 @@ func pathToPB(path snet.Path) *sdpb.Path {
 		},
 		Interfaces:   interfaces,
 		Mtu:          uint32(meta.MTU),
-		Expiration:   timestamppb.New(meta.Expiry.Truncate(time.Second)),
+		Expiration:   &timestamppb.Timestamp{Seconds: meta.Expiry.Unix()},
 		Latency:      latency,
 		Bandwidth:    meta.Bandwidth,
 		Geo:          geo,

--- a/daemon/internal/servers/grpc.go
+++ b/daemon/internal/servers/grpc.go
@@ -20,11 +20,11 @@ import (
 	"net"
 	"time"
 
-	durationpb "github.com/golang/protobuf/ptypes/duration"
-	timestamppb "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/opentracing/opentracing-go"
 	"golang.org/x/sync/singleflight"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	drkey_daemon "github.com/scionproto/scion/daemon/drkey"
 	"github.com/scionproto/scion/daemon/fetcher"
@@ -178,7 +178,7 @@ func pathToPB(path snet.Path) *sdpb.Path {
 		},
 		Interfaces:   interfaces,
 		Mtu:          uint32(meta.MTU),
-		Expiration:   &timestamppb.Timestamp{Seconds: meta.Expiry.Unix()},
+		Expiration:   timestamppb.New(meta.Expiry.Truncate(time.Second)),
 		Latency:      latency,
 		Bandwidth:    meta.Bandwidth,
 		Geo:          geo,

--- a/demo/drkey/BUILD.bazel
+++ b/demo/drkey/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//private/app/flag:go_default_library",
         "@com_github_spf13_pflag//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials/insecure:go_default_library",
         "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
 )

--- a/demo/drkey/main.go
+++ b/demo/drkey/main.go
@@ -23,6 +23,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/scionproto/scion/pkg/addr"
@@ -270,7 +271,9 @@ func (s Server) FetchSV(
 	}
 
 	// Contact CS directly for SV
-	conn, err := grpc.DialContext(ctx, cs[0], grpc.WithInsecure())
+	conn, err := grpc.DialContext(
+		ctx, cs[0], grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	if err != nil {
 		return drkey.SecretValue{}, serrors.Wrap("dialing control service", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/go-chi/cors v1.2.1
 	github.com/golang/mock v1.7.0-rc.1
-	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gopacket v1.1.19
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/pkg/experimental/hiddenpath/grpc/BUILD.bazel
+++ b/pkg/experimental/hiddenpath/grpc/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//pkg/snet:go_default_library",
         "//private/segment/segfetcher:go_default_library",
         "//private/segment/verifier:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//peer:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",

--- a/pkg/experimental/hiddenpath/grpc/discovery.go
+++ b/pkg/experimental/hiddenpath/grpc/discovery.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/scionproto/scion/pkg/experimental/hiddenpath"
 	"github.com/scionproto/scion/pkg/grpc"
-	libgrpc "github.com/scionproto/scion/pkg/grpc"
 	"github.com/scionproto/scion/pkg/private/serrors"
 	dspb "github.com/scionproto/scion/pkg/proto/discovery"
 )
@@ -28,7 +27,7 @@ import (
 // Discoverer can be used to discover remote hidden path instances.
 type Discoverer struct {
 	// Dialer dials a new gRPC connection.
-	Dialer libgrpc.Dialer
+	Dialer grpc.Dialer
 }
 
 // Discover discovers hidden path services at the discovery service that is

--- a/pkg/experimental/hiddenpath/grpc/requester.go
+++ b/pkg/experimental/hiddenpath/grpc/requester.go
@@ -18,8 +18,8 @@ import (
 	"context"
 	"net"
 
-	"github.com/golang/protobuf/proto"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/scionproto/scion/pkg/experimental/hiddenpath"
 	libgrpc "github.com/scionproto/scion/pkg/grpc"

--- a/pkg/grpc/BUILD.bazel
+++ b/pkg/grpc/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "@com_github_uber_jaeger_client_go//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
+        "@org_golang_google_grpc//credentials/insecure:go_default_library",
         "@org_golang_google_grpc//resolver:go_default_library",
         "@org_golang_google_grpc//resolver/manual:go_default_library",
     ],

--- a/pkg/grpc/dialer.go
+++ b/pkg/grpc/dialer.go
@@ -21,6 +21,7 @@ import (
 
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
 
@@ -43,7 +44,7 @@ type SimpleDialer struct{}
 // Dial dials the address by converting it to a string.
 func (SimpleDialer) Dial(ctx context.Context, address net.Addr) (*grpc.ClientConn, error) {
 	return grpc.DialContext(ctx, address.String(),
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithBlock(),
 		UnaryClientInterceptor(),
 		StreamClientInterceptor(),
@@ -106,7 +107,7 @@ func (t *TCPDialer) Dial(ctx context.Context, dst net.Addr) (*grpc.ClientConn, e
 		r.InitialState(resolver.State{Addresses: targets})
 		return grpc.DialContext(ctx, r.Scheme()+":///"+v.SVC.BaseString(),
 			grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
-			grpc.WithInsecure(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithResolvers(r),
 			UnaryClientInterceptor(),
 			StreamClientInterceptor(),
@@ -114,7 +115,7 @@ func (t *TCPDialer) Dial(ctx context.Context, dst net.Addr) (*grpc.ClientConn, e
 	}
 
 	return grpc.DialContext(ctx, dst.String(),
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		UnaryClientInterceptor(),
 		StreamClientInterceptor(),
 	)

--- a/pkg/private/xtest/grpc.go
+++ b/pkg/private/xtest/grpc.go
@@ -89,9 +89,11 @@ func (s *GRPCService) Start(t *testing.T) {
 }
 
 func (s *GRPCService) Dial(ctx context.Context, addr net.Addr) (*grpc.ClientConn, error) {
-	transportSecurity := grpc.WithInsecure()
+	var transportSecurity grpc.DialOption
 	if s.clientCredentials != nil {
 		transportSecurity = grpc.WithTransportCredentials(s.clientCredentials)
+	} else {
+		transportSecurity = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}
 	return grpc.DialContext(ctx, addr.String(),
 		grpc.WithContextDialer(

--- a/pkg/scrypto/signed/BUILD.bazel
+++ b/pkg/scrypto/signed/BUILD.bazel
@@ -11,9 +11,8 @@ go_library(
     deps = [
         "//pkg/private/serrors:go_default_library",
         "//pkg/proto/crypto:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
-        "@com_github_golang_protobuf//ptypes/timestamp",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
 )
 

--- a/pkg/snet/squic/BUILD.bazel
+++ b/pkg/snet/squic/BUILD.bazel
@@ -27,5 +27,6 @@ go_test(
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials/insecure:go_default_library",
     ],
 )

--- a/pkg/snet/squic/net_test.go
+++ b/pkg/snet/squic/net_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	cppb "github.com/scionproto/scion/pkg/proto/control_plane"
 	mock_cp "github.com/scionproto/scion/pkg/proto/control_plane/mock_control_plane"
@@ -78,7 +79,7 @@ func TestAcceptLoopParallelism(t *testing.T) {
 
 				dialer := connDialer(t)
 				conn, err := grpc.DialContext(ctx, "server",
-					grpc.WithInsecure(),
+					grpc.WithTransportCredentials(insecure.NewCredentials()),
 					grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 						return dialer.Dial(ctx, srvConn.LocalAddr())
 					}),
@@ -131,7 +132,7 @@ func TestGRPCQUIC(t *testing.T) {
 
 	dialer := connDialer(t)
 	conn, err := grpc.DialContext(context.Background(), "server",
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 			return dialer.Dial(ctx, srvConn.LocalAddr())
 		}),

--- a/private/trust/BUILD.bazel
+++ b/private/trust/BUILD.bazel
@@ -82,12 +82,12 @@ go_test(
         "//scion-pki/testcrypto:go_default_library",
         "//scion-pki/trcs:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
-        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_patrickmn_go_cache//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/testutil:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
     ],
 )
 

--- a/private/trust/grpc/BUILD.bazel
+++ b/private/trust/grpc/BUILD.bazel
@@ -20,8 +20,8 @@ go_library(
         "//private/tracing:go_default_library",
         "//private/trust:go_default_library",
         "//private/trust/internal/metrics:go_default_library",
-        "@com_github_golang_protobuf//ptypes/timestamp",
         "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
 )
 
@@ -47,7 +47,6 @@ go_test(
         "//private/trust/internal/metrics:go_default_library",
         "//scion-pki/testcrypto:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/private/trust/grpc/proto.go
+++ b/private/trust/grpc/proto.go
@@ -17,13 +17,12 @@ package grpc
 import (
 	"crypto/x509"
 
-	timestamppb "github.com/golang/protobuf/ptypes/timestamp"
-
 	"github.com/scionproto/scion/pkg/private/serrors"
 	cppb "github.com/scionproto/scion/pkg/proto/control_plane"
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
 	"github.com/scionproto/scion/private/trust"
 	trustmetrics "github.com/scionproto/scion/private/trust/internal/metrics"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func chainQueryToReq(query trust.ChainQuery) *cppb.ChainsRequest {

--- a/private/trust/grpc/proto.go
+++ b/private/trust/grpc/proto.go
@@ -17,12 +17,13 @@ package grpc
 import (
 	"crypto/x509"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/scionproto/scion/pkg/private/serrors"
 	cppb "github.com/scionproto/scion/pkg/proto/control_plane"
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
 	"github.com/scionproto/scion/private/trust"
 	trustmetrics "github.com/scionproto/scion/private/trust/internal/metrics"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func chainQueryToReq(query trust.ChainQuery) *cppb.ChainsRequest {

--- a/private/trust/grpc/proto_test.go
+++ b/private/trust/grpc/proto_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/scionproto/scion/pkg/addr"
@@ -44,11 +43,9 @@ func TestChainQueryToReq(t *testing.T) {
 	req := trustgrpc.ChainQueryToReq(query)
 	assert.Equal(t, uint64(query.IA), req.IsdAs)
 	assert.Equal(t, query.SubjectKeyID, req.SubjectKeyId)
-	validSince, err := ptypes.Timestamp(req.AtLeastValidSince)
-	assert.NoError(t, err)
+	validSince := req.AtLeastValidSince.AsTime()
 	assert.Equal(t, query.Validity.NotBefore, validSince)
-	validUntil, err := ptypes.Timestamp(req.AtLeastValidUntil)
-	assert.NoError(t, err)
+	validUntil := req.AtLeastValidUntil.AsTime()
 	assert.Equal(t, query.Validity.NotAfter, validUntil)
 }
 

--- a/private/trust/signer_test.go
+++ b/private/trust/signer_test.go
@@ -25,10 +25,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/scionproto/scion/pkg/addr"
 	cppb "github.com/scionproto/scion/pkg/proto/control_plane"


### PR DESCRIPTION
- replace deprecated `github.com/golang/protobuf` with `google.golang.org/protobuf`
- replace deprecated `ptypes.TimestampProto` from `github.com/golang/protobuf/ptypes` with `google.golang.org/protobuf/types/known/timestamppb`
- replace deprecated `grpc.WithInsecure()` with `google.golang.org/grpc/credentials/insecure`

Deprecation notice: https://pkg.go.dev/github.com/golang/protobuf