### PR TITLE
ci: fix gobra in github actions

### DIFF
--- a/.github/workflows/gobra.yml
+++ b/.github/workflows/gobra.yml
@@ -31,9 +31,6 @@ jobs:
           recursive: '1'
           timeout: 10m
           caching: '1'
-          # Explicitly set to preserve previous behavior; the default
-          # changed from VSWITHSILICON to SILICON in gobra-action v25.09.
-          viperBackend: 'VSWITHSILICON'
           # Work around JDK cgroup v2 NullPointerException on GitHub Actions
           # runners by disabling container support detection. The extra flag
           # is injected via javaXss because the action has no dedicated input


### PR DESCRIPTION
Upgrade Gobra workflow to fix cgroup v2 crash.

The gobra-action v22.10.2 ships with OpenJDK 11 that suffers a [known cgroup v2 bug](https://bugs.openjdk.org/browse/JDK-8287073)
that causes a NullPointerException (see [here](https://github.com/scionproto/scion/actions/runs/22069735394/job/63770840537#step:5:119)) on newer GitHub Actions runners.
Upgrade to v25.09.1 which includes a fixed JDK.

Also bump actions/checkout to v6, actions/cache to v5

Related PR to fix the warning: https://github.com/viperproject/gobra-action/pull/35