### PR TITLE
cmd/scion-pki: add certificate template command

### DIFF
--- a/scion-pki/certs/BUILD.bazel
+++ b/scion-pki/certs/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "observability.go",
         "renew.go",
         "sign.go",
+        "template.go",
         "validate.go",
         "verify.go",
     ],

--- a/scion-pki/certs/certs.go
+++ b/scion-pki/certs/certs.go
@@ -58,6 +58,7 @@ func Cmd(pather command.Pather) *cobra.Command {
 		newSignCmd(joined),
 		newFingerprintCmd(joined),
 		newInspectCmd(joined),
+		newTemplateCmd(joined),
 	)
 	return cmd
 }

--- a/scion-pki/certs/create.go
+++ b/scion-pki/certs/create.go
@@ -430,11 +430,9 @@ func loadSubject(tmpl string) (pkix.Name, error) {
 	if err != nil {
 		return pkix.Name{}, err
 	}
-	// Check if template is a x509 certificate.
-	cert, err := parseCertificate(raw)
-	if err == nil {
-		s := cert.Subject
-		for _, name := range cert.Subject.Names {
+	if subject, err := loadPkixNameFromRaw(raw); err == nil {
+		s := subject
+		for _, name := range subject.Names {
 			// Ignore common name.
 			if name.Type.Equal(asn1.ObjectIdentifier{2, 5, 4, 3}) {
 				continue

--- a/scion-pki/certs/template.go
+++ b/scion-pki/certs/template.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certs
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"github.com/scionproto/scion/pkg/scrypto/cppki"
+	"github.com/scionproto/scion/private/app/command"
+	"github.com/spf13/cobra"
+)
+
+func newTemplateCmd(_ command.Pather) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "template",
+		Short: "Create subject template from a certificate or CSR",
+		Long: `'template' creates a subject template from a certificate, certificate chain, or CSR.
+
+This command allows reconstructing the subject template that was used to cerate a certificate
+or a certificate signing request (CSR). It is not necessary to use this command to create a
+new certificate or CSR, as the template to the 'create' command can also be a certificate
+itself.
+
+In case the input is a certificate chain, the template is created from the first certificate
+in the chain.
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			subject, err := loadPkixNameFromFile(args[0])
+			if err != nil {
+				return fmt.Errorf("loading subject from file %q: %w", args[0], err)
+			}
+
+			ia, err := cppki.ExtractIA(subject)
+			if err != nil {
+				return fmt.Errorf("extracting ISD-AS from certificate: %w", err)
+			}
+
+			maybe := func(v []string) string {
+				if len(v) == 0 {
+					return ""
+				}
+				return v[0]
+			}
+			vars := SubjectVars{
+				IA:                 ia,
+				CommonName:         subject.CommonName,
+				Organization:       maybe(subject.Organization),
+				Country:            maybe(subject.Country),
+				Province:           maybe(subject.Province),
+				Locality:           maybe(subject.Locality),
+				OrganizationalUnit: maybe(subject.OrganizationalUnit),
+				PostalCode:         maybe(subject.PostalCode),
+				StreetAddress:      maybe(subject.StreetAddress),
+				SerialNumber:       subject.SerialNumber,
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(vars); err != nil {
+				return fmt.Errorf("encoding template: %w", err)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func loadPkixNameFromFile(filename string) (pkix.Name, error) {
+	raw, err := os.ReadFile(filename)
+	if err != nil {
+		return pkix.Name{}, fmt.Errorf("reading file %q: %w", filename, err)
+	}
+	return loadPkixNameFromRaw(raw)
+}
+
+func loadPkixNameFromRaw(raw []byte) (pkix.Name, error) {
+	pemData, _ := pem.Decode(raw)
+	if pemData == nil {
+		return pkix.Name{}, fmt.Errorf("not valid PEM")
+	}
+	switch pemData.Type {
+	case "CERTIFICATE":
+		cert, err := x509.ParseCertificate(pemData.Bytes)
+		if err != nil {
+			return pkix.Name{}, fmt.Errorf("parsing certificate: %w", err)
+		}
+		return cert.Subject, nil
+	case "CERTIFICATE REQUEST":
+		csr, err := x509.ParseCertificateRequest(pemData.Bytes)
+		if err != nil {
+			return pkix.Name{}, fmt.Errorf("parsing CSR: %w", err)
+		}
+		return csr.Subject, nil
+	default:
+		return pkix.Name{}, fmt.Errorf("invalid PEM block type %q", pemData.Type)
+	}
+}


### PR DESCRIPTION
Add a `scion-pki certificate template` command that extracts the subject template from an existing certificate or CSR. This command can be used to reconstruct the subject template used to create a certificate or CSR.