### PR TITLE
ci: disable benchmarking in ci

### DIFF
--- a/acceptance/router_benchmark/BUILD.bazel
+++ b/acceptance/router_benchmark/BUILD.bazel
@@ -32,6 +32,9 @@ data = [
     "//tools/mmbm:mmbm",
 ]
 
+# The router benchmark is excluded from CI. CI agents are shared, virtualized machines,
+# so the throughput they measure says little about the router.
+# Performance regression testing is scheduled on baremetal instead.
 raw_test(
     name = "test",
     src = "test.py",
@@ -40,6 +43,7 @@ raw_test(
     homedir = "$(rootpath //docker:router.tarball)",
     # This test uses sudo and accesses /var/run/netns.
     local = True,
+    tags = ["manual"],
     deps = ["benchmarklib"],
 )
 

--- a/doc/dev/testing/benchmarking.rst
+++ b/doc/dev/testing/benchmarking.rst
@@ -25,3 +25,17 @@ results available for pickup by :program:`benchmark.py`.
 Otherwise these operations still have to be carried out manually. The :program:`mmbm` and
 :program:`coremark` tools can be found in: ``bazel-bin/tools/mmbm/mmbm_/mmbm`` and
 ``bazel-bin/tools/coremark/coremark``.
+
+Router benchmark acceptance test
+================================
+
+The benchmark harness is also wrapped in a Bazel test that sets up a local topology and
+benchmarks the router in it:
+
+.. code-block:: sh
+
+   bazel test --test_output=streamed //acceptance/router_benchmark:test
+
+This test is tagged ``manual``. It is not part of the CI build nor of ``//...`` wildcards.
+CI agents are shared, virtualized machines, so the throughput they measure says little
+about the router. Performance regression testing is scheduled on baremetal instead.


### PR DESCRIPTION
Router benchmarks in CI are flaky and increase CI run times.

They're already disabled in #4892 because `AF_XDP` in `XDP_ZEROCOPY` is not even runnable on CI machines in the cloud; zero-copy underlays require bare-metal setups with supported hardware and drivers.

Scheduled performance regression tests on bare-metal machines (such as the SCION Association workstation) is, IMHO, the easier and more reliable option.