### PR TITLE
chore: resolve dependabot security alert #82

### DIFF
--- a/private/mgmtapi/tools/pnpm-lock.yaml
+++ b/private/mgmtapi/tools/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@types/jsonpath-plus': '>=10.0.0'
+  '@types/jsonpath-plus': '>=10.0.7'
 
-packageExtensionsChecksum: 12431cddfbc961e47dea32fc33af3a5c
+packageExtensionsChecksum: sha256-aUnoCsg+/7D3MfbKHX/YBBMLt7iUQrOeUaOXDeGB2tU=
 
 importers:
 


### PR DESCRIPTION
resolve https://github.com/scionproto/scion/security/dependabot/82 by running `pnpm install` in `private/mgmtapi/tools` that automatically sets `'@types/jsonpath-plus': '>=10.0.7'`.