### PR TITLE
refactor: scion-pki preparation for golangci-lint v2

### DIFF
--- a/scion-pki/certs/certformat.go
+++ b/scion-pki/certs/certformat.go
@@ -45,7 +45,7 @@ type formatBuffer struct {
 
 // Writef writes a string formated using fmt.Sprintf.
 func (b *formatBuffer) Writef(format string, args ...any) (int, error) {
-	return b.Buffer.WriteString(fmt.Sprintf(format, args...))
+	return fmt.Fprintf(b, format, args...)
 }
 
 type certificateShort struct {

--- a/scion-pki/certs/certformat.go
+++ b/scion-pki/certs/certformat.go
@@ -38,12 +38,12 @@ import (
 	"time"
 )
 
-// formatBuffer is a helper to write using sprintf.
+// formatBuffer is a formatted writing helper.
 type formatBuffer struct {
 	bytes.Buffer
 }
 
-// Writef writes a string formated using fmt.Sprintf.
+// Writef writes a formatted string to b.
 func (b *formatBuffer) Writef(format string, args ...any) (int, error) {
 	return fmt.Fprintf(b, format, args...)
 }

--- a/scion-pki/certs/certformat.go
+++ b/scion-pki/certs/certformat.go
@@ -93,33 +93,33 @@ func newCertificateShort(cert *x509.Certificate) *certificateShort {
 // String returns the certificateShort formated as a string.
 func (c *certificateShort) String() string {
 	var buf formatBuffer
-	buf.Writef("X.509v3 %s Certificate (%s) [Serial: %s]\n", c.Type, c.PublicKeyAlgorithm, c.SerialNumber)
+	_, _ = buf.Writef("X.509v3 %s Certificate (%s) [Serial: %s]\n", c.Type, c.PublicKeyAlgorithm, c.SerialNumber)
 	sans := c.SANs
 	if len(c.Subject) > 0 {
 		sans = append([]string{c.Subject}, sans...)
 	}
 	if len(sans) == 0 {
-		buf.Writef("  Subject: \n")
+		_, _ = buf.Writef("  Subject: \n")
 	} else {
 		for i, s := range sans {
 			if i == 0 {
-				buf.Writef("  Subject:     %s\n", s)
+				_, _ = buf.Writef("  Subject:     %s\n", s)
 			} else {
-				buf.Writef("               %s\n", s)
+				_, _ = buf.Writef("               %s\n", s)
 			}
 		}
 	}
-	buf.Writef("  Issuer:      %s\n", c.Issuer)
+	_, _ = buf.Writef("  Issuer:      %s\n", c.Issuer)
 	if c.Provisioner != nil {
 		if len(c.Provisioner.ID) == 0 {
-			buf.Writef("  Provisioner: %s\n", c.Provisioner.Name)
+			_, _ = buf.Writef("  Provisioner: %s\n", c.Provisioner.Name)
 		} else {
-			buf.Writef("  Provisioner: %s [ID: %s]\n", c.Provisioner.Name, c.Provisioner.ID)
+			_, _ = buf.Writef("  Provisioner: %s [ID: %s]\n", c.Provisioner.Name, c.Provisioner.ID)
 		}
 
 	}
-	buf.Writef("  Valid from:  %s\n", c.NotBefore.Format(time.RFC3339))
-	buf.Writef("          to:  %s\n", c.NotAfter.Format(time.RFC3339))
+	_, _ = buf.Writef("  Valid from:  %s\n", c.NotBefore.Format(time.RFC3339))
+	_, _ = buf.Writef("          to:  %s\n", c.NotAfter.Format(time.RFC3339))
 	return buf.String()
 }
 
@@ -140,19 +140,19 @@ func newCertificateRequestShort(cr *x509.CertificateRequest) *certificateRequest
 // String returns the certificateShort formated as a string.
 func (c *certificateRequestShort) String() string {
 	var buf formatBuffer
-	buf.Writef("X.509v3 Certificate Signing Request (%s)\n", c.PublicKeyAlgorithm)
+	_, _ = buf.Writef("X.509v3 Certificate Signing Request (%s)\n", c.PublicKeyAlgorithm)
 	sans := c.SANs
 	if len(c.Subject) > 0 {
 		sans = append([]string{c.Subject}, sans...)
 	}
 	if len(sans) == 0 {
-		buf.Writef("  Subject: \n")
+		_, _ = buf.Writef("  Subject: \n")
 	} else {
 		for i, s := range sans {
 			if i == 0 {
-				buf.Writef("  Subject:     %s\n", s)
+				_, _ = buf.Writef("  Subject:     %s\n", s)
 			} else {
-				buf.Writef("               %s\n", s)
+				_, _ = buf.Writef("               %s\n", s)
 			}
 		}
 	}

--- a/scion-pki/certs/certinfo.go
+++ b/scion-pki/certs/certinfo.go
@@ -174,12 +174,12 @@ func printName(names []pkix.AttributeTypeAndValue, buf *bytes.Buffer) []string {
 
 // dsaKeyPrinter formats the Y, P, Q, or G components of a DSA public key.
 func dsaKeyPrinter(name string, val *big.Int, buf *bytes.Buffer) {
-	buf.WriteString(fmt.Sprintf("%16s%s:", "", name))
+	fmt.Fprintf(buf, "%16s%s:", "", name)
 	for i, b := range val.Bytes() {
 		if (i % 15) == 0 {
-			buf.WriteString(fmt.Sprintf("\n%20s", ""))
+			fmt.Fprintf(buf, "\n%20s", "")
 		}
-		buf.WriteString(fmt.Sprintf("%02x", b))
+		fmt.Fprintf(buf, "%02x", b)
 		if i != len(val.Bytes())-1 {
 			buf.WriteString(":")
 		}
@@ -192,48 +192,48 @@ func printVersion(version int, buf *bytes.Buffer) {
 	if hexVersion < 0 {
 		hexVersion = 0
 	}
-	buf.WriteString(fmt.Sprintf("%8sVersion: %d (%#x)\n", "", version, hexVersion))
+	fmt.Fprintf(buf, "%8sVersion: %d (%#x)\n", "", version, hexVersion)
 }
 
 func printSubjectInformation(subj *pkix.Name, pkAlgo x509.PublicKeyAlgorithm, pk any, buf *bytes.Buffer) error {
-	buf.WriteString(fmt.Sprintf("%8sSubject:", ""))
+	fmt.Fprintf(buf, "%8sSubject:", "")
 	if len(subj.Names) > 0 {
 		buf.WriteString(" ")
 		printName(subj.Names, buf)
 	} else {
 		buf.WriteString("\n")
 	}
-	buf.WriteString(fmt.Sprintf("%8sSubject Public Key Info:\n%12sPublic Key Algorithm: ", "", ""))
+	fmt.Fprintf(buf, "%8sSubject Public Key Info:\n%12sPublic Key Algorithm: ", "", "")
 	switch pkAlgo {
 	case x509.RSA:
 		buf.WriteString("RSA\n")
 		if rsaKey, ok := pk.(*rsa.PublicKey); ok {
-			buf.WriteString(fmt.Sprintf("%16sPublic-Key: (%d bit)\n", "", rsaKey.N.BitLen()))
+			fmt.Fprintf(buf, "%16sPublic-Key: (%d bit)\n", "", rsaKey.N.BitLen())
 			// Some implementations (notably OpenSSL) prepend 0x00 to the modulus
 			// if its most-significant bit is set. There is no need to do that here
 			// because the modulus is always unsigned and the extra byte can be
 			// confusing given the bit length.
-			buf.WriteString(fmt.Sprintf("%16sModulus:", ""))
+			fmt.Fprintf(buf, "%16sModulus:", "")
 			for i, val := range rsaKey.N.Bytes() {
 				if (i % 15) == 0 {
-					buf.WriteString(fmt.Sprintf("\n%20s", ""))
+					fmt.Fprintf(buf, "\n%20s", "")
 				}
-				buf.WriteString(fmt.Sprintf("%02x", val))
+				fmt.Fprintf(buf, "%02x", val)
 				if i != len(rsaKey.N.Bytes())-1 {
 					buf.WriteString(":")
 				}
 			}
-			buf.WriteString(fmt.Sprintf("\n%16sExponent: %d (%#x)\n", "", rsaKey.E, rsaKey.E))
+			fmt.Fprintf(buf, "\n%16sExponent: %d (%#x)\n", "", rsaKey.E, rsaKey.E)
 		} else {
 			return errors.New("certinfo: Expected rsa.PublicKey for type x509.RSA")
 		}
 	case x509.ECDSA:
 		buf.WriteString("ECDSA\n")
 		if ecdsaKey, ok := pk.(*ecdsa.PublicKey); ok {
-			buf.WriteString(fmt.Sprintf("%16sPublic-Key: (%d bit)\n", "", ecdsaKey.Params().BitSize))
+			fmt.Fprintf(buf, "%16sPublic-Key: (%d bit)\n", "", ecdsaKey.Params().BitSize)
 			dsaKeyPrinter("X", ecdsaKey.X, buf)
 			dsaKeyPrinter("Y", ecdsaKey.Y, buf)
-			buf.WriteString(fmt.Sprintf("%16sCurve: %s\n", "", ecdsaKey.Params().Name))
+			fmt.Fprintf(buf, "%16sCurve: %s\n", "", ecdsaKey.Params().Name)
 		} else {
 			return errors.New("certinfo: Expected ecdsa.PublicKey for type x509.DSA")
 		}
@@ -241,12 +241,12 @@ func printSubjectInformation(subj *pkix.Name, pkAlgo x509.PublicKeyAlgorithm, pk
 		buf.WriteString("Ed25519\n")
 		if ed25519Key, ok := pk.(ed25519.PublicKey); ok {
 			bytes := []byte(ed25519Key)
-			buf.WriteString(fmt.Sprintf("%16sPublic-Key: (%d bit)", "", len(bytes)))
+			fmt.Fprintf(buf, "%16sPublic-Key: (%d bit)", "", len(bytes))
 			for i, b := range bytes {
 				if (i % 15) == 0 {
-					buf.WriteString(fmt.Sprintf("\n%20s", ""))
+					fmt.Fprintf(buf, "\n%20s", "")
 				}
-				buf.WriteString(fmt.Sprintf("%02x", b))
+				fmt.Fprintf(buf, "%02x", b)
 				if i != len(bytes)-1 {
 					buf.WriteString(":")
 				}
@@ -263,7 +263,7 @@ func printSubjectInformation(subj *pkix.Name, pkAlgo x509.PublicKeyAlgorithm, pk
 
 func printSubjKeyID(ext pkix.Extension, buf *bytes.Buffer) error {
 	// subjectKeyIdentifier: RFC 5280, 4.2.1.2
-	buf.WriteString(fmt.Sprintf("%12sX509v3 Subject Key Identifier:", ""))
+	fmt.Fprintf(buf, "%12sX509v3 Subject Key Identifier:", "")
 	if ext.Critical {
 		buf.WriteString(" critical\n")
 	} else {
@@ -275,9 +275,9 @@ func printSubjKeyID(ext pkix.Extension, buf *bytes.Buffer) error {
 	}
 	for i := 0; i < len(subjectKeyID); i++ {
 		if i == 0 {
-			buf.WriteString(fmt.Sprintf("%16s%02X", "", subjectKeyID[0]))
+			fmt.Fprintf(buf, "%16s%02X", "", subjectKeyID[0])
 		} else {
-			buf.WriteString(fmt.Sprintf(":%02X", subjectKeyID[i]))
+			fmt.Fprintf(buf, ":%02X", subjectKeyID[i])
 		}
 	}
 	buf.WriteString("\n")
@@ -288,37 +288,37 @@ func printSubjAltNames(ext pkix.Extension, dnsNames []string, emailAddresses []s
 	// subjectAltName: RFC 5280, 4.2.1.6
 	// TODO: Currently crypto/x509 only extracts DNS, email, and IP addresses.
 	// We should add the others to it or implement them here.
-	buf.WriteString(fmt.Sprintf("%12sX509v3 Subject Alternative Name:", ""))
+	fmt.Fprintf(buf, "%12sX509v3 Subject Alternative Name:", "")
 	if ext.Critical {
 		buf.WriteString(" critical\n")
 	} else {
 		buf.WriteString("\n")
 	}
 	if len(dnsNames) > 0 {
-		buf.WriteString(fmt.Sprintf("%16sDNS:%s", "", dnsNames[0]))
+		fmt.Fprintf(buf, "%16sDNS:%s", "", dnsNames[0])
 		for i := 1; i < len(dnsNames); i++ {
-			buf.WriteString(fmt.Sprintf(", DNS:%s", dnsNames[i]))
+			fmt.Fprintf(buf, ", DNS:%s", dnsNames[i])
 		}
 		buf.WriteString("\n")
 	}
 	if len(emailAddresses) > 0 {
-		buf.WriteString(fmt.Sprintf("%16semail:%s", "", emailAddresses[0]))
+		fmt.Fprintf(buf, "%16semail:%s", "", emailAddresses[0])
 		for i := 1; i < len(emailAddresses); i++ {
-			buf.WriteString(fmt.Sprintf(", email:%s", emailAddresses[i]))
+			fmt.Fprintf(buf, ", email:%s", emailAddresses[i])
 		}
 		buf.WriteString("\n")
 	}
 	if len(ipAddresses) > 0 {
-		buf.WriteString(fmt.Sprintf("%16sIP Address:%s", "", ipAddresses[0].String())) // XXX verify string format
+		fmt.Fprintf(buf, "%16sIP Address:%s", "", ipAddresses[0].String()) // XXX verify string format
 		for i := 1; i < len(ipAddresses); i++ {
-			buf.WriteString(fmt.Sprintf(", IP Address:%s", ipAddresses[i].String()))
+			fmt.Fprintf(buf, ", IP Address:%s", ipAddresses[i].String())
 		}
 		buf.WriteString("\n")
 	}
 	if len(uris) > 0 {
-		buf.WriteString(fmt.Sprintf("%16sURI:%s", "", uris[0].String()))
+		fmt.Fprintf(buf, "%16sURI:%s", "", uris[0].String())
 		for i := 1; i < len(uris); i++ {
-			buf.WriteString(fmt.Sprintf(", URI:%s", uris[i].String()))
+			fmt.Fprintf(buf, ", URI:%s", uris[i].String())
 		}
 		buf.WriteString("\n")
 	}
@@ -326,12 +326,12 @@ func printSubjAltNames(ext pkix.Extension, dnsNames []string, emailAddresses []s
 }
 
 func printSignature(sigAlgo x509.SignatureAlgorithm, sig []byte, buf *bytes.Buffer) {
-	buf.WriteString(fmt.Sprintf("%4sSignature Algorithm: %s", "", sigAlgo))
+	fmt.Fprintf(buf, "%4sSignature Algorithm: %s", "", sigAlgo)
 	for i, val := range sig {
 		if (i % 18) == 0 {
-			buf.WriteString(fmt.Sprintf("\n%9s", ""))
+			fmt.Fprintf(buf, "\n%9s", "")
 		}
-		buf.WriteString(fmt.Sprintf("%02x", val))
+		fmt.Fprintf(buf, "%02x", val)
 		if i != len(sig)-1 {
 			buf.WriteString(":")
 		}
@@ -359,19 +359,19 @@ func certificateText(cert *x509.Certificate) (string, error) {
 	buf.Grow(4096) // 4KiB should be enough
 
 	buf.WriteString("Certificate:\n")
-	buf.WriteString(fmt.Sprintf("%4sData:\n", ""))
+	fmt.Fprintf(&buf, "%4sData:\n", "")
 	printVersion(cert.Version, &buf)
-	buf.WriteString(fmt.Sprintf("%8sSerial Number: %d (%#x)\n", "", cert.SerialNumber, cert.SerialNumber))
-	buf.WriteString(fmt.Sprintf("%4sSignature Algorithm: %s\n", "", cert.SignatureAlgorithm))
+	fmt.Fprintf(&buf, "%8sSerial Number: %d (%#x)\n", "", cert.SerialNumber, cert.SerialNumber)
+	fmt.Fprintf(&buf, "%4sSignature Algorithm: %s\n", "", cert.SignatureAlgorithm)
 
 	// Issuer information
-	buf.WriteString(fmt.Sprintf("%8sIssuer: ", ""))
+	fmt.Fprintf(&buf, "%8sIssuer: ", "")
 	printName(cert.Issuer.Names, &buf)
 
 	// Validity information
-	buf.WriteString(fmt.Sprintf("%8sValidity\n", ""))
-	buf.WriteString(fmt.Sprintf("%12sNot Before: %s\n", "", cert.NotBefore.Format(validityTimeFormat)))
-	buf.WriteString(fmt.Sprintf("%12sNot After : %s\n", "", cert.NotAfter.Format(validityTimeFormat)))
+	fmt.Fprintf(&buf, "%8sValidity\n", "")
+	fmt.Fprintf(&buf, "%12sNot Before: %s\n", "", cert.NotBefore.Format(validityTimeFormat))
+	fmt.Fprintf(&buf, "%12sNot After : %s\n", "", cert.NotAfter.Format(validityTimeFormat))
 
 	// Subject information
 	err := printSubjectInformation(&cert.Subject, cert.PublicKeyAlgorithm, cert.PublicKey, &buf)
@@ -385,23 +385,23 @@ func certificateText(cert *x509.Certificate) (string, error) {
 		return "", errors.New(fmt.Sprintf("certinfo: Error parsing TBS unique attributes: %s\n", err.Error()))
 	}
 	if len(issuerUID) > 0 {
-		buf.WriteString(fmt.Sprintf("%8sIssuer Unique ID: %02x", "", issuerUID[0]))
+		fmt.Fprintf(&buf, "%8sIssuer Unique ID: %02x", "", issuerUID[0])
 		for i := 1; i < len(issuerUID); i++ {
-			buf.WriteString(fmt.Sprintf(":%02x", issuerUID[i]))
+			fmt.Fprintf(&buf, ":%02x", issuerUID[i])
 		}
 		buf.WriteString("\n")
 	}
 	if len(subjectUID) > 0 {
-		buf.WriteString(fmt.Sprintf("%8sSubject Unique ID: %02x", "", subjectUID[0]))
+		fmt.Fprintf(&buf, "%8sSubject Unique ID: %02x", "", subjectUID[0])
 		for i := 1; i < len(subjectUID); i++ {
-			buf.WriteString(fmt.Sprintf(":%02x", subjectUID[i]))
+			fmt.Fprintf(&buf, ":%02x", subjectUID[i])
 		}
 		buf.WriteString("\n")
 	}
 
 	// Optional extensions for X509v3
 	if cert.Version == 3 && len(cert.Extensions) > 0 {
-		buf.WriteString(fmt.Sprintf("%8sX509v3 extensions:\n", ""))
+		fmt.Fprintf(&buf, "%8sX509v3 extensions:\n", "")
 		for _, ext := range cert.Extensions {
 			if len(ext.Id) == 4 && ext.Id[0] == 2 && ext.Id[1] == 5 && ext.Id[2] == 29 {
 				switch ext.Id[3] {
@@ -409,7 +409,7 @@ func certificateText(cert *x509.Certificate) (string, error) {
 					err = printSubjKeyID(ext, &buf)
 				case 15:
 					// keyUsage: RFC 5280, 4.2.1.3
-					buf.WriteString(fmt.Sprintf("%12sX509v3 Key Usage:", ""))
+					fmt.Fprintf(&buf, "%12sX509v3 Key Usage:", "")
 					if ext.Critical {
 						buf.WriteString(" critical\n")
 					} else {
@@ -444,13 +444,13 @@ func certificateText(cert *x509.Certificate) (string, error) {
 						usages = append(usages, "Decipher Only")
 					}
 					if len(usages) > 0 {
-						buf.WriteString(fmt.Sprintf("%16s%s", "", usages[0]))
+						fmt.Fprintf(&buf, "%16s%s", "", usages[0])
 						for i := 1; i < len(usages); i++ {
-							buf.WriteString(fmt.Sprintf(", %s", usages[i]))
+							fmt.Fprintf(&buf, ", %s", usages[i])
 						}
 						buf.WriteString("\n")
 					} else {
-						buf.WriteString(fmt.Sprintf("%16sNone\n", ""))
+						fmt.Fprintf(&buf, "%16sNone\n", "")
 					}
 				case 17:
 					err = printSubjAltNames(ext, cert.DNSNames, cert.EmailAddresses, cert.IPAddresses, cert.URIs, &buf)
@@ -459,21 +459,21 @@ func certificateText(cert *x509.Certificate) (string, error) {
 					if !cert.BasicConstraintsValid {
 						break
 					}
-					buf.WriteString(fmt.Sprintf("%12sX509v3 Basic Constraints:", ""))
+					fmt.Fprintf(&buf, "%12sX509v3 Basic Constraints:", "")
 					if ext.Critical {
 						buf.WriteString(" critical\n")
 					} else {
 						buf.WriteString("\n")
 					}
 					if cert.IsCA {
-						buf.WriteString(fmt.Sprintf("%16sCA:TRUE", ""))
+						fmt.Fprintf(&buf, "%16sCA:TRUE", "")
 					} else {
-						buf.WriteString(fmt.Sprintf("%16sCA:FALSE", ""))
+						fmt.Fprintf(&buf, "%16sCA:FALSE", "")
 					}
 					if cert.MaxPathLenZero {
 						buf.WriteString(", pathlen:0\n")
 					} else if cert.MaxPathLen > 0 {
-						buf.WriteString(fmt.Sprintf(", pathlen:%d\n", cert.MaxPathLen))
+						fmt.Fprintf(&buf, ", pathlen:%d\n", cert.MaxPathLen)
 					} else {
 						buf.WriteString("\n")
 					}
@@ -482,72 +482,72 @@ func certificateText(cert *x509.Certificate) (string, error) {
 					// TODO: Currently crypto/x509 only supports "Permitted" and not "Excluded"
 					// subtrees. Furthermore it assumes all types are DNS names which is not
 					// necessarily true. This missing functionality should be implemented.
-					buf.WriteString(fmt.Sprintf("%12sX509v3 Name Constraints:", ""))
+					fmt.Fprintf(&buf, "%12sX509v3 Name Constraints:", "")
 					if ext.Critical {
 						buf.WriteString(" critical\n")
 					} else {
 						buf.WriteString("\n")
 					}
 					if len(cert.PermittedDNSDomains) > 0 || len(cert.PermittedEmailAddresses) > 0 || len(cert.PermittedURIDomains) > 0 || len(cert.PermittedIPRanges) > 0 {
-						buf.WriteString(fmt.Sprintf("%16sPermitted:\n", ""))
+						fmt.Fprintf(&buf, "%16sPermitted:\n", "")
 
 						if len(cert.PermittedDNSDomains) > 0 {
-							buf.WriteString(fmt.Sprintf("%18sDNS: %s", "", cert.PermittedDNSDomains[0]))
+							fmt.Fprintf(&buf, "%18sDNS: %s", "", cert.PermittedDNSDomains[0])
 							for i := 1; i < len(cert.PermittedDNSDomains); i++ {
-								buf.WriteString(fmt.Sprintf(", %s", cert.PermittedDNSDomains[i]))
+								fmt.Fprintf(&buf, ", %s", cert.PermittedDNSDomains[i])
 							}
 							buf.WriteString("\n")
 						}
 						if len(cert.PermittedEmailAddresses) > 0 {
-							buf.WriteString(fmt.Sprintf("%18sEmail: %s", "", cert.PermittedEmailAddresses[0]))
+							fmt.Fprintf(&buf, "%18sEmail: %s", "", cert.PermittedEmailAddresses[0])
 							for i := 1; i < len(cert.PermittedEmailAddresses); i++ {
-								buf.WriteString(fmt.Sprintf(", %s", cert.PermittedEmailAddresses[i]))
+								fmt.Fprintf(&buf, ", %s", cert.PermittedEmailAddresses[i])
 							}
 							buf.WriteString("\n")
 						}
 						if len(cert.PermittedURIDomains) > 0 {
-							buf.WriteString(fmt.Sprintf("%18sURI: %s", "", cert.PermittedURIDomains[0]))
+							fmt.Fprintf(&buf, "%18sURI: %s", "", cert.PermittedURIDomains[0])
 							for i := 1; i < len(cert.PermittedURIDomains); i++ {
-								buf.WriteString(fmt.Sprintf(", %s", cert.PermittedURIDomains[i]))
+								fmt.Fprintf(&buf, ", %s", cert.PermittedURIDomains[i])
 							}
 							buf.WriteString("\n")
 						}
 						if len(cert.PermittedIPRanges) > 0 {
-							buf.WriteString(fmt.Sprintf("%18sIP Range: %s", "", cert.PermittedIPRanges[0]))
+							fmt.Fprintf(&buf, "%18sIP Range: %s", "", cert.PermittedIPRanges[0])
 							for i := 1; i < len(cert.PermittedIPRanges); i++ {
-								buf.WriteString(fmt.Sprintf(", %s", cert.PermittedIPRanges[i]))
+								fmt.Fprintf(&buf, ", %s", cert.PermittedIPRanges[i])
 							}
 							buf.WriteString("\n")
 						}
 					}
 					if len(cert.ExcludedDNSDomains) > 0 || len(cert.ExcludedEmailAddresses) > 0 || len(cert.ExcludedURIDomains) > 0 || len(cert.ExcludedIPRanges) > 0 {
-						buf.WriteString(fmt.Sprintf("%16sExcluded:\n", ""))
+						fmt.Fprintf(&buf, "%16sExcluded:\n", "")
 
 						if len(cert.ExcludedDNSDomains) > 0 {
-							buf.WriteString(fmt.Sprintf("%18sDNS: %s", "", cert.ExcludedDNSDomains[0]))
+							fmt.Fprintf(&buf, "%18sDNS: %s", "", cert.ExcludedDNSDomains[0])
 							for i := 1; i < len(cert.ExcludedDNSDomains); i++ {
-								buf.WriteString(fmt.Sprintf(", %s", cert.ExcludedDNSDomains[i]))
+								fmt.Fprintf(&buf, ", %s", cert.ExcludedDNSDomains[i])
 							}
 							buf.WriteString("\n")
 						}
 						if len(cert.ExcludedEmailAddresses) > 0 {
-							buf.WriteString(fmt.Sprintf("%18sEmail: %s", "", cert.ExcludedEmailAddresses[0]))
+							fmt.Fprintf(&buf, "%18sEmail: %s", "", cert.ExcludedEmailAddresses[0])
 							for i := 1; i < len(cert.ExcludedEmailAddresses); i++ {
-								buf.WriteString(fmt.Sprintf(", %s", cert.ExcludedEmailAddresses[i]))
+								fmt.Fprintf(&buf, ", %s", cert.ExcludedEmailAddresses[i])
 							}
 							buf.WriteString("\n")
 						}
 						if len(cert.ExcludedURIDomains) > 0 {
-							buf.WriteString(fmt.Sprintf("%18sURI: %s", "", cert.ExcludedURIDomains[0]))
+							fmt.Fprintf(&buf, "%18sURI: %s", "", cert.ExcludedURIDomains[0])
 							for i := 1; i < len(cert.ExcludedURIDomains); i++ {
-								buf.WriteString(fmt.Sprintf(", %s", cert.ExcludedURIDomains[i]))
+								fmt.Fprintf(&buf, ", %s", cert.ExcludedURIDomains[i])
 							}
 							buf.WriteString("\n")
 						}
 						if len(cert.ExcludedIPRanges) > 0 {
-							buf.WriteString(fmt.Sprintf("%18sIP Range: %s", "", cert.ExcludedIPRanges[0]))
+							fmt.Fprintf(&buf, "%18sIP Range: %s", "", cert.ExcludedIPRanges[0])
 							for i := 1; i < len(cert.ExcludedIPRanges); i++ {
-								buf.WriteString(fmt.Sprintf(", %s", cert.ExcludedIPRanges[i]))
+								fmt.Fprintf(&buf, ", %s", cert.ExcludedIPRanges[i])
 							}
 							buf.WriteString("\n")
 						}
@@ -557,16 +557,16 @@ func certificateText(cert *x509.Certificate) (string, error) {
 					// CRLDistributionPoints: RFC 5280, 4.2.1.13
 					// TODO: Currently crypto/x509 does not fully implement this section,
 					// including types and reason flags.
-					buf.WriteString(fmt.Sprintf("%12sX509v3 CRL Distribution Points:", ""))
+					fmt.Fprintf(&buf, "%12sX509v3 CRL Distribution Points:", "")
 					if ext.Critical {
 						buf.WriteString(" critical\n")
 					} else {
 						buf.WriteString("\n")
 					}
 					if len(cert.CRLDistributionPoints) > 0 {
-						buf.WriteString(fmt.Sprintf("%16sFull Name:\n%18sURI:%s", "", "", cert.CRLDistributionPoints[0]))
+						fmt.Fprintf(&buf, "%16sFull Name:\n%18sURI:%s", "", "", cert.CRLDistributionPoints[0])
 						for i := 1; i < len(cert.CRLDistributionPoints); i++ {
-							buf.WriteString(fmt.Sprintf(", URI:%s", cert.CRLDistributionPoints[i]))
+							fmt.Fprintf(&buf, ", URI:%s", cert.CRLDistributionPoints[i])
 						}
 						buf.WriteString("\n")
 					}
@@ -574,31 +574,31 @@ func certificateText(cert *x509.Certificate) (string, error) {
 					// certificatePoliciesExt: RFC 5280, 4.2.1.4
 					// TODO: Currently crypto/x509 does not fully implement this section,
 					// including the Certification Practice Statement (CPS)
-					buf.WriteString(fmt.Sprintf("%12sX509v3 Certificate Policies:", ""))
+					fmt.Fprintf(&buf, "%12sX509v3 Certificate Policies:", "")
 					if ext.Critical {
 						buf.WriteString(" critical\n")
 					} else {
 						buf.WriteString("\n")
 					}
 					for _, val := range cert.PolicyIdentifiers {
-						buf.WriteString(fmt.Sprintf("%16sPolicy: %s\n", "", val.String()))
+						fmt.Fprintf(&buf, "%16sPolicy: %s\n", "", val.String())
 					}
 				case 35:
 					// authorityKeyIdentifier: RFC 5280, 4.2.1.1
-					buf.WriteString(fmt.Sprintf("%12sX509v3 Authority Key Identifier:", ""))
+					fmt.Fprintf(&buf, "%12sX509v3 Authority Key Identifier:", "")
 					if ext.Critical {
 						buf.WriteString(" critical\n")
 					} else {
 						buf.WriteString("\n")
 					}
-					buf.WriteString(fmt.Sprintf("%16skeyid", ""))
+					fmt.Fprintf(&buf, "%16skeyid", "")
 					for _, val := range cert.AuthorityKeyId {
-						buf.WriteString(fmt.Sprintf(":%02X", val))
+						fmt.Fprintf(&buf, ":%02X", val)
 					}
 					buf.WriteString("\n")
 				case 37:
 					// extKeyUsage: RFC 5280, 4.2.1.12
-					buf.WriteString(fmt.Sprintf("%12sX509v3 Extended Key Usage:", ""))
+					fmt.Fprintf(&buf, "%12sX509v3 Extended Key Usage:", "")
 					if ext.Critical {
 						buf.WriteString(" critical\n")
 					} else {
@@ -644,37 +644,37 @@ func certificateText(cert *x509.Certificate) (string, error) {
 						}
 					}
 					if len(list) > 0 {
-						buf.WriteString(fmt.Sprintf("%16s%s", "", list[0]))
+						fmt.Fprintf(&buf, "%16s%s", "", list[0])
 						for i := 1; i < len(list); i++ {
-							buf.WriteString(fmt.Sprintf(", %s", list[i]))
+							fmt.Fprintf(&buf, ", %s", list[i])
 						}
 						buf.WriteString("\n")
 					}
 				default:
-					buf.WriteString(fmt.Sprintf("Unknown extension 2.5.29.%d\n", ext.Id[3]))
+					fmt.Fprintf(&buf, "Unknown extension 2.5.29.%d\n", ext.Id[3])
 				}
 				if err != nil {
 					return "", err
 				}
 			} else if ext.Id.Equal(oidExtensionAuthorityInfoAccess) {
 				// authorityInfoAccess: RFC 5280, 4.2.2.1
-				buf.WriteString(fmt.Sprintf("%12sAuthority Information Access:", ""))
+				fmt.Fprintf(&buf, "%12sAuthority Information Access:", "")
 				if ext.Critical {
 					buf.WriteString(" critical\n")
 				} else {
 					buf.WriteString("\n")
 				}
 				if len(cert.OCSPServer) > 0 {
-					buf.WriteString(fmt.Sprintf("%16sOCSP - URI:%s", "", cert.OCSPServer[0]))
+					fmt.Fprintf(&buf, "%16sOCSP - URI:%s", "", cert.OCSPServer[0])
 					for i := 1; i < len(cert.OCSPServer); i++ {
-						buf.WriteString(fmt.Sprintf(",URI:%s", cert.OCSPServer[i]))
+						fmt.Fprintf(&buf, ",URI:%s", cert.OCSPServer[i])
 					}
 					buf.WriteString("\n")
 				}
 				if len(cert.IssuingCertificateURL) > 0 {
-					buf.WriteString(fmt.Sprintf("%16sCA Issuers - URI:%s", "", cert.IssuingCertificateURL[0]))
+					fmt.Fprintf(&buf, "%16sCA Issuers - URI:%s", "", cert.IssuingCertificateURL[0])
 					for i := 1; i < len(cert.IssuingCertificateURL); i++ {
-						buf.WriteString(fmt.Sprintf(",URI:%s", cert.IssuingCertificateURL[i]))
+						fmt.Fprintf(&buf, ",URI:%s", cert.IssuingCertificateURL[i])
 					}
 					buf.WriteString("\n")
 				}
@@ -686,12 +686,12 @@ func certificateText(cert *x509.Certificate) (string, error) {
 					return "", errors.New("certinfo: Error parsing OID " + ext.Id.String())
 				}
 				if ext.Critical {
-					buf.WriteString(fmt.Sprintf("%12sNetscape Comment: critical\n%16s%s\n", "", "", comment))
+					fmt.Fprintf(&buf, "%12sNetscape Comment: critical\n%16s%s\n", "", "", comment)
 				} else {
-					buf.WriteString(fmt.Sprintf("%12sNetscape Comment:\n%16s%s\n", "", "", comment))
+					fmt.Fprintf(&buf, "%12sNetscape Comment:\n%16s%s\n", "", "", comment)
 				}
 			} else if ext.Id.Equal(oidStepProvisioner) {
-				buf.WriteString(fmt.Sprintf("%12sX509v3 Step Provisioner:", ""))
+				fmt.Fprintf(&buf, "%12sX509v3 Step Provisioner:", "")
 				if ext.Critical {
 					buf.WriteString(" critical\n")
 				} else {
@@ -723,10 +723,10 @@ func certificateText(cert *x509.Certificate) (string, error) {
 				default:
 					typ = fmt.Sprintf("%d (unknown)", val.Type)
 				}
-				buf.WriteString(fmt.Sprintf("%16sType: %s\n", "", typ))
-				buf.WriteString(fmt.Sprintf("%16sName: %s\n", "", string(val.Name)))
+				fmt.Fprintf(&buf, "%16sType: %s\n", "", typ)
+				fmt.Fprintf(&buf, "%16sName: %s\n", "", string(val.Name))
 				if len(val.CredentialID) != 0 {
-					buf.WriteString(fmt.Sprintf("%16sCredentialID: %s\n", "", string(val.CredentialID)))
+					fmt.Fprintf(&buf, "%16sCredentialID: %s\n", "", string(val.CredentialID))
 				}
 				var key, value string
 				for i, l := 0, len(val.KeyValuePairs); i < l; i += 2 {
@@ -734,10 +734,10 @@ func certificateText(cert *x509.Certificate) (string, error) {
 					if i+1 < l {
 						value = val.KeyValuePairs[i+1]
 					}
-					buf.WriteString(fmt.Sprintf("%16s%s: %s\n", "", key, value))
+					fmt.Fprintf(&buf, "%16s%s: %s\n", "", key, value)
 				}
 			} else if ext.Id.Equal(oidStepCertificateAuthority) {
-				buf.WriteString(fmt.Sprintf("%12sX509v3 Step Registration Authority:", ""))
+				fmt.Fprintf(&buf, "%12sX509v3 Step Registration Authority:", "")
 				if ext.Critical {
 					buf.WriteString(" critical\n")
 				} else {
@@ -748,9 +748,9 @@ func certificateText(cert *x509.Certificate) (string, error) {
 				if err != nil || len(rest) > 0 {
 					return "", errors.New("certinfo: Error parsing OID " + ext.Id.String())
 				}
-				buf.WriteString(fmt.Sprintf("%16sType: %s\n", "", val.Type))
+				fmt.Fprintf(&buf, "%16sType: %s\n", "", val.Type)
 				if val.CertificateID != "" {
-					buf.WriteString(fmt.Sprintf("%16sCertificateID: %s\n", "", val.CertificateID))
+					fmt.Fprintf(&buf, "%16sCertificateID: %s\n", "", val.CertificateID)
 				}
 				var key, value string
 				for i, l := 0, len(val.KeyValuePairs); i < l; i += 2 {
@@ -758,10 +758,10 @@ func certificateText(cert *x509.Certificate) (string, error) {
 					if i+1 < l {
 						value = val.KeyValuePairs[i+1]
 					}
-					buf.WriteString(fmt.Sprintf("%16s%s: %s\n", "", key, value))
+					fmt.Fprintf(&buf, "%16s%s: %s\n", "", key, value)
 				}
 			} else {
-				buf.WriteString(fmt.Sprintf("%12s%s:", "", ext.Id.String()))
+				fmt.Fprintf(&buf, "%12s%s:", "", ext.Id.String())
 				if ext.Critical {
 					buf.WriteString(" critical\n")
 				} else {
@@ -776,7 +776,7 @@ func certificateText(cert *x509.Certificate) (string, error) {
 						sanitized[i] = '.'
 					}
 				}
-				buf.WriteString(fmt.Sprintf("%16s%s\n", "", string(sanitized)))
+				fmt.Fprintf(&buf, "%16s%s\n", "", string(sanitized))
 			}
 		}
 	}
@@ -873,7 +873,7 @@ func certificateRequestText(csr *x509.CertificateRequest) (string, error) {
 	buf.Grow(4096) // 4KiB should be enough
 
 	buf.WriteString("Certificate Request:\n")
-	buf.WriteString(fmt.Sprintf("%4sData:\n", ""))
+	fmt.Fprintf(&buf, "%4sData:\n", "")
 	printVersion(csr.Version, &buf)
 
 	// Subject information
@@ -884,7 +884,7 @@ func certificateRequestText(csr *x509.CertificateRequest) (string, error) {
 
 	// Optional extensions for PKCS #10, RFC 2986
 	if csr.Version == 0 && len(csr.Extensions) > 0 {
-		buf.WriteString(fmt.Sprintf("%8sRequested Extensions:\n", ""))
+		fmt.Fprintf(&buf, "%8sRequested Extensions:\n", "")
 		unknownExts := []pkix.Extension{}
 		for _, ext := range csr.Extensions {
 			switch {
@@ -896,10 +896,10 @@ func certificateRequestText(csr *x509.CertificateRequest) (string, error) {
 				// keyUsage: RFC 5280, 4.2.1.3
 				ku, err := parseKeyUsage(ext.Value)
 				if err != nil {
-					buf.WriteString(fmt.Sprintf("%12sX509v3 Key Usage: failed to decode\n", ""))
+					fmt.Fprintf(&buf, "%12sX509v3 Key Usage: failed to decode\n", "")
 					continue
 				}
-				buf.WriteString(fmt.Sprintf("%12sX509v3 Key Usage:", ""))
+				fmt.Fprintf(&buf, "%12sX509v3 Key Usage:", "")
 				if ext.Critical {
 					buf.WriteString(" critical\n")
 				} else {
@@ -926,37 +926,37 @@ func certificateRequestText(csr *x509.CertificateRequest) (string, error) {
 					}
 				}
 				if len(usages) > 0 {
-					buf.WriteString(fmt.Sprintf("%16s%s", "", usages[0]))
+					fmt.Fprintf(&buf, "%16s%s", "", usages[0])
 					for i := 1; i < len(usages); i++ {
-						buf.WriteString(fmt.Sprintf(", %s", usages[i]))
+						fmt.Fprintf(&buf, ", %s", usages[i])
 					}
 					buf.WriteString("\n")
 				} else {
-					buf.WriteString(fmt.Sprintf("%16sNone\n", ""))
+					fmt.Fprintf(&buf, "%16sNone\n", "")
 				}
 			case ext.Id.Equal(oidExtBasicConstraints):
 				// basicConstraints: RFC 5280, 4.2.1.9
 				var constraints basicConstraints
 				_, err := asn1.Unmarshal(ext.Value, &constraints)
 				if err != nil {
-					buf.WriteString(fmt.Sprintf("%12sX509v3 Basic Constraints: failed to decode\n", ""))
+					fmt.Fprintf(&buf, "%12sX509v3 Basic Constraints: failed to decode\n", "")
 					continue
 				}
-				buf.WriteString(fmt.Sprintf("%12sX509v3 Basic Constraints:", ""))
+				fmt.Fprintf(&buf, "%12sX509v3 Basic Constraints:", "")
 				if ext.Critical {
 					buf.WriteString(" critical\n")
 				} else {
 					buf.WriteString("\n")
 				}
 				if constraints.IsCA {
-					buf.WriteString(fmt.Sprintf("%16sCA:TRUE", ""))
+					fmt.Fprintf(&buf, "%16sCA:TRUE", "")
 				} else {
-					buf.WriteString(fmt.Sprintf("%16sCA:FALSE", ""))
+					fmt.Fprintf(&buf, "%16sCA:FALSE", "")
 				}
 				if constraints.MaxPathLen == 0 {
 					buf.WriteString(", pathlen:0\n")
 				} else if constraints.MaxPathLen > 0 {
-					buf.WriteString(fmt.Sprintf(", pathlen:%d\n", constraints.MaxPathLen))
+					fmt.Fprintf(&buf, ", pathlen:%d\n", constraints.MaxPathLen)
 				} else {
 					buf.WriteString("\n")
 				}
@@ -977,11 +977,11 @@ func certificateRequestText(csr *x509.CertificateRequest) (string, error) {
 				var constraints nameConstraints
 				_, err := asn1.Unmarshal(ext.Value, &constraints)
 				if err != nil {
-					buf.WriteString(fmt.Sprintf("%12sX509v3 Name Constraints: failed to decode\n", ""))
+					fmt.Fprintf(&buf, "%12sX509v3 Name Constraints: failed to decode\n", "")
 					continue
 				}
 				if len(constraints.Excluded) > 0 && ext.Critical {
-					buf.WriteString(fmt.Sprintf("%12sX509v3 Name Constraints: failed to decode: unexpected excluded name constraints\n", ""))
+					fmt.Fprintf(&buf, "%12sX509v3 Name Constraints: failed to decode: unexpected excluded name constraints\n", "")
 					continue
 				}
 				var permittedDNSDomains []string
@@ -991,16 +991,16 @@ func certificateRequestText(csr *x509.CertificateRequest) (string, error) {
 					}
 					permittedDNSDomains = append(permittedDNSDomains, subtree.Name)
 				}
-				buf.WriteString(fmt.Sprintf("%12sX509v3 Name Constraints:", ""))
+				fmt.Fprintf(&buf, "%12sX509v3 Name Constraints:", "")
 				if ext.Critical {
 					buf.WriteString(" critical\n")
 				} else {
 					buf.WriteString("\n")
 				}
 				if len(permittedDNSDomains) > 0 {
-					buf.WriteString(fmt.Sprintf("%16sPermitted:\n%18s%s", "", "", permittedDNSDomains[0]))
+					fmt.Fprintf(&buf, "%16sPermitted:\n%18s%s", "", "", permittedDNSDomains[0])
 					for i := 1; i < len(permittedDNSDomains); i++ {
-						buf.WriteString(fmt.Sprintf(", %s", permittedDNSDomains[i]))
+						fmt.Fprintf(&buf, ", %s", permittedDNSDomains[i])
 					}
 					buf.WriteString("\n")
 				}
@@ -1013,7 +1013,7 @@ func certificateRequestText(csr *x509.CertificateRequest) (string, error) {
 				// KeyPurposeId ::= OBJECT IDENTIFIER
 				var keyUsage []asn1.ObjectIdentifier
 				if _, err = asn1.Unmarshal(ext.Value, &keyUsage); err != nil {
-					buf.WriteString(fmt.Sprintf("%12sX509v3 Extended Key Usage: failed to decode\n", ""))
+					fmt.Fprintf(&buf, "%12sX509v3 Extended Key Usage: failed to decode\n", "")
 					continue
 				}
 				ekus := []struct {
@@ -1048,16 +1048,16 @@ func certificateRequestText(csr *x509.CertificateRequest) (string, error) {
 						list = append(list, fmt.Sprintf("UNKNOWN(%s)", u.String()))
 					}
 				}
-				buf.WriteString(fmt.Sprintf("%12sX509v3 Extended Key Usage:", ""))
+				fmt.Fprintf(&buf, "%12sX509v3 Extended Key Usage:", "")
 				if ext.Critical {
 					buf.WriteString(" critical\n")
 				} else {
 					buf.WriteString("\n")
 				}
 				if len(list) > 0 {
-					buf.WriteString(fmt.Sprintf("%16s%s", "", list[0]))
+					fmt.Fprintf(&buf, "%16s%s", "", list[0])
 					for i := 1; i < len(list); i++ {
-						buf.WriteString(fmt.Sprintf(", %s", list[i]))
+						fmt.Fprintf(&buf, ", %s", list[i])
 					}
 					buf.WriteString("\n")
 				}
@@ -1069,9 +1069,9 @@ func certificateRequestText(csr *x509.CertificateRequest) (string, error) {
 			}
 		}
 		if len(unknownExts) > 0 {
-			buf.WriteString(fmt.Sprintf("%8sAttributes:\n", ""))
+			fmt.Fprintf(&buf, "%8sAttributes:\n", "")
 			for _, ext := range unknownExts {
-				buf.WriteString(fmt.Sprintf("%12s%s:", "", ext.Id.String()))
+				fmt.Fprintf(&buf, "%12s%s:", "", ext.Id.String())
 				if ext.Critical {
 					buf.WriteString(" critical\n")
 				} else {
@@ -1088,11 +1088,11 @@ func certificateRequestText(csr *x509.CertificateRequest) (string, error) {
 						sanitized[i] = '.'
 					}
 				}
-				buf.WriteString(fmt.Sprintf("%16s%s\n", "", string(sanitized)))
+				fmt.Fprintf(&buf, "%16s%s\n", "", string(sanitized))
 				if hasSpecialChar {
-					buf.WriteString(fmt.Sprintf("%16s", ""))
+					fmt.Fprintf(&buf, "%16s", "")
 					for i, b := range ext.Value {
-						buf.WriteString(fmt.Sprintf("%02x", b))
+						fmt.Fprintf(&buf, "%02x", b)
 						if i != len(ext.Value)-1 {
 							buf.WriteString(":")
 						}

--- a/scion-pki/certs/fingerprint.go
+++ b/scion-pki/certs/fingerprint.go
@@ -69,7 +69,7 @@ If the flag \--format is set to "emoji", the format of the output is a string of
 			}
 
 			outputWriter := cmd.OutOrStdout()
-			fmt.Fprintln(outputWriter, output)
+			_, _ = fmt.Fprintln(outputWriter, output)
 
 			return nil
 		},

--- a/scion-pki/certs/sign.go
+++ b/scion-pki/certs/sign.go
@@ -198,8 +198,12 @@ offset from the current time.`,
 		"Bundle the certificate with the issuer certificate as a certificate chain",
 	)
 	scionpki.BindFlagKmsCA(cmd.Flags(), &flags.caKms)
-	cmd.MarkFlagRequired("ca")
-	cmd.MarkFlagRequired("ca-key")
+	if err := cmd.MarkFlagRequired("ca"); err != nil {
+		panic(err)
+	}
+	if err := cmd.MarkFlagRequired("ca-key"); err != nil {
+		panic(err)
+	}
 
 	return cmd
 }

--- a/scion-pki/certs/validate.go
+++ b/scion-pki/certs/validate.go
@@ -116,7 +116,9 @@ If the value is a timestamp, it is expected to either be an RFC 3339 formatted
 timestamp or a unix timestamp. If the value is a duration, it is used as the
 offset from the current time.`,
 	)
-	cmd.MarkFlagRequired("type")
+	if err := cmd.MarkFlagRequired("type"); err != nil {
+		panic(err)
+	}
 
 	return cmd
 }

--- a/scion-pki/certs/verify.go
+++ b/scion-pki/certs/verify.go
@@ -120,7 +120,9 @@ the expected ISD-AS value.
 	cmd.Flags().StringVar(&flags.subjectIA, "subject-isd-as", "",
 		"ISD-AS property of the subject of the certificate",
 	)
-	cmd.MarkFlagRequired("trc")
+	if err := cmd.MarkFlagRequired("trc"); err != nil {
+		panic(err)
+	}
 
 	joined := command.Join(pather, cmd)
 	cmd.AddCommand(newVerifyCACmd(joined))
@@ -190,7 +192,9 @@ The CA certificate must be a PEM encoded.
 	cmd.Flags().StringVar(&flags.trcFile, "trc", "", "trusted TRC (required)")
 	cmd.Flags().Int64Var(&flags.unixTime, "currenttime", 0,
 		"Optional unix timestamp that sets the current time")
-	cmd.MarkFlagRequired("trc")
+	if err := cmd.MarkFlagRequired("trc"); err != nil {
+		panic(err)
+	}
 
 	return cmd
 }


### PR DESCRIPTION
fixes `QF1012`, `QF1008` and `errcheck` in `scion-pki`. This is a sub-task of #4769.