### PR TITLE
tools: increase local topology cert validity to 365 days

### DIFF
--- a/doc/dev/run.rst
+++ b/doc/dev/run.rst
@@ -39,7 +39,7 @@ Quickstart
       ./scion.sh topology -c topology/tiny.topo
 
 
-   .. Attention:: The certificates created by this command expire after 3 days if the
+   .. Attention:: The certificates created by this command expire after 365 days if the
       infrastructure is not running for automatic renewal.
 
 #. To start the infrastructure we just generated, run:

--- a/tools/topology/cert.py
+++ b/tools/topology/cert.py
@@ -47,7 +47,8 @@ class CertGenerator(object):
         self.core_count = collections.defaultdict(int)
 
     def generate(self, topo_dicts):
-        self.pki('testcrypto', '-t', self.args.topo_config, '-o', self.args.output_dir)
+        self.pki('testcrypto', '-t', self.args.topo_config, '-o', self.args.output_dir,
+                 '--as-validity', '365d')
         self._master_keys(topo_dicts)
         self._copy_files(topo_dicts)
 


### PR DESCRIPTION
This patch increases the validity period of certificates generated by `scion.sh` for local topologies to 365 days from the current 3 days.

The 3 days expiration time makes working with local topologies quite annoying, especially when one manually changes the generated topology and is forced to repeat the modifications every 3 days.