### PR TITLE
private/app/flag: improve error handling when resolving SCION environment

### DIFF
--- a/demo/drkey/main.go
+++ b/demo/drkey/main.go
@@ -100,7 +100,12 @@ func realMain() int {
 		DstHost: clientAddr.Host.IP.String(),
 	}
 
-	daemon, err := daemon.NewAutoConnector(ctx, daemon.WithDaemon(scionEnv.Daemon()))
+	daemonAddr, err := scionEnv.Daemon()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error determining SCION Daemon address:", err)
+		return 2
+	}
+	daemon, err := daemon.NewAutoConnector(ctx, daemon.WithDaemon(daemonAddr))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error dialing SCION Daemon:", err)
 		return 1

--- a/private/app/flag/env.go
+++ b/private/app/flag/env.go
@@ -21,6 +21,7 @@ import (
 	"net/netip"
 	"os"
 	"runtime"
+	"slices"
 	"sync"
 
 	"github.com/spf13/pflag"
@@ -89,7 +90,7 @@ type SCIONEnvironment struct {
 	localFlag     *pflag.Flag
 	configDir     string
 	configDirFlag *pflag.Flag
-	file          env.SCION
+	file          *env.SCION
 	filepath      string
 
 	mtx sync.Mutex
@@ -179,7 +180,11 @@ func (e *SCIONEnvironment) LoadExternalVars() error {
 // from the environment file are not considered.
 func (e *SCIONEnvironment) loadFile() error {
 	if e.filepath == "" {
-		e.filepath = defaultEnvironmentFile
+		file := defaultEnvironmentFile
+		if f := os.Getenv("SCION_ENVIRONMENT_FILE"); f != "" {
+			file = f
+		}
+		e.filepath = file
 	}
 
 	raw, err := os.ReadFile(e.filepath)
@@ -190,9 +195,11 @@ func (e *SCIONEnvironment) loadFile() error {
 	if err != nil {
 		return serrors.Wrap("loading file", err)
 	}
-	if err := json.Unmarshal(raw, &e.file); err != nil {
+	var file env.SCION
+	if err := json.Unmarshal(raw, &file); err != nil {
 		return serrors.Wrap("parsing file", err)
 	}
+	e.file = &file
 	return nil
 }
 
@@ -220,31 +227,81 @@ func (e *SCIONEnvironment) loadEnv() error {
 // The value is loaded from one of the following sources with precedence:
 //  1. Command line flag (--sciond)
 //  2. Environment variable (SCION_DAEMON)
-//  3. Environment configuration file
+//  3. Environment configuration file with defaultIA or --isd-as flag
+//  4. Empty string (only if nothing is set).
 //
-// If none are set, returns empty string (not the default address).
-func (e *SCIONEnvironment) Daemon() string {
+// If no defaultIA is set but there is only one AS in the file, use that AS's daemon address.
+// If no defaultIA is set but there are multiple ASes in the file, return an error.
+// If --isd-as is set but the AS does not exist in the file, return an error.
+func (e *SCIONEnvironment) Daemon() (string, error) {
 	e.mtx.Lock()
 	defer e.mtx.Unlock()
 
-	if e.sciondFlag != nil && e.sciondFlag.Changed {
-		value := e.sciondFlag.Value.String()
-		if value == "default" {
+	resolveDefault := func(v string) string {
+		if v == "default" {
 			return defaultDaemon
 		}
-		return value
+		return v
 	}
+
+	// Priority 1: Command line flag
+	if e.sciondFlag != nil && e.sciondFlag.Changed {
+		return resolveDefault(e.sciondFlag.Value.String()), nil
+	}
+	// Priority 2: Environment variable
 	if e.sciondEnv != nil {
-		return *e.sciondEnv
+		return resolveDefault(*e.sciondEnv), nil
 	}
-	ia := e.file.General.DefaultIA
-	if e.iaFlag != nil && e.iaFlag.Changed {
-		ia = e.ia
+
+	// Priority 3: Environment configuration file
+	if e.file != nil {
+		// Collect the ASes that are present in the environment file.
+		ases := func() []addr.IA {
+			ases := make([]addr.IA, 0, len(e.file.ASes))
+			for ia := range e.file.ASes {
+				ases = append(ases, ia)
+			}
+			slices.Sort(ases)
+			return ases
+		}
+
+		// Take specific ISD-AS from flag or defaultIA, and look up the daemon for that AS.
+		var ia addr.IA
+		if e.iaFlag != nil && e.iaFlag.Changed {
+			ia = e.ia
+		} else if !e.file.General.DefaultIA.IsZero() {
+			ia = e.file.General.DefaultIA
+		}
+		if !ia.IsZero() {
+			if as, ok := e.file.ASes[ia]; ok {
+				return resolveDefault(as.DaemonAddress), nil
+			}
+			return "", serrors.New("isd-as not found in environment file",
+				"isd-as", ia, "file", e.filepath, "available", ases(),
+			)
+		}
+
+		// No defaultIA set, check how many ASes are in the file
+		switch len(e.file.ASes) {
+		case 0:
+			// No ASes in the file, so no daemon configured.
+			return "", nil
+		case 1:
+			for _, as := range e.file.ASes {
+				return resolveDefault(as.DaemonAddress), nil
+			}
+
+		default:
+			return "", serrors.New("multiple ASes in environment file but no default ISD-AS set",
+				"file", e.filepath,
+				"available", ases(),
+				"hint", "use --isd-as flag to select the local AS")
+		}
+
 	}
-	if as, ok := e.file.ASes[ia]; ok && as.DaemonAddress != "" {
-		return as.DaemonAddress
-	}
-	return ""
+
+	// Priority 4: No daemon configured
+	return "", nil
 }
 
 // Local returns the loca IP to listen on. The value is loaded from one of the

--- a/private/app/flag/env_test.go
+++ b/private/app/flag/env_test.go
@@ -26,17 +26,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/pkg/addr"
+	"github.com/scionproto/scion/pkg/daemon"
 	"github.com/scionproto/scion/private/app/env"
 	"github.com/scionproto/scion/private/app/flag"
 )
 
 func TestSCIONEnvironment(t *testing.T) {
-	setupFile := func(t *testing.T, envFlags *flag.SCIONEnvironment) {
-		f, err := os.CreateTemp(t.TempDir(), "env.json")
-		require.NoError(t, err)
-		fName := f.Name()
-		t.Cleanup(func() { os.Remove(fName) })
-		e := env.SCION{
+	defaultFile := func() env.SCION {
+		return env.SCION{
 			General: env.General{
 				DefaultIA: addr.MustParseIA("1-ff00:0:110"),
 			},
@@ -46,9 +43,17 @@ func TestSCIONEnvironment(t *testing.T) {
 				},
 			},
 		}
-		require.NoError(t, json.NewEncoder(f).Encode(e))
-		require.NoError(t, f.Close())
-		envFlags.SetFilePath(fName)
+	}
+	setupFile := func(e env.SCION) func(t *testing.T, envFlags *flag.SCIONEnvironment) {
+		return func(t *testing.T, envFlags *flag.SCIONEnvironment) {
+			f, err := os.CreateTemp(t.TempDir(), "env.json")
+			require.NoError(t, err)
+			fName := f.Name()
+			t.Cleanup(func() { os.Remove(fName) })
+			require.NoError(t, json.NewEncoder(f).Encode(e))
+			require.NoError(t, f.Close())
+			envFlags.SetFilePath(fName)
+		}
 	}
 	noFile := func(_ *testing.T, envFlags *flag.SCIONEnvironment) {
 		envFlags.SetFilePath("/non-existing")
@@ -75,6 +80,7 @@ func TestSCIONEnvironment(t *testing.T) {
 		daemon     string
 		dispatcher string
 		local      netip.Addr
+		daemonErr  bool
 	}{
 		"no flag, no file, no env, defaults only": {
 			flags:  noFlags,
@@ -100,23 +106,106 @@ func TestSCIONEnvironment(t *testing.T) {
 		"file values set": {
 			flags:  noFlags,
 			env:    noEnv,
-			file:   setupFile,
+			file:   setupFile(defaultFile()),
 			daemon: "scion_file:1234",
 			local:  netip.Addr{},
 		},
 		"all set, flag precedence": {
 			flags:  setupFlags,
 			env:    setupEnv,
-			file:   setupFile,
+			file:   setupFile(defaultFile()),
 			daemon: "scion:1234",
 			local:  netip.MustParseAddr("10.0.0.42"),
 		},
 		"env set, file set, env precedence": {
 			flags:  noFlags,
 			env:    setupEnv,
-			file:   setupFile,
+			file:   setupFile(defaultFile()),
 			daemon: "scion_env:1234",
 			local:  netip.MustParseAddr("10.0.42.0"),
+		},
+		"wrong --isd-as": {
+			flags: func(t *testing.T, fs *pflag.FlagSet) {
+				err := fs.Parse([]string{
+					"--isd-as", "1-ff00:0:999",
+				})
+				require.NoError(t, err)
+			},
+			file:      setupFile(defaultFile()),
+			env:       noEnv,
+			daemonErr: true,
+		},
+		"--isd-as for AS without daemon": {
+			flags: func(t *testing.T, fs *pflag.FlagSet) {
+				err := fs.Parse([]string{
+					"--isd-as", "1-ff00:0:120",
+				})
+				require.NoError(t, err)
+			},
+			file: setupFile(env.SCION{
+				ASes: map[addr.IA]env.AS{
+					addr.MustParseIA("1-ff00:0:120"): {
+						DaemonAddress: "",
+					},
+				},
+			}),
+			env: noEnv,
+		},
+		"--isd-as for AS with default daemon": {
+			flags: func(t *testing.T, fs *pflag.FlagSet) {
+				err := fs.Parse([]string{
+					"--isd-as", "1-ff00:0:120",
+				})
+				require.NoError(t, err)
+			},
+			file: setupFile(env.SCION{
+				ASes: map[addr.IA]env.AS{
+					addr.MustParseIA("1-ff00:0:120"): {
+						DaemonAddress: "default",
+					},
+				},
+			}),
+			env:    noEnv,
+			daemon: daemon.DefaultAPIAddress,
+		},
+		"wrong default ISD-AS": {
+			flags: noFlags,
+			file: setupFile(func() env.SCION {
+				e := defaultFile()
+				e.General.DefaultIA = addr.MustParseIA("1-ff00:0:999")
+				return e
+			}()),
+			env:       noEnv,
+			daemonErr: true,
+		},
+		"default ISD-AS for AS without daemon": {
+			flags: noFlags,
+			file: setupFile(env.SCION{
+				General: env.General{
+					DefaultIA: addr.MustParseIA("1-ff00:0:120"),
+				},
+				ASes: map[addr.IA]env.AS{
+					addr.MustParseIA("1-ff00:0:120"): {
+						DaemonAddress: "",
+					},
+				},
+			}),
+			env:       noEnv,
+			daemonErr: false,
+		}, "default ISD-AS for AS with default daemon": {
+			flags: noFlags,
+			file: setupFile(env.SCION{
+				General: env.General{
+					DefaultIA: addr.MustParseIA("1-ff00:0:120"),
+				},
+				ASes: map[addr.IA]env.AS{
+					addr.MustParseIA("1-ff00:0:120"): {
+						DaemonAddress: "default",
+					},
+				},
+			}),
+			env:    noEnv,
+			daemon: daemon.DefaultAPIAddress,
 		},
 	}
 	for name, tc := range testCases {
@@ -128,8 +217,115 @@ func TestSCIONEnvironment(t *testing.T) {
 			tc.env(t)
 			tc.file(t, &env)
 			require.NoError(t, env.LoadExternalVars())
-			assert.Equal(t, tc.daemon, env.Daemon())
+			daemonAddr, err := env.Daemon()
+			if tc.daemonErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.daemon, daemonAddr)
+			}
 			assert.Equal(t, tc.local, env.Local())
+		})
+	}
+}
+
+func TestSCIONEnvironmentMultipleASes(t *testing.T) {
+	setupFileSingleAS := func(t *testing.T, envFlags *flag.SCIONEnvironment) {
+		f, err := os.CreateTemp(t.TempDir(), "env.json")
+		require.NoError(t, err)
+		fName := f.Name()
+		t.Cleanup(func() { os.Remove(fName) })
+		e := env.SCION{
+			// No DefaultIA set
+			ASes: map[addr.IA]env.AS{
+				addr.MustParseIA("1-ff00:0:110"): {
+					DaemonAddress: "scion_single:1234",
+				},
+			},
+		}
+		require.NoError(t, json.NewEncoder(f).Encode(e))
+		require.NoError(t, f.Close())
+		envFlags.SetFilePath(fName)
+	}
+
+	setupFileMultipleASes := func(t *testing.T, envFlags *flag.SCIONEnvironment) {
+		f, err := os.CreateTemp(t.TempDir(), "env.json")
+		require.NoError(t, err)
+		fName := f.Name()
+		t.Cleanup(func() { os.Remove(fName) })
+		e := env.SCION{
+			// No DefaultIA set
+			ASes: map[addr.IA]env.AS{
+				addr.MustParseIA("1-ff00:0:110"): {
+					DaemonAddress: "scion_as1:1234",
+				},
+				addr.MustParseIA("1-ff00:0:120"): {
+					DaemonAddress: "scion_as2:1234",
+				},
+			},
+		}
+		require.NoError(t, json.NewEncoder(f).Encode(e))
+		require.NoError(t, f.Close())
+		envFlags.SetFilePath(fName)
+	}
+
+	setupFlagNonExistentAS := func(t *testing.T, fs *pflag.FlagSet) {
+		err := fs.Parse([]string{"--isd-as", "1-ff00:0:999"})
+		require.NoError(t, err)
+	}
+
+	setupFlagExistingAS := func(t *testing.T, fs *pflag.FlagSet) {
+		err := fs.Parse([]string{"--isd-as", "1-ff00:0:110"})
+		require.NoError(t, err)
+	}
+
+	noFlags := func(t *testing.T, fs *pflag.FlagSet) {
+		require.NoError(t, fs.Parse([]string{}))
+	}
+
+	testCases := map[string]struct {
+		flags     func(t *testing.T, fs *pflag.FlagSet)
+		file      func(t *testing.T, envFlags *flag.SCIONEnvironment)
+		daemon    string
+		daemonErr bool
+	}{
+		"single AS in file, no defaultIA": {
+			flags:  noFlags,
+			file:   setupFileSingleAS,
+			daemon: "scion_single:1234",
+		},
+		"multiple ASes in file, no defaultIA, error": {
+			flags:     noFlags,
+			file:      setupFileMultipleASes,
+			daemonErr: true,
+		},
+		"multiple ASes in file, --isd-as set to existing AS": {
+			flags:  setupFlagExistingAS,
+			file:   setupFileMultipleASes,
+			daemon: "scion_as1:1234",
+		},
+		"--isd-as set to non-existent AS, error": {
+			flags:     setupFlagNonExistentAS,
+			file:      setupFileMultipleASes,
+			daemonErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var env flag.SCIONEnvironment
+			fs := pflag.NewFlagSet("testSet", pflag.ContinueOnError)
+			env.Register(fs)
+			tc.flags(t, fs)
+			tc.file(t, &env)
+			require.NoError(t, env.LoadExternalVars())
+			daemonAddr, err := env.Daemon()
+			if tc.daemonErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.daemon, daemonAddr)
+			}
 		})
 	}
 }

--- a/scion-pki/certs/renew.go
+++ b/scion-pki/certs/renew.go
@@ -261,7 +261,10 @@ The template is expressed in JSON. A valid example::
 			if err := envFlags.LoadExternalVars(); err != nil {
 				return err
 			}
-			daemonAddr := envFlags.Daemon()
+			daemonAddr, err := envFlags.Daemon()
+			if err != nil {
+				return serrors.Wrap("determining SCION Daemon address", err)
+			}
 			localIP := net.IP(envFlags.Local().AsSlice())
 			log.Debug("Resolved SCION environment flags",
 				"daemon", daemonAddr,

--- a/scion/cmd/scion/address.go
+++ b/scion/cmd/scion/address.go
@@ -68,8 +68,12 @@ case, the host could have multiple SCION addresses.
 			span, traceCtx := tracing.CtxWith(context.Background(), "run")
 			defer span.Finish()
 
+			daemonAddr, err := envFlags.Daemon()
+			if err != nil {
+				return serrors.Wrap("determining SCION Daemon address", err)
+			}
 			sd, err := daemon.NewAutoConnector(traceCtx,
-				daemon.WithDaemon(envFlags.Daemon()),
+				daemon.WithDaemon(daemonAddr),
 				daemon.WithConfigDir(envFlags.ConfigDir()),
 			)
 			if err != nil {

--- a/scion/cmd/scion/ping.go
+++ b/scion/cmd/scion/ping.go
@@ -142,8 +142,12 @@ On other errors, ping will exit with code 2.
 			span.SetTag("dst.host", remote.Host.IP())
 			defer span.Finish()
 
+			daemonAddr, err := envFlags.Daemon()
+			if err != nil {
+				return serrors.Wrap("determining SCION Daemon address", err)
+			}
 			sd, err := daemon.NewAutoConnector(traceCtx,
-				daemon.WithDaemon(envFlags.Daemon()),
+				daemon.WithDaemon(daemonAddr),
 				daemon.WithConfigDir(envFlags.ConfigDir()),
 			)
 			if err != nil {

--- a/scion/cmd/scion/showpaths.go
+++ b/scion/cmd/scion/showpaths.go
@@ -109,8 +109,12 @@ On other errors, showpaths will exit with code 2.
 			ctx, cancel := context.WithTimeout(traceCtx, flags.timeout)
 			defer cancel()
 
+			daemonAddr, err := envFlags.Daemon()
+			if err != nil {
+				return serrors.Wrap("determining SCION Daemon address", err)
+			}
 			sd, err := daemon.NewAutoConnector(ctx,
-				daemon.WithDaemon(envFlags.Daemon()),
+				daemon.WithDaemon(daemonAddr),
 				daemon.WithConfigDir(envFlags.ConfigDir()),
 			)
 			if err != nil {

--- a/scion/cmd/scion/traceroute.go
+++ b/scion/cmd/scion/traceroute.go
@@ -115,8 +115,12 @@ On other errors, traceroute will exit with code 2.
 			span.SetTag("dst.host", remote.Host.IP())
 			defer span.Finish()
 
+			daemonAddr, err := envFlags.Daemon()
+			if err != nil {
+				return serrors.Wrap("determining SCION Daemon address", err)
+			}
 			sd, err := daemon.NewAutoConnector(traceCtx,
-				daemon.WithDaemon(envFlags.Daemon()),
+				daemon.WithDaemon(daemonAddr),
 				daemon.WithConfigDir(envFlags.ConfigDir()),
 			)
 			if err != nil {


### PR DESCRIPTION
Previously, we would fall back to returning the default SCION daemon address, even if the user provided obviously wrong values. E.g., no --isd-as flag set, but multiple ASes in the environment file without a default.

We are a bit more strict and now only return the default if no user input is given.