### PR TITLE
refactor: provide more/better context in panic messages

### DIFF
--- a/antlr/sequence/sequence_parser.go
+++ b/antlr/sequence/sequence_parser.go
@@ -1948,7 +1948,7 @@ func (p *SequenceParser) Sempred(localctx antlr.RuleContext, ruleIndex, predInde
 		return p.Sequence_Sempred(t, predIndex)
 
 	default:
-		panic(fmt.Errorf("no rule with index: %d", ruleIndex))
+		panic("No predicate with index: " + fmt.Sprint(ruleIndex))
 	}
 }
 
@@ -1970,6 +1970,6 @@ func (p *SequenceParser) Sequence_Sempred(localctx antlr.RuleContext, predIndex 
 		return p.Precpred(p.GetParserRuleContext(), 5)
 
 	default:
-		panic(fmt.Errorf("no predicate with index: %d", predIndex))
+		panic("No predicate with index: " + fmt.Sprint(predIndex))
 	}
 }

--- a/antlr/sequence/sequence_parser.go
+++ b/antlr/sequence/sequence_parser.go
@@ -1948,7 +1948,7 @@ func (p *SequenceParser) Sempred(localctx antlr.RuleContext, ruleIndex, predInde
 		return p.Sequence_Sempred(t, predIndex)
 
 	default:
-		panic("No predicate with index: " + fmt.Sprint(ruleIndex))
+		panic(fmt.Errorf("no rule with index: %d", ruleIndex))
 	}
 }
 
@@ -1970,6 +1970,6 @@ func (p *SequenceParser) Sequence_Sempred(localctx antlr.RuleContext, predIndex 
 		return p.Precpred(p.GetParserRuleContext(), 5)
 
 	default:
-		panic("No predicate with index: " + fmt.Sprint(predIndex))
+		panic(fmt.Errorf("no predicate with index: %d", predIndex))
 	}
 }

--- a/control/segreq/authoritative.go
+++ b/control/segreq/authoritative.go
@@ -49,7 +49,7 @@ func (a AuthoritativeLookup) LookupSegments(
 	case seg.TypeCore:
 		return getCoreSegments(ctx, a.PathDB, a.LocalIA, dst)
 	default:
-		panic(fmt.Errorf("unexpected segType: %d", segType))
+		panic(fmt.Errorf("unexpected segType: %d (%s)", segType, segType.String()))
 	}
 }
 

--- a/control/segreq/authoritative.go
+++ b/control/segreq/authoritative.go
@@ -35,8 +35,8 @@ type AuthoritativeLookup struct {
 	PathDB      pathdb.DB
 }
 
-func (a AuthoritativeLookup) LookupSegments(ctx context.Context, src,
-	dst addr.IA,
+func (a AuthoritativeLookup) LookupSegments(
+	ctx context.Context, src, dst addr.IA,
 ) (segfetcher.Segments, error) {
 	segType, err := a.classify(ctx, src, dst)
 	if err != nil {

--- a/control/segreq/authoritative.go
+++ b/control/segreq/authoritative.go
@@ -49,7 +49,7 @@ func (a AuthoritativeLookup) LookupSegments(
 	case seg.TypeCore:
 		return getCoreSegments(ctx, a.PathDB, a.LocalIA, dst)
 	default:
-		panic(fmt.Errorf("unexpected segType: %d (%s)", segType, segType.String()))
+		panic(fmt.Errorf("unexpected segType: %s", segType.String()))
 	}
 }
 

--- a/control/segreq/authoritative.go
+++ b/control/segreq/authoritative.go
@@ -16,6 +16,7 @@ package segreq
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/private/serrors"
@@ -35,8 +36,8 @@ type AuthoritativeLookup struct {
 }
 
 func (a AuthoritativeLookup) LookupSegments(ctx context.Context, src,
-	dst addr.IA) (segfetcher.Segments, error) {
-
+	dst addr.IA,
+) (segfetcher.Segments, error) {
 	segType, err := a.classify(ctx, src, dst)
 	if err != nil {
 		return nil, err
@@ -48,14 +49,14 @@ func (a AuthoritativeLookup) LookupSegments(ctx context.Context, src,
 	case seg.TypeCore:
 		return getCoreSegments(ctx, a.PathDB, a.LocalIA, dst)
 	default:
-		panic("unexpected segType")
+		panic(fmt.Errorf("unexpected segType: %d", segType))
 	}
 }
 
 // classify validates the request and determines the segment type for the request
 func (a AuthoritativeLookup) classify(ctx context.Context,
-	src, dst addr.IA) (seg.Type, error) {
-
+	src, dst addr.IA,
+) (seg.Type, error) {
 	switch {
 	case src != a.LocalIA:
 		return 0, serrors.JoinNoStack(segfetcher.ErrInvalidRequest, nil,
@@ -84,8 +85,8 @@ func (a AuthoritativeLookup) classify(ctx context.Context,
 // getCoreSegments loads core segments from localIA to dstIA from the path DB.
 // Wildcard dstIA is allowed.
 func getCoreSegments(ctx context.Context, pathDB pathdb.DB,
-	localIA, dstIA addr.IA) (segfetcher.Segments, error) {
-
+	localIA, dstIA addr.IA,
+) (segfetcher.Segments, error) {
 	res, err := pathDB.Get(ctx, &query.Params{
 		StartsAt: []addr.IA{dstIA},
 		EndsAt:   []addr.IA{localIA},
@@ -100,8 +101,8 @@ func getCoreSegments(ctx context.Context, pathDB pathdb.DB,
 // getDownSegments loads down segments from localIA to dstIA from the path DB.
 // Wildcard dstIA is _not_ allowed.
 func getDownSegments(ctx context.Context, pathDB pathdb.DB,
-	localIA, dstIA addr.IA) (segfetcher.Segments, error) {
-
+	localIA, dstIA addr.IA,
+) (segfetcher.Segments, error) {
 	res, err := pathDB.Get(ctx, &query.Params{
 		StartsAt: []addr.IA{localIA},
 		EndsAt:   []addr.IA{dstIA},

--- a/control/segreq/authoritative.go
+++ b/control/segreq/authoritative.go
@@ -16,7 +16,6 @@ package segreq
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/private/serrors"
@@ -49,7 +48,7 @@ func (a AuthoritativeLookup) LookupSegments(
 	case seg.TypeCore:
 		return getCoreSegments(ctx, a.PathDB, a.LocalIA, dst)
 	default:
-		panic(fmt.Errorf("unexpected segType: %s", segType.String()))
+		panic("unexpected segType: " + segType.String())
 	}
 }
 

--- a/control/segreq/expander.go
+++ b/control/segreq/expander.go
@@ -16,6 +16,7 @@ package segreq
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/private/serrors"
@@ -34,8 +35,8 @@ type WildcardExpander struct {
 }
 
 func (e *WildcardExpander) ExpandSrcWildcard(ctx context.Context,
-	req segfetcher.Request) (segfetcher.Requests, error) {
-
+	req segfetcher.Request,
+) (segfetcher.Requests, error) {
 	if req.Src.AS() != 0 {
 		return segfetcher.Requests{req}, nil
 	}
@@ -55,7 +56,10 @@ func (e *WildcardExpander) ExpandSrcWildcard(ctx context.Context,
 		return requestsSrcsToDst(cores, req.Dst, req.SegType), nil
 	default:
 		// no wildcard source for up requests
-		panic("Unexpected wildcard for up segment request, should not have passed validation")
+		panic(fmt.Errorf(
+			"unexpected wildcard for up segment request, should not have passed validation: %d",
+			req.SegType,
+		))
 	}
 }
 
@@ -71,7 +75,6 @@ func (e *WildcardExpander) coreASes(ctx context.Context, isd addr.ISD) ([]addr.I
 // providerCoreASes returns the core ASes that are providers of this AS, i.e.
 // those core ASes that are directly reachable with an up segment
 func (e *WildcardExpander) providerCoreASes(ctx context.Context) ([]addr.IA, error) {
-
 	if e.Core {
 		return []addr.IA{e.LocalIA}, nil
 	}

--- a/control/segreq/expander.go
+++ b/control/segreq/expander.go
@@ -16,7 +16,6 @@ package segreq
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/private/serrors"
@@ -56,10 +55,9 @@ func (e *WildcardExpander) ExpandSrcWildcard(ctx context.Context,
 		return requestsSrcsToDst(cores, req.Dst, req.SegType), nil
 	default:
 		// no wildcard source for up requests
-		panic(fmt.Errorf(
-			"unexpected wildcard for up segment request, should not have passed validation: %s",
-			req.SegType.String(),
-		))
+		panic("unexpected wildcard for up segment request, " +
+			"should not have passed validation: " +
+			req.SegType.String())
 	}
 }
 

--- a/control/segreq/expander.go
+++ b/control/segreq/expander.go
@@ -57,8 +57,8 @@ func (e *WildcardExpander) ExpandSrcWildcard(ctx context.Context,
 	default:
 		// no wildcard source for up requests
 		panic(fmt.Errorf(
-			"unexpected wildcard for up segment request, should not have passed validation: %d",
-			req.SegType,
+			"unexpected wildcard for up segment request, should not have passed validation: %s",
+			req.SegType.String(),
 		))
 	}
 }

--- a/control/segreq/fetcher.go
+++ b/control/segreq/fetcher.go
@@ -16,7 +16,6 @@ package segreq
 
 import (
 	"context"
-	"fmt"
 	"math/rand/v2"
 	"net"
 	"time"
@@ -197,11 +196,11 @@ func (p *dstProvider) Dst(ctx context.Context, req segfetcher.Request) (net.Addr
 		}
 		path = paths[rand.IntN(len(paths))]
 	default:
-		panic(fmt.Errorf(
-			"unsupported segment type for request forwarding: "+
-				"up segment should have been resolved locally: %s",
-			req.SegType.String(),
-		))
+		panic(
+			"unsupported segment type for request forwarding: " +
+				"up segment should have been resolved locally: " +
+				req.SegType.String(),
+		)
 	}
 	addr := &snet.SVCAddr{
 		IA:      path.Destination(),

--- a/control/segreq/fetcher.go
+++ b/control/segreq/fetcher.go
@@ -197,8 +197,11 @@ func (p *dstProvider) Dst(ctx context.Context, req segfetcher.Request) (net.Addr
 		}
 		path = paths[rand.IntN(len(paths))]
 	default:
-		panic(fmt.Errorf("unsupported segment type for request forwarding: "+
-			"up segment should have been resolved locally: %d", req.SegType))
+		panic(fmt.Errorf(
+			"unsupported segment type for request forwarding: "+
+				"up segment should have been resolved locally: %d (%s)",
+			req.SegType, req.SegType.String(),
+		))
 	}
 	addr := &snet.SVCAddr{
 		IA:      path.Destination(),

--- a/control/segreq/fetcher.go
+++ b/control/segreq/fetcher.go
@@ -167,7 +167,6 @@ type dstProvider struct {
 // Dsts provides the address of and the path to the authoritative server for
 // this request.
 func (p *dstProvider) Dst(ctx context.Context, req segfetcher.Request) (net.Addr, error) {
-
 	// The request is directed to the AS at the start of the requested segment:
 	dst := req.Src
 
@@ -198,8 +197,8 @@ func (p *dstProvider) Dst(ctx context.Context, req segfetcher.Request) (net.Addr
 		}
 		path = paths[rand.IntN(len(paths))]
 	default:
-		panic(fmt.Errorf("Unsupported segment type for request forwarding. "+
-			"Up segment should have been resolved locally. SegType: %s", req.SegType))
+		panic(fmt.Errorf("unsupported segment type for request forwarding: "+
+			"up segment should have been resolved locally: %d", req.SegType))
 	}
 	addr := &snet.SVCAddr{
 		IA:      path.Destination(),

--- a/control/segreq/fetcher.go
+++ b/control/segreq/fetcher.go
@@ -199,8 +199,8 @@ func (p *dstProvider) Dst(ctx context.Context, req segfetcher.Request) (net.Addr
 	default:
 		panic(fmt.Errorf(
 			"unsupported segment type for request forwarding: "+
-				"up segment should have been resolved locally: %d (%s)",
-			req.SegType, req.SegType.String(),
+				"up segment should have been resolved locally: %s",
+			req.SegType.String(),
 		))
 	}
 	addr := &snet.SVCAddr{

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -126,7 +127,7 @@ func realMain(ctx context.Context) error {
 	dialer := &libgrpc.TCPDialer{
 		SvcResolver: func(dst addr.SVC) []resolver.Address {
 			if base := dst.Base(); base != addr.SvcCS {
-				panic("Unsupported address type, implementation error?")
+				panic(fmt.Errorf("unsupported address type, possible implementation error: %d", addr.SvcCS))
 			}
 			targets := []resolver.Address{}
 			for _, entry := range topo.ControlServiceAddresses() {
@@ -361,8 +362,8 @@ func realMain(ctx context.Context) error {
 type acceptAllVerifier struct{}
 
 func (acceptAllVerifier) Verify(ctx context.Context, signedMsg *cryptopb.SignedMessage,
-	associatedData ...[]byte) (*signed.Message, error) {
-
+	associatedData ...[]byte,
+) (*signed.Message, error) {
 	return nil, nil
 }
 

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -127,10 +126,8 @@ func realMain(ctx context.Context) error {
 	dialer := &libgrpc.TCPDialer{
 		SvcResolver: func(dst addr.SVC) []resolver.Address {
 			if base := dst.Base(); base != addr.SvcCS {
-				panic(fmt.Errorf(
-					"unsupported address type, possible implementation error: %s",
-					base.String(),
-				))
+				panic("unsupported address type, possible implementation error: " +
+					base.String())
 			}
 			targets := []resolver.Address{}
 			for _, entry := range topo.ControlServiceAddresses() {

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -127,7 +127,10 @@ func realMain(ctx context.Context) error {
 	dialer := &libgrpc.TCPDialer{
 		SvcResolver: func(dst addr.SVC) []resolver.Address {
 			if base := dst.Base(); base != addr.SvcCS {
-				panic(fmt.Errorf("unsupported address type, possible implementation error: %d", addr.SvcCS))
+				panic(fmt.Errorf(
+					"unsupported address type, possible implementation error: %d",
+					addr.SvcCS,
+				))
 			}
 			targets := []resolver.Address{}
 			for _, entry := range topo.ControlServiceAddresses() {

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -128,8 +128,8 @@ func realMain(ctx context.Context) error {
 		SvcResolver: func(dst addr.SVC) []resolver.Address {
 			if base := dst.Base(); base != addr.SvcCS {
 				panic(fmt.Errorf(
-					"unsupported address type, possible implementation error: %d (%s)",
-					base, base.String(),
+					"unsupported address type, possible implementation error: %s",
+					base.String(),
 				))
 			}
 			targets := []resolver.Address{}

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -128,8 +128,8 @@ func realMain(ctx context.Context) error {
 		SvcResolver: func(dst addr.SVC) []resolver.Address {
 			if base := dst.Base(); base != addr.SvcCS {
 				panic(fmt.Errorf(
-					"unsupported address type, possible implementation error: %d",
-					addr.SvcCS,
+					"unsupported address type, possible implementation error: %d (%s)",
+					base, base.String(),
 				))
 			}
 			targets := []resolver.Address{}

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -161,7 +161,6 @@ func (s *Server) processMsgNextHop(
 	underlay netip.Addr,
 	prevHop netip.AddrPort,
 ) ([]byte, netip.AddrPort, error) {
-
 	err := s.parser.DecodeLayers(buf, &s.decoded)
 	if err != nil {
 		log.Error("Decoding layers", "err", err)
@@ -268,7 +267,7 @@ func (s *Server) processMsgNextHop(
 		}
 		s.outBuffer.PushLayer(s.scionLayer.LayerType())
 		outBuf = s.outBuffer.Bytes()
-	} else { //forward incoming byte array
+	} else { // forward incoming byte array
 		outBuf = buf
 	}
 
@@ -479,7 +478,6 @@ func ListenAndServe(
 	svcAddrs map[addr.Addr]netip.AddrPort,
 	addr *net.UDPAddr,
 ) error {
-
 	conn, err := net.ListenUDP(addr.Network(), addr)
 	if err != nil {
 		return err
@@ -535,7 +533,7 @@ func setIPPktInfo(conn *net.UDPConn) (*net.UDPConn, controlMessageParser) {
 	if udpAddr.AddrPort().Addr().Unmap().Is4() {
 		err := ipv4.NewPacketConn(conn).SetControlMessage(ipv4.FlagDst, true)
 		if err != nil {
-			panic(fmt.Sprintf("cannot set IP_PKTINFO on socket: %s", err))
+			panic(fmt.Sprintf("cannot set IP_PKTINFO on socket: %v", err))
 		}
 		cm = ipv4ControlMessage{
 			ControlMessage: new(ipv4.ControlMessage),
@@ -544,7 +542,7 @@ func setIPPktInfo(conn *net.UDPConn) (*net.UDPConn, controlMessageParser) {
 	if udpAddr.AddrPort().Addr().Unmap().Is6() {
 		err := ipv6.NewPacketConn(conn).SetControlMessage(ipv6.FlagDst, true)
 		if err != nil {
-			panic(fmt.Sprintf("cannot set IP_PKTINFO on socket: %s", err))
+			panic(fmt.Sprintf("cannot set IP_PKTINFO on socket: %v", err))
 		}
 		cm = ipv6ControlMessage{
 			ControlMessage: new(ipv6.ControlMessage),

--- a/gateway/control/sessionconfigurator.go
+++ b/gateway/control/sessionconfigurator.go
@@ -286,8 +286,8 @@ func diffRemoteGateway(a, b RemoteGateway) bool {
 // on removal of an IA). If the static configuration is nil an empty list is
 // returned.
 func buildSessionConfigs(sessionPolicies SessionPolicies,
-	remoteGateways RemoteGateways) ([]*SessionConfig, error) {
-
+	remoteGateways RemoteGateways,
+) ([]*SessionConfig, error) {
 	if sessionPolicies == nil {
 		return nil, nil
 	}
@@ -335,7 +335,6 @@ func PathPolicyWithAllowedInterfaces(
 	remote addr.IA,
 	allowedInterfaces []uint64,
 ) policies.PathPolicy {
-
 	if len(allowedInterfaces) == 0 {
 		return policy
 	}
@@ -382,7 +381,7 @@ func newPathPolForEnteringAS(ia addr.IA, allowedInterfaces []uint64) policies.Pa
 	rawSeq := fmt.Sprintf("0* (%s)", strings.Join(lastHops, "|"))
 	seq, err := pathpol.NewSequence(rawSeq)
 	if err != nil {
-		panic("invalid sequence: " + rawSeq)
+		panic(fmt.Errorf("invalid sequence: %q", rawSeq))
 	}
 	return &pathpol.Policy{Sequence: seq}
 }

--- a/gateway/dataplane/session.go
+++ b/gateway/dataplane/session.go
@@ -30,9 +30,7 @@ import (
 	"github.com/scionproto/scion/pkg/snet"
 )
 
-var (
-	crcTable = crc64.MakeTable(crc64.ECMA)
-)
+var crcTable = crc64.MakeTable(crc64.ECMA)
 
 type PathStatsPublisher interface {
 	PublishEgressStats(fingerprint string, frames int64, bytes int64)
@@ -206,7 +204,7 @@ func extractQuintuple(packet gopacket.Packet) []byte {
 		q = append(q, ip.DstIP...)
 		proto = ip.NextHeader
 	default:
-		panic(fmt.Sprintf("unexpected network layer %T", packet.NetworkLayer()))
+		panic(fmt.Sprintf("unexpected network layer: %T", packet.NetworkLayer()))
 	}
 	// Ports.
 	switch proto {

--- a/pkg/addr/host.go
+++ b/pkg/addr/host.go
@@ -99,7 +99,7 @@ func (h Host) Type() HostAddrType {
 // Panics if h.Type() is not HostTypeIP.
 func (h Host) IP() netip.Addr {
 	if h.t != HostTypeIP {
-		panic(fmt.Errorf("IP called on non-IP address: %d (%s)", h.t, h.t.String()))
+		panic(fmt.Errorf("IP called on non-IP address: %s", h.t.String()))
 	}
 	return h.ip
 }
@@ -108,7 +108,7 @@ func (h Host) IP() netip.Addr {
 // Panics if h.Type() is not HostTypeSVC.
 func (h Host) SVC() SVC {
 	if h.t != HostTypeSVC {
-		panic(fmt.Errorf("SVC called on non-SVC address: %d (%s)", h.t, h.t.String()))
+		panic(fmt.Errorf("SVC called on non-SVC address: %s", h.t.String()))
 	}
 	return h.svc
 }
@@ -122,7 +122,7 @@ func (h Host) String() string {
 	case HostTypeSVC:
 		return h.svc.String()
 	default:
-		panic(fmt.Errorf("unsupported host type: %d (%s)", t, t.String()))
+		panic(fmt.Errorf("unsupported host type: %s", t.String()))
 	}
 }
 

--- a/pkg/addr/host.go
+++ b/pkg/addr/host.go
@@ -99,7 +99,7 @@ func (h Host) Type() HostAddrType {
 // Panics if h.Type() is not HostTypeIP.
 func (h Host) IP() netip.Addr {
 	if h.t != HostTypeIP {
-		panic(fmt.Errorf("IP called on non-IP address: %d", h.t))
+		panic(fmt.Errorf("IP called on non-IP address: %d (%s)", h.t, h.t.String()))
 	}
 	return h.ip
 }
@@ -108,7 +108,7 @@ func (h Host) IP() netip.Addr {
 // Panics if h.Type() is not HostTypeSVC.
 func (h Host) SVC() SVC {
 	if h.t != HostTypeSVC {
-		panic(fmt.Errorf("SVC called on non-SVC address: %d", h.t))
+		panic(fmt.Errorf("SVC called on non-SVC address: %d (%s)", h.t, h.t.String()))
 	}
 	return h.svc
 }
@@ -122,7 +122,7 @@ func (h Host) String() string {
 	case HostTypeSVC:
 		return h.svc.String()
 	default:
-		panic(fmt.Errorf("unsupported host type: %d", t))
+		panic(fmt.Errorf("unsupported host type: %d (%s)", t, t.String()))
 	}
 }
 

--- a/pkg/addr/host.go
+++ b/pkg/addr/host.go
@@ -99,7 +99,7 @@ func (h Host) Type() HostAddrType {
 // Panics if h.Type() is not HostTypeIP.
 func (h Host) IP() netip.Addr {
 	if h.t != HostTypeIP {
-		panic("IP called on non-IP address")
+		panic(fmt.Errorf("IP called on non-IP address: %d", h.t))
 	}
 	return h.ip
 }
@@ -108,21 +108,22 @@ func (h Host) IP() netip.Addr {
 // Panics if h.Type() is not HostTypeSVC.
 func (h Host) SVC() SVC {
 	if h.t != HostTypeSVC {
-		panic("SVC called on non-SVC address")
+		panic(fmt.Errorf("SVC called on non-SVC address: %d", h.t))
 	}
 	return h.svc
 }
 
 func (h Host) String() string {
-	switch h.Type() {
+	switch t := h.Type(); t {
 	case HostTypeNone:
 		return "<None>"
 	case HostTypeIP:
 		return h.ip.String()
 	case HostTypeSVC:
 		return h.svc.String()
+	default:
+		panic(fmt.Errorf("unsupported host type: %d", t))
 	}
-	panic("unsupported host type")
 }
 
 // Set implements flag.Value interface

--- a/pkg/addr/host.go
+++ b/pkg/addr/host.go
@@ -99,7 +99,7 @@ func (h Host) Type() HostAddrType {
 // Panics if h.Type() is not HostTypeIP.
 func (h Host) IP() netip.Addr {
 	if h.t != HostTypeIP {
-		panic(fmt.Errorf("IP called on non-IP address: %s", h.t.String()))
+		panic("IP called on non-IP address: " + h.t.String())
 	}
 	return h.ip
 }
@@ -108,7 +108,7 @@ func (h Host) IP() netip.Addr {
 // Panics if h.Type() is not HostTypeSVC.
 func (h Host) SVC() SVC {
 	if h.t != HostTypeSVC {
-		panic(fmt.Errorf("SVC called on non-SVC address: %s", h.t.String()))
+		panic("SVC called on non-SVC address: " + h.t.String())
 	}
 	return h.svc
 }
@@ -122,7 +122,7 @@ func (h Host) String() string {
 	case HostTypeSVC:
 		return h.svc.String()
 	default:
-		panic(fmt.Errorf("unsupported host type: %s", t.String()))
+		panic("unsupported host type: " + t.String())
 	}
 }
 

--- a/pkg/addr/isdas.go
+++ b/pkg/addr/isdas.go
@@ -149,9 +149,11 @@ func (as *AS) UnmarshalText(text []byte) error {
 	return nil
 }
 
-var _ fmt.Stringer = IA(0)
-var _ encoding.TextUnmarshaler = (*IA)(nil)
-var _ flag.Value = (*IA)(nil)
+var (
+	_ fmt.Stringer             = IA(0)
+	_ encoding.TextUnmarshaler = (*IA)(nil)
+	_ flag.Value               = (*IA)(nil)
+)
 
 // IA represents the ISD (ISolation Domain) and AS (Autonomous System) Id of a given SCION AS.
 // The highest 16 bit form the ISD number and the lower 48 bits form the AS number.
@@ -163,7 +165,7 @@ type IA uint64
 func MustIAFrom(isd ISD, as AS) IA {
 	ia, err := IAFrom(isd, as)
 	if err != nil {
-		panic(fmt.Sprintf("parsing ISD-AS: %s", err))
+		panic(fmt.Sprintf("parsing ISD-AS: %v", err))
 	}
 	return ia
 }

--- a/pkg/private/ctrl/path_mgmt/proto/defs.go
+++ b/pkg/private/ctrl/path_mgmt/proto/defs.go
@@ -21,6 +21,8 @@ suitable place eventually.
 */
 package proto
 
+import "fmt"
+
 type LinkType uint16
 
 // Values of LinkType.
@@ -92,9 +94,8 @@ func (c PathSegType) String() string {
 		return "down"
 	case PathSegType_core:
 		return "core"
-
 	default:
-		return ""
+		return fmt.Sprintf("unknown(%d)", c)
 	}
 }
 

--- a/pkg/private/xtest/graph/graph.go
+++ b/pkg/private/xtest/graph/graph.go
@@ -124,8 +124,8 @@ func (g *Graph) GetSigner(ia string) *Signer {
 // xIfID in xIA and yIfID in yIA. If xIA or yIA are not valid string
 // representations of an ISD-AS, AddLink panics.
 func (g *Graph) AddLink(xIA string, xIfID uint16,
-	yIA string, yIfID uint16, peer bool) {
-
+	yIA string, yIfID uint16, peer bool,
+) {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 	x := MustParseIA(xIA)
@@ -259,7 +259,7 @@ func (g *Graph) beacon(ifIDs []uint16, addStaticInfo bool) *seg.PathSegment {
 	}
 
 	if _, ok := g.parents[ifIDs[0]]; !ok {
-		panic(fmt.Sprintf("%d unknown ifID", ifIDs[0]))
+		panic(fmt.Sprintf("unknown ifID: %d", ifIDs[0]))
 	}
 
 	segment, err := seg.CreateSegment(time.Now(), uint16(rand.Int()))
@@ -274,7 +274,7 @@ func (g *Graph) beacon(ifIDs []uint16, addStaticInfo bool) *seg.PathSegment {
 			var ok bool
 			outIF = ifIDs[i]
 			if remoteOutIF, ok = g.links[outIF]; !ok {
-				panic(fmt.Sprintf("%d unknown ifID", outIF))
+				panic(fmt.Sprintf("unknown ifID: %d", outIF))
 			}
 			outIA = g.parents[remoteOutIF]
 		case i == len(ifIDs):
@@ -376,7 +376,7 @@ func (g *Graph) Bandwidth(a, b uint16) uint64 {
 func (g *Graph) GeoCoordinates(ifID uint16) staticinfo.GeoCoordinates {
 	ia, ok := g.parents[ifID]
 	if !ok {
-		panic("unknown interface")
+		panic(fmt.Errorf("unknown interface: %d", ifID))
 	}
 	return staticinfo.GeoCoordinates{
 		Latitude:  float32(ifID),
@@ -461,8 +461,8 @@ func NewSigner(opts ...SignerOption) *Signer {
 }
 
 func (s Signer) Sign(ctx context.Context, msg []byte,
-	associatedData ...[]byte) (*cryptopb.SignedMessage, error) {
-
+	associatedData ...[]byte,
+) (*cryptopb.SignedMessage, error) {
 	var l int
 	for _, d := range associatedData {
 		l += len(d)
@@ -505,7 +505,7 @@ type AS struct {
 // Delete removes ifID from as.
 func (as *AS) Delete(ifID uint16) {
 	if _, ok := as.IfIDs[ifID]; !ok {
-		panic("ifID not found")
+		panic(fmt.Errorf("ifID not found: %d", ifID))
 	}
 	delete(as.IfIDs, ifID)
 }

--- a/pkg/scrypto/signed/msg.go
+++ b/pkg/scrypto/signed/msg.go
@@ -53,8 +53,8 @@ type Message struct {
 // Sign creates a signed message. The associated data is not included in the
 // header or body.
 func Sign(hdr Header, body []byte, signer crypto.Signer,
-	associatedData ...[]byte) (*cryptopb.SignedMessage, error) {
-
+	associatedData ...[]byte,
+) (*cryptopb.SignedMessage, error) {
 	if signer == nil {
 		return nil, serrors.New("singer must not be nil")
 	}
@@ -102,8 +102,8 @@ func Sign(hdr Header, body []byte, signer crypto.Signer,
 
 // Verify verifies the signed message.
 func Verify(signed *cryptopb.SignedMessage, key crypto.PublicKey,
-	associatedData ...[]byte) (*Message, error) {
-
+	associatedData ...[]byte,
+) (*Message, error) {
 	if key == nil {
 		return nil, serrors.New("public key must not be nil")
 	}
@@ -137,8 +137,8 @@ func Verify(signed *cryptopb.SignedMessage, key crypto.PublicKey,
 }
 
 func computeSignatureInput(algo SignatureAlgorithm, hdrAndBody []byte,
-	associatedData ...[]byte) ([]byte, crypto.Hash) {
-
+	associatedData ...[]byte,
+) ([]byte, crypto.Hash) {
 	hash := signatureAlgorithmDetails[algo].hash
 	if hash == 0 {
 		input := make([]byte, len(hdrAndBody)+associatedDataLen(associatedData...))
@@ -151,7 +151,7 @@ func computeSignatureInput(algo SignatureAlgorithm, hdrAndBody []byte,
 		return input, hash
 	}
 	if !hash.Available() {
-		panic(fmt.Sprintf("unavailable hash algorithm: %v", hash))
+		panic(fmt.Sprintf("unavailable hash algorithm: %#v", hash))
 	}
 	h := hash.New()
 	h.Write(hdrAndBody)

--- a/pkg/slayers/internal/fuzz/fuzz.go
+++ b/pkg/slayers/internal/fuzz/fuzz.go
@@ -124,7 +124,7 @@ func fuzzLayer(l fuzzableLayer, data []byte) int {
 	}
 	buf := gopacket.NewSerializeBuffer()
 	if err := l.SerializeTo(buf, gopacket.SerializeOptions{}); err != nil {
-		panic(fmt.Sprintf("cannot serialize without fix lengths %v", err))
+		panic(fmt.Sprintf("cannot serialize without fix lengths: %v", err))
 	}
 	if !bytes.Equal(buf.Bytes(), data[:len(buf.Bytes())]) {
 		panic("serialized data differs without fix lengths")
@@ -134,7 +134,7 @@ func fuzzLayer(l fuzzableLayer, data []byte) int {
 	// length fields.
 	buf = gopacket.NewSerializeBuffer()
 	if err := l.SerializeTo(buf, gopacket.SerializeOptions{FixLengths: true}); err != nil {
-		panic(fmt.Sprintf("cannot serialize with fix lengths %v", err))
+		panic(fmt.Sprintf("cannot serialize with fix lengths: %v", err))
 	}
 	return 1
 }

--- a/pkg/slayers/path/path.go
+++ b/pkg/slayers/path/path.go
@@ -75,7 +75,7 @@ type Metadata struct {
 func RegisterPath(pathMeta Metadata) {
 	pm := registeredPaths[pathMeta.Type]
 	if pm.inUse {
-		panic("path type already registered")
+		panic(fmt.Errorf("path type already registered: %d", pathMeta.Type))
 	}
 	registeredPaths[pathMeta.Type].inUse = true
 	registeredPaths[pathMeta.Type].Metadata = pathMeta

--- a/pkg/slayers/path/path.go
+++ b/pkg/slayers/path/path.go
@@ -75,8 +75,7 @@ type Metadata struct {
 func RegisterPath(pathMeta Metadata) {
 	pm := registeredPaths[pathMeta.Type]
 	if pm.inUse {
-		panic(fmt.Errorf("path type already registered: %s",
-			pathMeta.Type.String()))
+		panic("path type already registered: " + pathMeta.Type.String())
 	}
 	registeredPaths[pathMeta.Type].inUse = true
 	registeredPaths[pathMeta.Type].Metadata = pathMeta

--- a/pkg/slayers/path/path.go
+++ b/pkg/slayers/path/path.go
@@ -75,7 +75,8 @@ type Metadata struct {
 func RegisterPath(pathMeta Metadata) {
 	pm := registeredPaths[pathMeta.Type]
 	if pm.inUse {
-		panic(fmt.Errorf("path type already registered: %d", pathMeta.Type))
+		panic(fmt.Errorf("path type already registered: %d (%s)",
+			pathMeta.Type, pathMeta.Type.String()))
 	}
 	registeredPaths[pathMeta.Type].inUse = true
 	registeredPaths[pathMeta.Type].Metadata = pathMeta

--- a/pkg/slayers/path/path.go
+++ b/pkg/slayers/path/path.go
@@ -75,8 +75,8 @@ type Metadata struct {
 func RegisterPath(pathMeta Metadata) {
 	pm := registeredPaths[pathMeta.Type]
 	if pm.inUse {
-		panic(fmt.Errorf("path type already registered: %d (%s)",
-			pathMeta.Type, pathMeta.Type.String()))
+		panic(fmt.Errorf("path type already registered: %s",
+			pathMeta.Type.String()))
 	}
 	registeredPaths[pathMeta.Type].inUse = true
 	registeredPaths[pathMeta.Type].Metadata = pathMeta

--- a/private/app/launcher/launcher_unix.go
+++ b/private/app/launcher/launcher_unix.go
@@ -83,10 +83,13 @@ func (a *Application) run() error {
 
 		// If the main goroutine shuts down everything in time, this won't get
 		// a chance to run.
-		time.AfterFunc(5*time.Second, func() {
+		waitDur := 5 * time.Second
+		time.AfterFunc(waitDur, func() {
 			defer log.HandlePanic()
-			panic("Main goroutine did not shut down in time (waited 5s). " +
-				"It's probably stuck. Forcing shutdown.")
+			panic(fmt.Errorf(
+				"main goroutine did not shut down in time (waited for %s). "+
+					"It's probably stuck. Forcing shutdown",
+				waitDur.String()))
 		})
 
 		cancel()
@@ -96,7 +99,6 @@ func (a *Application) run() error {
 }
 
 func (a *Application) executeCommand(ctx context.Context, shortName string) error {
-
 	if err := a.ApplicationBase.loadConfig(); err != nil {
 		return err
 	}

--- a/private/app/launcher/launcher_unix.go
+++ b/private/app/launcher/launcher_unix.go
@@ -88,8 +88,7 @@ func (a *Application) run() error {
 			defer log.HandlePanic()
 			panic(fmt.Errorf(
 				"main goroutine did not shut down in time (waited for %s). "+
-					"It's probably stuck. Forcing shutdown",
-				waitDur.String()))
+					"It's probably stuck. Forcing shutdown", waitDur))
 		})
 
 		cancel()

--- a/private/app/path/path.go
+++ b/private/app/path/path.go
@@ -77,7 +77,6 @@ func Choose(
 	remote addr.IA,
 	opts ...Option,
 ) (snet.Path, error) {
-
 	o := applyOption(opts)
 	paths, err := fetchPaths(ctx, conn, remote, o.refresh, o.seq)
 	if err != nil {
@@ -129,7 +128,6 @@ func filterUnhealthy(
 	cfg *ProbeConfig,
 	epic bool,
 ) ([]snet.Path, error) {
-
 	// Filter and save empty paths. They are considered healthy by definition, but must not be used
 	// for path probing.
 	var nonEmptyPaths []snet.Path
@@ -175,7 +173,6 @@ func fetchPaths(
 	refresh bool,
 	seq string,
 ) ([]snet.Path, error) {
-
 	allPaths, err := conn.Paths(ctx, remote, 0, daemon.PathReqFlags{Refresh: refresh})
 	if err != nil {
 		return nil, serrors.Wrap("retrieving paths", err)
@@ -267,7 +264,7 @@ func (cs ColorScheme) KeyValue(k, v string) string {
 
 func (cs ColorScheme) KeyValues(kv ...string) []string {
 	if len(kv)%2 != 0 {
-		panic("KeyValues expects even number of parameters")
+		panic(fmt.Errorf("KeyValues expects even number of parameters: %d", len(kv)))
 	}
 	entries := make([]string, 0, len(kv)/2)
 	for i := 0; i < len(kv); i += 2 {

--- a/private/config/sample.go
+++ b/private/config/sample.go
@@ -41,7 +41,7 @@ func WriteSample(dst io.Writer, path Path, ctx CtxMap, samplers ...Sampler) {
 		sampler.Sample(&buf, path, ctx)
 		_, err := io.Copy(dst, &buf)
 		if err != nil {
-			panic(fmt.Sprintf("Unable to write sample err=%s", err))
+			panic(fmt.Sprintf("unable to write sample: %v", err))
 		}
 	}
 }
@@ -50,7 +50,7 @@ func WriteSample(dst io.Writer, path Path, ctx CtxMap, samplers ...Sampler) {
 func WriteString(dst io.Writer, s string) {
 	_, err := dst.Write([]byte(s))
 	if err != nil {
-		panic(fmt.Sprintf("Unable to write string err=%s", err))
+		panic(fmt.Sprintf("unable to write string: %v", err))
 	}
 }
 

--- a/private/path/combinator/graph.go
+++ b/private/path/combinator/graph.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"cmp"
 	"encoding/binary"
-	"fmt"
 	"math"
 	"slices"
 	"time"
@@ -592,7 +591,7 @@ func validNextSeg(currSeg, nextSeg *inputSegment) bool {
 	case proto.PathSegType_down:
 		return false
 	default:
-		panic(fmt.Sprintf("Invalid segment type: %s", currSeg.Type.String()))
+		panic("Invalid segment type: " + currSeg.Type.String())
 	}
 }
 

--- a/private/path/combinator/graph.go
+++ b/private/path/combinator/graph.go
@@ -38,11 +38,9 @@ const (
 	maxTimestamp = math.MaxUint32
 )
 
-var (
-	// MaxExpirationTime is the maximum absolute expiration time of SCION hop
-	// fields.
-	maxExpirationTime = time.Unix(maxTimestamp, 0).Add(path.ExpTimeToDuration(math.MaxUint8))
-)
+// MaxExpirationTime is the maximum absolute expiration time of SCION hop
+// fields.
+var maxExpirationTime = time.Unix(maxTimestamp, 0).Add(path.ExpTimeToDuration(math.MaxUint8))
 
 // vertexInfo maps destination vertices to the list of edges that point towards
 // them.
@@ -300,8 +298,8 @@ func vertexFromIA(ia addr.IA) vertex {
 }
 
 func vertexFromPeering(upIA addr.IA, upIfID iface.ID,
-	downIA addr.IA, downIfID iface.ID) vertex {
-
+	downIA addr.IA, downIfID iface.ID,
+) vertex {
 	return vertex{UpIA: upIA, UpIfID: upIfID, DownIA: downIA, DownIfID: downIfID}
 }
 
@@ -530,7 +528,6 @@ func reverseEpicAuths(s [][]byte) {
 }
 
 func calculateBeta(se *solutionEdge) uint16 {
-
 	// If this is a peer hop, we need to set beta[i] = beta[i+1]. That is, the SegID
 	// accumulator must correspond to the next (in construction order) hop.
 	//
@@ -595,7 +592,7 @@ func validNextSeg(currSeg, nextSeg *inputSegment) bool {
 	case proto.PathSegType_down:
 		return false
 	default:
-		panic(fmt.Sprintf("Invalid segment type: %v", currSeg.Type))
+		panic(fmt.Sprintf("Invalid segment type: %d", currSeg.Type))
 	}
 }
 

--- a/private/path/combinator/graph.go
+++ b/private/path/combinator/graph.go
@@ -592,7 +592,7 @@ func validNextSeg(currSeg, nextSeg *inputSegment) bool {
 	case proto.PathSegType_down:
 		return false
 	default:
-		panic(fmt.Sprintf("Invalid segment type: %d", currSeg.Type))
+		panic(fmt.Sprintf("Invalid segment type: %s", currSeg.Type.String()))
 	}
 }
 

--- a/private/path/combinator/staticinfo_accumulator.go
+++ b/private/path/combinator/staticinfo_accumulator.go
@@ -15,6 +15,7 @@
 package combinator
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -45,7 +46,10 @@ func collectMetadata(interfaces []snet.PathInterface, asEntries []seg.ASEntry) s
 		return snet.PathMetadata{}
 	}
 	if len(interfaces)%2 != 0 {
-		panic("the number of interfaces traversed by the path is expected to be even")
+		panic(fmt.Errorf(
+			"the number of interfaces traversed by the path is expected to be even: %d",
+			len(interfaces),
+		))
 	}
 
 	// Prepare lookup table of the connected remote interface IDs; this is not

--- a/private/revcache/memrevcache/memrevcache_test.go
+++ b/private/revcache/memrevcache/memrevcache_test.go
@@ -31,11 +31,11 @@ type testRevCache struct {
 }
 
 func (c *testRevCache) InsertExpired(t *testing.T, _ context.Context,
-	rev *path_mgmt.RevInfo) {
-
+	rev *path_mgmt.RevInfo,
+) {
 	ttl := time.Until(rev.Expiration())
 	if ttl >= 0 {
-		panic("Should only be used for expired elements")
+		panic("TTL should only be used for expired elements")
 	}
 	key := revcache.NewKey(rev.IA(), rev.IfID)
 	c.c.SetWithExpire(key, rev, time.Microsecond)

--- a/router/bfd/fsm.go
+++ b/router/bfd/fsm.go
@@ -59,8 +59,8 @@ const (
 // the integer value of the state when it is unknown.
 func (s state) String() string {
 	x := layers.BFDState(s)
-	if x == layers.BFDStateUp || x == layers.BFDStateDown || x == layers.BFDStateAdminDown ||
-		x == layers.BFDStateInit {
+	switch x {
+	case layers.BFDStateUp, layers.BFDStateDown, layers.BFDStateAdminDown, layers.BFDStateInit:
 		return layers.BFDState(s).String()
 	}
 	return fmt.Sprintf("Unknown (%d)", uint8(s))

--- a/router/bfd/jitter.go
+++ b/router/bfd/jitter.go
@@ -45,10 +45,10 @@ const (
 // periodic BFD Control packets should be reduced by. If gen is nil, math/rand is used
 // for randomness.
 func computeInterval(transmitInterval time.Duration, detectMult uint,
-	gen IntervalGenerator) time.Duration {
-
+	gen IntervalGenerator,
+) time.Duration {
 	if transmitInterval <= 0 {
-		panic("transmission interval must be > 0")
+		panic(fmt.Errorf("transmission interval must be > 0: %d", transmitInterval))
 	}
 	if detectMult == 0 {
 		panic("detection multiplier must be > 0")
@@ -89,7 +89,7 @@ type defaultIntervalGenerator struct {
 // The generator is not safe for cryptographic use.
 func (g defaultIntervalGenerator) Generate(x, y int) int {
 	if x < 0 || y <= x {
-		panic(fmt.Sprintf("bad integer range: [%d,%d)", x, y))
+		panic(fmt.Sprintf("bad integer range: [%d,%d]", x, y))
 	}
 	return g.intn(y-x) + x
 }

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1814,7 +1814,8 @@ func (d *dataPlane) resolveLocalDst(
 		}
 		return d.addEndhostPort(resolvedDst, lastLayer, dstIP)
 	default:
-		panic(fmt.Errorf("unexpected address type returned from DstAddr: %d", dstType))
+		panic(fmt.Errorf("unexpected address type returned from DstAddr: %d (%s)",
+			dstType, dstType.String()))
 	}
 }
 

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1814,8 +1814,8 @@ func (d *dataPlane) resolveLocalDst(
 		}
 		return d.addEndhostPort(resolvedDst, lastLayer, dstIP)
 	default:
-		panic(fmt.Errorf("unexpected address type returned from DstAddr: %d (%s)",
-			dstType, dstType.String()))
+		panic(fmt.Errorf("unexpected address type returned from DstAddr: %s",
+			dstType.String()))
 	}
 }
 

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -1814,8 +1814,7 @@ func (d *dataPlane) resolveLocalDst(
 		}
 		return d.addEndhostPort(resolvedDst, lastLayer, dstIP)
 	default:
-		panic(fmt.Errorf("unexpected address type returned from DstAddr: %s",
-			dstType.String()))
+		panic("unexpected address type returned from DstAddr: " + dstType.String())
 	}
 }
 

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -147,8 +147,10 @@ type slowPathRequest struct {
 }
 
 // Make sure that the packet structure has the size we expect.
-const _ uintptr = 64 - unsafe.Sizeof(Packet{}) // assert 64 >= sizeof(Packet)
-const _ uintptr = unsafe.Sizeof(Packet{}) - 64 // assert sizeof(Packet) >= 64
+const (
+	_ uintptr = 64 - unsafe.Sizeof(Packet{}) // assert 64 >= sizeof(Packet)
+	_ uintptr = unsafe.Sizeof(Packet{}) - 64 // assert sizeof(Packet) >= 64
+)
 
 // initPacket configures the given blank packet (and returns it, for convenience).
 func (p *Packet) init(buffer *[bufSize]byte) *Packet {
@@ -377,8 +379,8 @@ func (d *dataPlane) AddInternalInterface(conn BatchConn, ip netip.Addr) error {
 // If a connection for the given ID is already set this method will return an
 // error. This can only be called on a not yet running dataplane.
 func (d *dataPlane) AddExternalInterface(ifID uint16, conn BatchConn,
-	src, dst control.LinkEnd, cfg control.BFD) error {
-
+	src, dst control.LinkEnd, cfg control.BFD,
+) error {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
@@ -437,9 +439,9 @@ func (d *dataPlane) AddLinkType(ifID uint16, linkTo topology.LinkType) error {
 }
 
 // newExternalInterfaceBFD adds the inter AS connection BFD session.
-func (d *dataPlane) newExternalInterfaceBFD(ifID uint16,
-	src, dst control.LinkEnd, cfg control.BFD) (*bfd.Session, error) {
-
+func (d *dataPlane) newExternalInterfaceBFD(
+	ifID uint16, src, dst control.LinkEnd, cfg control.BFD,
+) (*bfd.Session, error) {
 	if *cfg.Disable {
 		return nil, nil
 	}
@@ -512,8 +514,8 @@ func (d *dataPlane) DelSvc(svc addr.SVC, a netip.AddrPort) error {
 // interface ID already has an address associated this operation fails. This can
 // only be called on a not yet running dataplane.
 func (d *dataPlane) AddNextHop(ifID uint16, src, dst netip.AddrPort, cfg control.BFD,
-	sibling string) error {
-
+	sibling string,
+) error {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
@@ -540,9 +542,9 @@ func (d *dataPlane) AddNextHop(ifID uint16, src, dst netip.AddrPort, cfg control
 }
 
 // AddNextHopBFD adds the BFD session for the next hop address.
-func (d *dataPlane) newNextHopBFD(src, dst netip.AddrPort, cfg control.BFD,
-	sibling string) (*bfd.Session, error) {
-
+func (d *dataPlane) newNextHopBFD(
+	src, dst netip.AddrPort, cfg control.BFD, sibling string,
+) (*bfd.Session, error) {
 	if *cfg.Disable {
 		return nil, nil
 	}
@@ -588,7 +590,6 @@ func (d *dataPlane) Run(ctx context.Context) error {
 	// Start our custom /proc/pid/stat collector to export iowait time and (in the future) other
 	// process-wide metrics that prometheus does not.
 	err := processmetrics.Init()
-
 	// we can live without these metrics. Just log the error.
 	if err != nil {
 		log.Error("Could not initialize processmetrics", "err", err)
@@ -638,7 +639,6 @@ func (d *dataPlane) initPacketPool(processorQueueSize int) {
 
 // initializes the processing routines and queues
 func (d *dataPlane) initQueues(processorQueueSize int) ([]chan *Packet, []chan *Packet) {
-
 	procQs := make([]chan *Packet, d.RunConfig.NumProcessors)
 	for i := 0; i < d.RunConfig.NumProcessors; i++ {
 		procQs[i] = make(chan *Packet, processorQueueSize)
@@ -659,7 +659,6 @@ func (d *dataPlane) returnPacketToPool(pkt *Packet) {
 }
 
 func (d *dataPlane) runProcessor(id int, q <-chan *Packet, slowQ chan<- *Packet) {
-
 	log.Debug("Initialize processor with", "id", id)
 	processor := newPacketProcessor(d)
 	for d.isRunning() {
@@ -712,7 +711,6 @@ func (d *dataPlane) runProcessor(id int, q <-chan *Packet, slowQ chan<- *Packet)
 }
 
 func (d *dataPlane) runSlowPathProcessor(id int, q <-chan *Packet) {
-
 	log.Debug("Initialize slow-path processor with", "id", id)
 	processor := newSlowPathProcessor(d)
 	for d.isRunning() {
@@ -818,17 +816,17 @@ func (p *slowPathPacketProcessor) processPacket(pkt *Packet) error {
 			return malformedPath
 		}
 	default:
-		//unsupported path type
+		// unsupported path type
 		return serrors.New("Path type not supported for slow-path", "type", pathType)
 	}
 
 	s := pkt.slowPathRequest
 	switch s.spType {
-	case slowPathRouterAlertIngress: //Traceroute
+	case slowPathRouterAlertIngress: // Traceroute
 		return p.handleSCMPTraceRouteRequest(p.ingressFromLink)
-	case slowPathRouterAlertEgress: //Traceroute
+	case slowPathRouterAlertEgress: // Traceroute
 		return p.handleSCMPTraceRouteRequest(p.pkt.egress)
-	default: //SCMP
+	default: // SCMP
 		var layer gopacket.SerializableLayer
 		scmpType := slayers.SCMPType(s.spType)
 		switch scmpType {
@@ -837,13 +835,17 @@ func (p *slowPathPacketProcessor) processPacket(pkt *Packet) error {
 		case slayers.SCMPTypeDestinationUnreachable:
 			layer = &slayers.SCMPDestinationUnreachable{}
 		case slayers.SCMPTypeExternalInterfaceDown:
-			layer = &slayers.SCMPExternalInterfaceDown{IA: p.d.localIA,
-				IfID: uint64(p.pkt.egress)}
+			layer = &slayers.SCMPExternalInterfaceDown{
+				IA:   p.d.localIA,
+				IfID: uint64(p.pkt.egress),
+			}
 		case slayers.SCMPTypeInternalConnectivityDown:
-			layer = &slayers.SCMPInternalConnectivityDown{IA: p.d.localIA,
-				Ingress: uint64(p.ingressFromLink), Egress: uint64(p.pkt.egress)}
+			layer = &slayers.SCMPInternalConnectivityDown{
+				IA:      p.d.localIA,
+				Ingress: uint64(p.ingressFromLink), Egress: uint64(p.pkt.egress),
+			}
 		default:
-			panic(fmt.Errorf("Unsupported slow-path type: %d", scmpType))
+			panic(fmt.Errorf("unsupported slow-path type: %d", scmpType))
 		}
 		return p.packSCMP(scmpType, s.code, layer, true)
 	}
@@ -862,7 +864,7 @@ func newPacketProcessor(d *dataPlane) *scionPacketProcessor {
 func (p *scionPacketProcessor) reset() error {
 	p.pkt = nil
 	p.ingressFromLink = 0
-	//p.scionLayer // cannot easily be reset
+	// p.scionLayer // cannot easily be reset
 	p.path = nil
 	p.hopField = path.HopField{}
 	p.infoField = path.InfoField{}
@@ -927,7 +929,6 @@ func (p *scionPacketProcessor) processPkt(pkt *Packet) disposition {
 }
 
 func (p *scionPacketProcessor) processBFD(data []byte) disposition {
-
 	session := p.pkt.Link.BFDSession()
 	if session == nil {
 		return errorDiscard("error", noBFDSessionFound)
@@ -941,7 +942,6 @@ func (p *scionPacketProcessor) processBFD(data []byte) disposition {
 }
 
 func (p *scionPacketProcessor) processSCION() disposition {
-
 	var ok bool
 	p.path, ok = p.scionLayer.Path.(*scion.Raw)
 	if !ok {
@@ -952,7 +952,6 @@ func (p *scionPacketProcessor) processSCION() disposition {
 }
 
 func (p *scionPacketProcessor) processEPIC() disposition {
-
 	epicPath, ok := p.scionLayer.Path.(*epic.Path)
 	if !ok {
 		return errorDiscard("error", malformedPath)
@@ -1035,7 +1034,6 @@ func (p *slowPathPacketProcessor) packSCMP(
 	scmpP gopacket.SerializableLayer,
 	isError bool,
 ) error {
-
 	// check invoking packet was an SCMP error:
 	if p.lastLayer.NextLayerType() == slayers.LayerTypeSCMP {
 		var scmpLayer slayers.SCMP
@@ -1099,7 +1097,6 @@ func determinePeer(pathMeta scion.MetaHdr, inf path.InfoField) (bool, error) {
 	}
 	if pathMeta.SegLen[1] == 0 {
 		return false, errPeeringEmptySeg1
-
 	}
 	if pathMeta.SegLen[2] != 0 {
 		return false, errPeeringNonemptySeg2
@@ -1528,7 +1525,6 @@ func (p *scionPacketProcessor) egressRouterAlertFlag() *bool {
 }
 
 func (p *slowPathPacketProcessor) handleSCMPTraceRouteRequest(ifID uint16) error {
-
 	if p.lastLayer.NextLayerType() != slayers.LayerTypeSCMP {
 		log.Debug("Packet with router alert, but not SCMP")
 		return nil
@@ -1783,12 +1779,11 @@ func (d *dataPlane) resolveLocalDst(
 	s slayers.SCION,
 	lastLayer gopacket.DecodingLayer,
 ) error {
-
 	dst, err := s.DstAddr()
 	if err != nil {
 		return invalidDstAddr
 	}
-	switch dst.Type() {
+	switch dstType := dst.Type(); dstType {
 	case addr.HostTypeSVC:
 		// For map lookup use the Base address, i.e. strip the multi cast
 		// information, because we only register base addresses in the map.
@@ -1818,7 +1813,7 @@ func (d *dataPlane) resolveLocalDst(
 		}
 		return d.addEndhostPort(resolvedDst, lastLayer, dstIP)
 	default:
-		panic("unexpected address type returned from DstAddr")
+		panic(fmt.Errorf("unexpected address type returned from DstAddr: %d", dstType))
 	}
 }
 
@@ -1827,7 +1822,6 @@ func (d *dataPlane) addEndhostPort(
 	lastLayer gopacket.DecodingLayer,
 	dst netip.Addr,
 ) error {
-
 	// Parse UPD port and rewrite underlay IP/UDP port
 	l4Type := nextHdr(lastLayer)
 	port := uint16(topology.EndhostPort)
@@ -2007,8 +2001,8 @@ type bfdSend struct {
 
 // newBFDSend creates and initializes a BFD Sender
 func newBFDSend(d *dataPlane, srcIA, dstIA addr.IA, srcAddr, dstAddr netip.AddrPort,
-	ifID uint16, mac hash.Hash) (*bfdSend, error) {
-
+	ifID uint16, mac hash.Hash,
+) (*bfdSend, error) {
 	scn := &slayers.SCION{
 		Version:      0,
 		TrafficClass: 0xb8,
@@ -2123,7 +2117,6 @@ func (p *slowPathPacketProcessor) prepareSCMP(
 	scmpP gopacket.SerializableLayer,
 	isError bool,
 ) error {
-
 	// *copy* and reverse path -- the original path should not be modified as this writes directly
 	// back to rawPkt (quote).
 	var path *scion.Raw
@@ -2135,14 +2128,12 @@ func (p *slowPathPacketProcessor) prepareSCMP(
 		if !ok {
 			return serrors.JoinNoStack(cannotRoute, nil, "details", "unsupported path type",
 				"path type", pathType)
-
 		}
 	case epic.PathType:
 		epicPath, ok := p.scionLayer.Path.(*epic.Path)
 		if !ok {
 			return serrors.JoinNoStack(cannotRoute, nil, "details", "unsupported path type",
 				"path type", pathType)
-
 		}
 		path = epicPath.ScionPath
 	default:
@@ -2393,8 +2384,8 @@ func (p *slowPathPacketProcessor) hasValidAuth(t time.Time) bool {
 // layer and additional, optional layers in the given order.
 // Returns the last decoded layer.
 func decodeLayers(data []byte, base gopacket.DecodingLayer,
-	opts ...gopacket.DecodingLayer) (gopacket.DecodingLayer, error) {
-
+	opts ...gopacket.DecodingLayer,
+) (gopacket.DecodingLayer, error) {
 	if err := base.DecodeFromBytes(data, gopacket.NilDecodeFeedback); err != nil {
 		return nil, err
 	}

--- a/router/dataplane.go
+++ b/router/dataplane.go
@@ -842,7 +842,8 @@ func (p *slowPathPacketProcessor) processPacket(pkt *Packet) error {
 		case slayers.SCMPTypeInternalConnectivityDown:
 			layer = &slayers.SCMPInternalConnectivityDown{
 				IA:      p.d.localIA,
-				Ingress: uint64(p.ingressFromLink), Egress: uint64(p.pkt.egress),
+				Ingress: uint64(p.ingressFromLink),
+				Egress:  uint64(p.pkt.egress),
 			}
 		default:
 			panic(fmt.Errorf("unsupported slow-path type: %d", scmpType))

--- a/scion/cmd/scion/ping.go
+++ b/scion/cmd/scion/ping.go
@@ -209,7 +209,7 @@ On other errors, ping will exit with code 2.
 			span.SetTag("src.host", localIP)
 			asNetipAddr, ok := netip.AddrFromSlice(localIP)
 			if !ok {
-				panic(fmt.Errorf("invalid local IP address: %v", localIP))
+				panic("invalid local IP address: " + localIP.String())
 			}
 			local := addr.Addr{
 				IA:   topo.LocalIA,

--- a/scion/cmd/scion/ping.go
+++ b/scion/cmd/scion/ping.go
@@ -90,7 +90,7 @@ func newPing(pather CommandPather) *cobra.Command {
 		format      string
 	}
 
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "ping [flags] <remote>",
 		Short: "Test connectivity to a remote SCION host using SCMP echo packets",
 		Example: fmt.Sprintf(`  %[1]s ping 1-ff00:0:110,10.0.0.1
@@ -202,7 +202,6 @@ On other errors, ping will exit with code 2.
 				}
 				if localIP, err = addrutil.ResolveLocal(target); err != nil {
 					return serrors.Wrap("resolving local address", err)
-
 				}
 				printf("Resolved local address:\n  %s\n", localIP)
 			}
@@ -210,7 +209,7 @@ On other errors, ping will exit with code 2.
 			span.SetTag("src.host", localIP)
 			asNetipAddr, ok := netip.AddrFromSlice(localIP)
 			if !ok {
-				panic("Invalid Local IP address")
+				panic(fmt.Errorf("invalid local IP address: %v", localIP))
 			}
 			local := addr.Addr{
 				IA:   topo.LocalIA,

--- a/scion/cmd/scion/traceroute.go
+++ b/scion/cmd/scion/traceroute.go
@@ -177,7 +177,7 @@ On other errors, traceroute will exit with code 2.
 			span.SetTag("src.host", localIP)
 			asNetipAddr, ok := netip.AddrFromSlice(localIP)
 			if !ok {
-				panic(fmt.Errorf("invalid local IP address: %v", localIP))
+				panic("invalid local IP address: " + localIP.String())
 			}
 			local := addr.Addr{
 				IA:   topo.LocalIA,

--- a/scion/cmd/scion/traceroute.go
+++ b/scion/cmd/scion/traceroute.go
@@ -71,7 +71,7 @@ func newTraceroute(pather CommandPather) *cobra.Command {
 		format      string
 	}
 
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:     "traceroute [flags] <remote>",
 		Aliases: []string{"tr"},
 		Short:   "Trace the SCION route to a remote SCION AS using SCMP traceroute packets",
@@ -177,7 +177,7 @@ On other errors, traceroute will exit with code 2.
 			span.SetTag("src.host", localIP)
 			asNetipAddr, ok := netip.AddrFromSlice(localIP)
 			if !ok {
-				panic("Invalid Local IP address")
+				panic(fmt.Errorf("invalid local IP address: %v", localIP))
 			}
 			local := addr.Addr{
 				IA:   topo.LocalIA,

--- a/scion/ping/ping.go
+++ b/scion/ping/ping.go
@@ -18,7 +18,6 @@ package ping
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"net"
 	"net/netip"
 	"sync"
@@ -128,7 +127,7 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 	localAddr := conn.LocalAddr().(*net.UDPAddr)
 	asNetipAddr, ok := netip.AddrFromSlice(localAddr.IP)
 	if !ok {
-		panic(fmt.Errorf("invalid local IP address: %v", localAddr.IP))
+		panic("invalid local IP address: " + localAddr.IP.String())
 	}
 	local := cfg.Local
 	local.Host = addr.HostIP(asNetipAddr)

--- a/scion/traceroute/traceroute.go
+++ b/scion/traceroute/traceroute.go
@@ -17,7 +17,6 @@ package traceroute
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/netip"
 	"time"
@@ -118,7 +117,7 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 	localAddr := conn.LocalAddr().(*net.UDPAddr)
 	asNetipAddr, ok := netip.AddrFromSlice(localAddr.IP)
 	if !ok {
-		panic(fmt.Errorf("invalid local IP address: %v", localAddr.IP))
+		panic("invalid local IP address: " + localAddr.IP.String())
 	}
 	local := cfg.Local
 	local.Host = addr.HostIP(asNetipAddr)

--- a/scion/traceroute/traceroute.go
+++ b/scion/traceroute/traceroute.go
@@ -17,6 +17,7 @@ package traceroute
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/netip"
 	"time"
@@ -114,9 +115,10 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 		return Stats{}, err
 	}
 	// Get our real local address.
-	asNetipAddr, ok := netip.AddrFromSlice(conn.LocalAddr().(*net.UDPAddr).IP)
+	localAddr := conn.LocalAddr().(*net.UDPAddr)
+	asNetipAddr, ok := netip.AddrFromSlice(localAddr.IP)
 	if !ok {
-		panic("Invalid Local IP address")
+		panic(fmt.Errorf("invalid local IP address: %v", localAddr.IP))
 	}
 	local := cfg.Local
 	local.Host = addr.HostIP(asNetipAddr)
@@ -129,7 +131,7 @@ func Run(ctx context.Context, cfg Config) (Stats, error) {
 		replies:       replies,
 		errHandler:    cfg.ErrHandler,
 		updateHandler: cfg.UpdateHandler,
-		id:            uint16(conn.LocalAddr().(*net.UDPAddr).Port),
+		id:            uint16(localAddr.Port),
 		path:          cfg.PathEntry,
 		nextHop:       cfg.NextHop,
 		epic:          cfg.EPIC,

--- a/tools/end2end_integration/main.go
+++ b/tools/end2end_integration/main.go
@@ -148,7 +148,7 @@ func runTests(in integration.Integration, pairs []integration.IAPair) error {
 				srvCtx, cancel := context.WithCancel(ctx)
 				waiter, err := in.StartServer(srvCtx, dst)
 				if err != nil {
-					log.Error(fmt.Sprintf("Error in server: %s", dst.String()), "err", err)
+					log.Error("Error in server: "+dst.String(), "err", err)
 				}
 				cleaner := func() {
 					cancel()
@@ -341,7 +341,6 @@ func filter(
 	pairs []integration.IAPair,
 	ases *integration.ASList,
 ) []integration.IAPair {
-
 	var res []integration.IAPair
 	s, err1 := addr.ParseIA(src)
 	d, err2 := addr.ParseIA(dst)

--- a/tools/mmbm/main.go
+++ b/tools/mmbm/main.go
@@ -36,8 +36,10 @@ import (
 )
 
 // The arena that we play with.
-const allBufs = 8192
-const cycleStep = 5 // Must not divide any working set size, must not be 1.
+const (
+	allBufs   = 8192
+	cycleStep = 5 // Must not divide any working set size, must not be 1.
+)
 
 // Block is a packet buffer representation arranged to make it easy to copy 1, 172 or 4096
 // bytes. It is exported to make sure go cannot optimize fields out.
@@ -119,7 +121,7 @@ func tc(name string, numBufs int, copySize int) (float64, float64) {
 			benchmarkCopyBlock(b.N, numBufs)
 		})
 	default:
-		panic("Size not supported")
+		panic(fmt.Errorf("size not supported: %d", copySize))
 	}
 	bytes := uint64(res.N) * uint64(copySize)
 	megaBytes := float64(bytes) / (1024 * 1024)


### PR DESCRIPTION
Use `%d` instead of `%v` for types that implement the `Stringer` interface because values outside of the valid range will be printed as "unknown" whereas a concrete number would have been more useful when investigating a panic.

Follow Go's convention of lower case error messages where possible.