### PR TITLE
fix: update deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -42,26 +42,6 @@ go_deps.from_file(go_mod = "//:go.mod")
 
 # go_deps.module() is needed for tools dependencies (previously tool_deps.bzl) that can't be added to go.mod
 go_deps.module(
-    path = "github.com/pavius/impi",
-    sum = "h1:DND6MzU+BLABhOZXbELR3FU8b+zDgcq4dOCNLhiTYuI=",
-    version = "v0.0.3",
-)
-go_deps.module(
-    path = "github.com/kisielk/gotool",
-    sum = "h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=",
-    version = "v1.0.0",
-)
-go_deps.module(
-    path = "github.com/Oncilla/ineffassign",
-    sum = "h1:zrpB8NIzy1hkO1dz2S+YWiOymA/2kL3Rk24uDg8DVUM=",
-    version = "v0.0.0-20190618100136-198c6a326229",
-)
-go_deps.module(
-    path = "github.com/golang/protobuf",
-    sum = "h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=",
-    version = "v1.5.4",
-)
-go_deps.module(
     path = "github.com/cilium/ebpf",
     sum = "h1:OsSwqS4y+gQHxaKgg2U/+Fev834kdnsQbtzRnbVC6Gs=",
     version = "v0.18.0",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -411,7 +411,7 @@
     },
     "@@aspect_rules_js+//npm:extensions.bzl%pnpm": {
       "general": {
-        "bzlTransitiveDigest": "MeYqcsZovx3KMjrN53tGCwQiYYIcAn+Sd1VBH2qIbr4=",
+        "bzlTransitiveDigest": "cYE3QE61mjLIM5IdiE+TCpLJPIIsMr0Plg/2aOdcHOA=",
         "usagesDigest": "8ggfSW1eOJDzHp5oo9r33sAB0sGvuQg4MjIOnRBgj2E=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1303,7 +1303,7 @@
     },
     "@@rules_python+//python/extensions:pip.bzl%pip": {
       "general": {
-        "bzlTransitiveDigest": "r+bk1AnSwkW8KDL7gOUT75vd7VD3mQRAxLOqbRT6Suc=",
+        "bzlTransitiveDigest": "ynEctVXvD5j3EVd/ITbHx2D6CkTijK64au5zmriT7cg=",
         "usagesDigest": "xr+U7navw2+SHogogmHRboKLbXAnkZfsctPQuyjmArw=",
         "recordedFileInputs": {
           "@@//doc/requirements.txt": "76028466c185c5f8bd40c59bcb03d97d9586456ba2aabee82bbebc2c459c7143",
@@ -4692,7 +4692,7 @@
     },
     "@@rules_rust+//rust:extensions.bzl%rust": {
       "general": {
-        "bzlTransitiveDigest": "jPW/LAnHHFTO9PkTb2xJNrv1C08DBJf+B47aC1ldodo=",
+        "bzlTransitiveDigest": "YsaTPw20Z8ZMM3WlG6OGXJBzyoyBZcY7FTiU04eEdYw=",
         "usagesDigest": "ozx08ZbgRXTJw0zCaO/xtMUzgGLvwaQkZGnUo6tlyHM=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/tools/env/debian/deps
+++ b/tools/env/debian/deps
@@ -7,4 +7,3 @@ xargs -a "$BASE/pkgs.txt" sudo DEBIAN_FRONTEND=noninteractive apt-get install --
 
 # see https://stackoverflow.com/a/77465534
 sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-remove --no-install-recommends --assume-yes linux-headers-`uname -r`
-sudo ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/asm

--- a/tools/env/debian/deps
+++ b/tools/env/debian/deps
@@ -4,3 +4,7 @@ set -e
 BASE=$(dirname "$0")
 
 xargs -a "$BASE/pkgs.txt" sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-remove --no-install-recommends --assume-yes
+
+# see https://stackoverflow.com/a/77465534
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --no-remove --no-install-recommends --assume-yes linux-headers-`uname -r`
+sudo ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/asm

--- a/tools/env/debian/pkgs.txt
+++ b/tools/env/debian/pkgs.txt
@@ -3,6 +3,7 @@ gawk
 bridge-utils
 build-essential
 cgroup-tools
+clang
 curl
 g++
 gcc


### PR DESCRIPTION
Some deps were deleted in #4760 and were incorrectly merged back in #4759. Also, one of the dependencies added in #4759 is not being installed via the `install_deps` script on Ubuntu.