### PR TITLE
doc: core peering

### DIFF
--- a/doc/beacon-metadata.rst
+++ b/doc/beacon-metadata.rst
@@ -75,6 +75,9 @@ to form end-to-end paths:
    dashed orange lines represent core beacons exchanged over core links
    (labeled "c"). All created forwarding paths in cases 1a-1e traverse the ISD
    core(s), whereas the paths in cases 2-4 do not enter the ISD core.
+   Note that peering links from/to a core AS are only allowed if that AS is part
+   of an UP or DOWN segment. CORE segments do not come with peering metadata,
+   see :doc:`metadata <control-plane>`.
 
 Representation in StaticInfoExtension
 -------------------------------------
@@ -89,7 +92,8 @@ Each ``ASEntry`` includes information about:
 - the intra-AS hop between egress and any (other) ``CORE``-link interface,
   for up-core or core-down segment cross-over
 - the intra-AS hop between egress and any ``PEER``-link interface, and
-  the inter-AS hop at any ``PEER``-interface
+  the inter-AS hop at any ``PEER``-interface. Note that core segment do not contain
+  any peering information.
 
 .. list-table:: Illustration of the information included in the individual ``ASEntry``\s in path segments and how this information is used in path segment combinations. The black circles represent ASes, the shaded circles are core ASes. Solid black lines connecting the ASes represent parent-child or core links, the dashed black line is a peering link. Each color represents an ``ASEntry``. Entries in the up segments are **blue**, core segments are **red** and down segments **green**. Dotted lines represent information about links that is included in the PCBs, but not used in this path segment combination.
 

--- a/doc/control-plane.rst
+++ b/doc/control-plane.rst
@@ -312,7 +312,7 @@ shortcuts are only allowed (and announced) between ASes that are on up- segment 
 This trivially allows peering shortcuts between non-core ASes and ASes.
 
 Whenever an AS is queried for up- or down-segments that terminate in that same AS,
-and if the AS has any peering links, it will return a "zero"-hop segment that contains only
+and if the AS has any peering links, it will return a single-AS segment that contains only
 the AS itself and its peering links.
 
 

--- a/doc/control-plane.rst
+++ b/doc/control-plane.rst
@@ -171,7 +171,7 @@ Peering Links
 
 PCBs do not traverse peering links.
 Instead, available peering links are announced along with a regular path in the individual AS
-entries of PCBs during *intra-AS* beaconing. Peering links are not announced in *inter-AS* beaconing.
+entries of PCBs during *intra-ISD* beaconing. Peering links are not announced in *inter-ISD* beaconing.
 If both ASes at either end of a peering link have registered path segments that include a specific
 peering link, then it can be used to during segment combination to create an end-to-end path.
 

--- a/doc/control-plane.rst
+++ b/doc/control-plane.rst
@@ -171,7 +171,7 @@ Peering Links
 
 PCBs do not traverse peering links.
 Instead, available peering links are announced along with a regular path in the individual AS
-entries of PCBs.
+entries of PCBs during *intra-AS* beaconing. Peering links are not announced in *inter-AS* beaconing.
 If both ASes at either end of a peering link have registered path segments that include a specific
 peering link, then it can be used to during segment combination to create an end-to-end path.
 
@@ -195,7 +195,7 @@ core AS that originated the PCB.
 Intra-ISD Path-Segment Registration
 -----------------------------------
 
-Every *registration period* (determined by each AS), the AS's control service selects of
+Every *registration period* (determined by each AS), the AS's control service selects
 PCBs to transform into path segments:
 
 - Up-segments, which allow the infrastructure entities and endpoints in this AS to communicate with
@@ -206,6 +206,9 @@ PCBs to transform into path segments:
   core AS that originated the PCB.
   As a result, a core AS's path database contains all down-segments registered by their
   direct or indirect customer ASes.
+
+In addition, if the AS is a core AS and if peering links are present, the control service adds
+an UP and a DOWN segment that contains only the AS itself along with all peering link metadata.
 
 Core Path-Segment Registration
 ------------------------------
@@ -225,13 +228,13 @@ Path Lookup
 An endpoint (source) that wants to start communication with another endpoint (destination), needs
 up to three path segments:
 
-- An up-path segment to reach the core of the source ISD
+- An up-path segment to reach the core of the source ISD or to get peering metadata for the core AS,
 - a core-path segment to reach
 
   - another core AS in the source ISD, in case the destination AS is in the same source ISD, or
   - a core AS in a remote ISD, if the destination AS is in another ISD, and
 
-- a down-path segment to reach the destination AS.
+- a down-path segment to reach the destination AS or to get peering metadata for the core AS.
 
 The process to look up and fetch path segments consists of the following steps:
 
@@ -296,6 +299,42 @@ end-to-end paths are encoded in the packet header.
    (labeled "c"). All created forwarding paths in cases 1a-1e traverse the ISD
    core(s), whereas the paths in cases 2-4 do not enter the ISD core.
 
+Peering Links in Core ASes
+--------------------------
+
+This section distinguished peering links and peering shortcuts:
+
+- Peering link: A physical link between two ASes.
+- Peering shortcut: A peering link that is used when constructing a full path.
+
+All ASes may have physical peering links. However, for segment combinations, peering
+shortcuts are only allowed (and announced) between ASes that are on UP segment or DOWN segments.
+This trivially allows peering shortcuts between non-core ASes and ASes.
+
+Peering shortcuts However, for segment combination,
+peering links with core ASes can only be used *indirectly* and only for the first and last AS in a core segment.
+Indirect means:
+
+- Any core AS that has peering links returns, when queried for an UP or DOWN segment,
+  a "zero"-hop segment that contains only itself and its peering links.
+- Client must always query for UP and DOWN links, even when they are located in a core AS.
+
+As a result, if the core ASes have peering links, any client will have at least one UP and one DOWN
+segment (even if source and destination AS are core ASes).
+These UP and DOWN segments, or any other UP or DOWN segments if they are available, can be used to
+create a peering shortcut.
+
+FAQ: Why do core segments not contain peering metadata?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+AS may use peering link instead of a public link if they
+does not want the link to be used for traffic that transits the ISD.
+The peering link allows usage to be limited to traffic that starts or ends in the local AS or one of its child ASes.
+If peering links were announced withe core segment metadata, they could be used on
+core segments that *transit* the local AS.
+
+Links
+=====
 
 .. seealso::
 

--- a/doc/control-plane.rst
+++ b/doc/control-plane.rst
@@ -308,23 +308,27 @@ This section distinguished peering links and peering shortcuts:
 - Peering shortcut: A peering link that is used when constructing a full path.
 
 All ASes may have physical peering links. However, for segment combinations, peering
-shortcuts are only allowed (and announced) between ASes that are on up- segment or down-segments.
-This trivially allows peering shortcuts between non-core ASes and ASes.
+shortcuts are only allowed (and announced) between ASes that are on up- or down-segments.
 
-Whenever an AS is queried for up- or down-segments that terminate in that same AS,
-and if the AS has any peering links, it will return a single-AS segment that contains only
-the AS itself and its peering links.
+Any core AS with peering links will also create one "single-AS" segment that contains only the AS itself
+and its peering links.
+When an AS is queried for up- or down-segments that terminate in itself (in the AS that is queried),
+and if the AS has any peering links, it will return this "single-AS" segment along
+with the the normal segments that result from beaconing.
 
-
-This ensures that, if the core ASes have peering links, any client will have at least one up- and one
-down-segment (even if source and destination AS are core ASes).
-The peering metadata from these single-AS up/down-segments, or any other up- or down-segments
-if they are available, can be used to create peering shortcuts.
+In cases where a path would normally begin or end with a core-segment, a client would not be able
+to construct peering shortcuts because core-segment don't contain peering information.
+However, with these additional single-AS segments, a client will always have up- and down-segments
+with peering information, so a client can always construct peering shortcuts if peering links are available.
 
 FAQ: Why do core segments not contain peering metadata?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Peering links enable two ASes to route traffic between each other and their respective downstream ASes while restricting global transit. Embedding this peering data within a core segment, which inherently facilitates transit, would directly contradict the non-transit nature of peering.
+Peering links enable two ASes to route traffic between each other and their
+respective downstream ASes while restricting global transit.
+Embedding this peering data within a core segment, which inherently facilitates
+transit, would directly contradict the non-transit nature of peering.
+
 
 Links
 =====

--- a/doc/control-plane.rst
+++ b/doc/control-plane.rst
@@ -318,7 +318,7 @@ the AS itself and its peering links.
 
 This ensures that, if the core ASes have peering links, any client will have at least one up- and one
 down-segment (even if source and destination AS are core ASes).
-The peering metadata from these zero-hop-up/down-segments, or any other up- or down-segments
+The peering metadata from these single-AS up/down-segments, or any other up- or down-segments
 if they are available, can be used to create peering shortcuts.
 
 FAQ: Why do core segments not contain peering metadata?

--- a/doc/control-plane.rst
+++ b/doc/control-plane.rst
@@ -324,11 +324,7 @@ if they are available, can be used to create peering shortcuts.
 FAQ: Why do core segments not contain peering metadata?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-AS may use peering link instead of a public link if they
-does not want the link to be used for traffic that transits the ISD.
-The peering link allows usage to be limited to traffic that starts or ends in the local AS or one of its child ASes.
-If peering links were announced withe core segment metadata, they could be used on
-core segments that *transit* the local AS.
+Peering links enable two ASes to route traffic between each other and their respective downstream ASes while restricting global transit. Embedding this peering data within a core segment, which inherently facilitates transit, would directly contradict the non-transit nature of peering.
 
 Links
 =====

--- a/doc/control-plane.rst
+++ b/doc/control-plane.rst
@@ -208,7 +208,7 @@ PCBs to transform into path segments:
   direct or indirect customer ASes.
 
 In addition, if the AS is a core AS and if peering links are present, the control service adds
-an UP and a DOWN segment that contains only the AS itself along with all peering link metadata.
+an up- and a down-segment that contains only the AS itself along with all peering link metadata.
 
 Core Path-Segment Registration
 ------------------------------
@@ -308,21 +308,18 @@ This section distinguished peering links and peering shortcuts:
 - Peering shortcut: A peering link that is used when constructing a full path.
 
 All ASes may have physical peering links. However, for segment combinations, peering
-shortcuts are only allowed (and announced) between ASes that are on UP segment or DOWN segments.
+shortcuts are only allowed (and announced) between ASes that are on up- segment or down-segments.
 This trivially allows peering shortcuts between non-core ASes and ASes.
 
-Peering shortcuts However, for segment combination,
-peering links with core ASes can only be used *indirectly* and only for the first and last AS in a core segment.
-Indirect means:
+Whenever an AS is queried for up- or down-segments that terminate in that same AS,
+and if the AS has any peering links, it will return a "zero"-hop segment that contains only
+the AS itself and its peering links.
 
-- Any core AS that has peering links returns, when queried for an UP or DOWN segment,
-  a "zero"-hop segment that contains only itself and its peering links.
-- Client must always query for UP and DOWN links, even when they are located in a core AS.
 
-As a result, if the core ASes have peering links, any client will have at least one UP and one DOWN
-segment (even if source and destination AS are core ASes).
-These UP and DOWN segments, or any other UP or DOWN segments if they are available, can be used to
-create a peering shortcut.
+This ensures that, if the core ASes have peering links, any client will have at least one up- and one
+down-segment (even if source and destination AS are core ASes).
+The peering metadata from these zero-hop-up/down-segments, or any other up- or down-segments
+if they are available, can be used to create peering shortcuts.
 
 FAQ: Why do core segments not contain peering metadata?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR proposes documentation that describes how peering shortcuts with core ASes work. See also: #4909

This PR does not add any diagrams. New/additional diagrams may be useful, in that case I would ask for access to the originals of the existing diagrams. It could generally be useful if diagram sources would be added to the repository.