### PR TITLE
router: add tcp support for dispatching to endhost

### DIFF
--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -2127,6 +2127,16 @@ func (d *DataPlane) addEndhostPort(
 		if port < d.dispatchedPortStart || port > d.dispatchedPortEnd {
 			port = topology.EndhostPort
 		}
+	case slayers.L4TCP:
+		if len(lastLayer.LayerPayload()) < 20 {
+			// TODO: Treat this as a parameter problem
+			return serrors.New("SCION/TCP header len too small", "length",
+				len(lastLayer.LayerPayload()))
+		}
+		port = binary.BigEndian.Uint16(lastLayer.LayerPayload()[2:])
+		if port < d.dispatchedPortStart || port > d.dispatchedPortEnd {
+			port = topology.EndhostPort
+		}
 	case slayers.L4SCMP:
 		var scmpLayer slayers.SCMP
 		err := scmpLayer.DecodeFromBytes(lastLayer.LayerPayload(), gopacket.NilDecodeFeedback)


### PR DESCRIPTION
This PR resolves #4698. 

I followed the same principle that we use for the other protocols, i.e., we dispatch to the mapped port if the destination port is within the dispatched port range. Otherwise, it is sent to the fix `EndhostPort`. 

This makes it compatible with implementations following the "Wireguard"-model, i.e., sending the encapsulated traffic over a fix UDP port, e.g., the [SCION-IP translator]( https://github.com/netsys-lab/scion-ip-translator); or alternative implementations that map the underlay port to the application port, e.g., what we do with SCMP or UDP/SCION, provided proper `dispatched_ports` configuration.