### PR TITLE
fix: enable linter contextcheck and fix potential problems

### DIFF
--- a/.golangcilint.yml
+++ b/.golangcilint.yml
@@ -19,6 +19,7 @@ linters:
     - lll
     - misspell
     - goheader
+    - contextcheck
 linters-settings:
   # ...
   forbidigo:

--- a/control/beaconing/originator_test.go
+++ b/control/beaconing/originator_test.go
@@ -1,4 +1,5 @@
 // Copyright 2019 Anapaya Systems
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -94,10 +95,10 @@ func TestOriginatorRun(t *testing.T) {
 
 				sender := mock_beaconing.NewMockSender(mctrl)
 				sender.EXPECT().Send(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
-					func(_ context.Context, b *seg.PathSegment) error {
+					func(ctx context.Context, b *seg.PathSegment) error {
 						// Check the beacon is valid and verifiable.
 						assert.NoError(t, b.Validate(seg.ValidateBeacon))
-						assert.NoError(t, b.VerifyASEntry(context.Background(),
+						assert.NoError(t, b.VerifyASEntry(ctx,
 							segVerifier{pubKey: pub}, b.MaxIdx()))
 						// Extract the hop field from the current AS entry to compare.
 						hopF := b.ASEntries[b.MaxIdx()].HopEntry.HopField

--- a/control/beaconing/propagator_test.go
+++ b/control/beaconing/propagator_test.go
@@ -95,12 +95,12 @@ func TestPropagatorRunNonCore(t *testing.T) {
 		gomock.Any()).Times(1).DoAndReturn(
 
 		func(_ context.Context, _ addr.IA, egIfID uint16,
-			nextHop *net.UDPAddr) (beaconing.Sender, error) {
-
+			nextHop *net.UDPAddr,
+		) (beaconing.Sender, error) {
 			sender := mock_beaconing.NewMockSender(mctrl)
 			sender.EXPECT().Send(gomock.Any(), gomock.Any()).Times(3).DoAndReturn(
-				func(_ context.Context, b *seg.PathSegment) error {
-					validateSend(t, b, egIfID, nextHop, pub, topo)
+				func(ctx context.Context, b *seg.PathSegment) error {
+					validateSend(ctx, t, b, egIfID, nextHop, pub, topo)
 					return nil
 				},
 			)
@@ -167,12 +167,12 @@ func TestPropagatorRunCore(t *testing.T) {
 	senderFactory.EXPECT().NewSender(gomock.Any(), gomock.Any(), uint16(1121),
 		gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ addr.IA, egIfID uint16,
-			nextHop *net.UDPAddr) (beaconing.Sender, error) {
-
+			nextHop *net.UDPAddr,
+		) (beaconing.Sender, error) {
 			sender := mock_beaconing.NewMockSender(mctrl)
 			sender.EXPECT().Send(gomock.Any(), gomock.Any()).Times(2).DoAndReturn(
-				func(_ context.Context, b *seg.PathSegment) error {
-					validateSend(t, b, egIfID, nextHop, pub, topo)
+				func(ctx context.Context, b *seg.PathSegment) error {
+					validateSend(ctx, t, b, egIfID, nextHop, pub, topo)
 					return nil
 				},
 			)
@@ -183,12 +183,12 @@ func TestPropagatorRunCore(t *testing.T) {
 	senderFactory.EXPECT().NewSender(gomock.Any(), gomock.Any(), uint16(1113),
 		gomock.Any()).DoAndReturn(
 		func(_ context.Context, _ addr.IA, egIfID uint16,
-			nextHop *net.UDPAddr) (beaconing.Sender, error) {
-
+			nextHop *net.UDPAddr,
+		) (beaconing.Sender, error) {
 			sender := mock_beaconing.NewMockSender(mctrl)
 			sender.EXPECT().Send(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(
-				func(_ context.Context, b *seg.PathSegment) error {
-					validateSend(t, b, egIfID, nextHop, pub, topo)
+				func(ctx context.Context, b *seg.PathSegment) error {
+					validateSend(ctx, t, b, egIfID, nextHop, pub, topo)
 					return nil
 				},
 			)
@@ -275,6 +275,7 @@ func TestPropagatorFastRecovery(t *testing.T) {
 }
 
 func validateSend(
+	ctx context.Context,
 	t *testing.T,
 	b *seg.PathSegment,
 	egIfID uint16,
@@ -284,7 +285,7 @@ func validateSend(
 ) {
 	// Check the beacon is valid and verifiable.
 	assert.NoError(t, b.Validate(seg.ValidateBeacon))
-	assert.NoError(t, b.VerifyASEntry(context.Background(),
+	assert.NoError(t, b.VerifyASEntry(ctx,
 		segVerifier{pubKey: pub}, b.MaxIdx()))
 	// Extract the hop field from the current AS entry to compare.
 	hopF := b.ASEntries[b.MaxIdx()].HopEntry.HopField

--- a/control/cmd/control/main.go
+++ b/control/cmd/control/main.go
@@ -395,9 +395,9 @@ func realMain(ctx context.Context) error {
 		})
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	ctxSigner, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
-	signer := cs.NewSigner(ctx, topo.IA(), trustDB, globalCfg.General.ConfigDir)
+	signer := cs.NewSigner(ctxSigner, topo.IA(), trustDB, globalCfg.General.ConfigDir)
 
 	var chainBuilder renewal.ChainBuilder
 	var caClient *caapi.Client

--- a/control/cmd/control/main.go
+++ b/control/cmd/control/main.go
@@ -224,7 +224,7 @@ func realMain(ctx context.Context) error {
 		MTU:                    topo.MTU(),
 		Topology:               adaptTopology(topo),
 	}
-	quicStack, err := nc.QUICStack(ctx)
+	quicStack, err := nc.QUICStack(context.Background())
 	if err != nil {
 		return serrors.Wrap("initializing QUIC stack", err)
 	}

--- a/control/cmd/control/main.go
+++ b/control/cmd/control/main.go
@@ -224,7 +224,7 @@ func realMain(ctx context.Context) error {
 		MTU:                    topo.MTU(),
 		Topology:               adaptTopology(topo),
 	}
-	quicStack, err := nc.QUICStack()
+	quicStack, err := nc.QUICStack(ctx)
 	if err != nil {
 		return serrors.Wrap("initializing QUIC stack", err)
 	}
@@ -393,10 +393,11 @@ func realMain(ctx context.Context) error {
 			},
 			Registrations: libmetrics.NewPromCounter(metrics.SegmentRegistrationsTotal),
 		})
-
 	}
 
-	signer := cs.NewSigner(topo.IA(), trustDB, globalCfg.General.ConfigDir)
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	signer := cs.NewSigner(ctx, topo.IA(), trustDB, globalCfg.General.ConfigDir)
 
 	var chainBuilder renewal.ChainBuilder
 	var caClient *caapi.Client
@@ -837,7 +838,6 @@ func createBeaconStore(
 	policyConfig config.Policies,
 	provider beacon.ChainProvider,
 ) (cs.Store, bool, error) {
-
 	if core {
 		policies, err := cs.LoadCorePolicies(policyConfig)
 		if err != nil {
@@ -967,7 +967,6 @@ func getCAHealth(
 	ctx context.Context,
 	caClient *caapi.Client,
 ) (api.CAHealthStatus, error) {
-
 	logger := log.FromCtx(ctx)
 	rep, err := caClient.GetHealthcheck(ctx)
 	if err != nil {

--- a/control/cmd/control/main.go
+++ b/control/cmd/control/main.go
@@ -224,7 +224,7 @@ func realMain(ctx context.Context) error {
 		MTU:                    topo.MTU(),
 		Topology:               adaptTopology(topo),
 	}
-	quicStack, err := nc.QUICStack(context.Background())
+	quicStack, err := nc.QUICStack(ctx)
 	if err != nil {
 		return serrors.Wrap("initializing QUIC stack", err)
 	}

--- a/control/drkey/grpc/drkey_service.go
+++ b/control/drkey/grpc/drkey_service.go
@@ -1,4 +1,5 @@
 // Copyright 2022 ETH Zurich
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,7 +42,7 @@ type Engine interface {
 	GetSecretValue(ctx context.Context, meta drkey.SecretValueMeta) (drkey.SecretValue, error)
 	GetLevel1Key(ctx context.Context, meta drkey.Level1Meta) (drkey.Level1Key, error)
 
-	DeriveLevel1(meta drkey.Level1Meta) (drkey.Level1Key, error)
+	DeriveLevel1(ctx context.Context, meta drkey.Level1Meta) (drkey.Level1Key, error)
 	DeriveASHost(ctx context.Context, meta drkey.ASHostMeta) (drkey.ASHostKey, error)
 	DeriveHostAS(ctx context.Context, meta drkey.HostASMeta) (drkey.HostASKey, error)
 	DeriveHostHost(ctx context.Context, meta drkey.HostHostMeta) (drkey.HostHostKey, error)
@@ -66,7 +67,6 @@ func (d *Server) DRKeyLevel1(
 	ctx context.Context,
 	req *cppb.DRKeyLevel1Request,
 ) (*cppb.DRKeyLevel1Response, error) {
-
 	peer, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, serrors.New("cannot retrieve peer information from ctx")
@@ -87,7 +87,7 @@ func (d *Server) DRKeyLevel1(
 			"proto_id", lvl1Meta.ProtoId)
 	}
 
-	lvl1Key, err := d.Engine.DeriveLevel1(lvl1Meta)
+	lvl1Key, err := d.Engine.DeriveLevel1(ctx, lvl1Meta)
 	if err != nil {
 		return nil, serrors.Wrap("deriving level 1 key", err)
 	}
@@ -100,7 +100,6 @@ func (d *Server) DRKeyIntraLevel1(
 	ctx context.Context,
 	req *cppb.DRKeyIntraLevel1Request,
 ) (*cppb.DRKeyIntraLevel1Response, error) {
-
 	peer, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, serrors.New("cannot retrieve peer information from ctx")
@@ -132,7 +131,6 @@ func (d *Server) DRKeyASHost(
 	ctx context.Context,
 	req *cppb.DRKeyASHostRequest,
 ) (*cppb.DRKeyASHostResponse, error) {
-
 	peer, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, serrors.New("cannot retrieve peer information from ctx")
@@ -160,7 +158,6 @@ func (d *Server) DRKeyHostAS(
 	ctx context.Context,
 	req *cppb.DRKeyHostASRequest,
 ) (*cppb.DRKeyHostASResponse, error) {
-
 	peer, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, serrors.New("cannot retrieve peer information from ctx")
@@ -187,7 +184,6 @@ func (d *Server) DRKeyHostHost(
 	ctx context.Context,
 	req *cppb.DRKeyHostHostRequest,
 ) (*cppb.DRKeyHostHostResponse, error) {
-
 	peer, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, serrors.New("cannot retrieve peer information from ctx")
@@ -215,7 +211,6 @@ func (d *Server) DRKeySecretValue(
 	ctx context.Context,
 	req *cppb.DRKeySecretValueRequest,
 ) (*cppb.DRKeySecretValueResponse, error) {
-
 	peer, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, serrors.New("cannot retrieve peer information from ctx")
@@ -363,7 +358,8 @@ func hostAddrFromPeer(peerAddr net.Addr) (net.IP, error) {
 }
 
 func getMeta(protoId drkeypb.Protocol, ts *timestamppb.Timestamp, srcIA,
-	dstIA addr.IA) (drkey.Level1Meta, error) {
+	dstIA addr.IA,
+) (drkey.Level1Meta, error) {
 	err := ts.CheckValid()
 	if err != nil {
 		return drkey.Level1Meta{}, serrors.Wrap("invalid valTime from pb req", err)

--- a/control/drkey/grpc/fetcher_test.go
+++ b/control/drkey/grpc/fetcher_test.go
@@ -1,4 +1,5 @@
 // Copyright 2022 ETH Zurich
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -62,7 +63,7 @@ func TestLevel1KeyFetching(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	lvl1db := mock_grpc.NewMockEngine(ctrl)
-	lvl1db.EXPECT().DeriveLevel1(gomock.Any()).AnyTimes().Return(drkey.Level1Key{}, nil)
+	lvl1db.EXPECT().DeriveLevel1(gomock.Any(), gomock.Any()).AnyTimes().Return(drkey.Level1Key{}, nil)
 
 	db := mock_trust.NewMockDB(ctrl)
 	db.EXPECT().SignedTRC(gomock.Any(), gomock.Any()).AnyTimes().Return(trc, nil)
@@ -94,7 +95,6 @@ func TestLevel1KeyFetching(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-
 			// TODO(matzf): change xtest library to allow specifying the client
 			// credentials for individual calls so that server does not need to be
 			// recreated here.

--- a/control/drkey/grpc/fetcher_test.go
+++ b/control/drkey/grpc/fetcher_test.go
@@ -63,7 +63,9 @@ func TestLevel1KeyFetching(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	lvl1db := mock_grpc.NewMockEngine(ctrl)
-	lvl1db.EXPECT().DeriveLevel1(gomock.Any(), gomock.Any()).AnyTimes().Return(drkey.Level1Key{}, nil)
+	lvl1db.EXPECT().DeriveLevel1(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		Return(drkey.Level1Key{}, nil)
 
 	db := mock_trust.NewMockDB(ctrl)
 	db.EXPECT().SignedTRC(gomock.Any(), gomock.Any()).AnyTimes().Return(trc, nil)

--- a/control/drkey/grpc/mock_grpc/mock.go
+++ b/control/drkey/grpc/mock_grpc/mock.go
@@ -81,18 +81,18 @@ func (mr *MockEngineMockRecorder) DeriveHostHost(arg0, arg1 interface{}) *gomock
 }
 
 // DeriveLevel1 mocks base method.
-func (m *MockEngine) DeriveLevel1(arg0 drkey.Level1Meta) (drkey.Level1Key, error) {
+func (m *MockEngine) DeriveLevel1(arg0 context.Context, arg1 drkey.Level1Meta) (drkey.Level1Key, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeriveLevel1", arg0)
+	ret := m.ctrl.Call(m, "DeriveLevel1", arg0, arg1)
 	ret0, _ := ret[0].(drkey.Level1Key)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DeriveLevel1 indicates an expected call of DeriveLevel1.
-func (mr *MockEngineMockRecorder) DeriveLevel1(arg0 interface{}) *gomock.Call {
+func (mr *MockEngineMockRecorder) DeriveLevel1(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeriveLevel1", reflect.TypeOf((*MockEngine)(nil).DeriveLevel1), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeriveLevel1", reflect.TypeOf((*MockEngine)(nil).DeriveLevel1), arg0, arg1)
 }
 
 // GetLevel1Key mocks base method.

--- a/control/drkey/service_engine.go
+++ b/control/drkey/service_engine.go
@@ -90,7 +90,9 @@ func (s *ServiceEngine) GetLevel1PrefetchInfo() []Level1PrefetchInfo {
 }
 
 // DeriveLevel1 returns a Level1 key based on the presented information.
-func (s *ServiceEngine) DeriveLevel1(ctx context.Context, meta drkey.Level1Meta) (drkey.Level1Key, error) {
+func (s *ServiceEngine) DeriveLevel1(
+	ctx context.Context, meta drkey.Level1Meta,
+) (drkey.Level1Key, error) {
 	sv, err := s.GetSecretValue(ctx, drkey.SecretValueMeta{
 		ProtoId:  meta.ProtoId,
 		Validity: meta.Validity,

--- a/control/drkey/service_engine.go
+++ b/control/drkey/service_engine.go
@@ -1,4 +1,5 @@
 // Copyright 2022 ETH Zurich
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,7 +35,7 @@ type Fetcher interface {
 // Level1PrefetchListKeeper maintains a list for those level1 keys
 // that are recently/frequently used.
 type Level1PrefetchListKeeper interface {
-	//Update updates the keys in Level1Cache based on the Level1Key metadata.
+	// Update updates the keys in Level1Cache based on the Level1Key metadata.
 	Update(key Level1PrefetchInfo)
 	// GetLevel1InfoArray retrieves an array whose members contains information regarding
 	// level1 keys to prefetch.
@@ -63,7 +64,6 @@ func (s *ServiceEngine) GetSecretValue(
 	ctx context.Context,
 	meta drkey.SecretValueMeta,
 ) (drkey.SecretValue, error) {
-
 	return s.SecretBackend.getSecretValue(ctx, meta)
 }
 
@@ -73,7 +73,6 @@ func (s *ServiceEngine) GetLevel1Key(
 	ctx context.Context,
 	meta drkey.Level1Meta,
 ) (drkey.Level1Key, error) {
-
 	key, err := s.getLevel1Key(ctx, meta)
 	if err == nil && ctx.Value(fromPrefetcher{}) == nil && meta.SrcIA != s.LocalIA {
 		keyInfo := Level1PrefetchInfo{
@@ -91,8 +90,8 @@ func (s *ServiceEngine) GetLevel1PrefetchInfo() []Level1PrefetchInfo {
 }
 
 // DeriveLevel1 returns a Level1 key based on the presented information.
-func (s *ServiceEngine) DeriveLevel1(meta drkey.Level1Meta) (drkey.Level1Key, error) {
-	sv, err := s.GetSecretValue(context.Background(), drkey.SecretValueMeta{
+func (s *ServiceEngine) DeriveLevel1(ctx context.Context, meta drkey.Level1Meta) (drkey.Level1Key, error) {
+	sv, err := s.GetSecretValue(ctx, drkey.SecretValueMeta{
 		ProtoId:  meta.ProtoId,
 		Validity: meta.Validity,
 	})
@@ -111,7 +110,6 @@ func (s *ServiceEngine) DeriveASHost(
 	ctx context.Context,
 	meta drkey.ASHostMeta,
 ) (drkey.ASHostKey, error) {
-
 	var key drkey.Key
 	var err error
 
@@ -146,7 +144,6 @@ func (s *ServiceEngine) DeriveHostAS(
 	ctx context.Context,
 	meta drkey.HostASMeta,
 ) (drkey.HostASKey, error) {
-
 	var key drkey.Key
 	var err error
 
@@ -182,7 +179,6 @@ func (s *ServiceEngine) DeriveHostHost(
 	ctx context.Context,
 	meta drkey.HostHostMeta,
 ) (drkey.HostHostKey, error) {
-
 	hostASMeta := drkey.HostASMeta{
 		ProtoId:  meta.ProtoId,
 		Validity: meta.Validity,
@@ -238,9 +234,8 @@ func (s *ServiceEngine) getLevel1Key(
 	ctx context.Context,
 	meta drkey.Level1Meta,
 ) (drkey.Level1Key, error) {
-
 	if meta.SrcIA == s.LocalIA {
-		return s.DeriveLevel1(meta)
+		return s.DeriveLevel1(ctx, meta)
 	}
 
 	if meta.DstIA != s.LocalIA {
@@ -278,7 +273,6 @@ func (s *ServiceEngine) obtainLevel1Key(
 	srcIA addr.IA,
 	dstIA addr.IA,
 ) (drkey.Level1Key, error) {
-
 	if !proto.IsPredefined() {
 		proto = drkey.Generic
 	}
@@ -289,7 +283,6 @@ func (s *ServiceEngine) obtainLevel1Key(
 		ProtoId:  proto,
 	}
 	return s.GetLevel1Key(ctx, level1Meta)
-
 }
 
 type fromPrefetcher struct{}

--- a/control/drkey/service_engine_test.go
+++ b/control/drkey/service_engine_test.go
@@ -1,4 +1,5 @@
 // Copyright 2022 ETH Zurich
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -89,7 +90,7 @@ func TestDeriveLevel1Key(t *testing.T) {
 		Validity: time.Now(),
 	}
 
-	key, err := store.DeriveLevel1(meta)
+	key, err := store.DeriveLevel1(context.Background(), meta)
 	assert.NoError(t, err)
 	assert.Equal(t, meta.DstIA, key.DstIA)
 	assert.Equal(t, meta.ProtoId, key.ProtoId)
@@ -135,7 +136,7 @@ func TestDeriveHostAS(t *testing.T) {
 		PrefetchKeeper: cache,
 	}
 
-	var tests = []drkey.Protocol{
+	tests := []drkey.Protocol{
 		drkey.SCMP,
 		drkey.Protocol(7),
 	}
@@ -231,7 +232,7 @@ func TestGetLevel1Key(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, secondLevel1Key, rcvKey3)
-	//Simulate a call coming from the prefetcher, it must not update cache
+	// Simulate a call coming from the prefetcher, it must not update cache
 	pref_ctx := context.WithValue(context.Background(), cs_drkey.FromPrefetcher(), true)
 	rcvKey4, err := store.GetLevel1Key(pref_ctx, drkey.Level1Meta{
 		ProtoId:  firstLevel1Key.ProtoId,
@@ -258,7 +259,6 @@ func TestGetLevel1Key(t *testing.T) {
 	}
 	_, err = store.GetLevel1Key(context.Background(), locallvl1Meta)
 	assert.NoError(t, err)
-
 }
 
 func newLevel1Database(t *testing.T) *level1_sql.Backend {

--- a/control/trust.go
+++ b/control/trust.go
@@ -78,13 +78,10 @@ func NewTLSCertificateLoader(
 }
 
 // NewSigner creates a renewing signer backed by a certificate chain.
-func NewSigner(ia addr.IA, db trust.DB, cfgDir string) cstrust.RenewingSigner {
+func NewSigner(ctx context.Context, ia addr.IA, db trust.DB, cfgDir string) cstrust.RenewingSigner {
 	signer := cstrust.RenewingSigner{
 		SignerGen: newCachingSignerGen(ia, x509.ExtKeyUsageAny, db, cfgDir),
 	}
-
-	ctx, cancelF := context.WithTimeout(context.Background(), time.Second)
-	defer cancelF()
 	if _, err := signer.SignerGen.Generate(ctx); err != nil {
 		log.Debug("Initial signer generation failed", "err", err)
 	}

--- a/control/trust.go
+++ b/control/trust.go
@@ -1,4 +1,5 @@
 // Copyright 2020 Anapaya Systems
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +34,7 @@ import (
 func LoadTrustMaterial(ctx context.Context, configDir string, db trust.DB) error {
 	logger := log.FromCtx(ctx)
 	certsDir := filepath.Join(configDir, "certs")
-	loaded, err := trust.LoadTRCs(context.Background(), certsDir, db)
+	loaded, err := trust.LoadTRCs(ctx, certsDir, db)
 	if err != nil {
 		return serrors.Wrap("loading TRCs from disk", err)
 	}
@@ -46,7 +47,7 @@ func LoadTrustMaterial(ctx context.Context, configDir string, db trust.DB) error
 		logger.Info("Ignoring non-TRC", "file", f, "reason", r)
 	}
 	localCertsDir := filepath.Join(configDir, "crypto/as")
-	loaded, err = trust.LoadChains(context.Background(), localCertsDir, db)
+	loaded, err = trust.LoadChains(ctx, localCertsDir, db)
 	if err != nil {
 		return serrors.Wrap("loading certificate chains from disk", err)
 	}
@@ -71,7 +72,6 @@ func NewTLSCertificateLoader(
 	db trust.DB,
 	cfgDir string,
 ) cstrust.TLSCertificateLoader {
-
 	return cstrust.TLSCertificateLoader{
 		SignerGen: newCachingSignerGen(ia, extKeyUsage, db, cfgDir),
 	}
@@ -100,7 +100,6 @@ func newCachingSignerGen(
 	db trust.DB,
 	cfgDir string,
 ) *cstrust.CachingSignerGen {
-
 	gen := trust.SignerGen{
 		IA: ia,
 		DB: &cstrust.CryptoLoader{

--- a/control/trust_test.go
+++ b/control/trust_test.go
@@ -36,6 +36,7 @@ func TestNewSigner(t *testing.T) {
 	require.NoError(t, err)
 
 	signer := cs.NewSigner(
+		context.Background(),
 		addr.MustParseIA("1-ff00:0:110"),
 		db,
 		filepath.Join(dir, "/ISD1/ASff00_0_110"),
@@ -59,7 +60,7 @@ func testCrypto(t *testing.T) string {
 
 	raw, err := os.ReadFile(filepath.Join(dir, "trcs/ISD1-B1-S1.trc"))
 	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(dir, "ISD1/ASff00_0_110/certs/ISD1-B1-S1.trc"), raw, 0666)
+	err = os.WriteFile(filepath.Join(dir, "ISD1/ASff00_0_110/certs/ISD1-B1-S1.trc"), raw, 0o666)
 	require.NoError(t, err)
 	return dir
 }

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -153,7 +153,9 @@ func realMain(ctx context.Context) error {
 			[]string{"driver", "operation", prom.LabelResult},
 		),
 	})
-	engine, err := daemon.TrustEngine(errCtx, globalCfg.General.ConfigDir, topo.IA(), trustDB, dialer)
+	engine, err := daemon.TrustEngine(
+		errCtx, globalCfg.General.ConfigDir, topo.IA(), trustDB, dialer,
+	)
 	if err != nil {
 		return serrors.Wrap("creating trust engine", err)
 	}

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -1,4 +1,5 @@
 // Copyright 2020 Anapaya Systems
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -152,7 +153,7 @@ func realMain(ctx context.Context) error {
 			[]string{"driver", "operation", prom.LabelResult},
 		),
 	})
-	engine, err := daemon.TrustEngine(globalCfg.General.ConfigDir, topo.IA(), trustDB, dialer)
+	engine, err := daemon.TrustEngine(ctx, globalCfg.General.ConfigDir, topo.IA(), trustDB, dialer)
 	if err != nil {
 		return serrors.Wrap("creating trust engine", err)
 	}

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -153,7 +153,7 @@ func realMain(ctx context.Context) error {
 			[]string{"driver", "operation", prom.LabelResult},
 		),
 	})
-	engine, err := daemon.TrustEngine(ctx, globalCfg.General.ConfigDir, topo.IA(), trustDB, dialer)
+	engine, err := daemon.TrustEngine(errCtx, globalCfg.General.ConfigDir, topo.IA(), trustDB, dialer)
 	if err != nil {
 		return serrors.Wrap("creating trust engine", err)
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,4 +1,5 @@
 // Copyright 2018 ETH Zurich, Anapaya Systems
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,13 +55,14 @@ func InitTracer(tracing env.Tracing, id string) (io.Closer, error) {
 
 // TrustEngine builds the trust engine backed by the trust database.
 func TrustEngine(
+	ctx context.Context,
 	cfgDir string,
 	ia addr.IA,
 	db trust.DB,
 	dialer libgrpc.Dialer,
 ) (trust.Engine, error) {
 	certsDir := filepath.Join(cfgDir, "certs")
-	loaded, err := trust.LoadTRCs(context.Background(), certsDir, db)
+	loaded, err := trust.LoadTRCs(ctx, certsDir, db)
 	if err != nil {
 		return trust.Engine{}, serrors.Wrap("loading TRCs", err)
 	}
@@ -72,11 +74,10 @@ func TrustEngine(
 		}
 		log.Info("Ignoring non-TRC", "file", f, "reason", r)
 	}
-	loaded, err = trust.LoadChains(context.Background(), certsDir, db)
+	loaded, err = trust.LoadChains(ctx, certsDir, db)
 	if err != nil {
 		return trust.Engine{}, serrors.Wrap("loading certificate chains",
 			err)
-
 	}
 	log.Info("Certificate chains loaded", "files", loaded.Loaded)
 	for f, r := range loaded.Ignored {

--- a/daemon/internal/servers/grpc.go
+++ b/daemon/internal/servers/grpc.go
@@ -71,8 +71,8 @@ type DaemonServer struct {
 
 // Paths serves the paths request.
 func (s *DaemonServer) Paths(ctx context.Context,
-	req *sdpb.PathsRequest) (*sdpb.PathsResponse, error) {
-
+	req *sdpb.PathsRequest,
+) (*sdpb.PathsResponse, error) {
 	start := time.Now()
 	dstI := addr.IA(req.DestinationIsdAs).ISD()
 	response, err := s.paths(ctx, req)
@@ -84,8 +84,8 @@ func (s *DaemonServer) Paths(ctx context.Context,
 }
 
 func (s *DaemonServer) paths(ctx context.Context,
-	req *sdpb.PathsRequest) (*sdpb.PathsResponse, error) {
-
+	req *sdpb.PathsRequest,
+) (*sdpb.PathsResponse, error) {
 	if _, ok := ctx.Deadline(); !ok {
 		var cancelF context.CancelFunc
 		ctx, cancelF = context.WithTimeout(ctx, 10*time.Second)
@@ -115,7 +115,6 @@ func (s *DaemonServer) fetchPaths(
 	src, dst addr.IA,
 	refresh bool,
 ) ([]snet.Path, error) {
-
 	r, err, _ := group.Do(fmt.Sprintf("%s%s%t", src, dst, refresh),
 		func() (any, error) {
 			return s.Fetcher.GetPaths(ctx, src, dst, refresh)
@@ -187,7 +186,6 @@ func pathToPB(path snet.Path) *sdpb.Path {
 		Notes:        meta.Notes,
 		EpicAuths:    epicAuths,
 	}
-
 }
 
 func linkTypeToPB(lt snet.LinkType) sdpb.LinkType {
@@ -210,7 +208,7 @@ func (s *DaemonServer) backgroundPaths(origCtx context.Context, src, dst addr.IA
 		// the original context is large enough no need to spin a background fetch.
 		return
 	}
-	ctx, cancelF := context.WithTimeout(context.Background(), backgroundTimeout)
+	ctx, cancelF := context.WithTimeout(origCtx, backgroundTimeout)
 	defer cancelF()
 	var spanOpts []opentracing.StartSpanOption
 	if span := opentracing.SpanFromContext(origCtx); span != nil {
@@ -259,8 +257,8 @@ func (s *DaemonServer) as(ctx context.Context, req *sdpb.ASRequest) (*sdpb.ASRes
 
 // Interfaces serves the interfaces request.
 func (s *DaemonServer) Interfaces(ctx context.Context,
-	req *sdpb.InterfacesRequest) (*sdpb.InterfacesResponse, error) {
-
+	req *sdpb.InterfacesRequest,
+) (*sdpb.InterfacesResponse, error) {
 	start := time.Now()
 	response, err := s.interfaces(ctx, req)
 	s.Metrics.InterfacesRequests.inc(
@@ -271,8 +269,8 @@ func (s *DaemonServer) Interfaces(ctx context.Context,
 }
 
 func (s *DaemonServer) interfaces(ctx context.Context,
-	_ *sdpb.InterfacesRequest) (*sdpb.InterfacesResponse, error) {
-
+	_ *sdpb.InterfacesRequest,
+) (*sdpb.InterfacesResponse, error) {
 	reply := &sdpb.InterfacesResponse{
 		Interfaces: make(map[uint64]*sdpb.Interface),
 	}
@@ -293,8 +291,8 @@ func (s *DaemonServer) interfaces(ctx context.Context,
 
 // Services serves the services request.
 func (s *DaemonServer) Services(ctx context.Context,
-	req *sdpb.ServicesRequest) (*sdpb.ServicesResponse, error) {
-
+	req *sdpb.ServicesRequest,
+) (*sdpb.ServicesResponse, error) {
 	start := time.Now()
 	respsonse, err := s.services(ctx, req)
 	s.Metrics.ServicesRequests.inc(
@@ -305,8 +303,8 @@ func (s *DaemonServer) Services(ctx context.Context,
 }
 
 func (s *DaemonServer) services(ctx context.Context,
-	_ *sdpb.ServicesRequest) (*sdpb.ServicesResponse, error) {
-
+	_ *sdpb.ServicesRequest,
+) (*sdpb.ServicesResponse, error) {
 	reply := &sdpb.ServicesResponse{
 		Services: make(map[string]*sdpb.ListService),
 	}
@@ -321,8 +319,8 @@ func (s *DaemonServer) services(ctx context.Context,
 
 // NotifyInterfaceDown notifies the server about an interface that is down.
 func (s *DaemonServer) NotifyInterfaceDown(ctx context.Context,
-	req *sdpb.NotifyInterfaceDownRequest) (*sdpb.NotifyInterfaceDownResponse, error) {
-
+	req *sdpb.NotifyInterfaceDownRequest,
+) (*sdpb.NotifyInterfaceDownResponse, error) {
 	start := time.Now()
 	response, err := s.notifyInterfaceDown(ctx, req)
 	s.Metrics.InterfaceDownNotifications.inc(
@@ -333,8 +331,8 @@ func (s *DaemonServer) NotifyInterfaceDown(ctx context.Context,
 }
 
 func (s *DaemonServer) notifyInterfaceDown(ctx context.Context,
-	req *sdpb.NotifyInterfaceDownRequest) (*sdpb.NotifyInterfaceDownResponse, error) {
-
+	req *sdpb.NotifyInterfaceDownRequest,
+) (*sdpb.NotifyInterfaceDownResponse, error) {
 	revInfo := &path_mgmt.RevInfo{
 		RawIsdas:     addr.IA(req.IsdAs),
 		IfID:         iface.ID(req.Id),
@@ -358,7 +356,6 @@ func (s *DaemonServer) PortRange(
 	_ context.Context,
 	_ *emptypb.Empty,
 ) (*sdpb.PortRangeResponse, error) {
-
 	startPort, endPort := s.Topology.PortRange()
 	return &sdpb.PortRangeResponse{
 		DispatchedPortStart: uint32(startPort),
@@ -370,7 +367,6 @@ func (s *DaemonServer) DRKeyASHost(
 	ctx context.Context,
 	req *pb_daemon.DRKeyASHostRequest,
 ) (*pb_daemon.DRKeyASHostResponse, error) {
-
 	if s.DRKeyClient == nil {
 		return nil, serrors.New("DRKey is not available")
 	}
@@ -395,7 +391,6 @@ func (s *DaemonServer) DRKeyHostAS(
 	ctx context.Context,
 	req *pb_daemon.DRKeyHostASRequest,
 ) (*pb_daemon.DRKeyHostASResponse, error) {
-
 	if s.DRKeyClient == nil {
 		return nil, serrors.New("DRKey is not available")
 	}
@@ -420,7 +415,6 @@ func (s *DaemonServer) DRKeyHostHost(
 	ctx context.Context,
 	req *pb_daemon.DRKeyHostHostRequest,
 ) (*pb_daemon.DRKeyHostHostResponse, error) {
-
 	if s.DRKeyClient == nil {
 		return nil, serrors.New("DRKey is not available")
 	}

--- a/daemon/internal/servers/grpc.go
+++ b/daemon/internal/servers/grpc.go
@@ -208,7 +208,9 @@ func (s *DaemonServer) backgroundPaths(origCtx context.Context, src, dst addr.IA
 		// the original context is large enough no need to spin a background fetch.
 		return
 	}
-	ctx, cancelF := context.WithTimeout(origCtx, backgroundTimeout)
+	// We're not passing origCtx because this is a background fetch that
+	// should continue even in case origCtx is cancelled.
+	ctx, cancelF := context.WithTimeout(context.Background(), backgroundTimeout)
 	defer cancelF()
 	var spanOpts []opentracing.StartSpanOption
 	if span := opentracing.SpanFromContext(origCtx); span != nil {

--- a/daemon/internal/servers/grpc.go
+++ b/daemon/internal/servers/grpc.go
@@ -218,6 +218,7 @@ func (s *DaemonServer) backgroundPaths(origCtx context.Context, src, dst addr.IA
 	}
 	span, ctx := opentracing.StartSpanFromContext(ctx, "fetch.paths.background", spanOpts...)
 	defer span.Finish()
+	//nolint:contextcheck // false positive.
 	if _, err := s.fetchPaths(ctx, &s.backgroundPathDedupe, src, dst, refresh); err != nil {
 		log.FromCtx(ctx).Debug("Error fetching paths (background)", "err", err,
 			"src", src, "dst", dst, "refresh", refresh)

--- a/daemon/internal/servers/metrics.go
+++ b/daemon/internal/servers/metrics.go
@@ -97,7 +97,7 @@ type metricsError struct {
 }
 
 func (e metricsError) Error() string {
-	return e.Error()
+	return e.err.Error()
 }
 
 func errToMetricResult(err error) string {

--- a/gateway/control/remotemonitor.go
+++ b/gateway/control/remotemonitor.go
@@ -1,4 +1,5 @@
 // Copyright 2020 Anapaya Systems
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -106,7 +107,7 @@ func (rm *RemoteMonitor) run(ctx context.Context) error {
 	for {
 		select {
 		case ias := <-rm.IAs:
-			rm.process(ctx, ias)
+			rm.process(log.FromCtx(ctx), ias)
 		case <-rm.workerBase.GetDoneChan():
 			rm.cancel()
 			return nil
@@ -114,10 +115,10 @@ func (rm *RemoteMonitor) run(ctx context.Context) error {
 	}
 }
 
-func (rm *RemoteMonitor) process(ctx context.Context, ias []addr.IA) {
+//nolint:contextcheck // Providing a context is not necessary in this case.
+func (rm *RemoteMonitor) process(logger log.Logger, ias []addr.IA) {
 	rm.stateMtx.Lock()
 	defer rm.stateMtx.Unlock()
-	logger := log.FromCtx(ctx)
 	newWatchers := make(map[addr.IA]watcherEntry)
 	for _, ia := range ias {
 		we, ok := rm.currentWatchers[ia]

--- a/gateway/pathhealth/monitor.go
+++ b/gateway/pathhealth/monitor.go
@@ -63,6 +63,8 @@ type Monitor struct {
 }
 
 // Register starts monitoring given AS under the specified selector.
+//
+//nolint:contextcheck // Internal context is only used for remoteWatcherItem
 func (m *Monitor) Register(remote addr.IA, selector PathSelector) *Registration {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
@@ -73,6 +75,7 @@ func (m *Monitor) Register(remote addr.IA, selector PathSelector) *Registration 
 	// Otherwise, increase its reference count.
 	item := m.remoteWatchers[remote]
 	if item == nil {
+		//nolint:contextcheck
 		ctx, cancel := context.WithCancel(context.Background())
 		item = &remoteWatcherItem{
 			RemoteWatcher: m.RemoteWatcherFactory.New(remote),

--- a/gateway/pathmonitor.go
+++ b/gateway/pathmonitor.go
@@ -37,7 +37,6 @@ func (pm *PathMonitor) Register(
 	policies *policies.Policies,
 	policyID string,
 ) control.PathMonitorRegistration {
-
 	reg := pm.Monitor.Register(remote, &pathhealth.FilteringPathSelector{
 		PathPolicy:      policies.PathPolicy,
 		PathCount:       policies.PathCount,

--- a/private/app/appnet/infraenv.go
+++ b/private/app/appnet/infraenv.go
@@ -93,9 +93,8 @@ func (nc *NetworkConfig) TCPStack() (net.Listener, error) {
 	})
 }
 
-func (nc *NetworkConfig) QUICStack() (*QUICStack, error) {
-
-	client, server, err := nc.initQUICSockets()
+func (nc *NetworkConfig) QUICStack(ctx context.Context) (*QUICStack, error) {
+	client, server, err := nc.initQUICSockets(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +207,9 @@ func (nc *NetworkConfig) AddressRewriter() *AddressRewriter {
 	}
 }
 
-func (nc *NetworkConfig) initQUICSockets() (net.PacketConn, net.PacketConn, error) {
+func (nc *NetworkConfig) initQUICSockets(
+	ctx context.Context,
+) (net.PacketConn, net.PacketConn, error) {
 	reply := &svc.Reply{
 		Transports: map[svc.Transport]string{
 			svc.QUIC: nc.Public.String(),
@@ -228,7 +229,7 @@ func (nc *NetworkConfig) initQUICSockets() (net.PacketConn, net.PacketConn, erro
 		SCMPHandler:       ignoreSCMP{},
 		PacketConnMetrics: nc.SCIONPacketConnMetrics,
 	}
-	pconn, err := serverNet.OpenRaw(context.Background(), nc.Public)
+	pconn, err := serverNet.OpenRaw(ctx, nc.Public)
 	if err != nil {
 		return nil, nil, serrors.Wrap("creating server raw PacketConn", err)
 	}
@@ -262,7 +263,7 @@ func (nc *NetworkConfig) initQUICSockets() (net.PacketConn, net.PacketConn, erro
 		IP:   nc.Public.IP,
 		Zone: nc.Public.Zone,
 	}
-	client, err := clientNet.Listen(context.Background(), "udp", clientAddr)
+	client, err := clientNet.Listen(ctx, "udp", clientAddr)
 	if err != nil {
 		return nil, nil, serrors.Wrap("creating client connection", err)
 	}

--- a/private/periodic/periodic.go
+++ b/private/periodic/periodic.go
@@ -1,4 +1,5 @@
 // Copyright 2018 Anapaya Systems
+// Copyright 2025 SCION Association
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -115,6 +116,8 @@ func Start(task Task, period, timeout time.Duration) *Runner {
 
 // StartWithMetrics is identical to Start but allows the caller to
 // specify the metric or no metric at all to be used.
+//
+//nolint:contextcheck // Providing a context is not necessary in this case.
 func StartWithMetrics(task Task, metric *Metrics, period, timeout time.Duration) *Runner {
 	ctx, cancelF := context.WithCancel(context.Background())
 	logger := log.New("debug_id", log.NewDebugID())

--- a/tools/await-connectivity
+++ b/tools/await-connectivity
@@ -76,6 +76,7 @@ check_connectivity() {
 	  echo "$as: Waiting for Upsegs"
 	  ret=1
     fi
+    sleep 2
   done
   return $ret
 }

--- a/tools/await-connectivity
+++ b/tools/await-connectivity
@@ -76,7 +76,6 @@ check_connectivity() {
 	  echo "$as: Waiting for Upsegs"
 	  ret=1
     fi
-    sleep 2
   done
   return $ret
 }


### PR DESCRIPTION
- ci: enable linter `contextcheck`
- fix: potentially incorrect uses of `context.Context`.