### PR TITLE
test: use capsh at runtime instead of setcap at buildtime

### DIFF
--- a/private/underlay/ebpf/BUILD.bazel
+++ b/private/underlay/ebpf/BUILD.bazel
@@ -66,24 +66,13 @@ go_test(
     ],
 )
 
-# Adds required capabilities to the portfilter test. Otherwise it cannot be executed.
-genrule(
-    name = "gen_portfilter_test_cap",
-    testonly = True,
-    srcs = [
-        "go_default_test",
-    ],
-    outs = [
-        "portfilter_test_cap",
-    ],
-    cmd_bash = "cp $< $@ ; /usr/bin/sudo setcap \"cap_bpf=ep cap_net_admin=ep cap_sys_admin=ep cap_net_raw=ep\" $@",
-)
-
 # This is the rule that actually runs the portfilter test.
 sh_test(
     name = "portfilter_test",
     testonly = True,
-    srcs = ["portfilter_test_cap"],
+    srcs = ["port_filter_test_cap.sh"],
+    args = ["$(location go_default_test)"],
+    data = [":go_default_test"],
     tags = [
         "supports-graceful-termination",
         "unit",

--- a/private/underlay/ebpf/port_filter_test_cap.sh
+++ b/private/underlay/ebpf/port_filter_test_cap.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+executable=$1
+shift
+
+
+/usr/bin/sudo capsh --caps="cap_bpf=ep cap_net_admin=ep cap_net_raw=ep" -- -c "$executable"


### PR DESCRIPTION
Bazel doesn't deal properly with extended file attributes. The original plan was to produce the capabilities enabled binary by copying the normal one and applying setcap to the result, but in some cases the copy can be left without the attributes and bazel considering the goal reached anyway. To work around that, wrapped the test in a script that executes the normal binary via capsh.