### PR TITLE
tools/dc: use bash instead of sh in exec_tester

### DIFF
--- a/tools/dc
+++ b/tools/dc
@@ -95,7 +95,7 @@ exec_tester() {
     local service="tester_$1"
     shift
     service_running "$service" || cmd_start "$service" &>/dev/null
-    cmd_scion exec -T "$service" sh -l -c "$*"
+    cmd_scion exec -T "$service" bash -l -c "$*"
 }
 
 glob_docker() {


### PR DESCRIPTION
In #4710 the docker tester container was modified to use `bash` instead of `sh`. However, this was not reflected in the tools/dc `exec_tester` command. This causes the command to fail with `"sh": executable file not found in $PATH`. This PR fixes the issue.