### PR TITLE
docs: cryptography fix, refactor and refer to draft

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@ import os
 # -- Project information -----------------------------------------------------
 
 project = "SCION"
-copyright = "2025, Anapaya Systems, ETH Zurich, SCION Association"
+copyright = "2026, Anapaya Systems, ETH Zurich, SCION Association"
 author = "Anapaya Systems, ETH Zurich, SCION Association"
 
 

--- a/doc/cryptography/ca-operations.rst
+++ b/doc/cryptography/ca-operations.rst
@@ -8,9 +8,13 @@ Once a new ISD is established through the completion of a key signing ceremony,
 certificates can be generated for the Certificate Authorities and ASes of
 the ISD.
 
-Trust within an ISD flows from the TRC. The TRC contains one or more Root Certificates,
-which are used to sign new CA Certificates, which are in turn used to sign one or more AS
-Certificates.
+Trust within an ISD flows from the TRC: the Root Certificates it contains are used
+to sign CA Certificates, which are in turn used to sign AS Certificates. For the
+architectural procedure of issuing AS certificates, see `Issuing Control Plane AS
+Certificates
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-issuing-control-plane-as-ce>`_
+in the SCION PKI draft. The steps below walk through running a manual CA for
+testing.
 
 The process of creating new CA Certificates is described in section `CA Certificates`_.
 The process of creating new AS Certificates is described in section `AS Certificates`_.

--- a/doc/cryptography/certificates.rst
+++ b/doc/cryptography/certificates.rst
@@ -52,20 +52,6 @@ This implementation supports all three mandatory algorithms - *ECDSA* with the c
 - NIST P-384
 - NIST P-521
 
-Issuer and Subject
-------------------
-
-The ``issuer`` field contains the distinguished name (DN) of the CA that created
-the certificate and the ``subject`` field contains the DN of the entity that owns
-it. Both are defined the same way (the ``Name`` syntax is defined in [X501]_)
-and MUST be non-empty. The DN is built from standard attributes plus the
-SCION-specific *ISD-AS number* attribute (``id-at-ia``), which MUST be present
-exactly once and uses the canonical ISD-AS string formatting (e.g.
-``1-ff00:0:110``). The attribute set, the ``id-at-ia`` OID and the canonical
-formatting are specified in the `Issuer
-<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-issuer>`_
-section of the SCION PKI draft.
-
 Extensions
 ----------
 

--- a/doc/cryptography/certificates.rst
+++ b/doc/cryptography/certificates.rst
@@ -4,565 +4,121 @@ Certificate Specification
 
 .. highlight:: text
 
-This document contains the specification for **Control Plane (CP) Root
-Certificates**, **CP CA Certificates** and **CP AS Certificates**.
+SCION uses three types of X.509 v3 **Control Plane (CP) certificates** that build
+on top of [RFC5280]_ (which in turn builds on [X509]_), adding more restrictive
+SCION-specific constraints:
 
-The *SCION Certificate Specification* builds on top of [RFC5280]_, which in turn
-builds on top of [X509]_. The SCION specification is a more restrictive set of
-[RFC5280]_, which means that [RFC5280]_ compliant implementations can be adapted
-to implement this specification by including the additional checks.
+- **CP Root Certificate** — a self-signed CA certificate, owned by a CA AS and
+  embedded in a TRC, that signals which ASes may act as certificate authorities in
+  an ISD.
+- **CP CA Certificate** — used by a CA AS to sign CP AS certificates.
+- **CP AS Certificate** — the end-entity certificate an AS uses to sign
+  control-plane messages.
 
-For each SCION CP certificate, this document defines the additional constraints
-when compared to [RFC5280]_. When something is marked as optional, it also
-includes how the Anapaya implementation behaves.
+The full normative specification — certificate fields, per-type profiles,
+extensions and the ASN.1 syntax — is defined in the `SCION PKI draft
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html>`_.
 
-Note that this document uses the new X.509-style SCION terminology (as opposed
-to the previous JSON SCION terminology). The following entities are used in this
-document:
-
-- **CP Root Key**. This is the previous **Issuing key**/**Issuing grant key**.
-  It is embedded in TRCs (via a certificate) to signal that an AS can act as a
-  certificate authority in the ISD (a CA AS).
-- **CP Root Certificate**. This is the container for the public key associated
-  with the **CP Root Key**.
-- **CP CA Key**. This is the previous **Issuing key**. It is used by CA ASes to
-  sign AS certificates.
-- **CP CA Certificate**. This is the container for the public key associated
-  with the **CP AS Key**.
-- **CP AS Key**. This is the previous **Signing key**. It is used by an AS to
-  sign control-plane messages.
-- **CP AS Certificate**. This is the container for the public key associated
-  with the **CP AS Key**.
-
-This documents assumes a trusted set of **CP Root Certificates** already exists.
-How such a set is selected is outside the scope of this document, and described
-in the *TRC Specification*.
-
-This document uses the Anapaya IANA Private Enterprise Number (55324) as root
-SCION OIDs:
-
-.. code-block:: text
-
-    id-ana ::= OBJECT IDENTIFIER {1 3 6 1 4 1 55324}
+This document assumes a trusted set of **CP Root Certificates** already exists.
+How such a set is selected is described in the :doc:`TRC Specification <trc>`.
 
 .. _general-certificate-requirements:
 
 General certificate requirements
 ================================
 
-SCION CP certificates are X.509 v3 certificates. Every certificate has a
-**subject** (the entity that owns the certificate) and a **issuer** (the entity
-that issued the certificate, usually a CA). Like in Internet PKI, in SCION
-sometimes both the **subject** and the **issuer** can be the same entity.
+SCION CP certificates are X.509 v3 certificates (the ``version`` field is always
+``v3``, since ``extensions`` are mandatory). Every certificate has a ``subject``
+and an ``issuer``, which are the same entity for self-signed and self-issued
+certificates. The detailed requirements for the ``version``, ``serialNumber``,
+``signature``, ``issuer``, ``validity``, ``subject``, ``subjectPublicKeyInfo`` and
+``extensions`` fields — including which [RFC5280]_/[X509]_ options are forbidden
+or constrained in SCION — are given in `X.509 Certificate Profiles and Constraints
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-x509-certificate-profiles-a>`_.
 
-The listing below shows the generic format of SCION CP certificates. For
-information regarding the full format, please see [X509]_, clause 7.2.
-
-.. code-block:: text
-
-    TBSCertificate ::= SEQUENCE {
-        version               [0]   EXPLICIT Version DEFAULT v1,
-        serialNumber                CertificateSerialNumber,
-        signature                   AlgorithmIdentifier{{SupportedAlgorithms}},
-        issuer                      Name,
-        validity                    Validity,
-        subject                     Name,
-        subjectPublicKeyInfo        SubjectPublicKeyInfo,
-        issuerUniqueID        [1]   IMPLICIT UniqueIdentifier OPTIONAL, -- disallowed in SCION
-        subjectUniqueID       [2]   IMPLICIT UniqueIdentifier OPTIONAL, -- disallowed in SCION
-        extensions            [3]   EXPLICIT Extensions OPTIONAL
-    }
-
-    Version ::= INTEGER { v1(0), v2(1), v3(2)}  -- v1, v2 disallowed in SCION
-    CertificateSerialNumber ::= INTEGER
-
-    Validity ::= SEQUENCE {
-        notBefore Time,
-        notAfter Time
-    }
-
-    Time ::= CHOICE {
-        utcTime UTCTime,
-        generalizedTime GeneralizedTime
-    }
-
-    SubjectPublicKeyInfo ::= SEQUENCE {
-        algorithm         AlgorithmIdentifier{{SupportedAlgorithms}},
-        subjectPublicKey  BIT STRING
-    }
-
-    Extensions ::= SEQUENCE SIZE (1..MAX) OF Extension
-
-    Extension ::= SEQUENCE {
-        extnId      OBJECT IDENTIFIER,
-        critical    BOOLEAN DEFAULT FALSE,
-        extnValue   OCTET STRING
-                        -- contains DER encoding of ASN.1 value
-                        -- corresponding to type identified by extnID
-    }
-
-Version
--------
-
-The ``version`` field is always ``v3`` in SCION; this is required because
-``extensions`` are mandatory.
-
-**Deprecation warning**: note that the X.509 ``version`` field has different
-semantics compared to the old SCION JSON format for certificates (where version
-was an incrementing counter).
-
-Serial number
--------------
-
-The ``serialNumber`` is used like in [RFC5280]_.
+One SCION-specific constraint: all certificates MUST have a
+well-defined expiration date. Certificates that use the ``99991231235959Z``
+GeneralizedTime value to indicate no well-defined expiration are not valid.
 
 .. _certificate-signature:
 
 Signature
 ---------
 
-For security reasons, SCION uses a custom list of acceptable algorithms. The
-list currently contains only the *ECDSA* signature algorithm (defined in
-[X962]_).
+For security reasons, SCION uses a custom list of acceptable algorithms. The list
+currently contains only the *ECDSA* signature algorithm (defined in [X962]_). The
+only accepted curves are NIST P-256, P-384 and P-521 (named ``secp256r1``,
+``secp384r1`` and ``secp521r1`` in [RFC5480]_; see also [NISTFIPS186-4]_), used
+with SHA-256, SHA-384 and SHA-512 respectively (the ECDSA OIDs are defined in
+[RFC5758]_). Implementations MUST include support for P-256, P-384 and P-521, and
+**MUST reject cryptographic algorithms not found on the list.**
 
-The OIDs for *ECDSA* are defined as ``ecdsa-with-SHA256``,
-``ecdsa-with-SHA384``, and ``ecdsa-with-SHA512`` in [RFC5758]_. We include them
-here::
-
-    sigAlg-ecdsa-SHA256      ALGORITHM         ::= { OID ecdsa-with-SHA256 }
-    sigAlg-ecdsa-SHA384      ALGORITHM         ::= { OID ecdsa-with-SHA384 }
-    sigAlg-ecdsa-SHA512      ALGORITHM         ::= { OID ecdsa-with-SHA512 }
-
-    ecdsa-with-SHA256 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
-        us(840) ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 2 }
-    ecdsa-with-SHA384 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
-        us(840) ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 3 }
-    ecdsa-with-SHA512 OBJECT IDENTIFIER ::= { iso(1) member-body(2)
-        us(840) ansi-X9-62(10045) signatures(4) ecdsa-with-SHA2(3) 4 }
-
-The only accepted curves for *ECDSA* are:
-
-- NIST P-256 ([NISTFIPS186-4]_, section D.1.2.3) (named ``secp256r1`` in [RFC5480]_)
-- NIST P-384 ([NISTFIPS186-4]_, section D.1.2.4) (named ``secp384r1`` in [RFC5480]_)
-- NIST P-521 ([NISTFIPS186-4]_, section D.1.2.5) (named ``secp521r1`` in [RFC5480]_)
-
-The OIDs for the above curves are::
-
-    secp256r1 OBJECT IDENTIFIER ::= {
-       iso(1) member-body(2) us(840) ansi-X9-62(10045) curves(3)
-       prime(1) 7 }
-    secp384r1 OBJECT IDENTIFIER ::= {
-       iso(1) identified-organization(3) certicom(132) curve(0) 34 }
-    secp521r1 OBJECT IDENTIFIER ::= {
-       iso(1) identified-organization(3) certicom(132) curve(0) 35 }
-
-If an ECDSA key is used to produce a signature, the appropriate hash size should
-be used:
-
-- If the signing key is P-256, the signature should use ECDSA with with SHA-256
-- If the signing key is P-384, the signature should use ECDSA with with SHA-384
-- If the signing key is P-521, the signature should use ECDSA with with SHA-512
-
-
-Implementations MUST include support for P-256, P-384, and P-521.
-
-Note that the list might be extended in the future. SCION implementations must
-reject cryptographic algorithms not found on the list. This document currently
-serves as the list of accepted cryptographic algorithms.
-
-For convenience, the ``AlgorithmIdentifier`` definition is included below:
-
-.. code-block:: text
-
-   AlgorithmIdentifier  ::=  SEQUENCE  {
-       algorithm   OBJECT IDENTIFIER,
-       parameters  ANY DEFINED BY algorithm OPTIONAL
-   }
-
-As defined in [RFC8410]_, the ``parameters`` field must be absent. If the
-``AlgorithmIdentifier`` is not the above, SCION implementations must error out.
-
-.. _issuer:
+The signature-algorithm OIDs, curve OIDs and ``AlgorithmIdentifier`` ASN.1 are
+listed in the `Signature field
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-signature>`_
+section and `Appendix A
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-certificate-extensions-in-a>`_
+of the SCION PKI draft.
 
 Issuer
 ------
 
-``issuer`` contains the distinguished name (DN) of the CA that created the
-certificate. The ``issuer`` field must be non-empty.
-
-The syntax for ``Name`` is defined in [X501]_ (10/2016), clause 9.2. For
-reference, it is:
-
-.. code-block:: text
-
-    Name ::= CHOICE {
-        rdnSequence RDNSequence
-    }
-
-    RDNSequence ::= SEQUENCE OF RelativeDistinguishedName
-
-    RelativeDistinguishedName ::= SET SIZE (1..MAX) OF AttributeTypeAndValue
-
-    AttributeType ::= OBJECT IDENTIFIER
-
-    AttributeValue ::= ANY -- DEFINED BY AttributeType
-
-Generally, the type will be a ``DirectoryString`` type, outlined below:
-
-.. code-block:: text
-
-    DirectoryString ::= CHOICE {
-        teletexStrings TeletexString (SIZE (1..MAX)),
-        printableString PrintableString (SIZE (1..MAX)),
-        universalString UniversalString (SIZE (1..MAX)),
-        utf8String UTF8String (SIZE (1..MAX)),
-        bmpString BMPString (SIZE (1..MAX)),
-    }
-
-SCION implementation must support the following standard attribute types:
-
-- country
-- organization
-- organizational unit
-- distinguished name qualifier
-- state or province name
-- common name
-- serial number
-- ISD-AS number
-
-Other than ``ISD-AS number``, all the above attributes are defined in [RFC5280]_
-as an added restriction when compared to the RFC, SCION implementations must use
-the ``UTF8String`` value type.
-
-The *ISD-AS number* attribute is used to identify the SCION ISD and AS. The
-attribute type is ``id-at-ia``, defined as:
-
-.. code-block:: text
-
-    id-at-ia AttributeType ::= {id-ana id-cppki(1) id-at(2) 1}
-
-The type of the attribute value for the *ISD-AS number* is a ``UTF8String``.
-
-The string representation MUST follow the canonical formatting defined in `ISD
-and AS numbering
-<https://github.com/scionproto/scion/wiki/ISD-and-AS-numbering>`_.
-
-The canonical string representation of the *ISD-AS number* uses a ``-``-separator
-between the ISD and AS numbers.
-
-The ISD numbers are formatted as decimal.
-
-The canonical string formatting of AS numbers in the BGP AS range (
-:math:`0 - 2^{32}-1`) is the decimal form.
-For larger AS numbers, it uses a 16-bit ``:``-separated lower-case hex encoding
-with leading 0's omitted: 1:0:0 to ffff:ffff:ffff.
-
-For example, AS ``ff00:0:110`` in ISD ``1`` is formatted as ``1-ff00:0:110``.
-
-The *ISD-AS number* must be present exactly once in all SCION CP certificates.
-Implementations must not create nor successfully verify certificates that do not
-include the *ISD-AS number*, or include it more than once.
-
-SCION implementations may support other attributes.
-
-Validity
---------
-
-The ``validity`` field is defined as in [RFC5280]_, Section 4.1.2.5.
-
-In addition to the definition, the following constraints apply to SCION CP
-certificates:
-
-- All certificates must have a well-defined expiration date. SCION CP certificates
-  that specify that they do not have a well-defined expiration date (by using
-  the 99991231235959Z Generalized Time value) are not valid. SCION
-  implementations must not create such certificates, and verifiers must error
-  out when encountering such a certificate.
-- The validity period of a certificate (defined as the duration between
-  ``notBefore`` and ``notAfter``) must be under a specific value. The exact value is
-  listed in the sections detailing each certificate type.
-
-Subject
--------
-
-The ``subject`` field describes the entity that owns the certificate. It is
-defined in the same way as the ``issuer`` field (see :ref:`issuer`). All SCION
-CP certificates MUST have the ``subject`` field defined (with the same
-requirements as the ``issuer`` field).
-
-Subject public key info
------------------------
-
-Field ``subjectPublicKeyInfo`` is used to carry the public key of the subject
-and identify which algorithm should be used with the key. The SCION constraints
-in section :ref:`certificate-signature` still apply: the key must be a valid key
-for the selected curve, and the algorithm must be ``sigAlg-ecdsa``.
+The ``issuer`` (and ``subject``) field carries a distinguished name built from
+standard X.500 attributes plus the SCION-specific *ISD-AS number* attribute
+(``id-at-ia``). The *ISD-AS number* MUST be present exactly once and uses the
+canonical ISD-AS string formatting (e.g. ``1-ff00:0:110``). The attribute set, the
+``id-at-ia`` OID and the canonical formatting are specified in the `Issuer
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-issuer>`_
+section of the SCION PKI draft.
 
 Extensions
 ----------
 
-This section includes only extensions that SCION relies on. For each extension,
-the way the Anapaya implementation deals with the extension is also listed.
-
-Anapaya software does not implement extensions other than those listed in this
-document.
-
-Authority key identifier extension
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This extension is defined [X509]_, clause 9.2.2.1.
-
-The authority key identifier extension is used to determine which public key was
-used to sign the certificate.
-
-.. code-block:: text
-
-    authorityKeyIdentifier EXTENSION ::= {
-        SYNTAX AuthorityKeyIdentifier
-        IDENTIFIED BY id-ce-authorityKeyIdentifier
-    }
-
-    AuthorityKeyIdentifier ::= SEQUENCE {
-        keyIdentifier             [0]   KeyIdentifier OPTIONAL,
-        authorityCertIssuer       [1]   GeneralNames OPTIONAL,
-        authorityCertSerialNumber [2]   CertificateSerialNumber OPTIONAL,
-        ...
-    }
-    (WITH COMPONENTS {..., authorityCertIssuer PRESENT,
-                            authorityCertSerialNumber PRESENT } |
-    WITH COMPONENTS {..., authorityCertIssuer ABSENT,
-                            authorityCertSerialNumber ABSENT } )
-
-    KeyIdentifier ::= OCTET STRING
-
-SCION implementations may implement support for ``authorityCertIssuer`` and
-``authorityCertSerialNumber``, but ``keyIdentifier`` is the preferred way of
-using the extension. If ``authorityCertIssuer`` or ``authorityCertSerialNumber``
-are set and support for them is missing, implementations should error out.
-
-**Anapaya implementation**. The current Anapaya implementation supports this
-extension (required by [RFC5280]_).
-
-This extension must always be non-critical. However, SCION implementations must
-error out if it is not present and the certificate is not self-signed.
-
-.. _subject-key-identifier-extension:
-
-Subject key identifier extension
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This extension is defined in [X509]_ (10/2016), clause 9.2.2.2.
-
-The subject key identifier extension identifies the public key being certified.
-It allows for overlapping CP CA keys, for example during updates.
-
-.. code-block:: text
-
-    subjectKeyIdentifier EXTENSION ::= {
-        SYNTAX SubjectKeyIdentifier
-        IDENTIFIED BY id-ce-subjectKeyIdentifier
-    }
-
-    SubjectKeyIdentifier ::= KeyIdentifier
-
-**Anapaya implementation**. The current Anapaya implementation supports this
-extension (this can be used by control-plane messages to identify which
-certificate to use for verification).
-
-This extension must always be non-critical. However, SCION implementations must
-error out if it is not present.
-
-Key usage extension
-^^^^^^^^^^^^^^^^^^^
-
-This extension is defined in [X509]_ (10/2016), clause 9.2.2.3.
-
-The key usage extension dictates how the public key within a certificate may be
-used. The ASN.1 definition is as follows:
-
-.. code-block:: text
-
-    keyUsage EXTENSION ::= {
-        SYNTAX KeyUsage
-        IDENTIFIED BY id-ce-keyUsage
-    }
-
-    KeyUsage ::= BIT STRING {
-        digitalSignature  (0),
-        contentCommitment (1),
-        keyEncipherment   (2),
-        dataEncipherment  (3),
-        keyAgreement      (4),
-        keyCertSign       (5),
-        cRLSign           (6),
-        encipherOnly      (7),
-        decipherOnly      (8),
-    }
-
-Each key usage attribute has the following semantics in SCION:
-
-- ``digitalSignature``: the key can be used to sign control-plane payloads
-- ``contentCommitment``: not used
-- ``keyEncipherment``: not used
-- ``dataEncipherment``: not used
-- ``keyAgreement``: not used
-- ``keyCertSign``: the key can be used to sign certificates
-- ``cRLSign``: not used
-- ``encipherOnly``: not used
-- ``decipherOnly``: not used
-
-Note that whenever a certificate is used for ``digitalSignature``, there needs to
-be a way to go back from the signature to the certificate/key that signed it.
-This can be easily done by referencing the ISD-AS and Subject Key Identifier.
-For more information about the latter, see :ref:`subject-key-identifier-extension`.
-
-Each control-plane certificate type has different key usage attributes. These
-are listed in the certificate descriptions below.
-
-When this extension is present, it should be marked as critical.
-
-Extended key usage extension
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This extension is defined in [X509]_, clause 9.2.2.4.
-
-The extended key usage extension adds one or more purposes for which the
-certified public key may be used.
-
-It is defined as follows:
-
-.. code-block:: text
-
-    extKeyUsage EXTENSION ::= {
-        SYNTAX             SEQUENCE SIZE (1..MAX) OF KeyPurposeId
-        IDENTIFIED BY      id-ce-extKeyUsage
-    }
-
-    KeyPurposeId ::= OBJECT IDENTIFIER
-
-This extension may be present in SCION certificates. Note that certain CP interactions
-require it (see the certificate-specific sections below for details).
-
-The following extended key usage defined by [RFC5280]_, Section 4.2.1.12, are used by
-SCION:
-
-- ``id-kp-serverAuth``: means that the key can be used for SCION CP server authentication
-- ``id-kp-clientAuth``: means that the key can be used for SCION CP client authentication
-
-Each control-plane certificate type has different extended key usage attributes. These are
-listed in the certificate descriptions below.
-
-Basic constraints extension
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This extension is defined in [X509]_,  clause 9.4.2.1.
-
-The basic constraints extension specifies whether the subject may act as a CA.
-
-The ASN.1 definition is as follows:
-
-.. code-block:: text
-
-    basicConstraints EXTENSION ::= {
-        SYNTAX          BasicConstraintsSyntax
-        IDENTIFIED BY   id-ce-basicConstraints
-    }
-
-    BasicConstraintsSyntax ::= SEQUENCE {
-        cA                BOOLEAN DEFAULT FALSE,
-        pathLenConstraint INTEGER(0..MAX) OPTIONAL,
-    }
-
-Each control-plane certificate has different basic constraints. There are listed
-in the certificate descriptions below.
+SCION relies on five X.509 extensions — Authority Key Identifier, Subject Key
+Identifier, Key Usage, Extended Key Usage and Basic Constraints — each with
+SCION-specific constraints (the per-type specifics are summarized per certificate
+type below). Their definitions and constraints are specified in the `Extensions
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-extensions>`_
+section of the SCION PKI draft.
 
 .. _cp-root-certificate:
 
 CP Root Certificate
 ===================
 
-**CP Root Certificates** state which ASes are CA ASes for an ISD.
-
-In X.509 terms, **CP Root Certificates** are *self-signed* CA certificates
-(``issuer`` and ``subject`` are the same entity, and the key within the
-certificate was used to sign it). They are owned by CA ASes.
-
-To bootstrap trust for **CP Root Certificates**, they are embedded in TRCs (see
-the TRC document for more information about the embedding). This is also how the
-set of ASes that can issue certificates for an ISD is defined.
-
-All constraints in :ref:`general-certificate-requirements` apply to **CP Root Certificates**.
+**CP Root Certificates** state which ASes are CA ASes for an ISD. They are
+self-signed CA certificates owned by CA ASes, and are embedded in TRCs to
+bootstrap trust (see the :doc:`TRC Specification <trc>`). Their full profile —
+key usage, extended key usage (including ``id-kp-root``) and basic constraints
+(``cA`` TRUE, ``pathLenConstraint`` 1) — is specified in `Control Plane Root
+Certificate
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-control-plane-root-certific>`_.
 
 The recommended maximum validity period of a **CP Root certificate** is 1 year.
-
-Extension constraints
----------------------
-
-**Key usage**.  The ``keyCertSign`` attributes must be set. The
-``digitalSignature`` attribute must not be set, as in the context of SCION this
-has the semantics of *allowed to sign control-plane messages*.
-
-**Extended key usage**. This extension must present. The ``id-kp-serverAuth``
-and ``id-kp-clientAuth`` purposes must not be set. The ``id-kp-root`` and
-``id-kp-timeStamping`` purpose must be set.
-
-.. code-block:: text
-
-    id-kp-root AttributeType ::= {id-ana id-cppki(1) id-kp(3) 3}
-
-**Basic constraints**. The extension must be present, with the ``cA`` component
-set to **TRUE**. The ``pathLenConstraint`` value should be set to 1. Note that
-X.509 requires that this be marked as critical.
 
 .. _cp-ca-certificate:
 
 CP CA Certificate
 =================
 
-**CP CA Certificates** are used by CA ASes for signing **CP AS Certificates**.
-
-In X.509 terms, **CP CA Certificates** are *self-issued* CA certificates
-(``issuer`` and ``subject`` are the same entity). They are owned by CA ASes.
-
-**CP CA Certificates** are signed by **CP Root Certificates**.
+**CP CA Certificates** are used by CA ASes to sign **CP AS Certificates**. They
+are self-issued CA certificates, signed by a **CP Root Certificate**. Their full
+profile — key usage, extended key usage and basic constraints (``cA`` TRUE,
+``pathLenConstraint`` 0) — is specified in `Control Plane Issuing CA Certificate
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-control-plane-issuing-ca-ce>`_.
 
 The recommended maximum validity period of a **CP CA certificate** is 1 week.
-
-Extension constraints
----------------------
-
-**Key usage**. The ``keyCertSign`` attributes must be set. The
-``digitalSignature`` attribute must not be set, as in the context of SCION this
-has the semantics of *allowed to sign control-plane messages*.
-
-**Extended key usage**. This extension may be present. If it is present, the
-``id-kp-serverAuth`` and ``id-kp-clientAuth`` purposes must not be present.
-
-**Basic constraints**. The extension must be present, with the ``cA`` component
-set to **TRUE**. The ``pathLenConstraint`` value should be set to 0. This means
-that the subject can only issue end-entity certificates. Note that X.509
-requires that this be marked as critical.
 
 .. _cp-as-certificate:
 
 CP AS Certificate
 =================
 
-**CP AS Certificates** are used by SCION ASes to sign control-plane messages.
-
-In X.509 terms, **CP AS Certificates** are end-entity certificates.
+**CP AS Certificates** are the end-entity certificates SCION ASes use to sign
+control-plane messages. Their full profile — key usage (``digitalSignature``),
+extended key usage (``id-kp-timeStamping``, and ``id-kp-serverAuth`` /
+``id-kp-clientAuth`` for CP TLS sessions) and basic constraints — is specified in
+`Control Plane AS Certificate
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-control-plane-as-certificat>`_.
 
 The recommended maximum validity period of a **CP AS certificate** is 3 days.
-
-Extension constraints
----------------------
-
-**Key usage**. The ``digitalSignature`` attribute must be set.
-The ``keyCertSign`` attribute must not be set.
-
-**Extended key usage**. This extension must be present. ``id-kp-timeStamping``
-must be set. If used on the server-side of CP TLS session establishment,
-``id-kp-serverAuth`` must be set. If used on the client-side of a CP TLS session
-establishment, ``id-kp-clientAuth`` must be set.
-
-**Basic constraints**. The extension should not be included.

--- a/doc/cryptography/certificates.rst
+++ b/doc/cryptography/certificates.rst
@@ -59,11 +59,14 @@ of the SCION PKI draft.
 Issuer
 ------
 
-The ``issuer`` (and ``subject``) field carries a distinguished name built from
-standard X.500 attributes plus the SCION-specific *ISD-AS number* attribute
-(``id-at-ia``). The *ISD-AS number* MUST be present exactly once and uses the
-canonical ISD-AS string formatting (e.g. ``1-ff00:0:110``). The attribute set, the
-``id-at-ia`` OID and the canonical formatting are specified in the `Issuer
+The ``issuer`` field contains the distinguished name (DN) of the CA that created
+the certificate; the ``subject`` field contains the DN of the entity that owns
+it. Both are defined the same way (the ``Name`` syntax is defined in [X501]_)
+and MUST be non-empty. The DN is built from standard attributes plus the
+SCION-specific *ISD-AS number* attribute (``id-at-ia``), which MUST be present
+exactly once and uses the canonical ISD-AS string formatting (e.g.
+``1-ff00:0:110``). The attribute set, the ``id-at-ia`` OID and the canonical
+formatting are specified in the `Issuer
 <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-issuer>`_
 section of the SCION PKI draft.
 

--- a/doc/cryptography/certificates.rst
+++ b/doc/cryptography/certificates.rst
@@ -8,12 +8,9 @@ SCION uses three types of X.509 v3 **Control Plane (CP) certificates** that buil
 on top of [RFC5280]_ (which in turn builds on [X509]_), adding more restrictive
 SCION-specific constraints:
 
-- **CP Root Certificate** — a self-signed CA certificate, owned by a CA AS and
-  embedded in a TRC, that signals which ASes may act as certificate authorities in
-  an ISD.
-- **CP CA Certificate** — used by a CA AS to sign CP AS certificates.
-- **CP AS Certificate** — the end-entity certificate an AS uses to sign
-  control-plane messages.
+- :ref:`CP Root Certificate <cp-root-certificate>`
+- :ref:`CP CA Certificate <cp-ca-certificate>`
+- :ref:`CP AS Certificate <cp-as-certificate>`
 
 The full normative specification — certificate fields, per-type profiles,
 extensions and the ASN.1 syntax — is defined in the `SCION PKI draft
@@ -41,16 +38,19 @@ or constrained in SCION — are given in `X.509 Certificate Profiles and Constra
 Signature
 ---------
 
-For security reasons, SCION uses a custom list of acceptable algorithms. The list
-currently contains only the *ECDSA* signature algorithm (defined in [X962]_) with
-the NIST P-256, P-384 and P-521 curves.
-
-The accepted algorithms and curves, their OIDs and the ``AlgorithmIdentifier``
+For security reasons, SCION uses a custom list of acceptable algorithms.
+The accepted algorithms and curves and the ``AlgorithmIdentifier``
 ASN.1 are listed in the `Signature field
 <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-signature>`_
 section and `Appendix A
 <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-certificate-extensions-in-a>`_
 of the SCION PKI draft.
+
+This implementation supports all three mandatory algorithms - *ECDSA* with the curves:
+
+- NIST P-256
+- NIST P-384
+- NIST P-521
 
 Issuer and Subject
 ------------------
@@ -89,8 +89,6 @@ key usage, extended key usage (including ``id-kp-root``) and basic constraints
 Certificate
 <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-control-plane-root-certific>`_.
 
-The recommended maximum validity period of a **CP Root certificate** is 1 year.
-
 .. _cp-ca-certificate:
 
 CP CA Certificate
@@ -101,8 +99,6 @@ are self-issued CA certificates, signed by a **CP Root Certificate**. Their full
 profile — key usage, extended key usage and basic constraints (``cA`` TRUE,
 ``pathLenConstraint`` 0) — is specified in `Control Plane Issuing CA Certificate
 <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-control-plane-issuing-ca-ce>`_.
-
-The recommended maximum validity period of a **CP CA certificate** is 1 week.
 
 .. _cp-as-certificate:
 
@@ -115,5 +111,3 @@ extended key usage (``id-kp-timeStamping``, and ``id-kp-serverAuth`` /
 ``id-kp-clientAuth`` for CP TLS sessions) and basic constraints — is specified in
 `Control Plane AS Certificate
 <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-control-plane-as-certificat>`_.
-
-The recommended maximum validity period of a **CP AS certificate** is 3 days.

--- a/doc/cryptography/certificates.rst
+++ b/doc/cryptography/certificates.rst
@@ -1,5 +1,5 @@
 *************************
-Certificate Specification
+Certificates
 *************************
 
 .. highlight:: text

--- a/doc/cryptography/certificates.rst
+++ b/doc/cryptography/certificates.rst
@@ -36,10 +36,6 @@ certificates. The detailed requirements for the ``version``, ``serialNumber``,
 or constrained in SCION — are given in `X.509 Certificate Profiles and Constraints
 <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-x509-certificate-profiles-a>`_.
 
-One SCION-specific constraint: all certificates MUST have a
-well-defined expiration date. Certificates that use the ``99991231235959Z``
-GeneralizedTime value to indicate no well-defined expiration are not valid.
-
 .. _certificate-signature:
 
 Signature

--- a/doc/cryptography/certificates.rst
+++ b/doc/cryptography/certificates.rst
@@ -46,15 +46,11 @@ Signature
 ---------
 
 For security reasons, SCION uses a custom list of acceptable algorithms. The list
-currently contains only the *ECDSA* signature algorithm (defined in [X962]_). The
-only accepted curves are NIST P-256, P-384 and P-521 (named ``secp256r1``,
-``secp384r1`` and ``secp521r1`` in [RFC5480]_; see also [NISTFIPS186-4]_), used
-with SHA-256, SHA-384 and SHA-512 respectively (the ECDSA OIDs are defined in
-[RFC5758]_). Implementations MUST include support for P-256, P-384 and P-521, and
-**MUST reject cryptographic algorithms not found on the list.**
+currently contains only the *ECDSA* signature algorithm (defined in [X962]_) with
+the NIST P-256, P-384 and P-521 curves.
 
-The signature-algorithm OIDs, curve OIDs and ``AlgorithmIdentifier`` ASN.1 are
-listed in the `Signature field
+The accepted algorithms and curves, their OIDs and the ``AlgorithmIdentifier``
+ASN.1 are listed in the `Signature field
 <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-signature>`_
 section and `Appendix A
 <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-certificate-extensions-in-a>`_

--- a/doc/cryptography/certificates.rst
+++ b/doc/cryptography/certificates.rst
@@ -12,6 +12,10 @@ SCION-specific constraints:
 - :ref:`CP CA Certificate <cp-ca-certificate>`
 - :ref:`CP AS Certificate <cp-as-certificate>`
 
+Additionally, SCION uses two **voting certificates** - the *sensitive voting
+certificate* and the *regular voting certificate* - which carry the keys that
+cast votes in the TRC update process (see the :doc:`TRC Specification <trc>`).
+
 The full normative specification — certificate fields, per-type profiles,
 extensions and the ASN.1 syntax — is defined in the `SCION PKI draft
 <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html>`_.

--- a/doc/cryptography/certificates.rst
+++ b/doc/cryptography/certificates.rst
@@ -56,11 +56,11 @@ section and `Appendix A
 <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-certificate-extensions-in-a>`_
 of the SCION PKI draft.
 
-Issuer
-------
+Issuer and Subject
+------------------
 
 The ``issuer`` field contains the distinguished name (DN) of the CA that created
-the certificate; the ``subject`` field contains the DN of the entity that owns
+the certificate and the ``subject`` field contains the DN of the entity that owns
 it. Both are defined the same way (the ``Name`` syntax is defined in [X501]_)
 and MUST be non-empty. The DN is built from standard attributes plus the
 SCION-specific *ISD-AS number* attribute (``id-at-ia``), which MUST be present

--- a/doc/cryptography/certificates.rst
+++ b/doc/cryptography/certificates.rst
@@ -92,7 +92,7 @@ CP AS Certificate
 =================
 
 **CP AS Certificates** are the end-entity certificates SCION ASes use to sign
-control-plane messages. Their full profile — key usage (``digitalSignature``),
+control plane messages. Their full profile — key usage (``digitalSignature``),
 extended key usage (``id-kp-timeStamping``, and ``id-kp-serverAuth`` /
 ``id-kp-clientAuth`` for CP TLS sessions) and basic constraints — is specified in
 `Control Plane AS Certificate

--- a/doc/cryptography/interactions.rst
+++ b/doc/cryptography/interactions.rst
@@ -2,101 +2,34 @@
 Cryptographic Interactions
 **************************
 
-The main purpose of the SCION control plane PKI is to provide a mechanism to to
-distribute and authenticate public keys that are used to verify control plane
-messages and information. For example the SCION path segments are signed with
-keys that are authenticated through the SCION CP-PKI.
+The main purpose of the SCION control plane PKI is to distribute and authenticate
+the public keys used to verify control-plane messages and information. For example,
+SCION path segments are signed with keys that are authenticated through the CP-PKI.
 
-In this document, we describe the cryptographic interactions between control
-plane entities. I.e., how certificates are distributed, and how they are used
-to verify messages and establish secret and authentic channels.
+These interactions cover how certificates are distributed, how they are used to
+verify messages, and how they establish secret and authentic channels. The
+normative specification of these operations is in `CP-PKI Operations
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-cp-pki-operations>`_.
 
 AS certificate use cases
 ========================
 
-Currently, we have two use cases: authenticating control plane messages, and
-establishing a secure channel. The basis for both of these use cases is the AS
-certificate. We discuss these use cases briefly and go into detail, how the
-relying parties get the required cryptographic material.
+There are two use cases, both rooted in the AS certificate: authenticating control
+plane messages, and establishing a secure channel.
 
 Authentic control plane messages
 --------------------------------
 
-In SCION, most control plane messages are signed. For example, each AS hop
-information in path segment is signed by the respective AS. All relying parties
-are able to verify the signatures with the help of the CP-PKI.
-
-Signing process
-^^^^^^^^^^^^^^^
-
-To sign a message, the signing entity chooses an AS certificate that
-authenticates their private key. With the private key, they sign the message and
-attach the following information as signature metadata:
-
-- ISD-AS: The ISD-AS number of the signing entity.
-- Subject Key Identifier: The key identifier of the public key used to verify the
-  message.
-
-This is the bare minimum information a relying party requires to identify which
-certificate to use to verify the signed message.
-
-Additionally, the signer should include the following information:
-
-- Serial and base number of the latest TRC: Including this information allows
-  relying parties to discover TRC updates and trust resets passively without
-  actively querying the authoritative ASes in the respective ISDs.
-- Timestamp: For many messages, the timestamp is useful information to ensure
-  recentness of the message.
-
-Verifying process
-^^^^^^^^^^^^^^^^^
-
-When the relying party gets a message that they want to verify, they first need
-to identify the certificate that authenticates the corresponding public key.
-
-AS certificates are bundled together with the CA certificate that signed them
-into certificate chains. For efficiency, these certificate chains are
-distributed decoupled from the signed messages. A certificate chain is verified
-against a root certificate. However, the root certificate is not bundled in the
-chain, it is bundled in the TRC. This allows TRC updates that extend the
-validity period of the root certificate without the need to modify the
-certificate chain.
-
-Now, to verify, the relying party first builds a collection of the root
-certificates from the latest TRC from the ISD referenced in the signature
-metadata. If the grace period introduced by the latest TRC is still on-going,
-the root certificates in the second to latest TRC are also included. For more
-detailed instruction, see :ref:`trc-selection`. If the signature metadata
-contains the serial and base number, the relying part checks that they have at
-least that TRC or a newer one available.
-
-After the relying party has constructed the pool of root certificates, they have
-to select a certificate chain that can be used to verify the message. To do so,
-they select a certificate chain with an AS certificate that has the following
-properties:
-
-- The ISD-AS in the subject of the AS certificate matches the ISD-AS in the
-  signature metadata.
-- The Subject Key Identifier of the AS certificate matches the Subject Key
-  Identifier in the signature metadata.
-- The AS certificate is valid at verification time. Normally, this will be the
-  current time. In special cases, e.g., auditing the time can be set to the past
-  to check if the message was verifiable at the given time.
-
-The relying party executes the regular X509 verification path to verify the
-messages against the set of root certificates. In addition, the relying party
-checks that all subjects carry the same ISD number, that each certificate is of
-valid type, i.e., that the AS certificate is indeed a valid AS certificate, and
-that the CA certificate validity period covers the AS certificate validity period.
-
-If any crypto material is missing in the process, the relying party queries the
-originator of the message for the missing material. If it can not be resolved,
-the verification process fails.
-
-An implication of this is that path segments should be checked whether they are
-verifiable at time of use. We cannot simply rely on them being verified on
-insert, since TRC updates that change the root key can invalidate a certificate
-chain.
+Most SCION control-plane messages (for example, each AS's hop information in a path
+segment) are signed, and any relying party can verify them via the CP-PKI. The
+signer attaches signature metadata — at minimum the ISD-AS and the Subject Key
+Identifier of the signing key, and typically the latest TRC's serial/base number
+and a timestamp. To verify, the relying party locates the AS certificate chain
+matching that metadata, builds the trust-anchor root pool from the relevant TRC(s),
+and runs the regular X.509 path verification, checking that the certificate is
+valid at verification time. The signing and verification procedures are specified
+in `Signing and Verifying Control Plane Messages
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-signing-and-verifying-contr>`_.
 
 Secret and authentic channel
 ----------------------------
@@ -124,38 +57,22 @@ latest available TRC.
 TRC update discovery
 ====================
 
-Relying parties need to have recent TRCs available. They should notice TRC
-updates in a reasonable time frame. There are multiple mechanisms for how a
-relying party notices these updates.
-
-Beaconing process
------------------
-
-The TRC version is announced in the beaconing process. Each AS announces what it
-considers to be the latest TRC. Furthermore, each AS includes the digest of the
-TRC contents to allow discovering discrepancies.
-
-Thus, relying parties that are part of the beaconing process notice TRC updates
-passively. I.e., the control service in a core AS notices TRC updates for remote
-ISDs that are on the beaconing path. The control service in a non-core AS only
-notices TRC updates for the local ISD through the beaconing process.
-
-Path resolution
----------------
-
-In every path segment, all ASes reference the latest TRC of their ISD. Thus,
-when resolving paths, every relying party notices TRC updates even remote ones.
-This mechanism only works for ISDs that the relying party actively communicates
-with.
-
-Active discovery
-----------------
-
-Relying parties actively query authoritative ASes in the ISDs they want to have
-recent TRCs.
+Relying parties must keep recent TRCs available and need to notice TRC updates in
+a reasonable time frame. Updates are discovered passively through the beaconing
+process and through path resolution (every AS references its latest TRC in path
+segments), and actively by querying authoritative ASes. These discovery mechanisms
+are specified in `TRC Update Discovery
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-trc-update-discovery>`_.
 
 Messages
 ========
+
+.. note::
+
+   The wire formats of the queries and responses below are not specified here.
+   They are defined by the SCION control-plane specification; see `Distribution of
+   Cryptographic Material
+   <https://scionassociation.github.io/scion-cp_I-D/draft-dekater-scion-controlplane.html#name-distribution-of-cryptograph>`_.
 
 To enable the interactions mentioned above, the following messages are necessary:
 

--- a/doc/cryptography/interactions.rst
+++ b/doc/cryptography/interactions.rst
@@ -3,7 +3,7 @@ Cryptographic Interactions
 **************************
 
 The main purpose of the SCION control plane PKI is to distribute and authenticate
-the public keys used to verify control-plane messages and information. For example,
+the public keys used to verify control plane messages and information. For example,
 SCION path segments are signed with keys that are authenticated through the CP-PKI.
 
 These interactions cover how certificates are distributed, how they are used to
@@ -20,7 +20,7 @@ plane messages, and establishing a secure channel.
 Authentic control plane messages
 --------------------------------
 
-Most SCION control-plane messages (for example, each AS's hop information in a path
+Most SCION control plane messages (for example, each AS's hop information in a path
 segment) are signed, and any relying party can verify them via the CP-PKI. The
 signer attaches signature metadata — at minimum the ISD-AS and the Subject Key
 Identifier of the signing key, and typically the latest TRC's serial/base number
@@ -70,7 +70,7 @@ Messages
 .. note::
 
    The wire formats of the queries and responses below are not specified here.
-   They are defined by the SCION control-plane specification; see `Distribution of
+   They are defined by the SCION control plane specification; see `Distribution of
    Cryptographic Material
    <https://scionassociation.github.io/scion-cp_I-D/draft-dekater-scion-controlplane.html#name-distribution-of-cryptograph>`_.
 

--- a/doc/cryptography/standards.rst
+++ b/doc/cryptography/standards.rst
@@ -5,15 +5,11 @@ Standards
 This page contains definitions for the various standards referenced in SCION
 cryptography documentation.
 
-.. [X501] Recommendation ITU-T X.501 (10/2016), The Directory: Models, http://handle.itu.int/11.1002/1000/13030
 .. [X509] Recommendation ITU-T X.509 (10/2016), The Directory: Public-key and attribute certificate frameworks, http://handle.itu.int/11.1002/1000/13031
-.. [X680] Recommendation ITU-T X.680 (08/2015), Information technology - Abstract Syntax Notation One (ASN.1): Specification of basic notation., https://www.itu.int/rec/T-REC-X.680-201508-I
-.. [X690] Recommendation ITU-T X.690 (08/2015), Information technology - ASN.1 encoding rules: Specification of Basic Encoding Rules (BER), Canonical Encoding Rules (CER) and Distinguished Encoding Rules (DER), https://www.itu.int/rec/T-REC-X.690-201508-I
 .. [X962] American National Standards Institute, Public Key Cryptography for the Financial Services Industry, The Elliptic Curve Digital Signature Algorithm (ECDSA), ANSI X9.62:2005, November 2005
 .. [RFC5280] Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile https://tools.ietf.org/html/rfc5280
 .. [RFC5480] Elliptic Curve Cryptography Subject Public Key Information https://tools.ietf.org/html/rfc5480
 .. [RFC5652] Cryptographic Message Syntax (CMS) https://tools.ietf.org/html/rfc5652
 .. [RFC5758] Internet X.509 Public Key Infrastructure: Additional Algorithms and Identifiers for DSA and ECDSA https://tools.ietf.org/html/rfc5758
-.. [RFC8410] Algorithm Identifiers for Ed25519, Ed448, X25519, and X448 for Use in the Internet X.509 Public Key Infrastructure https://tools.ietf.org/html/rfc8410
 .. [RFC8419] Use of Edwards-Curve Digital Signature Algorithm (EdDSA) Signatures in the Cryptographic Message Syntax (CMS) https://tools.ietf.org/html/rfc8419
 .. [NISTFIPS186-4] Digital Signature Standard (DSS)

--- a/doc/cryptography/standards.rst
+++ b/doc/cryptography/standards.rst
@@ -7,7 +7,6 @@ cryptography documentation.
 
 .. [X501] Recommendation ITU-T X.501 (10/2016), The Directory: Models, http://handle.itu.int/11.1002/1000/13030
 .. [X509] Recommendation ITU-T X.509 (10/2016), The Directory: Public-key and attribute certificate frameworks, http://handle.itu.int/11.1002/1000/13031
-.. [X962] American National Standards Institute, Public Key Cryptography for the Financial Services Industry, The Elliptic Curve Digital Signature Algorithm (ECDSA), ANSI X9.62:2005, November 2005
 .. [RFC5280] Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile https://tools.ietf.org/html/rfc5280
 .. [RFC5652] Cryptographic Message Syntax (CMS) https://tools.ietf.org/html/rfc5652
 .. [RFC8419] Use of Edwards-Curve Digital Signature Algorithm (EdDSA) Signatures in the Cryptographic Message Syntax (CMS) https://tools.ietf.org/html/rfc8419

--- a/doc/cryptography/standards.rst
+++ b/doc/cryptography/standards.rst
@@ -8,8 +8,5 @@ cryptography documentation.
 .. [X509] Recommendation ITU-T X.509 (10/2016), The Directory: Public-key and attribute certificate frameworks, http://handle.itu.int/11.1002/1000/13031
 .. [X962] American National Standards Institute, Public Key Cryptography for the Financial Services Industry, The Elliptic Curve Digital Signature Algorithm (ECDSA), ANSI X9.62:2005, November 2005
 .. [RFC5280] Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile https://tools.ietf.org/html/rfc5280
-.. [RFC5480] Elliptic Curve Cryptography Subject Public Key Information https://tools.ietf.org/html/rfc5480
 .. [RFC5652] Cryptographic Message Syntax (CMS) https://tools.ietf.org/html/rfc5652
-.. [RFC5758] Internet X.509 Public Key Infrastructure: Additional Algorithms and Identifiers for DSA and ECDSA https://tools.ietf.org/html/rfc5758
 .. [RFC8419] Use of Edwards-Curve Digital Signature Algorithm (EdDSA) Signatures in the Cryptographic Message Syntax (CMS) https://tools.ietf.org/html/rfc8419
-.. [NISTFIPS186-4] Digital Signature Standard (DSS)

--- a/doc/cryptography/standards.rst
+++ b/doc/cryptography/standards.rst
@@ -5,7 +5,6 @@ Standards
 This page contains definitions for the various standards referenced in SCION
 cryptography documentation.
 
-.. [X501] Recommendation ITU-T X.501 (10/2016), The Directory: Models, http://handle.itu.int/11.1002/1000/13030
 .. [X509] Recommendation ITU-T X.509 (10/2016), The Directory: Public-key and attribute certificate frameworks, http://handle.itu.int/11.1002/1000/13031
 .. [RFC5280] Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile https://tools.ietf.org/html/rfc5280
 .. [RFC5652] Cryptographic Message Syntax (CMS) https://tools.ietf.org/html/rfc5652

--- a/doc/cryptography/standards.rst
+++ b/doc/cryptography/standards.rst
@@ -5,6 +5,7 @@ Standards
 This page contains definitions for the various standards referenced in SCION
 cryptography documentation.
 
+.. [X501] Recommendation ITU-T X.501 (10/2016), The Directory: Models, http://handle.itu.int/11.1002/1000/13030
 .. [X509] Recommendation ITU-T X.509 (10/2016), The Directory: Public-key and attribute certificate frameworks, http://handle.itu.int/11.1002/1000/13031
 .. [X962] American National Standards Institute, Public Key Cryptography for the Financial Services Industry, The Elliptic Curve Digital Signature Algorithm (ECDSA), ANSI X9.62:2005, November 2005
 .. [RFC5280] Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile https://tools.ietf.org/html/rfc5280

--- a/doc/cryptography/trc.rst
+++ b/doc/cryptography/trc.rst
@@ -2,637 +2,112 @@
 Trust Root Configuration (TRC) Specification
 ********************************************
 
-This document contains the specification for **Trust Root Configuration (TRC)**,
-**Sensitive Voting Certificate** and **Regular Voting Certificate**.
+The **Trust Root Configuration (TRC)** is a signed collection of `X.509 v3
+certificates
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#section-2-2>`__
+and ISD policy information that establishes the trust anchors of an ISD. It contains the **CP Root Certificates** that root the verification path for
+**CP AS Certificates**, together with the **Sensitive Voting Certificates** and
+**Regular Voting Certificates** and the policy used to vote on the next TRC.
 
-For voting certificates, the *SCION Trust Root Configuration Specification*
-builds on top of [RFC5280]_, which in turn builds on top of [X509]_. The SCION
-specification is a more restrictive set of [RFC5280]_, which means that
-[RFC5280]_ compliant implementations can be adapted to implement this
-specification by including the additional checks.
-
-For each SCION voting certificate, this document defines the additional
-constraints when compared to [RFC5280]_. When something is marked as optional,
-it also includes how the Anapaya implementation behaves.
-
-Note that this document uses the new X.509-style SCION terminology (as opposed
-to the previous JSON SCION terminology). The following entities are used in this
-document:
-
-- **Sensitive Voting Key**. This is the previous **offline voting key**. It is
-  embedded in TRCs (via a sensitive voting certificate) to signal that a party
-  can cast a vote on a sensitive update.
-- **Regular Voting Key**. This is the previous **online voting key**. It is
-  embedded in TRCs (via a regular voting certificate) to signal that a party can
-  cast a vote on a regular update.
-- **Sensitive Voting Certificate**. This is the container for the public key
-  associated with the **Sensitive Voting Key**.
-- **Regular Voting Certificate**. This is the container for the public key
-  associated with the **Regular Voting Key**.
-
-This document uses the Anapaya IANA Private Enterprise Number (55324) as root
-SCION OIDs:
-
-.. code-block:: text
-
-    id-ana  ::=  OBJECT IDENTIFIER {1 3 6 1 4 1 55324}
+Like the certificates it carries, the TRC builds on [RFC5280]_/[X509]_ with more
+restrictive SCION constraints. The full normative specification — payload schema,
+fields, signing, updates and certification paths — is defined in the `SCION PKI
+draft <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html>`_.
 
 .. _trc-format:
 
 TRC Format
 ==========
 
-The SCION TRC is a signed collection of X.509 v3 certificates and some ISD
-policy information. This collection contains a set of *CP Root Certificates*
-that build the roots of the verification path for *CP AS Certificates* of an
-ISD. The remaining certificates are solely used, together with the ISD policy
-information, for voting the next TRC in the *TRC Update Process*.
-
-This section presents the TRC format definitions and encoding and uses the ITU-T
-[X680]_ syntax.
-
-TRC Payload Schema
-------------------
-
-The TRC payload is the container that holds the certificates and the policy
-information. For signature calculation, the data that is to be signed is encoded
-using ASN.1 distinguished encoding rules (DER) [X690]_.
-
-.. code-block:: text
-
-    TRCPayload  ::=  SEQUENCE {
-        version   TRCFormatVersion,
-        iD        TRCID,
-        validity  Validity,
-
-        gracePeriod   INTEGER,
-        noTrustReset  BOOLEAN DEFAULT FALSE,
-        votes         SEQUENCE OF INTEGER (SIZE (1..255)),
-
-        votingQuorum  INTEGER (1..255),
-
-        coreASes           SEQUENCE OF ASN,
-        authoritativeASes  SEQUENCE OF ASN,
-        description        UTF8String (SIZE (0..1024)),
-
-        certificates       SEQUENCE OF Certificate }
-
-    TRCFormatVersion  ::=  INTEGER { v1(0) }
-
-    TRCID  ::=  SEQUENCE {
-        iSD           ISD,
-        serialNumber  INTEGER (1..MAX),
-        baseNumber    INTEGER (1..MAX) }
-
-    ISD  ::=  INTEGER (1..65535)
-
-    Validity  ::=  SEQUENCE {
-        notBefore  Time,
-        notAfter   Time }
-
-    ASN  ::=  INTEGER (1..281474976710655)
-
-
-TRC Payload Fields
-------------------
-
-The sequence TRCPayload contains the identifying information of a TRC.
-Furthermore, it contains policy information for TRC updates, and a list of
-certificates that build the trust anchor for the ISD. The remainder of this
-section describes the syntax and semantics of these fields.
-
-.. _trc-version-field:
-
-Version
-^^^^^^^
-
-This field describes the version of the encoded TRC payload. For now, this
-version is always ``v1``.
-
-**Deprecation warning**: note that the ``version`` field has different semantics
-compared to the old SCION JSON format for TRCs (where version was an
-incrementing counter). The JSON style ``version`` is moved to the ``serial number``
-field in the :ref:`trc-id-field` sequence bellow.
-
-.. _trc-id-field:
-
-ID
-^^
-
-This field is a unique identifier of the TRC. It is a sequence of the ISD
-number, TRC serial number and the base number. The ISD number MUST be in the ISD
-numbering range and not be the wildcard ISD. I.e., the ISD number is an integer
-in the inclusive range between 1 and 65535. The serial and base number both
-MUST be a positive integer.
-
-The base number indicates the starting point of the TRC update chain this TRC
-is in. A TRC where the serial number is equal to the base number is called a
-*base* TRC. Trust for a *base* TRC cannot be inferred by verifying a TRC
-update, and has to be bootstrapped through another mechanism.
-
-The *initial* TRC is a special case of a *base* TRC. It MUST hold the serial
-number value 1 and base number 1. With every TRC update, the serial number MUST
-be incremented by one. This facilitates uniquely identifying the predecessor and
-successor TRC in a TRC update chain starting in the same base TRC.
-
-If a trust reset is necessary, a new *base* TRC is announced to start a new and
-clean TRC update chain. The base number SHOULD be the subsequent number of the
-serial number of the latest TRC that was produced by a non-compromised TRC
-update for this ISD.
-
-.. _trc-validity-field:
-
-Validity
-^^^^^^^^
-
-The TRC validity period is the interval during which the TRC may be considered
-in the valid state. This interval sets the lower and upper bound for which a TRC
-can be *active*.
-
-The validity is a sequence of two dates, as defined in [X509]_, Section 7.2.
-
-In addition to the definition, the following constraints apply:
-
-- All TRCs MUST have a well-defined expiration date. TRCS that specify that they
-  do not have a well-defined expiration date (by using the 99991231235959Z
-  Generalized Time value) are not valid. SCION implementations MUST NOT create
-  such TRCs, and verifiers MUST error out when encountering such a
-  TRCs.
-
-.. _trc-grace-period-field:
-
-GracePeriod
-^^^^^^^^^^^
-
-The grace period indicates the interval for how long the previous unexpired
-version of the TRC should be considered active. The field encodes the grace
-period as an integer of seconds. The start of the grace period is equal to the
-beginning of the validity period of this TRC.
-
-The predecessor of this TRC, if any, should be considered active until either 1.
-the grace period has passed, 2. the predecessor's expiration time is reached, or
-3. the successor TRC of this TRC has been announced.
-
-The grace period of a base TRC MUST be zero. The grace period of a non-base TRC
-SHOULD be non-zero and long enough to provide sufficient overlap between the
-TRCs in order to facilitate interruption free operations in the ISD. E.g., if
-the grace period is too short, some CP AS certificates might expire, before the
-subject can fetch an updated version from its CA.
-
-.. _trc-no-trust-reset-field:
-
-NoTrustReset
-^^^^^^^^^^^^
-
-This boolean indicates whether the TRC trust reset mechanism is disallowed by
-the ISD. Inside a TRC update chain, this value MUST NOT change. Thus, the base
-TRC decides on the value. This field is optional and defaults to FALSE.
-
-On trust resets, this value MAY be changed. Notice, however, that this implies
-that once the trust resets are disallowed, there is **no way** of re-enabling
-them. ISDs SHOULD always set this value to **FALSE**, unless they have a very
-specific use case and have assessed the risks and implications sufficiently.
-
-.. _trc-votes-field:
-
-Votes
-^^^^^
-
-Votes contains a sequence of indices of the voting certificates in the
-predecessor TRC. In a *base* TRC, this sequence is empty. Every entry in this
-sequence MUST be unique.
-
-If index ``i`` is part of ``votes``, then the voting certificate at position
-``i`` in the ``certificates`` sequence of the predecessor TRC casts a vote, for
-this TRC. Further restrictions on the votes is discussed in :ref:`trc-update`.
-
-This sequence is included to prevent stripping voting signatures from the TRC.
-If this sequence were not included, a TRC that has more voting signatures than
-the ``votingQuorum`` could be transformed into multiple verifiable TRCs with the
-same payload, but different voting signature sets. This would violate the
-uniqueness of a TRC, without the consent from a voting quorum.
-
-.. _trc-voting-quorum-field:
-
-VotingQuorum
-^^^^^^^^^^^^
-
-The voting quorum indicates the number of necessary votes on a successor TRC,
-for it to be verifiable.
-
-.. _trc-core-ases-field:
-
-CoreASes
-^^^^^^^^
-
-CoreASes contains a sequence of AS numbers that are the core ASes in this ISD.
-To revoke or add the core status for a given AS, a TRC update is necessary. The
-entries in this sequence MUST be unique.
-
-.. _trc-authoritative-ases-field:
-
-AuthoritativeASes
-^^^^^^^^^^^^^^^^^
-
-AuthoritativeASes contains a sequence of AS numbers that are authoritative in
-this ISD. To revoke or add the authoritative status for a given AS, a TRC update
-is necessary. The entries in this sequence MUST be unique. Every authoritative
-AS MUST be a core AS and listed there.
-
-.. _trc-description-field:
-
-Description
-^^^^^^^^^^^
-
-The description contains a UTF-8 encoded string that describes the ISD. This
-value SHOULD NOT be empty, and MAY contain information in multiple languages.
-
-.. _trc-certificates-field:
-
-Certificates
-^^^^^^^^^^^^
-
-Certificates is a sequence of self-signed X.509 certificates that fall under
-three categories:
-
-- :ref:`sensitive-voting-certificate`
-- :ref:`regular-voting-certificate`
-- :ref:`cp-root-certificate`
-
-The constraints on these certificates are described in their respective
-sub-sections.
-
-Certificates that do not fall under one of these categories MUST NOT be included
-in the certificates sequence. There are some additional constraints on the set
-of certificates. For each certificate, the following constraints MUST hold:
-
-#. Every certificate MUST be unique in the sequence.
-#. The Issuer/SerialNumber-pair for every certificate MUST be unique.
-#. If an ISD-AS number is present in the distinguished name, the ISD field MUST
-   be equal to the ISD number of this TRC defined in :ref:`trc-id-field`.
-#. Every certificate MUST have a validity period that fully contains the
-   validity period of this TRC. I.e., the TRC's ``not_before`` MUST be greater
-   or equal to the certificate's ``not_before``, and the TRC's ``not_after``
-   MUST be less or equal to the certificate's ``not_after``.
-#. Per certificate category, every certificate distinguished name MUST be
-   unique.
-
-For the the set of certificates, the following MUST hold:
-
-#. :ref:`trc-voting-quorum-field` <= count(Sensitive Voting Certificates)
-#. :ref:`trc-voting-quorum-field` <= count(Regular Voting Certificate)
+The TRC payload is a DER-encoded container holding the ISD's policy fields and the
+set of self-signed certificates that anchor trust for the ISD. Its schema, fields
+and the constraints on the certificate set are specified in `TRC Fields
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-trc-fields>`_.
 
 .. _signed-trc-format:
 
 Signed TRC Format
------------------
+=================
 
-The TRC payload is signed as a *CM Signed-data Content* defined in [RFC5652]_,
-Section 5, and encapsulated in a *CMS ContentInfo* defined in [RFC5652]_,
-Section 3.
-
-For convenience, the definitions are repeated here:
-
-.. code-block:: text
-
-    ContentInfo ::= SEQUENCE {
-        contentType ContentType,
-        content [0] EXPLICIT ANY DEFINED BY contentType }
-
-    ContentType ::= OBJECT IDENTIFIER
-
-    SignedData  ::=  SEQUENCE {
-        version               CMSVersion,
-        digestAlgorithms      DigestAlgorithmIdentifiers,
-        encapContentInfo      EncapsulatedContentInfo,
-        certificates      [0] IMPLICIT CertificateSet OPTIONAL,
-        crls              [1] IMPLICIT RevocationInfoChoices OPTIONAL,
-        signerInfos           SignerInfos }
-
-    DigestAlgorithmIdentifiers  ::=  SET OF DigestAlgorithmIdentifier
-
-    SignerInfos  ::=  SET OF SignerInfo
-
-    EncapsulatedContentInfo  ::=  SEQUENCE {
-        eContentType      ContentType,
-        eContent      [0] EXPLICIT OCTET STRING OPTIONAL }
-
-    SignerInfo  ::=  SEQUENCE {
-        version                 CMSVersion,
-        sid                     SignerIdentifier,
-        digestAlgorithm         DigestAlgorithmIdentifier,
-        signedAttrs         [0] IMPLICIT SignedAttributes OPTIONAL,
-        signatureAlgorithm      SignatureAlgorithmIdentifier,
-        signature               SignatureValue,
-        unsignedAttrs       [1] IMPLICIT UnsignedAttributes OPTIONAL }
-
-    SignerIdentifier  ::=  CHOICE {
-        issuerAndSerialNumber      IssuerAndSerialNumber,
-        subjectKeyIdentifier   [0] SubjectKeyIdentifier }
-
-    SignedAttributes  ::=  SET SIZE (1..MAX) OF Attribute
-
-    UnsignedAttributes  ::=  SET SIZE (1..MAX) OF Attribute
-
-    Attribute  ::=  SEQUENCE {
-        attrType    OBJECT IDENTIFIER,
-        attrValues  SET OF AttributeValue }
-
-    AttributeValue  ::=  ANY
-
-    SignatureValue  ::=  OCTET STRING
-
-We build on top of the rules from [RFC5652]_ and add the following restrictions:
-
-- The ``certificates`` field in ``SignedData`` is left empty. The certificate
-  pool used to verify the TRC updates is based on the previous TRC.
-- The ``eContentType`` is set to ``id-data``. The contents of the ``eContent``
-  is the DER encoded ``TRCPayload``, as specified above. This has the benefit that
-  the format is backwards compatible with PKCS #7, as described in [RFC5652]_,
-  Section 5.2.1.
-- Because we do not include certificates in ``SignedData`` and choose
-  ``id-data`` as the content type, the ``version`` in ``SignedData`` MUST be 1,
-  as required by [RFC5652]_, Section 5.1.
-- The ``SignerIdentifier`` MUST be the choice ``IssuerAndSerialNumber``, thus,
-  ``version`` in ``SignerInfo`` MUST be 1, as required by [RFC5652]_, Section 5.3.
-- The ``digestAlgorithm`` is implied by the ``signatureAlgorithm`` according to
-  the :ref:`supported-algorithms`.
-- The ``signatureAlgorithm`` MUST one of the listed :ref:`supported-algorithms`.
-
-Anapaya software does not implement support for adding custom signed or unsigned
-attributes.
+The TRC payload is signed as a CMS *SignedData* content and encapsulated in a CMS
+*ContentInfo*, following [RFC5652]_ with SCION-specific restrictions (an empty
+``certificates`` field, ``id-data`` content type, and ``IssuerAndSerialNumber``
+signer identifiers). The exact CMS profile is specified in `TRC Signature Syntax
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-trc-signature-syntax>`_.
 
 .. _trc-update:
 
 TRC Update
 ==========
 
-TRC updates are split into two categories: Sensitive and regular updates. The
-type of update is inferred from the information that is changed by the updated
-TRC. Based on the category of the update, a different set of voters is
-necessary to create a verifiable TRC update.
-
-The following rules MUST hold for both update categories:
-
-- The ``isd`` and ``baseNumber`` in the :ref:`trc-id-field` field MUST NOT
-  change. - The ``serialNumber`` in the ``iD`` field MUST be incremented by one.
-- The ``noTrustReset`` field MUST NOT change.
-- There MUST only be votes cast that are authenticated by **Sensitive Voting
-  Certificates** or **Regular Voting Certificates** present in the predecessor
-  TRC. This means, the ``votes`` sequence MUST only contain indices of the
-  **Sensitive Voting Certificates** or **Regular Voting Certificates**.
-- The number of votes MUST be greater than or equal to the ``votingQuorum`` of
-  the predecessor TRC.
-- Every **Sensitive Voting Certificate** and **Regular Voting Certificate**
-  that is new in the TRC attaches a signature to the TRC. This is done to ensure
-  the freshly included voting entity agrees with the contents of the TRC and
-  being part of it.
-
-In the context of a TRC update, we identify a certificate as *changing*, if the
-certificate is part of the ``certificates`` sequence in the predecessor TRC, but
-no longer part of the ``certificates`` sequence in the successor TRC, and
-instead, there is a certificate of the same category and distinguished name in
-the ``certificates`` of the successor TRC.
-
-We identify a certificate as *new*, if there is no certificate of the same
-category and distinguished name in the ``certificates`` of the predecessor TRC.
-
-.. _regular-trc-update:
-
-Regular TRC Update
-------------------
-
-A TRC update qualifies as a regular update, if all of the following restrictions
-apply:
-
-- The ``votingQuorum`` does not change.
-- The ``coreASes`` section does not change.
-- The ``authoritativeASes`` section does not change.
-- The number of **Sensitive Voting Certificates**, **Regular Voting
-  Certificates**, and **CP Root certificates** and their distinguished names
-  does not change.
-- The set of **Sensitive Voting Certificates** does not change.
-- For every **Regular Voting Certificate** that changes, the **Regular Voting
-  Certificate** in the predecessor TRC is part of the voters on the successor
-  TRC.
-- For every **CP Root Certificate** that changes, the **CP Root Certificate** in
-  the predecessor TRC attaches a signature to the signed successor TRC.
-
-In order for a regular TRC update to be verifiable, all votes MUST be cast by a
-*Regular Voting Certificate*.
-
-.. _sensitive-trc-update:
-
-Sensitive TRC Update
----------------------
-
-If a TRC update does not qualify as a regular update, it is considered a
-sensitive update. In order for sensitive updates to be verifiable, all votes
-MUST be cast by a **Sensitive Voting Certificate**.
-
-.. _trc-update-verification:
-
-TRC Update Verification
------------------------
-
-To verify a TRC update, the relying party first checks that the specified
-:ref:`trc-update` are respected. Then, the relying party checks whether the
-update is regular or sensitive. In case of a regular update, the relying party
-checks that signatures for the changing certificates are present and verifiable.
-Further, the relying party checks that all votes are cast by a **Regular Voting
-Certificate**. In case of a sensitive update, the relying party checks that all
-votes are cast by a **Sensitive Voting Certificate**. In both cases, the relying
-party checks that all signatures are verifiable, and no superfluous signatures
-are attached.
+A TRC update is either a **regular update** (routine re-issuance with unchanged
+voting quorum, core ASes, authoritative ASes and voting/root certificate sets;
+votes cast by Regular Voting Certificates) or a **sensitive update** (any other
+change, e.g. to policy or quorum; votes cast by Sensitive Voting Certificates).
+The update rules, the regular/sensitive distinction and the verification algorithm
+are specified in `TRC Updates
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-trc-updates>`_.
 
 .. _trc-equality:
 
 TRC Equality
 ============
 
-For certain operations, we require an equality definition for TRCs. The signer
-infos in the signed TRC are part of an unordered set, per [RFC5652]_. This
-implies, that the signer infos can be reordered without affecting verification.
+Two TRCs are equal if and only if their payloads are byte-equal; this is sufficient
+because the payload determines exactly which signatures must be attached. See `TRC
+Equality
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-trc-equality>`_.
 
-**Two TRCs are equal, if and only if their payloads are byte equal.**
-
-This definition of equality is sufficient, because the payload defines exactly
-which signatures need to be attached in the signed TRC. The required signature
-for voting certificates are explicitly mentioned in the ``votes`` field of the
-payload. The required signatures for *new* certificates is implied by the TRC
-payload, and, in case of a TRC update, the predecessor payload.
+.. _trc-selection:
 
 CP Certification Path
 =====================
 
 The certification path of a **CP AS Certificate** starts in a **CP Root
-Certificate**. The **CP Root Certificates** for a given ISD are distributed via
-the TRC. When validating the certification path, the relying party must build
-the correct set of **CP Root Certificates** as a trust anchor pool from the
-available TRCs. Based on this pool, the relying party can select candidate
-certification paths and verify them.
-
-.. _trc-selection:
-
-TRC Selection
--------------
-
-To build the trust anchor pool, the right set of TRCs must be selected. This
-depends on the time of verification. In the usual case, we want to verify a
-control plane message, and thus, the time will be the current time. In some
-special cases, i.e., for auditing, we might want to know if a signature was
-verifiable at a given point in time.
-
-The selection algorithm is described in pseudo-python code below:
-
-.. code-block:: python
-
-    def select_trust_anchors(trcs: Dict[(int,int), TRC], verification_time: int) -> Set[RootCert]:
-        """
-        Args:
-            trcs: The dictionary mapping (serial number, base number) to the TRC for a given ISD.
-            verification_time: The time of verification.
-
-        Returns:
-            The set of CP Root certificates that act as trust anchors.
-        """
-        # Find highest base number that has a TRC with a validity period
-        # starting before verification time.
-        base_nr = 1
-        for trc in trcs.values():
-            if trc.id.base_nr > base_nr and trc.validity.not_before <= verification_time:
-                base_nr = trc.id.base_nr
-
-        # Find TRC with highest serial number with the given base number and a
-        # validity period starting before verification time.
-        serial_nr = 1
-        for trc in trcs[isd].values():
-            if trc.id.base_nr != base_nr:
-                continue
-            if trc.id.serial_nr > serial_nr and trc.validity.not_before <= verification_time:
-                serial_nr = trc.id.serial_nr
-
-        candidate = trcs[(serial_nr, base_nr)]
-
-        # If the verification time is not inside the validity period,
-        # there is no valid set of trust anchors.
-        if not candidate.validity.contains(verification_time):
-            return set()
-
-        # If the grace period has passed, only the certificates in that TRCs
-        # may be used as trust anchors.
-        if candidate.validity.not_before + candidate.grace_period < verification_time:
-            return collect_trust_anchors(candidate)
-
-        predecessor = trcs.get((serial_nr-1, base_nr))
-        if not predecessor or predecessor.validity.not_after < verification_time:
-            return collect_trust_anchors(candidate)
-
-        return collect_trust_anchors(candidate) | collect_trust_anchors(predecessor)
-
-
-    def collect_trust_anchors(trc: TRC) -> Set[RootCert]:
-        """
-        Args:
-            trc: A TRC from which the CP Root Certificates shall be extracted.
-
-        Returns:
-            The set of CP Root certificates that act as trust anchors.
-        """
-        roots = set()
-        for cert in trc.certificates:
-            if not cert.basic_constraints.ca:
-                continue
-            roots.add(cert)
-        return roots
+Certificate**. To validate a path, the relying party builds the trust anchor pool
+of **CP Root Certificates** from the applicable TRCs (selected by verification
+time, accounting for validity and grace periods) and verifies candidate paths
+against it. The selection algorithm and the construction of the trust anchor pool
+are specified in `Certification Path — Trust Anchor Pool
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-certification-path-trust-an>`_.
 
 Voting Certificate
 ==================
 
-There are two types of voting certificates; The **Sensitive Voting Certificate**
-and the **Regular Voting Certificates**. They authenticate public keys for
-private keys that are allowed to cast votes in the TRC update process.
-
-Both certificates are x.509 style certificates, in general follow the **CP
-Certificates** format, with the exception that they are not required to include
-the ``ISD-AS number`` in their distinguished name.
+There are two types of voting certificates, which authenticate the keys allowed to
+cast votes in the TRC update process. Both are self-signed end-entity certificates
+that follow the **CP Certificate** format, except that they need not include the
+*ISD-AS number* in their distinguished name. Their full profiles are specified in
+`Voting Certificates
+<https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#name-voting-certificates>`_.
 
 .. _sensitive-voting-certificate:
 
 Sensitive Voting Certificate
 ----------------------------
 
-**Sensitive Voting Certificates** state which keys are allowed to cast votes in
-a sensitive update.
-
-In X.509 terms, **Sensitive Voting Certificates** are *self-signed* end-entity
-certificates (``issuer`` and ``subject`` are the same entity, and the key within
-the certificate was used to sign it).
-
-All constraints in :ref:`general-certificate-requirements` apply to **Sensitive
-Voting Certificates**.
+**Sensitive Voting Certificates** authenticate the keys allowed to cast votes in a
+sensitive update.
 
 The recommended maximum validity period of a **Sensitive Voting Certificate** is
-5 year.
-
-Extension constraints
-^^^^^^^^^^^^^^^^^^^^^
-
-**Key usage**. If this extension is present, the ``digitalSignature`` and
-``keyCertSign`` attribute MUST NOT be set.
-
-**Extended key usage**. This extension MUST be present. The ``id-kp-serverAuth``
-and ``id-kp-clientAuth`` purposes MUST NOT be set. The ``id-kp-sensitive``
-and ``id-kp-timeStamping`` purpose MUST be set.
-
-.. code-block:: text
-
-    id-kp-sensitive AttributeType ::= {id-ana id-cppki(1) id-kp(3) 1}
-
-**Basic constraints**. The extension SHOULD NOT be included. If it is included,
-the ``cA`` component MUST be set to **FALSE**.
+`5 years <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#section-2.5-1>`__.
 
 .. _regular-voting-certificate:
 
 Regular Voting Certificate
 --------------------------
 
-**Regular Voting Certificates** state which keys are allowed to cast votes in a
+**Regular Voting Certificates** authenticate the keys allowed to cast votes in a
 regular update.
 
-In X.509 terms, **Regular Voting Certificates** are *self-signed* end-entity
-certificates (``issuer`` and ``subject`` are the same entity, and the key within
-the certificate was used to sign it).
-
-All constraints in :ref:`general-certificate-requirements` apply to **Regular
-Voting Certificates**.
-
-The recommended maximum validity period of a **Regular Voting Certificate** is 1
-year.
-
-Extension constraints
-^^^^^^^^^^^^^^^^^^^^^
-
-**Key usage**. If this extension is present, the ``digitalSignature`` and
-``keyCertSign`` attribute MUST NOT be set.
-
-**Extended key usage**. This extension MUST be present. The ``id-kp-serverAuth``
-and ``id-kp-clientAuth`` purposes MUST NOT be set. The ``id-kp-regulars``
-and ``id-kp-timeStamping`` purpose MUST be set.
-
-.. code-block:: text
-
-    id-kp-regular AttributeType ::= {id-ana id-cppki(1) id-kp(3) 2}
-
-**Basic constraints**. The extension SHOULD NOT be included. If it is included,
-the ``cA`` component MUST be set to **FALSE**.
+The recommended maximum validity period of a **Regular Voting Certificate** is
+`5 years <https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html#section-2.5-1>`__.
 
 .. _supported-algorithms:
 
 Supported Algorithms
 ====================
 
-See :ref:`certificate-signature` for information about supported algorithms.
-In this section we only list the TRC-specific aspects.
-
-The Signed-data of the signed TRC format follows [RFC8419]_, Section 3.1.
+The signature algorithms for TRCs are the same as for certificates (see
+:ref:`certificate-signature`). The CMS *SignedData* of the signed TRC follows
+[RFC8419]_, Section 3.1.

--- a/doc/cryptography/trc.rst
+++ b/doc/cryptography/trc.rst
@@ -1,5 +1,5 @@
 ********************************************
-Trust Root Configuration (TRC) Specification
+Trust Root Configuration (TRC)
 ********************************************
 
 The **Trust Root Configuration (TRC)** is a signed collection of `X.509 v3


### PR DESCRIPTION
Instead of duplicating info on doc pages - simplify and refer to IETF drafts; specifically HTML in the latest version (currently 13: https://www.ietf.org/archive/id/draft-dekater-scion-pki-13.html)

Docs are giving a big picture introduction and leave the details to the actual spec.

This also fixes incorrect docs:
- Regular voting cert validity: align with the draft (1y -> 5y).
- Sensitive voting cert: "5 year" -> "5 years" wording.
- Docs copyright: bump to 2026.