### PR TITLE
fix: break loop and the not select

### DIFF
--- a/gateway/control/aggregator.go
+++ b/gateway/control/aggregator.go
@@ -97,13 +97,12 @@ func (a *Aggregator) run(ctx context.Context) error {
 	go func() {
 		defer log.HandlePanic()
 		ticker := time.NewTicker(a.ReportingInterval)
-	LOOP:
 		for {
 			select {
 			case <-ticker.C:
 				a.report()
 			case <-a.workerBase.GetDoneChan():
-				break LOOP
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
@oncilla Please correct me if I'm wrong but I suppose you wanted to break out of the loop in here. Currently, this `break` breaks on the `select` so it does nothing.

Second question: shouldn't it also break if `ctx` is canceled?