### PR TITLE
refactor: remove pkg/daemon dependency from pkg/snet

### DIFF
--- a/doc/command/scion-pki/scion-pki_certificate_renew.rst
+++ b/doc/command/scion-pki/scion-pki_certificate_renew.rst
@@ -35,7 +35,7 @@ issued the unverifiable certificate chain.
 The resulting certificate chain is written to the file system, either to
 <chain-file> or to \--out, if specified.
 
-The fresh private key is is written to the file stystem, either to <key-file>
+The fresh private key is is written to the file system, either to <key-file>
 or to \--out-key, if specified.
 
 Files are not allowed to be overwritten, by default. Either you have to specify
@@ -122,7 +122,7 @@ Options
       --curve string           The elliptic curve to use (P-256|P-384|P-521) (default "P-256")
       --expires-in string      Remaining time threshold for renewal
       --features strings       enable development features ()
-      --force                  Force overwritting existing files
+      --force                  Force overwriting existing files
   -h, --help                   help for renew
   -i, --interactive            interactive mode
       --isd-as isd-as          The local ISD-AS to use. (default 0-0)

--- a/gateway/cmd/gateway/main.go
+++ b/gateway/cmd/gateway/main.go
@@ -31,7 +31,7 @@ import (
 	"github.com/scionproto/scion/gateway/config"
 	"github.com/scionproto/scion/gateway/dataplane"
 	api "github.com/scionproto/scion/gateway/mgmtapi"
-	"github.com/scionproto/scion/pkg/daemon"
+	dpkg "github.com/scionproto/scion/pkg/daemon"
 	"github.com/scionproto/scion/pkg/log"
 	"github.com/scionproto/scion/pkg/private/serrors"
 	"github.com/scionproto/scion/pkg/snet/addrutil"
@@ -57,7 +57,7 @@ func realMain(ctx context.Context) error {
 
 	const retryDelay = 2
 
-	daemonService := &daemon.Service{
+	daemonService := &dpkg.Service{
 		Address: globalCfg.Daemon.Address,
 	}
 	daemon, err := daemonService.Connect(ctx)
@@ -67,7 +67,7 @@ func realMain(ctx context.Context) error {
 	defer daemon.Close()
 	localIA, err := daemon.LocalIA(ctx)
 	if err != nil {
-		// May be we were too early. Wait and retry the whole shebang.
+		// Maybe we were too early. Wait and retry the whole shebang.
 		log.Info("Retying daemon connection", "retryDelay", retryDelay)
 		time.Sleep(retryDelay * time.Second)
 		daemon.Close()
@@ -87,7 +87,7 @@ func realMain(ctx context.Context) error {
 		return serrors.Wrap("parsing control address", err)
 	}
 	if len(controlAddress.IP) == 0 {
-		controlAddress.IP, err = addrutil.DefaultLocalIP(ctx, daemon)
+		controlAddress.IP, err = addrutil.DefaultLocalIP(ctx, dpkg.TopoQuerier{Connector: daemon})
 		if err != nil {
 			return serrors.Wrap("determine default local IP", err)
 		}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -72,7 +72,7 @@ type Connector interface {
 	// Paths requests from the daemon a set of end to end paths between the source and destination.
 	Paths(ctx context.Context, dst, src addr.IA, f PathReqFlags) ([]snet.Path, error)
 	// ASInfo requests from the daemon information about AS ia, the zero IA can be
-	// use to detect the local IA.
+	// used to detect the local IA.
 	ASInfo(ctx context.Context, ia addr.IA) (ASInfo, error)
 	// SVCInfo requests from the daemon information about addresses and ports of
 	// infrastructure services.  Slice svcTypes contains a list of desired

--- a/pkg/snet/addrutil/BUILD.bazel
+++ b/pkg/snet/addrutil/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/addr:go_default_library",
-        "//pkg/daemon:go_default_library",
         "//pkg/private/serrors:go_default_library",
         "//pkg/private/util:go_default_library",
         "//pkg/segment:go_default_library",

--- a/pkg/snet/addrutil/addrutil.go
+++ b/pkg/snet/addrutil/addrutil.go
@@ -20,7 +20,6 @@ import (
 	"net"
 
 	"github.com/scionproto/scion/pkg/addr"
-	"github.com/scionproto/scion/pkg/daemon"
 	"github.com/scionproto/scion/pkg/private/serrors"
 	"github.com/scionproto/scion/pkg/private/util"
 	seg "github.com/scionproto/scion/pkg/segment"
@@ -97,6 +96,11 @@ func (p Pather) GetPath(svc addr.SVC, ps *seg.PathSegment) (*snet.SVCAddr, error
 
 }
 
+// TopoQuerier can be used to get topology information from the SCION Daemon.
+type TopoQuerier interface {
+	UnderlayAnycast(ctx context.Context, svc addr.SVC) (*net.UDPAddr, error)
+}
+
 // DefaultLocalIP returns _an_ IP of this host in the local AS.
 //
 // This returns a sensible but arbitrary local IP. In the general case the
@@ -107,9 +111,9 @@ func (p Pather) GetPath(svc addr.SVC, ps *seg.PathSegment) (*snet.SVCAddr, error
 // This is a simple workaround for not being able to use wildcard addresses
 // with snet. Once available, a wildcard address should be used instead and
 // this should be removed.
-func DefaultLocalIP(ctx context.Context, sdConn daemon.Connector) (net.IP, error) {
+func DefaultLocalIP(ctx context.Context, tq TopoQuerier) (net.IP, error) {
 	// Choose CS as default routing "target". Using any of the interfaces would also make sense.
-	csAddr, err := daemon.TopoQuerier{Connector: sdConn}.UnderlayAnycast(ctx, addr.SvcCS)
+	csAddr, err := tq.UnderlayAnycast(ctx, addr.SvcCS)
 	if err != nil {
 		return nil, err
 	}

--- a/scion-pki/certs/renew.go
+++ b/scion-pki/certs/renew.go
@@ -729,7 +729,10 @@ func (r *renewer) requestRemote(
 				return nil, serrors.Wrap("resolving local address", err)
 			}
 		} else {
-			if localIP, err = addrutil.DefaultLocalIP(ctx, daemon.TopoQuerier{Connector: r.Daemon}); err != nil {
+			if localIP, err = addrutil.DefaultLocalIP(
+				ctx,
+				daemon.TopoQuerier{Connector: r.Daemon},
+			); err != nil {
 				return nil, serrors.Wrap("resolving default address", err)
 			}
 		}

--- a/scion-pki/certs/renew.go
+++ b/scion-pki/certs/renew.go
@@ -173,7 +173,7 @@ issued the unverifiable certificate chain.
 The resulting certificate chain is written to the file system, either to
 <chain-file> or to \--out, if specified.
 
-The fresh private key is is written to the file stystem, either to <key-file>
+The fresh private key is is written to the file system, either to <key-file>
 or to \--out-key, if specified.
 
 Files are not allowed to be overwritten, by default. Either you have to specify
@@ -587,7 +587,7 @@ The template is expressed in JSON. A valid example::
 		"Remaining time threshold for renewal",
 	)
 	cmd.Flags().BoolVar(&flags.force, "force", false,
-		"Force overwritting existing files",
+		"Force overwriting existing files",
 	)
 	cmd.Flags().BoolVar(&flags.backup, "backup", false,
 		"Back up existing files before overwriting",
@@ -729,7 +729,7 @@ func (r *renewer) requestRemote(
 				return nil, serrors.Wrap("resolving local address", err)
 			}
 		} else {
-			if localIP, err = addrutil.DefaultLocalIP(ctx, r.Daemon); err != nil {
+			if localIP, err = addrutil.DefaultLocalIP(ctx, daemon.TopoQuerier{Connector: r.Daemon}); err != nil {
 				return nil, serrors.Wrap("resolving default address", err)
 			}
 		}

--- a/scion/cmd/scion/address.go
+++ b/scion/cmd/scion/address.go
@@ -74,7 +74,7 @@ case, the host could have multiple SCION addresses.
 				return err
 			}
 
-			localIP, err := addrutil.DefaultLocalIP(ctx, sd)
+			localIP, err := addrutil.DefaultLocalIP(ctx, daemon.TopoQuerier{Connector: sd})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Implementing https://github.com/scionproto/scion/issues/3378. The issue suggests moving the interface to `snet` package, but `Connector` is used in other packages as well, hence the simpler approach.

Fixed a couple of typos on the way too.