### PR TITLE
cppki: correct struct tag asn1

### DIFF
--- a/pkg/scrypto/cppki/trc_asn1.go
+++ b/pkg/scrypto/cppki/trc_asn1.go
@@ -46,7 +46,7 @@ type asn1TRCPayload struct {
 	Votes             []int64         `asn1:"votes"`
 	Quorum            int64           `asn1:"votingQuorum"`
 	CoreASes          []string        `asn1:"coreASes"`
-	AuthoritativeASes []string        `as1n:"authoritativeASes"`
+	AuthoritativeASes []string        `asn1:"authoritativeASes"`
 	Description       string          `asn1:"description,utf8"`
 	Certificates      []asn1.RawValue `asn1:"certificates"`
 }


### PR DESCRIPTION
I don't know how the asn1 encoder/decoder behaves but I assume that they just fall back to case-insensitive matching by field name so nothing broke despite the tag being wrong. That is assuming that it behaves similarly to how `encoding/json` maps fields. So this is most likely not a bug fix but a minor typo fix.