### PR TITLE
refactor: remove unnecessary defers in tests

### DIFF
--- a/control/beacon/beacon_test.go
+++ b/control/beacon/beacon_test.go
@@ -53,7 +53,6 @@ func TestBeaconDiversity(t *testing.T) {
 		},
 	}
 	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
 
 	g := graph.NewDefaultGraph(mctrl)
 	bseg := testBeacon(g, tests[0].beacon...)

--- a/control/beacon/store_test.go
+++ b/control/beacon/store_test.go
@@ -48,7 +48,6 @@ func testStoreSelection(t *testing.T,
 	methodToTest func(store *beacon.Store) ([]beacon.Beacon, error)) {
 
 	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
 	g := graph.NewDefaultGraph(mctrl)
 
 	// Ensure remote out if is set in last AS entry.
@@ -111,7 +110,6 @@ func testStoreSelection(t *testing.T,
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 			db := mock_beacon.NewMockDB(mctrl)
 			policies := beacon.Policies{
 				Prop:    beacon.Policy{BestSetSize: test.bestSize},
@@ -158,7 +156,6 @@ func testCoreStoreSelection(t *testing.T,
 	methodToTest func(store *beacon.CoreStore) ([]beacon.Beacon, error)) {
 
 	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
 	g := graph.NewDefaultGraph(mctrl)
 
 	// Ensure remote out if is set in last AS entry.
@@ -228,7 +225,6 @@ func testCoreStoreSelection(t *testing.T,
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 			db := mock_beacon.NewMockDB(mctrl)
 			policies := beacon.CorePolicies{
 				Prop:    beacon.Policy{BestSetSize: test.bestSize},

--- a/control/beaconing/extender_test.go
+++ b/control/beaconing/extender_test.go
@@ -92,7 +92,6 @@ func TestDefaultExtenderExtend(t *testing.T) {
 	for name, tc := range testsCases {
 		t.Run(name, func(t *testing.T) {
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 			// Setup interfaces with active parent, child and one peer interface.
 			intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
 			for _, peer := range tc.peers {
@@ -168,7 +167,6 @@ func TestDefaultExtenderExtend(t *testing.T) {
 	}
 	t.Run("the maximum expiration time is respected", func(t *testing.T) {
 		mctrl := gomock.NewController(t)
-		defer mctrl.Finish()
 		intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
 		require.NoError(t, err)
 		ext := &beaconing.DefaultExtender{
@@ -262,7 +260,6 @@ func TestDefaultExtenderExtend(t *testing.T) {
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
 				mctrl := gomock.NewController(t)
-				defer mctrl.Finish()
 				intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
 				require.NoError(t, err)
 				ext := &beaconing.DefaultExtender{
@@ -333,7 +330,6 @@ func TestDefaultExtenderExtend(t *testing.T) {
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
 				mctrl := gomock.NewController(t)
-				defer mctrl.Finish()
 				intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
 				ext := &beaconing.DefaultExtender{
 					IA: topo.IA(),

--- a/control/beaconing/extender_test.go
+++ b/control/beaconing/extender_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -91,7 +90,6 @@ func TestDefaultExtenderExtend(t *testing.T) {
 	}
 	for name, tc := range testsCases {
 		t.Run(name, func(t *testing.T) {
-			mctrl := gomock.NewController(t)
 			// Setup interfaces with active parent, child and one peer interface.
 			intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
 			for _, peer := range tc.peers {
@@ -166,7 +164,6 @@ func TestDefaultExtenderExtend(t *testing.T) {
 		})
 	}
 	t.Run("the maximum expiration time is respected", func(t *testing.T) {
-		mctrl := gomock.NewController(t)
 		intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
 		require.NoError(t, err)
 		ext := &beaconing.DefaultExtender{
@@ -259,7 +256,6 @@ func TestDefaultExtenderExtend(t *testing.T) {
 		}
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
-				mctrl := gomock.NewController(t)
 				intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
 				require.NoError(t, err)
 				ext := &beaconing.DefaultExtender{
@@ -329,7 +325,6 @@ func TestDefaultExtenderExtend(t *testing.T) {
 		}
 		for name, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
-				mctrl := gomock.NewController(t)
 				intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
 				ext := &beaconing.DefaultExtender{
 					IA: topo.IA(),

--- a/control/beaconing/handler_test.go
+++ b/control/beaconing/handler_test.go
@@ -47,7 +47,6 @@ func TestHandlerHandleBeacon(t *testing.T) {
 
 	validBeacon := func() beacon.Beacon {
 		mctrl := gomock.NewController(t)
-		defer mctrl.Finish()
 		g := graph.NewDefaultGraph(mctrl)
 		return beacon.Beacon{
 			Segment: testSegment(g, []uint16{graph.If_220_X_120_B, graph.If_120_A_110_X}),
@@ -257,7 +256,6 @@ func TestHandlerHandleBeacon(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 
 			handler := beaconing.Handler{
 				LocalIA:    localIA,

--- a/control/beaconing/originator_test.go
+++ b/control/beaconing/originator_test.go
@@ -63,7 +63,6 @@ func TestOriginatorRun(t *testing.T) {
 	}
 	t.Run("run originates ifID packets on all active interfaces", func(t *testing.T) {
 		mctrl := gomock.NewController(t)
-		defer mctrl.Finish()
 		intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
 		senderFactory := mock_beaconing.NewMockSenderFactory(mctrl)
 		o := beaconing.Originator{
@@ -126,7 +125,6 @@ func TestOriginatorRun(t *testing.T) {
 	})
 	t.Run("Fast recovery", func(t *testing.T) {
 		mctrl := gomock.NewController(t)
-		defer mctrl.Finish()
 		intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
 		senderFactory := mock_beaconing.NewMockSenderFactory(mctrl)
 		sender := mock_beaconing.NewMockSender(mctrl)

--- a/control/beaconing/propagator_test.go
+++ b/control/beaconing/propagator_test.go
@@ -52,7 +52,6 @@ func TestPropagatorRunNonCore(t *testing.T) {
 	}
 
 	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
 	topo, err := topology.FromJSONFile(topoNonCore)
 	require.NoError(t, err)
 	intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
@@ -126,7 +125,6 @@ func TestPropagatorRunCore(t *testing.T) {
 	}
 
 	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
 	topo, err := topology.FromJSONFile(topoCore)
 	require.NoError(t, err)
 	intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
@@ -212,7 +210,6 @@ func TestPropagatorFastRecovery(t *testing.T) {
 		{graph.If_130_B_120_A, graph.If_120_A_110_X},
 	}
 	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
 	topo, err := topology.FromJSONFile(topoCore)
 	require.NoError(t, err)
 	intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})

--- a/control/beaconing/writer_test.go
+++ b/control/beaconing/writer_test.go
@@ -87,7 +87,6 @@ func TestRegistrarRun(t *testing.T) {
 	for _, test := range testsLocal {
 		t.Run(test.name, func(t *testing.T) {
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 			topo, err := topology.FromJSONFile(test.fn)
 			require.NoError(t, err)
 			intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
@@ -173,7 +172,6 @@ func TestRegistrarRun(t *testing.T) {
 	for _, test := range testsRemote {
 		t.Run(test.name, func(t *testing.T) {
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 
 			topo, err := topology.FromJSONFile(test.fn)
 			require.NoError(t, err)
@@ -275,7 +273,6 @@ func TestRegistrarRun(t *testing.T) {
 
 	t.Run("Faulty beacons are not sent", func(t *testing.T) {
 		mctrl := gomock.NewController(t)
-		defer mctrl.Finish()
 
 		topo, err := topology.FromJSONFile(topoNonCore)
 		require.NoError(t, err)

--- a/control/drkey/grpc/drkey_service_test.go
+++ b/control/drkey/grpc/drkey_service_test.go
@@ -52,7 +52,6 @@ func TestDRKeySV(t *testing.T) {
 	sv, targetResp := getSVandResp(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	serviceStore := mock_grpc.NewMockEngine(ctrl)
 	serviceStore.EXPECT().GetSecretValue(gomock.Any(), gomock.Any()).Return(sv, nil)
@@ -305,7 +304,6 @@ func TestLevel1(t *testing.T) {
 
 func TestASHost(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	engine := mock_grpc.NewMockEngine(ctrl)
 	engine.EXPECT().DeriveASHost(gomock.Any(), gomock.Any()).Return(
@@ -336,7 +334,6 @@ func TestASHost(t *testing.T) {
 
 func TestHostAS(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	engine := mock_grpc.NewMockEngine(ctrl)
 	engine.EXPECT().DeriveHostAS(gomock.Any(), gomock.Any()).Return(
@@ -367,7 +364,6 @@ func TestHostAS(t *testing.T) {
 
 func TestHostHost(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	engine := mock_grpc.NewMockEngine(ctrl)
 	engine.EXPECT().DeriveHostHost(gomock.Any(), gomock.Any()).Return(

--- a/control/drkey/grpc/fetcher_test.go
+++ b/control/drkey/grpc/fetcher_test.go
@@ -60,7 +60,6 @@ func TestLevel1KeyFetching(t *testing.T) {
 	require.NoError(t, err)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	lvl1db := mock_grpc.NewMockEngine(ctrl)
 	lvl1db.EXPECT().DeriveLevel1(gomock.Any()).AnyTimes().Return(drkey.Level1Key{}, nil)

--- a/control/drkey/prefetcher_test.go
+++ b/control/drkey/prefetcher_test.go
@@ -33,7 +33,6 @@ var _ periodic.Task = (*cs_drkey.Prefetcher)(nil)
 
 func TestPrefetcherRun(t *testing.T) {
 	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
 
 	mock_engine := mock_drkey.NewMockLevel1Engine(mctrl)
 

--- a/control/drkey/service_engine_test.go
+++ b/control/drkey/service_engine_test.go
@@ -104,7 +104,6 @@ func TestDeriveHostAS(t *testing.T) {
 	defer lvl1db.Close()
 
 	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
 
 	fetcher := mock_drkey.NewMockFetcher(mctrl)
 	fetcher.EXPECT().Level1(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -182,7 +181,6 @@ func TestGetLevel1Key(t *testing.T) {
 	copy(secondLevel1Key.Key[:], k)
 
 	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
 
 	fetcher := mock_drkey.NewMockFetcher(mctrl)
 	gomock.InOrder(

--- a/control/mgmtapi/api_test.go
+++ b/control/mgmtapi/api_test.go
@@ -885,7 +885,6 @@ func TestAPI(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			req, err := http.NewRequest("GET", tc.RequestURL, nil)
 			require.NoError(t, err)

--- a/control/segreq/authoritative_test.go
+++ b/control/segreq/authoritative_test.go
@@ -120,7 +120,6 @@ func TestAuthoritativeClassify(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			p := AuthoritativeLookup{
 				LocalIA:     test.LocalIA,

--- a/control/segreq/forwarder_test.go
+++ b/control/segreq/forwarder_test.go
@@ -213,7 +213,6 @@ func TestForwarderClassify(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			f := ForwardingLookup{LocalIA: test.LocalIA, CoreChecker: newMockCoreChecker(ctrl)}
 			segType, err := f.classify(context.Background(), test.Request.Src, test.Request.Dst)

--- a/control/segreq/helpers_test.go
+++ b/control/segreq/helpers_test.go
@@ -72,7 +72,6 @@ func TestCoreChecker(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			i := mock_trust.NewMockInspector(ctrl)
 			test.PrepareInspector(i)
 			c := segreq.CoreChecker{Inspector: i}

--- a/control/trust/crypto_loader_test.go
+++ b/control/trust/crypto_loader_test.go
@@ -75,7 +75,6 @@ func TestChainLoaderChains(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			dir, db := tc.prepare(t, ctrl)
 			loader := cstrust.CryptoLoader{

--- a/daemon/drkey/grpc/fetching_test.go
+++ b/daemon/drkey/grpc/fetching_test.go
@@ -35,7 +35,6 @@ var _ sd_drkey.Fetcher = (*sd_grpc.Fetcher)(nil)
 
 func TestGetHostHost(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	now := time.Now().UTC()
 	epochBegin := timestamppb.New(now)

--- a/gateway/control/engine_test.go
+++ b/gateway/control/engine_test.go
@@ -32,7 +32,6 @@ func TestEngineRun(t *testing.T) {
 	t.Run("double run", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		engine := &control.Engine{
 			SessionConfigs:          nil,
@@ -55,7 +54,6 @@ func TestEngineRun(t *testing.T) {
 	t.Run("nil routing table", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		engine := &control.Engine{
 			PathMonitor:             mock_control.NewMockPathMonitor(ctrl),
@@ -69,7 +67,6 @@ func TestEngineRun(t *testing.T) {
 	t.Run("nil path monitor", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		engine := &control.Engine{
 			SessionConfigs:          nil,
@@ -84,7 +81,6 @@ func TestEngineRun(t *testing.T) {
 	t.Run("nil probe conn factory", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		engine := &control.Engine{
 			SessionConfigs:          nil,
@@ -99,7 +95,6 @@ func TestEngineRun(t *testing.T) {
 	t.Run("nil dataplane session factory", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		engine := &control.Engine{
 			SessionConfigs:   nil,
@@ -114,7 +109,6 @@ func TestEngineRun(t *testing.T) {
 	t.Run("close before run", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		engine := &control.Engine{
 			SessionConfigs:          nil,

--- a/gateway/control/enginecontroller_test.go
+++ b/gateway/control/enginecontroller_test.go
@@ -35,7 +35,6 @@ func TestEngineControllerRun(t *testing.T) {
 	t.Run("double run", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		configurationUpdates := make(chan []*control.SessionConfig)
 		routingTableSwapper := mock_control.NewMockRoutingTableSwapper(ctrl)
@@ -63,7 +62,6 @@ func TestEngineControllerRun(t *testing.T) {
 	t.Run("nil configuration updates", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		routingTableSwapper := mock_control.NewMockRoutingTableSwapper(ctrl)
 		routingTableFactory := mock_control.NewMockRoutingTableFactory(ctrl)
@@ -82,7 +80,6 @@ func TestEngineControllerRun(t *testing.T) {
 	t.Run("nil routing table swapper", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		configurationUpdates := make(chan []*control.SessionConfig)
 		routingTableFactory := mock_control.NewMockRoutingTableFactory(ctrl)
@@ -101,7 +98,6 @@ func TestEngineControllerRun(t *testing.T) {
 	t.Run("nil routing table factory", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		configurationUpdates := make(chan []*control.SessionConfig)
 		routingTableSwapper := mock_control.NewMockRoutingTableSwapper(ctrl)
@@ -120,7 +116,6 @@ func TestEngineControllerRun(t *testing.T) {
 	t.Run("nil engine factory", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		configurationUpdates := make(chan []*control.SessionConfig)
 		routingTableSwapper := mock_control.NewMockRoutingTableSwapper(ctrl)

--- a/gateway/control/grpc/prefix_server_test.go
+++ b/gateway/control/grpc/prefix_server_test.go
@@ -98,7 +98,6 @@ func TestIPPrefixServerPrefixes(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			s := grpc.IPPrefixServer{
 				LocalIA:    local,
 				Advertiser: tc.Advertiser(t, ctrl),

--- a/gateway/control/grpc/probeserver_test.go
+++ b/gateway/control/grpc/probeserver_test.go
@@ -35,7 +35,6 @@ import (
 
 func TestControlDispatcher(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	src := &snet.UDPAddr{IA: addr.MustParseIA("1-ff00:0:110")}
 

--- a/gateway/control/prefixesfilter_test.go
+++ b/gateway/control/prefixesfilter_test.go
@@ -171,7 +171,6 @@ accept    1-ff00:0:113    1-ff00:0:110    10.3.0.0/25`))
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			f := tc.CreateFilter(t, ctrl)
 			for _, input := range tc.Inputs {

--- a/gateway/control/publishingroutingtable_test.go
+++ b/gateway/control/publishingroutingtable_test.go
@@ -63,7 +63,6 @@ func TestNewPublishingRoutingTableLate(t *testing.T) {
 	chains, routeV4, routeV6 := getRoutingChains(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	publisher := mock_control.NewMockPublisher(ctrl)
 	publisher.EXPECT().AddRoute(routeV4)
@@ -91,7 +90,6 @@ func TestNewPublishingRoutingTableHealthiness(t *testing.T) {
 	chains, routeV4, routeV6 := getRoutingChains(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	publisher := mock_control.NewMockPublisher(ctrl)
 	publisher.EXPECT().AddRoute(routeV4)

--- a/gateway/control/remotemonitor_test.go
+++ b/gateway/control/remotemonitor_test.go
@@ -34,7 +34,6 @@ func TestRemoteMonitor(t *testing.T) {
 	ia2 := addr.MustParseIA("1-ff00:0:111")
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// runningWatcher represents a watcher that is running.
 	type runningWatcher struct {

--- a/gateway/control/router_test.go
+++ b/gateway/control/router_test.go
@@ -38,7 +38,6 @@ func TestRouterClose(t *testing.T) {
 
 func TestRouterRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	rt := mock_control.NewMockRoutingTable(ctrl)
 	logger := mock_log.NewMockLogger(ctrl)
 	logger.EXPECT().Debug(gomock.Any(), gomock.Any()).AnyTimes()

--- a/gateway/control/session_test.go
+++ b/gateway/control/session_test.go
@@ -33,7 +33,6 @@ import (
 func TestSessionRun(t *testing.T) {
 	t.Run("50ms poll interval", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		path := mock_snet.NewMockPath(ctrl)
 		pathMonitorRegistration := mock_control.NewMockPathMonitorRegistration(ctrl)

--- a/gateway/control/sessionconfigurator_test.go
+++ b/gateway/control/sessionconfigurator_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -79,7 +78,6 @@ func TestSessionConfigurator(t *testing.T) {
 		assert.Error(t, sc.Run(context.Background()))
 	})
 	t.Run("test Run", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
 		tpChan := make(chan control.SessionPolicies)
 		ruChan := make(chan control.RemoteGateways)
 		cfgChan := make(chan []*control.SessionConfig)

--- a/gateway/control/sessionconfigurator_test.go
+++ b/gateway/control/sessionconfigurator_test.go
@@ -80,7 +80,6 @@ func TestSessionConfigurator(t *testing.T) {
 	})
 	t.Run("test Run", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		tpChan := make(chan control.SessionPolicies)
 		ruChan := make(chan control.RemoteGateways)
 		cfgChan := make(chan []*control.SessionConfig)

--- a/gateway/control/sessionmonitor_test.go
+++ b/gateway/control/sessionmonitor_test.go
@@ -84,7 +84,6 @@ func (m udpAddrMatcher) String() string {
 
 func TestSessionMonitorTestProbing(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	conn := mock_net.NewMockPacketConn(ctrl)
 	pathReg := mock_control.NewMockPathMonitorRegistration(ctrl)
 	sessMon := control.SessionMonitor{
@@ -137,7 +136,6 @@ func TestSessionMonitorTestProbing(t *testing.T) {
 
 func TestSessionMonitorTestEvents(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	conn := mock_net.NewMockPacketConn(ctrl)
 	events := make(chan control.SessionEvent, 50)
 	pathReg := mock_control.NewMockPathMonitorRegistration(ctrl)

--- a/gateway/control/sessionpolicy_test.go
+++ b/gateway/control/sessionpolicy_test.go
@@ -165,7 +165,6 @@ func TestLoadSessionPolicies(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			p, err := control.LoadSessionPolicies(context.Background(), tc.File, tc.Parser(ctrl))
 			assert.Equal(t, tc.Expected, p)
 			tc.AssertErr(t, err)

--- a/gateway/control/watcher_test.go
+++ b/gateway/control/watcher_test.go
@@ -33,7 +33,6 @@ import (
 
 func TestGatewayWatcherRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	fetcherCounts := metrics.NewTestCounter()
 	discoveryCounts := metrics.NewTestCounter()
@@ -124,7 +123,6 @@ func TestGatewayWatcherRun(t *testing.T) {
 
 func TestPrefixWatcherRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	fetcherCounts := metrics.NewTestCounter()
 	consumerCounts := metrics.NewTestCounter()

--- a/gateway/dataplane/atomicroutingtable_test.go
+++ b/gateway/dataplane/atomicroutingtable_test.go
@@ -27,7 +27,6 @@ import (
 
 func TestAtomicRoutingTable(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	art := &dataplane.AtomicRoutingTable{}
 

--- a/gateway/dataplane/ipforwarder_test.go
+++ b/gateway/dataplane/ipforwarder_test.go
@@ -42,7 +42,6 @@ func TestIPForwarderRun(t *testing.T) {
 	t.Run("nil routing table", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		ipForwarder := &dataplane.IPForwarder{
 			Reader: mock_io.NewMockReader(ctrl),
@@ -54,7 +53,6 @@ func TestIPForwarderRun(t *testing.T) {
 	t.Run("nil packet reader", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		ipForwarder := &dataplane.IPForwarder{
 			RoutingTable: mock_control.NewMockRoutingTable(ctrl),
@@ -112,7 +110,6 @@ func TestIPForwarderRun(t *testing.T) {
 				t.Parallel()
 
 				ctrl := gomock.NewController(t)
-				defer ctrl.Finish()
 				reader := mock_io.NewMockReader(ctrl)
 
 				ipForwarder := &dataplane.IPForwarder{
@@ -145,7 +142,6 @@ func TestIPForwarderRun(t *testing.T) {
 	t.Run("successful run", func(t *testing.T) {
 		t.Parallel()
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		reader := mock_io.NewMockReader(ctrl)
 		rt := dataplane.NewRoutingTable([]*control.RoutingChain{

--- a/gateway/dataplane/sender_test.go
+++ b/gateway/dataplane/sender_test.go
@@ -101,7 +101,6 @@ func TestSender(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			conn := mock_net.NewMockPacketConn(ctrl)
 			conn.EXPECT().LocalAddr().Return(
 				&snet.UDPAddr{Host: &net.UDPAddr{IP: net.IP{192, 168, 1, 1}}},

--- a/gateway/dataplane/session_test.go
+++ b/gateway/dataplane/session_test.go
@@ -35,7 +35,6 @@ import (
 
 func TestNoPath(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	frameChan := make(chan ([]byte))
 	sess := createSession(t, ctrl, frameChan)
@@ -47,7 +46,6 @@ func TestNoPath(t *testing.T) {
 
 func TestSinglePath(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	frameChan := make(chan ([]byte))
 	sess := createSession(t, ctrl, frameChan)
@@ -59,7 +57,6 @@ func TestSinglePath(t *testing.T) {
 
 func TestTwoPaths(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	// Unbuffered channel guarantees that the frames won't be sent out
 	// immediately, but only when waitFrames is called.
@@ -88,7 +85,6 @@ func TestNoLeak(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	frameChan := make(chan ([]byte))
 	sess := createSession(t, ctrl, frameChan)

--- a/gateway/loader_test.go
+++ b/gateway/loader_test.go
@@ -232,7 +232,6 @@ func TestLoaderRun(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			tc(t, ctrl)
 		})
 	}

--- a/gateway/pathhealth/revocations_test.go
+++ b/gateway/pathhealth/revocations_test.go
@@ -37,7 +37,6 @@ var (
 
 func TestEmptyStore(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	s := pathhealth.MemoryRevocationStore{}
 	res := s.IsRevoked(createMockPath(ctrl, testIA, 1))
@@ -47,7 +46,6 @@ func TestEmptyStore(t *testing.T) {
 
 func TestRevocation(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	s := pathhealth.MemoryRevocationStore{}
 	s.AddRevocation(context.Background(), createRevInfo(testIA, 1, false))
@@ -60,7 +58,6 @@ func TestRevocation(t *testing.T) {
 
 func TestExpiredRevocation(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	s := pathhealth.MemoryRevocationStore{}
 	s.AddRevocation(context.Background(), createRevInfo(testIA, 1, true))

--- a/gateway/routemgr/device_test.go
+++ b/gateway/routemgr/device_test.go
@@ -43,7 +43,6 @@ func TestSingleDeviceManager(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		mockDeviceHandle := mock_control.NewMockDeviceHandle(ctrl)
 		mockDeviceOpener := mock_control.NewMockDeviceOpener(ctrl)
@@ -64,7 +63,6 @@ func TestSingleDeviceManager(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		mockDeviceHandle := mock_control.NewMockDeviceHandle(ctrl)
 		mockDeviceOpener := mock_control.NewMockDeviceOpener(ctrl)
@@ -88,7 +86,6 @@ func TestSingleDeviceManager(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		mockDeviceHandle := mock_control.NewMockDeviceHandle(ctrl)
 		mockDeviceOpener := mock_control.NewMockDeviceOpener(ctrl)
@@ -112,7 +109,6 @@ func TestSingleDeviceManager(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		mockDeviceOpener := mock_control.NewMockDeviceOpener(ctrl)
 		mockDeviceOpener.EXPECT().Open(gomock.Any(), gomock.Any()).
@@ -131,7 +127,6 @@ func TestSingleDeviceManager(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		mockDeviceHandle := mock_control.NewMockDeviceHandle(ctrl)
 		mockDeviceOpener := mock_control.NewMockDeviceOpener(ctrl)
@@ -152,7 +147,6 @@ func TestSingleDeviceManager(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		mockDeviceHandle := mock_control.NewMockDeviceHandle(ctrl)
 		mockDeviceOpener := mock_control.NewMockDeviceOpener(ctrl)
@@ -174,7 +168,6 @@ func TestSingleDeviceManager(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		mockDeviceHandle := mock_control.NewMockDeviceHandle(ctrl)
 		mockDeviceOpener := mock_control.NewMockDeviceOpener(ctrl)
@@ -226,7 +219,6 @@ func TestSingleDeviceManager(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		mockDeviceHandle := mock_control.NewMockDeviceHandle(ctrl)
 		mockDeviceOpener := mock_control.NewMockDeviceOpener(ctrl)
@@ -259,7 +251,6 @@ func TestSingleDeviceManager(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		mockDeviceHandle := mock_control.NewMockDeviceHandle(ctrl)
 		mockDeviceOpener := mock_control.NewMockDeviceOpener(ctrl)
@@ -301,7 +292,6 @@ func TestSingleDeviceManager(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		mockDeviceHandle := mock_control.NewMockDeviceHandle(ctrl)
 		mockDeviceOpener := mock_control.NewMockDeviceOpener(ctrl)
@@ -342,7 +332,6 @@ func TestSingleDeviceManager(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		mockDeviceHandle1 := mock_control.NewMockDeviceHandle(ctrl)
 		mockDeviceOpener := mock_control.NewMockDeviceOpener(ctrl)

--- a/gateway/routing/file_test.go
+++ b/gateway/routing/file_test.go
@@ -226,7 +226,6 @@ func TestNewPolicyHandler(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			ht := tc(t, ctrl)
 			handler := routing.NewPolicyHandler(ht.Publisher, ht.Path)

--- a/pkg/experimental/hiddenpath/authoritative_test.go
+++ b/pkg/experimental/hiddenpath/authoritative_test.go
@@ -216,7 +216,6 @@ func TestAuthoritativeServerSegments(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			server := hiddenpath.AuthoritativeServer{
 				Groups:  tc.groups(),

--- a/pkg/experimental/hiddenpath/beaconwriter_test.go
+++ b/pkg/experimental/hiddenpath/beaconwriter_test.go
@@ -190,7 +190,6 @@ func TestRemoteBeaconWriterWrite(t *testing.T) {
 			t.Parallel()
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			intfs := ifstate.NewInterfaces(interfaceInfos(topo), ifstate.Config{})
 
 			w := &hiddenpath.BeaconWriter{

--- a/pkg/experimental/hiddenpath/discovery_test.go
+++ b/pkg/experimental/hiddenpath/discovery_test.go
@@ -152,7 +152,6 @@ func TestRegistrationResolverResolve(t *testing.T) {
 			t.Parallel()
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			r := hiddenpath.RegistrationResolver{
 				Router:     tc.router(ctrl),

--- a/pkg/experimental/hiddenpath/forwarder_test.go
+++ b/pkg/experimental/hiddenpath/forwarder_test.go
@@ -106,7 +106,6 @@ func TestForwardServerSegments(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			resolver := mock_hiddenpath.NewMockAddressResolver(ctrl)
 			resolver.EXPECT().Resolve(gomock.Any(), gomock.Any()).Return(&net.UDPAddr{}, nil).

--- a/pkg/experimental/hiddenpath/grpc/discovery_test.go
+++ b/pkg/experimental/hiddenpath/grpc/discovery_test.go
@@ -72,7 +72,6 @@ func TestDiscovererDiscover(t *testing.T) {
 			t.Parallel()
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			svc := xtest.NewGRPCService()
 			dspb.RegisterDiscoveryServiceServer(svc.Server(), tc.server(ctrl))

--- a/pkg/experimental/hiddenpath/grpc/lookup_test.go
+++ b/pkg/experimental/hiddenpath/grpc/lookup_test.go
@@ -89,7 +89,6 @@ func TestSegmentServerHiddenSegments(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			server := &grpc.SegmentServer{
 				Lookup: tc.lookuper(ctrl),
@@ -239,7 +238,6 @@ func TestAuthoritativeSegmentServerAuthoritativeHiddenSegments(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			server := &grpc.AuthoritativeSegmentServer{
 				Lookup:   tc.lookuper(ctrl),

--- a/pkg/experimental/hiddenpath/grpc/registerer_test.go
+++ b/pkg/experimental/hiddenpath/grpc/registerer_test.go
@@ -98,7 +98,6 @@ func TestRegistererRegisterSegment(t *testing.T) {
 			t.Parallel()
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			svc := xtest.NewGRPCService()
 			hspb.RegisterHiddenSegmentRegistrationServiceServer(svc.Server(), tc.hpServer(ctrl))

--- a/pkg/experimental/hiddenpath/grpc/registry_test.go
+++ b/pkg/experimental/hiddenpath/grpc/registry_test.go
@@ -220,7 +220,6 @@ func TestRegistrationServerHiddenSegmentRegistration(t *testing.T) {
 			t.Parallel()
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			s := hpgrpc.RegistrationServer{
 				Registry: tc.registry(ctrl),

--- a/pkg/experimental/hiddenpath/grpc/requester_test.go
+++ b/pkg/experimental/hiddenpath/grpc/requester_test.go
@@ -108,7 +108,6 @@ func TestRequesterSegments(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 				ctrl := gomock.NewController(t)
-				defer ctrl.Finish()
 
 				server := mock_hidden_segment.NewMockHiddenSegmentLookupServiceServer(ctrl)
 				server.EXPECT().HiddenSegments(gomock.Any(), gomock.Any()).
@@ -175,7 +174,6 @@ func TestAuthoritativeRequesterHiddenSegments(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			svc := xtest.NewGRPCService()
 			hspb.RegisterAuthoritativeHiddenSegmentLookupServiceServer(svc.Server(),

--- a/pkg/experimental/hiddenpath/registry_test.go
+++ b/pkg/experimental/hiddenpath/registry_test.go
@@ -177,7 +177,6 @@ func TestRegistryRegister(t *testing.T) {
 			t.Parallel()
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			h := hiddenpath.RegistryServer{
 				Groups:   groups,

--- a/pkg/experimental/hiddenpath/store_test.go
+++ b/pkg/experimental/hiddenpath/store_test.go
@@ -87,7 +87,6 @@ func TestStorerGet(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			s := hiddenpath.Storer{
 				DB: tc.db(ctrl),
@@ -139,7 +138,6 @@ func TestStorerPut(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			s := hiddenpath.Storer{
 				DB: tc.db(ctrl),

--- a/pkg/snet/squic/net_test.go
+++ b/pkg/snet/squic/net_test.go
@@ -44,7 +44,6 @@ func TestAcceptLoopParallelism(t *testing.T) {
 	}
 
 	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
 
 	handler := mock_cp.NewMockTrustMaterialServiceServer(mctrl)
 	handler.EXPECT().TRC( // nolint - name from published protobuf
@@ -112,7 +111,6 @@ func TestAcceptLoopParallelism(t *testing.T) {
 
 func TestGRPCQUIC(t *testing.T) {
 	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
 
 	handler := mock_cp.NewMockTrustMaterialServiceServer(mctrl)
 	handler.EXPECT().TRC(gomock.Any(), gomock.Any()).Return(

--- a/private/app/appnet/addr_test.go
+++ b/private/app/appnet/addr_test.go
@@ -59,7 +59,6 @@ func TestRedirectQUIC(t *testing.T) {
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			router := mock_snet.NewMockRouter(ctrl)
 			router.EXPECT().Route(gomock.Any(), gomock.Any()).Times(0)
 			resolver := mock_infraenv.NewMockResolver(ctrl)
@@ -78,7 +77,6 @@ func TestRedirectQUIC(t *testing.T) {
 
 	t.Run("valid SVCAddr, returns no error and UPDAddr", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		router := mock_snet.NewMockRouter(ctrl)
 		resolver := mock_infraenv.NewMockResolver(ctrl)
 		resolver.EXPECT().LookupSVC(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -115,7 +113,6 @@ func TestRedirectQUIC(t *testing.T) {
 func TestBuildFullAddress(t *testing.T) {
 	t.Run("snet address without path, error retrieving path", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		router := mock_snet.NewMockRouter(ctrl)
 		remoteIA := addr.MustParseIA("1-ff00:0:2")
 		svcRouter := mock_infraenv.NewMockSVCResolver(ctrl)
@@ -131,7 +128,6 @@ func TestBuildFullAddress(t *testing.T) {
 
 	t.Run("snet address with path", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		router := mock_snet.NewMockRouter(ctrl)
 		remoteIA := addr.MustParseIA("1-ff00:0:2")
 		svcRouter := mock_infraenv.NewMockSVCResolver(ctrl)
@@ -152,7 +148,6 @@ func TestBuildFullAddress(t *testing.T) {
 
 	t.Run("snet address without path, successful retrieving path", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		router := mock_snet.NewMockRouter(ctrl)
 		remoteIA := addr.MustParseIA("1-ff00:0:2")
 		svcRouter := mock_infraenv.NewMockSVCResolver(ctrl)
@@ -182,7 +177,6 @@ func TestBuildFullAddress(t *testing.T) {
 
 	t.Run("snet address in local AS, underlay address extraction succeeds", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		router := mock_snet.NewMockRouter(ctrl)
 		localIA := addr.MustParseIA("1-ff00:0:1")
 		svcRouter := mock_infraenv.NewMockSVCResolver(ctrl)
@@ -218,7 +212,6 @@ func TestBuildFullAddress(t *testing.T) {
 
 	t.Run("snet address in local AS, underlay address extraction fails", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		router := mock_snet.NewMockRouter(ctrl)
 		localIA := addr.MustParseIA("1-ff00:0:1")
 		svcRouter := mock_infraenv.NewMockSVCResolver(ctrl)
@@ -281,7 +274,6 @@ func TestResolve(t *testing.T) {
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			resolver := mock_infraenv.NewMockResolver(ctrl)
 			path := mock_snet.NewMockPath(ctrl)
 			path.EXPECT().Destination().Return(addr.IA(0)).AnyTimes()

--- a/private/ca/renewal/ca_signer_gen_test.go
+++ b/private/ca/renewal/ca_signer_gen_test.go
@@ -273,7 +273,6 @@ func TestLoadingPolicyGenGenerate(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 			g := renewal.LoadingPolicyGen{
 				Validity:     time.Hour,
 				CertProvider: tc.CertProvider(t, mctrl),
@@ -380,7 +379,6 @@ func TestCACertLoaderCACerts(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			dir, db := tc.prepare(t, ctrl)
 			loader := renewal.CACertLoader{

--- a/private/ca/renewal/grpc/cms_test.go
+++ b/private/ca/renewal/grpc/cms_test.go
@@ -205,7 +205,6 @@ func TestCMSHandleCMSRequest(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			ctr := metrics.NewTestCounter()
 			s := &grpc.CMS{
 				Verifier:     tc.Verifier(ctrl),

--- a/private/ca/renewal/grpc/delegating_handler_test.go
+++ b/private/ca/renewal/grpc/delegating_handler_test.go
@@ -300,7 +300,6 @@ func TestDelegatingHandler(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			ctr := metrics.NewTestCounter()
 			h := renewalgrpc.DelegatingHandler{

--- a/private/ca/renewal/grpc/renewal_test.go
+++ b/private/ca/renewal/grpc/renewal_test.go
@@ -148,7 +148,6 @@ func TestRenewalServerChainRenewal(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			ctr := metrics.NewTestCounter()
-			defer ctrl.Finish()
 			s := &grpc.RenewalServer{
 				CMSHandler: tc.cmsHandler(ctrl),
 				CMSSigner:  tc.cmsSigner(ctrl),

--- a/private/discovery/toposervice_test.go
+++ b/private/discovery/toposervice_test.go
@@ -89,7 +89,6 @@ func TestGateways(t *testing.T) {
 			t.Parallel()
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			d := discovery.Topology{
 				Information: tc.info(t, ctrl),
@@ -200,7 +199,6 @@ func TestHiddenSegmentServices(t *testing.T) {
 			t.Parallel()
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			d := discovery.Topology{Information: tc.info(t, ctrl)}
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/private/mgmtapi/cppki/api/api_test.go
+++ b/private/mgmtapi/cppki/api/api_test.go
@@ -339,7 +339,6 @@ func TestAPI(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			req, err := http.NewRequest("GET", tc.RequestURL, nil)
 			require.NoError(t, err)

--- a/private/mgmtapi/segments/api/api_test.go
+++ b/private/mgmtapi/segments/api/api_test.go
@@ -236,7 +236,6 @@ func TestAPI(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			req, err := http.NewRequest("GET", tc.RequestURL, nil)
 			require.NoError(t, err)

--- a/private/path/combinator/combinator_test.go
+++ b/private/path/combinator/combinator_test.go
@@ -45,7 +45,6 @@ var (
 
 func TestBadPeering(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	// Test that paths are not constructed across peering links where the IFIDs
 	// on both ends do not match.
 	g := graph.NewDefaultGraph(ctrl)
@@ -98,7 +97,6 @@ func TestBadPeering(t *testing.T) {
 
 func TestMiscPeering(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	g := graph.NewDefaultGraph(ctrl)
 	// Add a core-core peering link. It can be used in some cases.
 	g.AddLink("1-ff00:0:130", 4001, "2-ff00:0:210", 4002, true)
@@ -165,7 +163,6 @@ func TestMiscPeering(t *testing.T) {
 
 func TestSameCoreParent(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	g := graph.NewDefaultGraph(ctrl)
 
 	testCases := []struct {
@@ -208,7 +205,6 @@ func TestSameCoreParent(t *testing.T) {
 
 func TestLoops(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	g := graph.NewDefaultGraph(ctrl)
 	testCases := []struct {
 		Name     string
@@ -259,7 +255,6 @@ func TestLoops(t *testing.T) {
 
 func TestComputePath(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	g := graph.NewDefaultGraph(ctrl)
 
 	testCases := []struct {

--- a/private/path/combinator/staticinfo_accumulator_test.go
+++ b/private/path/combinator/staticinfo_accumulator_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestStaticinfo(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	g := graph.NewDefaultGraph(ctrl)
 
 	testCases := []struct {

--- a/private/path/pathpol/acl_test.go
+++ b/private/path/pathpol/acl_test.go
@@ -284,7 +284,6 @@ func TestACLEval(t *testing.T) {
 		},
 	}
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	pp := NewPathProvider(ctrl)
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -303,7 +302,6 @@ func TestACLPanic(t *testing.T) {
 	}
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	pp := NewPathProvider(ctrl)
 	paths := pp.GetPaths(addr.MustParseIA("2-ff00:0:212"), addr.MustParseIA("2-ff00:0:211"))
 	assert.Panics(t, func() { acl.Eval(paths) })

--- a/private/path/pathpol/local_isdas_test.go
+++ b/private/path/pathpol/local_isdas_test.go
@@ -27,7 +27,6 @@ import (
 
 func TestLocalISDASEval(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	pp := NewPathProvider(ctrl)
 	paths212 := pp.GetPaths(addr.MustParseIA("2-ff00:0:212"), addr.MustParseIA("2-ff00:0:220"))
 	paths220 := pp.GetPaths(addr.MustParseIA("2-ff00:0:220"), addr.MustParseIA("2-ff00:0:212"))

--- a/private/path/pathpol/policy_test.go
+++ b/private/path/pathpol/policy_test.go
@@ -46,7 +46,6 @@ func TestBasicPolicy(t *testing.T) {
 		},
 	}
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	pp := NewPathProvider(ctrl)
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -251,7 +250,6 @@ func TestOptionsEval(t *testing.T) {
 		},
 	}
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	pp := NewPathProvider(ctrl)
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -571,7 +569,6 @@ func TestFilterOpt(t *testing.T) {
 		},
 	}
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	pp := NewPathProvider(ctrl)
 	src := addr.MustParseIA("1-ff00:0:110")
 	dst := addr.MustParseIA("2-ff00:0:220")

--- a/private/path/pathpol/remote_isdas_test.go
+++ b/private/path/pathpol/remote_isdas_test.go
@@ -71,7 +71,6 @@ func TestRemoteISDASEval(t *testing.T) {
 	}
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	pp := NewPathProvider(ctrl)
 	paths1_110 := pp.GetPaths(addr.MustParseIA("2-ff00:0:210"), addr.MustParseIA("1-ff00:0:110"))
 	paths2_212 := pp.GetPaths(addr.MustParseIA("2-ff00:0:210"), addr.MustParseIA("2-ff00:0:212"))

--- a/private/path/pathpol/sequence_test.go
+++ b/private/path/pathpol/sequence_test.go
@@ -307,7 +307,6 @@ func TestSequenceEval(t *testing.T) {
 		},
 	}
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	pp := NewPathProvider(ctrl)
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/private/revcache/util_test.go
+++ b/private/revcache/util_test.go
@@ -42,7 +42,6 @@ var (
 func TestNoRevokedHopIntf(t *testing.T) {
 	now := time.Now()
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	ctx, cancelF := context.WithTimeout(context.Background(), timeout)
 	defer cancelF()
 	seg210_222_1 := createSeg(ctrl)

--- a/private/segment/segfetcher/fetcher_test.go
+++ b/private/segment/segfetcher/fetcher_test.go
@@ -59,7 +59,6 @@ func (f *TestableFetcher) Fetcher() *segfetcher.Fetcher {
 
 func TestFetcher(t *testing.T) {
 	rootCtrl := gomock.NewController(t)
-	defer rootCtrl.Finish()
 	tg := newTestGraph(rootCtrl)
 	testErr := errors.New("Test err")
 

--- a/private/segment/segfetcher/fetcher_test.go
+++ b/private/segment/segfetcher/fetcher_test.go
@@ -93,7 +93,6 @@ func TestFetcher(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
 			defer cancelF()
 			f := NewTestFetcher(ctrl)

--- a/private/segment/segfetcher/requester_test.go
+++ b/private/segment/segfetcher/requester_test.go
@@ -62,7 +62,6 @@ var (
 
 func TestRequester(t *testing.T) {
 	rootCtrl := gomock.NewController(t)
-	defer rootCtrl.Finish()
 	tg := newTestGraph(rootCtrl)
 	const maxRetries = 13
 

--- a/private/segment/segfetcher/requester_test.go
+++ b/private/segment/segfetcher/requester_test.go
@@ -192,7 +192,6 @@ func TestRequester(t *testing.T) {
 			ctx, cancelF := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancelF()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			dstProvider := mock_segfetcher.NewMockDstProvider(ctrl)
 			dstProvider.EXPECT().Dst(gomock.Any(), gomock.Any()).AnyTimes()
 			rpc := mock_segfetcher.NewMockRPC(ctrl)

--- a/private/segment/segfetcher/resolver_test.go
+++ b/private/segment/segfetcher/resolver_test.go
@@ -64,8 +64,10 @@ func newTestGraph(ctrl *gomock.Controller) *testGraph {
 
 	seg210_120 := g.Beacon([]uint16{graph.If_210_X_110_X, graph.If_110_X_120_A})
 	seg210_130 := g.Beacon([]uint16{graph.If_210_X_110_X, graph.If_110_X_130_A})
-	seg210_130_2 := g.Beacon([]uint16{graph.If_210_X_220_X,
-		graph.If_220_X_120_B, graph.If_120_A_130_B})
+	seg210_130_2 := g.Beacon([]uint16{
+		graph.If_210_X_220_X,
+		graph.If_220_X_120_B, graph.If_120_A_130_B,
+	})
 	seg210_211 := g.Beacon([]uint16{graph.If_210_X_211_A})
 	seg210_212 := g.Beacon([]uint16{graph.If_210_X_211_A, graph.If_211_A_212_X})
 
@@ -226,8 +228,10 @@ func TestResolver(t *testing.T) {
 					StartsAt: []addr.IA{core_110}, EndsAt: []addr.IA{core_130},
 				})).Return(resultsFromSegs(tg.seg110_130_core), nil)
 			},
-			ExpectedSegments: segfetcher.Segments{tg.seg120_111_up, tg.seg130_111_up,
-				tg.seg110_120_core, tg.seg110_130_core},
+			ExpectedSegments: segfetcher.Segments{
+				tg.seg120_111_up, tg.seg130_111_up,
+				tg.seg110_120_core, tg.seg110_130_core,
+			},
 			ExpectedFetchReqs: nil,
 		},
 		"Up down": {
@@ -339,8 +343,10 @@ func TestResolver(t *testing.T) {
 				})).Return(resultsFromSegs(tg.seg120_111_down, tg.seg130_111_down), nil)
 				db.EXPECT().GetNextQuery(gomock.Any(), isd2, isd1)
 			},
-			ExpectedSegments: segfetcher.Segments{tg.seg210_211_up,
-				tg.seg120_111_down, tg.seg130_111_down},
+			ExpectedSegments: segfetcher.Segments{
+				tg.seg210_211_up,
+				tg.seg120_111_down, tg.seg130_111_down,
+			},
 			ExpectedFetchReqs: segfetcher.Requests{
 				segfetcher.Request{SegType: Core, Src: isd2, Dst: isd1},
 			},
@@ -352,7 +358,7 @@ func TestResolver(t *testing.T) {
 }
 
 func TestResolverCacheBypass(t *testing.T) {
-	rootCtrl := gomock.NewController(t)
+	// rootCtrl := gomock.NewController(t)
 	// tg := newTestGraph(rootCtrl)
 	// futureT := time.Now().Add(2 * time.Minute)
 

--- a/private/segment/segfetcher/resolver_test.go
+++ b/private/segment/segfetcher/resolver_test.go
@@ -100,7 +100,6 @@ type resolverTest struct {
 
 func (rt resolverTest) run(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	db := mock_pathdb.NewMockDB(ctrl)
 	rt.ExpectCalls(db)

--- a/private/segment/segfetcher/resolver_test.go
+++ b/private/segment/segfetcher/resolver_test.go
@@ -118,7 +118,6 @@ func (rt resolverTest) run(t *testing.T) {
 
 func TestResolver(t *testing.T) {
 	rootCtrl := gomock.NewController(t)
-	defer rootCtrl.Finish()
 	tg := newTestGraph(rootCtrl)
 	futureT := time.Now().Add(2 * time.Minute)
 
@@ -354,7 +353,6 @@ func TestResolver(t *testing.T) {
 
 func TestResolverCacheBypass(t *testing.T) {
 	rootCtrl := gomock.NewController(t)
-	defer rootCtrl.Finish()
 	// tg := newTestGraph(rootCtrl)
 	// futureT := time.Now().Add(2 * time.Minute)
 
@@ -382,7 +380,6 @@ func TestResolverCacheBypass(t *testing.T) {
 
 func TestResolverWithRevocations(t *testing.T) {
 	rootCtrl := gomock.NewController(t)
-	defer rootCtrl.Finish()
 	tg := newTestGraph(rootCtrl)
 	futureT := time.Now().Add(2 * time.Minute)
 

--- a/private/segment/segfetcher/splitter_test.go
+++ b/private/segment/segfetcher/splitter_test.go
@@ -29,7 +29,6 @@ import (
 
 func TestRequestSplitter(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	t.Run("multi-cores", func(t *testing.T) {
 		cores := map[addr.IA]struct{}{

--- a/private/segment/seghandler/seghandler_test.go
+++ b/private/segment/seghandler/seghandler_test.go
@@ -35,7 +35,6 @@ var TestTimeout = time.Second
 // TestReplyHandlerEmptyReply test that we can handle an empty SegReply.
 func TestReplyHandlerEmptyReply(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	ctx, cancelF := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancelF()
 
@@ -65,7 +64,6 @@ func TestReplyHandlerEmptyReply(t *testing.T) {
 // are properly stored in the result struct and that the result sets the Err.
 func TestHandleAllVerificationsFail(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	ctx, cancelF := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancelF()
 
@@ -116,7 +114,6 @@ func TestHandleAllVerificationsFail(t *testing.T) {
 // segments and 1 revocation are successfully verified and stored.
 func TestReplyHandlerNoErrors(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	ctx, cancelF := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancelF()
 
@@ -163,7 +160,6 @@ func TestReplyHandlerNoErrors(t *testing.T) {
 
 func TestReplyHandlerStorageError(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	ctx, cancelF := context.WithTimeout(context.Background(), TestTimeout)
 	defer cancelF()
 

--- a/private/segment/seghandler/storage_test.go
+++ b/private/segment/seghandler/storage_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestDefaultStorageStoreSegs(t *testing.T) {
 	rootCtrl := gomock.NewController(t)
-	defer rootCtrl.Finish()
 
 	tg := graph.NewDefaultGraph(rootCtrl)
 	seg110To130 := tg.Beacon([]uint16{graph.If_110_X_120_A, graph.If_120_A_130_B})

--- a/private/segment/seghandler/storage_test.go
+++ b/private/segment/seghandler/storage_test.go
@@ -130,7 +130,6 @@ func TestDefaultStorageStoreSegs(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			storage := seghandler.DefaultStorage{
 				PathDB: test.PathDB(ctrl),
 			}

--- a/private/svc/internal/ctxconn/ctxconn_test.go
+++ b/private/svc/internal/ctxconn/ctxconn_test.go
@@ -30,7 +30,6 @@ func TestCloseConeOnDone(t *testing.T) {
 
 	t.Run("if no deadline and no ctx canceled, close is called once", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		closer := mock_ctxconn.NewMockDeadlineCloser(ctrl)
 		closer.EXPECT().Close()
 		cancelFunc := CloseConnOnDone(context.Background(), closer)
@@ -39,7 +38,6 @@ func TestCloseConeOnDone(t *testing.T) {
 	})
 	t.Run("close error is returned", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		closer := mock_ctxconn.NewMockDeadlineCloser(ctrl)
 		testErr := errors.New("test")
 		closer.EXPECT().Close().Return(testErr)
@@ -49,7 +47,6 @@ func TestCloseConeOnDone(t *testing.T) {
 	})
 	t.Run("if no deadline and ctx canceled, close is called once", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		ctx, ctxCancelF := context.WithCancel(context.Background())
 		ctxCancelF()
 		closer := mock_ctxconn.NewMockDeadlineCloser(ctrl)
@@ -61,7 +58,6 @@ func TestCloseConeOnDone(t *testing.T) {
 
 	t.Run("if deadline expires, close is called once", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		deadline := time.Now().Add(20 * time.Millisecond)
 		ctx, ctxCancelF := context.WithDeadline(context.Background(), deadline)
 

--- a/private/svc/resolver_test.go
+++ b/private/svc/resolver_test.go
@@ -38,7 +38,6 @@ import (
 
 func TestResolver(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	srcIA := addr.MustParseIA("1-ff00:0:1")
 	dstIA := addr.MustParseIA("1-ff00:0:2")
@@ -173,7 +172,6 @@ func TestRoundTripper(t *testing.T) {
 			t.Parallel()
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			conn := mock_snet.NewMockPacketConn(ctrl)
 
 			if tc.ConnSetup != nil {

--- a/private/svc/svc_test.go
+++ b/private/svc/svc_test.go
@@ -162,7 +162,6 @@ func TestSVCResolutionServer(t *testing.T) {
 			t.Parallel()
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			pconn, err := tc.Network(ctrl).OpenRaw(
 				context.Background(),
@@ -294,7 +293,6 @@ func TestDefaultHandler(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			conn := mock_snet.NewMockPacketConn(ctrl)
 			if !tc.ExpectedError {
@@ -321,7 +319,6 @@ func TestDefaultHandler(t *testing.T) {
 
 	t.Run("Underlay addresses are forwarded", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		conn := mock_snet.NewMockPacketConn(ctrl)
 		packet := &snet.Packet{

--- a/private/trust/db_inspector_test.go
+++ b/private/trust/db_inspector_test.go
@@ -114,7 +114,6 @@ func TestDBInspectorByAttributes(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			i := trust.DBInspector{DB: tc.db(ctrl)}
 			ias, err := i.ByAttributes(context.Background(), tc.query.ISD, tc.query.Attrs)
 			tc.assertErr(t, err)
@@ -184,7 +183,6 @@ func TestDBInspectorHasAttributes(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			i := trust.DBInspector{DB: tc.db(ctrl)}
 			has, err := i.HasAttributes(context.Background(), tc.query.IA, tc.query.Attrs)
 			tc.assertErr(t, err)

--- a/private/trust/fetching_provider_test.go
+++ b/private/trust/fetching_provider_test.go
@@ -458,7 +458,6 @@ func TestFetchingProviderGetChains(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 			p := trust.FetchingProvider{
 				DB:       tc.DB(t, mctrl),
 				Recurser: tc.Recurser(t, mctrl),
@@ -777,7 +776,6 @@ func TestFetchingProviderNotifyTRC(t *testing.T) {
 			t.Parallel()
 
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 			p := trust.FetchingProvider{
 				DB:       tc.DB(t, mctrl),
 				Recurser: tc.Recurser(t, mctrl),

--- a/private/trust/grpc/fetcher_test.go
+++ b/private/trust/grpc/fetcher_test.go
@@ -168,7 +168,6 @@ func TestFetcherChains(t *testing.T) {
 			t.Parallel()
 
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 
 			svc := xtest.NewGRPCService()
 			cppb.RegisterTrustMaterialServiceServer(svc.Server(), tc.Server(mctrl))
@@ -254,7 +253,6 @@ func TestFetcherTRC(t *testing.T) {
 			t.Parallel()
 
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 
 			svc := xtest.NewGRPCService()
 			cppb.RegisterTrustMaterialServiceServer(svc.Server(), tc.Server(mctrl))

--- a/private/trust/router_test.go
+++ b/private/trust/router_test.go
@@ -139,7 +139,6 @@ func TestCSRouterChooseServer(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 			db := mock_trust.NewMockDB(mctrl)
 			r, p := mock_snet.NewMockRouter(mctrl), mock_snet.NewMockPath(mctrl)
 			test.Expect(db, r, p)

--- a/private/trust/signer_gen_test.go
+++ b/private/trust/signer_gen_test.go
@@ -422,7 +422,6 @@ func TestSignerGenGenerate(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 				mctrl := gomock.NewController(t)
-				defer mctrl.Finish()
 
 				gen := trust.SignerGen{
 					IA:      addr.MustParseIA("1-ff00:0:110"),
@@ -437,7 +436,6 @@ func TestSignerGenGenerate(t *testing.T) {
 	})
 	t.Run("metrics", func(t *testing.T) {
 		mctrl := gomock.NewController(t)
-		defer mctrl.Finish()
 		// Ensure the gauge is set to the expected value.
 		ring := mock_trust.NewMockKeyRing(mctrl)
 		ring.EXPECT().PrivateKeys(gomock.Any()).Return([]crypto.Signer{key}, nil)

--- a/private/trust/store_test.go
+++ b/private/trust/store_test.go
@@ -243,7 +243,6 @@ func TestLoadTRCs(t *testing.T) {
 	dir := genCrypto(t)
 
 	mctrl := gomock.NewController(t)
-	defer mctrl.Finish()
 
 	testCases := map[string]struct {
 		inputDir   string

--- a/private/trust/store_test.go
+++ b/private/trust/store_test.go
@@ -215,7 +215,6 @@ func TestLoadChains(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctlr := gomock.NewController(t)
-			defer ctlr.Finish()
 
 			dir := tc.genCrypto(t)
 

--- a/private/trust/tls_verifier_test.go
+++ b/private/trust/tls_verifier_test.go
@@ -57,7 +57,6 @@ func TestTLSCryptoVerifierVerifyServerCertificate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			db := tc.db(ctrl)
 			verifier := trust.TLSCryptoVerifier{
@@ -96,7 +95,6 @@ func TestTLSCryptoVerifierVerifyClientCertificate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			db := tc.db(ctrl)
 			verifier := trust.TLSCryptoVerifier{
@@ -113,7 +111,6 @@ func TestTLSCryptoVerifierVerifyClientCertificate(t *testing.T) {
 func TestHandshake(t *testing.T) {
 	dir := genCrypto(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	trc := xtest.LoadTRC(t, filepath.Join(dir, "trcs/ISD1-B1-S1.trc"))
 	crt111File := filepath.Join(dir, "certs/ISD1-ASff00_0_111.pem")

--- a/private/trust/verifier_test.go
+++ b/private/trust/verifier_test.go
@@ -182,7 +182,6 @@ func TestVerify(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			mctrl := gomock.NewController(t)
-			defer mctrl.Finish()
 
 			v := &trust.Verifier{
 				BoundIA:     tc.boundIA,

--- a/router/bfd/jitter_test.go
+++ b/router/bfd/jitter_test.go
@@ -31,7 +31,6 @@ func TestComputeInterval(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		// controller is shared between test cases, and clean-up runs once at the end,
 		// but it's fine here.
-		defer ctrl.Finish()
 
 		mockIntervalGenerator := mock_bfd.NewMockIntervalGenerator(ctrl)
 		testCases := []*struct {
@@ -114,7 +113,6 @@ func TestComputeInterval(t *testing.T) {
 
 		for i, tc := range testCases {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			mockGenerator := mock_bfd.NewMockIntervalGenerator(ctrl)
 			tc.generatorSetup(mockGenerator)
@@ -172,7 +170,6 @@ func TestGenerate(t *testing.T) {
 				panic(fmt.Sprintf("bad test data, %d >= (%d - %d)", tc.offset, tc.y, tc.x))
 			}
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			mockSource := mock_bfd.NewMockSource(ctrl)
 			mockSource.EXPECT().Intn(gomock.Any()).Return(tc.offset).AnyTimes()

--- a/router/dataplane_internal_test.go
+++ b/router/dataplane_internal_test.go
@@ -48,7 +48,6 @@ var testKey = []byte("testkey_xxxxxxxx")
 // the same number of packets as the receiver received.
 func TestReceiver(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	dp := newDataPlane(RunConfig{NumProcessors: 1, BatchSize: 64}, false)
 	counter := 0
 	mInternal := mock_router.NewMockBatchConn(ctrl)
@@ -128,7 +127,6 @@ func TestReceiver(t *testing.T) {
 // and that the buffers have been returned to the buffer pool.
 func TestForwarder(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	done := make(chan struct{})
 	prepareDP := func(ctrl *gomock.Controller) *dataPlane {
 		ret := newDataPlane(

--- a/router/mgmtapi/api_test.go
+++ b/router/mgmtapi/api_test.go
@@ -127,7 +127,6 @@ func TestAPI(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 
 			req, err := http.NewRequest("GET", tc.RequestURL, nil)
 			require.NoError(t, err)


### PR DESCRIPTION
Since Go 1.14 gomock will use `T.Cleanup` automatically.

This is the results of running:
```sh
find . -type f -name "*.go" -exec sed -i '' '/defer ctrl\.Finish()/d' {} +
find . -type f -name "*.go" -exec sed -i '' '/defer ctlr\.Finish()/d' {} +
find . -type f -name "*.go" -exec sed -i '' '/defer mctrl\.Finish()/d' {} +
find . -type f -name "*.go" -exec sed -i '' '/defer rootCtrl\.Finish()/d' {} +
```
And cleaning up unused variables by hand.