### PR TITLE
acceptance: add daemon_vs_standalone test

### DIFF
--- a/acceptance/daemon_vs_standalone/BUILD.bazel
+++ b/acceptance/daemon_vs_standalone/BUILD.bazel
@@ -1,0 +1,24 @@
+load("//acceptance/common:topogen.bzl", "topogen_test")
+
+# Test with standalone daemon (embedded daemon using topology files) - default
+topogen_test(
+    name = "test_standalone",
+    src = "test.py",
+    args = [
+        "--executable=end2end_integration:$(location //tools/end2end_integration)",
+    ],
+    data = ["//tools/end2end_integration"],
+    topo = "//topology:tiny.topo",
+)
+
+# Test with remote daemon (connecting to sciond via gRPC)
+topogen_test(
+    name = "test_daemon",
+    src = "test.py",
+    args = [
+        "--executable=end2end_integration:$(location //tools/end2end_integration)",
+        "--use-daemon",
+    ],
+    data = ["//tools/end2end_integration"],
+    topo = "//topology:tiny.topo",
+)

--- a/acceptance/daemon_vs_standalone/test.py
+++ b/acceptance/daemon_vs_standalone/test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 SCION Association
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test that compares daemon vs standalone mode for end2end connectivity.
+
+This test runs the end2end_integration test in two modes:
+- Daemon mode: Uses remote SCION daemon connector (connecting via gRPC)
+- Standalone mode: Uses embedded daemon with topology files (no sciond)
+
+The daemon mode can be selected via --use-daemon flag:
+- With --use-daemon: Uses remote daemon connector (via gRPC)
+- Without --use-daemon (default): Uses standalone daemon connector
+"""
+
+from plumbum import cli
+
+from acceptance.common import base
+
+
+class Test(base.TestTopogen):
+    """
+    Tests end2end connectivity using either daemon or standalone mode.
+    """
+
+    use_daemon = cli.Flag(
+        "--use-daemon",
+        help="Use remote SCION daemon instead of standalone daemon",
+    )
+
+    def setup_start(self):
+        super().setup_start()
+        self.await_connectivity()
+
+    def _run(self):
+        ping_test = self.get_executable("end2end_integration")
+
+        if self.use_daemon:
+            print("=== Running with remote daemon (sciond) ===")
+            ping_test["-d", "-sciond", "-outDir", self.artifacts].run_fg()
+        else:
+            print("=== Running with standalone daemon ===")
+            ping_test["-d", "-outDir", self.artifacts].run_fg()
+
+
+if __name__ == "__main__":
+    base.main(Test)

--- a/tools/integration/cmd.go
+++ b/tools/integration/cmd.go
@@ -47,6 +47,14 @@ func (c Cmd) Template(src, dst *snet.UDPAddr) (Cmd, error) {
 		}
 		args = replacePattern(Daemon, daemonAddr, args)
 	}
+	if needTopoDir(args) {
+		// In Docker mode, the gen directory is mounted at /share/gen inside the container
+		if *Docker {
+			args = replacePattern(TopoDir, "/share/gen", args)
+		} else {
+			args = replacePattern(TopoDir, GenFile(""), args)
+		}
+	}
 	return Cmd{Binary: c.Binary, Args: args}, nil
 }
 

--- a/tools/integration/integrationlib/common.go
+++ b/tools/integration/integrationlib/common.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -51,6 +52,7 @@ var (
 	Mode       string
 	Progress   string
 	daemonAddr string
+	topoDir    string
 	Attempts   int
 	logConsole string
 	features   string
@@ -75,11 +77,20 @@ func addFlags() error {
 	flag.Var(&Local, "local", "(Mandatory) address to listen on")
 	flag.StringVar(&Mode, "mode", ModeClient, "Run in "+ModeClient+" or "+ModeServer+" mode")
 	flag.StringVar(&Progress, "progress", "", "Socket to write progress to")
-	flag.StringVar(&daemonAddr, "sciond", envFlags.Daemon(), "SCION Daemon address")
+	flag.StringVar(
+		&daemonAddr, "sciond", "",
+		"SCION Daemon address. If set, uses remote daemon instead of standalone daemon.",
+	)
+	flag.StringVar(
+		&topoDir, "topoDir", "",
+		"Directory containing topology files. Used for standalone daemon (default mode).",
+	)
 	flag.IntVar(&Attempts, "attempts", 1, "Number of attempts before giving up")
 	flag.StringVar(&logConsole, "log.console", "info", "Console logging level: debug|info|error")
-	flag.StringVar(&features, "features", "",
-		fmt.Sprintf("enable development features (%v)", feature.String(&feature.Default{}, "|")))
+	flag.StringVar(
+		&features, "features", "",
+		fmt.Sprintf("enable development features (%v)", feature.String(&feature.Default{}, "|")),
+	)
 	return nil
 }
 
@@ -128,12 +139,43 @@ func validateFlags() {
 	}
 }
 
+// SDConn returns a daemon connector.
+// If -sciond is specified, it connects to a remote daemon.
+// Otherwise (default), it creates a standalone daemon connector using the topology file
+// from -topoDir.
 func SDConn() daemon.Connector {
-	ctx, cancelF := context.WithTimeout(context.Background(), DefaultIOTimeout)
-	defer cancelF()
-	conn, err := daemon.NewService(daemonAddr).Connect(ctx)
+	// If sciond address is specified, use remote daemon
+	if daemonAddr != "" {
+		ctx, cancelF := context.WithTimeout(context.Background(), DefaultIOTimeout)
+		defer cancelF()
+		conn, err := daemon.NewService(daemonAddr).Connect(ctx)
+		if err != nil {
+			LogFatal("Unable to initialize SCION Daemon connection", "err", err)
+		}
+		return conn
+	}
+
+	// Use standalone daemon by default (with topology file)
+	if topoDir == "" {
+		LogFatal("Either -sciond or -topoDir must be specified")
+	}
+
+	// Construct topology file path from the local IA
+	asDir := addr.FormatAS(Local.IA.AS(), addr.WithDefaultPrefix(), addr.WithFileSeparator())
+	asPath := filepath.Join(topoDir, asDir)
+	topoFile := filepath.Join(asPath, "topology.json")
+
+	log.Debug("Using standalone daemon", "topology", topoFile)
+	topo, err := daemon.LoadASInfoFromFile(topoFile)
 	if err != nil {
-		LogFatal("Unable to initialize SCION Daemon connection", "err", err)
+		LogFatal("Unable to load topology", "err", err, "topoFile", topoFile)
+	}
+	ctx := context.Background()
+	conn, err := daemon.NewStandaloneConnector(
+		ctx, topo, daemon.WithCertsDir(filepath.Join(asPath, "certs")),
+	)
+	if err != nil {
+		LogFatal("Unable to create standalone daemon", "err", err, "topoFile", topoFile)
 	}
 	return conn
 }


### PR DESCRIPTION
**Summary**

This PR adds acceptance tests comparing daemon and standalone operation modes.

This is part 4 of a series splitting #4853 into smaller, reviewable PRs. The original PR will be closed.

**Main Changes**

- **Add daemon_vs_standalone test**: Created `acceptance/daemon_vs_standalone/test.py` that runs end-to-end integration tests with both daemon and standalone modes.

- **Extend integration tooling**: Updated `tools/end2end_integration/main.go` to support standalone mode testing.

- **Add integration helpers**: Extended `tools/integration/binary.go` and `tools/integration/integrationlib/common.go` with helpers for standalone testing.

**Testing**

The tests are integrated in CI/CD as `AT: daemon_vs_standalone_daemon` and `AT: daemon_vs_standalone_standalone`.

Run locally with:
```bash
bazel test --test_output=streamed //acceptance/daemon_vs_standalone:test_ping
bazel test --test_output=streamed //acceptance/daemon_vs_standalone:test_standalone
```