### PR TITLE
doc: proposed adoption of the contributor's covenant as our code of conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,5 @@ Join us on our [slack workspace](https://scionproto.slack.com) with this invite 
 ## License
 
 [![License](https://img.shields.io/github/license/scionproto/scion.svg?maxAge=2592000)](https://github.com/scionproto/scion/blob/master/LICENSE)
+
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](doc/code_of_conduct.md)

--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ Join us on our [slack workspace](https://scionproto.slack.com) with this invite 
 
 [![License](https://img.shields.io/github/license/scionproto/scion.svg?maxAge=2592000)](https://github.com/scionproto/scion/blob/master/LICENSE)
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](doc/code_of_conduct.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -48,6 +48,28 @@ comments, commits, code, wiki edits, issues, and other contributions that are
 not aligned to this Code of Conduct, and will communicate reasons for moderation
 decisions when appropriate.
 
+"Community leaders" are the members of the SCION Technical Committee, implementation.
+A regularly updated list of members can be found
+[here](https://docs.scion.org/en/latest/dev/contribute.html#governance-tc-implementation)
+
+## Conflict Resolution
+
+We do not believe that all conflict is bad; healthy debate and disagreement often
+yield positive results. However, it is never okay to engage in behavior that violates
+the project’s code of conduct.
+
+If you see someone violating the code of conduct, you are encouraged to address the
+behavior directly with those involved. Many issues can be resolved quickly and
+easily, and this gives people more control over the outcome of their dispute. If you
+are unable to resolve the matter for any reason, or if the behavior is threatening or
+harassing, report it. We are dedicated to providing an environment where participants
+feel welcome and safe.
+
+Reports should be directed to the community leaders at conduct@scion.org. If, for any
+reason you are uncomfortable reaching out to the community leaders, or if you are one of
+the community leaders and cannot resolve the issue, please email the SCION Association's
+CEO at luzius.cameron@scion.org.
+
 ## Scope
 
 This Code of Conduct applies within all community spaces, and also applies when
@@ -121,6 +143,8 @@ version 2.1, available at
 Community Impact Guidelines were inspired by
 [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
+Conflict Resolution Guidelines were inspired by [Go Community Code of Conduct][Go CoC]
+
 For answers to common questions about this code of conduct, see the FAQ at
 [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
 [https://www.contributor-covenant.org/translations][translations].
@@ -130,4 +154,4 @@ For answers to common questions about this code of conduct, see the FAQ at
 [Mozilla CoC]: https://github.com/mozilla/diversity
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations
-
+[Go CoC]: https://go.dev/conduct

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -67,8 +67,9 @@ feel welcome and safe.
 
 Reports should be directed to the community leaders at <conduct@scion.org>. If, for any
 reason you are uncomfortable reaching out to the community leaders, or if you are one of
-the community leaders and cannot resolve the issue, please email the SCION Association's
-CEO at <luzius.cameron@scion.org>.
+the community leaders and cannot resolve the issue, please email either of the SCION
+Association's CEOs: <luzius.cameron@scion.org> or <nic@scion.org>. (Luzius Cameron is not
+a member of the SCION technical committee implementation.)
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -65,10 +65,15 @@ are unable to resolve the matter for any reason, or if the behavior is threateni
 harassing, report it. We are dedicated to providing an environment where participants
 feel welcome and safe.
 
-Reports should be directed to the community leaders at conduct@scion.org. If, for any
+Reports should be directed to the community leaders at <conduct@scion.org>. If, for any
 reason you are uncomfortable reaching out to the community leaders, or if you are one of
 the community leaders and cannot resolve the issue, please email the SCION Association's
-CEO at luzius.cameron@scion.org.
+CEO at <luzius.cameron@scion.org>.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders and SCION association staff members are obligated to
+respect the privacy and security of the reporter of any incident.
 
 ## Scope
 
@@ -77,16 +82,6 @@ an individual is officially representing the community in public spaces.
 Examples of representing our community include using an official email address,
 posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-nic@scion.org. All complaints will be reviewed and investigated promptly and
-fairly.
-
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
 
 ## Enforcement Guidelines
 

--- a/doc/code_of_conduct.md
+++ b/doc/code_of_conduct.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+nic@scion.org. All complaints will be reviewed and investigated promptly and
+fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/doc/dev/contribute.rst
+++ b/doc/dev/contribute.rst
@@ -6,10 +6,7 @@ Contribution Guide
 
 Welcome to the SCION contribution guide! If you are interested in contributing to
 the project, this page will help you out on your journey to your first SCION commit.
-.. Attention::
-   In all your interactions with the SCION developper
-   community you agree to be bound by our
-   `Code of Conduct <https://github.com/scionproto/scion>`__.
+.. Attention:: In all your interactions with the SCION developper community you agree to be bound by our `Code of Conduct <https://github.com/scionproto/scion>`__.
 
 .. _slack:
 

--- a/doc/dev/contribute.rst
+++ b/doc/dev/contribute.rst
@@ -6,9 +6,10 @@ Contribution Guide
 
 Welcome to the SCION contribution guide! If you are interested in contributing to
 the project, this page will help you out on your journey to your first SCION commit.
-   .. Attention:: In all your interactions with the SCION developper community
-		  you agree to be bound by our
-		  `Code of Conduct <https://github.com/scionproto/scion>`__.
+.. Attention::
+   In all your interactions with the SCION developper
+   community you agree to be bound by our
+   `Code of Conduct <https://github.com/scionproto/scion>`__.
 
 .. _slack:
 

--- a/doc/dev/contribute.rst
+++ b/doc/dev/contribute.rst
@@ -7,7 +7,7 @@ Contribution Guide
 Welcome to the SCION contribution guide! If you are interested in contributing to
 the project, this page will help you out on your journey to your first SCION commit.
 
-.. Attention:: In all your interactions with the SCION developper community you agree to be bound by our `Code of Conduct <https://github.com/scionproto/scion>`__.
+.. Attention:: In all your interactions with the SCION developer community, you agree to be bound by our `Code of Conduct <https://github.com/scionproto/scion>`__.
 
 .. _slack:
 

--- a/doc/dev/contribute.rst
+++ b/doc/dev/contribute.rst
@@ -6,6 +6,7 @@ Contribution Guide
 
 Welcome to the SCION contribution guide! If you are interested in contributing to
 the project, this page will help you out on your journey to your first SCION commit.
+
 .. Attention:: In all your interactions with the SCION developper community you agree to be bound by our `Code of Conduct <https://github.com/scionproto/scion>`__.
 
 .. _slack:

--- a/doc/dev/contribute.rst
+++ b/doc/dev/contribute.rst
@@ -113,7 +113,7 @@ The current members of the TC Implementation are:
 * Marc Frei (|span-github| `@marcfrei <https://github.com/marcfrei>`_, |span-slack| @marcfrei)
 * Markus Legner (|span-github| `@mlegner <https://github.com/mlegner>`_, |span-slack| @Markus Legner)
 * Roman Sharkov  (|span-github| `@romshark <https://github.com/romshark>`_, |span-slack| @Roman Scharkov)
-* Tilmann Zächke (|span-github| `@tzaeschke <https://github.com/tzaeschke>`_, |span-slack| @Tilmann Zäschke)
+* Tilmann Zäschke (|span-github| `@tzaeschke <https://github.com/tzaeschke>`_, |span-slack| @Tilmann Zäschke)
 
 .. rubric:: Responsibilities and Tasks
 

--- a/doc/dev/contribute.rst
+++ b/doc/dev/contribute.rst
@@ -6,6 +6,9 @@ Contribution Guide
 
 Welcome to the SCION contribution guide! If you are interested in contributing to
 the project, this page will help you out on your journey to your first SCION commit.
+   .. Attention:: In all your interactions with the SCION developper community
+		  you agree to be bound by our
+		  `Code of Conduct <https://github.com/scionproto/scion>`__.
 
 .. _slack:
 


### PR DESCRIPTION
It's been brought to the attention of the association that our GH pages lacked any kind of published code of conduct. Hopefully this one is fair and widely accepted.
