### PR TITLE
control: fix beacon grouping

### DIFF
--- a/control/BUILD.bazel
+++ b/control/BUILD.bazel
@@ -72,7 +72,6 @@ go_test(
     deps = [
         ":go_default_library",
         "//control/beacon:go_default_library",
-        "//control/beacon/mock_beacon:go_default_library",
         "//control/beaconing:go_default_library",
         "//control/segreg:go_default_library",
         "//pkg/addr:go_default_library",

--- a/control/beacon/policy.go
+++ b/control/beacon/policy.go
@@ -356,7 +356,7 @@ func (b *beaconAsPath) Metadata() *snet.PathMetadata {
 		// For the AS entries that are not the last, add the interface with egress interface.
 		if i < len(b.beacon.Segment.ASEntries)-1 {
 			md.Interfaces = append(md.Interfaces, snet.PathInterface{
-				IA: entry.Next,
+				IA: entry.Local,
 				ID: iface.ID(entry.HopEntry.HopField.ConsEgress),
 			})
 		}

--- a/control/beacon/store.go
+++ b/control/beacon/store.go
@@ -68,33 +68,6 @@ type GroupedBeacons map[string][]Beacon
 // This should also correspond to the ID of the default plugin.
 const DefaultGroup string = "default"
 
-// groupBeacons takes a slice of beacons and groups them according to the registration policies
-// defined in the provided policy.
-//
-// The beacons that do not match any registration policy are dropped.
-//
-// If the policy defines no registration policy, all the beacons will be put into
-// the default group, indexed by DefaultGroup.
-func groupBeacons(beacons []Beacon, policy *Policy) GroupedBeacons {
-	if len(policy.RegistrationPolicies) == 0 {
-		return map[string][]Beacon{
-			DefaultGroup: beacons,
-		}
-	}
-	// Go through every beacon, and group it into the first registration
-	// policy that matches it.
-	beaconBuckets := make(GroupedBeacons)
-	for _, b := range beacons {
-		for _, regPolicy := range policy.RegistrationPolicies {
-			if regPolicy.Matcher.Match(b) {
-				beaconBuckets[regPolicy.Name] = append(beaconBuckets[regPolicy.Name], b)
-				break
-			}
-		}
-	}
-	return beaconBuckets
-}
-
 // Store provides abstracted access to the beacon database in a non-core AS.
 // The store helps to insert beacons and revocations, and selects the best beacons
 // for given purposes based on the configured policies. It should not be used in a
@@ -128,13 +101,12 @@ func (s *Store) BeaconsToPropagate(ctx context.Context) ([]Beacon, error) {
 	return s.getBeacons(ctx, &s.policies.Prop)
 }
 
-// SegmentsToRegister returns a GroupedBeacons that provides all beacons to register
-// at the time of the call. The selections are based on the configured policy for the
-// requested segment type.
+// SegmentsToRegister returns all beacons to register at the time of the call.
+// The selections are based on the configured policy for the requested segment type.
 func (s *Store) SegmentsToRegister(
 	ctx context.Context,
 	segType seg.Type,
-) (GroupedBeacons, error) {
+) ([]Beacon, []RegistrationPolicy, error) {
 	var policy *Policy
 	switch segType {
 	case seg.TypeDown:
@@ -142,13 +114,13 @@ func (s *Store) SegmentsToRegister(
 	case seg.TypeUp:
 		policy = &s.policies.UpReg
 	default:
-		return nil, serrors.New("Unsupported segment type", "type", segType)
+		return nil, nil, serrors.New("Unsupported segment type", "type", segType)
 	}
 	beacons, err := s.getBeacons(ctx, policy)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return groupBeacons(beacons, policy), nil
+	return beacons, policy.RegistrationPolicies, nil
 }
 
 // getBeacons fetches the candidate beacons from the database and serves the
@@ -208,20 +180,20 @@ func (s *CoreStore) BeaconsToPropagate(ctx context.Context) ([]Beacon, error) {
 	return s.getBeacons(ctx, &s.policies.Prop)
 }
 
-// SegmentsToRegister returns a GroupedBeacons to register at the time of the call.
+// SegmentsToRegister returns the beacons to register at the time of the call.
 // The selection is based on the configured policy for the requested segment type.
 func (s *CoreStore) SegmentsToRegister(
 	ctx context.Context,
 	segType seg.Type,
-) (GroupedBeacons, error) {
+) ([]Beacon, []RegistrationPolicy, error) {
 	if segType != seg.TypeCore {
-		return nil, serrors.New("Unsupported segment type", "type", segType)
+		return nil, nil, serrors.New("Unsupported segment type", "type", segType)
 	}
 	beacons, err := s.getBeacons(ctx, &s.policies.CoreReg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return groupBeacons(beacons, &s.policies.CoreReg), nil
+	return beacons, s.policies.CoreReg.RegistrationPolicies, nil
 }
 
 // getBeacons fetches the candidate beacons from the database and serves the

--- a/control/beacon/store_test.go
+++ b/control/beacon/store_test.go
@@ -31,18 +31,18 @@ import (
 
 func TestStoreSegmentsToRegister(t *testing.T) {
 	testStoreSelection(t, func(store *beacon.Store) ([]beacon.Beacon, error) {
-		s, err := store.SegmentsToRegister(context.Background(), seg.TypeUp)
+		beacons, _, err := store.SegmentsToRegister(context.Background(), seg.TypeUp)
 		if err != nil {
 			return nil, err
 		}
-		return s[beacon.DefaultGroup], nil
+		return beacons, nil
 	})
 	testStoreSelection(t, func(store *beacon.Store) ([]beacon.Beacon, error) {
-		s, err := store.SegmentsToRegister(context.Background(), seg.TypeDown)
+		beacons, _, err := store.SegmentsToRegister(context.Background(), seg.TypeDown)
 		if err != nil {
 			return nil, err
 		}
-		return s[beacon.DefaultGroup], nil
+		return beacons, nil
 	})
 }
 
@@ -52,8 +52,10 @@ func TestStoreBeaconsToPropagate(t *testing.T) {
 	})
 }
 
-func testStoreSelection(t *testing.T,
-	methodToTest func(store *beacon.Store) ([]beacon.Beacon, error)) {
+func testStoreSelection(
+	t *testing.T,
+	methodToTest func(store *beacon.Store,
+	) ([]beacon.Beacon, error)) {
 
 	mctrl := gomock.NewController(t)
 	g := graph.NewDefaultGraph(mctrl)
@@ -150,11 +152,11 @@ func testStoreSelection(t *testing.T,
 
 func TestCoreStoreSegmentsToRegister(t *testing.T) {
 	testCoreStoreSelection(t, func(store *beacon.CoreStore) ([]beacon.Beacon, error) {
-		s, err := store.SegmentsToRegister(context.Background(), seg.TypeCore)
+		beacons, _, err := store.SegmentsToRegister(context.Background(), seg.TypeCore)
 		if err != nil {
 			return nil, err
 		}
-		return s[beacon.DefaultGroup], nil
+		return beacons, nil
 	})
 }
 

--- a/control/beaconing/mock_beaconing/mock.go
+++ b/control/beaconing/mock_beaconing/mock.go
@@ -219,12 +219,13 @@ func (m *MockSegmentProvider) EXPECT() *MockSegmentProviderMockRecorder {
 }
 
 // SegmentsToRegister mocks base method.
-func (m *MockSegmentProvider) SegmentsToRegister(arg0 context.Context, arg1 segment.Type) (beacon.GroupedBeacons, error) {
+func (m *MockSegmentProvider) SegmentsToRegister(arg0 context.Context, arg1 segment.Type) ([]beacon.Beacon, []beacon.RegistrationPolicy, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SegmentsToRegister", arg0, arg1)
-	ret0, _ := ret[0].(beacon.GroupedBeacons)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].([]beacon.Beacon)
+	ret1, _ := ret[1].([]beacon.RegistrationPolicy)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // SegmentsToRegister indicates an expected call of SegmentsToRegister.

--- a/control/beaconing/writer.go
+++ b/control/beaconing/writer.go
@@ -46,9 +46,9 @@ type Pather interface {
 // SegmentProvider provides segments to register for the specified type.
 type SegmentProvider interface {
 	// SegmentsToRegister returns the segments that should be registered for the
-	// given segment type as GroupedBeacons.
-	// The returned GroupedBeacons must not be nil if the returned error is nil.
-	SegmentsToRegister(ctx context.Context, segType seg.Type) (beacon.GroupedBeacons, error)
+	// given segment type.
+	// The returned slice must not be nil if the returned error is nil.
+	SegmentsToRegister(ctx context.Context, segType seg.Type) ([]beacon.Beacon, []beacon.RegistrationPolicy, error)
 }
 
 // SegmentStore stores segments in the path database.
@@ -86,7 +86,7 @@ type Writer interface {
 	// of the local IA. The returned statistics should provide insights about
 	// how many segments have been successfully written. The method should return
 	// an error if the writing did fail.
-	Write(ctx context.Context, beacons beacon.GroupedBeacons, peers []uint16) (WriteStats, error)
+	Write(ctx context.Context, beacons []beacon.Beacon, policies []beacon.RegistrationPolicy, peers []uint16) (WriteStats, error)
 }
 
 var _ periodic.Task = (*WriteScheduler)(nil)
@@ -130,12 +130,12 @@ func (r *WriteScheduler) run(ctx context.Context) error {
 	if !r.Tick.Overdue(r.lastWrite) && !r.Tick.Passed() {
 		return nil
 	}
-	segments, err := r.Provider.SegmentsToRegister(ctx, r.Type)
+	beacons, policies, err := r.Provider.SegmentsToRegister(ctx, r.Type)
 	if err != nil {
 		return err
 	}
 	peers := sortedIntfs(r.Intfs, topology.Peer)
-	stats, err := r.Writer.Write(ctx, segments, peers)
+	stats, err := r.Writer.Write(ctx, beacons, policies, peers)
 	if err != nil {
 		return err
 	}
@@ -449,62 +449,60 @@ type GroupWriter struct {
 
 var _ Writer = (*GroupWriter)(nil)
 
-// processSegments processes the segments by terminating them and filtering out
-// the segments that do not have a valid interface ID.
+// processSegments processes the segments by terminating them, filtering out
+// the segments that do not have a valid interface ID, and grouping them by
+// registration policy.
 func (w *GroupWriter) processSegments(
 	ctx context.Context,
-	beacons beacon.GroupedBeacons,
+	beacons []beacon.Beacon,
+	policies []beacon.RegistrationPolicy,
 	peers []uint16,
 ) beacon.GroupedBeacons {
 	logger := log.FromCtx(ctx)
-	processed := make(beacon.GroupedBeacons, len(beacons))
-	for group, beacons := range beacons {
-		processedGroup := make([]beacon.Beacon, 0, len(beacons))
-		for i, b := range beacons {
-			// If the beacon does not have a valid interface ID, skip it.
-			if w.Intfs != nil && w.Intfs.Get(b.InIfID) == nil {
+	// First, extend and filter the beacons.
+	processedBeacons := make([]beacon.Beacon, 0, len(beacons))
+	for i, b := range beacons {
+		// If the beacon does not have a valid interface ID, skip it.
+		if w.Intfs != nil && w.Intfs.Get(b.InIfID) == nil {
+			continue
+		}
+		// Try to terminate the segment if an extender is configured.
+		if w.Extender != nil {
+			err := w.Extender.Extend(ctx, b.Segment, b.InIfID, 0, peers)
+			var signerGenError trust.SignerGenError
+			if errors.As(err, &signerGenError) {
+				// In case of a signer generation error, we can break the loop,
+				// the chance we will get a working signer during this run is
+				// very low.
+				w.signerLogThrottle.Do(func(suppressedCount int) {
+					logger.Error(
+						"Unable to terminate beacon due to signer generation error, breaking loop",
+						"beacon", b,
+						"err", err,
+						"next_gen", signerGenError.NextGen,
+					)
+				})
+				// Keep old behavior regarding metrics:
+				metrics.CounterAdd(w.InternalErrors, float64(len(beacons)-i))
+				break
+			}
+			if err != nil {
+				// Throttle error logging here.
+				w.terminateLogThrottle.Do(func(suppressedCount int) {
+					logger.Error("Unable to terminate beacon",
+						"beacon", b,
+						"err", err,
+						"suppressed", suppressedCount,
+					)
+				})
+				metrics.CounterInc(w.InternalErrors)
 				continue
 			}
-			// Try to terminate the segment if an extender is configured.
-			if w.Extender != nil {
-				err := w.Extender.Extend(ctx, b.Segment, b.InIfID, 0, peers)
-				var signerGenError trust.SignerGenError
-				if errors.As(err, &signerGenError) {
-					// In case of a signer generation error, we can break the loop,
-					// the chance we will get a working signer during this run is
-					// very low.
-					w.signerLogThrottle.Do(func(suppressedCount int) {
-						logger.Error("Unable to terminate beacon due to signer generation error,"+
-							" breaking loop",
-							"beacon", b,
-							"err", err,
-							"next_gen", signerGenError.NextGen,
-						)
-					})
-					// Keep old behavior regarding metrics:
-					metrics.CounterAdd(w.InternalErrors, float64(len(beacons)-i))
-					break
-				}
-				if err != nil {
-					// Throttle error logging here.
-					w.terminateLogThrottle.Do(func(suppressedCount int) {
-						logger.Error("Unable to terminate beacon",
-							"beacon", b,
-							"err", err,
-							"suppressed", suppressedCount,
-						)
-					})
-					metrics.CounterInc(w.InternalErrors)
-					continue
-				}
-			}
-			processedGroup = append(processedGroup, b)
 		}
-		if len(processedGroup) > 0 {
-			processed[group] = processedGroup
-		}
+		processedBeacons = append(processedBeacons, b)
 	}
-	return processed
+	// Then, group the beacons according to the registration policies.
+	return w.groupBeacons(processedBeacons, policies)
 }
 
 // Write writes beacons to multiple segment registrars based on the PolicyType.
@@ -513,10 +511,12 @@ func (w *GroupWriter) processSegments(
 // and the group's name (which should correspond to the registration policy name).
 func (w *GroupWriter) Write(
 	ctx context.Context,
-	allBeacons beacon.GroupedBeacons,
+	beacons []beacon.Beacon,
+	policies []beacon.RegistrationPolicy,
 	peers []uint16,
 ) (WriteStats, error) {
-	processedBeacons := w.processSegments(ctx, allBeacons, peers)
+	// Process and group the beacons.
+	processedBeacons := w.processSegments(ctx, beacons, policies, peers)
 	writeStats := WriteStats{Count: 0, StartIAs: make(map[addr.IA]struct{})}
 	// Defines a concurrent task, i.e., registration of a group of segments with a
 	// specific registrar.
@@ -555,4 +555,28 @@ func (w *GroupWriter) Write(
 		writeStats.Extend(stats)
 	}
 	return writeStats, nil
+}
+
+// groupBeacons groups beacons according to the registration policies defined in the policy.
+// The beacons that do not match any registration policy are dropped.
+// If the policy defines no registration policy, all the beacons will be put into
+// the default group.
+func (w *GroupWriter) groupBeacons(beacons []beacon.Beacon, policies []beacon.RegistrationPolicy) beacon.GroupedBeacons {
+	if len(policies) == 0 {
+		return map[string][]beacon.Beacon{
+			beacon.DefaultGroup: beacons,
+		}
+	}
+	// Go through every beacon, and group it into the first registration
+	// policy that matches it.
+	beaconBuckets := make(beacon.GroupedBeacons)
+	for _, b := range beacons {
+		for _, regPolicy := range policies {
+			if regPolicy.Matcher.Match(b) {
+				beaconBuckets[regPolicy.Name] = append(beaconBuckets[regPolicy.Name], b)
+				break
+			}
+		}
+	}
+	return beaconBuckets
 }

--- a/control/beaconing/writer.go
+++ b/control/beaconing/writer.go
@@ -48,7 +48,10 @@ type SegmentProvider interface {
 	// SegmentsToRegister returns the segments that should be registered for the
 	// given segment type.
 	// The returned slice must not be nil if the returned error is nil.
-	SegmentsToRegister(ctx context.Context, segType seg.Type) ([]beacon.Beacon, []beacon.RegistrationPolicy, error)
+	SegmentsToRegister(
+		ctx context.Context,
+		segType seg.Type,
+	) ([]beacon.Beacon, []beacon.RegistrationPolicy, error)
 }
 
 // SegmentStore stores segments in the path database.
@@ -86,7 +89,12 @@ type Writer interface {
 	// of the local IA. The returned statistics should provide insights about
 	// how many segments have been successfully written. The method should return
 	// an error if the writing did fail.
-	Write(ctx context.Context, beacons []beacon.Beacon, policies []beacon.RegistrationPolicy, peers []uint16) (WriteStats, error)
+	Write(
+		ctx context.Context,
+		beacons []beacon.Beacon,
+		policies []beacon.RegistrationPolicy,
+		peers []uint16,
+	) (WriteStats, error)
 }
 
 var _ periodic.Task = (*WriteScheduler)(nil)
@@ -561,7 +569,10 @@ func (w *GroupWriter) Write(
 // The beacons that do not match any registration policy are dropped.
 // If the policy defines no registration policy, all the beacons will be put into
 // the default group.
-func (w *GroupWriter) groupBeacons(beacons []beacon.Beacon, policies []beacon.RegistrationPolicy) beacon.GroupedBeacons {
+func (w *GroupWriter) groupBeacons(
+	beacons []beacon.Beacon,
+	policies []beacon.RegistrationPolicy,
+) beacon.GroupedBeacons {
 	if len(policies) == 0 {
 		return map[string][]beacon.Beacon{
 			beacon.DefaultGroup: beacons,

--- a/control/beaconing/writer.go
+++ b/control/beaconing/writer.go
@@ -477,8 +477,7 @@ func (w *GroupWriter) processSegments(
 		// Try to terminate the segment if an extender is configured.
 		if w.Extender != nil {
 			err := w.Extender.Extend(ctx, b.Segment, b.InIfID, 0, peers)
-			var signerGenError trust.SignerGenError
-			if errors.As(err, &signerGenError) {
+			if signerGenError, ok := errors.AsType[trust.SignerGenError](err); ok {
 				// In case of a signer generation error, we can break the loop,
 				// the chance we will get a working signer during this run is
 				// very low.
@@ -510,7 +509,7 @@ func (w *GroupWriter) processSegments(
 		processedBeacons = append(processedBeacons, b)
 	}
 	// Then, group the beacons according to the registration policies.
-	return w.groupBeacons(processedBeacons, policies)
+	return groupBeacons(processedBeacons, policies)
 }
 
 // Write writes beacons to multiple segment registrars based on the PolicyType.
@@ -569,12 +568,12 @@ func (w *GroupWriter) Write(
 // The beacons that do not match any registration policy are dropped.
 // If the policy defines no registration policy, all the beacons will be put into
 // the default group.
-func (w *GroupWriter) groupBeacons(
+func groupBeacons(
 	beacons []beacon.Beacon,
 	policies []beacon.RegistrationPolicy,
 ) beacon.GroupedBeacons {
 	if len(policies) == 0 {
-		return map[string][]beacon.Beacon{
+		return beacon.GroupedBeacons{
 			beacon.DefaultGroup: beacons,
 		}
 	}

--- a/control/beaconing/writer_test.go
+++ b/control/beaconing/writer_test.go
@@ -141,14 +141,12 @@ func TestRegistrarRun(t *testing.T) {
 
 			g := graph.NewDefaultGraph(mctrl)
 			segProvider.EXPECT().SegmentsToRegister(gomock.Any(), test.segType).DoAndReturn(
-				func(_, _ any) (beacon.GroupedBeacons, error) {
+				func(_, _ any) ([]beacon.Beacon, []beacon.RegistrationPolicy, error) {
 					res := make([]beacon.Beacon, 0, len(test.beacons))
 					for _, desc := range test.beacons {
 						res = append(res, testBeacon(g, desc))
 					}
-					return beacon.GroupedBeacons{
-						beacon.DefaultGroup: res,
-					}, nil
+					return res, nil, nil
 				})
 
 			var stored []*seg.Meta

--- a/control/beaconing/writer_test.go
+++ b/control/beaconing/writer_test.go
@@ -252,14 +252,12 @@ func TestRegistrarRun(t *testing.T) {
 
 			g := graph.NewDefaultGraph(mctrl)
 			segProvider.EXPECT().SegmentsToRegister(gomock.Any(), test.segType).DoAndReturn(
-				func(_, _ any) (beacon.GroupedBeacons, error) {
-					res := make([]beacon.Beacon, len(test.beacons))
+				func(_, _ any) ([]beacon.Beacon, []beacon.RegistrationPolicy, error) {
+					res := make([]beacon.Beacon, 0, len(test.beacons))
 					for _, desc := range test.beacons {
 						res = append(res, testBeacon(g, desc))
 					}
-					return beacon.GroupedBeacons{
-						beacon.DefaultGroup: res,
-					}, nil
+					return res, nil, nil
 				})
 			type regMsg struct {
 				Meta seg.Meta
@@ -367,13 +365,10 @@ func TestRegistrarRun(t *testing.T) {
 		require.NoError(t, err)
 		segProvider.EXPECT().SegmentsToRegister(gomock.Any(),
 			seg.TypeDown).DoAndReturn(
-			func(_, _ any) (<-chan beacon.Beacon, error) {
-				res := make(chan beacon.Beacon, 1)
+			func(_, _ any) ([]beacon.Beacon, []beacon.RegistrationPolicy, error) {
 				b := testBeacon(g, []uint16{graph.If_120_X_111_B})
 				b.InIfID = 10
-				res <- b
-				close(res)
-				return res, nil
+				return []beacon.Beacon{b}, nil, nil
 			})
 		r.Run(context.Background())
 	})

--- a/control/registration_test.go
+++ b/control/registration_test.go
@@ -23,10 +23,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/control/beacon"
-	"github.com/scionproto/scion/control/beacon/mock_beacon"
 	"github.com/scionproto/scion/control/beaconing"
 	"github.com/scionproto/scion/control/segreg"
-	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/log"
 	"github.com/scionproto/scion/pkg/private/xtest/graph"
 	seg "github.com/scionproto/scion/pkg/segment"
@@ -59,130 +57,6 @@ func MustParseSequence(t *testing.T, seq string) *pathpol.Sequence {
 	return sequence
 }
 
-func TestRetrieveGroupedBeacons(t *testing.T) {
-	mctrl := gomock.NewController(t)
-	g := graph.NewDefaultGraph(mctrl)
-
-	stub := graph.If_111_A_112_X
-	beacons := []beacon.Beacon{
-		testBeacon(g, graph.If_120_X_111_B, stub),
-		testBeacon(g, graph.If_130_B_120_A, graph.If_120_X_111_B, stub),
-		testBeacon(g, graph.If_130_B_120_A, graph.If_120_X_111_B, stub),
-	}
-
-	wildCardSeq := MustParseSequence(t, "0*")
-	twoHopsSeq := MustParseSequence(t, "0-0#0 0-0#0")
-	threeHopsSeq := MustParseSequence(t, "0-0#0 0-0#0 0-0#0")
-
-	type testCase struct {
-		Name        string
-		RegPolicies []beacon.RegistrationPolicy
-		Expected    beacon.GroupedBeacons
-	}
-
-	testCases := []testCase{
-		{
-			Name: "No policies",
-			Expected: beacon.GroupedBeacons{
-				beacon.DefaultGroup: beacons,
-			},
-		},
-		{
-			Name: "Empty policy",
-			RegPolicies: []beacon.RegistrationPolicy{
-				{
-					Name: "empty",
-					Matcher: beacon.RegistrationPolicyMatcher{
-						Sequence: wildCardSeq,
-					},
-				},
-			},
-			Expected: beacon.GroupedBeacons{
-				"empty": beacons,
-			},
-		},
-		{
-			Name: "Disjoint policies",
-			RegPolicies: []beacon.RegistrationPolicy{
-				{
-					Name: "twoHops",
-					Matcher: beacon.RegistrationPolicyMatcher{
-						Sequence: twoHopsSeq,
-					},
-				},
-				{
-					Name: "threeHops",
-					Matcher: beacon.RegistrationPolicyMatcher{
-						Sequence: threeHopsSeq,
-					},
-				},
-			},
-			Expected: beacon.GroupedBeacons{
-				"twoHops": []beacon.Beacon{
-					beacons[0],
-				},
-				"threeHops": []beacon.Beacon{
-					beacons[1],
-					beacons[2],
-				},
-			},
-		},
-		{
-			Name: "Overlapping policies",
-			RegPolicies: []beacon.RegistrationPolicy{
-				{
-					Name: "threeHops",
-					Matcher: beacon.RegistrationPolicyMatcher{
-						Sequence: threeHopsSeq,
-					},
-				},
-				{
-					Name: "all",
-					Matcher: beacon.RegistrationPolicyMatcher{
-						Sequence: wildCardSeq,
-					},
-				},
-			},
-			Expected: beacon.GroupedBeacons{
-				"threeHops": []beacon.Beacon{
-					beacons[1],
-					beacons[2],
-				},
-				"all": []beacon.Beacon{
-					beacons[0],
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			ctx := t.Context()
-
-			// Create a mock database that returns the beacons.
-			db := mock_beacon.NewMockDB(mctrl)
-			db.EXPECT().CandidateBeacons(
-				gomock.Any(), gomock.Any(), gomock.Any(), addr.IA(0),
-			).Return(
-				beacons, nil,
-			)
-
-			policies := beacon.Policies{
-				UpReg: beacon.Policy{
-					RegistrationPolicies: tc.RegPolicies,
-				},
-			}
-			store, err := beacon.NewBeaconStore(policies, db)
-			require.NoError(t, err)
-
-			beacons, err := store.SegmentsToRegister(ctx, seg.TypeUp)
-			require.NoError(t, err)
-
-			require.Equal(t, tc.Expected, beacons)
-		})
-	}
-}
-
 func TestGroupWriter(t *testing.T) {
 	mctrl := gomock.NewController(t)
 	g := graph.NewDefaultGraph(mctrl)
@@ -197,40 +71,45 @@ func TestGroupWriter(t *testing.T) {
 	testReg1 := &testRegistrar{}
 	testReg2 := &testRegistrar{}
 
-	type testCase struct {
-		Name       string
-		Input      beacon.GroupedBeacons
-		Registrars map[string]*testRegistrar
+	twoHopsSeq := MustParseSequence(t, "0-0#0 0-0#0")
+	threeHopsSeq := MustParseSequence(t, "0-0#0 0-0#0 0-0#0")
 
-		Expected map[string][]beacon.Beacon
+	type testCase struct {
+		Name                 string
+		Input                []beacon.Beacon
+		RegistrationPolicies []beacon.RegistrationPolicy
+		Registrars           map[string]*testRegistrar
+		Expected             map[string][]beacon.Beacon
 	}
 
 	testCases := []testCase{
 		{
-			Name: "Basic",
-			Input: beacon.GroupedBeacons{
-				"all": []beacon.Beacon{
-					beacons[0],
-					beacons[1],
-					beacons[2],
+			Name:  "Grouped by policy",
+			Input: beacons,
+			RegistrationPolicies: []beacon.RegistrationPolicy{
+				{
+					Name: "twoHops",
+					Matcher: beacon.RegistrationPolicyMatcher{
+						Sequence: twoHopsSeq,
+					},
 				},
-				"some": []beacon.Beacon{
-					beacons[0],
-					beacons[2],
+				{
+					Name: "threeHops",
+					Matcher: beacon.RegistrationPolicyMatcher{
+						Sequence: threeHopsSeq,
+					},
 				},
 			},
 			Registrars: map[string]*testRegistrar{
-				"all":  testReg1,
-				"some": testReg2,
+				"twoHops":   testReg1,
+				"threeHops": testReg2,
 			},
 			Expected: map[string][]beacon.Beacon{
-				"all": {
+				"twoHops": {
 					beacons[0],
-					beacons[1],
-					beacons[2],
 				},
-				"some": {
-					beacons[0],
+				"threeHops": {
+					beacons[1],
 					beacons[2],
 				},
 			},
@@ -257,7 +136,7 @@ func TestGroupWriter(t *testing.T) {
 				Registrars: asRegistrars,
 			}
 
-			_, err := gw.Write(ctx, tc.Input, nil)
+			_, err := gw.Write(ctx, tc.Input, tc.RegistrationPolicies, nil)
 			require.NoError(t, err)
 
 			actual := make(map[string][]beacon.Beacon)

--- a/control/tasks.go
+++ b/control/tasks.go
@@ -386,10 +386,11 @@ type Store interface {
 	// potentially could be empty when no beacon is found) and no error.
 	// The selection is based on the configured propagation policy.
 	BeaconsToPropagate(ctx context.Context) ([]beacon.Beacon, error)
-	// SegmentsToRegister returns an error if for example connection or parsing error occurs;
-	// otherwise it returns grouped beacons (which is empty when no beacon is found). The
-	// selection is based on the configured propagation policy for the requested segment type.
-	SegmentsToRegister(ctx context.Context, segType seg.Type) (beacon.GroupedBeacons, error)
+	// SegmentsToRegister returns an error if for example connection or parsing
+	// error occurs; otherwise it returns beacons (which is empty when no beacon
+	// is found) and registration policies to use. The selection is based on the
+	// configured propagation policy for the requested segment type.
+	SegmentsToRegister(ctx context.Context, segType seg.Type) ([]beacon.Beacon, []beacon.RegistrationPolicy, error)
 	// InsertBeacon adds a verified beacon to the store, ignoring revocations.
 	InsertBeacon(ctx context.Context, beacon beacon.Beacon) (beacon.InsertStats, error)
 	// UpdatePolicy updates the policy. Beacons that are filtered by all

--- a/control/tasks.go
+++ b/control/tasks.go
@@ -390,7 +390,10 @@ type Store interface {
 	// error occurs; otherwise it returns beacons (which is empty when no beacon
 	// is found) and registration policies to use. The selection is based on the
 	// configured propagation policy for the requested segment type.
-	SegmentsToRegister(ctx context.Context, segType seg.Type) ([]beacon.Beacon, []beacon.RegistrationPolicy, error)
+	SegmentsToRegister(
+		ctx context.Context,
+		segType seg.Type,
+	) ([]beacon.Beacon, []beacon.RegistrationPolicy, error)
 	// InsertBeacon adds a verified beacon to the store, ignoring revocations.
 	InsertBeacon(ctx context.Context, beacon beacon.Beacon) (beacon.InsertStats, error)
 	// UpdatePolicy updates the policy. Beacons that are filtered by all


### PR DESCRIPTION
Instead of grouping the beacons when loading them from the database we only group them before we send them off to the registration plugins. This makes sure that the registration policy can use the "full" path including the ingress interface added in the extension.