### PR TITLE
daemon: refactoring to enable applications running in-library self-contained daemon logic (a.k.a standalone mode)

### DIFF
--- a/acceptance/daemon_vs_standalone/BUILD.bazel
+++ b/acceptance/daemon_vs_standalone/BUILD.bazel
@@ -1,0 +1,24 @@
+load("//acceptance/common:topogen.bzl", "topogen_test")
+
+# Test with standalone daemon (embedded daemon using topology files) - default
+topogen_test(
+    name = "test_standalone",
+    src = "test.py",
+    args = [
+        "--executable=end2end_integration:$(location //tools/end2end_integration)",
+    ],
+    data = ["//tools/end2end_integration"],
+    topo = "//topology:tiny.topo",
+)
+
+# Test with remote daemon (connecting to sciond via gRPC)
+topogen_test(
+    name = "test_daemon",
+    src = "test.py",
+    args = [
+        "--executable=end2end_integration:$(location //tools/end2end_integration)",
+        "--use-daemon",
+    ],
+    data = ["//tools/end2end_integration"],
+    topo = "//topology:tiny.topo",
+)

--- a/acceptance/daemon_vs_standalone/test.py
+++ b/acceptance/daemon_vs_standalone/test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 SCION Association
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test that compares daemon vs standalone mode for end2end connectivity.
+
+This test runs the end2end_integration test in two modes:
+- Daemon mode: Uses remote SCION daemon connector (connecting via gRPC)
+- Standalone mode: Uses embedded daemon with topology files (no sciond)
+
+The daemon mode can be selected via --use-daemon flag:
+- With --use-daemon: Uses remote daemon connector (via gRPC)
+- Without --use-daemon (default): Uses standalone daemon connector
+"""
+
+from plumbum import cli
+
+from acceptance.common import base
+
+
+class Test(base.TestTopogen):
+    """
+    Tests end2end connectivity using either daemon or standalone mode.
+    """
+
+    use_daemon = cli.Flag(
+        "--use-daemon",
+        help="Use remote SCION daemon instead of standalone daemon",
+    )
+
+    def setup_start(self):
+        super().setup_start()
+        self.await_connectivity()
+
+    def _run(self):
+        ping_test = self.get_executable("end2end_integration")
+
+        if self.use_daemon:
+            print("=== Running with remote daemon (sciond) ===")
+            ping_test["-d", "-sciond", "-outDir", self.artifacts].run_fg()
+        else:
+            print("=== Running with standalone daemon ===")
+            ping_test["-d", "-outDir", self.artifacts].run_fg()
+
+
+if __name__ == "__main__":
+    base.main(Test)

--- a/tools/integration/cmd.go
+++ b/tools/integration/cmd.go
@@ -47,6 +47,14 @@ func (c Cmd) Template(src, dst *snet.UDPAddr) (Cmd, error) {
 		}
 		args = replacePattern(Daemon, daemonAddr, args)
 	}
+	if needTopoDir(args) {
+		// In Docker mode, the gen directory is mounted at /share/gen inside the container
+		if *Docker {
+			args = replacePattern(TopoDir, "/share/gen", args)
+		} else {
+			args = replacePattern(TopoDir, GenFile(""), args)
+		}
+	}
 	return Cmd{Binary: c.Binary, Args: args}, nil
 }
 

--- a/tools/integration/integrationlib/common.go
+++ b/tools/integration/integrationlib/common.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -51,6 +52,7 @@ var (
 	Mode       string
 	Progress   string
 	daemonAddr string
+	topoDir    string
 	Attempts   int
 	logConsole string
 	features   string
@@ -75,11 +77,20 @@ func addFlags() error {
 	flag.Var(&Local, "local", "(Mandatory) address to listen on")
 	flag.StringVar(&Mode, "mode", ModeClient, "Run in "+ModeClient+" or "+ModeServer+" mode")
 	flag.StringVar(&Progress, "progress", "", "Socket to write progress to")
-	flag.StringVar(&daemonAddr, "sciond", envFlags.Daemon(), "SCION Daemon address")
+	flag.StringVar(
+		&daemonAddr, "sciond", "",
+		"SCION Daemon address. If set, uses remote daemon instead of standalone daemon.",
+	)
+	flag.StringVar(
+		&topoDir, "topoDir", "",
+		"Directory containing topology files. Used for standalone daemon (default mode).",
+	)
 	flag.IntVar(&Attempts, "attempts", 1, "Number of attempts before giving up")
 	flag.StringVar(&logConsole, "log.console", "info", "Console logging level: debug|info|error")
-	flag.StringVar(&features, "features", "",
-		fmt.Sprintf("enable development features (%v)", feature.String(&feature.Default{}, "|")))
+	flag.StringVar(
+		&features, "features", "",
+		fmt.Sprintf("enable development features (%v)", feature.String(&feature.Default{}, "|")),
+	)
 	return nil
 }
 
@@ -128,12 +139,43 @@ func validateFlags() {
 	}
 }
 
+// SDConn returns a daemon connector.
+// If -sciond is specified, it connects to a remote daemon.
+// Otherwise (default), it creates a standalone daemon connector using the topology file
+// from -topoDir.
 func SDConn() daemon.Connector {
-	ctx, cancelF := context.WithTimeout(context.Background(), DefaultIOTimeout)
-	defer cancelF()
-	conn, err := daemon.NewService(daemonAddr).Connect(ctx)
+	// If sciond address is specified, use remote daemon
+	if daemonAddr != "" {
+		ctx, cancelF := context.WithTimeout(context.Background(), DefaultIOTimeout)
+		defer cancelF()
+		conn, err := daemon.NewService(daemonAddr).Connect(ctx)
+		if err != nil {
+			LogFatal("Unable to initialize SCION Daemon connection", "err", err)
+		}
+		return conn
+	}
+
+	// Use standalone daemon by default (with topology file)
+	if topoDir == "" {
+		LogFatal("Either -sciond or -topoDir must be specified")
+	}
+
+	// Construct topology file path from the local IA
+	asDir := addr.FormatAS(Local.IA.AS(), addr.WithDefaultPrefix(), addr.WithFileSeparator())
+	asPath := filepath.Join(topoDir, asDir)
+	topoFile := filepath.Join(asPath, "topology.json")
+
+	log.Debug("Using standalone daemon", "topology", topoFile)
+	topo, err := daemon.LoadASInfoFromFile(topoFile)
 	if err != nil {
-		LogFatal("Unable to initialize SCION Daemon connection", "err", err)
+		LogFatal("Unable to load topology", "err", err, "topoFile", topoFile)
+	}
+	ctx := context.Background()
+	conn, err := daemon.NewStandaloneConnector(
+		ctx, topo, daemon.WithCertsDir(filepath.Join(asPath, "certs")),
+	)
+	if err != nil {
+		LogFatal("Unable to create standalone daemon", "err", err, "topoFile", topoFile)
 	}
 	return conn
 }


### PR DESCRIPTION
## MERGING NOTE

This PR has been divided in 4 smaller PRs #4868, #4869, #4870 and #4871, succesfully merged. The summary, description and testing notes still apply to the overall changes carried out on those 4 PRs.

---

## Summary
This PR allows applications to run without a SCION daemon by communicating with the control service directly and running daemon functionality in-process.

## Main Changes

1. **Split daemon server**: Separated the existing daemon gRPC server into gRPC (`DaemonServer`) and core logic (`DaemonEngine`) components. The engine contains the business logic, independent of transport.

2. **Move engine to pkg**: Moved the `DaemonEngine` into `pkg/daemon/private/engine` to make it accessible for in-process usage.

3. **Implement standalone connector**: Added `NewStandaloneConnector()` to create a `Connector` with in-process pathdb, trust verification, revocation cache, etc.

4. **Add DefaultConnector helper**: Implemented `NewDefaultConnector()` that selects between standalone and remote daemon based on availability:
   - Priority 1: Use supplied daemon address (gRPC)
   - Priority 2: Load from topology file if exists (standalone)
   - Priority 3: Connect to default daemon if reachable (gRPC)
   - Can be extended in the future with bootstrapping functionality.

5. **Update scion-cli**: Adapted the CLI to use the new connector system via `--sciond` flag. If supplied, a remote daemon is used, by default the standalone is used.

## Testing

Added `daemon_vs_standalone` acceptance test that runs e2e integration test with both modes. The test are already integrated in the CI/CD `AT: daemon_vs_standalone_daemon` and  `AT: daemon_vs_standalone_standalone`. 

One can alternatively run both test using the Bazel framework provided that the local development is installed (https://docs.scion.org/en/latest/dev/setup.html#setup). The commands are respectively:
```
bazel test --test_output=streamed //acceptance/daemon_vs_standalone:test_ping
bazel test --test_output=streamed //acceptance/daemon_vs_standalone:test_standalone
```

### Testing scion utility in your SCION environment

If not having or not wanting to use the development setup, one can also directly try out the standalone feature by compiling the `scion` utility. The `scion` utility is an endhost CLI tool that can ping or retrieve SCION path when run in an endhost connected to a SCION network (production network, local setup, container network, etc.).

To compile the tool, check out to this PR and:
```
CGO_ENABLED=0 go build -o bin/ ./scion/cmd/...
```
For example, if you want to try out the feature in the production network, you can try to fetch paths to the ETHZ AS, as follows.
```
bin/scion sp 64-2:0:9
```
The binary needs a valid `topology.json` file. By default it will try to find it under `/etc/scion/topology.json` if defined elsewhere please, specify the parent directory with the `--config` flag.

## Follow-up Tasks (not considered in this PR)

- **Bootstrapping functonality**: The `NewAutoConnector()` function should implement options to automatically bootstrap SCION connectivity from bootstrap servers / DNS records similar to JPAN.
- **DRKey in Standalone Mode**: The `NewStandaloneConnector()` should set up and manage a `DRKeyEngine` appropriately configured for standalone mode. Currently DRKey is explicitly disabled by setting the engine to `nil`.

## Open Discussion Points

### Naming/API
- [x] **Rename old Service?** (JordiSubira): Should `daemon.NewService()` be renamed to `daemon.NewRemoteService()` for symmetry with `NewStandaloneConnector()`, breaking the API?
- [x] **LocalASInfo naming**: Is the name `LocalASInfo` (formerly `CPInfo` and `Topology`) now ok?
- [x] **AcceptAllVerifier naming** (marcfrei): Should `verifier.AcceptAll` be renamed to `AcceptAllVerifier`, `TrustAllVerifier`, or `NoOpVerifier`?
- [x] **SuppliedOption naming** (marcfrei): Should `SuppliedOption` be renamed? Options: `DefaultOption`, `connectorOption`. Should it be exported? Should it match the pattern of `standaloneOption`?

### Logic/Design
- [x] **DefaultConnector logic**: Is the priority order correct? (1. supplied daemon addr -> 2. topology file -> 3. default daemon)

### Code Organization
- [x] **API types location** (marcfrei): Should `pkg/daemon/private/types` move to `pkg/daemon/types`, breaking the API?
- [x] **drkey grpc location** (marcfrei): Should `pkg/daemon/private/drkey` move to `private/drkey`?
- [x] **Public API surface**: Is the current `pkg/daemon` API minimal and appropriate?

### Documentation
- [x] **README**: Create a README for `pkg/daemon` documenting the public API and usage patterns (once other points resolved)