### PR TITLE
control/beaconing: set default policy type

### DIFF
--- a/control/policy.go
+++ b/control/policy.go
@@ -62,5 +62,6 @@ func loadPolicy(fn string, t beacon.PolicyType) (beacon.Policy, error) {
 		policy = *p
 	}
 	policy.InitDefaults()
+	policy.Type = t
 	return policy, nil
 }


### PR DESCRIPTION
When loading the default policy make sure that the type is set.