### PR TITLE
build: package the releases with cgo

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,6 +66,25 @@ steps:
             EOF
     key: dist
     retry: *automatic-retry
+  # Installs the actual release packages and starts the services from them.
+  # The per-PR steps never do that, which is how the broken v0.15.0 packages shipped:
+  # https://github.com/scionproto/scion/issues/4960
+  # This is expensive, hence tagged builds only.
+  - label: "Release Acceptance :debian: :openwrt: :rpm:"
+    if: build.tag != null
+    command:
+      - make dist-test-release BFLAGS="--file_name_version=${SCION_VERSION}"
+    depends_on: dist
+    key: release_acceptance
+    plugins:
+      - scionproto/metahook#v0.3.0:
+          pre-command: .buildkite/cleanup-leftovers.sh
+          pre-artifact: tar -chaf bazel-testlogs.tar.gz bazel-testlogs
+          pre-exit: .buildkite/cleanup-leftovers.sh
+    artifact_paths:
+      - bazel-testlogs.tar.gz
+    retry: *automatic-retry
+    timeout_in_minutes: 30
   - label: "Unit Tests :bazel:"
     command:
       - bazel test --config=race --config=unit_all

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -243,6 +243,29 @@ register_toolchains(
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "rules_cc", version = "0.2.20")
 
+# Hermetic C cross compilers for the package builds. The sqlite driver needs cgo,
+# which needs a C toolchain for the target platform.
+#
+# Only selected for platforms that ask for musl (see //dist).
+# Host builds and container images keep using the host C toolchain.
+bazel_dep(name = "hermetic_cc_toolchain", version = "4.3.0")
+single_version_override(
+    module_name = "hermetic_cc_toolchain",
+    # Upstream only declares x86_64 and aarch64. Add i386 and armel zig musl targets.
+    patch_strip = 1,
+    patches = ["//patches:hermetic_cc_toolchain/32bit.patch"],
+)
+
+zig_toolchains = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains")
+use_repo(zig_toolchains, "zig_sdk")
+
+register_toolchains(
+    "@zig_sdk//libc_aware/toolchain:linux_amd64_musl",
+    "@zig_sdk//libc_aware/toolchain:linux_arm64_musl",
+    "@zig_sdk//libc_aware/toolchain:linux_386_musl",
+    "@zig_sdk//libc_aware/toolchain:linux_arm_musl",
+)
+
 # Antlr
 bazel_dep(name = "rules_java", version = "9.6.1")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -111,6 +111,8 @@
     "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
     "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
     "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
+    "https://bcr.bazel.build/modules/hermetic_cc_toolchain/4.3.0/MODULE.bazel": "4157d273074a1876fa674deca1e551bad66f06b87da1603dd856244e97b7ced8",
+    "https://bcr.bazel.build/modules/hermetic_cc_toolchain/4.3.0/source.json": "ce6a4b5621b88b8707e362419d9972cc9669d5c24cec2a7610483a94be8fa4ae",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/source.json": "746bf13cac0860f091df5e4911d0c593971cd8796b5ad4e809b2f8e133eee3d5",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-dev dist-deb antlr clean docker-images gazelle go.mod licenses mocks mocksdiff protobuf scion-topo test test-integration write_all_source_files git-version
+.PHONY: all build build-dev dist-check-cgo dist-deb dist-test-release antlr clean docker-images gazelle go.mod licenses mocks mocksdiff protobuf scion-topo test test-integration write_all_source_files git-version
 
 build-dev:
 	rm -f bin/*
@@ -14,12 +14,16 @@ build:
 
 # BFLAGS is optional. It may contain additional command line flags for CI builds. Currently this is:
 # "--file_name_version=$(tools/git-version)" to include the git version in the artifacts names.
-dist-deb:
+dist-deb: dist-check-cgo
 	bazel build //dist:deb_all $(BFLAGS)
 	@ # These artefacts have unique names but varied locations. Link them somewhere convenient.
 	@ mkdir -p installables
 	@ cd installables ; ln -sfv ../bazel-out/*/bin/dist/*.deb .
 
+# No dist-check-cgo here: cgo_test only covers the deb and rpm architectures.
+# The openwrt platform has no cgo_off and its own musl C toolchain,
+# see //dist/openwrt:openwrt_amd64 and //dist/openwrt:x86_64_openwrt_toolchain.
+# These packages were always built with cgo.
 dist-openwrt:
 	bazel build //dist:openwrt_all $(BFLAGS)
 	@ # These artefacts have unique names but varied locations. Link them somewhere convenient.
@@ -32,11 +36,27 @@ dist-openwrt-testing:
 	@ mkdir -p installables
 	@ cd installables ; ln -sfv ../bazel-out/*/bin/dist/*.ipk .
 
-dist-rpm:
+dist-rpm: dist-check-cgo
 	bazel build //dist:rpm_all $(BFLAGS)
 	@ # These artefacts have unique names but varied locations. Link them somewhere convenient.
 	@ mkdir -p installables
 	@ cd installables ; ln -sfv ../bazel-out/*/bin/dist/*.rpm .
+
+# Checks that the binaries we are about to package are built with cgo. Without cgo their
+# sqlite driver is a stub that fails at runtime.
+dist-check-cgo:
+	bazel test //dist/test:cgo_test $(BFLAGS)
+
+# Install every package and start the services from their units. Includes tests excluded
+# from the per-PR runs, hence the explicit target list. Only covers architectures we can
+# execute, see dist/test/README.md.
+dist-test-release:
+	bazel test $(BFLAGS) \
+		//dist/test:cgo_test \
+		//dist/test:deb_test \
+		//dist/test:deb_test_i386 \
+		//dist/test:rpm_test \
+		//dist/test:openwrt_test
 
 # all: performs the code-generation steps and then builds; the generated code
 # is git controlled, and therefore this is only necessary when changing the

--- a/README.md
+++ b/README.md
@@ -33,8 +33,13 @@ SCION can be built with `go build`. To build all binaries used in a SCION deploy
 excluding the testing and development tools), run
 
 ```sh
-CGO_ENABLED=0 go build -o bin ./router/... ./control/... ./dispatcher/... ./daemon/... ./scion/... ./scion-pki/... ./gateway/...
+go build -o bin ./router/... ./control/... ./dispatcher/... ./daemon/... ./scion/... ./scion-pki/... ./gateway/...
 ```
+
+> [!WARNING]
+> The control service and the daemon need cgo for their sqlite driver. Building them
+> requires a C compiler. Without one, `go` silently sets `CGO_ENABLED=0`, the build still
+> succeeds, but both binaries fail at startup, as soon as they try to open their database.
 
 The default way to build SCION, however, uses Bazel.
 In particular, this allows to run all the tests, linters etc.

--- a/dist/BUILD.bazel
+++ b/dist/BUILD.bazel
@@ -2,18 +2,44 @@ load(":git_version.bzl", "git_version")
 load(":package.bzl", "scion_pkg_deb", "scion_pkg_ipk", "scion_pkg_rpm")
 load(":platform.bzl", "multiplatform_filegroup")
 
-DEB_PLATFORMS = [
-    "@rules_go//go/toolchain:linux_amd64",
-    "@rules_go//go/toolchain:linux_arm64",
-    "@rules_go//go/toolchain:linux_386",
-    "@rules_go//go/toolchain:linux_arm",
+# Platforms for the distribution packages.
+#
+# Do not use @rules_go//go/toolchain:linux_*: those carry cgo_off and silently produce
+# pure-Go binaries, which turns the sqlite driver into a stub.
+#
+# These ask for cgo_on plus musl, which selects the zig cross compilers from
+# //MODULE.bazel. musl is linked statically, so the binaries still have no libc runtime
+# dependency.
+PACKAGE_PLATFORMS = [
+    "@//dist:linux_amd64",
+    "@//dist:linux_arm64",
+    "@//dist:linux_386",
+    "@//dist:linux_arm",
 ]
 
-RPM_PLATFORMS = [
-    "@rules_go//go/toolchain:linux_amd64",
-    "@rules_go//go/toolchain:linux_arm64",
-    "@rules_go//go/toolchain:linux_386",
-    "@rules_go//go/toolchain:linux_arm",
+DEB_PLATFORMS = PACKAGE_PLATFORMS
+
+RPM_PLATFORMS = PACKAGE_PLATFORMS
+
+[
+    platform(
+        name = "linux_" + goarch,
+        constraint_values = [
+            "@platforms//os:linux",
+            "@platforms//cpu:" + bzlcpu,
+            # Build the sqlite driver for real, not as a stub.
+            "@rules_go//go/toolchain:cgo_on",
+            # Selects the zig cc toolchains from //MODULE.bazel.
+            "@zig_sdk//libc:musl",
+        ],
+        visibility = ["//visibility:public"],
+    )
+    for goarch, bzlcpu in [
+        ("amd64", "x86_64"),
+        ("arm64", "aarch64"),
+        ("386", "x86_32"),
+        ("arm", "armv7"),
+    ]
 ]
 
 # TODO(jice@scion.org):
@@ -155,6 +181,23 @@ multiplatform_filegroup(
         "tools_deb",
     ],
     target_platforms = DEB_PLATFORMS,
+    visibility = ["//dist:__subpackages__"],
+)
+
+# The binaries that go into the deb and rpm packages, for every release architecture.
+# Used by //dist/test:cgo_test.
+multiplatform_filegroup(
+    name = "package_binaries",
+    srcs = [
+        "//control/cmd/control",
+        "//daemon/cmd/daemon",
+        "//dispatcher/cmd/dispatcher",
+        "//gateway/cmd/gateway",
+        "//router/cmd/router",
+        "//scion-pki/cmd/scion-pki",
+        "//scion/cmd/scion",
+    ],
+    target_platforms = PACKAGE_PLATFORMS,
     visibility = ["//dist:__subpackages__"],
 )
 

--- a/dist/platform.bzl
+++ b/dist/platform.bzl
@@ -8,6 +8,8 @@ def multiplatform_filegroup(name, srcs, target_platforms, **kwargs):
             name = name + "_" + platform_name,
             srcs = srcs,
             target_platform = target_platform,
+            # Expose the per-platform groups too, e.g. to test one architecture.
+            visibility = kwargs.get("visibility", None),
         )
         all_platforms.append(name + "_" + platform_name)
 

--- a/dist/test/BUILD.bazel
+++ b/dist/test/BUILD.bazel
@@ -45,6 +45,7 @@ sh_test(
     ],
     env = {
         "SCION_DEB_PACKAGES": "$(locations //dist:deb_linux_amd64)",
+        "SCION_DEB_ARCH": "amd64",
     },
     tags = [
         "exclusive",

--- a/dist/test/BUILD.bazel
+++ b/dist/test/BUILD.bazel
@@ -1,14 +1,50 @@
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
+# Checks that the packaged binaries are built with cgo. It only reads the binaries and
+# never runs them. That way it also covers the architectures we cannot execute here.
+#
+# One test per architecture on purpose. The binaries of all architectures share the same
+# runfiles paths. A single test would only ever see one of them.
+[
+    sh_test(
+        name = "cgo_test_" + arch,
+        srcs = ["cgo_test.sh"],
+        data = ["//dist:package_binaries_linux_" + arch],
+        env = {
+            "SCION_PACKAGE_BINARIES": "$(locations //dist:package_binaries_linux_" + arch + ")",
+        },
+        tags = ["integration"],
+    )
+    for arch in [
+        "amd64",
+        "arm64",
+        "386",
+        "arm",
+    ]
+]
+
+test_suite(
+    name = "cgo_test",
+    tags = ["integration"],
+    tests = [
+        "cgo_test_386",
+        "cgo_test_amd64",
+        "cgo_test_arm",
+        "cgo_test_arm64",
+    ],
+)
+
+# Uses the amd64 release artifacts, not a host build. The two are built differently.
+# A host build tells us nothing about what we ship.
 sh_test(
     name = "deb_test",
     srcs = ["deb_test.sh"],
     data = [
         "Dockerfile",
-        "//dist:deb",
+        "//dist:deb_linux_amd64",
     ],
     env = {
-        "SCION_DEB_PACKAGES": "$(locations //dist:deb)",
+        "SCION_DEB_PACKAGES": "$(locations //dist:deb_linux_amd64)",
     },
     tags = [
         "exclusive",
@@ -32,15 +68,38 @@ sh_test(
     ],
 )
 
+# Same as deb_test, for i386. Runs natively on an x86_64 agent, no emulation.
+#
+# Tagged manual to keep it out of the per-PR integration steps, which come from a bazel
+# query that skips manual targets (see .buildkite/pipeline_lib.sh).
+# Run by `make dist-test-release`. arm64 and armel cannot be run this way.
+# See dist/test/README.md.
+sh_test(
+    name = "deb_test_i386",
+    srcs = ["deb_test.sh"],
+    data = [
+        "Dockerfile",
+        "//dist:deb_linux_386",
+    ],
+    env = {
+        "SCION_DEB_PACKAGES": "$(locations //dist:deb_linux_386)",
+        "SCION_DEB_ARCH": "i386",
+    },
+    tags = [
+        "exclusive",
+        "manual",
+    ],
+)
+
 sh_test(
     name = "rpm_test",
     srcs = ["rpm_test.sh"],
     data = [
         "Dockerfile.rpm",
-        "//dist:rpm",
+        "//dist:rpm_linux_amd64",
     ],
     env = {
-        "SCION_RPM_PACKAGES": "$(locations //dist:rpm)",
+        "SCION_RPM_PACKAGES": "$(locations //dist:rpm_linux_amd64)",
     },
     tags = [
         "exclusive",

--- a/dist/test/README.md
+++ b/dist/test/README.md
@@ -32,3 +32,28 @@ The test does **not** attempt to simulate a working SCION network.
 The assumption is that if the services installed from the packages
 can be started (meaning they don't crash immediately after startup), the
 findings of the various acceptence and end-to-end integration tests apply.
+
+## Architecture coverage
+
+We release deb and rpm packages for amd64, arm64, i386 and armel. These tests install and
+start the packages, so they only cover architectures the agent can execute:
+
+| Architecture | Covered by             | Note                                               |
+|--------------|------------------------|----------------------------------------------------|
+| amd64        | `deb_test`, `rpm_test` | packages installed and started, every pull request |
+| i386         | `deb_test_i386`        | the same, but release builds only (tagged manual)  |
+| arm64        | `cgo_test_arm64` only  | binaries inspected, never run, see below           |
+| armel        | `cgo_test_arm` only    | binaries inspected, never run, see below           |
+
+`cgo_test` covers *all* release architectures and runs on every pull request.
+It only inspects the binaries instead of running them. It exists because
+the v0.15.0 packages were built without cgo and shipped a sqlite driver stub that
+failed at startup, see [#4960](https://github.com/scionproto/scion/issues/4960).
+
+`make dist-test-release` runs the full set.
+The release pipeline invokes it for tagged builds.
+
+To also execute arm64 and armel, the agents need `qemu-user-static` and `binfmt-support`
+(add them to `tools/env/debian/pkgs.txt`, installed by `provision-agent.sh`), and
+`deb_test.sh` needs to accept those architectures. Note that systemd under qemu-user is
+fragile; starting the service binaries directly is likely more reliable there.

--- a/dist/test/cgo_test.sh
+++ b/dist/test/cgo_test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Checks that the packaged binaries are built with cgo, for every release architecture.
+#
+# The sqlite driver (github.com/mattn/go-sqlite3) needs cgo. Without it the driver still
+# compiles, but every call fails at run time. The control service and the daemon hit that
+# on their first database access, i.e. at startup. That is how v0.15.0 shipped, see
+# https://github.com/scionproto/scion/issues/4960.
+
+set -euo pipefail
+
+# Space-separated list of the binaries that go into the deb and rpm packages, for all
+# release architectures.
+binaries=${SCION_PACKAGE_BINARIES?}
+
+stub="Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work"
+# Only present if the sqlite C sources were compiled in.
+symbol="sqlite3_open_v2"
+
+checked=0
+failed=0
+for binary in ${binaries}; do
+    checked=$((checked + 1))
+    if grep -qa "${stub}" "${binary}"; then
+        echo "FAIL: ${binary}: built without cgo, sqlite driver is a stub"
+        failed=$((failed + 1))
+        continue
+    fi
+    if ! grep -qa "${symbol}" "${binary}"; then
+        echo "FAIL: ${binary}: no ${symbol}, sqlite was not compiled in"
+        failed=$((failed + 1))
+    fi
+done
+
+if [ "${checked}" -eq 0 ]; then
+    echo "FAIL: no binaries to check, the test is not wired up correctly"
+    exit 1
+fi
+
+if [ "${failed}" -ne 0 ]; then
+    echo "${failed} of ${checked} binaries were built without cgo;"
+    echo "check the PACKAGE_PLATFORMS definition and the toolchains it relies on, in"
+    echo "//dist/BUILD.bazel and //MODULE.bazel respectively."
+    exit 1
+fi
+
+echo "Success! ${checked} binaries are built with cgo."

--- a/dist/test/deb_test.sh
+++ b/dist/test/deb_test.sh
@@ -16,11 +16,26 @@ else
     SCION_DEB_PACKAGES_DIR=${SCION_DEB_PACKAGES_DIR:-${SCION_ROOT}/deb}
 fi
 DEBUG=${DEBUG:-0}
+
+# Architecture of the packages under test, default the host's. The container runs a
+# userland of this architecture. i386 runs natively on x86_64, no emulation. arm64 and
+# armel would need qemu, see dist/test/README.md.
+SCION_DEB_ARCH=${SCION_DEB_ARCH:-$(dpkg --print-architecture)}
+case "${SCION_DEB_ARCH}" in
+    amd64) platform="linux/amd64" ;;
+    i386)  platform="linux/386" ;;
+    *)
+        echo "deb_test: unsupported architecture '${SCION_DEB_ARCH}'," \
+             "only natively executable architectures are supported, see dist/test/README.md" >&2
+        exit 1
+        ;;
+esac
+image="debian-systemd-${SCION_DEB_ARCH}"
 set +x
 
 function cleanup {
-    docker container rm -f debian-systemd || true
-    docker image rm --no-prune debian-systemd || true
+    docker container rm -f "${image}" || true
+    docker image rm --no-prune "${image}" || true
 }
 cleanup
 
@@ -30,22 +45,24 @@ fi
 
 # Note: specify absolute path to Dockerfile because docker will not follow bazel's symlinks.
 # Luckily we don't need anything else in this directory.
-docker build -t debian-systemd -f $(realpath dist/test/Dockerfile) dist/test
+docker build --platform "${platform}" -t "${image}" -f $(realpath dist/test/Dockerfile) dist/test
 
 # Start container with systemd in PID 1.
 # Note: there are ways to avoid --privileged, but its unreliable and appears to depend on the host system
-docker run -d --rm --name debian-systemd -t \
+docker run -d --rm --name "${image}" -t \
+    --platform "${platform}" \
     --tmpfs /tmp \
     --tmpfs /run \
     --tmpfs /run/lock \
     --tmpfs /run/shm \
     -v $SCION_DEB_PACKAGES_DIR:/deb \
     --privileged \
-    debian-systemd:latest
+    "${image}:latest"
 
-docker exec -i debian-systemd /bin/bash <<'EOF'
+docker exec -e arch="${SCION_DEB_ARCH}" -i "${image}" /bin/bash <<'EOF'
     set -xeuo pipefail
-    arch=$(dpkg --print-architecture)
+    # The container userland must match the packages under test.
+    [ "$(dpkg --print-architecture)" = "${arch}" ]
 
     # check that the deb files are all here (avoid cryptic error from apt-get)
     stat /deb/scion-{router,control,dispatcher,daemon,ip-gateway,tools}_*_${arch}.deb > /dev/null

--- a/dist/test/deb_test.sh
+++ b/dist/test/deb_test.sh
@@ -17,10 +17,13 @@ else
 fi
 DEBUG=${DEBUG:-0}
 
-# Architecture of the packages under test, default the host's. The container runs a
-# userland of this architecture. i386 runs natively on x86_64, no emulation. arm64 and
-# armel would need qemu, see dist/test/README.md.
-SCION_DEB_ARCH=${SCION_DEB_ARCH:-$(dpkg --print-architecture)}
+# Architecture of the packages under test. The container runs a userland of this
+# architecture. i386 runs natively on x86_64, no emulation.
+# arm64 and armel would need qemu, see dist/test/README.md.
+#
+# Do not probe the host for this. dpkg is not on PATH in the bazel test sandbox,
+# and the bazel targets pin the packages to one architecture anyway.
+SCION_DEB_ARCH=${SCION_DEB_ARCH:-amd64}
 case "${SCION_DEB_ARCH}" in
     amd64) platform="linux/amd64" ;;
     i386)  platform="linux/386" ;;

--- a/doc/dev/build.rst
+++ b/doc/dev/build.rst
@@ -43,7 +43,14 @@ Build
 
    .. code-block:: bash
 
-      CGO_ENABLED=0 go build -o bin/ ./{router,control,dispatcher,daemon,scion,scion-pki,gateway}/cmd/...
+      go build -o bin/ ./{router,control,dispatcher,daemon,scion,scion-pki,gateway}/cmd/...
+
+   .. warning::
+
+      The control service and the daemon need cgo for their sqlite driver
+      (``github.com/mattn/go-sqlite3``). Building them requires a C compiler. Without one,
+      ``go`` silently sets ``CGO_ENABLED=0``, the build still succeeds, but both binaries
+      fail at startup, as soon as they try to open their database.
 
 * **Build all**
 

--- a/patches/hermetic_cc_toolchain/32bit.patch
+++ b/patches/hermetic_cc_toolchain/32bit.patch
@@ -1,0 +1,85 @@
+Adds 32 bit linux musl targets (i386 and armel) to hermetic_cc_toolchain.
+
+Upstream only declares x86_64 and aarch64 linux targets, but we ship deb and rpm
+packages for i386 and armel as well. Those packages contain cgo binaries (the sqlite
+driver), so they need a C cross compiler for every architecture we release,
+see https://github.com/scionproto/scion/issues/4960.
+
+Zig itself supports these targets; only hermetic_cc_toolchain's target list has to be
+extended. Two details differ from the 64 bit targets and are therefore parameterized:
+the zig cpu name does not match the @platforms//cpu constraint value (x86 vs x86_32,
+arm vs armv7), and 32 bit arm needs an explicit eabi in the zig triple.
+
+Upstream issue: https://github.com/uber/hermetic_cc_toolchain/issues/10
+
+diff --git a/toolchain/private/defs.bzl b/toolchain/private/defs.bzl
+index f900205..1960b33 100644
+--- a/toolchain/private/defs.bzl
++++ b/toolchain/private/defs.bzl
+@@ -43,6 +43,19 @@ def zig_tool_path(os):
+     else:
+         return _ZIG_TOOL_PATH
+ 
++# 32 bit linux targets, declared for musl only.
++#
++# Their zig cpu name does not match the @platforms//cpu constraint value, and 32 bit arm
++# additionally needs an explicit eabi in the zig triple, so both are spelled out here:
++# (zig cpu, go arch, @platforms//cpu constraint, zig libc/abi).
++#
++# The arm entry uses the soft float "musleabi" rather than "musleabihf", to match the
++# Debian armel port and the soft float binaries this repository already ships.
++_LINUX_MUSL_32BIT_CPUS = (
++    ("x86", "386", "x86_32", "musl"),
++    ("arm", "arm", "armv7", "musleabi"),
++)
++
+ def target_structs():
+     ret = []
+     for zigcpu, gocpu in (("x86_64", "amd64"), ("aarch64", "arm64")):
+@@ -51,6 +64,8 @@ def target_structs():
+         ret.append(_target_linux_musl(gocpu, zigcpu))
+         for glibc in _GLIBCS:
+             ret.append(_target_linux_gnu(gocpu, zigcpu, glibc))
++    for zigcpu, gocpu, bzlcpu, abi in _LINUX_MUSL_32BIT_CPUS:
++        ret.append(_target_linux_musl(gocpu, zigcpu, bzlcpu = bzlcpu, abi = abi))
+     ret.append(_target_wasm())
+     ret.append(_target_wasm_no_wasi())
+     return ret
+@@ -185,10 +200,12 @@ def _target_linux_gnu(gocpu, zigcpu, glibc_version):
+         artifact_name_patterns = [],
+     )
+ 
+-def _target_linux_musl(gocpu, zigcpu):
++def _target_linux_musl(gocpu, zigcpu, bzlcpu = None, abi = "musl"):
+     return struct(
+         gotarget = "linux_{}_musl".format(gocpu),
+-        zigtarget = "{}-linux-musl".format(zigcpu),
++        # The eabi suffix belongs in the compiler triple, but not in the header search
++        # paths: zig ships those under the plain "-linux-musl" name for every abi.
++        zigtarget = "{}-linux-{}".format(zigcpu, abi),
+         includes = [
+                        "libc/include/{}-linux-musl".format(zigcpu),
+                        "libc/include/generic-musl",
+@@ -206,7 +223,7 @@ def _target_linux_musl(gocpu, zigcpu):
+         bazel_target_cpu = "k8",
+         constraint_values = [
+             "@platforms//os:linux",
+-            "@platforms//cpu:{}".format(zigcpu),
++            "@platforms//cpu:{}".format(bzlcpu or zigcpu),
+         ],
+         libc_constraint = "@zig_sdk//libc:musl",
+         ld_zig_subcmd = "ld.lld",
+diff --git a/toolchain/zig-wrapper.zig b/toolchain/zig-wrapper.zig
+index 172b518..c0df428 100644
+--- a/toolchain/zig-wrapper.zig
++++ b/toolchain/zig-wrapper.zig
+@@ -378,7 +378,8 @@ fn getRunMode(self_exe: []const u8, self_base_noexe: []const u8) error{BadParent
+     var it = mem.splitScalar(u8, triple, '-');
+ 
+     const arch = it.next() orelse return error.BadParent;
+-    if (mem.indexOf(u8, "aarch64,x86_64,wasm32", arch) == null)
++    // Note that this is a substring match, so "x86" is accepted via "x86_64".
++    if (mem.indexOf(u8, "aarch64,arm,x86_64,wasm32", arch) == null)
+         return error.BadParent;
+ 
+     const got_os = it.next() orelse return error.BadParent;

--- a/scion.bzl
+++ b/scion.bzl
@@ -13,6 +13,9 @@ def scion_go_binary(name, visibility, *args, **kwargs):
         visibility = visibility,
         # disable automatically setting the build id since Go 1.24
         gc_linkopts = ["-B", "none"],
+        # The sqlite driver needs cgo, or it becomes a stub that fails at runtime.
+        # Without this, a missing C toolchain gives us that stub. With it, the build fails.
+        pure = "off",
         *args,
         **kwargs
     )


### PR DESCRIPTION
The deb and rpm packages build without cgo. Their cgo-dependent sqlite driver is a stub, therefore the control service and the daemon die at startup (see #4960).

- build: build the packages against platforms that require cgo, using [hermetic zig](https://github.com/uber/hermetic_cc_toolchain) cross compilers and static musl.
- build: make a missing C toolchain fail the build instead of passing silently.
- test: point the tests at the artifacts we release, not at a host build.
- ci: add a release-only step that installs and starts every package, including the i386 ones the per-pull-request runs skip.
- doc: document that `go build` needs a C compiler.

Fixes #4960 and should prevent such problems in the future.