### PR TITLE
docs: improve tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,7 @@ logger.log
 # emacs backup files
 ####################
 *~
+
+# Vagrant
+#########
+.vagrant

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -56,12 +56,14 @@ The topology of the ISD includes the inter-AS connections to neighboring ASes, a
 The difference between the core and non-core ASes is that core ASes are transit nodes.
 When going from ``ffaa:1:3`` to ``ffaa:1:2`` you will see a direct path and one going via the other core AS ``ffaa:1:1``, but you will NOT see a path going via ``ffaa:1:5`` or ``ffaa:1:4`` because they are non-core.
 
-ubuntu@scion03:~$ scion showpaths 15-ffaa:1:2
-Available paths to 15-ffaa:1:2
-2 Hops:
-[0] Hops: [15-ffaa:1:3 2>2 15-ffaa:1:2] MTU: 1472 NextHop: 127.0.0.1:31002 Status: alive LocalIP: 127.0.0.1
-3 Hops:
-[1] Hops: [15-ffaa:1:3 1>3 15-ffaa:1:1 2>1 15-ffaa:1:2] MTU: 1472 NextHop: 127.0.0.1:31002 Status: alive LocalIP: 127.0.0.1
+.. code-block:: sh
+
+   ubuntu@scion03:~$ scion showpaths 15-ffaa:1:2
+   Available paths to 15-ffaa:1:2
+   2 Hops:
+   [0] Hops: [15-ffaa:1:3 2>2 15-ffaa:1:2] MTU: 1472 NextHop: 127.0.0.1:31002 Status: alive LocalIP: 127.0.0.1
+   3 Hops:
+   [1] Hops: [15-ffaa:1:3 1>3 15-ffaa:1:1 2>1 15-ffaa:1:2] MTU: 1472 NextHop: 127.0.0.1:31002 Status: alive LocalIP: 127.0.0.1
 
 .. _prerequisites:
 

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -77,6 +77,7 @@ This deployment requires five virtual machines (VMs) - one for each AS. We recom
 - Using the naming convention for each VM of scion01, scion02, scion03, scion04, and scion05 will help follow along with this tutorial.
 - The VM names scion01-scion05 can be configured in /etc/hosts.
 
+**Note**: You can automatically prepare the VMs using Vagrant by running ``make vm-up``.
 
 Tasks to Perform
 ----------------

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -53,7 +53,7 @@ The topology of the ISD includes the inter-AS connections to neighboring ASes, a
 
    *Figure 1 - Topology of the sample SCION demo environment. It consists of 1 ISD, 3 core ASes and 2 non-core ASes.*
 
-The difference between the core and non-core ASes is that core ASes are inter-ISD transit nodes.
+The difference between the core and non-core ASes is that core ASes are transit nodes for the entire ISD while non-core are transit nodes only for their own child ASes.
 When going from ``ffaa:1:3`` to ``ffaa:1:2`` you will see a direct path and one going via the other core AS ``ffaa:1:1``, but you will NOT see a path going via ``ffaa:1:5`` or ``ffaa:1:4`` because they are non-core.
 
 .. code-block:: sh

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -53,7 +53,7 @@ The topology of the ISD includes the inter-AS connections to neighboring ASes, a
 
    *Figure 1 - Topology of the sample SCION demo environment. It consists of 1 ISD, 3 core ASes and 2 non-core ASes.*
 
-The difference between the core and non-core ASes is that core ASes are transit nodes.
+The difference between the core and non-core ASes is that core ASes are inter-AS transit nodes.
 When going from ``ffaa:1:3`` to ``ffaa:1:2`` you will see a direct path and one going via the other core AS ``ffaa:1:1``, but you will NOT see a path going via ``ffaa:1:5`` or ``ffaa:1:4`` because they are non-core.
 
 .. code-block:: sh

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -217,13 +217,17 @@ Step 4 - Service Configuration Files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Next, you have to download the service configuration file for the router and control service into the ``/etc/scion/`` directory of each AS host scion01-scion05.
-Refer to the :ref:`router-conf-toml` and :ref:`control-conf-toml` manuals for details.
-We use default settings for most of the available options, so that the same configuration file can be used in all of the VMs.
-
-Download the files, then copy it into the ``/etc/scion/`` directory of each host scion01 - scion05.
 
 - **Border router**: :download:`br.toml <deploy/base/br.toml>`
 - **Control service**: :download:`cs.toml <deploy/base/cs.toml>`
+
+.. code-block:: sh
+
+   sudo wget LINK_TO_BR.TOML_FILE -O /etc/scion/br.toml
+   sudo wget LINK_TO_CS.TOML_FILE -O /etc/scion/cs.toml
+
+Refer to the :ref:`router-conf-toml` and :ref:`control-conf-toml` manuals for details.
+We use default settings for most of the available options, so that the same configuration file can be used in all of the VMs.
 
 Step 5 - Start the Services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -184,13 +184,19 @@ In practice, the private keys of ASes are of course never revealed to other enti
 
   .. code-block:: bash
 
-     cd /tmp/tutorial-scion-certs
-     for i in {1..5}
-     do
-        ssh scion0$i 'mkdir -p /etc/scion/{crypto/as,certs}'
-        scp AS$i/cp-as.{key,pem} scion0$i:/etc/scion/crypto/as/
-        scp ISD15-B1-S1.trc scion0$i:/etc/scion/certs/
-     done
+      cd /tmp/tutorial-scion-certs
+
+      for i in {1..5}; do
+         ssh scion0$i 'sudo mkdir -p /etc/scion/crypto/as /etc/scion/certs'
+
+         scp AS$i/cp-as.pem   scion0$i:/tmp/cp-as.pem
+         scp AS$i/cp-as.key   scion0$i:/tmp/cp-as.key
+         scp ISD15-B1-S1.trc  scion0$i:/tmp/ISD15-B1-S1.trc
+
+         ssh scion0$i 'sudo mv /tmp/cp-as.pem /etc/scion/crypto/as/'
+         ssh scion0$i 'sudo mv /tmp/cp-as.key /etc/scion/crypto/as/'
+         ssh scion0$i 'sudo mv /tmp/ISD15-B1-S1.trc /etc/scion/certs/'
+      done
 
 
 Step 3 - Generate Forwarding Secret Keys
@@ -200,8 +206,9 @@ Two symmetric keys *master0.key* and *master1.key* are required per AS as the fo
 
 .. code-block:: bash
 
-   head -c 16 /dev/urandom | base64 - > /etc/scion/keys/master0.key
-   head -c 16 /dev/urandom | base64 - > /etc/scion/keys/master1.key
+   sudo mkdir -p /etc/scion/keys
+   sudo sh -c 'head -c 16 /dev/urandom | base64 > /etc/scion/keys/master0.key'
+   sudo sh -c 'head -c 16 /dev/urandom | base64 > /etc/scion/keys/master1.key'
 
 Repeat the above on each host scion01 - scion05.
 
@@ -227,6 +234,11 @@ and :doc:`/manuals/dispatcher` processes, by starting their systemd units. The d
 automatically as dependency of the control service and daemon.
 
 Execute the following commands on every AS:
+
+.. code-block:: sh
+
+   # Make scion user own the config dir
+   sudo chown -R scion:scion /etc/scion
 
 .. code-block:: sh
 

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -254,6 +254,17 @@ Execute the following commands on every AS:
 
 These steps need to be repeated on each host scion01 - scion05.
 
+Make sure your services are running and didn't fail to start:
+
+.. code-block:: sh
+
+   sudo systemctl status scion-*
+
+If any service failed, you can view the logs using journalctl, for example:
+
+.. code-block:: sh
+
+   sudo journalctl -u scion-router@br.service
 
 .. _step3:
 

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -53,7 +53,15 @@ The topology of the ISD includes the inter-AS connections to neighboring ASes, a
 
    *Figure 1 - Topology of the sample SCION demo environment. It consists of 1 ISD, 3 core ASes and 2 non-core ASes.*
 
+The difference between the core and non-core ASes is that core ASes are transit nodes.
+When going from ``ffaa:1:3`` to ``ffaa:1:2`` you will see a direct path and one going via the other core AS ``ffaa:1:1``, but you will NOT see a path going via ``ffaa:1:5`` or ``ffaa:1:4`` because they are non-core.
 
+ubuntu@scion03:~$ scion showpaths 15-ffaa:1:2
+Available paths to 15-ffaa:1:2
+2 Hops:
+[0] Hops: [15-ffaa:1:3 2>2 15-ffaa:1:2] MTU: 1472 NextHop: 127.0.0.1:31002 Status: alive LocalIP: 127.0.0.1
+3 Hops:
+[1] Hops: [15-ffaa:1:3 1>3 15-ffaa:1:1 2>1 15-ffaa:1:2] MTU: 1472 NextHop: 127.0.0.1:31002 Status: alive LocalIP: 127.0.0.1
 
 .. _prerequisites:
 

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -168,8 +168,9 @@ On scion01, download the topology1.json file. On scion02, download topology2.jso
 Step 2 - Generate the Required Certificates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The various cryptographic certificates need to be generated for each of the ASes.
-This requires first setting up the :term:`TRC` for this ISD, and then issuing AS-certificates from the :term:`CAs <CA>`.
+SCION's control plane messages and path information are all authenticated through the SCION PKI (Public Key Infrastructure).
+Setting up the PKI in a freshly created :term:`Isolation Domain <ISD>`, like in this tutorial, requires an initial trust bootstrapping process to create the initial :term:`TRC` for this ISD.
+Then, various certificates need to be generated for the intermediate :term:`CAs <CA>` and for each AS.
 
 For the sake of simplicity in this tutorial, we create all the keys and certificates centrally, and distribute the crypto material to the individual ASes.
 In practice, the private keys of ASes are of course never revealed to other entities; the TRC would be created in a :ref:`trc-ceremony` involving representatives of all core ASes. The creation of the AS-certificates would involve a certificate-signing request to the CA.

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -53,7 +53,7 @@ The topology of the ISD includes the inter-AS connections to neighboring ASes, a
 
    *Figure 1 - Topology of the sample SCION demo environment. It consists of 1 ISD, 3 core ASes and 2 non-core ASes.*
 
-The difference between the core and non-core ASes is that core ASes are inter-AS transit nodes.
+The difference between the core and non-core ASes is that core ASes are inter-ISD transit nodes.
 When going from ``ffaa:1:3`` to ``ffaa:1:2`` you will see a direct path and one going via the other core AS ``ffaa:1:1``, but you will NOT see a path going via ``ffaa:1:5`` or ``ffaa:1:4`` because they are non-core.
 
 .. code-block:: sh

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -101,7 +101,7 @@ OS Setup
 
 - Set up the host file
 
-  The host file (*/etc/hosts*) will need to be updated with the IP addresses of 5 VMs. This will need to be updated on scion01-scion05. Replace the IP addresses with the assigned IP addresses for the VMs deployed.
+  The host file (*/etc/hosts*) will need to be updated with the IP addresses of 5 VMs. Set this up on one of the machines, so that you can then use it as a jump box. This tutorial uses scion01. Replace the IP addresses with the assigned IP addresses for the VMs deployed.
 
   Set this up on scion01:
 

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -32,11 +32,11 @@ The sample SCION demo setup consists of one ISD with three core and two non-core
 ======== ==== ========= ======== =============== ============ ======================= ===== ====
 Hostname ISD  AS        Purpose  Notes           IP Address    OS                     Disk  RAM
 ======== ==== ========= ======== =============== ============ ======================= ===== ====
-scion01  15   ffaa:1:1  Core     Voting, CA      10.100.0.11  **Ubuntu** 22.04.3 LTS  4 GB  1 GB
-scion02  15   ffaa:1:2  Core     Non-Voting, CA  10.100.0.12  **Ubuntu** 22.04.3 LTS  4 GB  1 GB
-scion03  15   ffaa:1:3  Core     Voting          10.100.0.13  **Ubuntu** 22.04.3 LTS  4 GB  1 GB
-scion04  15   ffaa:1:4  Non-Core                 10.100.0.14  **Ubuntu** 22.04.3 LTS  4 GB  1 GB
-scion05  15   ffaa:1:5  Non-Core                 10.100.0.15  **Ubuntu** 22.04.3 LTS  4 GB  1 GB
+scion01  15   ffaa:1:1  Core     Voting, CA      10.100.0.11  **Ubuntu** 24.04 LTS    4 GB  1 GB
+scion02  15   ffaa:1:2  Core     Non-Voting, CA  10.100.0.12  **Ubuntu** 24.04 LTS    4 GB  1 GB
+scion03  15   ffaa:1:3  Core     Voting          10.100.0.13  **Ubuntu** 24.04 LTS    4 GB  1 GB
+scion04  15   ffaa:1:4  Non-Core                 10.100.0.14  **Ubuntu** 24.04 LTS    4 GB  1 GB
+scion05  15   ffaa:1:5  Non-Core                 10.100.0.15  **Ubuntu** 24.04 LTS    4 GB  1 GB
 ======== ==== ========= ======== =============== ============ ======================= ===== ====
 
 *Table 1: Required Infrastructure*
@@ -62,7 +62,7 @@ Infrastructure Prerequisites
 
 This deployment requires five virtual machines (VMs) - one for each AS. We recommend using Ubuntu VMs for this.
 
-- 5 VMs - **Ubuntu** 22.04.5 LTS (Jammy Jellyfish). For more information, see `Ubuntu Jammy Jellyfish <https://releases.ubuntu.com/jammy/>`_.
+- 5 VMs - **Ubuntu** 24.04.x LTS (Noble Numbat). For more information, see `Ubuntu Noble Numbat <https://releases.ubuntu.com/noble/>`_.
 - Each VM should have at least one IP address reachable by the other VMs. (If on AWS, be sure to set up the appropriate security groups.)
 - Each VM will need internet access to download the required files (or you will need an alternate way to download the SCION binaries).
 - One VM (scion01) should have SSH access (password or SSH keys) to the other hosts scion{02-05} to copy generated configuration files and keys.

--- a/doc/tutorials/deploy.rst
+++ b/doc/tutorials/deploy.rst
@@ -92,7 +92,7 @@ OS Setup
 
   The host file (*/etc/hosts*) will need to be updated with the IP addresses of 5 VMs. This will need to be updated on scion01-scion05. Replace the IP addresses with the assigned IP addresses for the VMs deployed.
 
-  Set this up on scion01-scion05.
+  Set this up on scion01:
 
   .. code-block:: sh
 
@@ -153,8 +153,6 @@ On scion01, download the topology1.json file. On scion02, download topology2.jso
 
    wget LINK_TO_TOPOLOGY.JSON_FILE -O /etc/scion/topology.json
 
-The AS topology files reference the hosts scion01-05 by host name.
-Ensure that you have set up the ``/etc/hosts`` file (:ref:`see above <step0>`) or replace the hostnames with IP addresses.
 
 Step 2 - Generate the Required Certificates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -172,7 +170,7 @@ In practice, the private keys of ASes are of course never revealed to other enti
 
 
 
-#. To generate all required certificates, execute the following script on any machine where ``scion-pki`` is installed (e.g. scion01).
+#. To generate all required certificates, execute the following script on scion01:
 
    .. literalinclude:: ./deploy/base/pki-generation.bash
       :language: bash

--- a/doc/tutorials/deploy/Makefile
+++ b/doc/tutorials/deploy/Makefile
@@ -33,3 +33,9 @@ down:
 purge: down
 	docker ps -aq --filter "name=scion" | xargs -r docker rm -f
 	docker network ls -q --filter "name=sciontutorial" | xargs -r docker network rm
+
+vm-up:
+	vagrant up
+
+vm-purge:
+	vagrant destroy

--- a/doc/tutorials/deploy/vagrantfile
+++ b/doc/tutorials/deploy/vagrantfile
@@ -1,0 +1,34 @@
+Vagrant.configure("2") do |config|
+  base_ssh_port = 2200
+
+  ip_map = {
+    1 => "10.100.0.11",
+    2 => "10.100.0.12",
+    3 => "10.100.0.13",
+    4 => "10.100.0.14",
+    5 => "10.100.0.15",
+  }
+
+  (1..5).each do |i|
+    ssh_host_port = base_ssh_port + i
+    static_ip_addr = ip_map[i]
+
+    
+    config.vm.define "scion%02d" % i do |node|
+        node.vm.box = "bento/ubuntu-24.04"  # Use a 64-bit x86 image compatible with VirtualBox
+        node.vm.hostname = "scion%02d" % i
+
+        # Static IP (host-only network)
+        node.vm.network "private_network", ip: static_ip_addr
+
+        # Optional: Forward SSH port to host (so you can SSH to each VM individually from host)
+        node.vm.network "forwarded_port", guest: 22, host: ssh_host_port, auto_correct: true
+
+        node.vm.provider "virtualbox" do |vb|
+            vb.name = "scion%02d" % i
+            vb.memory = 1024
+            vb.cpus = 1
+      end
+    end
+  end
+end


### PR DESCRIPTION
Most of this was done during the Hackathon on Wednesday

- Add vagrant for setting up tutorial VMs.
- Improve shell instructions that were causing permission issues.
- Clarify the difference between the core and non-core ASes.
- Upgrade to Ubuntu 24.04 LTS.

co-authored by @nicorusti @vincent10400094 @lsj0410