### PR TITLE
fix: correctly apply pr #4872

### DIFF
--- a/doc/command/scion/scion_ping.rst
+++ b/doc/command/scion/scion_ping.rst
@@ -11,8 +11,8 @@ Synopsis
 ~~~~~~~~
 
 
-'ping' test connectivity to a remote SCION host using SCMP echo packets. Use 'scion address'
-on the remote SCION host to determine the ISD-AS and pingable IP address.
+'ping' test connectivity to a remote SCION host using SCMP echo packets.
+Use 'scion address' on the remote SCION host to determine the ISD-AS and pingable IP address.
 
 When the \--count option is set, ping sends the specified number of SCMP echo packets
 and reports back the statistics.

--- a/scion/cmd/scion/ping.go
+++ b/scion/cmd/scion/ping.go
@@ -97,6 +97,7 @@ func newPing(pather CommandPather) *cobra.Command {
 		Example: fmt.Sprintf(`  %[1]s ping 1-ff00:0:110,10.0.0.1
   %[1]s ping 1-ff00:0:110,10.0.0.1 -c 5`, pather.CommandPath()),
 		Long: fmt.Sprintf(`'ping' test connectivity to a remote SCION host using SCMP echo packets.
+Use 'scion address' on the remote SCION host to determine the ISD-AS and pingable IP address.
 
 When the \--count option is set, ping sends the specified number of SCMP echo packets
 and reports back the statistics.


### PR DESCRIPTION
Running `make all` deletes the change made in #4872.
CI shouldn't have allowed that to happen but it did for yet unknown reasons.