### PR TITLE
test: replace xtest.MustTempDir with t.TempDir

### DIFF
--- a/dist/test/BUILD.bazel
+++ b/dist/test/BUILD.bazel
@@ -26,7 +26,7 @@ sh_test(
     },
     tags = [
         "exclusive",
-        # "integration",
+        "integration",
     ],
 )
 

--- a/dist/test/BUILD.bazel
+++ b/dist/test/BUILD.bazel
@@ -26,7 +26,7 @@ sh_test(
     },
     tags = [
         "exclusive",
-        "integration",
+        # "integration",
     ],
 )
 

--- a/pkg/private/xtest/helpers.go
+++ b/pkg/private/xtest/helpers.go
@@ -108,20 +108,6 @@ func MustTempFileName(dir, prefix string) string {
 	return name
 }
 
-// MustTempDir creates a new temporary directory under dir with the specified
-// prefix. If the function encounters an error it panics. The second return
-// value is a clean-up function that can be called to recursively delete the
-// entire directory.
-func MustTempDir(dir, prefix string) (string, func()) {
-	name, err := os.MkdirTemp(dir, prefix)
-	if err != nil {
-		panic(err)
-	}
-	return name, func() {
-		os.RemoveAll(name)
-	}
-}
-
 // SanitizedName sanitizes the test name such that it can be used as a file name.
 func SanitizedName(t testing.TB) string {
 	return strings.NewReplacer(" ", "_", "/", "_", "\\", "_", ":", "_").Replace(t.Name())

--- a/pkg/scrypto/cppki/certs_test.go
+++ b/pkg/scrypto/cppki/certs_test.go
@@ -34,9 +34,9 @@ import (
 
 var updateNonDeterministic = xtest.UpdateNonDeterminsticGoldenFiles()
 
-func updateCert(goldenCert string) ([]byte, error) {
-	dir, cleanF := xtest.MustTempDir("", "safedir")
-	defer cleanF()
+func updateCert(t *testing.T, goldenCert string) ([]byte, error) {
+	t.Helper()
+	dir := t.TempDir()
 
 	cmd := exec.Command("sh", "-c", "./testdata/update_certs.sh")
 	cmd.Env = []string{
@@ -275,7 +275,7 @@ func TestValidateRoot(t *testing.T) {
 	testF := cppki.ValidateRoot
 
 	if *updateNonDeterministic {
-		out, err := updateCert(goldenCert)
+		out, err := updateCert(t, goldenCert)
 		require.NoError(t, err, string(out))
 		t.Logf("git add ./testdata/%s", goldenCert)
 		return
@@ -338,7 +338,7 @@ func TestValidateCA(t *testing.T) {
 	goldenCert := "cp-ca.crt"
 
 	if *updateNonDeterministic {
-		out, err := updateCert(goldenCert)
+		out, err := updateCert(t, goldenCert)
 		require.NoError(t, err, string(out))
 		t.Logf("git add ./testdata/%s", goldenCert)
 		return
@@ -386,7 +386,7 @@ func TestValidateAS(t *testing.T) {
 	goldenCert := "cp-as.crt"
 
 	if *updateNonDeterministic {
-		out, err := updateCert(goldenCert)
+		out, err := updateCert(t, goldenCert)
 		require.NoError(t, err, string(out))
 		t.Logf("git add ./testdata/%s", goldenCert)
 		return
@@ -542,7 +542,7 @@ func TestValidateRegular(t *testing.T) {
 	testF := cppki.ValidateRegular
 
 	if *updateNonDeterministic {
-		out, err := updateCert(goldenCert)
+		out, err := updateCert(t, goldenCert)
 		require.NoError(t, err, out)
 		t.Logf("git add ./testdata/%s", goldenCert)
 		return
@@ -597,7 +597,7 @@ func TestValidateSensitive(t *testing.T) {
 	testF := cppki.ValidateSensitive
 
 	if *updateNonDeterministic {
-		out, err := updateCert(goldenCert)
+		out, err := updateCert(t, goldenCert)
 		require.NoError(t, err, out)
 		t.Logf("git add ./testdata/%s", goldenCert)
 		return

--- a/pkg/scrypto/cppki/signed_trc_test.go
+++ b/pkg/scrypto/cppki/signed_trc_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/scionproto/scion/pkg/private/xtest"
 	"github.com/scionproto/scion/pkg/scrypto/cms/oid"
 	"github.com/scionproto/scion/pkg/scrypto/cms/protocol"
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
@@ -37,8 +36,7 @@ func TestUpdateTRCs(t *testing.T) {
 		t.Skip("Specify -update-non-deterministic to update TRCs")
 	}
 
-	dir, cleanF := xtest.MustTempDir("", "safedir")
-	defer cleanF()
+	dir := t.TempDir()
 
 	root, err := filepath.Abs("../../../../")
 	require.NoError(t, err)

--- a/private/storage/trust/fspersister/db_test.go
+++ b/private/storage/trust/fspersister/db_test.go
@@ -37,14 +37,12 @@ const (
 
 type DB struct {
 	storage.TrustDB
-	Dir     string
-	cleanup []func()
+	Dir string
 }
 
 func (db *DB) Prepare(t *testing.T, _ context.Context) {
-	dir, cleanupF := xtest.MustTempDir("", "tmp")
+	dir := t.TempDir()
 	db.prepare(t, dir)
-	db.cleanup = append(db.cleanup, cleanupF)
 }
 
 func (db *DB) prepare(t *testing.T, dbDir string) {
@@ -61,9 +59,6 @@ func (db *DB) prepare(t *testing.T, dbDir string) {
 func TestDB(t *testing.T) {
 	testDB := &DB{}
 	dbtest.Run(t, testDB, dbtest.Config{})
-	for _, cleanup := range testDB.cleanup {
-		cleanup()
-	}
 }
 
 func TestInsertTRCWithFSPersistenceBadCfg(t *testing.T) {
@@ -147,10 +142,6 @@ func TestInsertTRCWithFSPersistence(t *testing.T) {
 		persistedTRC := xtest.LoadTRC(t, persistedTRCPath)
 		require.Equal(t, SignedTRC, persistedTRC)
 	})
-
-	for _, cleanup := range testDB.cleanup {
-		cleanup()
-	}
 }
 
 func getModTime(t *testing.T, file string) int64 {

--- a/private/trust/dbtest/dbtest_test.go
+++ b/private/trust/dbtest/dbtest_test.go
@@ -31,8 +31,7 @@ func TestUpdateCrypto(t *testing.T) {
 		t.Skip("Only runs if -update-non-deterministic is specified")
 	}
 
-	dir, cleanF := xtest.MustTempDir("", "trustdbtest")
-	defer cleanF()
+	dir := t.TempDir()
 
 	testdata, err := filepath.Abs("./testdata")
 	require.NoError(t, err)

--- a/scion-pki/certs/create_test.go
+++ b/scion-pki/certs/create_test.go
@@ -27,15 +27,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/scionproto/scion/pkg/private/xtest"
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
 	"github.com/scionproto/scion/private/app/command"
 	"github.com/scionproto/scion/scion-pki/key"
 )
 
 func TestNewCreateCmd(t *testing.T) {
-	dir, cleanup := xtest.MustTempDir("", "certificate-create-test")
-	defer cleanup()
+	dir := t.TempDir()
 
 	now := time.Now()
 
@@ -439,8 +437,7 @@ func TestNewCreateCmd(t *testing.T) {
 }
 
 func TestNewCreateCmdCSR(t *testing.T) {
-	dir, cleanup := xtest.MustTempDir("", "certificate-create-csr-test")
-	defer cleanup()
+	dir := t.TempDir()
 
 	testCases := map[string]struct {
 		Prepare      func(t *testing.T)

--- a/scion-pki/conf/trc_test.go
+++ b/scion-pki/conf/trc_test.go
@@ -35,8 +35,7 @@ func TestUpdateCerts(t *testing.T) {
 		t.Skip("Specify -update-non-deterministic to update certs")
 		return
 	}
-	dir, cleanF := xtest.MustTempDir("", "safedir")
-	defer cleanF()
+	dir := t.TempDir()
 
 	cmd := exec.Command("sh", "-c", "./testdata/update_certs.sh")
 	cmd.Env = []string{

--- a/scion-pki/file/BUILD.bazel
+++ b/scion-pki/file/BUILD.bazel
@@ -13,7 +13,6 @@ go_test(
     srcs = ["file_test.go"],
     deps = [
         ":go_default_library",
-        "//pkg/private/xtest:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],

--- a/scion-pki/file/file_test.go
+++ b/scion-pki/file/file_test.go
@@ -21,13 +21,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/scionproto/scion/pkg/private/xtest"
 	"github.com/scionproto/scion/scion-pki/file"
 )
 
 func TestWriteFile(t *testing.T) {
-	dir, cleanup := xtest.MustTempDir("", "file-write-file-test")
-	defer cleanup()
+	dir := t.TempDir()
 
 	testCases := map[string]struct {
 		Prepare      func(t *testing.T)

--- a/scion-pki/key/BUILD.bazel
+++ b/scion-pki/key/BUILD.bazel
@@ -36,7 +36,6 @@ go_test(
     data = glob(["testdata/**"]),
     deps = [
         ":go_default_library",
-        "//pkg/private/xtest:go_default_library",
         "//private/app/command:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",

--- a/scion-pki/key/private_test.go
+++ b/scion-pki/key/private_test.go
@@ -21,14 +21,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/scionproto/scion/pkg/private/xtest"
 	"github.com/scionproto/scion/private/app/command"
 	"github.com/scionproto/scion/scion-pki/key"
 )
 
 func TestNewPrivateCmd(t *testing.T) {
-	dir, cleanup := xtest.MustTempDir("", "private-key-test")
-	defer cleanup()
+	dir := t.TempDir()
 
 	testCases := map[string]struct {
 		Prepare      func(t *testing.T)

--- a/scion-pki/key/public_test.go
+++ b/scion-pki/key/public_test.go
@@ -21,14 +21,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/scionproto/scion/pkg/private/xtest"
 	"github.com/scionproto/scion/private/app/command"
 	"github.com/scionproto/scion/scion-pki/key"
 )
 
 func TestNewPublicCmd(t *testing.T) {
-	dir, cleanup := xtest.MustTempDir("", "public-key-test")
-	defer cleanup()
+	dir := t.TempDir()
 
 	testCases := map[string]struct {
 		Prepare      func(t *testing.T)

--- a/scion-pki/key/symmetric_test.go
+++ b/scion-pki/key/symmetric_test.go
@@ -25,14 +25,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/scionproto/scion/pkg/private/xtest"
 	"github.com/scionproto/scion/private/app/command"
 	"github.com/scionproto/scion/scion-pki/key"
 )
 
 func TestNewSymmetricCmd(t *testing.T) {
-	dir, cleanup := xtest.MustTempDir("", "symmetric-key-test")
-	defer cleanup()
+	dir := t.TempDir()
 
 	testCases := map[string]struct {
 		Prepare      func(t *testing.T)

--- a/scion-pki/testcrypto/BUILD.bazel
+++ b/scion-pki/testcrypto/BUILD.bazel
@@ -36,7 +36,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/addr:go_default_library",
-        "//pkg/private/xtest:go_default_library",
         "//pkg/scrypto/cppki:go_default_library",
         "//scion-pki/trcs:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",

--- a/scion-pki/testcrypto/testcrypto_test.go
+++ b/scion-pki/testcrypto/testcrypto_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/pkg/addr"
-	"github.com/scionproto/scion/pkg/private/xtest"
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
 	"github.com/scionproto/scion/scion-pki/testcrypto"
 	"github.com/scionproto/scion/scion-pki/trcs"
@@ -35,8 +34,7 @@ func TestCmd(t *testing.T) {
 	if _, bazel := os.LookupEnv("TEST_UNDECLARED_OUTPUTS_DIR"); bazel {
 		t.Skip("Test can't run through bazel because of symlinks and docker not playing nice")
 	}
-	outDir, cleanF := xtest.MustTempDir("", "testcrypto")
-	defer cleanF()
+	outDir := t.TempDir()
 	topo := "./testdata/test.topo"
 
 	var buf bytes.Buffer

--- a/scion-pki/testcrypto/update_test.go
+++ b/scion-pki/testcrypto/update_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/pkg/addr"
-	"github.com/scionproto/scion/pkg/private/xtest"
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
 	"github.com/scionproto/scion/scion-pki/testcrypto"
 	"github.com/scionproto/scion/scion-pki/trcs"
@@ -38,8 +37,7 @@ func TestUpdateExtend(t *testing.T) {
 	if _, bazel := os.LookupEnv("TEST_UNDECLARED_OUTPUTS_DIR"); bazel {
 		t.Skip("Test can't run through bazel because of symlinks and docker not playing nice")
 	}
-	outDir, cleanF := xtest.MustTempDir("", "testcrypto")
-	defer cleanF()
+	outDir := t.TempDir()
 	topo := "./testdata/test.topo"
 
 	var buf bytes.Buffer
@@ -112,8 +110,7 @@ func TestUpdateReSign(t *testing.T) {
 	if _, bazel := os.LookupEnv("TEST_UNDECLARED_OUTPUTS_DIR"); bazel {
 		t.Skip("Test can't run through bazel because of symlinks and docker not playing nice")
 	}
-	outDir, cleanF := xtest.MustTempDir("", "testcrypto")
-	defer cleanF()
+	outDir := t.TempDir()
 	topo := "./testdata/test.topo"
 
 	var buf bytes.Buffer
@@ -182,8 +179,7 @@ func TestUpdateReGen(t *testing.T) {
 	if _, bazel := os.LookupEnv("TEST_UNDECLARED_OUTPUTS_DIR"); bazel {
 		t.Skip("Test can't run through bazel because of symlinks and docker not playing nice")
 	}
-	outDir, cleanF := xtest.MustTempDir("", "testcrypto")
-	defer cleanF()
+	outDir := t.TempDir()
 	topo := "./testdata/test.topo"
 
 	var buf bytes.Buffer

--- a/scion-pki/trcs/combine_test.go
+++ b/scion-pki/trcs/combine_test.go
@@ -38,8 +38,7 @@ var updateNonDeterministic = xtest.UpdateNonDeterminsticGoldenFiles()
 
 func TestCombine(t *testing.T) {
 	if *updateNonDeterministic {
-		dir, cleanF := xtest.MustTempDir("", "safedir")
-		defer cleanF()
+		dir := t.TempDir()
 
 		root, err := filepath.Abs("../../../")
 		require.NoError(t, err)
@@ -76,8 +75,7 @@ func TestCombine(t *testing.T) {
 		require.NoError(t, os.WriteFile("./testdata/admin/ISD1-B1-S1.trc", raw, 0644))
 	}
 
-	dir, clean := xtest.MustTempDir("", "scion-pki-trcs-combine")
-	defer clean()
+	dir := t.TempDir()
 	out := filepath.Join(dir, "combined.der")
 
 	parts := []string{

--- a/scion-pki/trcs/format_test.go
+++ b/scion-pki/trcs/format_test.go
@@ -21,15 +21,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/scionproto/scion/pkg/private/xtest"
 	"github.com/scionproto/scion/private/app/command"
 )
 
 var NewFormatCmd = newFormatCmd
 
 func TestNewFormatCmd(t *testing.T) {
-	dir, cleanup := xtest.MustTempDir("", "format-trc-test")
-	defer cleanup()
+	dir := t.TempDir()
 
 	testCases := map[string]struct {
 		Prepare      func(t *testing.T)

--- a/scion-pki/trcs/sign_test.go
+++ b/scion-pki/trcs/sign_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/pkg/addr"
-	"github.com/scionproto/scion/pkg/private/xtest"
 	"github.com/scionproto/scion/pkg/scrypto/cppki"
 	"github.com/scionproto/scion/private/app/command"
 	"github.com/scionproto/scion/scion-pki/certs"
@@ -39,8 +38,7 @@ import (
 )
 
 func TestSign(t *testing.T) {
-	outDir, cleanF := xtest.MustTempDir("", "scion-pki-trcs-sign")
-	defer cleanF()
+	outDir := t.TempDir()
 	gen(t, outDir)
 
 	testCases := map[string]struct {
@@ -115,8 +113,7 @@ func TestOpensslCompatible(t *testing.T) {
 		t.Skip("This test only runs as integration test")
 	}
 
-	outDir, cleanF := xtest.MustTempDir("", "scion-pki-trcs-sign")
-	defer cleanF()
+	outDir := t.TempDir()
 	gen(t, outDir)
 
 	testCases := map[string]struct {

--- a/scion-pki/trcs/verify_test.go
+++ b/scion-pki/trcs/verify_test.go
@@ -27,8 +27,7 @@ import (
 
 func TestVerify(t *testing.T) {
 	// prepare certificate bundle
-	dir, clean := xtest.MustTempDir("", "scion-pki-trcs-verify")
-	defer clean()
+	dir := t.TempDir()
 
 	testCases := map[string]struct {
 		Files        []string


### PR DESCRIPTION
The original helper function written 7 years ago is no longer useful since Go 1.15 introduced [`TempDir`](https://pkg.go.dev/testing#B.TempDir).