### PR TITLE
doc: fix scion-pki certificate create command in TRC Ceremony Builder

### DIFF
--- a/doc/cryptography/trc-signing-ceremony-builder.rst
+++ b/doc/cryptography/trc-signing-ceremony-builder.rst
@@ -681,8 +681,8 @@ TRC Signing Ceremony - Script Builder
         --not-after <span x-text="cert.notAfter"></span> \
         --common-name "<span x-text="cert.commonName"></span>" \
         <span x-text="form.paths.workingDir"></span>/subject.tmpl \
-        <span x-text="cert.key"></span> \
         <span x-text="cert.cert"></span></div></pre></div>
+        <span x-text="cert.key"></span> \
             </div></template>
         </div></template>
 


### PR DESCRIPTION
The TRC Ceremony Builder had a typo where in the instructions to create certificates the key and certificate arguments are flipped. This PR fixes this typo.