### PR TITLE
fix: specify linux headers include in ebpf build

### DIFF
--- a/private/underlay/ebpf/BUILD.bazel
+++ b/private/underlay/ebpf/BUILD.bazel
@@ -13,7 +13,22 @@ genrule(
         "portfilter_bpfel.go",
         "portfilter_bpfel.o",
     ],
-    cmd = "GOPACKAGE=ebpf $(execpath @com_github_cilium_ebpf//cmd/bpf2go) -output-dir $$(dirname $(location portfilter_bpfel.go)) -tags linux portfilter $(location portfilter.c)",
+    cmd = """
+        ARCH=$$(uname -m)
+        if [ "$$ARCH" = "x86_64" ]; then
+            INC=/usr/include/x86_64-linux-gnu
+        elif [ "$$ARCH" = "aarch64" ]; then
+            INC=/usr/include/aarch64-linux-gnu
+        else
+            echo "Unsupported arch: $$ARCH" >&2
+            exit 1
+        fi
+        GOPACKAGE=ebpf $(execpath @com_github_cilium_ebpf//cmd/bpf2go) \
+            -output-dir $$(dirname $(location portfilter_bpfel.go)) \
+            -tags linux \
+            --cflags="-I$$INC" \
+            portfilter $(location portfilter.c)
+    """,
     tools = ["@com_github_cilium_ebpf//cmd/bpf2go"],
 )
 


### PR DESCRIPTION
Fixes build error that I get when running `make test`:
```
rsc@erasmus:~/Work/scion$ make test
bazel test --config=unit_all
(09:43:33) INFO: Invocation ID: 8633c207-e850-45a1-a034-d6a2cd3de9b3
(09:43:33) INFO: Current date is 2025-05-15
(09:43:33) ERROR: /home/rsc/Work/scion/private/underlay/ebpf/BUILD.bazel:4:8: Executing genrule //private/underlay/ebpf:gen_bpf_filter_go failed: (Exit 1): bash failed: error executing Genrule command (from target //private/underlay/ebpf:gen_bpf_filter_go) /bin/bash -c ... (remaining 1 argument skipped)
In file included from /home/rsc/.cache/bazel/_bazel_rsc/7d5e0b08b01169652bb71135b45027aa/execroot/_main/private/underlay/ebpf/portfilter.c:7:
In file included from /usr/include/linux/bpf.h:11:
/usr/include/linux/types.h:5:10: fatal error: 'asm/types.h' file not found
    5 | #include <asm/types.h>
      |          ^~~~~~~~~~~~~
1 error generated.
Error: compile: exit status 1
(09:43:33) ERROR: /home/rsc/Work/scion/private/underlay/ebpf/BUILD.bazel:20:11 GoCompilePkg private/underlay/ebpf/go_default_library.a failed: (Exit 1): bash failed: error executing Genrule command (from target //private/underlay/ebpf:gen_bpf_filter_go) /bin/bash -c ... (remaining 1 argument skipped)
(09:43:33) INFO: Elapsed time: 0.847s, Critical Path: 0.16s
(09:43:33) INFO: 2 processes: 2819 action cache hit, 2 internal.
(09:43:33) ERROR: Build did NOT complete successfully
...
//private/underlay/ebpf:portfilter_test                         FAILED TO BUILD

Executed 0 out of 53 tests: 52 tests pass and 1 fails to build.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
make: *** [Makefile:60: test] Error 1
```

System:
```sh
$ uname -r
6.11.0-19-generic

$ cat /etc/os-release 
PRETTY_NAME="Ubuntu 24.04.1 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.1 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo
```