### PR TITLE
doc: typos

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -11,7 +11,7 @@ explicit trust information for end-to-end communication.
 SCION's main goal is to offer highly available and efficient inter-domain packet delivery, even in
 the presence of actively malicious entities.
 
-SCION's aspiration is to improve *inter*-AS routing and to focuses on providing end-to-end
+SCION's aspiration is to improve *inter*-AS routing and to focus on providing end-to-end
 connectivity. However, SCION does not solve *intra*-AS routing issues, nor does it provide
 end-to-end payload encryption, and identity authentication. These topics, which are equally
 important for the Internet to perform well, lie outside the scope of SCION.

--- a/doc/sig.rst
+++ b/doc/sig.rst
@@ -85,7 +85,7 @@ All fields within SIG frame header are in network byte order.
 - ``Stream ID`` (20 bits), along with the session, it identifies a unique sequence of SIG frames. Frames from the same stream are, on the egress SIG, put into the same reassembly queue. There may be multiple streams per session.
 - ``Sequence Number`` (64 bits) indicates the position of the frame within a stream. Consecutive frames of a given stream have consecutive sequence numbers. IP packets split among multiple frames are re-assembled by concatenating the payloads of consecutive frames.
 
-A SIG MAY drop frames. In the current implementation, the egress SIG does not buffer frames that are received out-ot-order. Instead it drops any out-of-order and following frames until it finds the beginning of a new encapsulated IP packet.
+A SIG MAY drop frames. In the current implementation, the egress SIG does not buffer frames that are received out-of-order. Instead it drops any out-of-order and following frames until it finds the beginning of a new encapsulated IP packet.
 
 SIG frame payload
 -----------------


### PR DESCRIPTION
This pull request includes minor documentation updates to fix typographical errors and improve clarity in SCION's technical documentation.

Typographical corrections:

* [`doc/overview.rst`](diffhunk://#diff-6cc65603a3c60d4383d1e05dd6388e73773844c2f8e981f30d1ed116a7177e1bL14-R14): Corrected a grammatical error by changing "focuses on providing" to "focus on providing" in the description of SCION's aspirations for inter-AS routing.
* [`doc/sig.rst`](diffhunk://#diff-c28ddb50c1be3aaf4c126dd3dbc0ae78e427b6d23017c717cd570bd9783ba544L88-R88): Fixed a typographical error by correcting "out-ot-order" to "out-of-order" in the explanation of SIG frame handling.