### PR TITLE
fix: auto-select cpu architecture in tutorial docker setup

### DIFF
--- a/doc/tutorials/deploy/Makefile
+++ b/doc/tutorials/deploy/Makefile
@@ -1,33 +1,28 @@
-PLATFORM = linux/amd64
 DIST_TEST_DIR = $(CURDIR)/../../../dist/test
 
-.PHONY: all
+.PHONY: all build build-debian-base build-base build-scion up down purge
 
 all: up
 
 build-debian-base:
-	docker build --platform=$(PLATFORM) -t debian-systemd:1.0 \
-		-f $(DIST_TEST_DIR)/Dockerfile $(DIST_TEST_DIR)
+	docker build -t debian-systemd:1.0 \
+		-f $(DIST_TEST_DIR)/Dockerfile \
+		$(DIST_TEST_DIR)
 
 build-base: build-debian-base
-	docker build --platform=$(PLATFORM) -t scion-base:1.0 -f ./base/Dockerfile ./base
+	docker build -t scion-base:1.0 \
+		-f ./base/Dockerfile \
+		./base
 
-build-scion01:
-	docker build --platform=$(PLATFORM) -t scion01:1.0 -f ./scion01/Dockerfile ./scion01
+# pattern rule for scion01…scion05
+build-scion%:
+	docker build -t scion$*:1.0 \
+		-f ./scion$*/Dockerfile \
+		./scion$*
 
-build-scion02:
-	docker build --platform=$(PLATFORM) -t scion02:1.0 -f ./scion02/Dockerfile ./scion02
-
-build-scion03:
-	docker build --platform=$(PLATFORM) -t scion03:1.0 -f ./scion03/Dockerfile ./scion03
-
-build-scion04:
-	docker build --platform=$(PLATFORM) -t scion04:1.0 -f ./scion04/Dockerfile ./scion04
-
-build-scion05:
-	docker build --platform=$(PLATFORM) -t scion05:1.0 -f ./scion05/Dockerfile ./scion05
-
-build: build-base build-scion01 build-scion02 build-scion03 build-scion04 build-scion05
+build: build-base \
+       build-scion01 build-scion02 build-scion03 \
+       build-scion04 build-scion05
 
 up: build
 	docker compose up -d

--- a/doc/tutorials/deploy/base/Dockerfile
+++ b/doc/tutorials/deploy/base/Dockerfile
@@ -1,10 +1,13 @@
-FROM debian:12-slim
+# syntax = docker/dockerfile:1.3
+FROM --platform=$BUILDPLATFORM debian:12-slim
 
-ARG RELEASE="https://github.com/scionproto/scion/releases/download/v0.12.0/scion_0.12.0_deb_amd64.tar.gz"
+ARG TARGETARCH
+ARG SCION_VER=0.12.0
+ARG RELEASE="https://github.com/scionproto/scion/releases/download/v${SCION_VER}/scion_${SCION_VER}_deb_${TARGETARCH}.tar.gz"
 
 # Tell systemd it's running inside Docker. Without this, systemd may emit warnings
 # and fail to boot certain units (especially networking-related).
-ENV container docker
+ENV container=docker
 
 # Force debconf (called by apt-get) to be non-interactive.
 # This prevents interactive prompts during package installation.

--- a/doc/tutorials/deploy/docker-compose.yml
+++ b/doc/tutorials/deploy/docker-compose.yml
@@ -4,7 +4,6 @@ name: "SCION Tutorial"
 
 services:
   scion01:
-    platform: linux/amd64
     image: scion01:1.0
     container_name: scion01
     hostname: scion01
@@ -18,7 +17,6 @@ services:
       - /run
       - /run/lock
   scion02:
-    platform: linux/amd64
     image: scion02:1.0
     container_name: scion02
     hostname: scion02
@@ -33,7 +31,6 @@ services:
       - /run
       - /run/lock
   scion03:
-    platform: linux/amd64
     image: scion03:1.0
     container_name: scion03
     hostname: scion03
@@ -47,7 +44,6 @@ services:
       - /run
       - /run/lock
   scion04:
-    platform: linux/amd64
     image: scion04:1.0
     container_name: scion04
     hostname: scion04
@@ -61,7 +57,6 @@ services:
       - /run
       - /run/lock
   scion05:
-    platform: linux/amd64
     image: scion05:1.0
     container_name: scion05
     hostname: scion05


### PR DESCRIPTION
Remove hard-coding of `amd64` and automatically select `arm64` on Mac in the tutorial Docker setup.