### PR TITLE
fix: mark linux exclusive sources with build tags

### DIFF
--- a/acceptance/router_benchmark/brload/main.go
+++ b/acceptance/router_benchmark/brload/main.go
@@ -1,4 +1,4 @@
-// Copyright 2023 SCION Association
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build linux
 
 package main
 

--- a/acceptance/router_benchmark/brload/mmsg.go
+++ b/acceptance/router_benchmark/brload/mmsg.go
@@ -1,4 +1,4 @@
-// Copyright 2024 SCION Association
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build linux
 
 package main
 

--- a/tools/braccept/main.go
+++ b/tools/braccept/main.go
@@ -1,4 +1,5 @@
 // Copyright 2020 Anapaya Systems
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build linux
 
 package main
 

--- a/tools/braccept/runner/run_linux.go
+++ b/tools/braccept/runner/run_linux.go
@@ -1,4 +1,5 @@
 // Copyright 2020 Anapaya Systems
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build linux
 
 package runner
 
@@ -106,7 +109,6 @@ type ExpectedPacket struct {
 // the expected packet and no other packet is received nil is returned.
 // Otherwise details of what went wrong are returned in the error.
 func (c *RunConfig) ExpectPacket(pkt ExpectedPacket, normalizeFn NormalizePacketFn) error {
-
 	timerCh := time.After(pkt.Timeout)
 	c.packetChans[len(c.deviceNames)] = reflect.SelectCase{
 		Dir:  reflect.SelectRecv,
@@ -170,21 +172,6 @@ func (c *RunConfig) Close() {
 	c.handles = nil
 }
 
-type NormalizePacketFn func(gopacket.Packet)
-
-// Case represents a border router test case.
-type Case struct {
-	Name              string
-	WriteTo, ReadFrom string
-	Input, Want       []byte
-	StoreDir          string
-	IgnoreNonMatching bool
-	// NormalizePacket is a function that will be called both on actual and
-	// expected packet. It can modify the packet fields so that unpredictable
-	// values are zeroed out and the packets match.
-	NormalizePacket NormalizePacketFn
-}
-
 // Run executes a test case. It writes input pkt to interface `WriteTo` and
 // listens for want pkt in interface `ReadFrom`. It stores all the packets
 // in the artifact directory for further debug.
@@ -224,7 +211,6 @@ func (t *Case) Run(cfg *RunConfig) error {
 	}
 	return serrors.Wrap("Errors were found", err,
 		"Packets are stored in", t.StoreDir)
-
 }
 
 type packetStorer struct {
@@ -238,7 +224,7 @@ func (s *packetStorer) storePkt(fileName string, packet gopacket.Packet) {
 		return
 	}
 	filename := filepath.Join(s.StoreDir, fileName+".pcap")
-	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0600)
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		log.Error(s.TestName, "err", err)
 		return

--- a/tools/braccept/runner/runner.go
+++ b/tools/braccept/runner/runner.go
@@ -1,0 +1,33 @@
+// Copyright 2020 Anapaya Systems
+// Copyright 2025 SCION Association
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import "github.com/gopacket/gopacket"
+
+type NormalizePacketFn func(gopacket.Packet)
+
+// Case represents a border router test case.
+type Case struct {
+	Name              string
+	WriteTo, ReadFrom string
+	Input, Want       []byte
+	StoreDir          string
+	IgnoreNonMatching bool
+	// NormalizePacket is a function that will be called both on actual and
+	// expected packet. It can modify the packet fields so that unpredictable
+	// values are zeroed out and the packets match.
+	NormalizePacket NormalizePacketFn
+}


### PR DESCRIPTION
[github.com/gopacket/gopacket/afpacket](https://pkg.go.dev/github.com/gopacket/gopacket@v1.3.1/afpacket) works with [Linux only](https://github.com/gopacket/gopacket/blob/de38b3ed5f55a68c3e7cdf34809dac42bf41d22a/afpacket/afpacket.go#L7), hence marking all sources that depend on it improves DX for other platforms such as macOS.