### PR TITLE
control/beacon: selection algorithm becomes pluggable

### DIFF
--- a/control/beacon/selection_algo.go
+++ b/control/beacon/selection_algo.go
@@ -91,7 +91,9 @@ type chainsAvailableAlgo struct {
 
 // NewChainsAvailableAlgo creates a SelectionAlgorithm that filters beacons
 // based on the availability of their verification chains before passing them to
-// the provided selector.
+// the provided selector. This can be paired with a chain provider that only
+// returns locally available chains to ensure that beacons are verifiable with
+// cryptographic material available in the local trust store.
 func NewChainsAvailableAlgo(engine ChainProvider, selector SelectionAlgorithm) SelectionAlgorithm {
 	return chainsAvailableAlgo{
 		verifier: chainChecker{

--- a/control/beacon/store.go
+++ b/control/beacon/store.go
@@ -28,7 +28,6 @@ type usager interface {
 }
 
 type storeOptions struct {
-	chainChecker  ChainProvider
 	selectionAlgo SelectionAlgorithm
 }
 
@@ -40,17 +39,6 @@ type applyFunc func(o *storeOptions)
 
 func (f applyFunc) apply(o *storeOptions) {
 	f(o)
-}
-
-// WithCheckChain ensures that only beacons for which all the required
-// certificate chains are available are returned. This can be paired with a
-// chain provider that only returns locally available chains to ensure that
-// beacons are verifiable with cryptographic material available in the local
-// trust store.
-func WithCheckChain(p ChainProvider) StoreOption {
-	return applyFunc(func(o *storeOptions) {
-		o.chainChecker = p
-	})
 }
 
 // WithSelectionAlgorithm sets the selection algorithm used to select the best
@@ -306,9 +294,6 @@ func selectAlgo(o storeOptions) SelectionAlgorithm {
 		algo = o.selectionAlgo
 	} else {
 		algo = DefaultSelectionAlgorithm()
-	}
-	if o.chainChecker != nil {
-		return NewChainsAvailableAlgo(o.chainChecker, algo)
 	}
 	return algo
 }

--- a/control/cmd/control/main.go
+++ b/control/cmd/control/main.go
@@ -1126,14 +1126,16 @@ func createBeaconStore(
 	switch {
 	case policies.CorePolicies != nil:
 		policies := policies.CorePolicies
+		selectionAlgo := beacon.NewChainsAvailableAlgo(provider, beacon.DefaultSelectionAlgorithm())
 		store, err := beacon.NewCoreBeaconStore(*policies, db,
-			beacon.WithSelectionAlgorithm(beacon.NewChainsAvailableAlgo(provider, beacon.DefaultSelectionAlgorithm())),
+			beacon.WithSelectionAlgorithm(selectionAlgo),
 		)
 		return store, *policies.Prop.Filter.AllowIsdLoop, err
 	case policies.NonCorePolicies != nil:
 		policies := policies.NonCorePolicies
+		selectionAlgo := beacon.NewChainsAvailableAlgo(provider, beacon.DefaultSelectionAlgorithm())
 		store, err := beacon.NewBeaconStore(*policies, db,
-			beacon.WithSelectionAlgorithm(beacon.NewChainsAvailableAlgo(provider, beacon.DefaultSelectionAlgorithm())),
+			beacon.WithSelectionAlgorithm(selectionAlgo),
 		)
 		return store, *policies.Prop.Filter.AllowIsdLoop, err
 	default:


### PR DESCRIPTION
With this commit the selection algorithm of the beacon store can now be changed with options. This allows users of the beacon store to plug flexible selection algorithms based on their needs.